### PR TITLE
[BUG FIX] [MER-4288] Adaptive page lessons always show edits to publish

### DIFF
--- a/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
+++ b/assets/src/apps/authoring/store/groups/layouts/deck/actions/updateActivityRules.ts
@@ -121,7 +121,7 @@ export const updateActivityRules = createAsyncThunk(
         const referencedSequenceIds: string[] = [];
         let referencedVariableKeys: string[] = [];
 
-        const conditionWithExpression: string[] = [];
+        let conditionWithExpression: string[] = [];
         // ensure that all conditions and condition blocks are assigned an id
         await Promise.all(
           activityRulesClone.map(async (rule: any) => {
@@ -237,6 +237,7 @@ export const updateActivityRules = createAsyncThunk(
         childActivityClone.authoring.variablesRequiredForEvaluation =
           childActivityClone.authoring.variablesRequiredForEvaluation || [];
 
+        conditionWithExpression = [...new Set(conditionWithExpression)];
         const refConditionWithExpressionLengthEqual =
           childActivityClone.content.custom.conditionsRequiredEvaluation.length ===
           conditionWithExpression.length;


### PR DESCRIPTION
Hey @bsparks, could you take a look at the PR? Thanks!  

###  **Issue:**  
After an adaptive page is published, if the author opens the lesson in edit mode without making any changes and then attempts to publish again, a list of changes always appears.  

### **Root Cause:**  
When multiple trap states contain the same variable, the `conditionWithExpression` array ends up with duplicate entries for each trap state.  

Example:  
```js
conditionWithExpression: [
  "stage.HypothesisReflect.selectedChoice",
  "stage.HypothesisReflect.selectedChoice",
  "stage.HypothesisReflect.selectedChoice",
  "stage.HypothesisReflect.selectedChoice",
  "stage.HypothesisReflect.selectedChoice"
]
```  
However, the conditionsRequiredEvaluation variable had unique conditions like this
```js
conditionsRequiredEvaluation: ['stage.HypothesisReflect.selectedChoice']
```

As a result, the `refConditionWithExpressionLengthEqual` flag was being set to `false` for certain screens:  
```js
const refConditionWithExpressionLengthEqual =
  childActivityClone.content.custom.conditionsRequiredEvaluation.length ===
  conditionWithExpression.length;
```
Even though no actual changes were made, the system detected differences, leading it to incorrectly show that there were unpublished changes.

### **Reolution:**

I added code to remove the duplicate from the array

`conditionWithExpression = [...new Set(conditionWithExpression)];`