### PR TITLE
[BUG FIX] [MER-4262] fix an issue where admins cannot access assessment settings for sections

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
       {:error, error} ->
         {:ok, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, error))}
 
-      {_user_type, current_user, section} ->
+      {_user_type, _user, section} ->
         section =
           section
           |> Oli.Repo.preload([:base_project, :root_section_resource])
@@ -23,7 +23,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
 
         {:ok,
          assign(socket,
-           current_user: current_user,
            preview_mode: socket.assigns[:live_action] == :preview,
            title: "Assessment Settings",
            section: section,

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -586,6 +586,51 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
     end
   end
 
+  describe "admin can access" do
+    setup [:user_conn, :create_project]
+
+    test "the assessment settings view", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      page_3: page_3,
+      page_4: page_4
+    } do
+      admin =
+        author_fixture(%{
+          system_role_id: Oli.Accounts.SystemRole.role_id().system_admin,
+        })
+
+      # log out instructor, leaving only admin logged in
+      conn = conn
+        |> OliWeb.UserAuth.clear_all_session_data()
+        |> OliWeb.AuthorAuth.create_session(admin)
+
+
+      {:ok, view, html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      [assessment_1, assessment_2, assessment_3, assessment_4] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tbody tr td:nth-of-type(2)})
+        |> Enum.map(fn row -> Floki.text(row) |> String.split("\n") |> hd() end)
+
+      assert view
+             |> has_element?("p", "These are your current assessment settings.")
+
+      assert assessment_1 == page_1.title
+      assert assessment_2 == page_2.title
+      assert assessment_3 == page_3.title
+      assert assessment_4 == page_4.title
+
+      assert html =~
+               ~s(<a href="/sections/#{section.slug}/manage">Manage Section</a>)
+    end
+
+  end
+
   describe "user can access when is logged in as an instructor and is enrolled in the section" do
     setup [:user_conn, :create_project]
 

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -599,14 +599,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
     } do
       admin =
         author_fixture(%{
-          system_role_id: Oli.Accounts.SystemRole.role_id().system_admin,
+          system_role_id: Oli.Accounts.SystemRole.role_id().system_admin
         })
 
       # log out instructor, leaving only admin logged in
-      conn = conn
+      conn =
+        conn
         |> OliWeb.UserAuth.clear_all_session_data()
         |> OliWeb.AuthorAuth.create_session(admin)
-
 
       {:ok, view, html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
 
@@ -628,7 +628,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert html =~
                ~s(<a href="/sections/#{section.slug}/manage">Manage Section</a>)
     end
-
   end
 
   describe "user can access when is logged in as an instructor and is enrolled in the section" do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4262

Fixes an issue where when logged in as an admin, the assessment settings page throws a 500 error.

The issue was caused by the result user of `Mount.for` in `SettingsLive` overwriting the `current_user` assigns with an Author (the logged in admin account). This was causing some of the UserAuth logic to break.

This was originally being worked on as part of MER-4262, but since there is a separate ticket targeted for this specific issue I am submitting this fix for MER-4262 and any additional work done for MER-4262 will be tracked by that Jira ticket and completed with another PR.