### PR TITLE
[BUG FIX] [MER-4252] [MER-4255] restore basic page mutli tab with separate endpoint

### DIFF
--- a/assets/src/phoenix/activity_bridge.ts
+++ b/assets/src/phoenix/activity_bridge.ts
@@ -58,7 +58,7 @@ export const initActivityBridge = (elementId: string) => {
       };
 
       makeRequest(
-        `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}`,
+        `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/active`,
         'PATCH',
         { partInputs: e.detail.payload },
         newContinuation,
@@ -106,7 +106,7 @@ export const initActivityBridge = (elementId: string) => {
       e.preventDefault();
       e.stopPropagation();
       makeRequest(
-        `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.partAttemptGuid}`,
+        `/api/v1/state/course/${e.detail.sectionSlug}/activity_attempt/${e.detail.attemptGuid}/part_attempt/${e.detail.partAttemptGuid}/active`,
         'PATCH',
         { response: e.detail.payload },
         e.detail.continuation,

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -330,11 +330,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
 
   @doc """
   Processes a list of part inputs and saves the response to the corresponding
-  part attempt record.
+  part attempt record. If the `only_active` option is set to `true`, the function
+  will only update part attempts with a lifecycle state of `active`.
 
-  On success returns a tuple of the form `{:ok, %Postgrex.Result{}}`
+  On success returns a tuple of the form `{:ok, %Postgrex.Result{}}` or
+  `{:error, :already_submitted}` if `only_active` is set to `true` and no active part attempts
+  were found.
   """
-  def save_student_input(part_inputs) do
+  def save_student_input(part_inputs, opts \\ []) do
     {part_input_values, params, _} =
       Enum.reduce(part_inputs, {[], [], 0}, fn part_input, {values, params, i} ->
         {
@@ -346,6 +349,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
 
     part_input_values = Enum.join(part_input_values, ",")
 
+    constrain_part_attempt_lifecycle_state_active? = Keyword.get(opts, :only_active, false)
+
     sql = """
       UPDATE part_attempts
       SET
@@ -356,9 +361,16 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
           #{part_input_values}
       ) AS batch_values (attempt_guid, response)
       WHERE part_attempts.attempt_guid = batch_values.attempt_guid
+      #{if constrain_part_attempt_lifecycle_state_active?, do: " AND lifecycle_state = 'active'", else: ""}
     """
 
-    Ecto.Adapters.SQL.query(Oli.Repo, sql, params)
+    case Ecto.Adapters.SQL.query(Oli.Repo, sql, params) do
+      {:ok, %Postgrex.Result{num_rows: 0}} when constrain_part_attempt_lifecycle_state_active? ->
+        {:error, :already_submitted}
+
+      result ->
+        result
+    end
   end
 
   @doc """

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1201,8 +1201,16 @@ defmodule OliWeb.Delivery.Student.LessonLive do
            to: Utils.lesson_live_path(section.slug, revision_slug, request_path: request_path)
          )}
 
+      {:error, {:already_submitted}} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Failed to submit. This attempt has already been submitted."
+         )}
+
       {:error, {reason}}
-      when reason in [:already_submitted, :active_attempt_present, :no_more_attempts] ->
+      when reason in [:active_attempt_present, :no_more_attempts] ->
         {:noreply, put_flash(socket, :error, "Unable to finalize page")}
 
       e ->

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -108,6 +108,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
           page_context={@page_context}
           attempt_message={@attempt_message}
           ctx={@ctx}
+          is_adaptive={is_adaptive_page(@page_context.page)}
           allow_attempt?={@allow_attempt?}
           section_slug={@section.slug}
           request_path={@request_path}
@@ -137,6 +138,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   attr :attempt_message, :string
   attr :page_context, Oli.Delivery.Page.PageContext
   attr :ctx, OliWeb.Common.SessionContext
+  attr :is_adaptive, :boolean, required: true
   attr :allow_attempt?, :boolean
   attr :section_slug, :string
   attr :request_path, :string
@@ -171,6 +173,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
           section_slug={@section_slug}
           page_revision_slug={@page_context.page.slug}
           attempt={attempt}
+          is_adaptive={@is_adaptive}
           ctx={@ctx}
           allow_review_submission?={@page_context.effective_settings.review_submission == :allow}
           request_path={@request_path}
@@ -199,6 +202,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   attr :index, :integer
   attr :attempt, ResourceAttempt
   attr :ctx, OliWeb.Common.SessionContext
+  attr :is_adaptive, :boolean, required: true
   attr :allow_review_submission?, :boolean
   attr :section_slug, :string
   attr :page_revision_slug, :string
@@ -206,7 +210,12 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
 
   defp attempt_summary(assigns) do
     attempt = Core.preload_activity_part_attempts(assigns.attempt)
-    feedback_texts = Utils.extract_feedback_text(attempt.activity_attempts)
+
+    feedback_texts =
+      if assigns.is_adaptive,
+        do: Utils.extract_feedback_text(attempt.activity_attempts),
+        else: []
+
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""
@@ -284,7 +293,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
         </div>
       </div>
     </div>
-    <div :if={@feedback_texts != []} class="mt-2 mb-8">
+    <div :if={@is_adaptive && @feedback_texts != []} class="mt-2 mb-8">
       <div class="text-neutral-500 text-sm font-bold mb-2">Instructor Feedback:</div>
       <div class="flex flex-col gap-y-2">
         <%= for feedback <- @feedback_texts do %>

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -703,6 +703,9 @@ defmodule OliWeb.Router do
     post("/:activity_attempt_guid", Api.AttemptController, :new_activity)
     put("/:activity_attempt_guid", Api.AttemptController, :submit_activity)
     patch("/:activity_attempt_guid", Api.AttemptController, :save_activity)
+
+    patch("/active/:activity_attempt_guid", Api.AttemptController, :save_active_activity)
+
     put("/:activity_attempt_guid/evaluations", Api.AttemptController, :submit_evaluations)
 
     post(
@@ -727,6 +730,12 @@ defmodule OliWeb.Router do
       "/:activity_attempt_guid/part_attempt/:part_attempt_guid",
       Api.AttemptController,
       :save_part
+    )
+
+    patch(
+      "/active/:activity_attempt_guid/part_attempt/:part_attempt_guid",
+      Api.AttemptController,
+      :save_active_part
     )
 
     get(

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -704,7 +704,7 @@ defmodule OliWeb.Router do
     put("/:activity_attempt_guid", Api.AttemptController, :submit_activity)
     patch("/:activity_attempt_guid", Api.AttemptController, :save_activity)
 
-    patch("/active/:activity_attempt_guid", Api.AttemptController, :save_active_activity)
+    patch("/:activity_attempt_guid/active", Api.AttemptController, :save_active_activity)
 
     put("/:activity_attempt_guid/evaluations", Api.AttemptController, :submit_evaluations)
 
@@ -733,7 +733,7 @@ defmodule OliWeb.Router do
     )
 
     patch(
-      "/active/:activity_attempt_guid/part_attempt/:part_attempt_guid",
+      "/:activity_attempt_guid/part_attempt/:part_attempt_guid/active",
       Api.AttemptController,
       :save_active_part
     )

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -80,7 +80,6 @@ defmodule OliWeb.AttemptControllerTest do
   describe "activity and attempt already submitted" do
     setup [:setup_session]
 
-    @tag :skip
     test "cannot submit an already submitted activity in a graded page", %{
       conn: conn,
       map: map
@@ -98,7 +97,7 @@ defmodule OliWeb.AttemptControllerTest do
       conn =
         put(
           conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{activity_attempt.attempt_guid}",
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{activity_attempt.attempt_guid}",
           %{
             "section_slug" => map.section.slug,
             "activity_attempt_guid" => activity_attempt.attempt_guid,
@@ -114,7 +113,6 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
-    @tag :skip
     test "cannot change an already input submitted in a graded page", %{
       conn: conn,
       map: map
@@ -132,7 +130,7 @@ defmodule OliWeb.AttemptControllerTest do
       conn =
         patch(
           conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}",
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{map.activity_attempt1.attempt_guid}",
           %{
             "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
             "partInputs" => [
@@ -152,7 +150,6 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
-    @tag :skip
     test "cannot save an already part attempt submitted in a graded page", %{
       conn: conn,
       map: map
@@ -170,115 +167,9 @@ defmodule OliWeb.AttemptControllerTest do
       conn =
         patch(
           conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
           %{
             "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
-            "part_attempt_guid" => part_attempt.attempt_guid,
-            "response" => "Hello World"
-          }
-        )
-
-      assert %{
-               "message" =>
-                 "These changes could not be saved as this attempt may have already been submitted",
-               "error" => true
-             } =
-               json_response(conn, 403)
-    end
-
-    @tag :skip
-    test "cannot submit an already submitted activity in a adaptive page", %{
-      conn: conn,
-      map: map
-    } do
-      # Mark activity attempt as submitted
-      {:ok, activity_attempt} =
-        Core.get_latest_activity_attempts(map.adaptive_attempt1.id)
-        |> hd
-        |> Core.update_activity_attempt(%{
-          lifecycle_state: "submitted",
-          date_submitted: DateTime.utc_now()
-        })
-
-      # Submit activity attempt endpoint
-      conn =
-        put(
-          conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{activity_attempt.attempt_guid}",
-          %{
-            "section_slug" => map.section.slug,
-            "activity_attempt_guid" => activity_attempt.attempt_guid,
-            "partInputs" => []
-          }
-        )
-
-      assert %{
-               "message" =>
-                 "These changes could not be saved as this attempt may have already been submitted",
-               "error" => true
-             } =
-               json_response(conn, 403)
-    end
-
-    @tag :skip
-    test "cannot change an already input submitted in a adaptive page", %{
-      conn: conn,
-      map: map
-    } do
-      # Mark part attempt as submitted
-      {:ok, part_attempt} =
-        Core.get_latest_part_attempts(map.adaptive_activity_attempt1.attempt_guid)
-        |> hd
-        |> Core.update_part_attempt(%{
-          lifecycle_state: "submitted",
-          date_submitted: DateTime.utc_now()
-        })
-
-      # Save activity attempt endpoint
-      conn =
-        patch(
-          conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.adaptive_activity_attempt1.attempt_guid}",
-          %{
-            "activity_attempt_guid" => map.adaptive_activity_attempt1.attempt_guid,
-            "partInputs" => [
-              %{
-                "attemptGuid" => part_attempt.attempt_guid,
-                "response" => %{"input" => "Hello World"}
-              }
-            ]
-          }
-        )
-
-      assert %{
-               "message" =>
-                 "These changes could not be saved as this attempt may have already been submitted",
-               "error" => true
-             } =
-               json_response(conn, 403)
-    end
-
-    @tag :skip
-    test "cannot save an already part attempt submitted in a adaptive page", %{
-      conn: conn,
-      map: map
-    } do
-      # Mark part attempt as submitted
-      {:ok, part_attempt} =
-        Core.get_latest_part_attempts(map.adaptive_activity_attempt1.attempt_guid)
-        |> hd
-        |> Core.update_part_attempt(%{
-          lifecycle_state: "submitted",
-          date_submitted: DateTime.utc_now()
-        })
-
-      # Save part attempt endpoint
-      conn =
-        patch(
-          conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.adaptive_activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
-          %{
-            "activity_attempt_guid" => map.adaptive_activity_attempt1.attempt_guid,
             "part_attempt_guid" => part_attempt.attempt_guid,
             "response" => "Hello World"
           }

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -80,6 +80,33 @@ defmodule OliWeb.AttemptControllerTest do
   describe "activity and attempt already submitted" do
     setup [:setup_session]
 
+    test "can change an active input in a basic graded page", %{
+      conn: conn,
+      map: map
+    } do
+      part_attempt =
+        Core.get_latest_part_attempts(map.activity_attempt1.attempt_guid)
+        |> hd
+
+      # Save active activity attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/active",
+          %{
+            "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
+            "partInputs" => [
+              %{
+                "attemptGuid" => part_attempt.attempt_guid,
+                "response" => %{"input" => "Hello World"}
+              }
+            ]
+          }
+        )
+
+      assert %{"type" => "success"} = json_response(conn, 200)
+    end
+
     test "cannot change an already input submitted in a graded page", %{
       conn: conn,
       map: map
@@ -93,11 +120,11 @@ defmodule OliWeb.AttemptControllerTest do
           date_submitted: DateTime.utc_now()
         })
 
-      # Save activity attempt endpoint
+      # Save active activity attempt endpoint
       conn =
         patch(
           conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{map.activity_attempt1.attempt_guid}",
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/active",
           %{
             "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
             "partInputs" => [
@@ -117,6 +144,29 @@ defmodule OliWeb.AttemptControllerTest do
                json_response(conn, 403)
     end
 
+    test "can save an active part attempt in a graded page", %{
+      conn: conn,
+      map: map
+    } do
+      part_attempt =
+        Core.get_latest_part_attempts(map.activity_attempt1.attempt_guid)
+        |> hd
+
+      # Save active part attempt endpoint
+      conn =
+        patch(
+          conn,
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}/active",
+          %{
+            "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
+            "part_attempt_guid" => part_attempt.attempt_guid,
+            "response" => "Hello World"
+          }
+        )
+
+      assert %{"type" => "success"} = json_response(conn, 200)
+    end
+
     test "cannot save an already part attempt submitted in a graded page", %{
       conn: conn,
       map: map
@@ -130,11 +180,11 @@ defmodule OliWeb.AttemptControllerTest do
           date_submitted: DateTime.utc_now()
         })
 
-      # Save part attempt endpoint
+      # Save active part attempt endpoint
       conn =
         patch(
           conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}",
+          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/#{map.activity_attempt1.attempt_guid}/part_attempt/#{part_attempt.attempt_guid}/active",
           %{
             "activity_attempt_guid" => map.activity_attempt1.attempt_guid,
             "part_attempt_guid" => part_attempt.attempt_guid,

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -80,39 +80,6 @@ defmodule OliWeb.AttemptControllerTest do
   describe "activity and attempt already submitted" do
     setup [:setup_session]
 
-    test "cannot submit an already submitted activity in a graded page", %{
-      conn: conn,
-      map: map
-    } do
-      # Mark activity attempt as submitted
-      {:ok, activity_attempt} =
-        Core.get_latest_activity_attempts(map.attempt1.id)
-        |> hd
-        |> Core.update_activity_attempt(%{
-          lifecycle_state: "submitted",
-          date_submitted: DateTime.utc_now()
-        })
-
-      # Submit activity attempt endpoint
-      conn =
-        put(
-          conn,
-          ~p"/api/v1/state/course/#{map.section.slug}/activity_attempt/active/#{activity_attempt.attempt_guid}",
-          %{
-            "section_slug" => map.section.slug,
-            "activity_attempt_guid" => activity_attempt.attempt_guid,
-            "partInputs" => []
-          }
-        )
-
-      assert %{
-               "message" =>
-                 "These changes could not be saved as this attempt may have already been submitted",
-               "error" => true
-             } =
-               json_response(conn, 403)
-    end
-
     test "cannot change an already input submitted in a graded page", %{
       conn: conn,
       map: map


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4252
https://eliterate.atlassian.net/browse/MER-4255

This restores some previously removed changes which allow basic page assessments to be open in multiple browser windows and still work correctly.

The fix here follows the technical notes in the ticket by adding separate endpoints to save activity and part attempts for basic pages. These new endpoints, appended with `/active` are a slight variation of the original endpoints (which are still used by the adaptive player) and will only consider a currently active attempt, otherwise will return an error.

It also fixes an issue related to https://eliterate.atlassian.net/browse/MER-3777 that was blocking testing this functionality for basic pages. The issue here was that this logic was only intended for adaptive pages but was crashing the prologue page for basic assessment pages. This issue was captured by MER-4255