### PR TITLE
[ENHANCEMENT] [MER-3809] GrantedCertificate.generate_pdf/1 allows update

### DIFF
--- a/lib/oli/delivery/granted_certificates.ex
+++ b/lib/oli/delivery/granted_certificates.ex
@@ -18,9 +18,6 @@ defmodule Oli.Delivery.GrantedCertificates do
       nil ->
         {:error, :granted_certificate_not_found}
 
-      %GrantedCertificate{url: url} when not is_nil(url) ->
-        {:error, :granted_certificate_already_has_url}
-
       gc ->
         gc.guid
         |> invoke_lambda(CertificateRenderer.render(gc))

--- a/test/oli/delivery/granted_certificates_test.exs
+++ b/test/oli/delivery/granted_certificates_test.exs
@@ -22,14 +22,6 @@ defmodule Oli.Delivery.GrantedCertificatesTest do
       assert Repo.get(GrantedCertificate, gc.id).url =~ "/certificates/#{gc.guid}.pdf"
     end
 
-    test "does not generate a pdf if granted certificate already has a url" do
-      gc = insert(:granted_certificate, url: "foo/bar")
-      expect(Oli.Test.MockAws, :request, 0, fn _ -> :noop end)
-
-      assert {:error, :granted_certificate_already_has_url} =
-               GrantedCertificates.generate_pdf(gc.id)
-    end
-
     test "fails if aws operation fails" do
       gc = insert(:granted_certificate)
 


### PR DESCRIPTION
Allow generate_pdf/1 to be called even when the GrantedCertificate already has an url set.
This is because in case a Certificate PDF needs to be updates (e.g: A certificate of completion was upgrades to a certificate with distinction)