### PR TITLE
[BUG FIX] [MER-4259] fix an issue where user is redirected to unauthorized after login

### DIFF
--- a/lib/oli_web/plugs/enforce_paywall.ex
+++ b/lib/oli_web/plugs/enforce_paywall.ex
@@ -1,4 +1,4 @@
-defmodule Oli.Plugs.EnforceEnrollAndPaywall do
+defmodule Oli.Plugs.EnforcePaywall do
   import Plug.Conn
   import Phoenix.Controller
 
@@ -8,8 +8,6 @@ defmodule Oli.Plugs.EnforceEnrollAndPaywall do
 
   def init(opts), do: opts
 
-  # user should be enrolled before accessing any delivery route (via lms or open and
-  # free invitation) so if it's not, redirect to not authorized
   # show guard when paywall is required and user has not paid
   def call(conn, _opts) do
     section = conn.assigns.section

--- a/lib/oli_web/plugs/ensure_user_section_visit.ex
+++ b/lib/oli_web/plugs/ensure_user_section_visit.ex
@@ -1,9 +1,10 @@
-defmodule Oli.Plugs.EnsureUserSectionVisit do
+defmodule OliWeb.Plugs.EnsureUserSectionVisit do
+  use OliWeb, :verified_routes
+
   import Plug.Conn
   import Phoenix.Controller
 
   alias Oli.Delivery.Sections
-  alias OliWeb.Router.Helpers, as: Routes
 
   @visited_sections_key "visited_sections"
 
@@ -16,41 +17,32 @@ defmodule Oli.Plugs.EnsureUserSectionVisit do
 
     cond do
       is_admin ->
+        # Bypass the onboarding wizard for admins
         conn
 
       !has_visited_section_key(conn) ->
-        if user && Sections.is_enrolled?(user.id, section.slug) do
-          if Sections.has_instructor_role?(user, section.slug) do
+        if Sections.has_instructor_role?(user, section.slug) do
+          # Bypass the onboarding wizard for instructors by setting the section as visited
+          visited_sections =
+            Map.get(get_session(conn), @visited_sections_key, %{})
+            |> Map.put(section.slug, true)
+
+          put_session(conn, @visited_sections_key, visited_sections)
+        else
+          # If a student has already visited the section, update the visited sections map in the
+          # session. Otherwise, redirect to the onboarding wizard.
+          if Sections.has_visited_section(section, user) do
             visited_sections =
               Map.get(get_session(conn), @visited_sections_key, %{})
               |> Map.put(section.slug, true)
 
             put_session(conn, @visited_sections_key, visited_sections)
           else
-            if Sections.has_visited_section(section, user) do
-              visited_sections =
-                Map.get(get_session(conn), @visited_sections_key, %{})
-                |> Map.put(section.slug, true)
-
-              put_session(conn, @visited_sections_key, visited_sections)
-            else
-              redirect(conn,
-                to: Routes.live_path(conn, OliWeb.Delivery.StudentOnboarding.Wizard, section.slug)
-              )
-              |> Plug.Conn.halt()
-            end
+            redirect(conn,
+              to: ~p"/sections/#{section.slug}/welcome"
+            )
+            |> Plug.Conn.halt()
           end
-        else
-          case Map.get(section, :open_and_free) and !Map.get(section, :requires_enrollment) do
-            true ->
-              conn
-              |> redirect(to: Routes.delivery_path(conn, :show_enroll, section.slug))
-
-            _ ->
-              conn
-              |> redirect(to: Routes.static_page_path(OliWeb.Endpoint, :unauthorized))
-          end
-          |> Plug.Conn.halt()
         end
 
       true ->

--- a/lib/oli_web/plugs/require_enrollment.ex
+++ b/lib/oli_web/plugs/require_enrollment.ex
@@ -1,0 +1,35 @@
+defmodule OliWeb.Plugs.RequireEnrollment do
+  use OliWeb, :verified_routes
+
+  import Plug.Conn
+  import Phoenix.Controller
+
+  alias Oli.Delivery.Sections
+
+  def init(opts), do: opts
+
+  def call(conn, _opts) do
+    user = conn.assigns[:current_user]
+    section = conn.assigns[:section]
+    is_admin = conn.assigns[:is_admin]
+
+    cond do
+      is_admin ->
+        conn
+
+      Sections.is_enrolled?(user.id, section.slug) ->
+        conn
+
+      section.registration_open ->
+        conn
+        |> redirect(to: ~p"/sections/#{section.slug}/enroll")
+        |> Plug.Conn.halt()
+
+      true ->
+        conn
+        |> put_view(OliWeb.PageDeliveryView)
+        |> render("not_authorized.html")
+        |> halt()
+    end
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -99,8 +99,12 @@ defmodule OliWeb.Router do
     plug(Oli.Plugs.ForceRequiredSurvey)
   end
 
-  pipeline :enforce_enroll_and_paywall do
-    plug(Oli.Plugs.EnforceEnrollAndPaywall)
+  pipeline :enforce_paywall do
+    plug(Oli.Plugs.EnforcePaywall)
+  end
+
+  pipeline :require_enrollment do
+    plug(OliWeb.Plugs.RequireEnrollment)
   end
 
   pipeline :ensure_datashop_id do
@@ -177,7 +181,7 @@ defmodule OliWeb.Router do
   end
 
   pipeline :ensure_user_section_visit do
-    plug(Oli.Plugs.EnsureUserSectionVisit)
+    plug(OliWeb.Plugs.EnsureUserSectionVisit)
   end
 
   pipeline :delivery_preview do
@@ -1066,7 +1070,8 @@ defmodule OliWeb.Router do
       :ensure_datashop_id,
       :require_authenticated_user_or_guest,
       :student,
-      :enforce_enroll_and_paywall,
+      :enforce_paywall,
+      :require_enrollment,
       :ensure_user_section_visit,
       :force_required_survey
     ])
@@ -1158,7 +1163,8 @@ defmodule OliWeb.Router do
       :redirect_by_attempt_state,
       :delivery_protected,
       :maybe_gated_resource,
-      :enforce_enroll_and_paywall,
+      :enforce_paywall,
+      :require_enrollment,
       :ensure_user_section_visit,
       :force_required_survey
     ])

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -296,7 +296,8 @@ defmodule OliWeb.PageDeliveryControllerTest do
         conn
         |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
-      assert html_response(conn, 302) =~ "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
     end
 
     test "handles student access who is not enrolled", %{conn: conn, section: section} do
@@ -304,7 +305,8 @@ defmodule OliWeb.PageDeliveryControllerTest do
         conn
         |> get(~p"/sections/#{section.slug}")
 
-      assert html_response(conn, 302) =~ "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
+      assert html_response(conn, 302) =~
+               "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
     end
 
     test "handles student access who is not enrolled when section requires enrollment", %{

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -296,7 +296,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         conn
         |> get(~p"/sections/#{section.slug}/lesson/#{revision.slug}")
 
-      assert html_response(conn, 302) =~ "You are being <a href=\"/unauthorized\">redirected</a>"
+      assert html_response(conn, 302) =~ "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
     end
 
     test "handles student access who is not enrolled", %{conn: conn, section: section} do
@@ -304,7 +304,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         conn
         |> get(~p"/sections/#{section.slug}")
 
-      assert html_response(conn, 302) =~ "You are being <a href=\"/unauthorized\">redirected</a>"
+      assert html_response(conn, 302) =~ "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
     end
 
     test "handles student access who is not enrolled when section requires enrollment", %{

--- a/test/oli_web/live/collaboration_live_test.exs
+++ b/test/oli_web/live/collaboration_live_test.exs
@@ -274,7 +274,7 @@ defmodule OliWeb.CollaborationLiveTest do
       assert conn
              |> get(live_view_student_page(section.slug, page_revision.slug))
              |> html_response(302) =~
-               "You are being <a href=\"/unauthorized\">redirected</a>"
+               "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>"
     end
   end
 

--- a/test/oli_web/live/delivery/student/assignments_live_test.exs
+++ b/test/oli_web/live/delivery/student/assignments_live_test.exs
@@ -315,7 +315,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, live_view_assignments_live_route(section.slug))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
   end
 

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -198,7 +198,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, live_view_discussions_live_route(section.slug))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can access when enrolled to course", %{

--- a/test/oli_web/live/delivery/student/explorations_live_test.exs
+++ b/test/oli_web/live/delivery/student/explorations_live_test.exs
@@ -179,7 +179,7 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, ~p"/sections/#{section.slug}/explorations")
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can access when enrolled to course", %{conn: conn, user: user, section: section} do

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -701,7 +701,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, ~p"/sections/#{section.slug}")
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
   end
 

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2095,7 +2095,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, Utils.learn_live_path(section.slug, selected_view: :outline))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can not access Gallery view (default one) when not enrolled to course", %{
@@ -2105,7 +2105,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, Utils.learn_live_path(section.slug))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
   end
 

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -661,7 +661,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "redirects when page is adaptive", %{

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -454,7 +454,7 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, Utils.prologue_live_path(section.slug, page_1.slug))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can access when enrolled to course", %{

--- a/test/oli_web/live/delivery/student/review_live_test.exs
+++ b/test/oli_web/live/delivery/student/review_live_test.exs
@@ -288,7 +288,7 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, Utils.review_live_path(section.slug, page_1.slug, attempt.attempt_guid))
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can not access when review is not allowed", %{

--- a/test/oli_web/live/delivery/student/schedule_live_test.exs
+++ b/test/oli_web/live/delivery/student/schedule_live_test.exs
@@ -581,7 +581,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLiveTest do
       {:error, {:redirect, %{to: redirect_path, flash: _flash_msg}}} =
         live(conn, ~p"/sections/#{section.slug}/student_schedule")
 
-      assert redirect_path == "/unauthorized"
+      assert redirect_path == "/sections/#{section.slug}/enroll"
     end
 
     test "can access when enrolled to course", %{conn: conn, user: user, section: section} do

--- a/test/oli_web/plugs/ensure_user_section_visit_test.exs
+++ b/test/oli_web/plugs/ensure_user_section_visit_test.exs
@@ -16,9 +16,10 @@ defmodule OliWeb.Plugs.EnsureUserSectionVisitTest do
     test "does not redirect when user is an admin", %{conn: conn} do
       user = user_fixture()
 
-      conn = conn
-             |> assign(:current_user, user)
-             |> assign(:is_admin, true)
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:is_admin, true)
 
       assert conn == conn |> EnsureUserSectionVisit.call([])
     end
@@ -27,11 +28,12 @@ defmodule OliWeb.Plugs.EnsureUserSectionVisitTest do
       user = insert(:user)
       section = insert(:section)
 
-      conn = conn
-             |> assign(:current_user, user)
-             |> assign(:section, section)
-             |> fetch_session()
-             |> Plug.Conn.put_session("visited_sections", Map.put(%{}, section.slug, true))
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:section, section)
+        |> fetch_session()
+        |> Plug.Conn.put_session("visited_sections", Map.put(%{}, section.slug, true))
 
       assert conn == conn |> EnsureUserSectionVisit.call([])
     end
@@ -42,10 +44,11 @@ defmodule OliWeb.Plugs.EnsureUserSectionVisitTest do
 
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
-      conn = conn
-             |> assign(:current_user, user)
-             |> assign(:section, section)
-             |> EnsureUserSectionVisit.call([])
+      conn =
+        conn
+        |> assign(:current_user, user)
+        |> assign(:section, section)
+        |> EnsureUserSectionVisit.call([])
 
       assert redirected_to(conn) == "/sections/#{section.slug}/welcome"
     end

--- a/test/oli_web/plugs/ensure_user_section_visit_test.exs
+++ b/test/oli_web/plugs/ensure_user_section_visit_test.exs
@@ -1,0 +1,53 @@
+defmodule OliWeb.Plugs.EnsureUserSectionVisitTest do
+  use OliWeb.ConnCase
+  import Oli.Factory
+
+  alias OliWeb.Plugs.EnsureUserSectionVisit
+  alias Oli.Delivery.Sections
+  alias Lti_1p3.Tool.ContextRoles
+
+  describe "ensure_user_section_visit/2" do
+    setup %{conn: conn} do
+      conn = Plug.Test.init_test_session(conn, [])
+
+      {:ok, conn: conn}
+    end
+
+    test "does not redirect when user is an admin", %{conn: conn} do
+      user = user_fixture()
+
+      conn = conn
+             |> assign(:current_user, user)
+             |> assign(:is_admin, true)
+
+      assert conn == conn |> EnsureUserSectionVisit.call([])
+    end
+
+    test "does not redirect when user has visited the section", %{conn: conn} do
+      user = insert(:user)
+      section = insert(:section)
+
+      conn = conn
+             |> assign(:current_user, user)
+             |> assign(:section, section)
+             |> fetch_session()
+             |> Plug.Conn.put_session("visited_sections", Map.put(%{}, section.slug, true))
+
+      assert conn == conn |> EnsureUserSectionVisit.call([])
+    end
+
+    test "redirects to onboarding wizard when user has not visited the section", %{conn: conn} do
+      user = insert(:user)
+      section = insert(:section)
+
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn = conn
+             |> assign(:current_user, user)
+             |> assign(:section, section)
+             |> EnsureUserSectionVisit.call([])
+
+      assert redirected_to(conn) == "/sections/#{section.slug}/welcome"
+    end
+  end
+end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4259

When using a join link for a course section, a user was prompted to sign in then redirected to an "Unauthorized" page after being authenticated.

The issue identified here was some intertwined logic in the `OliWeb.Plugs.EnsureUserSectionVisit` plug. The original intention of this plug was to maintain a key in the user session that indicated whether a user has already visited a section or not in order to efficiently determine whether or not to show the welcome wizard. Though it appears this plug was also being used to verify user enrollment in the cases that `EnforceEnrollAndPaywall` didn't cover, specifically cases where there is no paywall required for a section. This plug was not considering the case where a user tries to access a course using a given invitation link or section URL, and is then asked to authenticate and then redirected back to the course section. In this case the user was being redirected to /unauthorized.

The main fix here is to handle this case by redirecting a newly authenticated user to the enroll screen, allowing them to continue where they left off with enrolling in the course after being authenticated. However, simply adding this to the existing plug seemed to further complicate the plug so it seemed to make sense to break out this enrollment check into a separate plug. Now there are 3 separate plugs that all perform a separate function for course sections:
1. EnforcePaywall - Enforces payment and enrollment only in the cases where a payment is required for a course section
2. RequireEnrollment - Ensures that a user is enrolled in the section being accessed. If a user is not currently enrolled and registration is open for the section, then the user is redirected to the "enroll" screen.
3. EnsureUserSectionVisit - Manages whether a student has visited a section already and redirects to the welcome wizard accordingly