### PR TITLE
[BUG FIX] [MER-4243] checkbox for omit student email verification not being honored

### DIFF
--- a/lib/oli_web/live/user_login_live.ex
+++ b/lib/oli_web/live/user_login_live.ex
@@ -69,7 +69,7 @@ defmodule OliWeb.UserLoginLive do
           <Components.Auth.login_form
             title="Sign In"
             form={@form}
-            action={~p"/users/log_in?#{[request_path: ~p"/workspaces/instructor"]}"}
+            action={~p"/users/log_in"}
             registration_link={~p"/users/register"}
             reset_password_link={~p"/users/reset_password"}
             authentication_providers={@authentication_providers}

--- a/lib/oli_web/plugs/maybe_skip_email_verification.ex
+++ b/lib/oli_web/plugs/maybe_skip_email_verification.ex
@@ -1,28 +1,32 @@
 defmodule OliWeb.Plugs.MaybeSkipEmailVerification do
   @moduledoc """
-  This plug assigns the `skip_email_verification` key to the connection
-  if the user is enrolled in a section that skips email verification.
+  This plug assigns the `skip_email_verification` key to the connection if the user is enrolled in a
+  section that skips email verification.
 
-  This assign is used by the `OliWeb.UserAuth` plug to bypass normally
-  required email verification check.
+  A database request to check if the user is enrolled in any section which omits email verification
+  is only made if the user has not confirmed their email.
+
+  This assign is used by the `OliWeb.UserAuth` plug to bypass normally required email verification
+  check.
   """
   import Plug.Conn
 
+  alias Oli.Accounts.User
   alias Oli.Delivery.Sections
 
   def init(default), do: default
 
   def call(conn, _opts) do
     case conn.assigns[:current_user] do
-      nil ->
-        conn
-
-      user ->
+      %User{email_confirmed_at: nil} = user ->
         conn
         |> assign(
           :skip_email_verification,
           Sections.user_enrolled_in_section_that_skips_email_confirmation?(user)
         )
+
+      _ ->
+        conn
     end
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -123,6 +123,8 @@ defmodule OliWeb.Router do
   pipeline :delivery_protected do
     plug(:delivery)
 
+    plug(OliWeb.Plugs.MaybeSkipEmailVerification)
+
     plug(:require_authenticated_user)
 
     plug(Oli.Plugs.RemoveXFrameOptions)
@@ -160,10 +162,6 @@ defmodule OliWeb.Router do
     plug(:require_authenticated_author)
 
     plug(:require_system_admin)
-  end
-
-  pipeline :maybe_skip_email_verification do
-    plug(OliWeb.Plugs.MaybeSkipEmailVerification)
   end
 
   # parse url encoded forms
@@ -346,7 +344,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/", OliWeb do
-    pipe_through([:browser, :maybe_skip_email_verification, :delivery_protected])
+    pipe_through([:browser, :delivery_protected])
 
     get("/research_consent", DeliveryController, :show_research_consent)
     post("/research_consent", DeliveryController, :research_consent)
@@ -790,7 +788,7 @@ defmodule OliWeb.Router do
 
   # User State Service, extrinsic state
   scope "/api/v1/state", OliWeb do
-    pipe_through([:api, :maybe_skip_email_verification, :delivery_protected])
+    pipe_through([:api, :delivery_protected])
 
     get("/", Api.GlobalStateController, :read)
     put("/", Api.GlobalStateController, :upsert)
@@ -952,7 +950,6 @@ defmodule OliWeb.Router do
   scope "/workspaces", OliWeb.Workspaces do
     pipe_through([
       :browser,
-      :maybe_skip_email_verification,
       :delivery_protected
     ])
 

--- a/test/oli_web/live/user_login_live_test.exs
+++ b/test/oli_web/live/user_login_live_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.UserLoginLiveTest do
 
       conn = submit_form(form, conn)
 
-      assert redirected_to(conn) == ~p"/workspaces/instructor"
+      assert redirected_to(conn) == ~p"/workspaces/student"
     end
 
     test "redirects to login page with a flash error if there are no valid credentials", %{


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4243

As seen by the multiple reworks of this issue, it is tricky to identify all routes that might need this check in place and as it expands, it is starting to impact more users and clutters the router pipelines.

This PR takes a more measured approach to restricting access to non-confirmed users. Instead of trying to "whack-a-mole" all of the routes that may or may not be required for non-confirmed user access, this PR simply adds the check for non-confirmed user to the delivery_protected plug and only runs the check for users who are not confirmed.

So for **all** delivery protected routes, if a user is non-confirmed then a check will be performed to see if the student is enrolled in any section that omits student email verification, and if so will allow access for the user. This database query check will only run if a user is non-confirmed, saving all other users the performance hit of an extra database query on every request.

Certain routes which do not utilize the `:delivery_protected` plug pipeline, such as account settings, remain as to require email confirmation before allowing access.