### PR TITLE
[BUG FIX] [MER-4231] LTI course sections are incorrectly automatically created

### DIFF
--- a/lib/oli/accounts.ex
+++ b/lib/oli/accounts.ex
@@ -410,11 +410,10 @@ defmodule Oli.Accounts do
   end
 
   @doc """
-  Preloads the user's LTI params.
+  Preloads the user's linked author.
   """
-  def load_lti_params(user) do
-    user
-    |> Repo.preload(:lti_params)
+  def preload_author(%User{} = user) do
+    Repo.preload(user, :author)
   end
 
   @doc """

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -48,7 +48,10 @@ defmodule Oli.Accounts.User do
              on_delete: :delete_all,
              foreign_key: :user_id
 
-    has_one :lti_params, Oli.Lti.LtiParams, on_delete: :delete_all, on_replace: :delete
+    has_many :lti_params,
+             Oli.Lti.LtiParams,
+             on_delete: :delete_all,
+             foreign_key: :user_id
 
     # A user may optionally be linked to an author account and Institution
     belongs_to :author, Oli.Accounts.Author

--- a/lib/oli/lti/lti_params.ex
+++ b/lib/oli/lti/lti_params.ex
@@ -110,6 +110,20 @@ defmodule Oli.Lti.LtiParams do
   end
 
   @doc """
+  Returns the latest lti params for the given user
+  """
+  def get_latest_user_lti_params(user_id) do
+    # LTI Params record is updated on every launch. We can use the updated_at field to get the
+    # latest record for the user.
+    from(p in LtiParams,
+      where: p.user_id == ^user_id,
+      order_by: [desc: p.updated_at],
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  @doc """
   Returns all lti param records for the given user id
   """
   def all_user_lti_params(user_id) do

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.DeliveryController do
     user = conn.assigns.current_user
 
     with false <- user.independent_learner,
-         %LtiParams{params: lti_params} <- LtiParams.get_latest_user_lti_params(user.id).params do
+         %LtiParams{params: lti_params} <- LtiParams.get_latest_user_lti_params(user.id) do
       lti_roles = lti_params["https://purl.imsglobal.org/spec/lti/claim/roles"]
       context_roles = ContextRoles.get_roles_by_uris(lti_roles)
       platform_roles = PlatformRoles.get_roles_by_uris(lti_roles)

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -44,8 +44,7 @@ defmodule OliWeb.DeliveryController do
     if user.independent_learner do
       redirect(conn, to: ~p"/workspaces/student")
     else
-      user = Accounts.load_lti_params(user)
-      lti_params = user.lti_params.params
+      lti_params = LtiParams.get_latest_user_lti_params(user.id).params
 
       lti_roles = lti_params["https://purl.imsglobal.org/spec/lti/claim/roles"]
       context_roles = ContextRoles.get_roles_by_uris(lti_roles)

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -41,11 +41,8 @@ defmodule OliWeb.DeliveryController do
   def index(conn, _params) do
     user = conn.assigns.current_user
 
-    if user.independent_learner do
-      redirect(conn, to: ~p"/workspaces/student")
-    else
-      lti_params = LtiParams.get_latest_user_lti_params(user.id).params
-
+    with false <- user.independent_learner,
+         %LtiParams{params: lti_params} <- LtiParams.get_latest_user_lti_params(user.id).params do
       lti_roles = lti_params["https://purl.imsglobal.org/spec/lti/claim/roles"]
       context_roles = ContextRoles.get_roles_by_uris(lti_roles)
       platform_roles = PlatformRoles.get_roles_by_uris(lti_roles)
@@ -83,6 +80,9 @@ defmodule OliWeb.DeliveryController do
             redirect_to_page_delivery(conn, section)
           end
       end
+    else
+      _ ->
+        redirect(conn, to: ~p"/workspaces/student")
     end
   end
 

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -71,7 +71,11 @@ defmodule OliWeb.Delivery.NewCourse do
           current_user =
             Accounts.preload_author(current_user)
 
-          lti_params = LtiParams.get_latest_user_lti_params(current_user.id).params
+          lti_params =
+            case LtiParams.get_latest_user_lti_params(current_user.id) do
+              nil -> nil
+              %LtiParams{params: lti_params} -> lti_params
+            end
 
           {current_user, lti_params}
       end

--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -20,6 +20,7 @@ defmodule OliWeb.Delivery.NewCourse do
   alias OliWeb.Components.Common
   alias OliWeb.Delivery.NewCourse.{CourseDetails, NameCourse, SelectSource}
   alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Lti.LtiParams
 
   alias Phoenix.LiveView.JS
 
@@ -68,15 +69,9 @@ defmodule OliWeb.Delivery.NewCourse do
 
         current_user ->
           current_user =
-            Accounts.load_lti_params(current_user)
-            |> Repo.preload([:author])
+            Accounts.preload_author(current_user)
 
-          lti_params =
-            if current_user.lti_params do
-              current_user.lti_params.params
-            else
-              nil
-            end
+          lti_params = LtiParams.get_latest_user_lti_params(current_user.id).params
 
           {current_user, lti_params}
       end

--- a/lib/oli_web/live/new_course/select_source.ex
+++ b/lib/oli_web/live/new_course/select_source.ex
@@ -156,7 +156,7 @@ defmodule OliWeb.Delivery.NewCourse.SelectSource do
               Link your authoring account to access projects where you are a collaborator.
             </p>
             <a
-              href={Routes.delivery_path(OliWeb.Endpoint, :link_account)}
+              href={~p"/users/link_account"}
               target="_blank"
               class="btn btn-primary link-account inline-block my-2"
             >

--- a/lib/oli_web/live/new_course/select_source.ex
+++ b/lib/oli_web/live/new_course/select_source.ex
@@ -6,7 +6,6 @@ defmodule OliWeb.Delivery.NewCourse.SelectSource do
   alias Oli.Publishing
   alias OliWeb.Common.{Filter, FilterBox, Listing, SessionContext}
   alias OliWeb.Common.Table.SortableTableModel
-  alias OliWeb.Router.Helpers, as: Routes
 
   alias Phoenix.LiveView.JS
 

--- a/test/oli/delivery/sections/ensure_resource_test.exs
+++ b/test/oli/delivery/sections/ensure_resource_test.exs
@@ -1,4 +1,4 @@
-defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
+defmodule Oli.Delivery.Sections.EnsureResourceTest do
   use Oli.DataCase
 
   import Ecto.Query


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4231

Fixes an issue related to the LTI launch issue where the system was using the wrong LTIParams for a user, resulting in a previous/incorrect section being loaded.

The underlying issue here is that the relationship for user LTI params was specified as a `has_one`, however a user can have multiple associated params records. It seems that by preloading the LTI params, we had no control over which record is loaded (I assume it is the first one returned ordered by the database id, which would result in the first/oldest section a user ever launched into).

The fix here updates the relationship to be more accurately specified as a `has_many` and adds a function to load the latest LTI launch params ordered by the `updated_at` field, which are then used to locate the section.