### PR TITLE
[FEATURE] [MER-4087] Certificates Design and Preview Tab

### DIFF
--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -6,38 +6,63 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
     @page {
       size: landscape;
     }
-  </style>
-  <div style="border: 1px solid #ccc; padding: 20px; width: 800px; text-align: center; font-family: Arial, sans-serif;">
-    <h1 style="color: gold;"><%= @certificate_type %></h1>
-    <p>This certificate is presented to</p>
-    <h2 style="font-size: 24px; font-weight: bold;"><%= @student_name %></h2>
-    <p>on <%= @completion_date %> for completing</p>
-    <h3 style="font-size: 22px; font-weight: bold;"><%= @course_name %></h3>
-    <p style="font-style: italic;"><%= @course_description %></p>
 
-    <div style="margin-top: 40px;">
-      <div style="display: flex; justify-content: space-around;">
-        <%= for {admin_name, admin_description} <- @administrators do %>
-          <div>
-            <p style="margin: 0; font-weight: bold; font-family: 'Alex Brush', cursive; font-size: 20px;">
-              <%= admin_name %>
-            </p>
-            <p style="margin: 0; font-size: small;"><%= admin_description %></p>
+    body {
+      background-color: white;
+      margin: 0;
+      padding: 0;
+    }
+
+    .outer-container {
+      border: 4px solid #917e08;
+      padding: 2px;
+      width: 800px;
+      margin: 40px auto;
+    }
+
+    .inner-container {
+      border: 2px solid #ad9e52;
+      padding: 20px;
+      text-align: center;
+      font-family: Arial, sans-serif;
+      background-color: white;
+    }
+  </style>
+  <body>
+    <div class="outer-container">
+      <div class="inner-container">
+        <h1 style="color: #8f7b00; font-family: 'Times New Roman', Times, serif; font-weight: normal; font-size: 50px;"><%= @certificate_type %></h1>
+
+        <p>This certificate is presented to</p>
+        <h2 style="font-size: 24px; font-weight: bold;"><%= @student_name %></h2>
+        <p>on <strong><%= @completion_date %></strong> for completing</p>
+        <h3 style="font-size: 22px; font-weight: bold;"><%= @course_name %></h3>
+        <p style="font-style: italic;"><%= @course_description %></p>
+
+        <div style="margin-top: 40px;">
+          <div style="display: flex; justify-content: space-around;">
+            <%= for {admin_name, admin_description} <- @administrators do %>
+              <div>
+                <p style="margin: 0; font-weight: bold; font-family: 'Alex Brush', cursive; font-size: 20px;">
+                  <%= admin_name %>
+                </p>
+                <p style="margin: 0; font-size: small;"><%= admin_description %></p>
+              </div>
+            <% end %>
           </div>
-        <% end %>
+        </div>
+
+        <div style="margin-top: 20px; display: flex; justify-content: center;">
+          <%= for logo <- @logos do %>
+            <img src="<%= logo %>" style="max-height: 50px; margin-right: 50px;" />
+          <% end %>
+        </div>
+
+        <p style="margin-top: 20px; font-size: small;">Certificate ID: <%= @certificate_id %></p>
       </div>
     </div>
-
-    <div style="margin-top: 20px; display: flex; justify-content: center;">
-      <%= for logo <- @logos do %>
-        <img src="<%= logo %>" style="max-height: 50px; margin-right: 10px;" />
-      <% end %>
-    </div>
-
-    <p style="margin-top: 20px; font-size: small;">Certificate ID: <%= @certificate_id %></p>
-  </div>
+  </body>
   </html>
-
   """
 
   def render(assigns) do

--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -1,0 +1,46 @@
+defmodule Oli.Delivery.Certificates.CertificateRenderer do
+  @template """
+  <html lang="en">
+  <meta charset="UTF-8" />
+  <style>
+    @page {
+      size: landscape;
+    }
+  </style>
+  <div style="border: 1px solid #ccc; padding: 20px; width: 800px; text-align: center; font-family: Arial, sans-serif;">
+    <h1 style="color: gold;"><%= @certificate_type %></h1>
+    <p>This certificate is presented to</p>
+    <h2 style="font-size: 24px; font-weight: bold;"><%= @student_name %></h2>
+    <p>on <%= @completion_date %> for completing</p>
+    <h3 style="font-size: 22px; font-weight: bold;"><%= @course_name %></h3>
+    <p style="font-style: italic;"><%= @course_description %></p>
+
+    <div style="margin-top: 40px;">
+      <div style="display: flex; justify-content: space-around;">
+        <%= for {admin_name, admin_description} <- @administrators do %>
+          <div>
+            <p style="margin: 0; font-weight: bold; font-family: 'Alex Brush', cursive; font-size: 20px;">
+              <%= admin_name %>
+            </p>
+            <p style="margin: 0; font-size: small;"><%= admin_description %></p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div style="margin-top: 20px; display: flex; justify-content: center;">
+      <%= for logo <- @logos do %>
+        <img src="<%= logo %>" style="max-height: 50px; margin-right: 10px;" />
+      <% end %>
+    </div>
+
+    <p style="margin-top: 20px; font-size: small;">Certificate ID: <%= @certificate_id %></p>
+  </div>
+  </html>
+
+  """
+
+  def render(assigns) do
+    EEx.eval_string(@template, assigns: assigns, engine: Phoenix.LiveView.HTMLEngine)
+  end
+end

--- a/lib/oli/delivery/sections/certificate.ex
+++ b/lib/oli/delivery/sections/certificate.ex
@@ -29,9 +29,9 @@ defmodule Oli.Delivery.Sections.Certificate do
     field :admin_name3, :string
     field :admin_title3, :string
 
-    field :logo1, :string
-    field :logo2, :string
-    field :logo3, :string
+    field :logo1, :binary
+    field :logo2, :binary
+    field :logo3, :binary
 
     belongs_to :section, Section
 

--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -9,6 +9,7 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
   alias Oli.Publishing.DeliveryResolver
   alias OliWeb.Certificates.CertificatesIssuedTableModel
   alias OliWeb.Certificates.Components.CertificatesIssuedTab
+  alias OliWeb.Certificates.Components.DesignTab
   alias OliWeb.Certificates.Components.ThresholdsTab
   alias OliWeb.Common.Breadcrumb
   alias OliWeb.Common.Params
@@ -178,7 +179,13 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
 
   defp render_tab(%{params: %{"active_tab" => :design}} = assigns) do
     ~H"""
-    <div>Design</div>
+    <.live_component
+      module={DesignTab}
+      id="design_component"
+      product={@product}
+      certificate={@certificate}
+      active_tab={@active_tab}
+    />
     """
   end
 

--- a/lib/oli_web/live/certificates/components/design_tab.ex
+++ b/lib/oli_web/live/certificates/components/design_tab.ex
@@ -279,8 +279,7 @@ defmodule OliWeb.Certificates.Components.DesignTab do
          )}
 
       {:error, %Ecto.Changeset{} = changeset} ->
-        send(self(), {:put_flash, [:error, "Failed to save certificate design"]})
-        assign(socket, certificate_changeset: changeset)
+        {:noreply, assign(socket, certificate_changeset: changeset)}
     end
   end
 

--- a/lib/oli_web/live/certificates/components/design_tab.ex
+++ b/lib/oli_web/live/certificates/components/design_tab.ex
@@ -1,0 +1,350 @@
+defmodule OliWeb.Certificates.Components.DesignTab do
+  use OliWeb, :live_component
+
+  alias Oli.Delivery.Certificates.CertificateRenderer
+  alias Oli.Delivery.Sections.Certificate
+  alias Oli.Repo
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="w-full flex-col">
+      <div class="mb-14 text-base font-medium">
+        Create and preview your certificate.
+      </div>
+
+      <.form
+        :let={f}
+        id="certificate-settings-design-form"
+        for={@certificate_changeset}
+        phx-change="validate"
+        phx-drop-target={@uploads.logo.ref}
+        phx-submit="save"
+        phx-target={@myself}
+        class="w-full justify-start items-center gap-3"
+      >
+        <div class="w-3/4 flex-col justify-start items-start gap-10 inline-flex">
+          <!-- Title -->
+          <div class="self-stretch flex-col justify-start items-start gap-3 flex">
+            <div class="text-base font-bold">
+              Course Title
+            </div>
+            <div class="w-full text-base">
+              <.input
+                type="text"
+                field={f[:title]}
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+            </div>
+          </div>
+          <!-- Subtitle -->
+          <div class="self-stretch flex-col justify-start items-start gap-3 flex">
+            <div class="text-base font-bold">
+              Subtitle
+            </div>
+            <div class="text-base font-small">
+              The description that appears under the name of the awardee
+            </div>
+            <div class="w-full text-base font-medium">
+              <.input
+                type="text"
+                field={f[:description]}
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+            </div>
+          </div>
+          <!-- Administrators -->
+          <div class="self-stretch flex-col justify-start items-start gap-3 flex">
+            <div class="text-base font-bold">
+              Administrators
+            </div>
+            <div class="text-base font-small">
+              Include up to three administrators on your certificate.
+            </div>
+            <div class="flex gap-3 items-center">
+              <.input
+                type="text"
+                field={f[:admin_name1]}
+                placeholder="Name 1"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+              <.input
+                type="text"
+                field={f[:admin_title1]}
+                placeholder="Title 1"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+            </div>
+            <div class="flex gap-3 items-center">
+              <.input
+                type="text"
+                field={f[:admin_name2]}
+                placeholder="Name 2"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+              <.input
+                type="text"
+                field={f[:admin_title2]}
+                placeholder="Title 2"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+            </div>
+            <div class="flex gap-3 items-center">
+              <.input
+                type="text"
+                field={f[:admin_name3]}
+                placeholder="Name 3"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+              <.input
+                type="text"
+                field={f[:admin_title3]}
+                placeholder="Title 3"
+                errors={f.errors}
+                phx-debounce="blur"
+                class="pl-6 border-[#D4D4D4] rounded"
+              />
+            </div>
+          </div>
+          <!-- Logos -->
+          <div class="self-stretch flex-col justify-start items-start gap-3 flex">
+            <div class="text-base font-bold">
+              Logos
+            </div>
+            <div class="text-base font-small">
+              Upload up to three logos for your certificate (Max size: 1MB each).
+            </div>
+            <!-- File Input -->
+            <.live_file_input upload={@uploads.logo} />
+            <section class="flex gap-4 flex-wrap mt-4">
+              <!-- Display existing logos -->
+              <%= for logo <- saved_logos(@certificate_changeset) do %>
+                <div class="relative w-24 h-24 flex-shrink-0">
+                  <img src={logo} class="object-cover w-full h-full rounded border border-gray-300" />
+                </div>
+              <% end %>
+              <!-- Display uploaded previews -->
+              <%= for entry <- @uploads.logo.entries do %>
+                <div class="relative w-24 h-24 flex-shrink-0">
+                  <.live_img_preview
+                    entry={entry}
+                    class="object-cover w-full h-full rounded border border-gray-300"
+                  />
+                  <a
+                    href="#"
+                    class="absolute top-1 right-1 bg-white rounded-full w-5 h-5 flex items-center justify-center text-red-500 shadow hover:bg-red-100"
+                    phx-click="cancel"
+                    phx-target={@myself}
+                    phx-value-ref={entry.ref}
+                  >
+                    ✖
+                  </a>
+                </div>
+              <% end %>
+            </section>
+          </div>
+          <!-- Preview -->
+          <%= if @show_preview do %>
+            <div class="fixed inset-0 z-50 flex items-center justify-center bg-gray-900">
+              <div class="relative w-11/12 max-w-4xl bg-white rounded shadow-lg p-6">
+                <!-- Modal Header -->
+                <div class="flex justify-between items-center border-b pb-4 mb-4">
+                  <h2 class="text-xl font-bold">Certificate Preview</h2>
+                  <button
+                    type="button"
+                    phx-click="close_preview"
+                    phx-target={@myself}
+                    class="text-gray-500 hover:text-gray-800"
+                  >
+                    ✖
+                  </button>
+                </div>
+                <!-- Modal Content -->
+                <div class="overflow-y-auto max-h-[90vh] bg-gray-100">
+                  <iframe
+                    srcdoc={elem(@certificate_html, @preview_page)}
+                    class="w-full h-auto border-0"
+                    style="height: 80vh;"
+                  >
+                  </iframe>
+                </div>
+                <!-- Modal Footer -->
+                <div class="flex justify-between mt-4">
+                  <!-- Previous Button -->
+                  <%= if @preview_page > 0 do %>
+                    <button
+                      type="button"
+                      phx-click="prev_preview_page"
+                      phx-target={@myself}
+                      class="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-700"
+                    >
+                      Previous
+                    </button>
+                  <% end %>
+                  <!-- Next Button -->
+                  <%= if @preview_page < 1 do %>
+                    <button
+                      type="button"
+                      phx-click="next_preview_page"
+                      phx-target={@myself}
+                      class="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-700"
+                    >
+                      Next
+                    </button>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+          <div>
+            <!-- Save -->
+            <button
+              type="submit"
+              name="save"
+              form={f.id}
+              phx-disable-with="Saving..."
+              class="px-6 py-4 bg-blue-500 text-white rounded opacity-90 hover:opacity-100"
+            >
+              Save Design
+            </button>
+          </div>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    {:ok,
+     socket
+     |> allow_upload(:logo, max_entries: 3, accept: ~w(.jpg .jpeg .png), max_file_size: 1_000_000)}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign(
+       show_preview: false,
+       preview_page: 0,
+       certificate_html: {nil, nil}
+     )
+     |> assign_new(:certificate_changeset, fn -> certificate_changeset(assigns.certificate) end)}
+  end
+
+  @impl true
+  def handle_event("validate", %{"certificate" => params}, socket) do
+    changeset = Certificate.changeset(socket.assigns.certificate, params)
+    {:noreply, assign(socket, certificate_changeset: changeset)}
+  end
+
+  def handle_event("cancel", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :logo, ref)}
+  end
+
+  def handle_event("save", _params, %{assigns: assigns} = socket) do
+    {completion_cert, distinction_cert, logos} = generate_previews(socket)
+
+    attrs =
+      assigns.certificate_changeset.changes
+      |> Map.put(:logo1, Enum.at(logos, 0))
+      |> Map.put(:logo2, Enum.at(logos, 1))
+      |> Map.put(:logo3, Enum.at(logos, 2))
+
+    socket.assigns.certificate
+    |> Certificate.changeset(attrs)
+    |> Repo.insert_or_update()
+    |> case do
+      {:ok, _certificate} ->
+        {:noreply,
+         assign(socket,
+           show_preview: true,
+           certificate_html: {completion_cert, distinction_cert}
+         )}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        send(self(), {:put_flash, [:error, "Failed to save certificate design"]})
+        assign(socket, certificate_changeset: changeset)
+    end
+  end
+
+  def handle_event("close_preview", _params, socket) do
+    {:noreply, assign(socket, show_preview: false, certificate_html: nil)}
+  end
+
+  def handle_event("next_preview_page", _params, socket) do
+    {:noreply, assign(socket, preview_page: 1)}
+  end
+
+  def handle_event("prev_preview_page", _params, socket) do
+    {:noreply, assign(socket, preview_page: 0)}
+  end
+
+  defp generate_previews(%{assigns: assigns} = socket) do
+    changeset = assigns.certificate_changeset
+
+    admins =
+      [
+        {changeset.changes[:admin_name1] || changeset.data.admin_name1,
+         changeset.changes[:admin_title1] || changeset.data.admin_title1},
+        {changeset.changes[:admin_name2] || changeset.data.admin_name2,
+         changeset.changes[:admin_title2] || changeset.data.admin_title2},
+        {changeset.changes[:admin_name3] || changeset.data.admin_name3,
+         changeset.changes[:admin_title3] || changeset.data.admin_title3}
+      ]
+      |> Enum.reject(fn {name, _} -> name == "" || !name end)
+
+    logos =
+      socket
+      |> consume_uploaded_entries(:logo, fn %{path: path}, entry ->
+        b64 = path |> File.read!() |> Base.encode64()
+        {:ok, "data:#{entry.client_type};base64, #{b64}"}
+      end)
+      |> case do
+        [] -> saved_logos(changeset)
+        new_logos -> new_logos
+      end
+
+    attrs = %{
+      certificate_type: "Certificate of Completion",
+      student_name: "Student Name",
+      completion_date: Date.utc_today() |> Calendar.strftime("%B %d, %Y"),
+      certificate_id: "00000000-0000-0000-0000-000000000000",
+      course_name: changeset.changes[:title] || changeset.data.title,
+      course_description: changeset.changes[:description] || changeset.data.description,
+      administrators: admins,
+      logos: logos
+    }
+
+    completion_cert = CertificateRenderer.render(attrs)
+
+    distinction_cert =
+      CertificateRenderer.render(%{attrs | certificate_type: "Certificate with Distinction"})
+
+    {completion_cert, distinction_cert, logos}
+  end
+
+  defp certificate_changeset(nil), do: Certificate.changeset()
+  defp certificate_changeset(%Certificate{} = cert), do: Certificate.changeset(cert, %{})
+
+  defp saved_logos(changeset) do
+    [changeset.data.logo1, changeset.data.logo2, changeset.data.logo3]
+    |> Enum.reject(&is_nil/1)
+  end
+end

--- a/priv/repo/migrations/20250131002210_certificates_modify_logos_to_bytea.exs
+++ b/priv/repo/migrations/20250131002210_certificates_modify_logos_to_bytea.exs
@@ -1,0 +1,21 @@
+defmodule Oli.Repo.Migrations.CertificatesModifyLogosToBytea do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    ALTER TABLE certificates
+      ALTER COLUMN logo1 TYPE bytea USING logo1::bytea,
+      ALTER COLUMN logo2 TYPE bytea USING logo2::bytea,
+      ALTER COLUMN logo3 TYPE bytea USING logo3::bytea;
+    """)
+  end
+
+  def down do
+    execute("""
+    ALTER TABLE certificates
+      ALTER COLUMN logo1 TYPE text USING NULL,
+      ALTER COLUMN logo2 TYPE text USING NULL,
+      ALTER COLUMN logo3 TYPE text USING NULL;
+    """)
+  end
+end

--- a/test/oli/delivery/certificates/certificate_renderer_test.exs
+++ b/test/oli/delivery/certificates/certificate_renderer_test.exs
@@ -1,0 +1,38 @@
+defmodule Oli.Delivery.Certificates.CertificateRendererTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Delivery.Certificates.CertificateRenderer
+
+  test "renders certificate template correctly" do
+    assigns = %{
+      certificate_type: "Completion Certificate",
+      student_name: "John Doe",
+      completion_date: "2025-02-06",
+      course_name: "Introduction to Testing",
+      course_description: "Learn how to write tests in Elixir",
+      administrators: [
+        {"Alice Smith", "Program Administrator"},
+        {"Bob Johnson", "Course Administrator"}
+      ],
+      logos: [
+        "data:image/gif;base64,R0lGODlhAQABAAAAACw=",
+        "data:image/gif;base64,R0lGODlhAQABAAAAACw="
+      ],
+      certificate_id: "CERT123456"
+    }
+
+    rendered_html = CertificateRenderer.render(assigns)
+
+    assert rendered_html =~ "Completion Certificate"
+    assert rendered_html =~ "John Doe"
+    assert rendered_html =~ "Introduction to Testing"
+    assert rendered_html =~ "Learn how to write tests in Elixir"
+    assert rendered_html =~ "2025-02-06"
+    assert rendered_html =~ "Alice Smith"
+    assert rendered_html =~ "Program Administrator"
+    assert rendered_html =~ "Bob Johnson"
+    assert rendered_html =~ "Course Administrator"
+    assert rendered_html =~ "<img src=\"data:image/gif;base64,R0lGODlhAQABAAAAACw=\""
+    assert rendered_html =~ "Certificate ID: CERT123456"
+  end
+end

--- a/test/oli_web/live/certificates/components/design_tab_test.exs
+++ b/test/oli_web/live/certificates/components/design_tab_test.exs
@@ -1,0 +1,56 @@
+defmodule OliWeb.Certificates.Components.DesignTabTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import LiveComponentTests
+  import Oli.Factory
+
+  alias OliWeb.Certificates.Components.DesignTab
+
+  describe "certificate design component" do
+    setup [:setup_certificate]
+
+    test "renders design component correctly", %{conn: conn, certificate: certificate} do
+      {:ok, comp, _html} =
+        live_component_isolated(conn, DesignTab, %{
+          id: "certificate_design_component",
+          certificate: certificate
+        })
+
+      # Check for static text and key form elements
+      assert has_element?(comp, "div", "Create and preview your certificate.")
+      assert has_element?(comp, "form#certificate-settings-design-form")
+      assert has_element?(comp, ".text-base.font-bold", "Course Title")
+      assert has_element?(comp, ".text-base.font-bold", "Subtitle")
+      assert has_element?(comp, ".text-base.font-bold", "Administrators")
+      assert has_element?(comp, "button", "Save Design")
+    end
+
+    test "validates certificate design changes on input change", %{
+      conn: conn,
+      certificate: certificate
+    } do
+      {:ok, comp, _html} =
+        live_component_isolated(conn, DesignTab, %{
+          id: "certificate_design_component",
+          certificate: certificate
+        })
+
+      # Simulate a change on the certificate form (triggers the "validate" event)
+      comp
+      |> element("form#certificate-settings-design-form")
+      |> render_change(%{"certificate" => %{"title" => "New Course Title"}})
+
+      # Check that the input has been updated with the new value
+      assert has_element?(
+               comp,
+               "input[name=\"certificate[title]\"][value=\"New Course Title\"]"
+             )
+    end
+  end
+
+  defp setup_certificate(_context) do
+    certificate = insert(:certificate)
+    %{certificate: certificate}
+  end
+end


### PR DESCRIPTION
See: https://eliterate.atlassian.net/browse/MER-4087 and https://eliterate.atlassian.net/browse/MER-3793

Implement the Design tab where the author will input the values needed for generating certificates and preview them.

There are 2 differences with the Figma design:
- There are simple buttons to navigate the different certificate previews instead of chevrons and a carousel style (This will be implemented in another PR)
- In order to be able to have access to the uploaded images, the form had to be submitted, that is why there is only one button "Save Design" instead of two ("Preview" and "Save Design")


https://github.com/user-attachments/assets/778d7933-c300-47e8-a93e-dc4601c5a20e

