### PR TITLE
[BUG FIX] [MER-4403] mint new datashop id after 30 mins of inactivity

### DIFF
--- a/lib/oli_web/plugs/ensure_datashop_id.ex
+++ b/lib/oli_web/plugs/ensure_datashop_id.ex
@@ -3,29 +3,44 @@ defmodule OliWeb.Plugs.EnsureDatashopId do
   This plug ensures that a unique datashop session ID is present in the session and assigned to the
   connection. If the session already has a datashop session ID, it will be used. Otherwise, a new
   datashop session ID will be generated and put into the current session.
+
+  If the session is older than the configured session lifetime, a new datashop session ID will be
+  generated and put into the current session.
   """
   import Plug.Conn
+  import Oli.Utils, only: [trap_nil: 1]
 
-  @datashop_session_key :datashop_session_id
+  # 30 minutes
+  @datashop_session_ttl_sec 30 * 60
+  @datashop_session_id_key :datashop_session_id
+  @datashop_session_timestamp_key :datashop_session_updated_at
 
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    case get_session(conn, @datashop_session_key) do
-      nil ->
-        datashop_session_id = generate_datashop_session_id()
+    with {:ok, datashop_session_id} <- get_session(conn, @datashop_session_id_key) |> trap_nil(),
+         {:ok, datashop_session_updated_at} <-
+           get_session(conn, @datashop_session_timestamp_key) |> trap_nil(),
+         {:ok, datashop_session_updated_at} <- datashop_session_updated_at |> Time.from_erl(),
+         true <-
+           Time.diff(Time.utc_now(), datashop_session_updated_at, :second) <
+             @datashop_session_ttl_sec do
+      # use existing datashop id and update the timestamp in the session
+      timestamp = Time.utc_now() |> Time.to_erl()
+
+      conn
+      |> put_session(@datashop_session_timestamp_key, timestamp)
+      |> assign(:datashop_session_id, datashop_session_id)
+    else
+      _ ->
+        # session is older than the configured session lifetime, generate a new datashop id
+        datashop_session_id = UUID.uuid4()
+        timestamp = Time.utc_now() |> Time.to_erl()
 
         conn
-        |> put_session(@datashop_session_key, datashop_session_id)
+        |> put_session(@datashop_session_id_key, datashop_session_id)
+        |> put_session(@datashop_session_timestamp_key, timestamp)
         |> assign(:datashop_session_id, datashop_session_id)
-
-      datashop_session_id ->
-        assign(conn, :datashop_session_id, datashop_session_id)
     end
-  end
-
-  defp generate_datashop_session_id do
-    # Generate a unique session ID
-    UUID.uuid4()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.30.0",
+      version: "0.31.0",
       elixir: "~> 1.17.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli_web/plugs/ensure_datashop_id_test.exs
+++ b/test/oli_web/plugs/ensure_datashop_id_test.exs
@@ -1,31 +1,74 @@
 defmodule OliWeb.Plugs.EnsureDatashopIdTest do
-  use OliWeb.ConnCase
+  use OliWeb.ConnCase, async: true
 
   alias OliWeb.Plugs.EnsureDatashopId
 
   @opts []
 
   describe "ensure datashop id plug" do
-    test "assigns a new datashop_session_id if not present in session", %{conn: conn} do
+    test "create a new datashop_session_id if not present in session", %{conn: conn} do
       conn =
         Plug.Test.init_test_session(conn, %{})
 
       conn = EnsureDatashopId.call(conn, @opts)
 
       assert get_session(conn, :datashop_session_id) != nil
+      assert get_session(conn, :datashop_session_updated_at) != nil
+
       assert conn.assigns[:datashop_session_id] == get_session(conn, :datashop_session_id)
     end
 
-    test "uses existing datashop_session_id if present in session", %{conn: conn} do
-      existing_id = "existing-session-id"
+    test "create a new datashop_session_id if present in session but a timestamp is not", %{
+      conn: conn
+    } do
+      existing_session_id = "existing-session-id"
 
       conn =
-        Plug.Test.init_test_session(conn, %{datashop_session_id: existing_id})
+        Plug.Test.init_test_session(conn, %{datashop_session_id: existing_session_id})
 
       conn = EnsureDatashopId.call(conn, @opts)
 
-      assert get_session(conn, :datashop_session_id) == existing_id
-      assert conn.assigns[:datashop_session_id] == existing_id
+      assert existing_session_id != get_session(conn, :datashop_session_id)
+      assert get_session(conn, :datashop_session_updated_at) != nil
+    end
+
+    test "updates timestamp on existing datashop_session_id if present in session", %{conn: conn} do
+      # lifetime is 30 minutes
+      existing_session_id = "existing-session-id"
+      original_timestamp = Time.utc_now() |> Time.shift(minute: -29) |> Time.to_erl()
+
+      conn =
+        Plug.Test.init_test_session(conn, %{
+          datashop_session_id: existing_session_id,
+          datashop_session_updated_at: original_timestamp
+        })
+
+      conn = EnsureDatashopId.call(conn, @opts)
+
+      assert existing_session_id == get_session(conn, :datashop_session_id)
+
+      assert get_session(conn, :datashop_session_updated_at) |> Time.from_erl!() >
+               original_timestamp
+    end
+
+    test "create new datashop session id if session is older than the configured session lifetime",
+         %{conn: conn} do
+      # lifetime is 30 minutes
+      existing_session_id = "existing-session-id"
+      expired_timestamp = Time.utc_now() |> Time.shift(minute: -31) |> Time.to_erl()
+
+      conn =
+        Plug.Test.init_test_session(conn, %{
+          datashop_session_id: existing_session_id,
+          datashop_session_updated_at: expired_timestamp
+        })
+
+      conn = EnsureDatashopId.call(conn, @opts)
+
+      assert existing_session_id != get_session(conn, :datashop_session_id)
+
+      assert get_session(conn, :datashop_session_updated_at) |> Time.from_erl!() >
+               expired_timestamp
     end
   end
 end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4403

This PR implements a datashop session id refresh policy that mints a new datashop session id after 30 mins of inactivity.

This is implemented via the `OliWeb.Plugs.EnsureDatashopId` plug. A new value `:datashop_session_updated_at` is not tracked in the session and is checked to see if the last update was more than 30 mins ago. If so, then a new datashop id is created and set in the session. Otherwise, this timestamp is updated to the current time to keep the datashop session "rolling" until 30 mins of inactivity occurs.