### PR TITLE
[BUG FIX] [MER-4298] Fixes social login account course invite bug

### DIFF
--- a/lib/oli_web/live/users/invitations/users_invite_view.ex
+++ b/lib/oli_web/live/users/invitations/users_invite_view.ex
@@ -297,7 +297,17 @@ defmodule OliWeb.Users.Invitations.UsersInviteView do
   defp emails_match?(_user_email, email_param) when is_nil(email_param), do: true
   defp emails_match?(user_email, email_param), do: user_email == email_param
 
-  defp new_invited_user?(%User{password_hash: nil}), do: true
+  defp new_invited_user?(%User{password_hash: nil} = user) do
+    user = user |> Oli.Repo.preload(:user_identities)
+
+    # if the user has identities, it means that the user is signed up via social login
+    if Enum.empty?(user.user_identities) do
+      true
+    else
+      false
+    end
+  end
+
   defp new_invited_user?(_), do: false
 
   defp current_user_is_the_invited_one?(nil, _user), do: false

--- a/test/oli_web/live/users/invitations/users_invite_view_test.exs
+++ b/test/oli_web/live/users/invitations/users_invite_view_test.exs
@@ -22,7 +22,7 @@ defmodule OliWeb.Users.Invitations.UsersInviteViewTest do
   end
 
   defp social_login_user() do
-      insert(:user, user_identities: [%UserIdentity{uid: "123", provider: "google"}])
+    insert(:user, user_identities: [%UserIdentity{uid: "123", provider: "google"}])
   end
 
   defp insert_invitation_token_and_enrollment(


### PR DESCRIPTION
This PR fixes and issue where the student invitation process will not allow a student account created via social login to complete accepting an invitation to a course. It erroneously lands the student on a “create account” page after they have accepted the invitation