### PR TITLE
[BUG FIX] [MER-4401] User login is not being constrained to independent users

### DIFF
--- a/lib/oli_web/controllers/user_session_controller.ex
+++ b/lib/oli_web/controllers/user_session_controller.ex
@@ -29,7 +29,7 @@ defmodule OliWeb.UserSessionController do
         user_params
       end
 
-    if user = Accounts.get_user_by_email_and_password(email, password) do
+    if user = Accounts.get_independent_user_by_email_and_password(email, password) do
       conn
       |> maybe_add_flash_message(opts[:flash_message])
       |> UserAuth.log_in_user(user, user_params)


### PR DESCRIPTION
[MER-4401](https://eliterate.atlassian.net/browse/MER-4401)

Fixed a 500 error when logging in with an email associated with both an LTI user and an independent learner.

Root Cause

The issue was caused by a query that did not properly filter independent users, resulting in multiple records for the same email. Since LTI users and independent learners can share the same email, the query returned multiple results, leading to an Ecto.MultipleResultsError.

Fix

An existing function that properly filters users based on the independent_learner flag was used, ensuring that any login attempt by email only considers independent learners and preventing the multiple results error.

[MER-4401]: https://eliterate.atlassian.net/browse/MER-4401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ