### PR TITLE
[BUG FIX] [MER-4331] fix an issue where infiniscope users cannot enroll in direct delivery course

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -224,10 +224,6 @@ defmodule OliWeb.DeliveryController do
         redirect(conn,
           to: ~p"/users/log_in?#{params}"
         )
-
-      # redirect to course index when user is not an independent learner (LTI user)
-      {:redirect, :non_independent_learner} ->
-        redirect(conn, to: Routes.delivery_path(conn, :index))
     end
   end
 
@@ -294,9 +290,6 @@ defmodule OliWeb.DeliveryController do
         else
           if requires_enrollment, do: {:redirect, nil}, else: {:redirect, :enroll}
         end
-
-      %User{independent_learner: false} ->
-        {:redirect, :non_independent_learner}
 
       %User{guest: true} = guest ->
         if requires_enrollment, do: {:redirect, nil}, else: {:ok, guest}

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -163,12 +163,12 @@ defmodule OliWeb.DeliveryControllerTest do
       assert html_response(conn, 403) =~ "Section Not Available"
     end
 
-    test "blocks LMS users from manually enrollment", %{
+    test "allow cognito users manual enrollment in section", %{
       conn: conn,
       section: section,
       student: student
     } do
-      # Assert that the user is an LMS user
+      # Assert that the user is a cognito user
       assert student.independent_learner == false
 
       conn =
@@ -177,7 +177,8 @@ defmodule OliWeb.DeliveryControllerTest do
 
       enrollment_path = ~p"/sections/#{section.slug}/enroll"
       conn = get(conn, enrollment_path)
-      assert response(conn, 302) =~ "You are being <a href=\"/sections\">redirected</a>"
+
+      assert response(conn, 200) =~ "Enroll in Course Section"
     end
 
     test "redirect to requested path after login", %{conn: conn, section: section} do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4331

This PR reverts the changes in https://github.com/Simon-Initiative/oli-torus/pull/5208. The original ticket [MER-3169](https://eliterate.atlassian.net/browse/MER-3169) didn't consider this use case of infiniscope users needing the ability to enroll themselves in direct delivery sections, even though they are not independent users.

The spirit of the original ticket still remains an issue, LMS/LTI users who are not infiniscope user and unintentionally enroll in a direct delivery section while logged in as an LTI account could lose access to that direct delivery section and their progress when their LMS access expires at whichever institution they are currently a part of. But this PR resolves the immediate need for infiniscope users.

[MER-3169]: https://eliterate.atlassian.net/browse/MER-3169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ