### PR TITLE
[BUG FIX] [MER-4262] 500 internal server error when accessing assessment settings

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
       {:error, error} ->
         {:ok, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, error))}
 
-      {_user_type, _user, section} ->
+      {_user_type, user, section} ->
         section =
           section
           |> Oli.Repo.preload([:base_project, :root_section_resource])
@@ -26,6 +26,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
            preview_mode: socket.assigns[:live_action] == :preview,
            title: "Assessment Settings",
            section: section,
+           user: user,
            student_exceptions: student_exceptions,
            students:
              Sections.enrolled_students(section.slug)
@@ -108,6 +109,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
             assessments={@assessments}
             params={@params}
             section={@section}
+            user={@user}
             ctx={@ctx}
             update_sort_order={@update_sort_order}
           />

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -73,6 +73,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
        total_count: total_count,
        params: params,
        section: assigns.section,
+       user: assigns.user,
        ctx: assigns.ctx,
        assessments: assigns.assessments,
        form_id: UUID.uuid4(),
@@ -444,7 +445,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   def handle_event("confirm_bulk_apply", _params, socket) do
     %{
       section: section,
-      ctx: %{user: user},
+      user: user,
       assessments: assessments,
       modal_assigns: %{base_assessment: base_assessment}
     } =
@@ -571,7 +572,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   end
 
   def handle_event("update_setting", params, socket) do
-    %{section: section, ctx: %{user: user} = ctx, assessments: assessments} = socket.assigns
+    %{section: section, ctx: ctx, user: user, assessments: assessments} = socket.assigns
     resources = %{section: section, user: user, assessments: assessments}
 
     case decode_target(params, ctx) do
@@ -640,7 +641,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
         },
         socket
       ) do
-    %{section: section, ctx: %{user: user}} = socket.assigns
+    %{section: section, user: user} = socket.assigns
 
     utc_datetime =
       FormatDateTime.datestring_to_utc_datetime(
@@ -806,7 +807,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
 
   defp on_edit_date(date_field, new_date, socket) do
     assessment = socket.assigns.selected_assessment
-    %{section: section, ctx: %{user: user}} = socket.assigns
+    %{section: section, user: user} = socket.assigns
 
     {new_start_date, new_end_date, message} =
       maybe_adjust_dates(date_field, new_date, assessment, socket.assigns.ctx)

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -599,14 +599,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
     } do
       admin =
         author_fixture(%{
-          system_role_id: Oli.Accounts.SystemRole.role_id().system_admin,
+          system_role_id: Oli.Accounts.SystemRole.role_id().system_admin
         })
 
       # log out instructor, leaving only admin logged in
-      conn = conn
+      conn =
+        conn
         |> OliWeb.UserAuth.clear_all_session_data()
         |> OliWeb.AuthorAuth.create_session(admin)
-
 
       {:ok, view, html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
 
@@ -628,7 +628,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert html =~
                ~s(<a href="/sections/#{section.slug}/manage">Manage Section</a>)
     end
-
   end
 
   describe "user can access when is logged in as an instructor and is enrolled in the section" do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4262

Fixes an issue where when logged in as an admin, the assessment settings page throws a 500 error.

The issue was caused by the result user of `Mount.for` in `SettingsLive` overwriting the `current_user` assigns with an Author (when logged in admin account). This was causing some of the UserAuth logic to break.

This was originally being worked on as part of MER-4262, but since there is a separate ticket targeted for this specific issue I am submitting this fix for MER-4262 and any additional work done for MER-4262 will be tracked by that Jira ticket and completed with another PR.