### PR TITLE
[FEATURE] [MER-4333] Instructor approval email template

### DIFF
--- a/lib/oli/delivery/sections/certificates/email_templates.ex
+++ b/lib/oli/delivery/sections/certificates/email_templates.ex
@@ -56,4 +56,37 @@ defmodule Oli.Delivery.Sections.Certificates.EmailTemplates do
     </p>
     """
   end
+
+  attr :instructor_name, :string, default: "[Instructor Name]"
+  attr :student_name, :string, default: "[Student]"
+  attr :course_name, :string, default: "[Course Name]"
+  attr :section_slug, :string, required: true
+
+  attr :certificate_type, :string,
+    default: "[certificate of completion]",
+    doc: "'certificate of completion' or 'certificate with distinction'"
+
+  def instructor_pending_approval(assigns) do
+    ~H"""
+    <p class="text-[#373a44]" style="text-align: left;">
+      Dear <strong><%= @instructor_name %></strong>, <br />
+
+      <br />
+      <strong><%= @student_name %></strong>
+      has met the thresholds set in place to receive their certificate for <%= @course_name %>. You are required to approve this status before
+      <strong><%= @student_name %></strong>
+      will be issued a <strong><%= @certificate_type %></strong>. <br />
+
+      <br />
+      <.link
+        href={
+          url(OliWeb.Endpoint, ~p"/sections/#{@section_slug}/instructor_dashboard/overview/students")
+        }
+        class="text-[#0062f2]"
+      >
+        View pending credentials.
+      </.link>
+    </p>
+    """
+  end
 end

--- a/lib/oli_web/templates/email/certificate_instructor_pending_approval.html.eex
+++ b/lib/oli_web/templates/email/certificate_instructor_pending_approval.html.eex
@@ -1,0 +1,1 @@
+<%= Oli.Delivery.Sections.Certificates.EmailTemplates.instructor_pending_approval(%{instructor_name: @instructor_name, student_name: @student_name, section_slug: @section_slug, course_name: @course_name, certificate_type: @certificate_type}) %>

--- a/lib/oli_web/templates/email/certificate_instructor_pending_approval.text.eex
+++ b/lib/oli_web/templates/email/certificate_instructor_pending_approval.text.eex
@@ -1,0 +1,6 @@
+<%#
+THIS FILE IS NOT USED
+
+But it is required to be here by Phoenix.Swoosh. Email text is generated from the
+corresponding html template. See Oli.Email for details.
+%>


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4333) to the ticket

Note: this email will be triggered automatically by the Check Certification Worker ([MER-4106](https://eliterate.atlassian.net/browse/MER-4106)) once the required wiring is done ([MER-4334](https://eliterate.atlassian.net/browse/MER-4334))

After manually triggering the email in the console, we see this result:

![Screenshot 2025-02-27 at 9 13 14 AM](https://github.com/user-attachments/assets/f9a66fa5-e86a-4e86-ac4b-e66c7e55c28a)


[MER-4106]: https://eliterate.atlassian.net/browse/MER-4106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-4334]: https://eliterate.atlassian.net/browse/MER-4334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ