### PR TITLE
[BUG FIX] [MER-4350]Simplify, and use the current author for is_admin check

### DIFF
--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -39,29 +39,6 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   attr(:class, :string, default: "")
   attr(:dropdown_class, :string, default: "")
 
-  def workspace_menu(%{is_admin: true} = assigns) do
-    ~H"""
-    <div class="relative">
-      <button
-        id={@id}
-        class={"flex flex-row items-center justify-center rounded-full outline outline-2 outline-neutral-300 dark:outline-neutral-700 hover:outline-4 hover:dark:outline-zinc-600 focus:outline-4 focus:outline-primary-300 dark:focus:outline-zinc-600 #{@class}"}
-        phx-click={toggle_menu("##{@id}-dropdown")}
-      >
-        <.user_picture_icon user={@ctx.author} />
-      </button>
-      <.dropdown_menu id={"#{@id}-dropdown"} class={@dropdown_class}>
-        <.account_label label="Admin" class="text-[#F68E2E]" />
-        <.author_menu_items
-          ctx={@ctx}
-          id={@id}
-          target_signout_path={target_signout_path(@active_workspace)}
-          is_admin={true}
-        />
-      </.dropdown_menu>
-    </div>
-    """
-  end
-
   def workspace_menu(%{active_workspace: :course_author} = assigns) do
     ~H"""
     <div class="relative">
@@ -73,12 +50,13 @@ defmodule OliWeb.Components.Delivery.UserAccount do
         <.user_picture_icon user={@ctx.author} />
       </button>
       <.dropdown_menu id={"#{@id}-dropdown"} class={@dropdown_class}>
-        <.account_label label="Author" class="text-[#EC8CFF]" />
+        <.account_label :if={Accounts.is_admin?(@ctx.author)} label="Author" class="text-[#EC8CFF]" />
+        <.account_label :if={!Accounts.is_admin?(@ctx.author)} label="Admin" class="text-[#F68E2E]" />
         <.author_menu_items
           ctx={@ctx}
           id={@id}
           target_signout_path={target_signout_path(@active_workspace)}
-          is_admin={false}
+          is_admin={Accounts.is_admin?(@ctx.author)}
         />
       </.dropdown_menu>
     </div>


### PR DESCRIPTION
This PR fixes the problem that an "Account" only admin was not seeing the Admin menu.  The fix here was to directly use the `Author` struct that is in the context for determining if the user is an Admin