### PR TITLE
[BUG FIX] [MER-4395] Ensures that a section resource page query with zero page ids returns empty array

### DIFF
--- a/lib/oli/delivery/depot/match_spec_translator.ex
+++ b/lib/oli/delivery/depot/match_spec_translator.ex
@@ -131,11 +131,9 @@ defmodule Oli.Delivery.Depot.MatchSpecTranslator do
   # The :in operator is a special case as we map the values of the list to multiple
   # :orelse equality conditions
   defp handle_cond(type, {_f, {:in, value}}, _, {m, c, v}) do
-    {:orelse, {:==, :"$1", 1}, {:orelse, {:==, :"$1", 2}, {:==, :"$1", 3}}}
-
     case Enum.count(value) do
       0 ->
-        {m, c, v}
+        {m, [{:==, 1, 2}], v}
 
       1 ->
         {m, [{:==, field(v), encode(Enum.at(value, 0), type)} | c], v}

--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -112,16 +112,22 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
   Return the SectionResource records for a given section and a list of page ids.
   """
   def get_pages(section_id, page_ids) do
-    depot_coordinator().init_if_necessary(@depot_desc, section_id, __MODULE__)
+    case Enum.empty?(page_ids) do
+      true ->
+        []
 
-    query_conditions = {:resource_id, {:in, page_ids}}
+      false ->
+        depot_coordinator().init_if_necessary(@depot_desc, section_id, __MODULE__)
 
-    Depot.query(
-      @depot_desc,
-      section_id,
-      query_conditions
-    )
-    |> Enum.sort_by(& &1.numbering_index)
+        query_conditions = {:resource_id, {:in, page_ids}}
+
+        Depot.query(
+          @depot_desc,
+          section_id,
+          query_conditions
+        )
+        |> Enum.sort_by(& &1.numbering_index)
+    end
   end
 
   @doc """

--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -112,22 +112,16 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
   Return the SectionResource records for a given section and a list of page ids.
   """
   def get_pages(section_id, page_ids) do
-    case Enum.empty?(page_ids) do
-      true ->
-        []
+    depot_coordinator().init_if_necessary(@depot_desc, section_id, __MODULE__)
 
-      false ->
-        depot_coordinator().init_if_necessary(@depot_desc, section_id, __MODULE__)
+    query_conditions = {:resource_id, {:in, page_ids}}
 
-        query_conditions = {:resource_id, {:in, page_ids}}
-
-        Depot.query(
-          @depot_desc,
-          section_id,
-          query_conditions
-        )
-        |> Enum.sort_by(& &1.numbering_index)
-    end
+    Depot.query(
+      @depot_desc,
+      section_id,
+      query_conditions
+    )
+    |> Enum.sort_by(& &1.numbering_index)
   end
 
   @doc """

--- a/test/oli/delivery/sections/section_resource_depot_test.exs
+++ b/test/oli/delivery/sections/section_resource_depot_test.exs
@@ -237,6 +237,29 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
       # Test Depot
       test_depot(section_id)
     end
+
+    test "returns a list of SectionResource pages from page ids", ctx do
+      %{
+        section: %{id: section_id} = _section,
+        page_1_revision: page_1_revision,
+        page_2_revision: page_2_revision
+      } = ctx
+
+      revision_ids = [page_1_revision.id, page_2_revision.id]
+      page_sr_ids = get_section_resource_ids(revision_ids)
+      resource_ids = [page_1_revision.resource_id, page_2_revision.resource_id]
+
+      [%SectionResource{id: id1}, %SectionResource{id: id2}] =
+        SectionResourceDepot.get_pages(section_id, resource_ids)
+
+      assert Enum.all?([id1, id2], &(&1 in page_sr_ids))
+
+      IO.inspect("--------------------")
+      assert Enum.empty?(SectionResourceDepot.get_pages(section_id, []))
+
+      # Test Depot
+      test_depot(section_id)
+    end
   end
 
   describe "get_section_resources_by_type_ids/2" do

--- a/test/oli/delivery/sections/section_resource_depot_test.exs
+++ b/test/oli/delivery/sections/section_resource_depot_test.exs
@@ -254,7 +254,6 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
 
       assert Enum.all?([id1, id2], &(&1 in page_sr_ids))
 
-      IO.inspect("--------------------")
       assert Enum.empty?(SectionResourceDepot.get_pages(section_id, []))
 
       # Test Depot


### PR DESCRIPTION
This PR addresses an issue where a course without surveys lists all section resources when one views the `Surveys` table under the course `Insights` tab.