### PR TITLE
[BUG FIX] [MER-4243] fix omit email verification

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1249,9 +1249,10 @@ defmodule OliWeb.Router do
     end
   end
 
-  scope "/sections", OliWeb do
+  scope "/sections/:section_slug", OliWeb do
     pipe_through([
       :browser,
+      :require_section,
       :delivery_protected
     ])
 
@@ -1265,7 +1266,7 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.RequireEnrollment
       ] do
       live(
-        "/:section_slug/welcome",
+        "/welcome",
         Delivery.StudentOnboarding.Wizard
       )
     end

--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -391,11 +391,15 @@ defmodule OliWeb.UserAuth do
   end
 
   defp require_confirmed_email(conn) do
-    case conn.assigns[:current_user] do
-      nil ->
+    case {conn.assigns[:current_user], conn.assigns[:section]} do
+      {nil, _} ->
         conn
 
-      %Accounts.User{independent_learner: true, guest: false, email_confirmed_at: nil} ->
+      {_user, %Section{open_and_free: true, skip_email_verification: true}} ->
+        # The section is independent and specifies to skip email verification
+        conn
+
+      {%Accounts.User{independent_learner: true, guest: false, email_confirmed_at: nil}, _} ->
         conn
         |> renew_session()
         |> delete_resp_cookie(@remember_me_cookie)


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4243

This PR fixes an issue where students enrolling/accessing an independent section where the "Omit email verification" setting is checked were still being prompted to confirm their email.

The issue was simply that this feature was not re-implemented when we migrated away from Pow auth. It is now included.

There are some strange quirks with this feature that probably existed before the Pow migration, specifically when a user/student tries to access any route that doesn't require a section, including the Edit Account screen. Since no section is loaded the system cannot identify that a user should have access without requiring email verification, therefore as soon as a student in this mode steps outside of the the section view, they are required to confirm their email. This seems like a reasonable thing to enforce since the rest of the system assumes that a user has a valid and confirmed email address.