### PR TITLE
[FEATURE] [MER-4039] Fix hint triggers and adjust teaser window styling

### DIFF
--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -160,19 +160,22 @@ defmodule Oli.Conversation.Triggers do
            t.trigger_type == :hint and t.ref_id == hint_ordinal
          end) do
       [trigger | _other] ->
-
         # we have to look up the page id for this activity attempt
-        page_id = case set_resource_id do
-          true ->  Repo.one(
-            from(ra in ResourceAttempt,
-              join: r in ResourceAccess,
-              on: ra.resource_access_id == r.id,
-              where: ra.id == ^activity_attempt.resource_attempt_id,
-              select: r.resource_id
-            )
-          )
-          false -> nil
-        end
+        page_id =
+          case set_resource_id do
+            true ->
+              Repo.one(
+                from(ra in ResourceAttempt,
+                  join: r in ResourceAccess,
+                  on: ra.resource_access_id == r.id,
+                  where: ra.id == ^activity_attempt.resource_attempt_id,
+                  select: r.resource_id
+                )
+              )
+
+            false ->
+              nil
+          end
 
         %Trigger{
           trigger_type: :hint,

--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -2,7 +2,7 @@ defmodule Oli.Conversation.Triggers do
   require Logger
   import Ecto.Query
   alias Oli.Repo
-
+  alias Oli.Delivery.Attempts.Core.{ResourceAttempt, ResourceAccess}
   alias Phoenix.PubSub
   alias Oli.Conversation.Trigger
   alias Oli.Activities.Model.{Part}
@@ -14,7 +14,7 @@ defmodule Oli.Conversation.Triggers do
     :content_block,
     :correct_answer,
     :incorrect_answer,
-    :hint_request,
+    :hint,
     :explanation,
     :targeted_feedback
   ]
@@ -37,7 +37,7 @@ defmodule Oli.Conversation.Triggers do
   def description(:incorrect_answer, data),
     do: "Answered incorrectly question: #{data["question"]}"
 
-  def description(:hint_request, data),
+  def description(:hint, data),
     do: "Requested a hint (id: #{data["ref_id"]}) from question: #{data["question"]}"
 
   def description(:explanation, data),
@@ -157,17 +157,28 @@ defmodule Oli.Conversation.Triggers do
       end
 
     case Enum.filter(part.triggers, fn t ->
-           t.trigger_type == :hint_request and t.ref_id == hint_ordinal
+           t.trigger_type == :hint and t.ref_id == hint_ordinal
          end) do
       [trigger | _other] ->
+
+        # we have to look up the page id for this activity attempt
+        page_id = Repo.one(
+          from(ra in ResourceAttempt,
+            join: r in ResourceAccess,
+            on: ra.resource_access_id == r.id,
+            where: ra.id == ^activity_attempt.resource_attempt_id,
+            select: r.resource_id
+          )
+        )
+
         %Trigger{
-          trigger_type: :hint_request,
+          trigger_type: :hint,
           data: %{
             "ref_id" => hint_ordinal,
-            "hint" => hint.hint,
+            "activity_attempt_guid" => activity_attempt.attempt_guid,
             "activity_id" => activity_attempt.resource_id
           },
-          resource_id: activity_attempt.resource_id,
+          resource_id: page_id,
           prompt: trigger.prompt
         }
 

--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -147,7 +147,7 @@ defmodule Oli.Conversation.Triggers do
 
   If a matching trigger is found, return the trigger, otherwise return nil.
   """
-  def check_for_hint_trigger(activity_attempt, part_attempt, model, hint) do
+  def check_for_hint_trigger(activity_attempt, part_attempt, model, hint, set_resource_id \\ true) do
     part = Enum.filter(model.parts, fn p -> p.id == part_attempt.part_id end) |> hd()
 
     hint_ordinal =
@@ -162,14 +162,17 @@ defmodule Oli.Conversation.Triggers do
       [trigger | _other] ->
 
         # we have to look up the page id for this activity attempt
-        page_id = Repo.one(
-          from(ra in ResourceAttempt,
-            join: r in ResourceAccess,
-            on: ra.resource_access_id == r.id,
-            where: ra.id == ^activity_attempt.resource_attempt_id,
-            select: r.resource_id
+        page_id = case set_resource_id do
+          true ->  Repo.one(
+            from(ra in ResourceAttempt,
+              join: r in ResourceAccess,
+              on: ra.resource_access_id == r.id,
+              where: ra.id == ^activity_attempt.resource_attempt_id,
+              select: r.resource_id
+            )
           )
-        )
+          false -> nil
+        end
 
         %Trigger{
           trigger_type: :hint,

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -262,8 +262,8 @@ defmodule OliWeb.Dialogue.WindowLive do
         |> JS.push("hide_teaser")
         |> JS.focus(to: "#ai_bot_input")
       }
-      style="height: 150px; width: 200px;"
-      class={"p-1 shadow-lg bg-white dark:bg-[#0A0A17] flex flex-col " <> if(@teaser_visible, do: "", else: "hidden")}
+      style="height: 150px; width: 200px; margin-right: 35px;"
+      class={"p-1 shadow-lg bg-white dark:bg-[#0A0A17] rounded-md flex flex-col " <> if(@teaser_visible, do: "", else: "hidden")}
     >
       <div class="flex flex-none justify-right">
         <button

--- a/test/oli/conversation/triggers_test.exs
+++ b/test/oli/conversation/triggers_test.exs
@@ -141,7 +141,9 @@ defmodule Oli.Conversation.TriggersTest do
 
   test "check hint trigger" do
     activity_attempt = %{
-      resource_id: "activity_id"
+      resource_id: "activity_id",
+      resource_attempt_id: 1,
+      attempt_guid: "attempt_guid"
     }
 
     part_attempt = %{
@@ -161,7 +163,7 @@ defmodule Oli.Conversation.TriggersTest do
           triggers: [
             %Oli.Activities.Model.Trigger{
               id: "trigger_id1",
-              trigger_type: :hint_request,
+              trigger_type: :hint,
               prompt: "hint prompt",
               ref_id: 1
             }
@@ -175,7 +177,7 @@ defmodule Oli.Conversation.TriggersTest do
       hint: "this is the hint"
     }
 
-    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint)
+    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint, false)
 
     assert trigger.data["ref_id"] == 1
     assert trigger.prompt == "hint prompt"
@@ -183,7 +185,9 @@ defmodule Oli.Conversation.TriggersTest do
 
   test "check for hint trigger when multiple present" do
     activity_attempt = %{
-      resource_id: "activity_id"
+      resource_id: "activity_id",
+      resource_attempt_id: 1,
+      attempt_guid: "attempt_guid"
     }
 
     part_attempt = %{
@@ -210,7 +214,7 @@ defmodule Oli.Conversation.TriggersTest do
           ],
           triggers: [
             %{
-              trigger_type: :hint_request,
+              trigger_type: :hint,
               prompt: "hint prompt",
               ref_id: 3
             }
@@ -224,7 +228,7 @@ defmodule Oli.Conversation.TriggersTest do
       hint: "this is the hint"
     }
 
-    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint)
+    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint, false)
 
     assert trigger.data["ref_id"] == 3
     assert trigger.prompt == "hint prompt"
@@ -234,7 +238,7 @@ defmodule Oli.Conversation.TriggersTest do
       hint: "this is the hint1"
     }
 
-    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint)
+    trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint, false)
     assert is_nil(trigger)
   end
 end


### PR DESCRIPTION
Hint requesting wasn't working when Trigger points feature was being developed, due to a datashop session id issue.  This PR fixes problems with hint triggers that now are visible. 

It also adjusts the styling and position of the Trigger "teaser" window