### PR TITLE
[BUG FIX] [MER-3510] Cannot create adaptive page from all pages

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -398,7 +398,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
   end
 
-  def handle_event("create_page", %{"type" => type}, socket) do
+  def handle_event("create_page", %{"type" => type, "scored" => scored}, socket) do
     %{
       project: project,
       author: author
@@ -406,8 +406,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
 
     case ContainerEditor.add_new(
            nil,
-           "Basic",
            type,
+           scored,
            author,
            project
          ) do
@@ -596,11 +596,18 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
             type="button"
             class="dropdown-item"
             phx-click="create_page"
-            phx-value-type="Unscored"
+            phx-value-type="Basic"
+            phx-value-scored="Unscored"
           >
             Practice Page
           </button>
-          <button type="button" class="dropdown-item" phx-click="create_page" phx-value-type="Scored">
+          <button
+            type="button"
+            class="dropdown-item"
+            phx-click="create_page"
+            phx-value-type="Basic"
+            phx-value-scored="Scored"
+          >
             Scored Assessment
           </button>
           <%= if Oli.Features.enabled?("adaptivity") do %>
@@ -609,6 +616,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
               class="dropdown-item"
               phx-click="create_page"
               phx-value-type="Adaptive"
+              phx-value-scored="Unscored"
             >
               Adaptive Page
             </button>

--- a/test/oli_web/live/workspaces/course_author/pages_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/pages_live_test.exs
@@ -488,6 +488,113 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLiveTest do
                )
     end
 
+    test "create a practice page works correctly", %{conn: conn, project: project, admin: admin} do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      ## Create a new practice page
+      view
+      |> element(
+        "button[phx-click=\"create_page\"][phx-value-scored=\"Unscored\"][phx-value-type=\"Basic\"",
+        "Practice Page"
+      )
+      |> render_click()
+
+      ## Get created practice page
+      new_practice_page =
+        project.id
+        |> Course.list_project_resources()
+        |> Enum.max_by(& &1.resource_id)
+        |> Map.get(:resource_id)
+        |> then(&Resources.get_revisions_by_resource_id([&1]))
+        |> List.first()
+
+      conn = recycle_author_session(conn, admin)
+
+      ## Go to the new practice page edit view
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/workspaces/course_author/#{project.slug}/curriculum/#{new_practice_page.slug}/edit"
+        )
+
+      assert view
+             |> element("li[aria-current=\"page\"]")
+             |> render() =~ new_practice_page.title
+    end
+
+    test "create a scored page works correctly", %{conn: conn, project: project, admin: admin} do
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      ## Create a new scored page
+      view
+      |> element(
+        "button[phx-click=\"create_page\"][phx-value-scored=\"Scored\"][phx-value-type=\"Basic\"",
+        "Scored Assessment"
+      )
+      |> render_click()
+
+      ## Get created scored page
+      new_scored_page =
+        project.id
+        |> Course.list_project_resources()
+        |> Enum.max_by(& &1.resource_id)
+        |> Map.get(:resource_id)
+        |> then(&Resources.get_revisions_by_resource_id([&1]))
+        |> List.first()
+
+      conn = recycle_author_session(conn, admin)
+
+      ## Go to the new scored page edit view
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/workspaces/course_author/#{project.slug}/curriculum/#{new_scored_page.slug}/edit"
+        )
+
+      assert view
+             |> element("li[aria-current=\"page\"]")
+             |> render() =~ new_scored_page.title
+    end
+
+    test "create an adaptive page works correctly", %{conn: conn, project: project, admin: admin} do
+      Oli.Features.change_state("adaptivity", :enabled)
+
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      ## Create a new adaptive page
+      view
+      |> element(
+        "button[phx-click=\"create_page\"][phx-value-scored=\"Unscored\"][phx-value-type=\"Adaptive\"",
+        "Adaptive Page"
+      )
+      |> render_click()
+
+      ## Get created adaptive page
+      new_adaptive_page =
+        project.id
+        |> Course.list_project_resources()
+        |> Enum.max_by(& &1.resource_id)
+        |> Map.get(:resource_id)
+        |> then(&Resources.get_revisions_by_resource_id([&1]))
+        |> List.first()
+
+      conn = recycle_author_session(conn, admin)
+
+      ## Go to the new adaptive page edit view
+      {:ok, view, _html} =
+        live(
+          conn,
+          "/workspaces/course_author/#{project.slug}/curriculum/#{new_adaptive_page.slug}/edit"
+        )
+
+      assert view
+             |> element("li[aria-current=\"page\"]")
+             |> render() =~ new_adaptive_page.title
+    end
+
     test "create a page and back to the all pages view works correctly", %{
       conn: conn,
       project: project,
@@ -499,7 +606,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLiveTest do
       ## Create a new page
       view
       |> element(
-        "button[phx-click=\"create_page\"][phx-value-type=\"Unscored\"]",
+        "button[phx-click=\"create_page\"][phx-value-scored=\"Unscored\"]",
         "Practice Page"
       )
       |> render_click()


### PR DESCRIPTION
[MER-3510](https://eliterate.atlassian.net/browse/MER-3510)

This PR fixes the issue where attempting to create an adaptive page from the `All Pages` view resulted in a page reload without actually creating a new adaptive page.

Root Cause

The root cause of the issue was that incorrect parameters were being passed to the function responsible for creating both adaptive and basic pages.

Fix

The fix was based on fixing the parameters passed to the function responsible for creating pages, ensuring the page type and grading status are properly defined.


https://github.com/user-attachments/assets/b0e723b9-7502-4e95-913e-3f735bcda3e4



[MER-3510]: https://eliterate.atlassian.net/browse/MER-3510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ