### PR TITLE
[BUG FIX] [MER-4324] Fixes an issue where sometimes launching a modal requires a page refresh

### DIFF
--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -121,5 +121,4 @@
       Map.get(assigns, :has_license) && assigns[:license]
     } />
   </div>
-  <%= react_component("Components.ModalDisplay") %>
 </main>

--- a/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/activity_bank_live.ex
@@ -49,7 +49,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLive do
             id: "activity-bank"
           ) %>
         </div>
-        <%= React.component(@ctx, "Components.ModalDisplay", %{}, id: "modal-display") %>
       <% else %>
         <.loader />
       <% end %>

--- a/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/bibliography_live.ex
@@ -44,8 +44,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.BibliographyLive do
     <div :if={!@error} id="editor" phx-update="ignore">
       <%= React.component(@ctx, "Components.Bibliography", @context, id: "bibliography") %>
     </div>
-
-    <%= React.component(@ctx, "Components.ModalDisplay", @context, id: "modal-display") %>
     """
   end
 end

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -154,6 +154,8 @@
 
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
 
+    <%= react_component("Components.ModalDisplay") %>
+
     <%= render(OliWeb.SharedView, "_help.html", conn: @conn) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -160,6 +160,8 @@
 
     <%= Map.get(assigns, :inner_layout) || @inner_content %>
 
+    <%= react_component("Components.ModalDisplay") %>
+
     <%= render(OliWeb.SharedView, "_help.html", conn: @conn) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/workspace.html.heex
+++ b/lib/oli_web/templates/layout/workspace.html.heex
@@ -31,6 +31,4 @@
       </div>
     </div>
   </div>
-
-  <%= react_component("Components.ModalDisplay") %>
 <% end %>

--- a/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
@@ -56,7 +56,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLiveTest do
       refute has_element?(view, "#eventIntercept [role='status']")
 
       assert has_element?(view, ~s(div[data-live-react-class='Components.ActivityBank']))
-      assert has_element?(view, ~s(div[data-live-react-class='Components.ModalDisplay']))
     end
 
     test "renders error message when failed to load scripts", %{conn: conn, project: project} do


### PR DESCRIPTION
This PR addresses issues described in both [MER-4324 ](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4324)and [MER-4325](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4325). 

The problem was that every time a live component remounts due to a change in navigation, a new react `Components.ModalDisplay` web component is rendered but never registered in the web component's global scope. 

The solution was to shift the react component `Components.ModalDisplay` placement out of particular live components into the `delivery` and `authoring` layout templates. 

[MER-4325]: https://eliterate.atlassian.net/browse/MER-4325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ