### PR TITLE
[PERFORMANCE] [MER-4342] Eliminate page revision from analytics base query

### DIFF
--- a/lib/oli/analytics/summary/attempt_group.ex
+++ b/lib/oli/analytics/summary/attempt_group.ex
@@ -45,10 +45,10 @@ defmodule Oli.Analytics.Summary.AttemptGroup do
   def from_attempt_summary([], _project_id, _host_name), do: nil
 
   def from_attempt_summary(attempt_summary, project_id, host_name) do
-    {_, _, ra, _, page_revision, _} = List.first(attempt_summary)
+    {_, _, ra, resource_access, _} = List.first(attempt_summary)
 
     part_attempts =
-      Enum.map(attempt_summary, fn {pa, aa, _, _, _, ar} ->
+      Enum.map(attempt_summary, fn {pa, aa, _, _, ar} ->
         Map.merge(pa, %{
           activity_attempt: aa,
           activity_revision: ar
@@ -56,11 +56,11 @@ defmodule Oli.Analytics.Summary.AttemptGroup do
       end)
 
     activity_attempts =
-      Enum.map(attempt_summary, fn {_, aa, _, _, _, _} -> aa end)
+      Enum.map(attempt_summary, fn {_, aa, _, _, _} -> aa end)
       |> Enum.filter(fn activity_attempt -> activity_attempt.lifecycle_state == :evaluated end)
       |> Enum.dedup()
 
-    resource_attempt = Map.merge(ra, %{resource_id: page_revision.resource_id})
+    resource_attempt = Map.merge(ra, %{resource_id: resource_access.resource_id})
 
     context = build_context(attempt_summary, project_id, host_name)
 
@@ -72,7 +72,7 @@ defmodule Oli.Analytics.Summary.AttemptGroup do
     }
   end
 
-  defp build_context([{_, _, _, access, _, _} | _rest], project_id, host_name) do
+  defp build_context([{_, _, _, access, _} | _rest], project_id, host_name) do
     %Context{
       host_name: host_name,
       user_id: access.user_id,

--- a/lib/oli/delivery/snapshots/worker.ex
+++ b/lib/oli/delivery/snapshots/worker.ex
@@ -50,12 +50,10 @@ defmodule Oli.Delivery.Snapshots.Worker do
         on: aa.resource_attempt_id == ra.id,
         join: a in ResourceAccess,
         on: ra.resource_access_id == a.id,
-        join: r1 in Revision,
-        on: ra.revision_id == r1.id,
         join: r2 in Revision,
         on: aa.revision_id == r2.id,
         where: pa.attempt_guid in ^part_attempt_guids and pa.lifecycle_state == :evaluated,
-        select: {pa, aa, ra, a, r1, r2}
+        select: {pa, aa, ra, a, r2}
       )
       |> Repo.all()
 
@@ -65,7 +63,7 @@ defmodule Oli.Delivery.Snapshots.Worker do
         [] ->
           Oli.Delivery.Sections.get_section_by_slug(section_slug).base_project_id
 
-        [{_, _, _, ra, _, _} | _] ->
+        [{_, _, _, ra, _} | _] ->
           Oli.Delivery.Sections.determine_which_project_id(ra.section_id, ra.resource_id)
       end
 


### PR DESCRIPTION
The base query that runs to pull all the info needed to execute the summary analytics pipeline and to emit xAPI statements includes the full page revision **joined through to every part attempt returned**.  The page revision was only being used to get the resource_id, which can instead be retrieved from the already included `ResourceAccess`.   This PR removes the page revision, lowering the overall overhead of this query. 