### PR TITLE
[BUG FIX] [MER-4254] Image Component height repopulates with old numbers

### DIFF
--- a/assets/src/components/parts/janus-image/ImageAuthor.tsx
+++ b/assets/src/components/parts/janus-image/ImageAuthor.tsx
@@ -28,7 +28,7 @@ const ImageAuthor: React.FC<AuthorPartComponentProps<ImageModel>> = (props) => {
   };
 
   const debounceWaitTime = 1000;
-  const debounceInputText = useCallback(
+  const debounceImage = useCallback(
     debounce((updatedModel: any) => {
       manipulateImageSize(updatedModel, true);
     }, debounceWaitTime),
@@ -36,8 +36,8 @@ const ImageAuthor: React.FC<AuthorPartComponentProps<ImageModel>> = (props) => {
   );
 
   useEffect(() => {
-    if (src != defaultSrc) {
-      debounceInputText(model);
+    if (src != defaultSrc && model?.lockAspectRatio) {
+      debounceImage(model);
     }
   }, [model]);
   const imageContainerRef = useRef<HTMLImageElement>(null);


### PR DESCRIPTION
Hey @bsparks could you please look at the PR. Thanks

The behavior is coming due to the changes made for [Image component has fixed aspect ratio based on image dimensions](https://eliterate.atlassian.net/browse/MER-3418). 

With this PR, I am making sure that we only adjust the aspect ratio changes if he `lockAspectRatio` property is set to true else do not adjust the aspect ratio. This property was never used anywhere so I didn't know what this was really meant for.