### PR TITLE
[ENHANCEMENT] [MER-4306] mobile responsiveness design chisel

### DIFF
--- a/lib/oli_web/backgrounds.ex
+++ b/lib/oli_web/backgrounds.ex
@@ -562,7 +562,7 @@ defmodule OliWeb.Backgrounds do
 
   def enrollment_info(assigns) do
     ~H"""
-    <div class="flex justify-end relative w-full h-[427px]">
+    <div class="flex justify-end relative w-full min-h-[427px]">
       <img
         src="/images/enrollment_info.png"
         alt="A student looks at her computer to browse course topics."

--- a/lib/oli_web/components/auth.ex
+++ b/lib/oli_web/components/auth.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.Components.Auth do
 
   def login_form(assigns) do
     ~H"""
-    <div class={["w-96 dark:bg-neutral-700 sm:rounded-md sm:shadow-lg dark:text-white", @class]}>
+    <div class={["w-96 dark:bg-neutral-700 rounded-md sm:shadow-lg dark:text-white", @class]}>
       <div class="text-center text-xl font-normal leading-7 py-8">
         <%= @title %>
       </div>
@@ -130,7 +130,7 @@ defmodule OliWeb.Components.Auth do
   def registration_form(assigns) do
     ~H"""
     <div class={[
-      "w-96 dark:bg-neutral-700 sm:rounded-md sm:shadow-lg dark:text-white",
+      "w-96 dark:bg-neutral-700 rounded-md sm:shadow-lg dark:text-white",
       @class
     ]}>
       <div class="text-center text-xl font-normal leading-7 py-8">

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -890,7 +890,7 @@ defmodule OliWeb.Components.Common do
 
   def hero_banner(assigns) do
     ~H"""
-    <div class={["w-full bg-cover bg-center bg-no-repeat py-24 px-16", @class]}>
+    <div class={["w-full bg-cover bg-center bg-no-repeat py-12 md:py-24 px-8 md:px-16", @class]}>
       <div class="container mx-auto flex flex-col">
         <%= render_slot(@inner_block) %>
       </div>

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -588,13 +588,14 @@ defmodule OliWeb.Components.Common do
     end
   end
 
-  attr(:if, :boolean, default: true)
+  attr(:class, :string, default: nil)
+  attr(:icon_class, :string, default: nil)
 
   def loader(assigns) do
     ~H"""
-    <div :if={@if} class="h-full w-full flex items-center justify-center">
+    <div class={@class || "flex items-center justify-center"}>
       <span
-        class="spinner-border spinner-border-sm text-primary h-16 w-16"
+        class={["spinner-border spinner-border-sm text-primary", @icon_class]}
         role="status"
         aria-hidden="true"
       />

--- a/lib/oli_web/components/delivery/instructor_dashboard.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard.ex
@@ -173,7 +173,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard do
       <div class="container mx-auto flex flex-row">
         <div class="flex items-center">
           <a
-            class="navbar-brand dark torus-logo my-1 mr-auto"
+            class="navbar-brand dark torus-logo shrink-0 my-1 mr-auto"
             href={logo_link(@section, @preview_mode)}
           >
             <%= if assigns[:section],

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -52,7 +52,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <div
       id="header"
-      class="sticky top-0 z-50 w-full py-2.5 h-14 flex flex-row bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]"
+      class="sticky top-0 z-50 w-full py-2.5 h-14 flex flex-row gap-6 bg-delivery-header dark:bg-black border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]"
     >
       <.link
         :if={@include_logo}
@@ -62,11 +62,8 @@ defmodule OliWeb.Components.Delivery.Layouts do
       >
         <.logo_img section={@section} />
       </.link>
-      <div class={[
-        if(@sidebar_expanded, do: "md:!pl-[226px]"),
-        "w-full flex flex-row md:pl-[95px]"
-      ]}>
-        <div class="flex items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']">
+      <div class="flex flex-row flex-1 justify-between">
+        <div class="flex hidden md:flex items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']">
           <.title section={@section} project={@project} preview_mode={@preview_mode} />
         </div>
         <div class="justify-end items-center flex">
@@ -81,7 +78,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             />
           </div>
         </div>
-        <div class="flex items-center p-2 ml-auto">
+        <div class="flex items-center p-2">
           <button
             class={[
               "py-1.5 px-3 rounded border border-transparent hover:border-gray-300 active:bg-gray-100",
@@ -101,12 +98,14 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:project, Project, default: nil)
   attr(:preview_mode, :boolean)
 
+  attr :rest, :global, include: ~w(class)
+
   def title(assigns) do
     ~H"""
-    <span :if={@section} class="text-2xl text-bold hidden md:block">
+    <span :if={@section} class={["text-2xl text-bold", @rest[:class]]}>
       <%= @section.title %><%= if @preview_mode, do: " (Preview Mode)" %>
     </span>
-    <span :if={@project} class="text-2xl text-bold hidden md:block">
+    <span :if={@project} class={["text-2xl text-bold", @rest[:class]]}>
       <%= @project.title %>
     </span>
     """

--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -69,7 +69,7 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
   def render(assigns) do
     ~H"""
     <div>
-      <.loader if={!@table_model} />
+      <.loader :if={!@table_model} />
       <div :if={@table_model} class="bg-white shadow-sm dark:bg-gray-800 dark:text-white">
         <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:justify-between px-9 lg:items-center">
           <h4 class="torus-h4 whitespace-nowrap">Practice Activities</h4>

--- a/lib/oli_web/components/delivery/schedule.ex
+++ b/lib/oli_web/components/delivery/schedule.ex
@@ -73,48 +73,50 @@ defmodule OliWeb.Components.Delivery.Schedule do
                     } <- scheduled_resources do %>
                     <div class="flex flex-row gap-4 mb-3">
                       <.page_icon progress={progress} graded={graded} purpose={purpose} />
-                      <div class="flex-1">
-                        <.link
-                          href={
-                            Utils.lesson_live_path(@section_slug, resource.revision_slug,
-                              request_path: @request_path
-                            )
-                          }
-                          class="hover:no-underline"
-                        >
-                          <%= resource.title %>
-                        </.link>
+                      <div class="flex flex-col md:flex-row gap-2 md:gap-6">
+                        <div class="flex-1">
+                          <.link
+                            href={
+                              Utils.lesson_live_path(@section_slug, resource.revision_slug,
+                                request_path: @request_path
+                              )
+                            }
+                            class="hover:no-underline"
+                          >
+                            <%= resource.title %>
+                          </.link>
 
-                        <div class="text-sm text-gray-700 dark:text-gray-300 group-[.past-start]:text-gray-400 dark:group-[.past-start]:text-gray-700">
-                          <%= resource_scheduling_label(resource.scheduling_type) %>
-                          <%= if is_nil(effective_settings),
-                            do:
-                              date(
-                                Utils.coalesce(resource.end_date, resource.start_date),
-                                ctx: @ctx,
-                                precision: :date
-                              ),
-                            else:
-                              date(
-                                Utils.coalesce(
-                                  effective_settings.end_date,
-                                  effective_settings.start_date
+                          <div class="text-sm text-gray-700 dark:text-gray-300 group-[.past-start]:text-gray-400 dark:group-[.past-start]:text-gray-700">
+                            <%= resource_scheduling_label(resource.scheduling_type) %>
+                            <%= if is_nil(effective_settings),
+                              do:
+                                date(
+                                  Utils.coalesce(resource.end_date, resource.start_date),
+                                  ctx: @ctx,
+                                  precision: :date
                                 ),
-                                ctx: @ctx,
-                                precision: :date
-                              ) %>
+                              else:
+                                date(
+                                  Utils.coalesce(
+                                    effective_settings.end_date,
+                                    effective_settings.start_date
+                                  ),
+                                  ctx: @ctx,
+                                  precision: :date
+                                ) %>
+                          </div>
                         </div>
-                      </div>
-                      <div :if={graded} class="flex flex-col">
-                        <Student.attempts_dropdown
-                          ctx={@ctx}
-                          section_slug={@section_slug}
-                          page_revision_slug={resource.revision_slug}
-                          attempt_summary={@historical_graded_attempt_summary}
-                          attempts_count={resource_attempt_count}
-                          effective_settings={effective_settings}
-                        />
-                        <Student.score_summary raw_avg_score={raw_avg_score} />
+                        <div :if={graded} class="flex flex-col justify-center">
+                          <Student.attempts_dropdown
+                            ctx={@ctx}
+                            section_slug={@section_slug}
+                            page_revision_slug={resource.revision_slug}
+                            attempt_summary={@historical_graded_attempt_summary}
+                            attempts_count={resource_attempt_count}
+                            effective_settings={effective_settings}
+                          />
+                          <Student.score_summary raw_avg_score={raw_avg_score} />
+                        </div>
                       </div>
                     </div>
                   <% end %>
@@ -148,7 +150,7 @@ defmodule OliWeb.Components.Delivery.Schedule do
                 title={title}
               />
 
-              <div class="flex flex-col my-6 mx-10">
+              <div class="flex flex-col my-6 ml-10">
                 <%= for %ScheduledSectionResource{
                       resource: resource,
                       purpose: purpose,
@@ -167,28 +169,30 @@ defmodule OliWeb.Components.Delivery.Schedule do
                         </div>
                       </div>
                     </div>
-                    <div class="flex-1">
-                      <.link
-                        href={
-                          Utils.lesson_live_path(@section_slug, resource.revision_slug,
-                            request_path: @request_path
-                          )
-                        }
-                        class="text-left dark:text-white opacity-90 text-base font-['Open Sans'] hover:no-underline"
-                      >
-                        <%= resource.title %>
-                      </.link>
-                    </div>
-                    <div :if={graded} class="flex flex-col">
-                      <Student.attempts_dropdown
-                        ctx={@ctx}
-                        section_slug={@section_slug}
-                        page_revision_slug={resource.revision_slug}
-                        attempt_summary={@historical_graded_attempt_summary}
-                        attempts_count={resource_attempt_count}
-                        effective_settings={effective_settings}
-                      />
-                      <Student.score_summary raw_avg_score={raw_avg_score} />
+                    <div class="flex flex-col md:flex-row gap-2 md:gap-6">
+                      <div class="flex-1">
+                        <.link
+                          href={
+                            Utils.lesson_live_path(@section_slug, resource.revision_slug,
+                              request_path: @request_path
+                            )
+                          }
+                          class="text-left dark:text-white opacity-90 text-base font-['Open Sans'] hover:no-underline"
+                        >
+                          <%= resource.title %>
+                        </.link>
+                      </div>
+                      <div :if={graded} class="flex flex-col justify-center">
+                        <Student.attempts_dropdown
+                          ctx={@ctx}
+                          section_slug={@section_slug}
+                          page_revision_slug={resource.revision_slug}
+                          attempt_summary={@historical_graded_attempt_summary}
+                          attempts_count={resource_attempt_count}
+                          effective_settings={effective_settings}
+                        />
+                        <Student.score_summary raw_avg_score={raw_avg_score} />
+                      </div>
                     </div>
                   </div>
                 <% end %>

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -145,7 +145,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
           </div>
         </div>
       </button>
-      <.loader if={!@table_model} />
+      <.loader :if={!@table_model} />
       <div :if={@table_model} class="bg-white shadow-sm dark:bg-gray-800 dark:text-white">
         <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:justify-between px-9">
           <%= if @current_assessment != nil do %>

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.Components.Delivery.Student do
     <div class="self-stretch justify-start items-start gap-6 inline-flex relative mb-1">
       <button
         id={"#{@id}-dropdown-button"}
-        class="opacity-80 dark:text-white text-sm font-bold font-['Open Sans'] uppercase no-wrap tracking-wider"
+        class="opacity-80 dark:text-white text-sm font-bold font-['Open Sans'] uppercase whitespace-nowrap tracking-wider"
         phx-click={show_attempts_dropdown("##{@id}-dropdown", @page_revision_slug)}
         phx-value-hide-target={"##{@id}-dropdown"}
       >

--- a/lib/oli_web/components/delivery/surveys/surveys.ex
+++ b/lib/oli_web/components/delivery/surveys/surveys.ex
@@ -63,7 +63,7 @@ defmodule OliWeb.Components.Delivery.Surveys do
   def render(assigns) do
     ~H"""
     <div>
-      <.loader if={!@table_model} />
+      <.loader :if={!@table_model} />
       <div :if={@table_model} class="bg-white shadow-sm dark:bg-gray-800 dark:text-white">
         <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:justify-between px-9 lg:items-center">
           <h4 class="torus-h4 whitespace-nowrap">Surveys</h4>

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -105,21 +105,23 @@ defmodule OliWeb.Components.Header do
       <a class="navbar-brand torus-logo shrink-0 my-1 mr-auto" href={~p"/"}>
         <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
       </a>
-      <.sign_in_button href="/instructors/log_in" request_path={assigns.conn.request_path}>
-        For Instructors
-      </.sign_in_button>
-      <.sign_in_button href="/authors/log_in" request_path={assigns.conn.request_path}>
-        For Course Authors
-      </.sign_in_button>
-      <.button
-        id="support-button"
-        href="#"
-        class="pt-[12px] text-high-24 hover:text-high-24 hover:underline hover:underline-offset-8"
-        onclick="window.showHelpModal();"
-        phx-click={JS.dispatch("maybe_add_underline_classes", to: "#help-modal")}
-      >
-        Support
-      </.button>
+      <div class="hidden md:flex">
+        <.sign_in_button href="/instructors/log_in" request_path={assigns.conn.request_path}>
+          For Instructors
+        </.sign_in_button>
+        <.sign_in_button href="/authors/log_in" request_path={assigns.conn.request_path}>
+          For Course Authors
+        </.sign_in_button>
+        <.button
+          id="support-button"
+          href="#"
+          class="pt-[12px] text-high-24 hover:text-high-24 hover:underline hover:underline-offset-8"
+          onclick="window.showHelpModal();"
+          phx-click={JS.dispatch("maybe_add_underline_classes", to: "#help-modal")}
+        >
+          Support
+        </.button>
+      </div>
     </nav>
     """
   end

--- a/lib/oli_web/components/header.ex
+++ b/lib/oli_web/components/header.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Components.Header do
     <nav class="navbar py-1 bg-delivery-header dark:bg-delivery-header-dark shadow-sm">
       <div class="container mx-auto flex flex-row">
         <a
-          class="navbar-brand torus-logo my-1 mr-auto"
+          class="navbar-brand torus-logo shrink-0 my-1 mr-auto"
           href={
             case assigns[:logo_link] do
               nil ->
@@ -102,7 +102,7 @@ defmodule OliWeb.Components.Header do
   def delivery_header(assigns) do
     ~H"""
     <nav class="bg-primary-24 dark h-[111px] flex items-center pl-4 pr-10">
-      <a class="navbar-brand torus-logo my-1 mr-auto" href={~p"/"}>
+      <a class="navbar-brand torus-logo shrink-0 my-1 mr-auto" href={~p"/"}>
         <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>
       </a>
       <.sign_in_button href="/instructors/log_in" request_path={assigns.conn.request_path}>

--- a/lib/oli_web/components/layouts/instructor_dashboard.html.heex
+++ b/lib/oli_web/components/layouts/instructor_dashboard.html.heex
@@ -13,10 +13,7 @@
   />
 
   <div class="relative flex-1 flex flex-col pt-4 pb-[60px]">
-    <div
-      :if={assigns[:params]["active_tab"] != "settings"}
-      class="container mx-auto sticky top-16 z-50"
-    >
+    <div class="container mx-auto sticky top-16 z-50">
       <.flash_group flash={@flash} />
     </div>
 

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -6,6 +6,7 @@
       section={@section}
       preview_mode={@preview_mode}
       sidebar_expanded={@sidebar_expanded}
+      include_logo={true}
     />
     <div class="absolute top-0 z-50">
       <Components.Delivery.Layouts.sidebar_nav

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -160,7 +160,7 @@ defmodule OliWeb.DeliveryController do
           end
 
         _ ->
-          ~p"/course"
+          ~p"/sections"
       end
 
     institution = Institutions.get_institution_by_lti_user(user)

--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -423,7 +423,7 @@ defmodule OliWeb.LtiController do
                   # sign current user in and redirect to home page
                   conn
                   |> UserAuth.create_session(user)
-                  |> redirect(to: "/course")
+                  |> redirect(to: "/sections")
               end
 
             {:error, changeset} ->

--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -63,7 +63,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
   def render(assigns) do
     ~H"""
     <.top_hero_banner />
-    <div class="flex justify-center py-9 px-20 w-full">
+    <div class="flex justify-center py-9 px-3 md:px-20 w-full">
       <.assignments_agenda assignments={@assignments} ctx={@ctx} section_slug={@section.slug} />
     </div>
     """
@@ -73,11 +73,11 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
     ~H"""
     <div
       role="hero banner"
-      class="w-full bg-cover bg-center bg-no-repeat h-[247px]"
+      class="w-full bg-cover bg-center bg-no-repeat h-[160px] h-[247px]"
       style="background-image: url('/images/gradients/assignments-bg.png');"
     >
-      <div class="h-[247px] bg-gradient-to-r from-[#e4e4ea] dark:from-[#0a0b11] to-transparent">
-        <h1 class="py-20 pl-[76px] text-4xl md:text-6xl font-normal tracking-tight dark:text-white">
+      <div class="h-[160px] md:h-[247px] bg-gradient-to-r from-[#e4e4ea] dark:from-[#0a0b11] to-transparent">
+        <h1 class="py-12 md:py-20 pl-[76px] text-4xl md:text-6xl font-normal tracking-tight dark:text-white">
           Assignments
         </h1>
       </div>

--- a/lib/oli_web/live/delivery/student/explorations_live.ex
+++ b/lib/oli_web/live/delivery/student/explorations_live.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Delivery.Student.ExplorationsLive do
       <p>All your explorations in one place.</p>
       <p>You unlock explorations as you solve problems and gain useful skills.</p>
     </.hero_banner>
-    <div class="overflow-x-scroll md:overflow-x-auto container mx-auto flex flex-col mt-6 px-16">
+    <div class="overflow-x-scroll md:overflow-x-auto container mx-auto flex flex-col mt-6 px-3 md:px-16">
       <div :if={Enum.count(@explorations_by_container) == 0} class="text-center" role="alert">
         <h6>There are no explorations available</h6>
       </div>

--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -377,10 +377,10 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
             <% resource_completed = resource.progress == 100 %>
             <div
               role="group_item"
-              class="w-full flex self-stretch pl-7 pr-4 py-2.5 rounded-lg justify-start items-start gap-5 hover:bg-[#000000]/5 dark:hover:bg-[#FFFFFF]/5 hover:font-medium hover:cursor-pointer"
+              class="w-full flex self-stretch px-3 md:pl-7 pr-4 py-2.5 rounded-lg justify-start items-start gap-2 md:gap-5 hover:bg-[#000000]/5 dark:hover:bg-[#FFFFFF]/5 hover:font-medium hover:cursor-pointer"
             >
-              <div class="grow shrink h-auto justify-start items-start gap-5 flex">
-                <div class="justify-start items-start gap-5 flex">
+              <div class="grow shrink h-auto justify-start items-start gap-2 md:gap-5 flex">
+                <div class="justify-start items-start gap-2 md:gap-5 flex">
                   <div class="w-5 h-5 flex-col justify-center items-center inline-flex">
                     <div class="justify-center items-center inline-flex">
                       <Icons.check :if={resource_completed} progress={1.0} />

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -236,7 +236,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
       <div
         :if={!is_nil(@suggested_page)}
-        class="flex flex-col w-full px-9 absolute flex-col justify-center items-start gap-2 md:gap-6"
+        class="flex flex-col w-full px-3 md:px-9 absolute flex-col justify-center items-start gap-2 md:gap-6"
       >
         <h3 class="text-white text-lg md:text-2xl font-bold leading-loose tracking-tight">
           Continue Learning
@@ -344,22 +344,20 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         </div>
       </div>
 
-      <div class="w-full pl-14 pr-5 absolute flex flex-col justify-center items-start gap-6">
-        <div class="w-full text-white text-2xl font-bold tracking-wide whitespace-nowrap overflow-hidden">
+      <div class="flex flex-col w-full px-9 absolute flex-col justify-center items-start gap-2 md:gap-6">
+        <h3 class="w-full text-white text-2xl font-bold tracking-wide">
           Hi, <%= user_given_name(@ctx) %> !
-        </div>
-        <div class="w-full flex flex-col items-start gap-2.5">
-          <div class="w-full whitespace-nowrap overflow-hidden">
-            <span class="text-3xl text-white font-medium">
-              <%= build_welcome_title(@section.welcome_title) %>
-            </span>
-          </div>
-          <div class="w-96 text-white/60 text-lg font-semibold">
+        </h3>
+        <div class="flex flex-col items-start gap-2.5">
+          <h4 class="text-3xl text-white font-medium">
+            <%= build_welcome_title(@section.welcome_title) %>
+          </h4>
+          <div class="text-white/60 text-lg font-semibold">
             <%= @section.encouraging_subtitle ||
               "Dive Into Discovery. Begin Your Learning Adventure Now!" %>
           </div>
         </div>
-        <div class="pt-5 flex items-start gap-6">
+        <div class="flex flex-col md:flex-row w-full justify-end items-start gap-3.5">
           <.link
             href={
               Utils.lesson_live_path(
@@ -368,17 +366,20 @@ defmodule OliWeb.Delivery.Student.IndexLive do
                 request_path: ~p"/sections/#{@section_slug}"
               )
             }
-            class="hover:no-underline"
+            class="w-full md:w-auto hover:no-underline"
           >
-            <div class="w-52 h-11 px-5 py-2.5 bg-blue-600 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-blue-500">
-              <div class="text-white text-base font-bold leading-tight">
+            <div class="px-5 py-2.5 bg-blue-600 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-blue-500">
+              <div class="text-white text-base font-bold leading-tight whitespace-nowrap">
                 Start course
               </div>
             </div>
           </.link>
-          <.link href={Utils.learn_live_path(@section_slug)} class="hover:no-underline">
-            <div class="w-52 h-11 px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-opacity-40">
-              <div class="text-white text-base font-semibold leading-tight">
+          <.link
+            href={Utils.learn_live_path(@section_slug)}
+            class="w-full md:w-auto hover:no-underline"
+          >
+            <div class="px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-opacity-40">
+              <div class="text-white text-base font-semibold leading-tight whitespace-nowrap">
                 Discover content
               </div>
             </div>

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -171,9 +171,9 @@ defmodule OliWeb.Delivery.Student.IndexLive do
       suggested_page={@last_open_and_unfinished_page || @nearest_upcoming_lesson}
       unfinished_lesson={!is_nil(@last_open_and_unfinished_page)}
     />
-    <div id="home-view" class="w-full h-full bg-stone-950 dark:text-white" phx-hook="Countdown">
-      <div class="w-full p-8 justify-start items-start gap-6 inline-flex">
-        <div class="w-2/5 h-48 flex-col justify-start items-start gap-6 inline-flex">
+    <div id="home-view" class="bg-stone-950 dark:text-white" phx-hook="Countdown">
+      <div class="flex flex-col md:flex-row p-3 md:p-8 justify-start items-start gap-6">
+        <div class="flex flex-col-reverse md:flex-col w-full md:w-2/5 md:h-48 justify-start items-start gap-6">
           <.assignments
             upcoming_assignments={@upcoming_assignments}
             latest_assignments={@latest_assignments}
@@ -196,7 +196,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
         <div
           :if={@section.agenda && not is_nil(@grouped_agenda_resources)}
-          class="w-3/5 h-full flex-col justify-start items-start gap-6 inline-flex"
+          class="flex flex-col w-full md:w-3/5 justify-start items-start gap-6"
         >
           <.agenda
             section_slug={@section_slug}
@@ -219,109 +219,107 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
   defp header_banner(%{has_visited_section: true} = assigns) do
     ~H"""
-    <div class="relative">
-      <div class="w-full h-72 relative flex items-center">
-        <div class="inset-0 absolute">
-          <div class="inset-0 absolute bg-purple-700 bg-opacity-50"></div>
-          <img
-            src="/images/gradients/home-bg.png"
-            alt="Background Image"
-            class="absolute inset-0 w-full h-full object-cover border border-gray-300 dark:border-black mix-blend-luminosity"
-          />
-          <div class="absolute inset-0 opacity-60">
-            <div class="absolute left-[1250px] top-0 origin-top-left rotate-180 bg-gradient-to-r from-white to-white">
-            </div>
-            <div class="absolute inset-0 bg-gradient-to-r from-blue-700 to-cyan-500"></div>
+    <div class="w-full h-[20rem] md:h-72 relative flex items-center">
+      <div class="inset-0 absolute">
+        <div class="inset-0 absolute bg-purple-700 bg-opacity-50"></div>
+        <img
+          src="/images/gradients/home-bg.png"
+          alt="Background Image"
+          class="absolute inset-0 w-full h-full object-cover border border-gray-300 dark:border-black mix-blend-luminosity"
+        />
+        <div class="absolute inset-0 opacity-60">
+          <div class="absolute left-[1250px] top-0 origin-top-left rotate-180 bg-gradient-to-r from-white to-white">
           </div>
+          <div class="absolute inset-0 bg-gradient-to-r from-blue-700 to-cyan-500"></div>
         </div>
+      </div>
 
-        <div
-          :if={!is_nil(@suggested_page)}
-          class="w-full px-9 absolute flex-col justify-center items-start gap-6 inline-flex"
-        >
-          <div class="text-white text-2xl font-bold leading-loose tracking-tight">
-            Continue Learning
+      <div
+        :if={!is_nil(@suggested_page)}
+        class="flex flex-col w-full px-9 absolute flex-col justify-center items-start gap-2 md:gap-6"
+      >
+        <h3 class="text-white text-lg md:text-2xl font-bold leading-loose tracking-tight">
+          Continue Learning
+        </h3>
+        <div class="flex flex-col lg:flex-row self-stretch p-6 bg-zinc-900 bg-opacity-40 rounded-xl justify-between lg:items-end gap-3">
+          <div class="flex-col justify-center items-start gap-3.5 inline-flex">
+            <div class="self-stretch h-3 justify-start items-center gap-3.5 inline-flex">
+              <div
+                :if={show_page_module?(@suggested_page)}
+                class="justify-start items-start gap-1 flex"
+              >
+                <div class="opacity-50 text-white text-sm font-bold uppercase tracking-tight">
+                  Module <%= @suggested_page.module_index %>
+                </div>
+              </div>
+              <div class="grow shrink basis-0 h-5 justify-start items-center gap-1 flex">
+                <div class="text-right text-white text-sm font-bold">Due:</div>
+                <div class="text-right text-white text-sm font-bold">
+                  <%= format_date(
+                    @suggested_page.end_date,
+                    @ctx,
+                    "{WDshort} {Mshort} {D}, {YYYY}"
+                  ) %>
+                </div>
+              </div>
+            </div>
+            <div class="justify-start items-center gap-10 inline-flex">
+              <div class="justify-start items-center gap-5 flex">
+                <div class="py-0.5 justify-start items-start gap-2.5 flex">
+                  <div class="text-white text-xs font-semibold">
+                    <%= @suggested_page.numbering_index %>
+                  </div>
+                </div>
+                <div class="flex-col justify-center items-start gap-1 inline-flex">
+                  <div class="text-white md:text-lg font-semibold">
+                    <%= @suggested_page.title %>
+                  </div>
+                </div>
+              </div>
+              <div
+                :if={@suggested_page.duration_minutes}
+                class="w-36 self-stretch justify-end items-center gap-1.5 flex"
+              >
+                <div class="h-6 px-2 py-1 bg-white bg-opacity-10 rounded-xl shadow justify-end items-center gap-1 flex">
+                  <div class="text-white text-xs font-semibold">
+                    Estimated time <%= @suggested_page.duration_minutes %> m
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="self-stretch p-6 bg-zinc-900 bg-opacity-40 rounded-xl justify-between items-end inline-flex">
-            <div class="flex-col justify-center items-start gap-3.5 inline-flex">
-              <div class="self-stretch h-3 justify-start items-center gap-3.5 inline-flex">
-                <div
-                  :if={show_page_module?(@suggested_page)}
-                  class="justify-start items-start gap-1 flex"
-                >
-                  <div class="opacity-50 text-white text-sm font-bold uppercase tracking-tight">
-                    Module <%= @suggested_page.module_index %>
-                  </div>
-                </div>
-                <div class="grow shrink basis-0 h-5 justify-start items-center gap-1 flex">
-                  <div class="text-right text-white text-sm font-bold">Due:</div>
-                  <div class="text-right text-white text-sm font-bold">
-                    <%= format_date(
-                      @suggested_page.end_date,
-                      @ctx,
-                      "{WDshort} {Mshort} {D}, {YYYY}"
-                    ) %>
-                  </div>
+          <div class="flex flex-col md:flex-row justify-end items-start gap-3.5">
+            <.link
+              href={
+                Utils.lesson_live_path(
+                  @section_slug,
+                  @suggested_page.slug,
+                  request_path: ~p"/sections/#{@section_slug}"
+                )
+              }
+              class="w-full hover:no-underline"
+            >
+              <div class="px-5 py-2.5 bg-blue-600 rounded-lg shadow justify-center items-center gap-2.5 flex hover:bg-blue-500">
+                <div class="text-white text-sm font-bold leading-tight whitespace-nowrap">
+                  <%= lesson_button_label(@unfinished_lesson, @suggested_page) %>
                 </div>
               </div>
-              <div class="justify-start items-center gap-10 inline-flex">
-                <div class="justify-start items-center gap-5 flex">
-                  <div class="py-0.5 justify-start items-start gap-2.5 flex">
-                    <div class="text-white text-xs font-semibold">
-                      <%= @suggested_page.numbering_index %>
-                    </div>
-                  </div>
-                  <div class="flex-col justify-center items-start gap-1 inline-flex">
-                    <div class="text-white text-lg font-semibold">
-                      <%= @suggested_page.title %>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  :if={@suggested_page.duration_minutes}
-                  class="w-36 self-stretch justify-end items-center gap-1.5 flex"
-                >
-                  <div class="h-6 px-2 py-1 bg-white bg-opacity-10 rounded-xl shadow justify-end items-center gap-1 flex">
-                    <div class="text-white text-xs font-semibold">
-                      Estimated time <%= @suggested_page.duration_minutes %> m
-                    </div>
-                  </div>
+            </.link>
+            <.link
+              href={
+                Utils.learn_live_path(@section_slug,
+                  target_resource_id: @suggested_page.resource_id,
+                  request_path: ~p"/sections/#{@section_slug}"
+                )
+              }
+              class="w-full hover:no-underline"
+            >
+              <div class="px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow justify-center items-center gap-2.5 flex hover:bg-opacity-40">
+                <div class="text-white text-sm font-semibold leading-tight whitespace-nowrap">
+                  Show in course
                 </div>
               </div>
-            </div>
-            <div class="justify-start items-start gap-3.5 flex">
-              <.link
-                href={
-                  Utils.lesson_live_path(
-                    @section_slug,
-                    @suggested_page.slug,
-                    request_path: ~p"/sections/#{@section_slug}"
-                  )
-                }
-                class="hover:no-underline"
-              >
-                <div class="w-full h-10 px-5 py-2.5 bg-blue-600 rounded-lg shadow justify-center items-center gap-2.5 flex hover:bg-blue-500">
-                  <div class="text-white text-sm font-bold leading-tight">
-                    <%= lesson_button_label(@unfinished_lesson, @suggested_page) %>
-                  </div>
-                </div>
-              </.link>
-              <.link
-                href={
-                  Utils.learn_live_path(@section_slug,
-                    target_resource_id: @suggested_page.resource_id,
-                    request_path: ~p"/sections/#{@section_slug}"
-                  )
-                }
-                class="hover:no-underline"
-              >
-                <div class="w-44 h-10 px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow justify-center items-center gap-2.5 flex hover:bg-opacity-40">
-                  <div class="text-white text-sm font-semibold leading-tight">
-                    Show in course
-                  </div>
-                </div>
-              </.link>
-            </div>
+            </.link>
           </div>
         </div>
       </div>
@@ -331,62 +329,60 @@ defmodule OliWeb.Delivery.Student.IndexLive do
 
   defp header_banner(assigns) do
     ~H"""
-    <div class="relative">
-      <div class="w-full h-72 relative flex items-center">
-        <div class="inset-0 absolute">
-          <div class="inset-0 absolute bg-purple-700 bg-opacity-50"></div>
-          <img
-            src="/images/gradients/home-bg.png"
-            alt="Background Image"
-            class="absolute inset-0 w-full h-full object-cover border border-gray-300 dark:border-black mix-blend-luminosity"
-          />
-          <div class="absolute inset-0 opacity-60">
-            <div class="absolute left-[1250px] top-0 origin-top-left rotate-180 bg-gradient-to-r from-white to-white">
-            </div>
-            <div class="absolute inset-0 bg-gradient-to-r from-blue-700 to-cyan-500"></div>
+    <div class="w-full h-[20rem] md:h-72 relative flex items-center">
+      <div class="inset-0 absolute">
+        <div class="inset-0 absolute bg-purple-700 bg-opacity-50"></div>
+        <img
+          src="/images/gradients/home-bg.png"
+          alt="Background Image"
+          class="absolute inset-0 w-full h-full object-cover border border-gray-300 dark:border-black mix-blend-luminosity"
+        />
+        <div class="absolute inset-0 opacity-60">
+          <div class="absolute left-[1250px] top-0 origin-top-left rotate-180 bg-gradient-to-r from-white to-white">
+          </div>
+          <div class="absolute inset-0 bg-gradient-to-r from-blue-700 to-cyan-500"></div>
+        </div>
+      </div>
+
+      <div class="w-full pl-14 pr-5 absolute flex flex-col justify-center items-start gap-6">
+        <div class="w-full text-white text-2xl font-bold tracking-wide whitespace-nowrap overflow-hidden">
+          Hi, <%= user_given_name(@ctx) %> !
+        </div>
+        <div class="w-full flex flex-col items-start gap-2.5">
+          <div class="w-full whitespace-nowrap overflow-hidden">
+            <span class="text-3xl text-white font-medium">
+              <%= build_welcome_title(@section.welcome_title) %>
+            </span>
+          </div>
+          <div class="w-96 text-white/60 text-lg font-semibold">
+            <%= @section.encouraging_subtitle ||
+              "Dive Into Discovery. Begin Your Learning Adventure Now!" %>
           </div>
         </div>
-
-        <div class="w-full pl-14 pr-5 absolute flex flex-col justify-center items-start gap-6">
-          <div class="w-full text-white text-2xl font-bold tracking-wide whitespace-nowrap overflow-hidden">
-            Hi, <%= user_given_name(@ctx) %> !
-          </div>
-          <div class="w-full flex flex-col items-start gap-2.5">
-            <div class="w-full whitespace-nowrap overflow-hidden">
-              <span class="text-3xl text-white font-medium">
-                <%= build_welcome_title(@section.welcome_title) %>
-              </span>
-            </div>
-            <div class="w-96 text-white/60 text-lg font-semibold">
-              <%= @section.encouraging_subtitle ||
-                "Dive Into Discovery. Begin Your Learning Adventure Now!" %>
-            </div>
-          </div>
-          <div class="pt-5 flex items-start gap-6">
-            <.link
-              href={
-                Utils.lesson_live_path(
-                  @section_slug,
-                  DeliveryResolver.get_first_page_slug(@section_slug),
-                  request_path: ~p"/sections/#{@section_slug}"
-                )
-              }
-              class="hover:no-underline"
-            >
-              <div class="w-52 h-11 px-5 py-2.5 bg-blue-600 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-blue-500">
-                <div class="text-white text-base font-bold leading-tight">
-                  Start course
-                </div>
+        <div class="pt-5 flex items-start gap-6">
+          <.link
+            href={
+              Utils.lesson_live_path(
+                @section_slug,
+                DeliveryResolver.get_first_page_slug(@section_slug),
+                request_path: ~p"/sections/#{@section_slug}"
+              )
+            }
+            class="hover:no-underline"
+          >
+            <div class="w-52 h-11 px-5 py-2.5 bg-blue-600 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-blue-500">
+              <div class="text-white text-base font-bold leading-tight">
+                Start course
               </div>
-            </.link>
-            <.link href={Utils.learn_live_path(@section_slug)} class="hover:no-underline">
-              <div class="w-52 h-11 px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-opacity-40">
-                <div class="text-white text-base font-semibold leading-tight">
-                  Discover content
-                </div>
+            </div>
+          </.link>
+          <.link href={Utils.learn_live_path(@section_slug)} class="hover:no-underline">
+            <div class="w-52 h-11 px-5 py-2.5 bg-white bg-opacity-20 rounded-lg shadow flex justify-center items-center gap-2.5 hover:bg-opacity-40">
+              <div class="text-white text-base font-semibold leading-tight">
+                Discover content
               </div>
-            </.link>
-          </div>
+            </div>
+          </.link>
         </div>
       </div>
     </div>
@@ -478,8 +474,8 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         </div>
       </Modal.modal>
     </div>
-    <div class="w-full h-fit p-6 bg-white shadow dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start gap-32 inline-flex">
-      <div class="flex-col justify-start items-start gap-5 inline-flex grow">
+    <div class="w-full h-fit p-6 bg-white shadow dark:bg-[#1C1A20] dark:bg-opacity-100 rounded-2xl justify-start items-start inline-flex">
+      <div class="flex-col justify-start items-start gap-3 md:gap-5 inline-flex grow">
         <div class="flex items-baseline gap-2.5 relative">
           <div class="text-2xl font-bold leading-loose">
             Course Progress
@@ -516,10 +512,10 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         <%= if @has_visited_section do %>
           <div class="flex-col justify-start items-start flex">
             <div>
-              <span class="text-6xl font-bold leading-[76px]">
+              <span class="text-3xl md:text-6xl font-bold leading-[76px]">
                 <%= parse_progress(@completed_pages.completed_pages / @completed_pages.total_pages) %>
               </span>
-              <span class="text-3xl font-bold leading-[44px]">%</span>
+              <span class="text-xl md:text-3xl font-bold leading-[44px]">%</span>
             </div>
           </div>
           <Common.progress_bar

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -758,19 +758,18 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     %{section: %{id: _section_id}} = assigns
 
     ~H"""
-    <div id="student_learn" class="lg:container lg:mx-auto p-[25px]" phx-hook="Scroller">
+    <div id="student_learn" class="lg:container lg:mx-auto p-3 md:p-[25px]" phx-hook="Scroller">
       <.video_player />
-      <div class="flex justify-end md:p-[25px] sticky top-12 z-40 bg-delivery-body dark:bg-delivery-body-dark">
+      <div class="flex justify-between p-3 md:p-[25px] sticky top-12 z-40 bg-delivery-body dark:bg-delivery-body-dark">
+        <DeliveryUtils.toggle_visibility_button
+          target_selector="div[data-completed='true']"
+          class="dark:text-[#bab8bf] text-sm font-medium hover:text-black dark:hover:text-white"
+        />
+
         <.live_component
           id="view_selector"
           module={OliWeb.Delivery.Student.Learn.Components.ViewSelector}
           selected_view={@selected_view}
-        />
-      </div>
-      <div class="sticky w-fit top-20 md:px-[25px] md:pl-[20px] z-40 bg-delivery-body dark:bg-delivery-body-dark">
-        <DeliveryUtils.toggle_visibility_button
-          target_selector="div[data-completed='true']"
-          class="dark:text-[#bab8bf] text-sm font-medium hover:text-black dark:hover:text-white"
         />
       </div>
 
@@ -801,20 +800,18 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   def render(%{selected_view: :gallery} = assigns) do
     ~H"""
-    <div id="student_learn" class="lg:container lg:mx-auto p-[25px]" phx-hook="Scroller">
+    <div id="student_learn" class="lg:container lg:mx-auto p-3 md:p-[25px]" phx-hook="Scroller">
       <.video_player />
-      <div class="flex justify-end md:p-[25px] sticky top-12 z-40 bg-delivery-body dark:bg-delivery-body-dark">
-        <.live_component
-          id="view_selector"
-          module={OliWeb.Delivery.Student.Learn.Components.ViewSelector}
-          selected_view={@selected_view}
-        />
-      </div>
-      <div class="sticky w-fit top-20 md:px-[25px] md:pl-[50px] z-40 bg-delivery-body dark:bg-delivery-body-dark">
+      <div class="flex justify-between p-3 md:p-[25px] sticky top-12 z-40 bg-delivery-body dark:bg-delivery-body-dark">
         <DeliveryUtils.toggle_visibility_button
           class="dark:text-[#bab8bf] text-sm font-medium hover:text-black dark:hover:text-white"
           target_selector={completed_resources_css_selector()}
           on_toggle={&JS.push(&1, "toggle_completed_visibility")}
+        />
+        <.live_component
+          id="view_selector"
+          module={OliWeb.Delivery.Student.Learn.Components.ViewSelector}
+          selected_view={@selected_view}
         />
       </div>
 
@@ -1256,14 +1253,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <div class="accordion my-2" id="accordionExample">
         <div class="card py-4 bg-white/20 dark:bg-[#0d0c0e] shadow-none">
           <div
-            class={"card-header border-b-[1px] #{if @progress == 100, do: "border-b-[#39E581]", else: "border-b-[#3B3740]"} pb-1"}
+            class={"card-header border-b-[1px] #{if @progress == 100, do: "border-b-[#39E581]", else: "border-b-gray-300 dark:border-b-gray-700"} pb-1"}
             id={"header-#{@row["resource_id"]}"}
           >
             <h6 class="dark:text-[#eeebf5]/75 text-sm font-bold font-['Open Sans'] uppercase leading-none">
               <%= "#{String.upcase(Sections.get_container_label_and_numbering(1, @row["numbering"]["index"], @section.customizations))}" %>
             </h6>
-            <div class="flex justify-between items-center h-8 mt-3 mb-1">
-              <div class="grow shrink basis-0 dark:text-white text-2xl font-semibold font-['Open Sans'] leading-loose">
+            <div class="flex justify-between items-center mt-3 mb-1">
+              <div class="grow shrink basis-0 dark:text-white md:text-2xl font-semibold font-['Open Sans'] md:leading-loose">
                 <%= @row["title"] %>
               </div>
               <div class="flex flex-row gap-x-2">
@@ -1274,7 +1271,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 <% end %>
               </div>
             </div>
-            <div class="flex justify-between items-center h-6 mb-3">
+            <div class="flex justify-between items-center mb-3">
               <div class="dark:text-[#eeebf5]/75 text-sm font-semibold font-['Open Sans'] leading-none">
                 <%= if @row["section_resource"].end_date in [nil, "Not yet scheduled"],
                   do: "Due by:",
@@ -1423,14 +1420,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <div class="accordion my-2" id="accordionExample">
         <div class="card bg-white/20 dark:bg-[#0d0c0e] py-4 pr-0 shadow-none">
           <div
-            class="card-header border-b-[1px] border-b-[#3B3740] pb-2"
+            class="card-header border-b-[1px] border-b-gray-300 dark:border-b-gray-700 pb-2"
             id={"header-#{@row["resource_id"]}"}
           >
             <h6 class="dark:text-[#eeebf5]/75 text-sm font-bold font-['Open Sans'] uppercase leading-none">
               <%= "#{String.upcase(Sections.get_container_label_and_numbering(@row["numbering"]["level"], @row["numbering"]["index"], @section.customizations))}" %>
             </h6>
             <div class="flex justify-between items-center h-8 mt-3 mb-1">
-              <div class="grow shrink basis-0 dark:text-white text-2xl font-semibold font-['Open Sans'] leading-loose">
+              <div class="grow shrink basis-0 dark:text-white md:text-2xl font-semibold font-['Open Sans'] md:leading-loose">
                 <%= @row["title"] %>
               </div>
             </div>
@@ -1456,7 +1453,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                     JS.toggle_class("rotate-180",
                       to: "#icon-#{@row["resource_id"]}"
                     )
-                    |> JS.toggle_class("border-b-[1px] border-b-[#3B3740]",
+                    |> JS.toggle_class("border-b-[1px] border-b-gray-300 dark:border-b-gray-700",
                       to: "#header-#{@row["resource_id"]}"
                     )
                   }
@@ -1488,8 +1485,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             class="collapse"
             aria-labelledby={"header-#{@row["resource_id"]}"}
           >
-            <div class="card-body pl-20 pt-8">
-              <div role="completed count" class="flex gap-2.5 border-b-[1px] border-b-[#3B3740] h-10">
+            <div class="card-body pl-6 md:pl-20 pt-4 md:pt-8">
+              <div
+                role="completed count"
+                class="flex gap-2.5 border-b-[1px] border-b-gray-300 dark:border-b-gray-700 h-10"
+              >
                 <div class="w-7 h-8 py-1 flex gap-2.5">
                   <Icons.check />
                 </div>
@@ -1593,7 +1593,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       <button
         role={"page #{@row["numbering"]["index"]} details"}
         class={[
-          "w-full pl-[5px] pr-[7px] py-2.5 justify-start items-center gap-2 flex rounded-lg focus:bg-[#000000]/5 hover:bg-[#000000]/5 dark:focus:bg-[#FFFFFF]/5 dark:hover:bg-[#FFFFFF]/5 #{if @row["numbering"]["level"] == 2, do: "border-b-[1px] border-b-[#3B3740]"}",
+          "w-full pl-[5px] pr-[7px] py-2.5 justify-start items-center gap-2 flex focus:bg-[#000000]/5 hover:bg-[#000000]/5 dark:focus:bg-[#FFFFFF]/5 dark:hover:bg-[#FFFFFF]/5 #{if @row["numbering"]["level"] == 2, do: "border-b-[1px] border-b-gray-300 dark:border-b-gray-700"}",
           if(@row["graded"],
             do: "font-semibold hover:font-bold focus:font-bold",
             else: "font-normal hover:font-medium focus:font-medium"

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -881,7 +881,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             <%= "PAGE #{@unit["numbering"]["index"]}" %>
           </div>
           <div class="mb-6 flex flex-col items-start gap-[6px] w-full">
-            <div class="flex w-full">
+            <div class="flex flex-col md:flex-row w-full">
               <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
                 <%= @unit["title"] %>
               </h3>
@@ -948,11 +948,11 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             ) %>
           </div>
           <div class="mb-6 flex flex-col items-start gap-[6px] w-full">
-            <div class="flex w-full">
+            <div class="flex flex-col md:flex-row w-full justify-between gap-2">
               <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
                 <%= @unit["title"] %>
               </h3>
-              <div class="ml-auto flex items-center gap-3" role="schedule_details">
+              <div class="flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
                     <%= if @unit["section_resource"].end_date in [nil, "Not yet scheduled"],
@@ -962,11 +962,13 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                           Map.get(@contained_scheduling_types, @unit["resource_id"])
                         ) %>
                   </span>
-                  <%= format_date(
-                    @unit["section_resource"].end_date,
-                    @ctx,
-                    "{WDshort}, {Mshort} {D}, {YYYY} ({h12}:{m}{am})"
-                  ) %>
+                  <span class="whitespace-nowrap">
+                    <%= format_date(
+                      @unit["section_resource"].end_date,
+                      @ctx,
+                      "{WDshort}, {Mshort} {D}, {YYYY} ({h12}:{m}{am})"
+                    ) %>
+                  </span>
                 </div>
               </div>
             </div>
@@ -1052,7 +1054,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
       >
         <.custom_focus_wrap
           :if={Map.has_key?(@selected_module_per_unit_resource_id, @unit["resource_id"])}
-          class="px-[50px] rounded-lg flex-col justify-start items-center gap-[25px] flex"
+          class="px-3 md:px-[50px] rounded-lg flex-col justify-start items-center gap-[25px] flex"
           role="module_details"
           id={"selected_module_in_unit_#{@unit["resource_id"]}"}
           data-animate={
@@ -1091,7 +1093,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 ) %>
               </div>
             </div>
-            <h2 class="self-stretch opacity-90 text-center text-[26px] font-normal leading-loose tracking-tight dark:text-white">
+            <h2 class="self-stretch opacity-90 text-center text-xl md:text-[26px] font-normal md:leading-loose tracking-tight dark:text-white">
               <%= selected_module[
                 "title"
               ] %>
@@ -1118,7 +1120,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             }
             id={"module_intro_contentin_unit_#{@unit["resource_id"]}"}
             role="module intro content"
-            class="max-w-[760px] w-full pt-[25px] pb-2.5 justify-start items-start gap-[23px] inline-flex"
+            class="max-w-[760px] w-full pt-4 md:pt-[25px] pb-2.5 justify-start items-start gap-[23px] inline-flex"
           >
             <div class="flex flex-col opacity-80">
               <span
@@ -1178,7 +1180,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
           <div
             role="module index"
-            class="flex flex-col max-w-[760px] pt-[25px] pb-2.5 justify-start items-start gap-[23px] w-full"
+            class="flex flex-col max-w-[760px] pt-4 md:pt-[25px] pb-2.5 justify-start items-start gap-[23px] w-full"
           >
             <div class="w-full">
               <% module =

--- a/lib/oli_web/live/delivery/student/practice_live.ex
+++ b/lib/oli_web/live/delivery/student/practice_live.ex
@@ -20,7 +20,7 @@ defmodule OliWeb.Delivery.Student.PracticeLive do
     <.hero_banner class="bg-practice">
       <h1 class="text-4xl md:text-6xl mb-8">Your Practice Pages</h1>
     </.hero_banner>
-    <div class="overflow-x-scroll md:overflow-x-auto container mx-auto flex flex-col mt-6 px-16">
+    <div class="overflow-x-scroll md:overflow-x-auto container mx-auto flex flex-col mt-6 px-3 md:px-16">
       <div :if={Enum.count(@practices_by_container) == 0} class="text-center" role="alert">
         <h6>There are no practice pages available</h6>
       </div>

--- a/lib/oli_web/live/delivery/student/schedule_live.ex
+++ b/lib/oli_web/live/delivery/student/schedule_live.ex
@@ -66,11 +66,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
       <h1 class="text-4xl md:text-6xl mb-8">Course Schedule</h1>
     </.hero_banner>
 
-    <div
-      id="schedule-view"
-      class="overflow-x-scroll md:overflow-x-auto container mx-auto h-full"
-      phx-hook="Scroller"
-    >
+    <div id="schedule-view" class="container mx-auto h-full" phx-hook="Scroller">
       <.schedule
         ctx={@ctx}
         schedule={@schedule}
@@ -89,8 +85,8 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
       <h1 class="text-4xl md:text-6xl mb-8">Course Schedule</h1>
     </.hero_banner>
 
-    <div id="schedule-view" class="overflow-x-scroll md:overflow-x-auto container mx-auto h-full">
-      <div class="my-8 px-16">
+    <div id="schedule-view" class="container mx-auto h-full">
+      <div class="my-8 px-3 md:px-16">
         <.schedule_header />
         <div class="flex flex-col">
           <Schedule.non_scheduled_container_groups
@@ -115,7 +111,7 @@ defmodule OliWeb.Delivery.Student.ScheduleLive do
 
   def schedule(assigns) do
     ~H"""
-    <div class="my-8 px-16" id="schedule_live" phx-hook="Countdown">
+    <div class="my-8 px-3 md:px-16" id="schedule_live" phx-hook="Countdown">
       <div class="flex flex-col">
         <%= for {{month, _year}, weekly_schedule} <- @schedule do %>
           <div class="flex flex-col md:flex-row">

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -153,7 +153,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
       <div class="container mx-auto py-2 flex flex-row justify-between">
         <div class="flex-1 flex items-center">
           <a
-            class="navbar-brand dark torus-logo my-1 mr-auto"
+            class="navbar-brand dark torus-logo shrink-0 my-1 mr-auto"
             href={logo_link(@section, @student.id, @preview_mode)}
           >
             <%= brand_logo(Map.merge(assigns, %{class: "d-inline-block align-top mr-2"})) %>

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -244,39 +244,4 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   end
 
   defp is_active_tab?(tab, active_tab), do: tab == active_tab
-
-  defp flash_message(assigns) do
-    ~H"""
-    <%= if Phoenix.Flash.get(@flash, :info) do %>
-      <div class="alert alert-info flex flex-row justify-between" role="alert">
-        <%= Phoenix.Flash.get(@flash, :info) %>
-        <button
-          type="button"
-          class="close ml-4"
-          data-bs-dismiss="alert"
-          aria-label="Close"
-          phx-click="lv:clear-flash"
-          phx-value-key="info"
-        >
-          <i class="fa-solid fa-xmark fa-lg" />
-        </button>
-      </div>
-    <% end %>
-    <%= if Phoenix.Flash.get(@flash, :error) do %>
-      <div class="alert alert-danger flex flex-row justify-between" role="alert">
-        <%= Phoenix.Flash.get(@flash, :error) %>
-        <button
-          type="button"
-          class="close ml-4"
-          data-bs-dismiss="alert"
-          aria-label="Close"
-          phx-click="lv:clear-flash"
-          phx-value-key="error"
-        >
-          <i class="fa-solid fa-xmark fa-lg" />
-        </button>
-      </div>
-    <% end %>
-    """
-  end
 end

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -99,7 +99,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
             </li>
           <% end %>
         </ul>
-        <div class="ml-auto"><.flash_message flash={@flash} /></div>
       </div>
       <div class="mb-5">
         <%= if @active_tab == :settings do %>

--- a/lib/oli_web/live/sections/assistant/student_conversations.ex
+++ b/lib/oli_web/live/sections/assistant/student_conversations.ex
@@ -137,7 +137,7 @@ defmodule OliWeb.Sections.Assistant.StudentConversationsLive do
   def render(assigns) do
     ~H"""
     <div class="container mx-auto mb-10">
-      <.loader if={!@table_model} />
+      <.loader :if={!@table_model} />
 
       <div :if={@table_model} class="flex flex-col-reverse md:flex-row">
         <div class={if @conversation_messages, do: "md:w-8/12", else: "flex-1"}>

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -129,7 +129,7 @@ defmodule OliWeb.Sections.OverviewView do
 
     ~H"""
     <%= render_modal(assigns) %>
-    <div class="ml-auto"><.flash_message flash={@flash} /></div>
+
     <Groups.render>
       <Group.render label="Details" description="Overview of course section details">
         <ReadOnly.render label="Course Section ID" value={@section.slug} />

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -759,41 +759,6 @@ defmodule OliWeb.Sections.OverviewView do
     """
   end
 
-  defp flash_message(assigns) do
-    ~H"""
-    <%= if Phoenix.Flash.get(@flash, :info) do %>
-      <div class="alert alert-info flex flex-row justify-between" role="alert">
-        <%= Phoenix.Flash.get(@flash, :info) %>
-        <button
-          type="button"
-          class="close ml-4"
-          data-bs-dismiss="alert"
-          aria-label="Close"
-          phx-click="lv:clear-flash"
-          phx-value-key="info"
-        >
-          <i class="fa-solid fa-xmark fa-lg" />
-        </button>
-      </div>
-    <% end %>
-    <%= if Phoenix.Flash.get(@flash, :error) do %>
-      <div class="alert alert-danger flex flex-row justify-between" role="alert">
-        <%= Phoenix.Flash.get(@flash, :error) %>
-        <button
-          type="button"
-          class="close ml-4"
-          data-bs-dismiss="alert"
-          aria-label="Close"
-          phx-click="lv:clear-flash"
-          phx-value-key="error"
-        >
-          <i class="fa-solid fa-xmark fa-lg" />
-        </button>
-      </div>
-    <% end %>
-    """
-  end
-
   defp ext(entry) do
     [ext | _] = MIME.extensions(entry.client_type)
     ext

--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -231,7 +231,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
             <p>You are not enrolled in any courses as an instructor.</p>
           <% else %>
             <div class="flex flex-wrap w-full gap-3">
-              <.course_card
+              <.instructor_course_card
                 :for={{section, index} <- Enum.with_index(@filtered_sections)}
                 index={index}
                 section={section}
@@ -252,7 +252,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   attr :index, :integer
   attr :params, :map
 
-  def course_card(assigns) do
+  def instructor_course_card(assigns) do
     ~H"""
     <div
       id={"course_card_#{@section.id}"}

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -170,7 +170,7 @@ defmodule OliWeb.Workspaces.Student do
     </div>
     <div class="flex flex-col items-start py-6 md:py-[60px] px-4 md:px-[100px]">
       <div class="flex flex-col md:flex-row mb-9 w-full">
-        <h3 class="w-full py-2 md:py-0 text-[26px] leading-[32px] tracking-[0.02px] font-semibold dark:text-white">
+        <h3 class="w-full py-2 md:py-0 text-xl md:text-[26px] md:leading-[32px] tracking-[0.02px] font-semibold dark:text-white">
           Courses available
         </h3>
         <div class="ml-auto flex items-center w-full justify-start md:justify-end gap-3">

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -240,7 +240,10 @@ defmodule OliWeb.Workspaces.Student do
           <h5 class="text-2xl md:text-[36px] md:leading-[49px] font-semibold drop-shadow-md">
             <%= @section.title %>
           </h5>
-          <div class="flex drop-shadow-md" role={"progress_for_section_#{@section.id}"}>
+          <div
+            class="flex flex-col md:flex-row drop-shadow-md"
+            role={"progress_for_section_#{@section.id}"}
+          >
             <h4 class="text-sm md:text-[16px] md:leading-[32px] tracking-[1.28px] uppercase mr-9">
               Course Progress
             </h4>

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -115,7 +115,7 @@ defmodule OliWeb.Workspaces.Student do
       <div class="z-20 flex justify-center gap-2 lg:gap-12 xl:gap-32 px-6 sm:px-0">
         <div class="w-1/4 lg:w-1/2 flex items-start justify-center">
           <div class="w-96 flex-col justify-start items-start gap-0 lg:gap-3.5 inline-flex">
-            <div class="text-left lg:text-3xl xl:text-4xl">
+            <div class="text-left text-xl lg:text-3xl xl:text-4xl">
               <span class="text-white font-normal font-['Open Sans'] leading-10">
                 Welcome to
               </span>

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -5,9 +5,10 @@ defmodule OliWeb.Workspaces.Student do
   alias Oli.Delivery.Sections
   alias OliWeb.Backgrounds
   alias OliWeb.Common.{Params, SearchInput}
+  alias OliWeb.Components.Delivery.Workspace
+  alias OliWeb.Common.SourceImage
 
   import Ecto.Query, warn: false
-  import OliWeb.Common.SourceImage
   import OliWeb.Components.Delivery.Layouts
 
   @default_params %{
@@ -158,21 +159,21 @@ defmodule OliWeb.Workspaces.Student do
 
   def render(assigns) do
     ~H"""
-    <div class="relative flex items-center h-[247px] w-full bg-gray-100 dark:bg-[#0B0C11]">
+    <div class="relative flex items-center min-h-[100px] md:min-h-[247px] w-full bg-gray-100 dark:bg-[#0B0C11]">
       <div
         class="absolute top-0 left-0 h-full w-full"
         style="background: linear-gradient(90deg, #D9D9D9 0%, rgba(217, 217, 217, 0.00) 100%);"
       />
-      <h1 class="text-[64px] leading-[87px] tracking-[0.02px] pl-[100px] z-10">
+      <h1 class="text-3xl md:text-[64px] leading-[87px] tracking-[0.02px] px-4 md:pl-[100px] z-10">
         Hi, <span class="font-bold"><%= user_given_name(@ctx) %></span>
       </h1>
     </div>
-    <div class="flex flex-col items-start py-[60px] px-[100px]">
-      <div class="flex mb-9 w-full">
-        <h3 class="w-full text-[26px] leading-[32px] tracking-[0.02px] font-semibold dark:text-white">
+    <div class="flex flex-col items-start py-6 md:py-[60px] px-4 md:px-[100px]">
+      <div class="flex flex-col md:flex-row mb-9 w-full">
+        <h3 class="w-full py-2 md:py-0 text-[26px] leading-[32px] tracking-[0.02px] font-semibold dark:text-white">
           Courses available
         </h3>
-        <div class="ml-auto flex items-center w-full justify-end gap-3">
+        <div class="ml-auto flex items-center w-full justify-start md:justify-end gap-3">
           <.form for={%{}} phx-change="search_section" class="w-[330px]">
             <SearchInput.render
               id="section_search_input"
@@ -189,46 +190,12 @@ defmodule OliWeb.Workspaces.Student do
           <p>You are not enrolled in any courses.</p>
         <% else %>
           <div class="flex flex-col w-full gap-3">
-            <.link
+            <.course_card
               :for={{section, index} <- Enum.with_index(@filtered_sections)}
-              href={get_course_url(section, @params.sidebar_expanded)}
-              phx-click={JS.add_class("opacity-0", to: "#content")}
-              phx-mounted={
-                JS.transition(
-                  {"ease-out duration-300", "opacity-0 -translate-x-1/2",
-                   "opacity-100 translate-x-0"},
-                  time: if(index < 6, do: 100 + index * 20, else: 240)
-                )
-                |> JS.remove_class("opacity-100 translate-x-0")
-              }
-              class="opacity-0 relative flex items-center self-stretch h-[201px] w-full bg-cover py-12 px-24 text-white hover:text-white rounded-xl shadow-lg hover:no-underline transition-all hover:translate-x-3"
-              style={"background-image: url('#{cover_image(section)}');"}
-            >
-              <div class="top-0 left-0 rounded-xl absolute w-full h-full mix-blend-difference bg-[linear-gradient(180deg,rgba(0,0,0,0.00)_0%,rgba(0,0,0,0.80)_100%),linear-gradient(90deg,rgba(0,0,0,0.80)_0%,rgba(0,0,0,0.40)_100%)]" />
-              <div class="top-0 left-0 rounded-xl absolute w-full h-full dark:bg-black/40" />
-              <div class="top-0 left-0 rounded-xl absolute w-full h-full backdrop-blur-[30px] bg-[rgba(0,0,0,0.01)]" />
-              <span
-                :if={section.progress == 100}
-                role={"complete_badge_for_section_#{section.id}"}
-                class="absolute w-32 top-0 right-0 rounded-tr-xl rounded-bl-xl bg-[#0CAF61] uppercase py-2 text-center text-[12px] leading-[16px] tracking-[1.2px] font-bold"
-              >
-                Complete
-              </span>
-              <div class="z-10 flex w-full items-center">
-                <div class="flex flex-col items-start gap-6">
-                  <h5 class="text-[36px] leading-[49px] font-semibold drop-shadow-md">
-                    <%= section.title %>
-                  </h5>
-                  <div class="flex drop-shadow-md" role={"progress_for_section_#{section.id}"}>
-                    <h4 class="text-[16px] leading-[32px] tracking-[1.28px] uppercase mr-9">
-                      Course Progress
-                    </h4>
-                    <.progress_bar percent={section.progress} show_percent={true} width="100px" />
-                  </div>
-                </div>
-                <i class="fa-solid fa-arrow-right ml-auto text-2xl p-[7px] drop-shadow-md"></i>
-              </div>
-            </.link>
+              index={index}
+              section={section}
+              params={@params}
+            />
             <p :if={length(@filtered_sections) == 0} class="mt-4">
               No course found matching <strong>"<%= @params.text_search %>"</strong>
             </p>
@@ -239,55 +206,50 @@ defmodule OliWeb.Workspaces.Student do
     """
   end
 
-  attr :section, :map
   attr :index, :integer
+  attr :section, :map
   attr :params, :map
 
   def course_card(assigns) do
     ~H"""
-    <div
-      id={"course_card_#{@section.id}"}
+    <.link
+      href={get_course_url(@section, @params.sidebar_expanded)}
+      phx-click={JS.add_class("opacity-0", to: "#content")}
       phx-mounted={
         JS.transition(
           {"ease-out duration-300", "opacity-0 -translate-x-1/2", "opacity-100 translate-x-0"},
           time: if(@index < 6, do: 100 + @index * 20, else: 240)
         )
+        |> JS.remove_class("opacity-100 translate-x-0")
       }
-      class="opacity-0 flex flex-col w-96 h-[500px] rounded-lg border-2 border-gray-700 transition-all overflow-hidden bg-white"
+      class="opacity-0 relative flex items-center self-stretch md:h-[200px] w-full bg-cover py-4 md:py-12 px-6 md:px-24 text-white hover:text-white rounded-xl shadow-lg hover:no-underline transition-all hover:translate-x-3"
+      style={"background-image: url('#{SourceImage.cover_image(@section)}');"}
     >
-      <div
-        class="w-96 h-[220px] bg-cover border-b-2 border-gray-700"
-        style={"background-image: url('#{cover_image(@section)}');"}
+      <div class="top-0 left-0 rounded-xl absolute w-full h-full mix-blend-difference bg-[linear-gradient(180deg,rgba(0,0,0,0.00)_0%,rgba(0,0,0,0.80)_100%),linear-gradient(90deg,rgba(0,0,0,0.80)_0%,rgba(0,0,0,0.40)_100%)]" />
+      <div class="top-0 left-0 rounded-xl absolute w-full h-full dark:bg-black/40" />
+      <div class="top-0 left-0 rounded-xl absolute w-full h-full backdrop-blur-[30px] bg-[rgba(0,0,0,0.01)]" />
+      <span
+        :if={@section.progress == 100}
+        role={"complete_badge_for_section_#{@section.id}"}
+        class="absolute w-32 top-0 right-0 rounded-tr-xl rounded-bl-xl bg-[#0CAF61] uppercase py-2 text-center text-[12px] leading-[16px] tracking-[1.2px] font-bold"
       >
-      </div>
-      <div class="flex-col justify-start items-start gap-6 inline-flex p-8">
-        <h5
-          class="text-black text-base font-bold font-['Inter'] leading-normal overflow-hidden"
-          style="display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical;"
-          role="course title"
-        >
-          <%= @section.title %>
-        </h5>
-        <div class="text-black text-base font-normal leading-normal h-[100px] overflow-hidden">
-          <p
-            role="course description"
-            style="display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical;"
-          >
-            <%= @section.description %>
-          </p>
+        Complete
+      </span>
+      <div class="z-10 flex w-full items-center">
+        <div class="flex flex-col items-start gap-6">
+          <h5 class="text-2xl md:text-[36px] md:leading-[49px] font-semibold drop-shadow-md">
+            <%= @section.title %>
+          </h5>
+          <div class="flex drop-shadow-md" role={"progress_for_section_#{@section.id}"}>
+            <h4 class="text-sm md:text-[16px] md:leading-[32px] tracking-[1.28px] uppercase mr-9">
+              Course Progress
+            </h4>
+            <.progress_bar percent={@section.progress} show_percent={true} width="100px" />
+          </div>
         </div>
-        <div class="self-stretch justify-end items-start gap-4 inline-flex">
-          <.link
-            href={get_course_url(@section, @params.sidebar_expanded)}
-            class="px-5 py-3 bg-[#0080FF] hover:bg-[#0075EB] dark:bg-[#0062F2] dark:hover:bg-[#0D70FF] hover:no-underline rounded-md justify-center items-center gap-2 flex text-white text-base font-normal leading-normal"
-          >
-            <div class="text-white text-base font-normal font-['Inter'] leading-normal whitespace-nowrap">
-              View Course
-            </div>
-          </.link>
-        </div>
+        <i class="fa-solid fa-arrow-right ml-auto text-2xl p-[7px] drop-shadow-md"></i>
       </div>
-    </div>
+    </.link>
     """
   end
 

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -5,7 +5,6 @@ defmodule OliWeb.Workspaces.Student do
   alias Oli.Delivery.Sections
   alias OliWeb.Backgrounds
   alias OliWeb.Common.{Params, SearchInput}
-  alias OliWeb.Components.Delivery.Workspace
   alias OliWeb.Common.SourceImage
 
   import Ecto.Query, warn: false

--- a/lib/oli_web/plugs/restrict_admin_access.ex
+++ b/lib/oli_web/plugs/restrict_admin_access.ex
@@ -9,7 +9,6 @@ defmodule Oli.Plugs.RestrictAdminAccess do
   def call(conn, _opts) do
     if Oli.Accounts.is_admin?(conn.assigns[:current_author]) do
       conn
-      |> put_flash(:error, "Admins are not allowed to access this page.")
       |> redirect(to: ~p"/workspaces/course_author")
       |> halt()
     else

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -947,6 +947,9 @@ defmodule OliWeb.Router do
   scope "/sections", OliWeb do
     pipe_through([:browser])
 
+    # Resolve root /sections route using the DeliveryController index action
+    get("/", DeliveryController, :index)
+
     live("/join/invalid", Sections.InvalidSectionInviteView)
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1420,22 +1420,6 @@ defmodule OliWeb.Router do
     post("/:section_slug/auto_enroll", LaunchController, :auto_enroll_as_guest)
   end
 
-  # Delivery Auth (Signin)
-  scope "/course", OliWeb do
-    pipe_through([:browser, :delivery, :delivery_layout])
-
-    get("/create_account", DeliveryController, :create_account)
-  end
-
-  scope "/course", OliWeb do
-    pipe_through([:browser, :delivery_protected])
-
-    get("/", DeliveryController, :index)
-
-    get("/link_account", DeliveryController, :link_account)
-    post("/link_account", DeliveryController, :process_link_account)
-  end
-
   scope "/course", OliWeb do
     pipe_through([:browser, :delivery_protected])
 

--- a/lib/oli_web/templates/email/_header.html.eex
+++ b/lib/oli_web/templates/email/_header.html.eex
@@ -1,5 +1,5 @@
 <tr>
-    <a class="navbar-brand torus-logo" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
+    <a class="navbar-brand torus-logo shrink-0" href="<%= Routes.static_page_url(OliWeb.Endpoint, :index) %>">
         <td style="padding: 20px 0; text-align: center">
             <img src="<%= Oli.Branding.brand_logo_url() %>" width="277" height="100" alt="torus-logo" border="0" style="height: auto;">
         </td>

--- a/lib/oli_web/templates/static_page/index.html.heex
+++ b/lib/oli_web/templates/static_page/index.html.heex
@@ -1,17 +1,11 @@
 <div class="relative h-[calc(100vh-112px)] flex justify-center items-center">
-  <div class="absolute h-[calc(100vh-112px)] w-full top-0 left-0">
-    <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
-  </div>
-  <div class="flex flex-col gap-y-10 lg:flex-row w-full relative z-50 overflow-y-scroll lg:overflow-y-auto h-[calc(100vh-270px)] md:h-[calc(100vh-220px)] lg:h-auto py-4 sm:py-8 lg:py-0">
-    <div class="w-full lg:w-1/2 flex items-start lg:pt-10 justify-center">
-      <div class="w-96 flex-col justify-start items-start gap-3.5 inline-flex">
-        <div class="text-left">
-          <span class="text-white text-4xl font-normal font-['Open Sans'] leading-10">
-            Welcome to
-          </span>
-          <span class="text-white text-4xl font-bold font-['Open Sans'] leading-10">
-            <%= Oli.VendorProperties.product_short_name() %>
-          </span>
+  <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
+
+  <div class="absolute lg:h-[calc(100vh-112px)] w-full top-0 left-0 flex flex-col gap-y-10 lg:flex-row z-50 px-3 py-3 sm:py-8 lg:py-[135px]">
+    <div class="w-full lg:w-1/2 flex items-center justify-center py-12 lg:py-0">
+      <div class="w-96 flex-col justify-start items-start gap-3.5 inline-flex text-white font-normal font-['Open Sans']">
+        <div class="text-left text-4xl leading-10">
+          Welcome to <%= Oli.VendorProperties.product_short_name() %>
         </div>
         <div class="w-48 h-11 justify-start items-end gap-1 inline-flex">
           <div class="justify-start items-end gap-px flex">
@@ -49,51 +43,49 @@
     </div>
   </div>
 </div>
-<div id="enrollment_info" class="relative h-screen flex justify-center items-center">
-  <div class="absolute h-screen w-full top-0 left-0">
-    <div class="flex flex-col w-full bg-black h-full">
-      <%= OliWeb.Backgrounds.enrollment_info(%{}) %>
-      <div class="text-left -top-24 md:-top-40 lg:-top-56 mx-20 lg:mx-48 relative text-white text-2xl lg:text-4xl font-normal font-['Open Sans'] leading-10">
-        Course Enrollment
+<div id="enrollment_info" class="flex justify-center items-start min-h-screen bg-black">
+  <div class="flex flex-col w-full h-full">
+    <%= OliWeb.Backgrounds.enrollment_info(%{}) %>
+    <div class="text-left -top-24 md:-top-40 lg:-top-56 mx-20 lg:mx-48 relative text-white text-2xl lg:text-4xl font-normal font-['Open Sans'] leading-10">
+      Course Enrollment
+    </div>
+    <div
+      style="min-height: 18rem;"
+      class="flex flex-col lg:flex-row relative -top-16 lg:-top-28 w-full lg:h-auto self-center px-8 lg:px-32 gap-y-4 lg:gap-x-8"
+    >
+      <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+        <div class="text-black text-xl font-bold font-['Inter']">
+          Locate your Enrollment Link
+        </div>
+        <p class="text-black text-base font-medium font-['Inter'] pt-10">
+          Your instructor will provide an enrollment link to sign up and access your course. Please contact your instructor if you have not received this link or have misplaced it.
+        </p>
       </div>
-      <div
-        style="min-height: 18rem;"
-        class="flex flex-col lg:flex-row relative -top-16 lg:-top-28 w-full lg:h-auto self-center px-8 lg:px-32 gap-y-4 lg:gap-x-8 overflow-y-scroll"
-      >
-        <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
-          <div class="text-black text-xl font-bold font-['Inter']">
-            Locate your Enrollment Link
-          </div>
-          <p class="text-black text-base font-medium font-['Inter'] pt-10">
-            Your instructor will provide an enrollment link to sign up and access your course. Please contact your instructor if you have not received this link or have misplaced it.
+      <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+        <div class="text-black text-xl !font-bold font-['Inter']">Create an Account</div>
+        <p class="text-black text-base font-medium font-['Inter'] pt-10">
+          Follow your enrollment link to the account creation page where you will create a user ID and password.
+        </p>
+      </div>
+      <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
+        <div class="text-black text-xl !font-bold font-['Inter']">Still need an account?</div>
+        <div class="pt-10 pb-8 md:pb-0">
+          <p class="text-stone-900 font-medium text-base font-['Inter']">
+            <a
+              href={Oli.VendorProperties.company_faq_url()}
+              target="_blank"
+              class="!text-[#4CA6FF] text-base font-bold font-['Inter'] hover:text-[#4CA6FF]"
+            >
+              Visit our FAQs document
+            </a>
+            for help enrolling or setting up your Torus student account. If you require further assistance, please
+            <a
+              onclick="window.showHelpModal();"
+              class="text-[#4CA6FF] text-base font-bold font-['Inter'] hover:text-[#4CA6FF]"
+            >
+              contact our support team.
+            </a>
           </p>
-        </div>
-        <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
-          <div class="text-black text-xl !font-bold font-['Inter']">Create an Account</div>
-          <p class="text-black text-base font-medium font-['Inter'] pt-10">
-            Follow your enrollment link to the account creation page where you will create a user ID and password.
-          </p>
-        </div>
-        <div class="w-auto lg:w-1/3 h-auto bg-white rounded-md py-8 px-10">
-          <div class="text-black text-xl !font-bold font-['Inter']">Still need an account?</div>
-          <div class="pt-10 pb-8 md:pb-0">
-            <p class="text-stone-900 font-medium text-base font-['Inter']">
-              <a
-                href={Oli.VendorProperties.company_faq_url()}
-                target="_blank"
-                class="!text-[#4CA6FF] text-base font-bold font-['Inter'] hover:text-[#4CA6FF]"
-              >
-                Visit our FAQs document
-              </a>
-              for help enrolling or setting up your Torus student account. If you require further assistance, please
-              <a
-                onclick="window.showHelpModal();"
-                class="text-[#4CA6FF] text-base font-bold font-['Inter'] hover:text-[#4CA6FF]"
-              >
-                contact our support team.
-              </a>
-            </p>
-          </div>
         </div>
       </div>
     </div>

--- a/lib/oli_web/templates/static_page/index.html.heex
+++ b/lib/oli_web/templates/static_page/index.html.heex
@@ -1,7 +1,7 @@
 <div class="relative h-[calc(100vh-112px)] flex justify-center items-center">
   <%= OliWeb.Backgrounds.student_sign_in(%{}) %>
 
-  <div class="absolute lg:h-[calc(100vh-112px)] w-full top-0 left-0 flex flex-col gap-y-10 lg:flex-row z-50 px-3 py-3 sm:py-8 lg:py-[135px]">
+  <div class="absolute lg:h-[calc(100vh-112px)] w-full top-0 left-0 flex flex-col gap-y-10 lg:flex-row z-50 px-3 py-8 lg:py-[135px]">
     <div class="w-full lg:w-1/2 flex items-center justify-center py-12 lg:py-0">
       <div class="w-96 flex-col justify-start items-start gap-3.5 inline-flex text-white font-normal font-['Open Sans']">
         <div class="text-left text-4xl leading-10">
@@ -22,9 +22,21 @@
         </div>
         <a
           href="#enrollment_info"
-          class="w-auto h-[18.56px] text-white text-xl font-normal font-['Inter'] leading-normal mt-4 lg:mt-10 underline underline-offset-4 hover:text-zinc-300"
+          class="text-white text-xl font-normal font-['Inter'] leading-normal mt-4 lg:mt-10 underline underline-offset-4 hover:text-zinc-300"
         >
           Need an account?
+        </a>
+        <a
+          href={~p"/instructors/log_in"}
+          class="md:hidden text-white text-xl font-normal font-['Inter'] leading-normal mt-2 underline underline-offset-4 hover:text-zinc-300"
+        >
+          For Instructors
+        </a>
+        <a
+          href={~p"/authors/log_in"}
+          class="md:hidden text-white text-xl font-normal font-['Inter'] leading-normal mt-2 underline underline-offset-4 hover:text-zinc-300"
+        >
+          For Course Authors
         </a>
       </div>
     </div>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -177,7 +177,7 @@ defmodule OliWeb.DeliveryControllerTest do
 
       enrollment_path = ~p"/sections/#{section.slug}/enroll"
       conn = get(conn, enrollment_path)
-      assert response(conn, 302) =~ "You are being <a href=\"/course\">redirected</a>"
+      assert response(conn, 302) =~ "You are being <a href=\"/sections\">redirected</a>"
     end
 
     test "redirect to requested path after login", %{conn: conn, section: section} do

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -174,9 +174,6 @@ defmodule OliWeb.StaticPageControllerTest do
     } do
       conn = get(conn, Routes.static_page_path(conn, :index))
 
-      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
-               "Admins are not allowed to access this page."
-
       assert html_response(conn, 302) =~
                "You are being <a href=\"/workspaces/course_author\">redirected"
     end

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -807,7 +807,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(view, "div", "Hi, #{user.given_name} !")
 
       # Shows welcome title respecting the strong tag
-      assert has_element?(view, "span", "Welcome to")
+      assert has_element?(view, "h4", "Welcome to")
       assert has_element?(view, "strong", "the best course ever!")
 
       # Shows encouraging subtitle
@@ -856,7 +856,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(view, "div", "Hi, #{user.given_name} !")
 
       # Shows welcome title respecting the strong tag
-      assert has_element?(view, "span", "Welcome to the Course")
+      assert has_element?(view, "h4", "Welcome to the Course")
 
       # Shows encouraging subtitle
       assert has_element?(view, "div", "Dive Into Discovery. Begin Your Learning Adventure Now!")

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1538,12 +1538,13 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert view
              |> element(~s{div[role="unit_1"] div[role="schedule_details"]})
              |> render() =~
-               "Read by: \n              </span>\n              Sun, Dec 31, 2023 (8:00pm)"
+               "Read by: \n              </span><span class=\"whitespace-nowrap\">\n                Sun, Dec 31, 2023 (8:00pm)"
 
       # unit 2 has not been scheduled by instructor, so there must not be a schedule details data
       assert view
              |> element(~s{div[role="unit_2"] div[role="schedule_details"]})
-             |> render() =~ "Due by:\n              </span>\n              Not yet scheduled"
+             |> render() =~
+               "Due by:\n              </span><span class=\"whitespace-nowrap\">\n                Not yet scheduled"
     end
 
     test "can see units, modules and page (at module level) progresses", %{

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -297,7 +297,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       wait_for_completion()
 
-      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/course")
+      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/sections")
     end
 
     @tag :skip
@@ -331,7 +331,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
 
       assert blueprint_section.contains_explorations == true
 
-      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/course")
+      assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/sections")
     end
 
     test "creates a section with analytics_version :v2 ", %{conn: conn} = context do

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -809,7 +809,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
         end)
 
       assert view
-             |> has_element?("div .alert-info", "Setting updated!")
+             |> has_element?("#flash[role='alert']", "Setting updated!")
 
       assert updated_page_1_assessment_settings.late_submit == :disallow
     end
@@ -1865,7 +1865,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       # a flash message confirms the removal and the exception is not listed anymore
       assert has_element?(
                view,
-               ~s{div.alert.alert-info},
+               "#flash[role='alert']",
                "Student Exception/s removed!"
              )
 

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -204,21 +204,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       refute Course.get_project!(project.id).allow_transfer_payment_codes
     end
 
-    test "does not display datashop analytics link when author is not admin", %{
-      conn: conn,
-      author: author
-    } do
-      project = create_project_with_author(author)
-
-      {:ok, view, _html} = live(conn, live_view_route(project.slug))
-
-      refute has_element?(
-               view,
-               "a[href=#{~p"/project/#{project.slug}/datashop"}]",
-               "Datashop Analytics"
-             )
-    end
-
     defp create_project_with_author(author) do
       %{project: project} = base_project_with_curriculum(nil)
       insert(:author_project, project_id: project.id, author_id: author.id)


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4306

This PR cleans up some of the mobile styles and aspects of the user experience in preparation for v30. Most of the changes here are geared toward making the student facing views more mobile friendly, understanding that there is still some larger design tasks and work to do here in the future. This PR represents a minimal amount of changes required to make the mobile experience more acceptable.
![2025-02-28 12 49 55](https://github.com/user-attachments/assets/b7067be9-3c84-4827-9297-6f5dd6dd8bb7)
![2025-02-28 14 15 39](https://github.com/user-attachments/assets/4801aaeb-a42b-4135-ba27-abc7e981090b)
![2025-02-28 12 48 49](https://github.com/user-attachments/assets/e228cda0-b7e0-4466-9749-d0c671fc11e4)
![2025-02-28 12 48 14](https://github.com/user-attachments/assets/c24c0320-ed18-45d9-8e73-0aeb9d444ffe)
![2025-02-28 16 57 23](https://github.com/user-attachments/assets/ed2cabef-ff83-445f-b801-2b12ec47654a)


This PR also includes the following improvements:
- Remove unnecessary duplicate flash messages
<img width="1732" alt="Screenshot 2025-02-26 at 10 18 47 AM" src="https://github.com/user-attachments/assets/d3391f4c-f7c1-43e0-86a7-5f0afcc70ce2" />

- Fix excessively large loading spinner when creating a section (and other parts of the UI)
![2025-02-28 14 23 00](https://github.com/user-attachments/assets/c026f27a-d328-445a-884f-965b070e4c11)

- Remove unused `/course` routes that lead to nowhere since v30 changes
- Remove unnecessary and confusing "Admins are not allowed to access this page" flash message when accessing the index route. It now just simply redirects to the course author workspace without displaying this message.
<img width="1731" alt="Screenshot 2025-02-25 at 10 15 40 AM" src="https://github.com/user-attachments/assets/de5259d6-7319-461c-8505-44aee0e98ca4" />



