### PR TITLE
[FEATURE] [MER-3882] Add Certificate Requirements to Assignments Page

### DIFF
--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1757,6 +1757,27 @@ defmodule OliWeb.Icons do
     """
   end
 
+  attr :class, :string, default: "fill-[#FF8787]"
+
+  def asterisk(assigns) do
+    ~H"""
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 13 13"
+      fill="currentColor"
+      class={@class}
+      xmlns="http://www.w3.org/2000/svg"
+      role="asterisk icon"
+    >
+      <path
+        opacity="0.9"
+        d="M8.20654 0.0561523L7.69385 4.95239L12.6157 3.5553L13.0002 6.2854L8.3988 6.69556L11.3853 10.6818L8.89868 12.0276L6.73254 7.73376L4.79712 12.0148L2.20801 10.6818L5.16882 6.69556L0.593018 6.27258L1.02881 3.5553L5.86096 4.95239L5.34827 0.0561523H8.20654Z"
+      />
+    </svg>
+    """
+  end
+
   ########## Instructor Navigation Bar Icons (end) ##########
 
   ########## Start of Sidebar Icons  ##########

--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -123,7 +123,10 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
 
   def certificate_requirements(assigns) do
     ~H"""
-    <div class="w-full h-[81px] justify-center items-center inline-flex mb-20 sm:mb-0">
+    <div
+      id="certificate_requirements"
+      class="w-full h-[81px] justify-center items-center inline-flex mb-20 sm:mb-0"
+    >
       <div class="grow shrink basis-0 self-stretch flex-col justify-start items-start gap-[5px] inline-flex">
         <div class="flex-col justify-center items-start gap-[8px] flex">
           <div class="w-full h-fit dark:text-[#e6e9f2]">
@@ -353,6 +356,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
       fill="currentColor"
       class={@class}
       xmlns="http://www.w3.org/2000/svg"
+      role="asterisk icon"
     >
       <path
         opacity="0.9"
@@ -413,6 +417,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
   def filter_option(%{option: :all} = assigns) do
     ~H"""
     <button
+      id="select_all_option"
       class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-black/10 dark:bg-white/10 hover:bg-black/20 hover:dark:bg-white/20"
       phx-click="select_filter"
       phx-value-filter="all"
@@ -428,6 +433,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
   def filter_option(%{option: :required} = assigns) do
     ~H"""
     <button
+      id="select_required_option"
       class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-black/10 dark:bg-white/10 hover:bg-black/20 hover:dark:bg-white/20"
       phx-click="select_filter"
       phx-value-filter="required"

--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -126,34 +126,38 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
     <div class="w-full h-[81px] justify-center items-center inline-flex mb-20 sm:mb-0">
       <div class="grow shrink basis-0 self-stretch flex-col justify-start items-start gap-[5px] inline-flex">
         <div class="flex-col justify-center items-start gap-[8px] flex">
-          <div class="w-full h-fit">
-            <span class="text-[#e6e9f2] font-bold">
+          <div class="w-full h-fit dark:text-[#e6e9f2]">
+            <span class="font-bold">
               This is a Certificate Course.
             </span>
-            <span class="text-[#e6e9f2] font-normal">
+            <span class="dark:text-[#e6e9f2] font-normal">
               Complete all required assignments (
             </span>
             <span class="text-[#ff8787] text-xl font-normal">*</span>
-            <span class="text-[#e6e9f2] font-normal"> ) and follow these scoring guidelines:</span>
+            <span class="dark:text-[#e6e9f2] font-normal">
+              ) and follow these scoring guidelines:
+            </span>
           </div>
           <div class="w-full grow shrink basis-0">
             <div class="w-full h-fit">
-              <span class="text-[#e6e9f2] text-sm font-bold">
+              <span class="text-sm font-bold">
                 Certificate of Completion:
               </span>
-              <span class="text-[#e6e9f2] text-sm font-normal"> Earn </span><span class="text-[#39e581] text-sm font-bold">
-              <%= format_percentage(@certificate.min_percentage_for_completion) %>
+              <span class="text-sm font-normal"> Earn </span>
+              <span class="text-[#2db767] dark:text-[#39e581] text-sm font-bold">
+                <%= format_percentage(@certificate.min_percentage_for_completion) %>
               </span>
-              <span class="text-[#39e581] text-sm font-normal"></span><span class="text-white text-sm font-normal">or above on all required assignments</span>
+              <span class="text-sm font-normal">or above on all required assignments</span>
             </div>
             <div class="w-full h-fit">
-              <span class="text-[#e6e9f2] text-sm font-bold">
+              <span class="text-sm font-bold">
                 Certificate with Distinction:
               </span>
-              <span class="text-white text-sm font-bold"></span><span class="text-white text-sm font-normal">Earn</span><span class="text-[#30db9d] text-sm font-normal"> </span><span class="text-[#39e581] text-sm font-bold">
-              <%= format_percentage(@certificate.min_percentage_for_distinction) %>
+              <span class="text-sm font-bold"></span><span class="text-sm font-normal">Earn</span>
+              <span class="text-[#2db767] dark:text-[#39e581] text-sm font-bold">
+                <%= format_percentage(@certificate.min_percentage_for_distinction) %>
               </span>
-              <span class="text-[#30db9d] text-sm font-normal"></span><span class="text-white text-sm font-normal">or above on all required assignments</span>
+              <span class="text-sm font-normal"></span><span class="text-sm font-normal">or above on all required assignments</span>
             </div>
           </div>
         </div>
@@ -363,10 +367,10 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
 
   defp filter_dropdown(assigns) do
     ~H"""
-    <div class="flex relative justify-end mb-6 z-99" phx-click-away="collapse_select">
+    <div class="flex relative justify-end mb-6" phx-click-away="collapse_select">
       <button
         class={[
-          "h-6 px-2 py-[3px] bg-white/10 rounded-xl justify-start items-center gap-2 overflow-hidden hover:cursor-pointer hover:bg-white/20",
+          "h-6 px-2 py-[3px] bg-black/10 dark:bg-white/10 rounded-xl justify-start items-center gap-2 overflow-hidden hover:cursor-pointer hover:bg-black/20 hover:dark:bg-white/20",
           if(@filter == :all, do: "w-[180px]", else: "w-[210px]")
         ]}
         phx-click="toggle_filter_open"
@@ -375,12 +379,12 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
           <%= case @filter do %>
             <% :all -> %>
               <Icons.transparent_flag class="dark:stroke-white" />
-              <div class="text-white text-[13px] font-semibold">
+              <div class="text-[13px] font-semibold">
                 All Assignments
               </div>
             <% :required -> %>
-              <.asterisk_icon class="fill-white" />
-              <div class="text-white text-[13px] font-semibold">
+              <.asterisk_icon class="dark:fill-white" />
+              <div class="text-[13px] font-semibold">
                 Required Assignments
               </div>
           <% end %>
@@ -395,7 +399,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
       <div
         :if={@filter_expanded}
         class={[
-          "h-13 absolute top-8 flex flex-col rounded-lg border border-[#3B3740] justify-start items-center overflow-hidden divide-y divide-[#3B3740] dark:divide-white/20",
+          "h-13 absolute top-8 flex flex-col rounded-lg border border-black/20 dark:border-[#3B3740] justify-start items-center overflow-hidden divide-y divide-black/20 dark:divide-white/20",
           if(@filter == :all, do: "w-[180px]", else: "w-[210px]")
         ]}
       >
@@ -409,12 +413,12 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
   def filter_option(%{option: :all} = assigns) do
     ~H"""
     <button
-      class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-[#0D0C0F] hover:bg-white/20"
+      class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-black/10 dark:bg-white/10 hover:bg-black/20 hover:dark:bg-white/20"
       phx-click="select_filter"
       phx-value-filter="all"
     >
       <Icons.transparent_flag class="dark:stroke-white" />
-      <div class="text-white text-[13px] font-semibold">
+      <div class="text-[13px] font-semibold">
         All
       </div>
     </button>
@@ -424,12 +428,12 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
   def filter_option(%{option: :required} = assigns) do
     ~H"""
     <button
-      class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-[#0D0C0F] hover:bg-white/20"
+      class="w-full h-6 p-3 justify-start items-center gap-2.5 flex hover:cursor-pointer bg-black/10 dark:bg-white/10 hover:bg-black/20 hover:dark:bg-white/20"
       phx-click="select_filter"
       phx-value-filter="required"
     >
-      <.asterisk_icon class="fill-white" />
-      <div class="text-white text-[13px] font-semibold pl-1.5">
+      <.asterisk_icon class="dark:fill-white" />
+      <div class="text-[13px] font-semibold pl-1.5">
         Required
       </div>
     </button>


### PR DESCRIPTION
[MER-3882](https://eliterate.atlassian.net/browse/MER-3882)

Add Certificate requirements information to the assignments page when the course section has a certificate.
Add filter to display all assignments or required assignments for the certificate.


https://github.com/user-attachments/assets/18a75bb8-5780-45b6-91f1-b691dc863fd0



[MER-3882]: https://eliterate.atlassian.net/browse/MER-3882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ