### PR TITLE
[BUG FIX] [MER-4243] fix an issue where non-confirmed students could not access research consent form

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -346,7 +346,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/", OliWeb do
-    pipe_through([:browser, :delivery_protected])
+    pipe_through([:browser, :maybe_skip_email_verification, :delivery_protected])
 
     get("/research_consent", DeliveryController, :show_research_consent)
     post("/research_consent", DeliveryController, :research_consent)


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4243

The issue is related to the enforcement of research consent by redirecting a user to the `/research_consent` route which landed in parallel with this one, and it was not included in the list of routes that allow access when a student is enrolled in any section that omits email verification.

The fix here is to add the `maybe_skip_email_verification` pipe to the research consent route.