### PR TITLE
[FEATURE] [MER-3809] Certificate Verification

### DIFF
--- a/cloud/generate-pdf-certificate/lambda_function.py
+++ b/cloud/generate-pdf-certificate/lambda_function.py
@@ -32,7 +32,10 @@ def lambda_handler(event, context):
         # Upload the PDF to S3
         s3 = boto3.client('s3')
         with open(pdf_file_path, 'rb') as pdf_file:
-            s3.upload_fileobj(pdf_file, bucket_name, s3_file_path)
+            s3_extra_args = {
+                "ContentType": "application/pdf"
+            }
+            s3.upload_fileobj(pdf_file, bucket_name, s3_file_path, s3_extra_args)
 
         # Cleanup local file
         os.remove(pdf_file_path)

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -79,6 +79,11 @@ config :oli, :user_auth_providers,
          ]
      end)
 
+config :oli, :certificates,
+  generate_pdf_lambda:
+    System.get_env("CERTIFICATES_GENERATE_PDF_LAMBDA", "generate_certificate_pdf_from_html"),
+  s3_pdf_bucket: System.get_env("CERTIFICATES_S3_PDF_URL", "torus-pdf-certificates")
+
 ####################### Production-only configurations ########################
 ## Note: These configurations are only applied in production
 ###############################################################################

--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -31,7 +31,7 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
   <body>
     <div class="outer-container">
       <div class="inner-container">
-        <h1 style="color: #8f7b00; font-family: 'Times New Roman', Times, serif; font-weight: normal; font-size: 50px;"><%= @certificate_type %></h1>
+        <h1 style="color:#8f7b00;font-family:'DejaVu Serif', 'Times New Roman', Times, serif;font-weight:400;font-size:50px;"><%= @certificate_type %></h1>
 
         <p>This certificate is presented to</p>
         <h2 style="font-size: 24px; font-weight: bold;"><%= @student_name %></h2>

--- a/lib/oli/delivery/granted_certificates.ex
+++ b/lib/oli/delivery/granted_certificates.ex
@@ -9,8 +9,6 @@ defmodule Oli.Delivery.GrantedCertificates do
   alias Oli.Delivery.Certificates.CertificateRenderer
   alias Oli.{HTTP, Repo}
 
-  @generate_pdf_lambda_function "generate_certificate_pdf_from_html"
-
   def get_granted_certificate_by_guid(guid) do
     Repo.get_by(GrantedCertificate, guid: guid)
   end
@@ -24,11 +22,8 @@ defmodule Oli.Delivery.GrantedCertificates do
         {:error, :granted_certificate_already_has_url}
 
       gc ->
-        certificate_html = CertificateRenderer.render(gc)
-
-        @generate_pdf_lambda_function
-        |> Lambda.invoke(%{certificate_id: gc.guid, html: certificate_html}, %{})
-        |> aws_request()
+        gc.guid
+        |> invoke_lambda(CertificateRenderer.render(gc))
         |> case do
           {:error, error} ->
             {:error, :invoke_lambda_error, error}
@@ -36,7 +31,7 @@ defmodule Oli.Delivery.GrantedCertificates do
           {:ok, result} ->
             if result["statusCode"] == 200 do
               gc
-              |> Changeset.change(url: result["body"]["s3Path"])
+              |> Changeset.change(url: certificate_s3_url(gc.guid))
               |> Repo.update()
             else
               {:error, :error_generating_pdf, result}
@@ -45,5 +40,16 @@ defmodule Oli.Delivery.GrantedCertificates do
     end
   end
 
-  defp aws_request(operation), do: apply(HTTP.aws(), :request, [operation])
+  defp certificate_s3_url(guid) do
+    s3_pdf_bucket = Application.fetch_env!(:oli, :certificates)[:s3_pdf_bucket]
+    "https://#{s3_pdf_bucket}.s3.amazonaws.com/certificates/#{guid}.pdf"
+  end
+
+  defp invoke_lambda(guid, html) do
+    :oli
+    |> Application.fetch_env!(:certificates)
+    |> Keyword.fetch!(:generate_pdf_lambda)
+    |> Lambda.invoke(%{certificate_id: guid, html: html}, %{})
+    |> HTTP.aws().request()
+  end
 end

--- a/lib/oli/delivery/granted_certificates.ex
+++ b/lib/oli/delivery/granted_certificates.ex
@@ -6,12 +6,14 @@ defmodule Oli.Delivery.GrantedCertificates do
   alias Ecto.Changeset
   alias ExAws.Lambda
   alias Oli.Delivery.Sections.GrantedCertificate
+  alias Oli.Delivery.Certificates.CertificateRenderer
   alias Oli.{HTTP, Repo}
 
-  # TODO: Change once we know where we'll generate the granted certificate HTML
-  @certificate_html ""
-
   @generate_pdf_lambda_function "generate_certificate_pdf_from_html"
+
+  def get_granted_certificate_by_guid(guid) do
+    Repo.get_by(GrantedCertificate, guid: guid)
+  end
 
   def generate_pdf(granted_certificate_id) do
     case Repo.get(GrantedCertificate, granted_certificate_id) do
@@ -21,9 +23,14 @@ defmodule Oli.Delivery.GrantedCertificates do
       %GrantedCertificate{url: url} when not is_nil(url) ->
         {:error, :granted_certificate_already_has_url}
 
+      %GrantedCertificate{state: state} when state != :earned ->
+        {:error, :granted_certificate_is_not_earned}
+
       gc ->
+        certificate_html = generate_html(gc)
+
         @generate_pdf_lambda_function
-        |> Lambda.invoke(%{certificate_id: gc.guid, html: @certificate_html}, %{})
+        |> Lambda.invoke(%{certificate_id: gc.guid, html: certificate_html}, %{})
         |> aws_request()
         |> case do
           {:error, error} ->
@@ -39,6 +46,51 @@ defmodule Oli.Delivery.GrantedCertificates do
             end
         end
     end
+  end
+
+  def generate_html(granted_certificate) do
+    granted_certificate = Repo.preload(granted_certificate, [:certificate, :user])
+
+    certificate_type =
+      if granted_certificate.with_distinction,
+        do: "Certificate with Distinction",
+        else: "Certificate of Completion"
+
+    admin_fields =
+      Map.take(granted_certificate.certificate, [
+        :admin_name1,
+        :admin_title1,
+        :admin_name2,
+        :admin_title2,
+        :admin_name3,
+        :admin_title3
+      ])
+
+    admins =
+      [
+        {admin_fields.admin_name1, admin_fields.admin_title1},
+        {admin_fields.admin_name2, admin_fields.admin_title2},
+        {admin_fields.admin_name3, admin_fields.admin_title3}
+      ]
+      |> Enum.reject(fn {name, _} -> name == "" || !name end)
+
+    logos =
+      Map.take(granted_certificate.certificate, [:logo1, :logo2, :logo3])
+      |> Enum.reject(fn {name, _} -> name == "" || !name end)
+
+    attrs = %{
+      certificate_type: certificate_type,
+      student_name: granted_certificate.user.name,
+      completion_date:
+        granted_certificate.issued_at |> DateTime.to_date() |> Calendar.strftime("%B %d, %Y"),
+      certificate_id: granted_certificate.guid,
+      course_name: granted_certificate.certificate.title,
+      course_description: granted_certificate.certificate.description,
+      administrators: admins,
+      logos: logos
+    }
+
+    CertificateRenderer.render(attrs)
   end
 
   defp aws_request(operation), do: apply(HTTP.aws(), :request, [operation])

--- a/lib/oli_web/controllers/certificate_controller.ex
+++ b/lib/oli_web/controllers/certificate_controller.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.CertificateController do
 
   defp recaptcha_verified?(params) do
     recaptcha_response = Map.get(params, "g-recaptcha-response", "")
-    Oli.Utils.Recaptcha.verify(recaptcha_response) == {:success, true}
+    Oli.Recaptcha.verify(recaptcha_response) == {:success, true}
   end
 
   defp s3_certificate_url(%{guid: guid}),

--- a/lib/oli_web/controllers/certificate_controller.ex
+++ b/lib/oli_web/controllers/certificate_controller.ex
@@ -1,0 +1,17 @@
+defmodule OliWeb.CertificateController do
+  use OliWeb, :controller
+
+  alias Oli.Delivery.GrantedCertificates
+  alias Oli.Repo
+
+  def show(conn, %{"guid" => guid}) do
+    case GrantedCertificates.get_granted_certificate_by_guid(guid) do
+      nil ->
+        send_resp(conn, 404, "Not Found")
+
+      gc ->
+        granted_certificate = Repo.preload(gc, [:certificate, :user])
+        render(conn, "show.html", certificate: granted_certificate)
+    end
+  end
+end

--- a/lib/oli_web/controllers/certificate_controller.ex
+++ b/lib/oli_web/controllers/certificate_controller.ex
@@ -8,7 +8,8 @@ defmodule OliWeb.CertificateController do
   def verify(conn, params) do
     if recaptcha_verified?(params) do
       certificate = GrantedCertificates.get_granted_certificate_by_guid(params["guid"]["value"])
-      render(conn, "show.html", certificate: certificate)
+      certificate_url = s3_certificate_url(certificate)
+      render(conn, "show.html", certificate: certificate, certificate_url: certificate_url)
     else
       render(conn, "index.html", recaptcha_error: "ReCaptcha failed, please try again")
     end
@@ -18,4 +19,9 @@ defmodule OliWeb.CertificateController do
     recaptcha_response = Map.get(params, "g-recaptcha-response", "")
     Oli.Utils.Recaptcha.verify(recaptcha_response) == {:success, true}
   end
+
+  defp s3_certificate_url(%{guid: guid}),
+    do: "https://torus-pdf-certificates.s3.amazonaws.com/certificates/#{guid}.pdf"
+
+  defp s3_certificate_url(_), do: nil
 end

--- a/lib/oli_web/controllers/certificate_controller.ex
+++ b/lib/oli_web/controllers/certificate_controller.ex
@@ -7,9 +7,13 @@ defmodule OliWeb.CertificateController do
 
   def verify(conn, params) do
     if recaptcha_verified?(params) do
-      certificate = GrantedCertificates.get_granted_certificate_by_guid(params["guid"]["value"])
-      certificate_url = s3_certificate_url(certificate)
-      render(conn, "show.html", certificate: certificate, certificate_url: certificate_url)
+      case GrantedCertificates.get_granted_certificate_by_guid(params["guid"]["value"]) do
+        c when c.state == :earned ->
+          render(conn, "show.html", certificate: c, certificate_url: s3_certificate_url(c))
+
+        _ ->
+          render(conn, "show.html", certificate: nil)
+      end
     else
       render(conn, "index.html", recaptcha_error: "ReCaptcha failed, please try again")
     end

--- a/lib/oli_web/controllers/certificate_controller.ex
+++ b/lib/oli_web/controllers/certificate_controller.ex
@@ -9,7 +9,7 @@ defmodule OliWeb.CertificateController do
     if recaptcha_verified?(params) do
       case GrantedCertificates.get_granted_certificate_by_guid(params["guid"]["value"]) do
         c when c.state == :earned ->
-          render(conn, "show.html", certificate: c, certificate_url: s3_certificate_url(c))
+          render(conn, "show.html", certificate: c)
 
         _ ->
           render(conn, "show.html", certificate: nil)
@@ -23,9 +23,4 @@ defmodule OliWeb.CertificateController do
     recaptcha_response = Map.get(params, "g-recaptcha-response", "")
     Oli.Recaptcha.verify(recaptcha_response) == {:success, true}
   end
-
-  defp s3_certificate_url(%{guid: guid}),
-    do: "https://torus-pdf-certificates.s3.amazonaws.com/certificates/#{guid}.pdf"
-
-  defp s3_certificate_url(_), do: nil
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -255,7 +255,8 @@ defmodule OliWeb.Router do
 
     get "/users/auth/:provider/callback", UserAuthorizationController, :callback
 
-    get "/certificates/:guid", CertificateController, :show
+    get "/certificates/", CertificateController, :index
+    post "/certificates/verify", CertificateController, :verify
   end
 
   scope "/", OliWeb do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -254,6 +254,8 @@ defmodule OliWeb.Router do
       only: [:new, :delete]
 
     get "/users/auth/:provider/callback", UserAuthorizationController, :callback
+
+    get "/certificates/:guid", CertificateController, :show
   end
 
   scope "/", OliWeb do

--- a/lib/oli_web/templates/certificate/index.html.eex
+++ b/lib/oli_web/templates/certificate/index.html.eex
@@ -1,0 +1,22 @@
+<Components.Header.header {assigns} />
+
+<div class="container">
+  <%= form_for @conn, Routes.certificate_path(@conn, :verify, %{}), [as: :guid], fn f -> %>
+    <div class="form-group" style="width: 100%;">
+      <label>Enter certificate ID...</label>
+      <%= text_input(f, :value, class: "form-control") %>
+      <%= submit("Submit", class: "btn btn-primary mt-3") %>
+    </div>
+
+    <div class="form-label-group mt-4">
+      <div class="g-recaptcha" data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}>
+      </div>
+
+      <%= case assigns[:recaptcha_error] do %>
+        <% recaptcha_error -> %>
+          <span class="help-block text-danger"><%= recaptcha_error %></span>
+      <% end %>
+    </div>
+
+  <% end %>
+</div>

--- a/lib/oli_web/templates/certificate/index.html.eex
+++ b/lib/oli_web/templates/certificate/index.html.eex
@@ -13,7 +13,7 @@
     </div>
 
     <div class="flex justify-center mt-6">
-      <div class="g-recaptcha" data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}></div>
+      <div class="g-recaptcha" data-sitekey=<%= Application.fetch_env!(:oli, :recaptcha)[:site_key] %>></div>
     </div>
 
     <%= if assigns[:recaptcha_error] do %>

--- a/lib/oli_web/templates/certificate/index.html.eex
+++ b/lib/oli_web/templates/certificate/index.html.eex
@@ -1,22 +1,23 @@
-<Components.Header.header {assigns} />
+<div class="h-screen w-screen bg-primary-24 flex flex-col items-center pt-24">
+  <h2 class="text-center mt-2 mb-16">OLI Torus Certificate Verification</h2>
 
-<div class="container">
   <%= form_for @conn, Routes.certificate_path(@conn, :verify, %{}), [as: :guid], fn f -> %>
-    <div class="form-group" style="width: 100%;">
-      <label>Enter certificate ID...</label>
-      <%= text_input(f, :value, class: "form-control") %>
-      <%= submit("Submit", class: "btn btn-primary mt-3") %>
-    </div>
-
-    <div class="form-label-group mt-4">
-      <div class="g-recaptcha" data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}>
+    <div class="flex flex-col w-[50ch] space-y-2">
+      <%= label f, :value, "Certificate ID", class: "text-white text-base" %>
+      <div class="flex w-full">
+        <%= text_input f, :value,
+          placeholder: "Enter certificate ID...",
+          class: "w-full bg-primary-24 border border-gray-600 rounded-l-sm px-4 py-2" %>
+        <%= submit "Submit", class: "bg-[#4CA6FF] hover:bg-blue-400 text-white font-semibold px-4 py-2 rounded-r-sm" %>
       </div>
-
-      <%= case assigns[:recaptcha_error] do %>
-        <% recaptcha_error -> %>
-          <span class="help-block text-danger"><%= recaptcha_error %></span>
-      <% end %>
     </div>
 
+    <div class="flex justify-center mt-6">
+      <div class="g-recaptcha" data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}></div>
+    </div>
+
+    <%= if assigns[:recaptcha_error] do %>
+      <span class="text-red-500 mt-2 block text-center"><%= assigns[:recaptcha_error] %></span>
+    <% end %>
   <% end %>
 </div>

--- a/lib/oli_web/templates/certificate/show.html.eex
+++ b/lib/oli_web/templates/certificate/show.html.eex
@@ -1,4 +1,7 @@
 <div class="container">
-  <h1>Certificate</h1>
-  <pre><%= inspect(@certificate, pretty: true) %></pre>
+  <%= if @certificate do %>
+    <pre><%= inspect(@certificate, pretty: true) %></pre>
+  <% else %>
+    <p>No certificate found.</p>
+  <% end %>
 </div>

--- a/lib/oli_web/templates/certificate/show.html.eex
+++ b/lib/oli_web/templates/certificate/show.html.eex
@@ -5,6 +5,6 @@
     Certificate ID: <span class="font-semibold"><%= @certificate.guid %></span>
     </p>
   <% else %>
-      <h2>No certificate found.</h2>
+      <h2>A certificate with that ID does not exist</h2>
   <% end %>
 </div>

--- a/lib/oli_web/templates/certificate/show.html.eex
+++ b/lib/oli_web/templates/certificate/show.html.eex
@@ -1,7 +1,10 @@
-<div class="container">
+<div class="h-screen w-screen bg-primary-24 flex flex-col items-center">
   <%= if @certificate do %>
-    <pre><%= inspect(@certificate, pretty: true) %></pre>
+    <embed src=<%= @certificate_url %> type="application/pdf" style="width: 66vw; height: 66vh;">
+    <p class="text-blue-400 mt-4">
+    Certificate ID: <span class="font-semibold"><%= @certificate.guid %></span>
+    </p>
   <% else %>
-    <p>No certificate found.</p>
+      <h2>No certificate found.</h2>
   <% end %>
 </div>

--- a/lib/oli_web/templates/certificate/show.html.eex
+++ b/lib/oli_web/templates/certificate/show.html.eex
@@ -1,0 +1,4 @@
+<div class="container">
+  <h1>Certificate</h1>
+  <pre><%= inspect(@certificate, pretty: true) %></pre>
+</div>

--- a/lib/oli_web/templates/certificate/show.html.eex
+++ b/lib/oli_web/templates/certificate/show.html.eex
@@ -1,6 +1,6 @@
 <div class="h-screen w-screen bg-primary-24 flex flex-col items-center">
   <%= if @certificate do %>
-    <embed src=<%= @certificate_url %> type="application/pdf" style="width: 66vw; height: 66vh;">
+    <embed src=<%= @certificate.url %> type="application/pdf" style="width: 66vw; height: 66vh;">
     <p class="text-blue-400 mt-4">
     Certificate ID: <span class="font-semibold"><%= @certificate.guid %></span>
     </p>

--- a/lib/oli_web/views/certificate_view.ex
+++ b/lib/oli_web/views/certificate_view.ex
@@ -1,0 +1,3 @@
+defmodule OliWeb.CertificateView do
+  use OliWeb, :view
+end

--- a/oli.example.env
+++ b/oli.example.env
@@ -161,3 +161,7 @@ EMAIL_REPLY_TO=admin@example.edu
 
 ## Configure student sign in background color
 # STUDENT_SIGNIN_BACKGROUND_COLOR=#FF82E4
+
+## Configure Certificates
+# CERTIFICATES_GENERATE_PDF_LAMBDA=name-of-the-lambda-that-generates-certificates-pdf
+# CERTIFICATES_S3_PDF_URL=name-of-the-s3-bucket-where-certificates-are-stored

--- a/test/oli/delivery/certificates/certificate_renderer_test.exs
+++ b/test/oli/delivery/certificates/certificate_renderer_test.exs
@@ -1,9 +1,18 @@
 defmodule Oli.Delivery.Certificates.CertificateRendererTest do
-  use ExUnit.Case, async: true
+  use Oli.DataCase
+  import Oli.Factory
 
   alias Oli.Delivery.Certificates.CertificateRenderer
 
-  test "renders certificate template correctly" do
+  test "renders certificate template correctly using a granted certificate" do
+    gc = insert(:granted_certificate)
+
+    rendered_html = CertificateRenderer.render(gc)
+
+    assert rendered_html =~ "Certificate ID: #{gc.guid}"
+  end
+
+  test "renders certificate template correctly using assigns map" do
     assigns = %{
       certificate_type: "Completion Certificate",
       student_name: "John Doe",

--- a/test/oli/delivery/granted_certificates_test.exs
+++ b/test/oli/delivery/granted_certificates_test.exs
@@ -19,7 +19,7 @@ defmodule Oli.Delivery.GrantedCertificatesTest do
       end)
 
       assert {:ok, _multi} = GrantedCertificates.generate_pdf(gc.id)
-      assert Repo.get(GrantedCertificate, gc.id).url == "foo/bar"
+      assert Repo.get(GrantedCertificate, gc.id).url =~ "/certificates/#{gc.guid}.pdf"
     end
 
     test "does not generate a pdf if granted certificate already has a url" do

--- a/test/oli_web/controllers/certificate_controller_test.exs
+++ b/test/oli_web/controllers/certificate_controller_test.exs
@@ -1,0 +1,67 @@
+defmodule OliWeb.CertificateControllerTest do
+  use OliWeb.ConnCase, async: true
+  import Oli.Factory
+
+  describe "GET /certificates" do
+    test "renders index", %{conn: conn} do
+      conn = get(conn, Routes.certificate_path(conn, :index))
+      assert html_response(conn, 200) =~ "Certificate Verification"
+    end
+  end
+
+  describe "POST /certificate/verify" do
+    test "verifies a valid certificate", %{conn: conn} do
+      certificate = insert(:granted_certificate, state: :earned)
+      recaptcha_ok()
+
+      params = %{"guid" => %{"value" => certificate.guid}, "g-recaptcha-response" => "valid"}
+      conn = post(conn, Routes.certificate_path(conn, :verify), params)
+
+      assert html_response(conn, 200) =~ certificate.guid
+    end
+
+    test "rejects invalid certificate", %{conn: conn} do
+      recaptcha_ok()
+
+      params = %{"guid" => %{"value" => "invalid"}, "g-recaptcha-response" => "valid"}
+      conn = post(conn, Routes.certificate_path(conn, :verify), params)
+
+      assert html_response(conn, 200) =~ "A certificate with that ID does not exist"
+    end
+
+    test "rejects pending certificate", %{conn: conn} do
+      certificate = insert(:granted_certificate, state: :pending)
+
+      recaptcha_ok()
+
+      params = %{"guid" => %{"value" => certificate.guid}, "g-recaptcha-response" => "valid"}
+      conn = post(conn, Routes.certificate_path(conn, :verify), params)
+
+      assert html_response(conn, 200) =~ "A certificate with that ID does not exist"
+    end
+
+    test "rejects denied certificate", %{conn: conn} do
+      certificate = insert(:granted_certificate, state: :denied)
+
+      recaptcha_ok()
+
+      params = %{"guid" => %{"value" => certificate.guid}, "g-recaptcha-response" => "valid"}
+      conn = post(conn, Routes.certificate_path(conn, :verify), params)
+
+      assert html_response(conn, 200) =~ "A certificate with that ID does not exist"
+    end
+
+    test "fails recaptcha validation", %{conn: conn} do
+      recaptcha_fail()
+      params = %{"guid" => %{"value" => "some-guid"}, "g-recaptcha-response" => "invalid"}
+      conn = post(conn, Routes.certificate_path(conn, :verify), params)
+
+      assert html_response(conn, 200) =~ "ReCaptcha failed, please try again"
+    end
+  end
+
+  defp recaptcha_ok, do: Mox.expect(Oli.Test.RecaptchaMock, :verify, fn _ -> {:success, true} end)
+
+  defp recaptcha_fail,
+    do: Mox.expect(Oli.Test.RecaptchaMock, :verify, fn _ -> {:success, false} end)
+end


### PR DESCRIPTION
Implement page for verification of granted certificates

Changes:
- Add new endpoint `GET /certificates/` for searching a certificate by its ID (guid)
- Add new endpoint `POST /certificates/verify` for veryfing if the certificate is earned and if so, display it on the browser
- **cloud/generate-pdf-certificate/lambda_function.py**:
  - Store certificate in S3 so it is served with `Content-Type: 'application/pdf'`
- **lib/oli/delivery/certificates/certificate_renderer.ex**: 
  - `render/1 `now allows to pass a `GrantedCertificate` struct.
  - Use `DejaVu Serif` if available, if not `Times New Roman` for the title
 - **lib/oli/delivery/granted_certificates.ex**:
   - Add `get_granted_certificate_by_guid/1` function
   - Rely on `CertificateRenderer.render/1` for generating the certificate html in `generate_pdf/1`
 - The URL in a `GrantedCertificate` is now derived from the `CERTIFICATES_S3_PDF_URL` env variable
 - The lambda function used to generate the pdf for a certificate given a html can be changed via the `CERTIFICATES_GENERATE_PDF_LAMBDA` env variable


https://github.com/user-attachments/assets/998e2d42-d3c3-4df4-b31a-230bcf21a204




See: https://eliterate.atlassian.net/browse/MER-3809