### PR TITLE
[BUG FIX] [MER-4291] Fix cache coherence issue caused by Assessment Settings update

### DIFF
--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -152,10 +152,10 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
   end
 
   @doc """
-  Updates a SectionResource record.
+  Updates a SectionResource record's entry in the (potentially distributed) cache.
   """
   def update_section_resource(section_resource) do
-    Depot.update(@depot_desc, section_resource)
+    Oli.Delivery.DepotCoordinator.update_all(@depot_desc, [section_resource])
   end
 
   @doc """


### PR DESCRIPTION
This PR fixes a subtle problem in the way that the original code was allowing an update to the `SectionResourceDepot`.  The code was directly updating the ETS table - which works fine on single node setups, but which will fail on multi-node.

Instead, we have to use the `DepotCoordinator.update_all/2` - which (through delegation to the `DistributedDepotCoordinator` impl on multi-node setups) will broadcast a message to the depots in all nodes in the cluster telling them to update this entry in their cache.

Without this, we would have seen:
1. Instructor changes some setting for an assessment
2. Only the local node Depot is updated
3. Processes running on the other node will continue to pull stale section resource records due to this cache coherence issue

