### PR TITLE
[ENHANCEMENT] [MER-4405] Allow erlang download to failover to secondary download location

### DIFF
--- a/.github/actions/amazon-linux-builder/Dockerfile
+++ b/.github/actions/amazon-linux-builder/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install ncurses-devel openssl11-devel -y
 RUN yum groupinstall "Development Tools" -y
 
 WORKDIR /tmp
-RUN RUN wget --tries=1 --timeout=30 "http://erlang.org/download/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz || wget "https://github.com/erlang/otp/releases/download/OTP-26.1/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz
+RUN wget --tries=1 --timeout=30 "http://erlang.org/download/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz || wget "https://github.com/erlang/otp/releases/download/OTP-26.1/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz
 RUN tar xfz otp_src_26.1.tar.gz
 WORKDIR /tmp/otp_src_26.1/
 RUN ./configure


### PR DESCRIPTION
The erlang.org site primary downloads become unavailable when the site is under maintenance. This will allow getting the source from the secondary location if the first wget fails.

This PR fixes a typo in a previous PR.