### PR TITLE
[BUG FIX] [MER-4357] Fix issue preventing threshold checks from triggering on completed jobs

### DIFF
--- a/lib/oli/certification_eligibility.ex
+++ b/lib/oli/certification_eligibility.ex
@@ -67,7 +67,9 @@ defmodule Oli.CertificationEligibility do
   """
 
   defp enqueue_certification_check(user_id, section_id) do
-    CheckCertification.restart_certificate_check(user_id, section_id)
+    %{user_id: user_id, section_id: section_id}
+    |> CheckCertification.new()
+    |> Oban.insert()
   end
 
   # Case: Discussion Post

--- a/lib/oli/certification_eligibility.ex
+++ b/lib/oli/certification_eligibility.ex
@@ -67,9 +67,7 @@ defmodule Oli.CertificationEligibility do
   """
 
   defp enqueue_certification_check(user_id, section_id) do
-    %{user_id: user_id, section_id: section_id}
-    |> CheckCertification.new()
-    |> Oban.insert()
+    CheckCertification.restart_certificate_check(user_id, section_id)
   end
 
   # Case: Discussion Post

--- a/lib/oli/delivery/sections/certificates/workers/check_certification.ex
+++ b/lib/oli/delivery/sections/certificates/workers/check_certification.ex
@@ -5,11 +5,30 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.CheckCertification do
     max_attempts: 1
 
   alias Oli.Delivery.GrantedCertificates
+  alias Oli.Delivery.Sections.Certificates.Workers.CheckCertification
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id, "section_id" => section_id}}) do
     GrantedCertificates.has_qualified(user_id, section_id)
 
     :ok
+  end
+
+  def restart_certificate_check(user_id, section_id) do
+    Ecto.Adapters.SQL.query!(
+      Oli.Repo,
+      """
+      DELETE FROM oban_jobs
+      WHERE id = (
+        SELECT id FROM oban_jobs
+        WHERE queue = 'certificate_eligibility'
+        AND args @> $1
+        LIMIT 1
+      )
+      """,
+      [%{"user_id" => user_id, "section_id" => section_id}]
+    )
+
+    %{user_id: user_id, section_id: section_id} |> CheckCertification.new() |> Oban.insert()
   end
 end

--- a/lib/oli/delivery/sections/certificates/workers/check_certification.ex
+++ b/lib/oli/delivery/sections/certificates/workers/check_certification.ex
@@ -1,34 +1,23 @@
 defmodule Oli.Delivery.Sections.Certificates.Workers.CheckCertification do
+  @moduledoc """
+  Worker responsible for checking if a user qualifies for a certificate in a specific section.
+  """
   use Oban.Worker,
     queue: :certificate_eligibility,
-    unique: [keys: [:user_id, :section_id]],
+    unique: [
+      keys: [:user_id, :section_id],
+      # Prevents duplicate jobs in these states
+      states: [:available, :scheduled, :retryable],
+      period: :infinity
+    ],
     max_attempts: 1
 
   alias Oli.Delivery.GrantedCertificates
-  alias Oli.Delivery.Sections.Certificates.Workers.CheckCertification
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"user_id" => user_id, "section_id" => section_id}}) do
     GrantedCertificates.has_qualified(user_id, section_id)
 
     :ok
-  end
-
-  def restart_certificate_check(user_id, section_id) do
-    Ecto.Adapters.SQL.query!(
-      Oli.Repo,
-      """
-      DELETE FROM oban_jobs
-      WHERE id = (
-        SELECT id FROM oban_jobs
-        WHERE queue = 'certificate_eligibility'
-        AND args @> $1
-        LIMIT 1
-      )
-      """,
-      [%{"user_id" => user_id, "section_id" => section_id}]
-    )
-
-    %{user_id: user_id, section_id: section_id} |> CheckCertification.new() |> Oban.insert()
   end
 end


### PR DESCRIPTION
Ticket: [MER-4357](https://eliterate.atlassian.net/browse/MER-4357)

When a student submits a graded page, our system kicks off an Oban job. This job’s job (pun intended!) is to figure out if the student has hit the required thresholds. It’s supposed to run every time a student submits a graded page (with some smart optimizations in the mix). But right now, it only runs once, and any follow-up submissions get skipped. This is a problem because the student’s page thinks the thresholds have been reached, but that’s not actually the case since we’re not running all the necessary checks.

The Issue: Once an Oban job runs, it’s marked as "completed." Because of a unique constraint, we can’t run the same job again for the same user and section.

The Fix We’re Proposing: Before inserting a new Oban job, we’ll clear out any existing jobs for the same user_id and section_id combo. Then, we’ll add a fresh Oban job to make sure all the checks run properly.



[MER-4357]: https://eliterate.atlassian.net/browse/MER-4357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ