### PR TITLE
[FEATURE] [MER-4335] Implement new liveview to show certificate to a student

### DIFF
--- a/lib/oli/delivery/certificates.ex
+++ b/lib/oli/delivery/certificates.ex
@@ -186,7 +186,7 @@ defmodule Oli.Delivery.Certificates do
         select:
           merge(
             map(c, ^Certificate.__schema__(:fields)),
-            %{granted_certificate_state: gc.state}
+            %{granted_certificate_state: gc.state, granted_certificate_guid: gc.guid}
           )
       )
       |> Repo.one()
@@ -219,7 +219,8 @@ defmodule Oli.Delivery.Certificates do
         required_assignments: %{
           completed: required_assignment_ids_count,
           total: required_assignment_ids_count
-        }
+        },
+        granted_certificate_guid: certificate.granted_certificate_guid
       }
     else
       %{
@@ -241,7 +242,8 @@ defmodule Oli.Delivery.Certificates do
             section_id,
             required_assignment_ids,
             certificate.min_percentage_for_completion
-          )
+          ),
+        granted_certificate_guid: certificate.granted_certificate_guid
       }
     end
   end

--- a/lib/oli_web/live/delivery/student/certificate_live.ex
+++ b/lib/oli_web/live/delivery/student/certificate_live.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.Delivery.Student.CertificateLive do
       <.back_button section_slug={@section.slug} />
     </div>
     <div class="flex flex-col justify-center items-center p-10">
-      <h1>The requested certificate does not exist or it belongs to another student</h1>
+      <h3>The requested certificate does not exist or belongs to another student</h3>
     </div>
     """
   end
@@ -37,7 +37,7 @@ defmodule OliWeb.Delivery.Student.CertificateLive do
       <.back_button section_slug={@section.slug} />
     </div>
     <div class="flex flex-col justify-center items-center p-10">
-      <h1>The requested certificate is being created. Please revisit the page in some minutes</h1>
+      <h3>The requested certificate is being created. Please revisit the page in some minutes</h3>
     </div>
     """
   end

--- a/lib/oli_web/live/delivery/student/certificate_live.ex
+++ b/lib/oli_web/live/delivery/student/certificate_live.ex
@@ -1,0 +1,69 @@
+defmodule OliWeb.Delivery.Student.CertificateLive do
+  use OliWeb, :live_view
+
+  alias Oli.Delivery.GrantedCertificates
+  alias OliWeb.Icons
+
+  @impl Phoenix.LiveView
+  def mount(params, _session, socket) do
+    granted_certificate =
+      GrantedCertificates.get_granted_certificate_by_guid(params["certificate_guid"]) || %{}
+
+    {:ok,
+     socket
+     |> assign(:granted_certificate, granted_certificate)
+     |> assign(
+       :show_certificate?,
+       Map.get(granted_certificate, :user_id) == socket.assigns.current_user.id
+     )
+     |> assign(active_tab: :index)}
+  end
+
+  @impl Phoenix.LiveView
+  def render(%{show_certificate?: false} = assigns) do
+    ~H"""
+    <div class="p-10">
+      <.back_button section_slug={@section.slug} />
+    </div>
+    <div class="flex flex-col justify-center items-center p-10">
+      <h1>The requested certificate does not exist or it belongs to another student</h1>
+    </div>
+    """
+  end
+
+  def render(%{show_certificate?: true, granted_certificate: %{url: nil}} = assigns) do
+    ~H"""
+    <div class="p-10">
+      <.back_button section_slug={@section.slug} />
+    </div>
+    <div class="flex flex-col justify-center items-center p-10">
+      <h1>The requested certificate is being created. Please revisit the page in some minutes</h1>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="p-10">
+      <.back_button section_slug={@section.slug} />
+    </div>
+    <div class="flex flex-col justify-center items-center p-10">
+      <embed src={@granted_certificate.url} type="application/pdf" style="width: 66vw; height: 66vh;">
+      </embed>
+      <p class="text-blue-400 mt-4">
+        Certificate ID: <span class="font-semibold"><%= @granted_certificate.guid %></span>
+      </p>
+    </div>
+    """
+  end
+
+  attr :section_slug, :string, required: true
+
+  def back_button(assigns) do
+    ~H"""
+    <.link navigate={~p"/sections/#{@section_slug}"}>
+      <Icons.left_arrow class="hover:opacity-100 hover:scale-105 fill-[#9D9D9D]" />
+    </.link>
+    """
+  end
+end

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -191,6 +191,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
             completed_pages={@completed_pages}
             certificate_enabled={@certificate_enabled}
             certificate_progress={@certificate_progress}
+            section_slug={@section_slug}
           />
         </div>
 
@@ -398,6 +399,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   attr(:completed_pages, :map, required: true)
   attr(:certificate_enabled, :boolean, required: true)
   attr(:certificate_progress, :map, required: true)
+  attr(:section_slug, :string, required: true)
 
   defp course_progress(assigns) do
     ~H"""
@@ -547,11 +549,15 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         <.certificate_progress
           :if={@certificate_enabled}
           certificate_progress={@certificate_progress}
+          section_slug={@section_slug}
         />
       </div>
     </div>
     """
   end
+
+  attr :certificate_progress, :map, required: true
+  attr :section_slug, :string, required: true
 
   def certificate_progress(assigns) do
     ~H"""
@@ -646,10 +652,11 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           </div>
           <.link
             :if={all_certificate_requirements_met?(certificate_progress)}
-            navigate="#"
+            navigate={
+              ~p"/sections/#{@section_slug}/certificate/#{certificate_progress.granted_certificate_guid}"
+            }
             class=" text-[#4ca6ff] dark:text-[#3399FF] text-base font-bold ml-auto hover:text-opacity-80 hover:no-underline"
           >
-            <%!-- TODO: hidden button. Unhide and link to certificate when https://eliterate.atlassian.net/browse/MER-3809 is done --%>
             Access my certificate
           </.link>
         </div>
@@ -673,7 +680,8 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
   defp all_certificate_requirements_met?(certificate_progress),
     do:
-      Enum.all?(certificate_progress, fn {_criteria, result} ->
+      Map.drop(certificate_progress, [:granted_certificate_guid])
+      |> Enum.all?(fn {_criteria, result} ->
         result.completed >= result.total
       end)
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1100,6 +1100,7 @@ defmodule OliWeb.Router do
         live("/student_schedule", Delivery.Student.ScheduleLive)
         live("/explorations", Delivery.Student.ExplorationsLive)
         live("/practice", Delivery.Student.PracticeLive)
+        live("/certificate/:certificate_guid", Delivery.Student.CertificateLive)
       end
     end
 

--- a/test/oli_web/live/delivery/student/certificate_live_test.exs
+++ b/test/oli_web/live/delivery/student/certificate_live_test.exs
@@ -1,0 +1,177 @@
+defmodule OliWeb.Delivery.Student.CertificateLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Delivery.Sections
+
+  describe "student" do
+    setup [:user_conn, :create_elixir_project]
+
+    test "does not see a certificate if the provided guid does not exist", %{
+      conn: conn,
+      section: section
+    } do
+      guid = "non_existent_guid"
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/certificate/#{guid}")
+
+      assert has_element?(
+               view,
+               "h3",
+               "The requested certificate does not exist or belongs to another student"
+             )
+    end
+
+    test "does not see a certificate if the provided guid belongs to another student", %{
+      conn: conn,
+      section: section,
+      certificate: certificate
+    } do
+      granted_certificate_from_another_user =
+        insert(:granted_certificate, certificate: certificate)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/sections/#{section.slug}/certificate/#{granted_certificate_from_another_user.guid}"
+        )
+
+      assert has_element?(
+               view,
+               "h3",
+               "The requested certificate does not exist or belongs to another student"
+             )
+    end
+
+    test "sees a message if the certificate is being created", %{
+      conn: conn,
+      certificate: certificate,
+      user: student
+    } do
+      granted_certificate =
+        insert(:granted_certificate, %{
+          certificate: certificate,
+          user: student,
+          url: nil
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/sections/#{certificate.section.slug}/certificate/#{granted_certificate.guid}"
+        )
+
+      assert has_element?(
+               view,
+               "h3",
+               "The requested certificate is being created. Please revisit the page in some minutes"
+             )
+    end
+
+    test "sees the certificate if the user_id matches its own id", %{
+      conn: conn,
+      certificate: certificate,
+      user: student
+    } do
+      granted_certificate =
+        insert(:granted_certificate, %{
+          certificate: certificate,
+          user: student,
+          url: "some_valid_pdf_url",
+          guid: "some_guid"
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/sections/#{certificate.section.slug}/certificate/#{granted_certificate.guid}"
+        )
+
+      assert has_element?(view, "embed[src='some_valid_pdf_url']")
+      assert render(view) =~ "some_guid"
+    end
+
+    test "can navigate back to the home page", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/certificate/some_guid")
+
+      element(view, "a[href='/sections/#{section.slug}']")
+      |> render_click()
+
+      assert_redirected(view, ~p"/sections/#{section.slug}")
+    end
+  end
+
+  defp create_elixir_project(ctx) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # revisions...
+    ## pages...
+    page_1_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("page"),
+        title: "Start here"
+      )
+
+    ## root container...
+    container_revision =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.get_id_by_type("container"),
+        children: [
+          page_1_revision.resource_id
+        ],
+        title: "Root Container"
+      })
+
+    all_revisions = [page_1_revision, container_revision]
+
+    # asociate resources to project
+    Enum.each(all_revisions, fn revision ->
+      insert(:project_resource, %{
+        project_id: project.id,
+        resource_id: revision.resource_id
+      })
+    end)
+
+    # publish project
+    publication =
+      insert(:publication, %{project: project, root_resource_id: container_revision.resource_id})
+
+    # publish resources
+    Enum.each(all_revisions, fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    # create section...
+    section =
+      insert(:section,
+        base_project: project,
+        title: "The best course ever!"
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+    {:ok, _} = Sections.rebuild_contained_pages(section)
+
+    # enroll user to the section
+    Sections.enroll(ctx.user.id, section.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.mark_section_visited_for_student(section, ctx.user)
+
+    certificate = insert(:certificate, section: section)
+
+    %{section: section, certificate: certificate}
+  end
+end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4335) to the ticket

https://github.com/user-attachments/assets/471eb50e-0c83-4408-a2e6-3fdef7412439


#### When modifying the URL (trying to guess another user's certificate guid)
<img width="1439" alt="Screenshot 2025-02-26 at 9 41 39 PM" src="https://github.com/user-attachments/assets/6041a425-cdc1-4810-ad4e-c403f6f33125" />


#### When modifying the URL with the guid of another student (not the one logged in)
<img width="1439" alt="Screenshot 2025-02-26 at 9 41 39 PM" src="https://github.com/user-attachments/assets/6041a425-cdc1-4810-ad4e-c403f6f33125" />

#### PDF creation still in progress
In case the student tries to see the certificate while it has not yet finished it's PDF creation process (very unlikely case), this will be the feedback
<img width="1439" alt="Screenshot 2025-02-26 at 9 41 02 PM" src="https://github.com/user-attachments/assets/9e0657d6-1b6d-4e4b-8125-94598a25ea53" />

