### PR TITLE
[BUG FIX] [MER-4370] Fixes error navigating as an instructor from certificate settings

### DIFF
--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -21,6 +21,7 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
 
   def mount(params, session, socket) do
     slug = params["product_id"] || params["section_slug"]
+    IO.inspect(slug)
     socket = assigns_for(socket, :page)
 
     case Mount.for(slug, session) do
@@ -65,13 +66,18 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
   defp assigns_for(socket, :breadcrumbs) do
     %{assigns: %{route_name: route_name, section: section}} = socket
 
+    IO.inspect(route_name)
+
     case route_name do
       :workspaces ->
         project = socket.assigns.project
-        socket |> assign(breadcrumbs: breadcrumbs(:workspaces, project.slug, section.slug))
+        socket |> assign(breadcrumbs: breadcrumbs(:workspaces, project.slug, section))
 
-      route_name when route_name in [:authoring, :delivery] ->
-        socket |> assign(breadcrumbs: breadcrumbs(:authoring, nil, section.slug))
+      :delivery ->
+        socket |> assign(breadcrumbs: breadcrumbs(:delivery, nil, section))
+
+      :authoring ->
+        socket |> assign(breadcrumbs: breadcrumbs(:authoring, nil, section))
     end
   end
 
@@ -306,21 +312,31 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
      |> put_flash(type, message)}
   end
 
-  defp breadcrumbs(:authoring, _project_slug, section_slug) do
+  defp breadcrumbs(:delivery, _project_slug, section) do
     [
       Breadcrumb.new(%{
-        full_title: "Manage Section",
-        link: ~p"/authoring/products/#{section_slug}"
+        full_title: section.title,
+        link: ~p"/sections/#{section.slug}/manage"
       }),
       Breadcrumb.new(%{full_title: "Manage Certificate Settings"})
     ]
   end
 
-  defp breadcrumbs(:workspaces, project_slug, section_slug) do
+  defp breadcrumbs(:authoring, _project_slug, section) do
+    [
+      Breadcrumb.new(%{
+        full_title: "Manage Section",
+        link: ~p"/authoring/products/#{section.slug}"
+      }),
+      Breadcrumb.new(%{full_title: "Manage Certificate Settings"})
+    ]
+  end
+
+  defp breadcrumbs(:workspaces, project_slug, section) do
     [
       Breadcrumb.new(%{
         full_title: "Product Overview",
-        link: ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+        link: ~p"/workspaces/course_author/#{project_slug}/products/#{section.slug}"
       }),
       Breadcrumb.new(%{full_title: "Manage Certificate Settings"})
     ]

--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -21,7 +21,6 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
 
   def mount(params, session, socket) do
     slug = params["product_id"] || params["section_slug"]
-    IO.inspect(slug)
     socket = assigns_for(socket, :page)
 
     case Mount.for(slug, session) do
@@ -65,8 +64,6 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
 
   defp assigns_for(socket, :breadcrumbs) do
     %{assigns: %{route_name: route_name, section: section}} = socket
-
-    IO.inspect(route_name)
 
     case route_name do
       :workspaces ->

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -233,7 +233,7 @@ defmodule OliWeb.Sections.OverviewView do
       >
         <div class="flex flex-col md:col-span-8 gap-2">
           <div>
-            This product <b>does <%= unless @section.certificate_enabled, do: "not" %></b>
+            This section <b>does <%= unless @section.certificate_enabled, do: "not" %></b>
             currently produce a certificate.
           </div>
           <div :if={@section.certificate_enabled}>


### PR DESCRIPTION
This PR address an issue where the breadcrumb link under a delivery course `Manage Certificate Settings` page erroneously redirects a course instructor into an `authoring` page, generating a 500 error.