### PR TITLE
[ENHANCEMENT] [MER-4250] Anonymous option

### DIFF
--- a/lib/oli/analytics/datasets.ex
+++ b/lib/oli/analytics/datasets.ex
@@ -105,13 +105,14 @@ defmodule Oli.Analytics.Datasets do
 
   1. Initialize the job with the provided configuration, generating a unique job ID
   2. Preprocess the job configuration, depending on the job type
-  3. Submit the job to the EMR serverless environment
-  4. Persist the job to the database
+  3. Stage the lookup data in S3 for the job
+  4. Submit the job to the EMR serverless environment
+  5. Persist the job to the database
 
-  Any of steps 2-4 can fail, in which case the job will not be persisted to the database
+  Any of steps 2-5 can fail, in which case the job will not be persisted to the database
   and an error will be returned.  The error will be logged to the console. If the job
-  submission fails in step 3, it is okay that the context had been successfully
-  staged in step 2, as the staging is done in a way that is idempotent for job ids, but more
+  submission fails in step 4, it is okay that the context had been successfully
+  staged in step 3, as the staging is done in a way that is idempotent for job ids, but more
   importantly, retries of the entire job creation process results in a new context
   being staged in S3 for a new job id.
 
@@ -128,6 +129,7 @@ defmodule Oli.Analytics.Datasets do
 
     with {:ok, job} <- init(job_type, project_id, initiated_by_id, config),
          {:ok, job} <- preprocess(job),
+         {:ok, job} <- stage_lookup_data(job),
          {:ok, job} <- submit(job),
          {:ok, job} <- persist(job) do
       Logger.info(
@@ -495,13 +497,16 @@ defmodule Oli.Analytics.Datasets do
   defp preprocess(%DatasetJob{job_type: :datashop} = job) do
     job = set_ignore_student_ids(job)
 
-    result =
-      build_json_context(job)
-      |> stage_json_context(job)
-
     Logger.debug("Preprocessed dataset job #{job.job_id}")
 
-    result
+    {:ok, job}
+  end
+
+  defp stage_lookup_data(%DatasetJob{job_type: :datashop} = job) do
+    Logger.debug("Staging lookup data for dataset job #{job.job_id}")
+
+    build_json_context(job)
+    |> stage_json_context(job)
   end
 
   defp set_ignore_student_ids(%DatasetJob{configuration: config} = job) do
@@ -510,10 +515,10 @@ defmodule Oli.Analytics.Datasets do
     %DatasetJob{job | configuration: config}
   end
 
-  defp build_json_context(%DatasetJob{project_id: project_id}) do
+  defp build_json_context(%DatasetJob{project_id: project_id, configuration: config}) do
     result =
       Oli.Analytics.Datasets.Utils.context_sql()
-      |> Repo.query([project_id, project_id, project_id, project_id])
+      |> Repo.query([config.section_ids, project_id, project_id, project_id, project_id])
 
     case result do
       {:ok, %Postgrex.Result{rows: [[context]]}} ->

--- a/lib/oli/analytics/datasets.ex
+++ b/lib/oli/analytics/datasets.ex
@@ -517,8 +517,8 @@ defmodule Oli.Analytics.Datasets do
 
   defp build_json_context(%DatasetJob{project_id: project_id, configuration: config}) do
     result =
-      Oli.Analytics.Datasets.Utils.context_sql()
-      |> Repo.query([config.section_ids, project_id, project_id, project_id, project_id])
+      Oli.Analytics.Datasets.Utils.context_sql(config.section_ids)
+      |> Repo.query([project_id, project_id, project_id, project_id])
 
     case result do
       {:ok, %Postgrex.Result{rows: [[context]]}} ->

--- a/lib/oli/analytics/datasets/emr_serverless.ex
+++ b/lib/oli/analytics/datasets/emr_serverless.ex
@@ -149,6 +149,8 @@ defmodule Oli.Analytics.Datasets.EmrServerless do
       "#{if Enum.count(job.configuration.page_ids) == 0, do: "all", else: job.configuration.page_ids |> to_str}",
       "--action",
       "#{if job.job_type == :datashop, do: "datashop", else: job.configuration.event_type}",
+      "--anonymize",
+      "#{if job.configuration.anonymize == false, do: "false", else: "true"}",
       "--enforce_project_id",
       "#{job.project_id}"
     ]

--- a/lib/oli/analytics/datasets/job_config.ex
+++ b/lib/oli/analytics/datasets/job_config.ex
@@ -10,6 +10,7 @@ defmodule Oli.Analytics.Datasets.JobConfig do
     field(:ignored_student_ids, {:array, :integer}, default: [])
     field(:page_ids, {:array, :integer}, default: [])
     field(:excluded_fields, {:array, :string}, default: [])
+    field(:anonymize, :boolean, default: true)
   end
 
   @doc false
@@ -22,7 +23,8 @@ defmodule Oli.Analytics.Datasets.JobConfig do
       :event_sub_types,
       :ignored_student_ids,
       :page_ids,
-      :excluded_fields
+      :excluded_fields,
+      :anonymize
     ])
     |> validate_required([:section_ids, :chunk_size, :event_type])
   end

--- a/lib/oli/analytics/datasets/utils.ex
+++ b/lib/oli/analytics/datasets/utils.ex
@@ -52,7 +52,6 @@ defmodule Oli.Analytics.Datasets.Utils do
   end
 
   def context_sql(section_ids) do
-
     section_ids = Enum.join(section_ids, ", ")
 
     """

--- a/lib/oli/analytics/datasets/utils.ex
+++ b/lib/oli/analytics/datasets/utils.ex
@@ -54,6 +54,15 @@ defmodule Oli.Analytics.Datasets.Utils do
   def context_sql() do
     """
     SELECT jsonb_build_object(
+           'users', (
+               SELECT jsonb_object_agg(u.id::text, jsonb_build_object(
+                        'email', MIN(u.email)
+                      ))
+               FROM users u
+               JOIN enrollments e ON e.user_id = u.id
+               WHERE e.section_id = ANY($1::int[])
+               GROUP BY u.id;
+           ),
            'dataset_name', (SELECT slug FROM projects WHERE id = $1) || '-' || substring(md5(random()::text) from 1 for 10),
            'skill_titles', (
                SELECT jsonb_object_agg(r.resource_id::text, r.title)

--- a/lib/oli_web/live/workspaces/course_author/create_job_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/create_job_live.ex
@@ -285,6 +285,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
     end
   end
 
+  def handle_event("toggle_anonymize", _params, socket) do
+    anonymize = socket.assigns.anonymize
+    {:noreply, assign(socket, anonymize: !anonymize)}
+  end
+
   @impl true
   def handle_event("create_job", _params, socket) do
     project_id = socket.assigns.project.id

--- a/lib/oli_web/live/workspaces/course_author/create_job_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/create_job_live.ex
@@ -177,8 +177,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
             name="toggle_anonymize"
           />
         </div>
-
-
       <% end %>
 
       <p class="mt-5">

--- a/lib/oli_web/live/workspaces/course_author/create_job_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/create_job_live.ex
@@ -62,6 +62,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
        options: options,
        project: project,
        total_count: total_count,
+       anonymize: true,
        section_ids: [],
        emails: [],
        emails_valid?: true,
@@ -166,6 +167,18 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
           phx-hook="TextInputListener"
           placeholder="Email addresses separated by commas"
         />
+
+        <div class="inline-flex py-2 mb-2">
+          <span>Anonymize student identifiers</span>
+          <.toggle_switch
+            class="ml-4"
+            checked={@anonymize}
+            on_toggle="toggle_anonymize"
+            name="toggle_anonymize"
+          />
+        </div>
+
+
       <% end %>
 
       <p class="mt-5">
@@ -277,6 +290,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
     project_id = socket.assigns.project.id
     initiated_by_id = socket.assigns.author.id
     section_ids = socket.assigns.section_ids
+    anonymize = socket.assigns.anonymize
 
     # Get the true job type and a default config based on the selected job shortcut
     {job_type, job_config} = JobShortcuts.configure(socket.assigns.shortcut.value, section_ids)
@@ -294,6 +308,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
         _ ->
           job_config
       end
+
+    # Update the anonymize field in the job config
+    job_config = %{job_config | anonymize: anonymize}
 
     # Invoke the job asynchronously
     pid = self()

--- a/test/oli/analytics/datasets_test.exs
+++ b/test/oli/analytics/datasets_test.exs
@@ -25,7 +25,8 @@ defmodule Oli.Analytics.Datasets.Test do
         event_type: "attempt_e",
         event_sub_types: [],
         ignored_student_ids: [],
-        excluded_fields: []
+        excluded_fields: [],
+        anonymize: true
       }
     }
 


### PR DESCRIPTION
This PR adds a new option for dataset job creation - whether to anonymize the student identifiers.  If anonymize is `true` (which is the default), datasets will continue to use opaque database ids for student identifiers.  When set to `false`, the dataset will use the student email address.  

In the case where there is no email address (e.g. for a guest user), the dataset falls back to using the database id.  

This change required that all jobs (not just Datashop jobs, as previously implemented) generate and have access to "lookup data".  This lookup data has been extended to include the mapping of database id to user email address. 

