### PR TITLE
[BUG FIX] [MER-4339] handle scenario where an invited user is registering an account from invitation email

### DIFF
--- a/lib/oli_web/controllers/invite_controller.ex
+++ b/lib/oli_web/controllers/invite_controller.ex
@@ -54,7 +54,7 @@ defmodule OliWeb.InviteController do
           case user.status do
             :new_user ->
               {"Join now",
-               ~p"/registration/new?#{[section: section.slug, from_invitation_link?: true]}"}
+               ~p"/registration/new?#{[section: section.slug, from_invitation_link?: true, token: user.invitation_token]}"}
 
             :existing_user ->
               {"Go to the course", ~p"/sections/#{section.slug}?#{[from_invitation_link?: true]}"}

--- a/lib/oli_web/controllers/pow/registration_html/new.html.heex
+++ b/lib/oli_web/controllers/pow/registration_html/new.html.heex
@@ -189,6 +189,10 @@
         <%= hidden_input(f, :section, value: @conn.params["section"]) %>
       <% end %>
 
+      <%= if @conn.params["token"] do %>
+        <%= hidden_input(f, :invitation_token, value: @conn.params["token"]) %>
+      <% end %>
+
       <%= submit("Create Account", class: "btn btn-md btn-primary btn-block") %>
       <%= link("Cancel",
         to: value_or(assigns[:cancel_path], Routes.static_page_path(@conn, :index)),

--- a/lib/oli_web/pow/user_context.ex
+++ b/lib/oli_web/pow/user_context.ex
@@ -93,7 +93,7 @@ defmodule OliWeb.Pow.UserContext do
               |> Repo.update()
 
             _ ->
-              {:ok, user}
+              {:error, %{email: "has already been taken"}}
           end
         end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4339

This PR addresses an issue where users who are invited via bulk invitation were not able to complete the registration process. The issue here was the Pow auth custom `create` logic was not taking into account the scenario where a user may already have an existing User record from the bulk invite process and when attempting to complete the registration process the system would assume that a user was trying to register an account that already exists.

The fix here includes a check for the invitation token, and if present along with a nil invitation_accepted_at, then it will process the registration as completing the invitation flow.