### PR TITLE
[ENHANCEMENT] [MER-4190] Font Size Dropdown Not Reflecting Selected Option and Lacking Clear Labels (Simple & Advanced Author)

### DIFF
--- a/assets/src/apps/authoring/store/activities/templates/simpleText.ts
+++ b/assets/src/apps/authoring/store/activities/templates/simpleText.ts
@@ -4,7 +4,7 @@ import guid from 'utils/guid';
 // async because this may change to calling an authoring function of the part component
 export const createSimpleText = async (
   msg: string,
-  style: CSSProperties = {},
+  style: CSSProperties = { fontSize: '1.25rem' },
   transform = { x: 10, y: 10, z: 0, width: 330, height: 22 },
 ) => {
   const textComponent = {

--- a/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
@@ -38,6 +38,7 @@ FontSizeAttributor.whitelist = [
   '20px',
   '24px',
   '32px',
+  '36px',
   '48px',
   '72px',
 ];

--- a/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
@@ -28,7 +28,6 @@ Quill.register(FontAttributor, true);
 
 const FontSizeAttributor = Quill.import('attributors/style/size');
 // Expanding the font-size whitelist to include sizes above 20px, ensuring that migrated lessons with larger font sizes render correctly.
-// Updating content will no longer affect font size higher than 20px.
 // This also resolves an issue where editing a text field with a larger font size previously caused the editor to remove the font size, making the text smaller.
 FontSizeAttributor.whitelist = [
   '10px',

--- a/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
@@ -27,7 +27,7 @@ FontAttributor.whitelist = supportedFonts.map(getFontName);
 Quill.register(FontAttributor, true);
 
 const FontSizeAttributor = Quill.import('attributors/style/size');
-FontSizeAttributor.whitelist = ['10px', '12px', '14px', '16px', '18px'];
+FontSizeAttributor.whitelist = ['12px', '14px', '16px', '18px', '20px'];
 Quill.register(FontSizeAttributor, true);
 
 const getCssForFonts = (fonts: string[]) => {
@@ -51,30 +51,44 @@ const getCssForFonts = (fonts: string[]) => {
 const fontStyles = `${getCssForFonts(supportedFonts)}
 /* default normal size */
 .ql-container {
-  font-size: 14px !important;
-}
-.ql-snow .ql-picker.ql-size .ql-picker-item[data-value="10px"]::before {
-  content: 'Smaller (10px)';
-  font-size: 10px !important;
+  font-size: 20px !important;
 }
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="12px"]::before {
-  content: 'Small (12px)';
+  content: '12px';
   font-size: 12px !important;
 }
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="14px"]::before {
-  content: 'Normal (14px)';
+  content: '14px';
   font-size: 14px !important;
 }
-
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="16px"]::before {
-  content: 'Large (16px)';
+  content: '16px';
   font-size: 16px !important;
 }
-
 .ql-snow .ql-picker.ql-size .ql-picker-item[data-value="18px"]::before {
-  content: 'Larger (18px)';
+  content: '18px';
   font-size: 18px !important;
 }
+.ql-snow .ql-picker.ql-size .ql-picker-item[data-value="20px"]::before {
+  content: '20px';
+  font-size: 20px !important;
+}
+  .ql-snow .ql-picker.ql-size .ql-picker-label[data-value="12px"]::before {
+  content: '12px';
+}
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="14px"]::before {
+  content: '14px';
+}
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="16px"]::before {
+  content: '16px';
+}
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="18px"]::before {
+  content: '18px';
+}
+.ql-snow .ql-picker.ql-size .ql-picker-label[data-value="20px"]::before {
+  content: '20px';
+}
+
 `;
 export const QuillEditor: React.FC<QuillEditorProps> = ({
   tree,
@@ -208,7 +222,7 @@ export const QuillEditor: React.FC<QuillEditorProps> = ({
             },
             { background: [] },
           ], // dropdown with defaults from theme
-          [{ font: FontAttributor.whitelist }, { size: ['10px', '12px', '14px', '16px', '18px'] }],
+          [{ font: FontAttributor.whitelist }, { size: ['12px', '14px', '16px', '18px', '20px'] }],
           [{ align: [] }],
           ['link', 'adaptivity'],
           ['clean'], // remove formatting button

--- a/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
@@ -27,6 +27,9 @@ FontAttributor.whitelist = supportedFonts.map(getFontName);
 Quill.register(FontAttributor, true);
 
 const FontSizeAttributor = Quill.import('attributors/style/size');
+// Expanding the font-size whitelist to include sizes above 20px, ensuring that migrated lessons with larger font sizes render correctly.
+// Updating content will no longer affect font size higher than 20px.
+// This also resolves an issue where editing a text field with a larger font size previously caused the editor to remove the font size, making the text smaller.
 FontSizeAttributor.whitelist = [
   '10px',
   '12px',

--- a/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillEditor.tsx
@@ -27,7 +27,18 @@ FontAttributor.whitelist = supportedFonts.map(getFontName);
 Quill.register(FontAttributor, true);
 
 const FontSizeAttributor = Quill.import('attributors/style/size');
-FontSizeAttributor.whitelist = ['12px', '14px', '16px', '18px', '20px'];
+FontSizeAttributor.whitelist = [
+  '10px',
+  '12px',
+  '14px',
+  '16px',
+  '18px',
+  '20px',
+  '24px',
+  '32px',
+  '48px',
+  '72px',
+];
 Quill.register(FontSizeAttributor, true);
 
 const getCssForFonts = (fonts: string[]) => {

--- a/assets/src/components/parts/janus-text-flow/quill-utils.ts
+++ b/assets/src/components/parts/janus-text-flow/quill-utils.ts
@@ -29,6 +29,8 @@ const convertFontName = (fontCode: string) => {
 
 const convertFontSize = (fontSize: string, conversionType: 'px' | 'rem'): string => {
   const numericValue = parseFloat(fontSize);
+  // With the new REM-based font size rendering, the selectable font sizes range from 12px to 20px.
+  // Font sizes above this range are not converted, as they belong to existing migrated lessons that should remain unaffected by these changes.
   if (
     typeof fontSize !== 'string' ||
     isNaN(numericValue) ||

--- a/assets/src/components/parts/janus-text-flow/quill-utils.ts
+++ b/assets/src/components/parts/janus-text-flow/quill-utils.ts
@@ -26,7 +26,7 @@ const convertFontName = (fontCode: string) => {
     .join(' ');
   return result;
 };
-
+const maxmimumFontSizeAvailableForSelection = 20;
 const convertFontSize = (fontSize: string, conversionType: 'px' | 'rem'): string => {
   const numericValue = parseFloat(fontSize);
   // With the new REM-based font size rendering, the selectable font sizes range from 12px to 20px.
@@ -34,7 +34,7 @@ const convertFontSize = (fontSize: string, conversionType: 'px' | 'rem'): string
   if (
     typeof fontSize !== 'string' ||
     isNaN(numericValue) ||
-    numericValue > 20 ||
+    numericValue > maxmimumFontSizeAvailableForSelection ||
     (!fontSize.endsWith('px') && !fontSize.endsWith('rem'))
   ) {
     return `${fontSize}px`;

--- a/assets/src/components/parts/janus-text-flow/quill-utils.ts
+++ b/assets/src/components/parts/janus-text-flow/quill-utils.ts
@@ -32,6 +32,7 @@ const convertFontSize = (fontSize: string, conversionType: 'px' | 'rem'): string
   if (
     typeof fontSize !== 'string' ||
     isNaN(numericValue) ||
+    numericValue > 20 ||
     (!fontSize.endsWith('px') && !fontSize.endsWith('rem'))
   ) {
     return `${fontSize}px`;

--- a/assets/src/components/parts/janus-text-flow/schema.ts
+++ b/assets/src/components/parts/janus-text-flow/schema.ts
@@ -111,7 +111,7 @@ export const createSchema = (context?: CreationContext): Partial<TextFlowModel> 
         children: [
           {
             tag: 'span',
-            style: {},
+            style: { fontSize: '20' },
             children: [
               {
                 tag: 'text',

--- a/assets/src/components/parts/janus-text-flow/schema.ts
+++ b/assets/src/components/parts/janus-text-flow/schema.ts
@@ -111,7 +111,7 @@ export const createSchema = (context?: CreationContext): Partial<TextFlowModel> 
         children: [
           {
             tag: 'span',
-            style: { fontSize: '20' },
+            style: { fontSize: '1.25rem' },
             children: [
               {
                 tag: 'text',


### PR DESCRIPTION
Hey @bsparks could you please review the PR? Thanks

This PR contains 2 main changes:

1. newly added text flow will have REM based font rendering
2. updated the Quill Editor font size whitelist to include bigger font size. They won't be visible in font size selection