### PR TITLE
[BUG FIX] [MER-4107] Fix: ensure checkbox value is submitted even when disabled. The hidden input reflects the checkbox state based on @checked

### DIFF
--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -323,7 +323,7 @@ defmodule OliWeb.Components.Common do
     ~H"""
     <div class="contents" phx-feedback-for={@name}>
       <label class={"flex gap-2 items-center #{@label_class}"}>
-        <input type="hidden" name={@name} value="false" />
+        <input type="hidden" name={@name} value={if @checked, do: "true", else: "false"} />
         <input
           type="checkbox"
           id={@id}

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -151,18 +151,18 @@ defmodule OliWeb.Sections.EditLiveTest do
       assert Oli.Repo.get(Section, section.id).has_grace_period == true
       assert has_element?(view, "#section_has_grace_period[checked=\"checked\"]")
 
+      # Handle event "validate" shouldn't change has_grace_period
       view
       |> element("form[phx-change=\"validate\"")
       |> render_change(section: %{title: "New title"})
 
       assert has_element?(view, "#section_has_grace_period[checked=\"checked\"]")
 
-      # Handle event "validate" shouldn't change has_grace_period
+      # Handle event "save" shouldn't change has_grace_period
       view
       |> element("form[phx-submit=\"save\"")
       |> render_submit(section: %{title: "New title"})
 
-      # Handle event "save" shouldn't change has_grace_period
       assert has_element?(view, "#section_has_grace_period[checked=\"checked\"]")
       assert Oli.Repo.get(Section, section.id).has_grace_period == true
     end


### PR DESCRIPTION
Ticket: [MER-4374](https://eliterate.atlassian.net/browse/MER-4374)

This PR addresses the issue encountered when modifying section details, which also altered other unrelated parts that were not touched.

The problem was caused by how we were handling the disabled attribute. When an input is set to disabled, the browser ignores it during form submission, causing the hidden input to send its corresponding value, which was set to false. This behavior is expected since browsers intentionally exclude disabled inputs from form data.

This ticket is part of v31 and should point to master. ⚠️ 

[MER-4374]: https://eliterate.atlassian.net/browse/MER-4374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ