### PR TITLE
[BUG FIX] [MER-4426] Attempts auto submit after suggested date has passed

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -135,7 +135,15 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       now = DateTime.utc_now() |> to_epoch
 
       attempt_expired_auto_submit =
-        now > effective_end_time and auto_submit and !page_context.review_mode
+        with true <- now > effective_end_time,
+             true <- auto_submit,
+             false <- page_context.review_mode,
+             :due_by <- page_context.effective_settings.scheduling_type do
+          true
+        else
+          _ ->
+            false
+        end
 
       socket =
         socket

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1451,6 +1451,35 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       refute has_element?(view, "div[id='dialogue-window']")
       refute has_element?(view, "div[id=ai_bot_collapsed]")
     end
+
+    test "no auto-submit when late disallowed and read_by is past due", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: page_3
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      attempt_in_progress =
+        create_attempt(user, section, page_3, %{lifecycle_state: :active})
+
+      ## update the section resource needed for the test
+      Sections.get_section_resource(section.id, attempt_in_progress.resource_access.resource_id)
+      |> Sections.update_section_resource(%{
+        end_date: yesterday(),
+        late_submit: :disallow,
+        late_start: :disallow,
+        scheduling_type: :read_by
+      })
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_3.slug))
+      ensure_content_is_visible(view)
+
+      ## assert that redirect is not happening and the submit button and title are present
+      assert has_element?(view, "div[role='page title']", page_3.title)
+      assert has_element?(view, "button[id='submit_answers']", "Submit Answers")
+    end
   end
 
   describe "annotations toggle" do


### PR DESCRIPTION
[MER-4426](https://eliterate.atlassian.net/browse/MER-4426)

This PR ensures that when an assessment has a past suggested date with the late policy set to “Disallow late start and late submit” and the scheduling type is :read_by, the attempt is not auto-submitted upon entering the page.

Root Cause

Previously, the logic determining whether an attempt should be auto-submitted did not account for assessments with :read_by scheduling type. As a result, even when late start and late submit were disallowed, and the suggested date had passed, the attempt was incorrectly auto-submitted upon page entry.

Fix

The logic now correctly excludes :read_by assessments from the auto-submit condition, ensuring that students can enter and view their attempt without it being immediately submitted.


https://github.com/user-attachments/assets/770a3a60-bdcb-494f-b132-eda5abe1ff5d



[MER-4426]: https://eliterate.atlassian.net/browse/MER-4426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ