### PR TITLE
[PERFORMANCE] [MER-4412] Truncate in memory representation of log messages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,14 @@ get_env_as_boolean = fn key, default ->
   end
 end
 
+get_env_as_integer = fn key, default ->
+  System.get_env(key, default)
+  |> String.to_integer()
+end
+
 config :oli,
+  logger_truncation_enabled: get_env_as_boolean.("LOGGER_TRUNCATION_ENABLED", "true"),
+  logger_truncation_length: get_env_as_integer.("LOGGER_TRUNCATION_LENGTH", "5000"),
   instructor_dashboard_details: get_env_as_boolean.("INSTRUCTOR_DASHBOARD_DETAILS", "true"),
   depot_coordinator: Oli.Delivery.DistributedDepotCoordinator,
   depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -180,6 +180,8 @@ if config_env() == :prod do
 
   # General OLI app config
   config :oli,
+    logger_truncation_enabled: get_env_as_boolean.("LOGGER_TRUNCATION_ENABLED", "true"),
+    logger_truncation_length: get_env_as_integer.("LOGGER_TRUNCATION_LENGTH", "5000"),
     instructor_dashboard_details: get_env_as_boolean.("INSTRUCTOR_DASHBOARD_DETAILS", "true"),
     depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5"),
     depot_warmer_max_number_of_entries: System.get_env("DEPOT_WARMER_MAX_NUMBER_OF_ENTRIES", "0"),

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -6,7 +6,6 @@ defmodule Oli.Application do
   use Application
 
   def start(_type, _args) do
-
     # Install the logger truncator
     Oli.LoggerTruncator.init()
 

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -6,6 +6,10 @@ defmodule Oli.Application do
   use Application
 
   def start(_type, _args) do
+
+    # Install the logger truncator
+    Oli.LoggerTruncator.init()
+
     # List all child processes to be supervised
     children =
       [

--- a/lib/oli/logger_truncator.ex
+++ b/lib/oli/logger_truncator.ex
@@ -1,5 +1,4 @@
 defmodule Oli.LoggerTruncator do
-
   @moduledoc """
   A Logger filter to prevent excessive memory usage by truncating large log messages and
   metadata.
@@ -41,12 +40,15 @@ defmodule Oli.LoggerTruncator do
   def init() do
     if Application.get_env(:oli, :logger_truncation_enabled) do
       max_length = Application.get_env(:oli, :logger_truncation_length)
-      :logger.add_primary_filter(:logger_truncator, {&Oli.LoggerTruncator.filter/2, [max_length: max_length]})
+
+      :logger.add_primary_filter(
+        :logger_truncator,
+        {&Oli.LoggerTruncator.filter/2, [max_length: max_length]}
+      )
     end
   end
 
   def filter(%{msg: {format, msg}} = log_event, opts) do
-
     max_length = Keyword.get(opts, :max_length, 5000)
 
     new_msg = sanitize_msg(msg, max_length)
@@ -54,7 +56,6 @@ defmodule Oli.LoggerTruncator do
   end
 
   def filter(%{msg: {format, mod, msg}} = log_event, opts) do
-
     max_length = Keyword.get(opts, :max_length, 5000)
 
     new_msg = sanitize_msg(msg, max_length)
@@ -76,7 +77,8 @@ defmodule Oli.LoggerTruncator do
 
   defp sanitize_msg(msg, max_length) when is_map(msg) do
     msg
-    |> Enum.take(50) # truncate to first 50 keys if needed
+    # truncate to first 50 keys if needed
+    |> Enum.take(50)
     |> Enum.map(fn {k, v} ->
       {k, sanitize_msg(v, max_length)}
     end)
@@ -94,5 +96,4 @@ defmodule Oli.LoggerTruncator do
       msg
     end
   end
-
 end

--- a/lib/oli/logger_truncator.ex
+++ b/lib/oli/logger_truncator.ex
@@ -1,0 +1,98 @@
+defmodule Oli.LoggerTruncator do
+
+  @moduledoc """
+  A Logger filter to prevent excessive memory usage by truncating large log messages and
+  metadata.
+
+  ### Why is this important?
+
+  In Elixir systems, log events and their associated metadata are passed around
+  as **fully constructed Elixir terms** (maps, lists, binaries) before being
+  formatted for console or external backends like AppSignal.
+
+  Without truncation, a single **large log message** (e.g., logging a large Ecto struct,
+  deeply nested map, or session data) can cause the `Logger` process or any downstream
+  handlers to hold onto **multi-megabyte terms** in memory. This may lead to:
+
+  - Excessive memory usage (observed as spikes in `eheap_alloc` via the Erlang VM)
+  - Increased payload sizes for observability tools like AppSignal
+  - Potential crashes or slowdowns due to bloated Logger or telemetry queues
+
+  ### What does this module do?
+
+  This filter automatically truncates **long binaries inside log messages and metadata** to
+  a configurable `max_length` to:
+  - Prevent accidental heap bloat from oversized logs.
+  - Ensure consistent log sizes.
+  - Avoid expensive telemetry or tracing calls related to large log events.
+
+  ### How does it work?
+
+  - If the `msg` is a binary (e.g., `"Some large string..."`), it will be truncated if it
+    exceeds the limit.
+  - If the `msg` is a list (common with Phoenix structured logs like `[prefix, params]`),
+    only large **binary elements inside the list** are truncated.
+  - Metadata fields are also truncated on a per-key basis, while preserving their structure.
+
+  """
+
+  @truncate_msg " [TRUNCATED]"
+
+  def init() do
+    if Application.get_env(:oli, :logger_truncation_enabled) do
+      max_length = Application.get_env(:oli, :logger_truncation_length)
+      :logger.add_primary_filter(:logger_truncator, {&Oli.LoggerTruncator.filter/2, [max_length: max_length]})
+    end
+  end
+
+  def filter(%{msg: {format, msg}} = log_event, opts) do
+
+    max_length = Keyword.get(opts, :max_length, 5000)
+
+    new_msg = sanitize_msg(msg, max_length)
+    %{log_event | msg: {format, new_msg}}
+  end
+
+  def filter(%{msg: {format, mod, msg}} = log_event, opts) do
+
+    max_length = Keyword.get(opts, :max_length, 5000)
+
+    new_msg = sanitize_msg(msg, max_length)
+    %{log_event | msg: {format, mod, new_msg}}
+  end
+
+  def filter(log_event, _opts) do
+    log_event
+  end
+
+  defp sanitize_msg(msg, max_length) when is_binary(msg), do: truncate_if_needed(msg, max_length)
+
+  defp sanitize_msg(msg, max_length) when is_list(msg) do
+    Enum.map(msg, fn
+      str when is_binary(str) -> truncate_if_needed(str, max_length)
+      other -> other
+    end)
+  end
+
+  defp sanitize_msg(msg, max_length) when is_map(msg) do
+    msg
+    |> Enum.take(50) # truncate to first 50 keys if needed
+    |> Enum.map(fn {k, v} ->
+      {k, sanitize_msg(v, max_length)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp sanitize_msg(other, _) do
+    other
+  end
+
+  defp truncate_if_needed(msg, max_length) when is_binary(msg) do
+    if byte_size(msg) > max_length do
+      String.slice(msg, 0, max_length) <> @truncate_msg
+    else
+      msg
+    end
+  end
+
+end


### PR DESCRIPTION
This PR introduces and installs a configurable `Oli.LoggerTruncator`, which truncates items being logged.  

This addresses a shortcoming of the currently used `:logger` `truncate` (see `runtime.exs`) which only truncates what is actually written to the logs.  The new `Oli.LoggerTruncator` truncates the in-memory representation, which is important as that is what is passed around between things like the Logger and downstream backends like AppSignal.  

We have been seeing huge memory spikes on Proton which look like this:

<img width="1155" alt="Screenshot 2025-03-18 at 7 34 30 AM" src="https://github.com/user-attachments/assets/5bd43d4b-8a90-4ac5-bd17-bb6417fe2cc5" />

This PR will eliminate this problem by ensure that the seemingly HUGE message being stored in memory gets truncated down to max size in bytes (default `5_000`)

This is a low risk addition because we can completely turn this off by setting `LOGGER_TRUNCATION_ENABLED` equal to `false`


## TO VERIFY DURING PR REVIEW

Set both `LOGGER_TRUNCATION_ENABLED` to `true` and `LOGGER_TRUNCATION_LENGTH` to something observably low like `10`.  Then start the app and click around, you should see the logging messages being appropriately truncated.  