### PR TITLE
[ENHANCEMENT] [MER-4367] Add 'items' to activities context

### DIFF
--- a/lib/oli/analytics/datasets/utils.ex
+++ b/lib/oli/analytics/datasets/utils.ex
@@ -91,6 +91,7 @@ defmodule Oli.Analytics.Datasets.Utils do
            'activities', (
                SELECT jsonb_object_agg(r.resource_id::text, jsonb_build_object(
                           'choices', r.content->'choices',
+                          'items', r.content->'items',
                           'type', a.slug,
                           'parts', (
                               SELECT jsonb_agg(


### PR DESCRIPTION
This adds the "items" attribute of the activity `:content` to the Datasets lookup file. 

This is necessary to allow post-processing tasks to pull out the full text of Likert Activity "items". 