### PR TITLE
[BUG FIX] [MER-4375] Do not create duplicate certificates in thresholds tab

### DIFF
--- a/lib/oli_web/live/certificates/components/thresholds_tab.ex
+++ b/lib/oli_web/live/certificates/components/thresholds_tab.ex
@@ -267,7 +267,10 @@ defmodule OliWeb.Certificates.Components.ThresholdsTab do
         {:ok, certificate} ->
           send(self(), {:put_flash, [:info, "Certificate settings saved successfully"]})
 
-          assign(socket, certificate_changeset: certificate_changeset(certificate))
+          assign(socket,
+            certificate: certificate,
+            certificate_changeset: certificate_changeset(certificate)
+          )
 
         {:error, %Ecto.Changeset{} = changeset} ->
           send(self(), {:put_flash, [:error, "Failed to save certificate settings"]})


### PR DESCRIPTION
Assign certificate to socket assigns after inserting it so next time an update happens instead a new insert.
See: https://eliterate.atlassian.net/browse/MER-4375