### PR TITLE
[BUG FIX] [MER-4361] Fix product credentials issued tab

### DIFF
--- a/lib/oli/delivery/certificates.ex
+++ b/lib/oli/delivery/certificates.ex
@@ -124,6 +124,7 @@ defmodule Oli.Delivery.Certificates do
         on: a.id == gc.issued_by and gc.issued_by_type == :author
       )
       |> where(^filter_by_section_or_blueprint)
+      |> where([gc, c, s, u, u1, a], gc.state == :earned)
       |> offset(^offset)
       |> limit(^limit)
       |> select(

--- a/lib/oli/delivery/certificates.ex
+++ b/lib/oli/delivery/certificates.ex
@@ -101,7 +101,6 @@ defmodule Oli.Delivery.Certificates do
         text_search,
         %Section{id: section_id, type: type}
       ) do
-
     # if the section is blueprint (a product) we search for the granted certificates
     # in all the courses created based on that product
     filter_by_section_or_blueprint =
@@ -110,7 +109,6 @@ defmodule Oli.Delivery.Certificates do
       else
         dynamic([gc, c, s, u, u1, a], s.id == ^section_id)
       end
-
 
     query =
       GrantedCertificate

--- a/lib/oli_web/controllers/granted_certificates_controller.ex
+++ b/lib/oli_web/controllers/granted_certificates_controller.ex
@@ -4,9 +4,18 @@ defmodule OliWeb.GrantedCertificatesController do
   alias Oli.Analytics.DataTables.DataTable
   alias OliWeb.Common.Utils
 
+  @doc """
+  Download granted certificates in CSV format.
+  It only considers certificates that are in the earned state.
+
+  Since we are querying a product, this will include all certificates granted
+  by all courses created based on that product.
+  """
   def download_granted_certificates(conn, params) do
     data =
-      Oli.Delivery.Certificates.get_granted_certificates_by_section_slug(params["product_id"])
+      Oli.Delivery.Certificates.get_granted_certificates_by_section_id(params["product_id"],
+        filter_by_state: [:earned]
+      )
       |> Enum.reduce([], fn %{recipient: recipient, issuer: issuer} = gc, acc ->
         record = %{
           student_name: Utils.name(recipient.name, recipient.family_name, recipient.given_name),

--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -108,10 +108,13 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
     sorting = %Sorting{direction: params["direction"], field: params["sort_by"]}
     text_search = params["text_search"]
 
-    section_id = socket.assigns.section.id
-
     granted_certificates =
-      Certificates.browse_granted_certificates(paging, sorting, text_search, section_id)
+      Certificates.browse_granted_certificates(
+        paging,
+        sorting,
+        text_search,
+        socket.assigns.section
+      )
 
     table_model = socket.assigns[:table_model]
     table_model = %{table_model | rows: granted_certificates, sort_order: params["direction"]}

--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -181,6 +181,7 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
       module={CertificatesIssuedTab}
       id="certificates_issued_component"
       params={@params}
+      section_id={@section.id}
       section_slug={@section.slug}
       table_model={@table_model}
       ctx={@ctx}

--- a/lib/oli_web/live/certificates/components/certificates_issued_tab.ex
+++ b/lib/oli_web/live/certificates/components/certificates_issued_tab.ex
@@ -34,7 +34,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTab do
           <a
             :if={!@read_only}
             role="export"
-            href={~p"/authoring/products/#{assigns.section_slug}/downloads/granted_certificates"}
+            href={~p"/authoring/products/#{@section_id}/downloads/granted_certificates"}
             class="flex items-center justify-center gap-x-2"
           >
             <Icons.download /> Download CSV

--- a/lib/oli_web/live/certificates/components/certificates_issued_tab.ex
+++ b/lib/oli_web/live/certificates/components/certificates_issued_tab.ex
@@ -134,6 +134,10 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTab do
     ~p"/workspaces/course_author/#{project.slug}/products/#{section_slug}/certificate_settings?#{params}"
   end
 
+  def select_path(:delivery, _project, section_slug, params) do
+    ~p"/sections/#{section_slug}/certificate_settings?#{params}"
+  end
+
   def decode_params(params) do
     text_search = Params.get_param(params, "text_search", @default_values.text_search)
     limit = Params.get_int_param(params, "limit", @default_values.paging.limit)

--- a/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/helpers.ex
@@ -255,7 +255,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.Helpers do
 
   defp maybe_add_certificates(students, section) do
     certificates =
-      Certificates.get_granted_certificates_by_section_slug(section.slug)
+      Certificates.get_granted_certificates_by_section_id(section.id)
       |> Enum.into(%{}, fn cert -> {cert.recipient.id, cert} end)
 
     Enum.map(students, fn student ->

--- a/test/oli_web/controllers/granted_certificates_controller_test.exs
+++ b/test/oli_web/controllers/granted_certificates_controller_test.exs
@@ -1,0 +1,35 @@
+defmodule OliWeb.GrantedCertificatesControllerTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+
+  describe "download_granted_certificates" do
+    test "returns a csv with the granted certificates - state = earned - of the provided product id",
+         %{conn: conn} do
+      {:ok, conn: conn, author: _} = author_conn(%{conn: conn})
+      product = insert(:section, type: :blueprint)
+      section = insert(:section, type: :enrollable, blueprint_id: product.id)
+      certificate = insert(:certificate, section: section)
+      [gc_1, gc_2] = insert_pair(:granted_certificate, certificate: certificate, state: :earned)
+      [gc_3, gc_4] = insert_pair(:granted_certificate, certificate: certificate, state: :denied)
+
+      conn = get(conn, ~p"/authoring/products/#{product.id}/downloads/granted_certificates")
+
+      assert response(conn, 200)
+
+      assert Enum.any?(conn.resp_headers, fn h ->
+               h ==
+                 {"content-disposition",
+                  "attachment; filename=\"#{product.id}_granted_certificates_content.csv\""}
+             end)
+
+      assert Enum.any?(conn.resp_headers, fn h -> h == {"content-type", "text/csv"} end)
+      assert conn.resp_body =~ "student_name,student_email,issued_at,issuer_name,guid"
+
+      assert conn.resp_body =~ gc_1.user.given_name
+      assert conn.resp_body =~ gc_2.user.given_name
+      refute conn.resp_body =~ gc_3.user.given_name
+      refute conn.resp_body =~ gc_4.user.given_name
+    end
+  end
+end

--- a/test/oli_web/live/certificates/components/certificates_issued_tab_test.exs
+++ b/test/oli_web/live/certificates/components/certificates_issued_tab_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTabTest do
       sorting = %Sorting{field: sort_by, direction: direction}
 
       granted_certificates =
-        Certificates.browse_granted_certificates(paging, sorting, text_search, section_id)
+        Certificates.browse_granted_certificates(paging, sorting, text_search, section)
 
       table_model =
         CertificatesIssuedTableModel.new(session_context, granted_certificates, section_slug)
@@ -44,6 +44,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTabTest do
         id: id,
         params: params,
         section_slug: section_slug,
+        section_id: section_id,
         table_model: table_model,
         ctx: session_context,
         route_name: route_name,
@@ -119,7 +120,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTabTest do
       sorting = %Sorting{field: sort_by, direction: direction}
 
       granted_certificates =
-        Certificates.browse_granted_certificates(paging, sorting, text_search, section_id)
+        Certificates.browse_granted_certificates(paging, sorting, text_search, section)
 
       table_model =
         CertificatesIssuedTableModel.new(session_context, granted_certificates, section_slug)
@@ -128,6 +129,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTabTest do
         id: id,
         params: params,
         section_slug: section_slug,
+        section_id: section_id,
         table_model: table_model,
         ctx: session_context,
         route_name: route_name,


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4361) to the ticket

### Granted certificates not being listed

The main issue was that the query that fetches the granted certificates for the current product did not include all granted certificates of courses created based on that product.
The fix was to extend `browse_granted_certificates/4` to include those certificates.

That same query was not filtering by state -> now [we only consider GC with state = :earned](https://eliterate.atlassian.net/browse/MER-4361?focusedCommentId=25919)

Tests for all modified/extended context functions are included in the PR.

#### Before
<img width="1439" alt="Screenshot 2025-03-07 at 10 57 19 AM" src="https://github.com/user-attachments/assets/ef03764b-cb12-40c3-9789-32acee4327d4" />

#### After
<img width="1440" alt="Screenshot 2025-03-07 at 10 50 13 AM" src="https://github.com/user-attachments/assets/6de5b7df-ae86-4f3c-8a41-d2caae30d755" />


### Download CSV returned a blank spreadsheet

The `download CSV` link returned a blank spreadsheet since the query used to fetch the GCs had the same issue as the other one (it was not considering GC from courses created based on that product and was not filtering by earned state).
Now it returns the same GCs shown in the table.

A test was added to the `OliWeb.GrantedCertificatesController` module (the one that handles the CSV download)

#### Before
<img width="821" alt="Screenshot 2025-03-07 at 10 52 40 AM" src="https://github.com/user-attachments/assets/250f318a-3dd6-4aaa-b4ac-7a2a1b5051a3" />

#### After
<img width="744" alt="Screenshot 2025-03-07 at 10 51 14 AM" src="https://github.com/user-attachments/assets/e3fe5b85-d24d-4825-b386-26f8dfe31fc3" />

### Filtering GC by text was broken.
The CertificatesIssuedTab component is rendered both in the authoring and in the instructor UI.
The `delivery` path case was missing on the `select_path/4` helper function (the one used to patch the URL while filtering by text).

#### Before

https://github.com/user-attachments/assets/52508318-3b49-4de4-8c48-84d528564409


#### After

https://github.com/user-attachments/assets/fab5c4bc-aab6-4ed0-b209-24cb1f019410


