### PR TITLE
[BUG FIX] [MER-4366] Fix author label on workspace menu

### DIFF
--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -74,8 +74,8 @@ defmodule OliWeb.Components.Delivery.UserAccount do
         <.user_picture_icon user={@ctx.author} />
       </button>
       <.dropdown_menu id={"#{@id}-dropdown"} class={@dropdown_class}>
-        <.account_label :if={Accounts.is_admin?(@ctx.author)} label="Author" class="text-[#EC8CFF]" />
-        <.account_label :if={!Accounts.is_admin?(@ctx.author)} label="Admin" class="text-[#F68E2E]" />
+        <.account_label :if={!Accounts.is_admin?(@ctx.author)} label="Author" class="text-[#EC8CFF]" />
+        <.account_label :if={Accounts.is_admin?(@ctx.author)} label="Admin" class="text-[#F68E2E]" />
         <.author_menu_items
           ctx={@ctx}
           id={@id}


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4366) to the ticket

As [Dovid pointed](https://eliterate.atlassian.net/browse/MER-4366?focusedCommentId=25922) the bug was introduced on MER-4350.

The `!` on the if condition was on the admin case instead of the author case.

### After

#### Author account
<img width="286" alt="Screenshot 2025-03-07 at 11 22 56 AM" src="https://github.com/user-attachments/assets/0ae318e7-4e84-4f0c-8500-da0c80267d96" />

#### Admin account
<img width="286" alt="Screenshot 2025-03-07 at 11 22 25 AM" src="https://github.com/user-attachments/assets/5644275b-957d-4297-ab89-2e2fb2cf3ce1" />

