### PR TITLE
[ENHANCEMENT] [MER-3809] Certificate Verification: placeholder text white

### DIFF
--- a/lib/oli_web/templates/certificate/index.html.eex
+++ b/lib/oli_web/templates/certificate/index.html.eex
@@ -7,7 +7,7 @@
       <div class="flex w-full">
         <%= text_input f, :value,
           placeholder: "Enter certificate ID...",
-          class: "w-full bg-primary-24 border border-gray-600 rounded-l-sm px-4 py-2" %>
+          class: "w-full bg-primary-24 border border-gray-600 rounded-l-sm px-4 py-2 placeholder-white" %>
         <%= submit "Submit", class: "bg-[#4CA6FF] hover:bg-blue-400 text-white font-semibold px-4 py-2 rounded-r-sm" %>
       </div>
     </div>


### PR DESCRIPTION
So it follows the Figma Design: 
<img width="732" alt="image" src="https://github.com/user-attachments/assets/80955448-7071-4f39-b28c-43b26f56b43a" />
