### PR TITLE
[BUG FIX] [MER-4421] Certificate logo not centered

### DIFF
--- a/.github/actions/amazon-linux-builder/Dockerfile
+++ b/.github/actions/amazon-linux-builder/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install ncurses-devel openssl11-devel -y
 RUN yum groupinstall "Development Tools" -y
 
 WORKDIR /tmp
-RUN wget "http://erlang.org/download/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz
+RUN wget --tries=1 --timeout=30 "http://erlang.org/download/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz || wget "https://github.com/erlang/otp/releases/download/OTP-26.1/otp_src_26.1.tar.gz" -O otp_src_26.1.tar.gz
 RUN tar xfz otp_src_26.1.tar.gz
 WORKDIR /tmp/otp_src_26.1/
 RUN ./configure

--- a/assets/src/apps/authoring/components/Flowchart/flowchart-actions/add-screen.ts
+++ b/assets/src/apps/authoring/components/Flowchart/flowchart-actions/add-screen.ts
@@ -33,6 +33,7 @@ import {
   createEndOfActivityPath,
   createExitPath,
 } from '../paths/path-factories';
+import { QuestionTypeMapping } from '../paths/path-options';
 import { AuthoringFlowchartScreenData } from '../paths/path-types';
 import {
   hasDestinationPath,
@@ -79,7 +80,7 @@ export const addFlowchartScreen = createAsyncThunk(
       const { title: requestedTitle = 'New Screen', screenType = 'blank_screen' } = payload;
 
       const title = clearTitle(requestedTitle, otherActivityNames);
-
+      const isHubSpokeScreen = screenType === QuestionTypeMapping.HUB_SPOKE;
       const activity: IActivityTemplate = {
         ...createActivityTemplate(),
         title,
@@ -90,6 +91,7 @@ export const addFlowchartScreen = createAsyncThunk(
 
       activity.model.custom.maxAttempt = 3;
 
+      const sourceScreenId = payload.fromScreenId;
       const flowchartData: AuthoringFlowchartScreenData = {
         paths: [],
         screenType,
@@ -102,6 +104,15 @@ export const addFlowchartScreen = createAsyncThunk(
       } else {
         if (screenType === 'end_screen') {
           flowchartData.paths.push(createExitPath());
+        } else if (sourceScreenId && !isHubSpokeScreen) {
+          const sourceScreen = cloneT(selectActivityById(rootState, sourceScreenId));
+          // if this new screen get added after the hub_spoke screen, we need to add the path to return to the source screen
+          if (
+            sourceScreen &&
+            sourceScreen.authoring?.flowchart?.screenType === QuestionTypeMapping.HUB_SPOKE
+          ) {
+            flowchartData.paths.push(createAlwaysGoToPath(sourceScreenId));
+          }
         } else {
           flowchartData.paths.push(createEndOfActivityPath());
         }

--- a/assets/src/apps/authoring/components/Flowchart/paths/path-options.ts
+++ b/assets/src/apps/authoring/components/Flowchart/paths/path-options.ts
@@ -17,7 +17,6 @@ import {
   createInputNumberCommonErrorPath,
   createMCQCommonErrorPath,
   createMCQSpecificPath,
-  createSpokeCommonPath,
   createSpokeCorrectPath,
   createUnknownPathWithDestination,
 } from './path-factories';
@@ -131,10 +130,7 @@ const createMultipleChoicePathOptions = (mcq: IMCQPartLayout | undefined) => {
 
 const createHubAndSpokePathOptions = (spoke: IHubSpokePartLayout | undefined) => {
   if (spoke) {
-    const commonErrorOptions = (spoke.custom?.spokeItems || [])
-      .map((_, index) => index)
-      .map((index) => createSpokeCommonPath(spoke, index));
-    return [...commonErrorOptions, createSpokeCorrectPath(spoke.id)];
+    return [createSpokeCorrectPath(spoke.id)];
   }
   return [];
 };
@@ -163,11 +159,10 @@ const questionMapping: Record<string, QuestionType> = {
 const availableQuestionTypes = ['janus-mcq', ...Object.keys(questionMapping)];
 
 export enum QuestionTypeMapping {
-  MULTIPLE_CHOICE = 'Multiple Choice',
-  MULTILINE_TEXT = 'Multi-line Text',
-  JANUS_TEXT = 'Text Input',
-  INPUT_NUMBER = 'Number Input',
-  HUB_SPOKE = 'Hub and Spoke',
+  MULTILINE_TEXT = 'multi-line-text',
+  JANUS_TEXT = 'input-text',
+  INPUT_NUMBER = 'input-number',
+  HUB_SPOKE = 'hub_spoke',
   DROPDOWN = 'Dropdown',
   SLIDER = 'Slider',
 }

--- a/assets/src/apps/authoring/components/Flowchart/sidebar/FlowchartSidebar.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/sidebar/FlowchartSidebar.tsx
@@ -12,6 +12,7 @@ import { addPath } from '../flowchart-actions/add-path';
 import { changeTitle } from '../flowchart-actions/change-title';
 import {
   QuestionType,
+  QuestionTypeMapping,
   getAvailablePaths,
   getScreenPrimaryQuestion,
   getScreenQuestionType,
@@ -76,7 +77,9 @@ const SelectedScreen: React.FC<{ screen: IActivity }> = ({ screen }) => {
   };
 
   const paths = screen.authoring?.flowchart?.paths || [];
-  const addPathDisabled = questionType === 'none' && paths.length > 0;
+  const screenType = screen.authoring?.flowchart?.screenType || 'none';
+  const addPathDisabled =
+    screenType === QuestionTypeMapping.HUB_SPOKE || (questionType === 'none' && paths.length > 0);
 
   return (
     <>
@@ -103,6 +106,7 @@ const SelectedScreen: React.FC<{ screen: IActivity }> = ({ screen }) => {
             screens={screens}
             questionId={primaryQuestion?.id || ''}
             screenId={screen.id}
+            screenType={screen.authoring?.flowchart?.screenType}
             questionType={questionTypeLabel}
             availablePaths={getAvailablePaths(screen)}
             paths={paths}

--- a/assets/src/apps/authoring/components/Flowchart/sidebar/PathEditor.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/sidebar/PathEditor.tsx
@@ -30,6 +30,7 @@ interface Props {
   questionId: string | null;
   screens: Record<string, string>;
   usedPathIds: string[];
+  screenType?: string;
 }
 
 export const PathEditBox: React.FC<Props> = ({
@@ -40,6 +41,7 @@ export const PathEditBox: React.FC<Props> = ({
   usedPathIds,
   path,
   screens,
+  screenType,
 }) => {
   const autoOpen = useSelector(selectAutoOpenPath);
   const [editMode, toggleEditMode] = useToggle(false);
@@ -56,8 +58,7 @@ export const PathEditBox: React.FC<Props> = ({
     );
   };
   const effectiveEditMode = editMode || autoOpen === path.id;
-  const disablePathEdit =
-    (questionType === QuestionTypeMapping.HUB_SPOKE && path.type !== 'correct') || false;
+  const disablePathEdit = screenType === QuestionTypeMapping.HUB_SPOKE || false;
   return effectiveEditMode ? (
     <PathEditor
       questionType={questionType}
@@ -251,8 +252,8 @@ const ReadOnlyPath: React.FC<ROParams> = ({
         <Tooltip id="button-tooltip" style={{ fontSize: '12px' }}>
           {disablePathEdit ? (
             <div>
-              You cannot edit the flowchart logic for this screen here. Please update the part
-              component in Authoring to regenerate the updated flowchart logic.
+              To update the logic, please go to this page in Screen Panel view and update the Hub
+              and Spoke component.
             </div>
           ) : (
             'Click to update the flowchart logic'

--- a/assets/src/apps/authoring/components/Flowchart/sidebar/PathsEditor.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/sidebar/PathsEditor.tsx
@@ -11,6 +11,7 @@ interface Props {
   screenId: EntityId;
   questionId: string | null;
   screens: Record<string, string>;
+  screenType?: string;
 }
 
 export const PathsEditor: React.FC<Props> = ({
@@ -20,6 +21,7 @@ export const PathsEditor: React.FC<Props> = ({
   availablePaths,
   paths,
   screens,
+  screenType,
 }) => {
   const sortedPath = [...paths].sort(sortByPriority);
   const usedPathIds = paths.map((p) => p.id);
@@ -35,6 +37,7 @@ export const PathsEditor: React.FC<Props> = ({
           availablePaths={availablePaths}
           usedPathIds={usedPathIds}
           path={path}
+          screenType={screenType}
         />
       ))}
     </div>

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartTopToolbar.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartTopToolbar.tsx
@@ -5,8 +5,8 @@ interface FlowchartTopToolbarProps {}
 export const FlowchartTopToolbar: React.FC<FlowchartTopToolbarProps> = () => {
   return (
     <div className="top-toolbar">
-      <div className="left-header">Basic</div>
-      <div className="right-header">Screen with choices component</div>
+      <div className="left-header">Static Screens</div>
+      <div className="right-header">Interactive Screens</div>
 
       <ToolbarItem label="Instructional screen" screenType="blank_screen" />
 

--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -13,6 +13,7 @@ import { MCQOptionsEditor } from './custom/MCQOptionsEditor';
 import { OptionsCorrectPicker } from './custom/OptionsCorrectPicker';
 import { OptionsCustomErrorFeedbackAuthoring } from './custom/OptionsCustomErrorFeedbackAuthoring';
 import ScreenDropdownTemplate from './custom/ScreenDropdownTemplate';
+import { SpokeCompletedOption } from './custom/SpokeCompletedOption';
 import { SpokeCustomErrorFeedbackAuthoring } from './custom/SpokeCustomErrorFeedbackAuthoring';
 import { SpokeOptionsEditor } from './custom/SpokeOptionsEditor';
 import { TorusAudioBrowser } from './custom/TorusAudioBrowser';
@@ -42,6 +43,7 @@ const widgets: any = {
   MCQCorrectAnswerEditor: MCQCorrectAnswerEditor,
   MCQOptionsEditor: MCQOptionsEditor,
   SpokeOptionsEditor: SpokeOptionsEditor,
+  SpokeCompletedOption: SpokeCompletedOption,
   DropdownOptionsEditor: DropdownOptionsEditor,
   MCQCustomErrorFeedbackAuthoring: MCQCustomErrorFeedbackAuthoring,
 };

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/SpokeCompletedOption.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/SpokeCompletedOption.tsx
@@ -1,0 +1,56 @@
+import React, { useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { selectAllActivities } from 'apps/delivery/store/features/activities/slice';
+
+interface Props {
+  id: string;
+  value: number;
+  onChange: (value: number) => void;
+}
+
+export const SpokeCompletedOption: React.FC<Props> = ({ id, value, onChange }) => {
+  const [currentSpokeDestination, setCurrentSpokeDestination] = useState(value);
+  const activities = useSelector(selectAllActivities);
+  const screens: Record<string, string> = useMemo(() => {
+    return activities.reduce((acc, activity, index) => {
+      if (index == 0) {
+        acc['0'] = '--select hub destination--';
+      }
+
+      const filterhubSpokeScreens = activity.content?.partsLayout.find(
+        (parts) => parts.type === 'janus-hub-spoke',
+      );
+      const validScreens = activity.authoring?.flowchart?.screenType !== 'welcome_screen';
+
+      if (!filterhubSpokeScreens && validScreens) {
+        return {
+          ...acc,
+          [activity.id]: activity.title || 'Untitled',
+        };
+      }
+      return acc;
+    }, {} as Record<string, string>);
+  }, [activities]);
+  return (
+    <div>
+      <label className="form-label">Completed hub destination</label>
+      <div>
+        <select
+          className="form-group custom-select"
+          style={{ width: '100%' }}
+          value={currentSpokeDestination}
+          onChange={(e) => {
+            setCurrentSpokeDestination(Number(e.target.value));
+            onChange(Number(e.target.value));
+          }}
+        >
+          {Object.keys(screens).map((screenId) => (
+            <option key={screenId} value={screenId}>
+              {screens[screenId]}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/SpokeOptionsEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/SpokeOptionsEditor.tsx
@@ -94,7 +94,10 @@ const OptionsEditor: React.FC<{
   const [currentSpokeDestination, setCurrentSpokeDestination] = useState('');
   const [currentSpokeDestinationActivityId, setCurrentSpokeDestinationActivityId] = useState('');
   const screens: Record<string, string> = useMemo(() => {
-    return activities.reduce((acc, activity) => {
+    return activities.reduce((acc, activity, index) => {
+      if (index == 0) {
+        acc['0'] = '--select spoke destination--';
+      }
       const filterhubSpokeScreens = activity.content?.partsLayout.find(
         (parts) => parts.type === 'janus-hub-spoke',
       );

--- a/assets/src/apps/authoring/store/parts/actions/updatePart.ts
+++ b/assets/src/apps/authoring/store/parts/actions/updatePart.ts
@@ -52,10 +52,7 @@ export const updatePart = createAsyncThunk(
       ) {
         try {
           //for hub & spoke, we need to create flowchart path automatically based on the spoke destinations
-          let paths =
-            activityClone.authoring.flowchart?.paths?.filter(
-              (path: any) => path.type === 'correct',
-            ) || [];
+          let paths: any[] = [];
           const flowchartPaths =
             payload?.changes?.custom?.spokeItems?.map((spoke: any) => {
               return {
@@ -69,10 +66,22 @@ export const updatePart = createAsyncThunk(
                 type: 'option-common-error',
               };
             }) || [];
+          const hubCompletionDestination = payload?.changes?.custom?.hubCompletionDestination;
+          // Generate the hub completed destination
+          const correctflowPath = {
+            id: `spoke-correct-path-${partDef.id}`,
+            completed: true,
+            destinationScreenId: Number(hubCompletionDestination),
+            type: 'correct',
+            componentId: partDef.id,
+            label: 'Hub Completed',
+            priority: 8,
+          };
           if (flowchartPaths?.length) {
             paths = paths.filter((path: any) => path.type === 'correct');
-            paths = [...paths, ...flowchartPaths];
+            paths = [...paths, ...flowchartPaths, correctflowPath];
             activityClone.authoring.flowchart.paths = paths;
+            activityClone.authoring.flowchart.screenType = 'hub_spoke';
           }
         } catch (ex) {
           //Ignore

--- a/assets/src/components/parts/janus-hub-spoke/schema.ts
+++ b/assets/src/components/parts/janus-hub-spoke/schema.ts
@@ -37,6 +37,7 @@ export interface hubSpokeModel extends JanusAbsolutePositioned, JanusCustomCss {
   spokeItems: Item[];
   spokeFeedback?: string;
   requiredSpoke?: number;
+  hubCompletedDestination?: number;
 }
 
 export const schema: JSONSchema7Object = {
@@ -64,6 +65,12 @@ export const schema: JSONSchema7Object = {
     title: 'Show progress bar',
     type: 'boolean',
     default: true,
+  },
+  hubCompletionDestination: {
+    title: 'Complete Feedback',
+    description: 'Feedback shown when all the required spokes are completed',
+    type: 'number',
+    default: 0,
   },
   correctFeedback: {
     title: 'Complete Feedback',
@@ -139,6 +146,12 @@ export const simpleSchema: JSONSchema7Object = {
     type: 'boolean',
     default: true,
   },
+  hubCompletionDestination: {
+    title: 'Complete Feedback',
+    description: 'Feedback shown when all the required spokes are completed',
+    type: 'number',
+    default: 0,
+  },
   correctFeedback: {
     title: 'Complete Feedback',
     description: 'Feedback shown when all the required spokes are completed',
@@ -194,6 +207,7 @@ export const simpleUiSchema = {
     'requiredSpoke',
     'anyCorrectAnswer',
     'showProgressBar',
+    'hubCompletionDestination',
     'correctFeedback',
     'incorrectFeedback',
     'spokeFeedback',
@@ -201,6 +215,7 @@ export const simpleUiSchema = {
   ],
   layoutType: { classNames: 'col-span-12 spokeItem' },
   spokeItems: { 'ui:widget': 'SpokeOptionsEditor', classNames: 'col-span-12 spokeItem' },
+  hubCompletionDestination: { 'ui:widget': 'SpokeCompletedOption' },
   commonErrorFeedback: {
     'ui:widget': 'SpokeCustomErrorFeedbackAuthoring',
   },
@@ -213,6 +228,7 @@ export const adaptivitySchema = {
   spokeCompleted: CapiVariableTypes.NUMBER,
   selectedSpoke: CapiVariableTypes.NUMBER,
   spokeFeedback: CapiVariableTypes.STRING,
+  hubCompletionDestination: CapiVariableTypes.NUMBER,
 };
 
 export const uiSchema = {};
@@ -241,6 +257,7 @@ export const createSchema = (): Partial<hubSpokeModel> => {
     requiredSpoke: 3,
     requireManualGrading: false,
     showProgressBar: true,
+    hubCompletedDestination: 0,
     enabled: true,
     spokeItems: [1, 2, 3].map(createSimpleOption),
     correctAnswer: [true, true, true],

--- a/assets/styles/authoring/flowchart.scss
+++ b/assets/styles/authoring/flowchart.scss
@@ -134,7 +134,7 @@ $hover: #dce7f9;
     display: grid;
     padding-top: 15px;
     padding-bottom: 3px;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     grid-template-rows: 0.2fr repeat(2, 1fr);
     grid-column-gap: 0px;
     grid-row-gap: 0px;
@@ -158,7 +158,7 @@ $hover: #dce7f9;
       grid-area: 1 / 1 / 2 / 2;
     }
     .right-header {
-      grid-area: 1 / 2 / 2 / 5;
+      grid-area: 1 / 2 / 2 / 6;
     }
 
     .toolbar-option {

--- a/config/config.exs
+++ b/config/config.exs
@@ -35,7 +35,14 @@ get_env_as_boolean = fn key, default ->
   end
 end
 
+get_env_as_integer = fn key, default ->
+  System.get_env(key, default)
+  |> String.to_integer()
+end
+
 config :oli,
+  logger_truncation_enabled: get_env_as_boolean.("LOGGER_TRUNCATION_ENABLED", "true"),
+  logger_truncation_length: get_env_as_integer.("LOGGER_TRUNCATION_LENGTH", "5000"),
   instructor_dashboard_details: get_env_as_boolean.("INSTRUCTOR_DASHBOARD_DETAILS", "true"),
   depot_coordinator: Oli.Delivery.DistributedDepotCoordinator,
   depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -180,6 +180,8 @@ if config_env() == :prod do
 
   # General OLI app config
   config :oli,
+    logger_truncation_enabled: get_env_as_boolean.("LOGGER_TRUNCATION_ENABLED", "true"),
+    logger_truncation_length: get_env_as_integer.("LOGGER_TRUNCATION_LENGTH", "5000"),
     instructor_dashboard_details: get_env_as_boolean.("INSTRUCTOR_DASHBOARD_DETAILS", "true"),
     depot_warmer_days_lookback: System.get_env("DEPOT_WARMER_DAYS_LOOKBACK", "5"),
     depot_warmer_max_number_of_entries: System.get_env("DEPOT_WARMER_MAX_NUMBER_OF_ENTRIES", "0"),

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -6,6 +6,9 @@ defmodule Oli.Application do
   use Application
 
   def start(_type, _args) do
+    # Install the logger truncator
+    Oli.LoggerTruncator.init()
+
     # List all child processes to be supervised
     children =
       [

--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -65,9 +65,9 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
             </div>
           </div>
 
-          <div style="margin-top: 20px; display: flex; justify-content: center;">
-            <%= for logo <- @logos do %>
-              <img src="<%= logo %>" style="max-height: 50px; margin-right: 50px;" />
+          <div style="margin-top: 20px; margin-bottom: 10px; display: flex; justify-content: center;">
+            <%= for logo <- @logos, logo not in ["", nil] do %>
+              <img src="<%= logo %>" style="max-height: 50px; margin-right: 25px; margin-left: 25px;" />
             <% end %>
           </div>
           <a href="<%= @certificate_verification_url %>" style="margin-top: 20px; font-size: small; text-decoration-line: none; color: black">Certificate ID: <%= @certificate_id %></a>

--- a/lib/oli/delivery/depot/match_spec_translator.ex
+++ b/lib/oli/delivery/depot/match_spec_translator.ex
@@ -131,11 +131,9 @@ defmodule Oli.Delivery.Depot.MatchSpecTranslator do
   # The :in operator is a special case as we map the values of the list to multiple
   # :orelse equality conditions
   defp handle_cond(type, {_f, {:in, value}}, _, {m, c, v}) do
-    {:orelse, {:==, :"$1", 1}, {:orelse, {:==, :"$1", 2}, {:==, :"$1", 3}}}
-
     case Enum.count(value) do
       0 ->
-        {m, c, v}
+        {m, [{:==, 1, 2}], v}
 
       1 ->
         {m, [{:==, field(v), encode(Enum.at(value, 0), type)} | c], v}

--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -93,18 +93,21 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
   end
 
   @doc """
-  Returns a list of SectionResource records for all containers
+  Returns a list of SectionResource records for all containers.
+  An optional keyword list can be passed to extend the filtering conditions.
+  For example, SectionResourceDepot.containers(some_section_id, numbering_level: {:in, [1, 2]}) will
+  return all units and moduled for the given section.
   """
-  def containers(section_id) do
+  def containers(section_id, additional_conditions \\ []) do
     depot_coordinator().init_if_necessary(@depot_desc, section_id, __MODULE__)
 
-    container = Oli.Resources.ResourceType.id_for_container()
+    conditions =
+      Keyword.merge(
+        [resource_type_id: Oli.Resources.ResourceType.id_for_container()],
+        additional_conditions
+      )
 
-    Depot.query(
-      @depot_desc,
-      section_id,
-      resource_type_id: container
-    )
+    Depot.query(@depot_desc, section_id, conditions)
     |> Enum.sort_by(& &1.numbering_index)
   end
 

--- a/lib/oli/logger_truncator.ex
+++ b/lib/oli/logger_truncator.ex
@@ -1,0 +1,99 @@
+defmodule Oli.LoggerTruncator do
+  @moduledoc """
+  A Logger filter to prevent excessive memory usage by truncating large log messages and
+  metadata.
+
+  ### Why is this important?
+
+  In Elixir systems, log events and their associated metadata are passed around
+  as **fully constructed Elixir terms** (maps, lists, binaries) before being
+  formatted for console or external backends like AppSignal.
+
+  Without truncation, a single **large log message** (e.g., logging a large Ecto struct,
+  deeply nested map, or session data) can cause the `Logger` process or any downstream
+  handlers to hold onto **multi-megabyte terms** in memory. This may lead to:
+
+  - Excessive memory usage (observed as spikes in `eheap_alloc` via the Erlang VM)
+  - Increased payload sizes for observability tools like AppSignal
+  - Potential crashes or slowdowns due to bloated Logger or telemetry queues
+
+  ### What does this module do?
+
+  This filter automatically truncates **long binaries inside log messages and metadata** to
+  a configurable `max_length` to:
+  - Prevent accidental heap bloat from oversized logs.
+  - Ensure consistent log sizes.
+  - Avoid expensive telemetry or tracing calls related to large log events.
+
+  ### How does it work?
+
+  - If the `msg` is a binary (e.g., `"Some large string..."`), it will be truncated if it
+    exceeds the limit.
+  - If the `msg` is a list (common with Phoenix structured logs like `[prefix, params]`),
+    only large **binary elements inside the list** are truncated.
+  - Metadata fields are also truncated on a per-key basis, while preserving their structure.
+
+  """
+
+  @truncate_msg " [TRUNCATED]"
+
+  def init() do
+    if Application.get_env(:oli, :logger_truncation_enabled) do
+      max_length = Application.get_env(:oli, :logger_truncation_length)
+
+      :logger.add_primary_filter(
+        :logger_truncator,
+        {&Oli.LoggerTruncator.filter/2, [max_length: max_length]}
+      )
+    end
+  end
+
+  def filter(%{msg: {format, msg}} = log_event, opts) do
+    max_length = Keyword.get(opts, :max_length, 5000)
+
+    new_msg = sanitize_msg(msg, max_length)
+    %{log_event | msg: {format, new_msg}}
+  end
+
+  def filter(%{msg: {format, mod, msg}} = log_event, opts) do
+    max_length = Keyword.get(opts, :max_length, 5000)
+
+    new_msg = sanitize_msg(msg, max_length)
+    %{log_event | msg: {format, mod, new_msg}}
+  end
+
+  def filter(log_event, _opts) do
+    log_event
+  end
+
+  defp sanitize_msg(msg, max_length) when is_binary(msg), do: truncate_if_needed(msg, max_length)
+
+  defp sanitize_msg(msg, max_length) when is_list(msg) do
+    Enum.map(msg, fn
+      str when is_binary(str) -> truncate_if_needed(str, max_length)
+      other -> other
+    end)
+  end
+
+  defp sanitize_msg(msg, max_length) when is_map(msg) do
+    msg
+    # truncate to first 50 keys if needed
+    |> Enum.take(50)
+    |> Enum.map(fn {k, v} ->
+      {k, sanitize_msg(v, max_length)}
+    end)
+    |> Enum.into(%{})
+  end
+
+  defp sanitize_msg(other, _) do
+    other
+  end
+
+  defp truncate_if_needed(msg, max_length) when is_binary(msg) do
+    if byte_size(msg) > max_length do
+      String.slice(msg, 0, max_length) <> @truncate_msg
+    else
+      msg
+    end
+  end
+end

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -40,6 +40,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:section, Section, default: nil)
   attr(:project, Project, default: nil)
   attr(:preview_mode, :boolean)
+  attr(:resource_title, :string, default: nil)
 
   attr(:sidebar_enabled, :boolean,
     default: false,
@@ -66,7 +67,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
       </.link>
       <div class="flex flex-row flex-1 justify-end md:justify-between">
         <div class="flex hidden md:flex items-center flex-grow-1 dark:text-[#BAB8BF] text-base font-medium font-['Roboto']">
-          <.title section={@section} project={@project} preview_mode={@preview_mode} />
+          <.title
+            resource_title={@resource_title}
+            section={@section}
+            project={@project}
+            preview_mode={@preview_mode}
+          />
         </div>
         <div class="justify-end items-center flex shrink-0">
           <div class={[
@@ -109,12 +115,16 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   attr(:section, Section, default: nil)
   attr(:project, Project, default: nil)
+  attr(:resource_title, :string, default: nil)
   attr(:preview_mode, :boolean)
 
   attr :rest, :global, include: ~w(class)
 
   def title(assigns) do
     ~H"""
+    <span :if={@resource_title} class={["text-2xl text-bold", @rest[:class]]}>
+      <%= @resource_title %>
+    </span>
     <span :if={@section} class={["text-2xl text-bold", @rest[:class]]}>
       <%= @section.title %><%= if @preview_mode, do: " (Preview Mode)" %>
     </span>

--- a/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
   use Phoenix.Component
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
-  alias Phoenix.LiveView.JS
 
   def new(assessments, ctx, target) do
     column_specs = [
@@ -41,7 +40,7 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
       rows: assessments,
       column_specs: column_specs,
       event_suffix: "",
-      id_field: [:id],
+      id_field: [:resource_id],
       data: %{
         ctx: ctx,
         target: target
@@ -63,16 +62,11 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
     assigns =
       Map.merge(assigns, %{
         title: assessment.title,
-        container_label: assessment.container_label,
-        id: assessment.id
+        container_label: assessment.container_label
       })
 
     ~H"""
-    <div
-      class="pl-9 pr-4 flex flex-col"
-      phx-click={JS.push("paged_table_selection_change", target: @target)}
-      phx-value-id={@id}
-    >
+    <div class="pl-9 pr-4 flex flex-col">
       <%= if @container_label do %>
         <span class="text-gray-600 font-bold text-sm"><%= @container_label %></span>
       <% end %>

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -7,6 +7,7 @@
       preview_mode={@preview_mode}
       sidebar_expanded={@sidebar_expanded}
       sidebar_enabled={!@disable_sidebar?}
+      resource_title={assigns[:resource_title]}
       include_logo
     />
     <div class={"top-0 #{if @disable_sidebar?, do: "w-full", else: "absolute"}"}>

--- a/lib/oli_web/controllers/user_session_controller.ex
+++ b/lib/oli_web/controllers/user_session_controller.ex
@@ -29,7 +29,7 @@ defmodule OliWeb.UserSessionController do
         user_params
       end
 
-    if user = Accounts.get_user_by_email_and_password(email, password) do
+    if user = Accounts.get_independent_user_by_email_and_password(email, password) do
       conn
       |> maybe_add_flash_message(opts[:flash_message])
       |> UserAuth.log_in_user(user, user_params)

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1757,6 +1757,27 @@ defmodule OliWeb.Icons do
     """
   end
 
+  attr :class, :string, default: "fill-[#FF8787]"
+
+  def asterisk(assigns) do
+    ~H"""
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 13 13"
+      fill="currentColor"
+      class={@class}
+      xmlns="http://www.w3.org/2000/svg"
+      role="asterisk icon"
+    >
+      <path
+        opacity="0.9"
+        d="M8.20654 0.0561523L7.69385 4.95239L12.6157 3.5553L13.0002 6.2854L8.3988 6.69556L11.3853 10.6818L8.89868 12.0276L6.73254 7.73376L4.79712 12.0148L2.20801 10.6818L5.16882 6.69556L0.593018 6.27258L1.02881 3.5553L5.86096 4.95239L5.34827 0.0561523H8.20654Z"
+      />
+    </svg>
+    """
+  end
+
   ########## Instructor Navigation Bar Icons (end) ##########
 
   ########## Start of Sidebar Icons  ##########

--- a/lib/oli_web/live/common/paged_table.ex
+++ b/lib/oli_web/live/common/paged_table.ex
@@ -103,7 +103,8 @@ defmodule OliWeb.Common.PagedTable do
     delegate_handle_event(event, params, socket, patch_fn, model_key)
   end
 
-  def delegate_handle_event("paged_table_page_change", %{"offset" => offset}, socket, patch_fn, _) do
+  def delegate_handle_event("paged_table_page_change", params, socket, patch_fn, _) do
+    offset = OliWeb.Common.Params.get_int_param(params, "offset", 0)
     patch_fn.(socket, %{offset: offset})
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -171,6 +171,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       |> assign_new(:activity_types_map, fn %{activities: activities} ->
         Enum.reduce(activities, %{}, fn e, m -> Map.put(m, e.id, e) end)
       end)
+      |> assign_new(:units_and_modules_options, fn ->
+        Helpers.build_units_and_modules_options(socket.assigns.section.id)
+      end)
 
     {:noreply, socket}
   end
@@ -626,6 +629,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         students={@students}
         scripts={@scripts}
         activity_types_map={@activity_types_map}
+        units_and_modules_options={@units_and_modules_options}
         view={@view}
         ctx={@ctx}
       />

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
         <ul class="font-normal list-disc ml-6">
           <%= if has_required_survey(@section) do %>
             <li>
-              A 5 minute survey to help shape your learning experience and let your instructor get to know you
+              A short survey to help shape your learning experience and let your instructor get to know you
             </li>
           <% end %>
           <%= if has_explorations(@section) do %>

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
         <ul class="font-normal list-disc ml-6">
           <%= if has_required_survey(@section) do %>
             <li>
-              A 5 minute survey to help shape learning your experience and let your instructor get to know you
+              A 5 minute survey to help shape your learning experience and let your instructor get to know you
             </li>
           <% end %>
           <%= if has_explorations(@section) do %>

--- a/lib/oli_web/live/user_login_live.ex
+++ b/lib/oli_web/live/user_login_live.ex
@@ -69,7 +69,7 @@ defmodule OliWeb.UserLoginLive do
           <Components.Auth.login_form
             title="Sign In"
             form={@form}
-            action={~p"/users/log_in?#{[request_path: ~p"/workspaces/instructor"]}"}
+            action={~p"/users/log_in"}
             registration_link={~p"/users/register"}
             reset_password_link={~p"/users/reset_password"}
             authentication_providers={@authentication_providers}

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -558,6 +558,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
           socket
           |> assign(:project, project)
           |> assign(:changeset, Project.changeset(project))
+          |> assign(:resource_title, project.title)
           |> put_flash(:info, "Project updated successfully.")
 
         {:error, %Ecto.Changeset{} = changeset} ->

--- a/lib/oli_web/plugs/ensure_datashop_id.ex
+++ b/lib/oli_web/plugs/ensure_datashop_id.ex
@@ -3,29 +3,44 @@ defmodule OliWeb.Plugs.EnsureDatashopId do
   This plug ensures that a unique datashop session ID is present in the session and assigned to the
   connection. If the session already has a datashop session ID, it will be used. Otherwise, a new
   datashop session ID will be generated and put into the current session.
+
+  If the session is older than the configured session lifetime, a new datashop session ID will be
+  generated and put into the current session.
   """
   import Plug.Conn
+  import Oli.Utils, only: [trap_nil: 1]
 
-  @datashop_session_key :datashop_session_id
+  # 30 minutes
+  @datashop_session_ttl_sec 30 * 60
+  @datashop_session_id_key :datashop_session_id
+  @datashop_session_timestamp_key :datashop_session_updated_at
 
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    case get_session(conn, @datashop_session_key) do
-      nil ->
-        datashop_session_id = generate_datashop_session_id()
+    with {:ok, datashop_session_id} <- get_session(conn, @datashop_session_id_key) |> trap_nil(),
+         {:ok, datashop_session_updated_at} <-
+           get_session(conn, @datashop_session_timestamp_key) |> trap_nil(),
+         {:ok, datashop_session_updated_at} <- datashop_session_updated_at |> Time.from_erl(),
+         true <-
+           Time.diff(Time.utc_now(), datashop_session_updated_at, :second) <
+             @datashop_session_ttl_sec do
+      # use existing datashop id and update the timestamp in the session
+      timestamp = Time.utc_now() |> Time.to_erl()
+
+      conn
+      |> put_session(@datashop_session_timestamp_key, timestamp)
+      |> assign(:datashop_session_id, datashop_session_id)
+    else
+      _ ->
+        # session is older than the configured session lifetime, generate a new datashop id
+        datashop_session_id = UUID.uuid4()
+        timestamp = Time.utc_now() |> Time.to_erl()
 
         conn
-        |> put_session(@datashop_session_key, datashop_session_id)
+        |> put_session(@datashop_session_id_key, datashop_session_id)
+        |> put_session(@datashop_session_timestamp_key, timestamp)
         |> assign(:datashop_session_id, datashop_session_id)
-
-      datashop_session_id ->
-        assign(conn, :datashop_session_id, datashop_session_id)
     end
-  end
-
-  defp generate_datashop_session_id do
-    # Generate a unique session ID
-    UUID.uuid4()
   end
 end

--- a/lib/oli_web/plugs/maybe_skip_email_verification.ex
+++ b/lib/oli_web/plugs/maybe_skip_email_verification.ex
@@ -1,28 +1,32 @@
 defmodule OliWeb.Plugs.MaybeSkipEmailVerification do
   @moduledoc """
-  This plug assigns the `skip_email_verification` key to the connection
-  if the user is enrolled in a section that skips email verification.
+  This plug assigns the `skip_email_verification` key to the connection if the user is enrolled in a
+  section that skips email verification.
 
-  This assign is used by the `OliWeb.UserAuth` plug to bypass normally
-  required email verification check.
+  A database request to check if the user is enrolled in any section which omits email verification
+  is only made if the user has not confirmed their email.
+
+  This assign is used by the `OliWeb.UserAuth` plug to bypass normally required email verification
+  check.
   """
   import Plug.Conn
 
+  alias Oli.Accounts.User
   alias Oli.Delivery.Sections
 
   def init(default), do: default
 
   def call(conn, _opts) do
     case conn.assigns[:current_user] do
-      nil ->
-        conn
-
-      user ->
+      %User{email_confirmed_at: nil} = user ->
         conn
         |> assign(
           :skip_email_verification,
           Sections.user_enrolled_in_section_that_skips_email_confirmation?(user)
         )
+
+      _ ->
+        conn
     end
   end
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -123,6 +123,8 @@ defmodule OliWeb.Router do
   pipeline :delivery_protected do
     plug(:delivery)
 
+    plug(OliWeb.Plugs.MaybeSkipEmailVerification)
+
     plug(:require_authenticated_user)
 
     plug(Oli.Plugs.RemoveXFrameOptions)
@@ -160,10 +162,6 @@ defmodule OliWeb.Router do
     plug(:require_authenticated_author)
 
     plug(:require_system_admin)
-  end
-
-  pipeline :maybe_skip_email_verification do
-    plug(OliWeb.Plugs.MaybeSkipEmailVerification)
   end
 
   # parse url encoded forms
@@ -346,7 +344,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/", OliWeb do
-    pipe_through([:browser, :maybe_skip_email_verification, :delivery_protected])
+    pipe_through([:browser, :delivery_protected])
 
     get("/research_consent", DeliveryController, :show_research_consent)
     post("/research_consent", DeliveryController, :research_consent)
@@ -790,7 +788,7 @@ defmodule OliWeb.Router do
 
   # User State Service, extrinsic state
   scope "/api/v1/state", OliWeb do
-    pipe_through([:api, :maybe_skip_email_verification, :delivery_protected])
+    pipe_through([:api, :delivery_protected])
 
     get("/", Api.GlobalStateController, :read)
     put("/", Api.GlobalStateController, :upsert)
@@ -952,7 +950,6 @@ defmodule OliWeb.Router do
   scope "/workspaces", OliWeb.Workspaces do
     pipe_through([
       :browser,
-      :maybe_skip_email_verification,
       :delivery_protected
     ])
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -346,7 +346,7 @@ defmodule OliWeb.Router do
   end
 
   scope "/", OliWeb do
-    pipe_through([:browser, :delivery_protected])
+    pipe_through([:browser, :maybe_skip_email_verification, :delivery_protected])
 
     get("/research_consent", DeliveryController, :show_research_consent)
     post("/research_consent", DeliveryController, :research_consent)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.30.0",
+      version: "0.31.0",
       elixir: "~> 1.17.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.31.0",
+      version: "0.30.0",
       elixir: "~> 1.17.2",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli/delivery/sections/section_resource_depot_test.exs
+++ b/test/oli/delivery/sections/section_resource_depot_test.exs
@@ -237,6 +237,28 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
       # Test Depot
       test_depot(section_id)
     end
+
+    test "returns a list of SectionResource pages from page ids", ctx do
+      %{
+        section: %{id: section_id} = _section,
+        page_1_revision: page_1_revision,
+        page_2_revision: page_2_revision
+      } = ctx
+
+      revision_ids = [page_1_revision.id, page_2_revision.id]
+      page_sr_ids = get_section_resource_ids(revision_ids)
+      resource_ids = [page_1_revision.resource_id, page_2_revision.resource_id]
+
+      [%SectionResource{id: id1}, %SectionResource{id: id2}] =
+        SectionResourceDepot.get_pages(section_id, resource_ids)
+
+      assert Enum.all?([id1, id2], &(&1 in page_sr_ids))
+
+      assert Enum.empty?(SectionResourceDepot.get_pages(section_id, []))
+
+      # Test Depot
+      test_depot(section_id)
+    end
   end
 
   describe "get_section_resources_by_type_ids/2" do

--- a/test/oli/delivery/sections/section_resource_depot_test.exs
+++ b/test/oli/delivery/sections/section_resource_depot_test.exs
@@ -326,6 +326,39 @@ defmodule Oli.Delivery.Sections.SectionResourceDepotTest do
     end
   end
 
+  describe "containers/1 and /2" do
+    setup [:create_project]
+
+    test "returns all containers for a given section", ctx do
+      %{
+        section: %{id: section_id} = _section,
+        container_revision: container_revision,
+        module_1_revision: module_1_revision
+      } = ctx
+
+      revision_ids = [container_revision.id, module_1_revision.id]
+      container_sr_ids = get_section_resource_ids(revision_ids)
+
+      assert [%SectionResource{id: sr_1}, %SectionResource{id: sr_2}] =
+               SectionResourceDepot.containers(section_id)
+
+      assert Enum.all?([sr_1, sr_2], &(&1 in container_sr_ids))
+    end
+
+    test "returns all containers for a given section with a specific list of numbering levels",
+         ctx do
+      %{
+        section: %{id: section_id} = _section,
+        module_1_revision: module_1_revision
+      } = ctx
+
+      assert [%SectionResource{revision_id: revision_id}] =
+               SectionResourceDepot.containers(section_id, numbering_level: {:in, [1, 2]})
+
+      assert revision_id == module_1_revision.id
+    end
+  end
+
   defp setup_depot_warmer_max_number_of_entries_env(max_entries) do
     Application.put_env(:oli, :depot_warmer_max_number_of_entries, max_entries)
   end

--- a/test/oli_web/components/delivery/layouts_test.exs
+++ b/test/oli_web/components/delivery/layouts_test.exs
@@ -1,0 +1,139 @@
+defmodule OliWeb.Components.Delivery.LayoutsTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias OliWeb.Components.Delivery.Layouts
+  alias OliWeb.Common.SessionContext
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Authoring.Course.Project
+  alias Oli.Accounts.User
+  alias Oli.Resources.Collaboration.CollabSpaceConfig
+
+  describe "header/1" do
+    test "renders header with logo if include_logo is true" do
+      assigns = %{
+        include_logo: true,
+        preview_mode: false,
+        section: %Section{id: 1, brand: nil, lti_1p3_deployment: nil},
+        ctx: %SessionContext{
+          user: %User{id: 1},
+          browser_timezone: "America/Montevideo",
+          is_liveview: true,
+          author: nil,
+          local_tz: "America/Montevideo"
+        },
+        sidebar_expanded: true,
+        is_admin: true
+      }
+
+      assert render_component(&Layouts.header/1, assigns) =~ "header_logo_button"
+    end
+  end
+
+  describe "title/1" do
+    test "renders resource title if provided" do
+      assigns = %{resource_title: "Test Resource", rest: %{class: "custom-class"}}
+      assert render_component(&Layouts.title/1, assigns) =~ "Test Resource"
+      assert render_component(&Layouts.title/1, assigns) =~ "custom-class"
+    end
+
+    test "renders section title if provided" do
+      assigns = %{
+        section: %Section{title: "Test Section", brand: nil, lti_1p3_deployment: nil},
+        rest: %{class: "custom-class"},
+        preview_mode: false
+      }
+
+      assert render_component(&Layouts.title/1, assigns) =~ "Test Section"
+      assert render_component(&Layouts.title/1, assigns) =~ "custom-class"
+    end
+
+    test "appends '(Preview Mode)' when preview_mode is true" do
+      assigns = %{
+        section: %Section{title: "Test Section", brand: nil, lti_1p3_deployment: nil},
+        preview_mode: true,
+        rest: %{class: "custom-class"}
+      }
+
+      assert render_component(&Layouts.title/1, assigns) =~ "Test Section (Preview Mode)"
+    end
+
+    test "renders project title if provided" do
+      assigns = %{project: %Project{title: "Test Project"}, rest: %{class: "custom-class"}}
+      assert render_component(&Layouts.title/1, assigns) =~ "Test Project"
+      assert render_component(&Layouts.title/1, assigns) =~ "custom-class"
+    end
+
+    test "does not render anything if no title is provided" do
+      assigns = %{rest: %{class: "custom-class"}}
+      assert render_component(&Layouts.title/1, assigns) == "\n\n"
+    end
+  end
+
+  describe "user_given_name/1" do
+    test "returns 'Guest' if user is a guest" do
+      ctx = %SessionContext{
+        user: %User{guest: true},
+        browser_timezone: "America/Montevideo",
+        is_liveview: true,
+        author: nil,
+        local_tz: "America/Montevideo"
+      }
+
+      assert Layouts.user_given_name(ctx) == "Guest"
+    end
+
+    test "returns user's given_name if user is present" do
+      ctx = %SessionContext{
+        user: %User{id: 1, given_name: "John"},
+        browser_timezone: "America/Montevideo",
+        is_liveview: true,
+        author: nil,
+        local_tz: "America/Montevideo"
+      }
+
+      assert Layouts.user_given_name(ctx) == "John"
+    end
+  end
+
+  describe "user_name/1" do
+    test "returns 'Guest' if user is a guest" do
+      ctx = %SessionContext{
+        user: %User{guest: true},
+        browser_timezone: "America/Montevideo",
+        is_liveview: true,
+        author: nil,
+        local_tz: "America/Montevideo"
+      }
+
+      assert Layouts.user_name(ctx) == "Guest"
+    end
+
+    test "returns user's name if user is present" do
+      ctx = %SessionContext{
+        user: %User{name: "John Doe"},
+        browser_timezone: "America/Montevideo",
+        is_liveview: true,
+        author: nil,
+        local_tz: "America/Montevideo"
+      }
+
+      assert Layouts.user_name(ctx) == "John Doe"
+    end
+  end
+
+  describe "show_collab_space?/1" do
+    test "returns false if config is nil" do
+      assert Layouts.show_collab_space?(nil) == false
+    end
+
+    test "returns false if status is disabled" do
+      assert Layouts.show_collab_space?(%CollabSpaceConfig{status: :disabled}) == false
+    end
+
+    test "returns true otherwise" do
+      assert Layouts.show_collab_space?(%CollabSpaceConfig{status: :enabled}) == true
+    end
+  end
+end

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1,0 +1,1755 @@
+defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+  import Phoenix.LiveViewTest
+
+  alias Lti_1p3.Tool.ContextRoles
+  alias Oli.Activities
+  alias Oli.Analytics.Common.Pipeline
+  alias Oli.Analytics.Summary
+  alias Oli.Analytics.XAPI.Events.Context
+
+  alias Oli.Analytics.Summary.{
+    AttemptGroup
+  }
+
+  alias Oli.Delivery.Attempts.Core.ResourceAccess
+  alias Oli.Delivery.Sections
+  alias Oli.Repo
+  alias Oli.Resources.ResourceType
+
+  defp live_view_practice_activities_route(section_slug, params \\ %{}) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+      section_slug,
+      :insights,
+      :practice_activities,
+      params
+    )
+  end
+
+  defp set_activity_attempt(
+         page,
+         %{activity_type_id: activity_type_id} = activity_revision,
+         student,
+         section,
+         project_id,
+         publication_id,
+         response_input_value,
+         correct
+       ) do
+    resource_access = get_or_insert_resource_access(student, section, page.resource)
+
+    resource_attempt =
+      insert(:resource_attempt, %{
+        resource_access: resource_access,
+        revision: page,
+        lifecycle_state: :evaluated,
+        date_evaluated: ~U[2020-01-01 00:00:00Z]
+      })
+
+    activity_registration = Activities.get_registration(activity_type_id)
+
+    transformed_model =
+      case activity_registration.slug do
+        "oli_multi_input" ->
+          %{
+            "authoring" => %{},
+            "inputs" => [%{"id" => "1458555427", "inputType" => "text", "partId" => "1"}]
+          }
+
+        "oli_multiple_choice" ->
+          %{choices: generate_choices(activity_revision.id)}
+
+        "oli_likert" ->
+          Oli.TestHelpers.likert_activity_content()
+
+        _ ->
+          nil
+      end
+
+    activity_attempt =
+      insert(:activity_attempt, %{
+        revision: activity_revision,
+        resource: activity_revision.resource,
+        resource_attempt: resource_attempt,
+        lifecycle_state: :evaluated,
+        transformed_model: transformed_model,
+        score: if(correct, do: 1, else: 0),
+        out_of: 1
+      })
+
+    part_attempt =
+      insert(:part_attempt, %{
+        part_id: "1",
+        activity_attempt: activity_attempt,
+        response: %{"files" => [], "input" => response_input_value}
+      })
+
+    context = %Context{
+      user_id: student.id,
+      host_name: "localhost",
+      section_id: section.id,
+      project_id: project_id,
+      publication_id: publication_id
+    }
+
+    build_analytics_v2(
+      context,
+      page.resource_id,
+      activity_revision,
+      activity_attempt,
+      part_attempt
+    )
+  end
+
+  defp build_analytics_v2(
+         context,
+         page_id,
+         activity_revision,
+         activity_attempt,
+         part_attempt
+       ) do
+    group = %AttemptGroup{
+      context: context,
+      part_attempts: [
+        %{
+          id: part_attempt.id,
+          part_id: part_attempt.part_id,
+          response: part_attempt.response,
+          score: activity_attempt.score,
+          lifecycle_state: :evaluated,
+          out_of: activity_attempt.out_of,
+          activity_revision: activity_revision,
+          hints: [],
+          attempt_number: activity_attempt.attempt_number,
+          activity_attempt: activity_attempt
+        }
+      ],
+      activity_attempts: [],
+      resource_attempt: %{resource_id: page_id}
+    }
+
+    Pipeline.init("test")
+    |> Map.put(:data, group)
+    |> Summary.upsert_resource_summaries()
+    |> Summary.upsert_response_summaries()
+  end
+
+  defp get_or_insert_resource_access(student, section, resource) do
+    resource_access =
+      Repo.get_by(
+        ResourceAccess,
+        resource_id: resource.id,
+        section_id: section.id,
+        user_id: student.id
+      )
+
+    if resource_access do
+      resource_access
+    else
+      insert(:resource_access, %{
+        resource: resource,
+        resource_id: resource.id,
+        section: section,
+        section_id: section.id,
+        user: student,
+        user_id: student.id
+      })
+    end
+  end
+
+  defp generate_single_response_content(title) do
+    %{
+      "stem" => %{
+        "id" => "1122006446",
+        "content" => [
+          %{
+            "id" => "286746399",
+            "type" => "p",
+            "children" => [%{"text" => "#{title}"}]
+          }
+        ]
+      },
+      "bibrefs" => [],
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "hints" => [
+              %{
+                "id" => "261621518",
+                "content" => [
+                  %{"id" => "3539571997", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "3720232586",
+                "content" => [
+                  %{"id" => "646828153", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "4061998735",
+                "content" => [
+                  %{"id" => "1840398296", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              }
+            ],
+            "responses" => [
+              %{
+                "id" => "414211103",
+                "rule" => "input contains {answer}",
+                "score" => 1,
+                "feedback" => %{
+                  "id" => "2661284074",
+                  "content" => [
+                    %{"id" => "1350343319", "type" => "p", "children" => [%{"text" => "Correct"}]}
+                  ]
+                }
+              },
+              %{
+                "id" => "354281247",
+                "rule" => "input like {.*}",
+                "score" => 0,
+                "feedback" => %{
+                  "id" => "3230456808",
+                  "content" => [
+                    %{
+                      "id" => "3182181303",
+                      "type" => "p",
+                      "children" => [%{"text" => "Incorrect"}]
+                    }
+                  ]
+                }
+              }
+            ],
+            "scoringStrategy" => "average"
+          }
+        ],
+        "previewText" => "single response",
+        "transformations" => []
+      },
+      "inputType" => "text"
+    }
+  end
+
+  defp generate_mcq_content(title) do
+    %{
+      "stem" => %{
+        "id" => "2028833010",
+        "content" => [
+          %{"id" => "280825708", "type" => "p", "children" => [%{"text" => title}]}
+        ]
+      },
+      "choices" => generate_choices("2028833010"),
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "hints" => [
+              %{
+                "id" => "540968727",
+                "content" => [
+                  %{"id" => "2256338253", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "2627194758",
+                "content" => [
+                  %{"id" => "3013119256", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              },
+              %{
+                "id" => "2413327578",
+                "content" => [
+                  %{"id" => "3742562774", "type" => "p", "children" => [%{"text" => ""}]}
+                ]
+              }
+            ],
+            "outOf" => nil,
+            "responses" => [
+              %{
+                "id" => "4122423546",
+                "rule" => "(!(input like {1968053412})) && (input like {1436663133})",
+                "score" => 1,
+                "feedback" => %{
+                  "id" => "685174561",
+                  "content" => [
+                    %{
+                      "id" => "2621700133",
+                      "type" => "p",
+                      "children" => [%{"text" => "Correct"}]
+                    }
+                  ]
+                }
+              },
+              %{
+                "id" => "3738563441",
+                "rule" => "input like {.*}",
+                "score" => 0,
+                "feedback" => %{
+                  "id" => "3796426513",
+                  "content" => [
+                    %{
+                      "id" => "1605260471",
+                      "type" => "p",
+                      "children" => [%{"text" => "Incorrect"}]
+                    }
+                  ]
+                }
+              }
+            ],
+            "gradingApproach" => "automatic",
+            "scoringStrategy" => "average"
+          }
+        ],
+        "correct" => [["1436663133"], "4122423546"],
+        "version" => 2,
+        "targeted" => [],
+        "previewText" => "",
+        "transformations" => [
+          %{
+            "id" => "1349799137",
+            "path" => "choices",
+            "operation" => "shuffle",
+            "firstAttemptOnly" => true
+          }
+        ]
+      }
+    }
+  end
+
+  defp generate_multi_input_content(title) do
+    %{
+      "authoring" => %{
+        "parts" => [
+          %{
+            "gradingApproach" => "automatic",
+            "hints" => [
+              %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => ""}],
+                    "id" => "3144326996",
+                    "type" => "p"
+                  }
+                ],
+                "editor" => "slate",
+                "id" => "2324370830",
+                "textDirection" => "ltr"
+              }
+            ],
+            "id" => "1",
+            "outOf" => nil,
+            "responses" => [
+              %{
+                "feedback" => %{
+                  "content" => [
+                    %{
+                      "children" => [%{"text" => "Correct"}],
+                      "id" => "1443012830",
+                      "type" => "p"
+                    }
+                  ],
+                  "editor" => "slate",
+                  "id" => "4023967540",
+                  "textDirection" => "ltr"
+                },
+                "id" => "3595683503",
+                "rule" => "input = {1}",
+                "score" => 1
+              },
+              %{
+                "feedback" => %{
+                  "content" => [
+                    %{
+                      "children" => [%{"text" => "Incorrect"}],
+                      "id" => "862813719",
+                      "type" => "p"
+                    }
+                  ],
+                  "editor" => "slate",
+                  "id" => "409522953",
+                  "textDirection" => "ltr"
+                },
+                "id" => "2117868767",
+                "rule" => "input like {.*}",
+                "score" => 0
+              }
+            ],
+            "scoringStrategy" => "average"
+          }
+        ],
+        "previewText" => "Write NUMBER .",
+        "targeted" => [],
+        "transformations" => [
+          %{
+            "firstAttemptOnly" => true,
+            "id" => "273348963",
+            "operation" => "shuffle",
+            "path" => "choices"
+          }
+        ]
+      },
+      "bibrefs" => [],
+      "choices" => [],
+      "inputs" => [%{"id" => "1458555427", "inputType" => "text", "partId" => 1}],
+      "stem" => %{
+        "content" => [
+          %{
+            "children" => [
+              %{"text" => title},
+              %{
+                "children" => [%{"text" => ""}],
+                "id" => "763756970",
+                "type" => "input_ref"
+              },
+              %{"text" => "."}
+            ],
+            "id" => "1622099819",
+            "type" => "p"
+          }
+        ],
+        "id" => "3205611195"
+      },
+      "submitPerPart" => false
+    }
+  end
+
+  defp generate_choices(id),
+    do: [
+      %{
+        # this id value is the one that should be passed to set_activity_attempt as response_input_value
+        id: "id_for_option_a",
+        content: [
+          %{
+            id: "1866911747",
+            type: "p",
+            children: [%{text: "Choice 1 for #{id}"}]
+          }
+        ]
+      },
+      %{
+        id: "id_for_option_b",
+        content: [
+          %{
+            id: "3926142114",
+            type: "p",
+            children: [%{text: "Choice 2 for #{id}"}]
+          }
+        ]
+      }
+    ]
+
+  defp enroll_instructor(%{section: section, instructor: instructor}) do
+    {:ok, _enrollment} =
+      Sections.enroll(instructor.id, section.id, [
+        ContextRoles.get_role(:context_instructor)
+      ])
+
+    :ok
+  end
+
+  defp create_project(%{instructor: instructor}) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    # revisions...
+    ## objectives
+    objective_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Objective 1"
+      )
+
+    objective_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Objective 2"
+      )
+
+    objective_3_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Objective 3"
+      )
+
+    objective_4_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Objective 4"
+      )
+
+    ## activities...
+    mcq_reg = Oli.Activities.get_registration_by_slug("oli_multiple_choice")
+    single_response_reg = Oli.Activities.get_registration_by_slug("oli_short_answer")
+    multi_input_reg = Oli.Activities.get_registration_by_slug("oli_multi_input")
+    likert_reg = Oli.Activities.get_registration_by_slug("oli_likert")
+
+    mcq_activity_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_activity(),
+        objectives: %{
+          "1" => [
+            objective_1_revision.resource_id
+          ]
+        },
+        activity_type_id: mcq_reg.id,
+        title: "Multiple Choice 1",
+        content: generate_mcq_content("This is the first question")
+      )
+
+    mcq_activity_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_activity(),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: mcq_reg.id,
+        title: "Multiple Choice 2",
+        content: generate_mcq_content("This is the second question")
+      )
+
+    single_response_activity_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_activity(),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: single_response_reg.id,
+        title: "The Single Response question",
+        content: generate_single_response_content("This is a single response question")
+      )
+
+    multi_input_activity_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_activity(),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: multi_input_reg.id,
+        title: "The Multi Input question",
+        content: generate_multi_input_content("This is a multi input question")
+      )
+
+    likert_activity_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_activity(),
+        objectives: %{
+          "1" => []
+        },
+        activity_type_id: likert_reg.id,
+        title: "The Likert question",
+        content: Oli.TestHelpers.likert_activity_content("This is a likert question")
+      )
+
+    ## graded pages (assessments)...
+    page_1_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_1_revision.resource_id]},
+        title: "Page 1",
+        graded: false,
+        content: %{
+          model: [
+            %{
+              id: "4286170280",
+              type: "content",
+              children: [
+                %{
+                  id: "2905665054",
+                  type: "p",
+                  children: [
+                    %{
+                      text: "This is a page with a multiple choice activity."
+                    }
+                  ]
+                }
+              ]
+            },
+            %{
+              id: "3330767711",
+              type: "activity-reference",
+              children: [],
+              activity_id: mcq_activity_1_revision.resource.id
+            },
+            %{
+              id: "3330767712",
+              type: "activity-reference",
+              children: [],
+              activity_id: mcq_activity_2_revision.resource.id
+            },
+            %{
+              id: "3330767713",
+              type: "activity-reference",
+              children: [],
+              activity_id: single_response_activity_revision.resource.id
+            },
+            %{
+              id: "3330767714",
+              type: "activity-reference",
+              children: [],
+              activity_id: multi_input_activity_revision.resource.id
+            },
+            %{
+              id: "3330767714",
+              type: "activity-reference",
+              children: [],
+              activity_id: likert_activity_revision.resource.id
+            }
+          ],
+          bibrefs: [],
+          version: "0.1.0"
+        }
+      )
+
+    page_2_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_2_revision.resource_id]},
+        title: "Page 2",
+        graded: false
+      )
+
+    page_3_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_3_revision.resource_id]},
+        title: "Page 3",
+        graded: false
+      )
+
+    page_4_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_4_revision.resource_id]},
+        title: "Page 4",
+        graded: false
+      )
+
+    page_5_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        objectives: %{"attached" => [objective_4_revision.resource_id]},
+        title: "Orphaned Page",
+        graded: false
+      )
+
+    ## modules...
+    module_1_revision =
+      insert(:revision, %{
+        resource: insert(:resource),
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [page_1_revision.resource_id, page_2_revision.resource_id],
+        content: %{},
+        deleted: false,
+        title: "Introduction"
+      })
+
+    module_2_revision =
+      insert(:revision, %{
+        resource: insert(:resource),
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [page_3_revision.resource_id, page_4_revision.resource_id],
+        content: %{},
+        deleted: false,
+        title: "Basics"
+      })
+
+    ## units...
+    unit_1_revision =
+      insert(:revision, %{
+        resource: insert(:resource),
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [module_1_revision.resource_id],
+        content: %{},
+        deleted: false,
+        title: "Unit 1"
+      })
+
+    unit_2_revision =
+      insert(:revision, %{
+        resource: insert(:resource),
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [module_2_revision.resource_id],
+        content: %{},
+        deleted: false,
+        title: "Unit 2"
+      })
+
+    ## root container...
+    container_revision =
+      insert(:revision, %{
+        resource: insert(:resource),
+        objectives: %{},
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        children: [
+          unit_1_revision.resource_id,
+          unit_2_revision.resource_id,
+          page_5_revision.resource_id
+        ],
+        content: %{},
+        deleted: false,
+        title: "Root Container"
+      })
+
+    # asociate resources to project
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: objective_1_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: objective_2_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: objective_3_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: objective_4_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: mcq_activity_1_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: mcq_activity_2_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: single_response_activity_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: multi_input_activity_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: likert_activity_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: page_1_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: page_2_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: page_3_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: page_4_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: page_5_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: module_1_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: module_2_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: unit_1_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: unit_2_revision.resource_id
+    })
+
+    insert(:project_resource, %{
+      project_id: project.id,
+      resource_id: container_revision.resource_id
+    })
+
+    # publish project and resources
+    publication =
+      insert(:publication, %{
+        project: project,
+        root_resource_id: container_revision.resource_id
+      })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: objective_1_revision.resource,
+      revision: objective_1_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: objective_2_revision.resource,
+      revision: objective_2_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: objective_3_revision.resource,
+      revision: objective_3_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: objective_4_revision.resource,
+      revision: objective_4_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: mcq_activity_1_revision.resource,
+      revision: mcq_activity_1_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: mcq_activity_2_revision.resource,
+      revision: mcq_activity_2_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: single_response_activity_revision.resource,
+      revision: single_response_activity_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: multi_input_activity_revision.resource,
+      revision: multi_input_activity_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: likert_activity_revision.resource,
+      revision: likert_activity_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_1_revision.resource,
+      revision: page_1_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_2_revision.resource,
+      revision: page_2_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_3_revision.resource,
+      revision: page_3_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_4_revision.resource,
+      revision: page_4_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: page_5_revision.resource,
+      revision: page_5_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: module_1_revision.resource,
+      revision: module_1_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: module_2_revision.resource,
+      revision: module_2_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: unit_1_revision.resource,
+      revision: unit_1_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: unit_2_revision.resource,
+      revision: unit_2_revision,
+      author: author
+    })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_revision.resource,
+      revision: container_revision,
+      author: author
+    })
+
+    # create section with analytics v2...
+    section =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true,
+        type: :enrollable,
+        analytics_version: :v2
+      )
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+    {:ok, _} = Sections.rebuild_contained_pages(section)
+
+    # enroll students to section
+    student_1 = insert(:user, %{given_name: "Lionel", family_name: "Messi"})
+    student_2 = insert(:user, %{given_name: "Angel", family_name: "Di Maria"})
+    [student_3, student_4] = insert_pair(:user)
+
+    Sections.enroll(student_1.id, section.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.enroll(student_2.id, section.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.enroll(student_3.id, section.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.enroll(student_4.id, section.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.enroll(instructor.id, section.id, [
+      ContextRoles.get_role(:context_instructor)
+    ])
+
+    # create section with analytics v1...
+    section_v1 =
+      insert(:section,
+        base_project: project,
+        context_id: UUID.uuid4(),
+        open_and_free: true,
+        registration_open: true,
+        type: :enrollable,
+        analytics_version: :v1
+      )
+
+    {:ok, section_v1} = Sections.create_section_resources(section_v1, publication)
+    {:ok, _} = Sections.rebuild_contained_pages(section_v1)
+
+    # enroll students to section
+    Sections.enroll(student_1.id, section_v1.id, [
+      ContextRoles.get_role(:context_learner)
+    ])
+
+    Sections.enroll(instructor.id, section_v1.id, [
+      ContextRoles.get_role(:context_instructor)
+    ])
+
+    # Data to feed progress_across_for_pages/3
+    for student <- [student_1, student_2, student_3, student_4] do
+      insert(:resource_access,
+        user: student,
+        section: section,
+        resource: page_1_revision.resource,
+        progress: 0.25
+      )
+    end
+
+    %{
+      section: section,
+      section_v1: section_v1,
+      project: project,
+      publication: publication,
+      mcq_activity_1: mcq_activity_1_revision,
+      mcq_activity_2: mcq_activity_2_revision,
+      single_response_activity: single_response_activity_revision,
+      multi_input_activity: multi_input_activity_revision,
+      likert_activity: likert_activity_revision,
+      page_1: page_1_revision,
+      page_2: page_2_revision,
+      page_3: page_3_revision,
+      page_4: page_4_revision,
+      page_5: page_5_revision,
+      page_1_objective: objective_1_revision,
+      page_2_objective: objective_2_revision,
+      page_3_objective: objective_3_revision,
+      page_4_objective: objective_4_revision,
+      module_1: module_1_revision,
+      module_2: module_2_revision,
+      unit_1: unit_1_revision,
+      unit_2: unit_2_revision,
+      student_1: student_1,
+      student_2: student_2,
+      student_3: student_3,
+      student_4: student_4,
+      instructor: instructor
+    }
+  end
+
+  defp table_as_list_of_maps(view) do
+    keys =
+      [
+        :order,
+        :title,
+        :due_date,
+        :avg_score,
+        :total_attempts,
+        :students_completion
+      ]
+
+    rows =
+      view
+      |> render()
+      |> Floki.parse_fragment!()
+      |> Floki.find(~s{.instructor_dashboard_table tbody tr})
+      |> Enum.map(fn row ->
+        Floki.find(row, "td")
+        |> Enum.map(fn data ->
+          case Floki.find(data, "select") do
+            [] ->
+              Floki.text(data)
+              |> String.split("\n")
+              |> Enum.map(fn string -> String.trim(string) end)
+              |> Enum.join()
+
+            select ->
+              Floki.find(select, "option[selected]") |> Floki.text()
+          end
+        end)
+      end)
+
+    Enum.map(rows, fn a ->
+      Enum.zip(keys, a)
+      |> Enum.into(%{})
+    end)
+  end
+
+  describe "user" do
+    test "cannot access page when it is not logged in", %{conn: conn} do
+      section = insert(:section)
+
+      redirect_path =
+        "/users/log_in"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(conn, live_view_practice_activities_route(section.slug))
+    end
+  end
+
+  describe "student" do
+    setup [:user_conn]
+
+    test "cannot access page", %{user: user, conn: conn} do
+      section = insert(:section)
+
+      Sections.enroll(user.id, section.id, [
+        ContextRoles.get_role(:context_learner)
+      ])
+
+      redirect_path = "/unauthorized"
+
+      assert {:error, {:redirect, %{to: ^redirect_path}}} =
+               live(conn, live_view_practice_activities_route(section.slug))
+    end
+  end
+
+  describe "practice activities assessments table" do
+    setup [:instructor_conn, :section_without_pages, :enroll_instructor]
+
+    test "loads correctly when there are no assessments", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      assert has_element?(view, "h4", "Practice Activities")
+      assert has_element?(view, "p", "None exist")
+    end
+  end
+
+  describe "practice activities assessments table WITH activities" do
+    setup [:instructor_conn, :create_project]
+
+    test "loads correctly", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
+
+      assert has_element?(view, "h4", "Practice Activities")
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title =~ "Orphaned Page"
+
+      # Checks for displaying student progress with a value different from null
+      assert a0.total_attempts == "25%"
+    end
+
+    test "gets results correctly when changing the container selection", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      unit_1: unit_1,
+      module_1: module_1
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("form[phx-change=\"change_container\"")
+      |> render_change(%{container_id: module_1.resource_id})
+
+      [page0, page1] = table_as_list_of_maps(view)
+
+      assert element(
+               view,
+               "table tbody tr[id=#{page_1.resource_id}]",
+               page0.title
+             )
+
+      assert element(
+               view,
+               "table tbody tr td div[phx-value-id=\"#{page_2.id}\"]",
+               page1.title
+             )
+
+      assert has_element?(
+               view,
+               "table tbody tr td div span",
+               module_1.title
+             )
+
+      # unit 1 does not have any direct practice page attached
+      # (the filter only shows direct children pages of the selected container)
+      view
+      |> element("form[phx-change=\"change_container\"")
+      |> render_change(%{container_id: unit_1.resource_id})
+
+      refute has_element?(
+               view,
+               "table tbody tr td div span",
+               unit_1.title
+             )
+
+      assert view |> element("p", "None exist")
+    end
+  end
+
+  describe "details of assessment activities" do
+    setup [:instructor_conn, :create_project]
+
+    test "loads correctly when there are no activites for that assessment", %{
+      conn: conn,
+      section: section,
+      page_5: page_5
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_5.resource_id}]")
+      |> render_click()
+
+      assert has_element?(view, "p", "No attempt registered for this question")
+    end
+
+    test "multiple choice details get rendered correctly when page is selected", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      project: project,
+      publication: publication
+    } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert element(
+               view,
+               "table tbody tr:nth-of-type(1)[class=\"table-active bg-delivery-primary-100\"]"
+             )
+
+      activity_id =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-multiple-choice-authoring})
+        |> Floki.attribute("activity_id")
+        |> hd()
+        |> String.split("_")
+        |> Enum.at(1)
+        |> String.to_integer()
+
+      assert mcq_activity_1.resource_id == activity_id
+    end
+
+    test "single response details get rendered correctly when page is selected",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           student_2: student_2,
+           mcq_activity_1: mcq_activity_1,
+           single_response_activity: single_response_activity,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        single_response_activity,
+        student_2,
+        section,
+        project.id,
+        publication.id,
+        "This is an incorrect answer from student 2",
+        false
+      )
+
+      set_activity_attempt(
+        page_1,
+        single_response_activity,
+        student_2,
+        section,
+        project.id,
+        publication.id,
+        "This is the second answer (correct) from student 2",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        single_response_activity,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "This is the first answer (correct) from the GOAT",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert element(
+               view,
+               "table tbody tr:nth-of-type(2)[class=\"table-active bg-delivery-primary-100\"]"
+             )
+
+      # check that the single response details render correctly
+      selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-short-answer-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      assert has_element?(
+               view,
+               ~s(div[role="activity_title"]),
+               "#{single_response_activity.title} - Question details"
+             )
+
+      assert selected_activity_model =~
+               "{\"authoring\":{\"parts\":[{\"hints\":[{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"3539571997\",\"type\":\"p\"}],\"id\":\"261621518\"},{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"646828153\",\"type\":\"p\"}],\"id\":\"3720232586\"},{\"content\":[{\"children\":[{\"text\":\"\"}],\"id\":\"1840398296\",\"type\":\"p\"}],\"id\":\"4061998735\"}],\"id\":\"1\",\"responses\":[{\"feedback\":{\"content\":[{\"children\":[{\"text\":\"Correct\"}],\"id\":\"1350343319\",\"type\":\"p\"}],\"id\":\"2661284074\"},\"id\":\"414211103\",\"rule\":\"input contains {answer}\",\"score\":1},{\"feedback\":{\"content\":[{\"children\":[{\"text\":\"Incorrect\"}],\"id\":\"3182181303\",\"type\":\"p\"}],\"id\":\"3230456808\"},\"id\":\"354281247\",\"rule\":\"input like {.*}\",\"score\":0}],\"scoringStrategy\":\"average\"}],\"previewText\":\"single response\",\"transformations\":[]},\"bibrefs\":[],\"inputType\":\"text\",\"responses\":[{\"text\":\"This is the first answer (correct) from the GOAT\",\"users\":[\"Messi, Lionel\"]},{\"text\":\"This is the second answer (correct) from student 2\",\"users\":[\"Di Maria, Angel\"]},{\"text\":\"This is an incorrect answer from student 2\",\"users\":[\"Di Maria, Angel\"]}],\"stem\":{\"content\":[{\"children\":[{\"text\":\"This is a single response question\"}],\"id\":\"286746399\",\"type\":\"p\"}],\"id\":\"1122006446\"}}"
+    end
+
+    test "multi input activity details get rendered correctly when page is selected",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           multi_input_activity: multi_input_activity,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        multi_input_activity,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "Answer for input 1",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      # check that the multi input details render correctly
+      _selected_activity_model =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{oli-multi-input-authoring})
+        |> Floki.attribute("model")
+        |> hd
+
+      assert has_element?(
+               view,
+               ~s(div[role="activity_title"]),
+               "#{multi_input_activity.title} - Question details"
+             )
+    end
+
+    test "likert activity details get rendered correctly when page is selected",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           likert_activity: likert_activity,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        likert_activity,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      # check that the likert VegaLite visualization renders correctly
+      selected_activity_data =
+        view
+        |> element("div[data-live-react-class=\"Components.VegaLiteRenderer\"]")
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.attribute("data-live-react-props")
+        |> hd()
+        |> Jason.decode!()
+
+      assert has_element?(
+               view,
+               ~s(div[role="activity_title"]),
+               "#{likert_activity.title} - Question details"
+             )
+
+      assert selected_activity_data["spec"]["title"]["text"] == likert_activity.title
+    end
+
+    test "student attempts summary gets rendered correctly when no students have attempted", %{
+      conn: conn,
+      section: section,
+      page_1: page_1
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert has_element?(view, "p", "No attempt registered for this question")
+    end
+
+    test "student attempts summary gets rendered correctly when one student has attempted", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      project: project,
+      publication: publication
+    } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "1 student has completed 1 attempt."
+
+      assert view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "3 students have not completed any attempt"
+    end
+
+    test "student attempts summary gets rendered correctly when more than one student has attempted",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           student_2: student_2,
+           student_3: student_3,
+           mcq_activity_1: mcq_activity_1,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_2,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_3,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "3 students have completed 3 attempts."
+
+      assert view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "1 student has not completed any attempt"
+    end
+
+    test "student attempts summary gets rendered correctly when all students have attempted (even more than once)",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           student_2: student_2,
+           student_3: student_3,
+           student_4: student_4,
+           mcq_activity_1: mcq_activity_1,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_2,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_3,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_b",
+        false
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_3,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_4,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_b",
+        false
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_4,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "4 students have completed 6 attempts."
+
+      refute view
+             |> element(~s{#student_attempts_summary})
+             |> render() =~ "not completed"
+
+      refute view
+             |> has_element?("#copy_emails_button", "Copy their email addresses")
+    end
+
+    test "instructor can copy email of students that have not yet attempted",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1,
+           student_2: student_2,
+           mcq_activity_1: mcq_activity_1,
+           project: project,
+           publication: publication
+         } do
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      set_activity_attempt(
+        page_1,
+        mcq_activity_1,
+        student_2,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      view
+      |> element("table tbody tr[id=#{page_1.resource_id}]")
+      |> render_click()
+
+      assert view
+             |> has_element?("#copy_emails_button", "Copy email addresses")
+    end
+  end
+
+  describe "page size change" do
+    setup [:instructor_conn, :create_project]
+
+    test "lists table elements according to the default page size", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
+
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title =~ "Orphaned Page"
+
+      # It does not display pagination options
+      refute has_element?(view, "nav[aria-label=\"Paging\"]")
+
+      # It displays page size dropdown
+      assert has_element?(view, "form select.torus-select option[selected]", "20")
+    end
+
+    test "updates page size and list expected elements", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      # Change page size from default (20) to 2
+      view
+      |> element("#footer_paging_page_size_form")
+      |> render_change(%{limit: "2"})
+
+      [a0, a1] = table_as_list_of_maps(view)
+
+      # Page 1
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+    end
+
+    test "keeps showing the same elements when changing the page size", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_practice_activities_route(section.slug, %{
+            limit: 2,
+            offset: 2
+          })
+        )
+
+      [a2, a3] = table_as_list_of_maps(view)
+
+      # Pages 3 and 4
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+
+      # Change page size from 2 to 1
+      view
+      |> element("#footer_paging_page_size_form")
+      |> render_change(%{limit: "1"})
+
+      [a2] = table_as_list_of_maps(view)
+
+      # Page 3. It keeps showing the same element.
+      assert a2.title == "Module 2: BasicsPage 3"
+    end
+  end
+end

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -77,7 +77,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       refute has_element?(
                view,
                "li",
-               "A 5 minute survey to help shape your learning experience and let your instructor get to know yous"
+               "A short survey to help shape your learning experience and let your instructor get to know yous"
              )
 
       refute has_element?(
@@ -120,7 +120,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       assert has_element?(
                view,
                "li",
-               "A 5 minute survey to help shape your learning experience and let your instructor get to know you"
+               "A short survey to help shape your learning experience and let your instructor get to know you"
              )
 
       assert has_element?(view, "button", "Start Survey")

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -77,7 +77,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       refute has_element?(
                view,
                "li",
-               "A 5 minute survey to help shape learning your experience and let your instructor get to know yous"
+               "A 5 minute survey to help shape your learning experience and let your instructor get to know yous"
              )
 
       refute has_element?(
@@ -120,7 +120,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       assert has_element?(
                view,
                "li",
-               "A 5 minute survey to help shape learning your experience and let your instructor get to know you"
+               "A 5 minute survey to help shape your learning experience and let your instructor get to know you"
              )
 
       assert has_element?(view, "button", "Start Survey")

--- a/test/oli_web/live/user_login_live_test.exs
+++ b/test/oli_web/live/user_login_live_test.exs
@@ -35,7 +35,7 @@ defmodule OliWeb.UserLoginLiveTest do
 
       conn = submit_form(form, conn)
 
-      assert redirected_to(conn) == ~p"/workspaces/instructor"
+      assert redirected_to(conn) == ~p"/workspaces/student"
     end
 
     test "redirects to login page with a flash error if there are no valid credentials", %{

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -88,6 +88,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       assert has_element?(view, "div.alert-info", "Project updated successfully.")
       assert has_element?(view, "input[name=\"project[title]\"][value=\"updated title\"]")
       assert has_element?(view, "textarea[name=\"project[description]\"]", "updated description")
+      assert has_element?(view, "#header", "updated title")
 
       assert has_element?(
                view,

--- a/test/oli_web/plugs/ensure_datashop_id_test.exs
+++ b/test/oli_web/plugs/ensure_datashop_id_test.exs
@@ -1,31 +1,74 @@
 defmodule OliWeb.Plugs.EnsureDatashopIdTest do
-  use OliWeb.ConnCase
+  use OliWeb.ConnCase, async: true
 
   alias OliWeb.Plugs.EnsureDatashopId
 
   @opts []
 
   describe "ensure datashop id plug" do
-    test "assigns a new datashop_session_id if not present in session", %{conn: conn} do
+    test "create a new datashop_session_id if not present in session", %{conn: conn} do
       conn =
         Plug.Test.init_test_session(conn, %{})
 
       conn = EnsureDatashopId.call(conn, @opts)
 
       assert get_session(conn, :datashop_session_id) != nil
+      assert get_session(conn, :datashop_session_updated_at) != nil
+
       assert conn.assigns[:datashop_session_id] == get_session(conn, :datashop_session_id)
     end
 
-    test "uses existing datashop_session_id if present in session", %{conn: conn} do
-      existing_id = "existing-session-id"
+    test "create a new datashop_session_id if present in session but a timestamp is not", %{
+      conn: conn
+    } do
+      existing_session_id = "existing-session-id"
 
       conn =
-        Plug.Test.init_test_session(conn, %{datashop_session_id: existing_id})
+        Plug.Test.init_test_session(conn, %{datashop_session_id: existing_session_id})
 
       conn = EnsureDatashopId.call(conn, @opts)
 
-      assert get_session(conn, :datashop_session_id) == existing_id
-      assert conn.assigns[:datashop_session_id] == existing_id
+      assert existing_session_id != get_session(conn, :datashop_session_id)
+      assert get_session(conn, :datashop_session_updated_at) != nil
+    end
+
+    test "updates timestamp on existing datashop_session_id if present in session", %{conn: conn} do
+      # lifetime is 30 minutes
+      existing_session_id = "existing-session-id"
+      original_timestamp = Time.utc_now() |> Time.shift(minute: -29) |> Time.to_erl()
+
+      conn =
+        Plug.Test.init_test_session(conn, %{
+          datashop_session_id: existing_session_id,
+          datashop_session_updated_at: original_timestamp
+        })
+
+      conn = EnsureDatashopId.call(conn, @opts)
+
+      assert existing_session_id == get_session(conn, :datashop_session_id)
+
+      assert get_session(conn, :datashop_session_updated_at) |> Time.from_erl!() >
+               original_timestamp
+    end
+
+    test "create new datashop session id if session is older than the configured session lifetime",
+         %{conn: conn} do
+      # lifetime is 30 minutes
+      existing_session_id = "existing-session-id"
+      expired_timestamp = Time.utc_now() |> Time.shift(minute: -31) |> Time.to_erl()
+
+      conn =
+        Plug.Test.init_test_session(conn, %{
+          datashop_session_id: existing_session_id,
+          datashop_session_updated_at: expired_timestamp
+        })
+
+      conn = EnsureDatashopId.call(conn, @opts)
+
+      assert existing_session_id != get_session(conn, :datashop_session_id)
+
+      assert get_session(conn, :datashop_session_updated_at) |> Time.from_erl!() >
+               expired_timestamp
     end
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4421) to the ticket

The issue was that 3 `img` tags where being rendered not considering the amount of the logos provided.
The solution discards "blank" logos, and modifies the margin to keep 100% centered no matter the amount of logos provided.

#### Before (image from the ticket)

![image](https://github.com/user-attachments/assets/8de05478-5388-43fc-ad99-d839c4fedfa8)


#### After
##### 1 logo
<img width="838" alt="Screenshot 2025-03-19 at 3 42 01 PM" src="https://github.com/user-attachments/assets/421ae134-0434-4c05-86db-a326754f2bbf" />


##### 2 logos
<img width="838" alt="Screenshot 2025-03-19 at 3 42 01 PM" src="https://github.com/user-attachments/assets/32a35808-c3ee-4dd0-9384-4b1f05154f56" />


##### 3 logos
<img width="838" alt="Screenshot 2025-03-19 at 3 42 01 PM" src="https://github.com/user-attachments/assets/f50691eb-c6e3-42c2-be0c-fad4adbf4e8a" />

