### PR TITLE
[BUG FIX] [MER-4243] allow non-confirmed user to access student workspace

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5395,7 +5395,7 @@ defmodule Oli.Delivery.Sections do
     from(e in Enrollment,
       join: s in assoc(e, :section),
       where: e.user_id == ^user.id,
-      where: s.skip_email_verification == true
+      where: e.status == :enrolled and s.skip_email_verification == true
     )
     |> Repo.exists?()
   end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5387,4 +5387,20 @@ defmodule Oli.Delivery.Sections do
     )
     |> Repo.all()
   end
+
+  @doc """
+  Returns true if the user is enrolled in any sections that do not require email confirmation
+  """
+  def user_enrolled_in_section_that_skips_email_confirmation?(user) do
+    from(e in Enrollment,
+      join: s in assoc(e, :section),
+      where: e.user_id == ^user.id,
+      where: s.skip_email_verification == true
+    )
+    |> Repo.all()
+    |> case do
+      [] -> false
+      _ -> true
+    end
+  end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5397,10 +5397,6 @@ defmodule Oli.Delivery.Sections do
       where: e.user_id == ^user.id,
       where: s.skip_email_verification == true
     )
-    |> Repo.all()
-    |> case do
-      [] -> false
-      _ -> true
-    end
+    |> Repo.exists?()
   end
 end

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -209,7 +209,13 @@ defmodule OliWeb.Components.Delivery.UserAccount do
 
   def user_menu_items(assigns) do
     ~H"""
-    <.menu_item_edit_account :if={is_independent_learner?(@ctx.user)} href={~p"/users/settings"} />
+    <.menu_item_edit_account
+      :if={is_independent_learner?(@ctx.user) && !Accounts.user_confirmation_pending?(@ctx.user)}
+      href={~p"/users/settings"}
+    />
+    <.menu_item_confirm_user_account :if={
+      is_independent_learner?(@ctx.user) && Accounts.user_confirmation_pending?(@ctx.user)
+    } />
     <.maybe_my_courses_menu_item_link user={@ctx.user} />
     <.menu_item_dark_mode_selector id={"#{@id}-dark-mode-selector"} ctx={@ctx} />
     <.menu_divider />
@@ -335,9 +341,23 @@ defmodule OliWeb.Components.Delivery.UserAccount do
 
   def menu_item_edit_account(assigns) do
     ~H"""
-    <.menu_item_link href={@href}>
-      Edit Account
-    </.menu_item_link>
+    <.menu_item>
+      <.menu_item_link href={@href}>
+        Edit Account
+      </.menu_item_link>
+    </.menu_item>
+
+    <.menu_divider />
+    """
+  end
+
+  def menu_item_confirm_user_account(assigns) do
+    ~H"""
+    <.menu_item>
+      <.menu_item_link href={~p"/users/confirm"}>
+        Confirm Account
+      </.menu_item_link>
+    </.menu_item>
 
     <.menu_divider />
     """
@@ -348,9 +368,11 @@ defmodule OliWeb.Components.Delivery.UserAccount do
   def maybe_my_courses_menu_item_link(assigns) do
     ~H"""
     <%= if is_independent_learner?(@user) do %>
-      <.menu_item_link href={~p"/workspaces/student"}>
-        My Courses
-      </.menu_item_link>
+      <.menu_item>
+        <.menu_item_link href={~p"/workspaces/student"}>
+          My Courses
+        </.menu_item_link>
+      </.menu_item>
 
       <.menu_divider />
     <% end %>

--- a/lib/oli_web/live/author_confirmation_instructions_live.ex
+++ b/lib/oli_web/live/author_confirmation_instructions_live.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.AuthorConfirmationInstructionsLive do
             </:title>
             <:subtitle>
               <p>
-                You must confirm your email address before you can sign in. Check your inbox for a confirmation link.
+                Please check your inbox for a confirmation link.
               </p>
 
               <p class="mt-4">

--- a/lib/oli_web/live/user_confirmation_instructions_live.ex
+++ b/lib/oli_web/live/user_confirmation_instructions_live.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.UserConfirmationInstructionsLive do
             </:title>
             <:subtitle>
               <p>
-                You must confirm your email address before you can sign in. Check your inbox for a confirmation link.
+                Please check your inbox for a confirmation link.
               </p>
 
               <p class="mt-4">

--- a/lib/oli_web/user_auth.ex
+++ b/lib/oli_web/user_auth.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.UserAuth do
 
   alias Oli.Accounts
   alias Oli.Accounts.{User}
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias OliWeb.AuthorAuth
 
@@ -399,13 +400,20 @@ defmodule OliWeb.UserAuth do
         # The section is independent and specifies to skip email verification
         conn
 
-      {%Accounts.User{independent_learner: true, guest: false, email_confirmed_at: nil}, _} ->
-        conn
-        |> renew_session()
-        |> delete_resp_cookie(@remember_me_cookie)
-        |> put_flash(:info, "You must confirm your email to continue.")
-        |> redirect(to: ~p"/users/confirm")
-        |> halt()
+      {%Accounts.User{independent_learner: true, guest: false, email_confirmed_at: nil} = user, _} ->
+        # If the request path is student workspace and the user is enrolled in at least one section
+        # where email confirmation is not required, allow the user to access the workspace.
+        if conn.request_path == ~p"/workspaces/student" and
+             Sections.user_enrolled_in_section_that_skips_email_confirmation?(user) do
+          conn
+        else
+          conn
+          |> renew_session()
+          |> delete_resp_cookie(@remember_me_cookie)
+          |> put_flash(:info, "You must confirm your email to continue.")
+          |> redirect(to: ~p"/users/confirm")
+          |> halt()
+        end
 
       _ ->
         conn

--- a/test/oli_web/live/workspaces/student_test.exs
+++ b/test/oli_web/live/workspaces/student_test.exs
@@ -220,6 +220,17 @@ defmodule OliWeb.Workspaces.StudentTest do
 
       assert render(view) =~ "desktop-workspace-nav-menu"
     end
+
+    test "can access student workspace when user is enrolled in any section that omits email verification",
+         %{conn: conn, user: user} do
+      {:ok, user} = Accounts.update_user(user, %{email_confirmed_at: nil})
+
+      section = insert(:section, open_and_free: true, skip_email_verification: true)
+
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} = live(conn, ~p"/workspaces/student")
+    end
   end
 
   describe "admin" do

--- a/test/oli_web/user_auth_test.exs
+++ b/test/oli_web/user_auth_test.exs
@@ -308,7 +308,7 @@ defmodule OliWeb.UserAuthTest do
       refute conn.status
     end
 
-    test "does not required user to confirm email if independent section has omit email verification set",
+    test "does not required user to confirm email when accesssing independent section has omit email verification set",
          %{conn: conn, user: user} do
       {:ok, user} = Accounts.update_user(user, %{email_confirmed_at: nil})
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4243

Fixes an issue uncovered in QA where an unconfirmed student can get lost and have no way to return to their section.

The fix here allows unconfirmed students to access the student workspace when they are enrolled in any course that does not require email confirmation.