### PR TITLE
[BUG FIX] [MER-4212] Adjust late message

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -215,6 +215,14 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
+  defp submit_term(%{effective_settings: %{late_submit: :allow, time_limit: 0}} = assigns) do
+    ~H"""
+    <li id="page_submit_term">
+      If you submit after the due date, it will be marked late.
+    </li>
+    """
+  end
+
   defp submit_term(%{effective_settings: %{late_submit: :allow}} = assigns) do
     ~H"""
     <li id="page_submit_term">

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1155,7 +1155,7 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       enroll_and_mark_visited(user, section)
 
-      params = %{late_submit: :allow}
+      params = %{late_submit: :allow, time_limit: 10}
 
       get_and_update_section_resource(section.id, page_2.resource_id, params)
 
@@ -1163,6 +1163,21 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       assert view |> element("#page_submit_term") |> render() =~
                "<li id=\"page_submit_term\">\n  If you exceed this time, it will be marked late.\n</li>"
+    end
+
+    test "page terms render a late submit message regarding the date, not the time limit", ctx do
+      %{conn: conn, user: user, section: section, page_2: page_2} = ctx
+
+      enroll_and_mark_visited(user, section)
+
+      params = %{late_submit: :allow, time_limit: 0}
+
+      get_and_update_section_resource(section.id, page_2.resource_id, params)
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+      assert view |> element("#page_submit_term") |> render() =~
+               "<li id=\"page_submit_term\">\n  If you submit after the due date, it will be marked late.\n</li>"
     end
 
     test "page terms render no message when late submit is disallowed", ctx do


### PR DESCRIPTION
This PR adjusts the message that students see on the prologue page when Late Submit is set to Allow and there is no time limit.  It that case, we instead tell them " If you submit after the due date, it will be marked late."

