### PR TITLE
[BUG FIX] [MER-4359] Fixes group container header styling issue on delivery

### DIFF
--- a/lib/oli/rendering/group/html.ex
+++ b/lib/oli/rendering/group/html.ex
@@ -28,7 +28,7 @@ defmodule Oli.Rendering.Group.Html do
       end
 
     [
-      ~s|<div id="#{id}" class="group content-purpose #{purpose}"><div class="flex justify-between"><div class="content-purpose-label">#{Purposes.label_for(purpose)}</div><div>#{trigger_button}</div></div><div class="content-purpose-content content">|,
+      ~s|<div id="#{id}" class="group content-purpose #{purpose}"><div class="flex content-purpose-label"><div class="flex-grow-1">#{Purposes.label_for(purpose)}</div><div>#{trigger_button}</div></div><div class="content-purpose-content content">|,
       next.(),
       "</div></div>\n"
     ]

--- a/test/oli/rendering/page/html_test.exs
+++ b/test/oli/rendering/page/html_test.exs
@@ -52,7 +52,7 @@ defmodule Oli.Content.Page.HtmlTest do
       assert rendered_html_string =~ "<oli-multiple-choice-delivery"
       assert rendered_html_string =~ "<oli-check-all-that-apply-delivery"
 
-      assert rendered_html_string =~ "<div class=\"content-purpose-label\">Learn by doing"
+      assert rendered_html_string =~ "<div class=\"flex content-purpose-label\"><div class=\"flex-grow-1\">Learn by doing"
 
       assert rendered_html_string =~
                "The American Revolution was a colonial revolt which occurred between 1765 and 1783"

--- a/test/oli/rendering/page/html_test.exs
+++ b/test/oli/rendering/page/html_test.exs
@@ -52,7 +52,8 @@ defmodule Oli.Content.Page.HtmlTest do
       assert rendered_html_string =~ "<oli-multiple-choice-delivery"
       assert rendered_html_string =~ "<oli-check-all-that-apply-delivery"
 
-      assert rendered_html_string =~ "<div class=\"flex content-purpose-label\"><div class=\"flex-grow-1\">Learn by doing"
+      assert rendered_html_string =~
+               "<div class=\"flex content-purpose-label\"><div class=\"flex-grow-1\">Learn by doing"
 
       assert rendered_html_string =~
                "The American Revolution was a colonial revolt which occurred between 1765 and 1783"


### PR DESCRIPTION
This PR addresses an issue where when accessing any course in v30, the group styles (Learn by doing, Did I Get This, etc…) are missing.

This issue was introduced by a previous PR that added the new AI trigger button on the group header.