### PR TITLE
[BUG FIX] [MER-3000] Lost Quiz Answers by Working in a Second Tab of an Already-Submitted Attempt

### DIFF
--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -25,6 +25,9 @@ function makeRequest(
     .then((result) => continuation(result))
     .catch((error) => continuation(undefined, error));
 }
+const saveTransform = (result: any) => {
+  return result.error ? Promise.reject({ message: result.message }) : Promise.resolve(result);
+};
 const nothingTransform = (result: any) => Promise.resolve(result);
 const submissionTransform = (key: string, result: any) => {
   return Promise.resolve({ actions: result[key] });
@@ -63,6 +66,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { partInputs: e.detail.payload },
         newContinuation,
+        saveTransform,
       );
     },
     false,
@@ -110,6 +114,7 @@ export const initActivityBridge = (elementId: string) => {
         'PATCH',
         { response: e.detail.payload },
         e.detail.continuation,
+        saveTransform,
       );
     },
     false,

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -419,6 +419,15 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
+      {:error, :already_submitted} ->
+        conn
+        |> put_status(403)
+        |> json(%{
+          "error" => true,
+          "message" =>
+            "These changes could not be saved as this attempt may have already been submitted"
+        })
+
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save part", e)
         error(conn, 500, msg)
@@ -514,6 +523,15 @@ defmodule OliWeb.Api.AttemptController do
 
       {:error, {:no_more_hints}} ->
         json(conn, %{"type" => "success", "hasMoreHints" => false})
+
+      {:error, :already_submitted} ->
+        conn
+        |> put_status(403)
+        |> json(%{
+          "error" => true,
+          "message" =>
+            "These changes could not be saved as this attempt may have already been submitted"
+        })
 
       {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not get hint", e)


### PR DESCRIPTION
Hey @darrensiegel  / @eliknebe, this is the PR that contains the changes done in the original [PR](https://github.com/Simon-Initiative/oli-torus/pull/4765).

We already removed the change from the test as part of this [PR](https://github.com/Simon-Initiative/oli-torus/pull/5091) because we didn't need that hence I didn't included that.

This is just for reference. You can merge the original PR or this.