### PR TITLE
[BUG FIX] [MER-4246] Fix youtube URL parsing to handle "share"-generated urls

### DIFF
--- a/assets/src/components/editing/elements/youtube/youtubeActions.tsx
+++ b/assets/src/components/editing/elements/youtube/youtubeActions.tsx
@@ -10,21 +10,29 @@ import { getQueryVariableFromString } from 'utils/params';
 export const youtubeUrlToId = (src?: string | null) => {
   if (!src) return null;
 
-  // https://www.youtube.com/embed/W98qXD35kXY
+  // check for query string including a v param
+  // e.g. http://youtube.com/watch?v=W98qXD35kXY&list=x8wefc
+  const [urlBase, queryString] = src.split('?');
+  if (queryString) {
+    const vParam = getQueryVariableFromString('v', queryString);
+    if (vParam !== '') return vParam;
+  }
+
+  // else examine urlBase = url w/any query string stripped
+
+  // embed url form https://www.youtube.com/embed/W98qXD35kXY
   const embedRegex = /embed\/([a-zA-Z0-9_-]+)/;
-  const match = embedRegex.exec(src);
+  const match = embedRegex.exec(urlBase);
   if (match) {
     return match[1];
   }
 
-  const hasParams = src.includes('?');
-  if (hasParams) {
-    const queryString = src.substr(src.indexOf('?') + 1);
-    src = getQueryVariableFromString('v', queryString);
-  } else if (src.indexOf('/youtu.be/') !== -1) {
-    src = src.substr(src.lastIndexOf('/') + 1);
+  // short url form https://youtu.be/W98qXD35kXY
+  if (urlBase.indexOf('/youtu.be/') !== -1) {
+    return urlBase.substr(src.lastIndexOf('/') + 1);
   }
 
+  // else treat as bare video id
   return src;
 };
 


### PR DESCRIPTION
For about a year now, hitting "share" for a video on youtube generates a URL of the form
`https://youtu.be/_gnfkFb8h3U?si=aw76mRazP7ZRHNDl`
where the “si” parameter is a token appended to allow google to track the sharing of videos. Torus'  insert youtube dialog was failing silently on these. But it is natural for authors to obtain a URL via the "share" button. 

The bug stemmed from an error in parsing logic used to extract the video id from a URL. The code  in effect assumed that if the URL had a query parameter at all, it must be the video id parameter as used in the "watch" form URL `https://youtube.com/watch?v=_gnfkFb8h3U` However, query parameters can be included in other form URLs as seen above (and other query parameters are possible in any form). 

This PR recodes the relevant routine to avoid that problem, examining query parameters for a video id first, and then examining the URL "base" with any query parameters stripped for the other recognized URL forms.