### PR TITLE
[BUG FIX] [MER-4411] using social login with existing lti account email adds identity provider to lti user

### DIFF
--- a/lib/oli_web/common/assent_auth_web.ex
+++ b/lib/oli_web/common/assent_auth_web.ex
@@ -107,8 +107,6 @@ defmodule OliWeb.Common.AssentAuthWeb do
   end
 
   defp split_user_identity_params(params, _provider) do
-    Logger.error("No sub found in user params: #{inspect(params)}")
-
     {:error, {:invalid_user_identity_params, {:missing_param, "sub", params}}}
   end
 

--- a/test/oli_web/common/assent_auth_web_test.exs
+++ b/test/oli_web/common/assent_auth_web_test.exs
@@ -4,12 +4,11 @@ defmodule OliWeb.Common.AssentAuthWebTest do
   import Oli.Factory
 
   alias Oli.Accounts
-  alias Oli.AssentAuth.{AuthorAssentAuth, AuthorIdentity}
-  alias OliWeb.AuthorAuth
+  alias Oli.AssentAuth.{AuthorAssentAuth, AuthorIdentity, UserAssentAuth}
+  alias OliWeb.{AuthorAuth, UserAuth}
   alias OliWeb.Common.AssentAuthWeb
-  alias Swoosh.TestAssertions
 
-  defp test_config(),
+  defp author_test_config(),
     do: %AssentAuthWeb.Config{
       authentication_providers: [
         google: [
@@ -31,7 +30,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
       assent_auth_module: AuthorAssentAuth
     }
 
-  describe "assent" do
+  describe "author assent" do
     setup %{conn: conn} do
       conn = conn |> Phoenix.ConnTest.init_test_session(%{}) |> fetch_session()
 
@@ -56,7 +55,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
         "email_verified" => true
       }
 
-      config = test_config()
+      config = author_test_config()
 
       {:ok, :authenticate, conn} =
         AssentAuthWeb.handle_authorization_success(
@@ -70,7 +69,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
                conn.assigns[:current_author]
 
       # no confirmation email is sent for an already verified email
-      TestAssertions.assert_no_email_sent()
+      Swoosh.TestAssertions.assert_no_email_sent()
     end
 
     test "handle_authorization_success/4 handles successful authorization of new author", %{
@@ -88,7 +87,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
         "email_verified" => true
       }
 
-      config = test_config()
+      config = author_test_config()
 
       {:ok, :create_user, _conn} =
         AssentAuthWeb.handle_authorization_success(
@@ -99,7 +98,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
         )
 
       # no confirmation email is sent for an already verified email
-      TestAssertions.assert_no_email_sent()
+      Swoosh.TestAssertions.assert_no_email_sent()
     end
 
     test "handle_authorization_success/4 returns email_confirmation_required", %{
@@ -116,7 +115,7 @@ defmodule OliWeb.Common.AssentAuthWebTest do
         "sub" => "123"
       }
 
-      config = test_config()
+      config = author_test_config()
 
       {:email_confirmation_required, :create_user, _conn} =
         AssentAuthWeb.handle_authorization_success(
@@ -129,6 +128,110 @@ defmodule OliWeb.Common.AssentAuthWebTest do
       # no confirmation email is sent for author params with missing email_verified
       [%Oban.Job{args: %{"email" => %{"subject" => "Confirm your email"}}} | _] =
         queued_email_jobs()
+    end
+
+    test "handle_authorization_success/4 handles error", %{
+      conn: conn
+    } do
+      provider = "google"
+
+      author_email = "new_author@example.edu"
+      author_name = "New Author"
+
+      author = %{
+        "email" => author_email,
+        "name" => author_name
+      }
+
+      config = author_test_config()
+
+      {:error, error, _conn} =
+        AssentAuthWeb.handle_authorization_success(
+          conn,
+          provider,
+          author,
+          config
+        )
+
+      assert error ==
+               {:invalid_user_identity_params,
+                {:missing_param, "sub",
+                 %{
+                   "email" => author_email,
+                   "name" => author_name
+                 }}}
+    end
+  end
+
+  defp user_test_config(),
+    do: %AssentAuthWeb.Config{
+      authentication_providers: [
+        google: [
+          client_id: "some_client_id",
+          client_secret: "some_secret",
+          strategy: Assent.Strategy.Google
+        ]
+      ],
+      redirect_uri: fn provider -> ~p"/users/auth/#{provider}/callback" end,
+      current_user_assigns_key: :current_author,
+      get_user_by_provider_uid: &UserAssentAuth.get_user_by_provider_uid(&1, &2),
+      create_session: &UserAuth.create_session(&1, &2),
+      deliver_user_confirmation_instructions: fn user ->
+        Accounts.deliver_user_confirmation_instructions(
+          user,
+          &url(~p"/users/confirm/#{&1}")
+        )
+      end,
+      assent_auth_module: UserAssentAuth
+    }
+
+  describe "user assent" do
+    setup %{conn: conn} do
+      conn = conn |> Phoenix.ConnTest.init_test_session(%{}) |> fetch_session()
+
+      %{conn: conn}
+    end
+
+    test "handle_authorization_success/4 creates a new separate user account when LTI user with same email already exists",
+         %{
+           conn: conn
+         } do
+      lti_user = insert(:user, independent_learner: false)
+
+      provider = "google"
+
+      user_email = lti_user.email
+      user_name = "New Independent Learner"
+
+      user = %{
+        "email" => user_email,
+        "name" => user_name,
+        "sub" => "123",
+        "email_verified" => true
+      }
+
+      config = user_test_config()
+
+      {:ok, :create_user, _conn} =
+        AssentAuthWeb.handle_authorization_success(
+          conn,
+          provider,
+          user,
+          config
+        )
+
+      independent_user = Accounts.get_independent_user_by_email(user_email)
+
+      assert independent_user.email == user_email
+      assert independent_user.name == user_name
+      assert independent_user.independent_learner == true
+      assert independent_user.email_confirmed_at != nil
+
+      # assert that the new user is not the same as the LTI user
+      assert independent_user.id != lti_user.id
+
+      # no confirmation email is sent for an already verified email
+      Swoosh.TestAssertions.assert_no_email_sent()
     end
   end
 end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4411

After an extensive investigation, I was unable to reproduce this issue but verified the situation that occurred was due to existing production data from an issue with a previous release. I confirmed that the user_identities record used to link the user account with the google provider was actually created back in August 2024 so it could not have been caused by an issue in the latest version.

The PR confirms this by introducing a unit test to exercise this case and is passing with the expected behavior. I also noticed and removed a duplicate log statement as part of this work.