### PR TITLE
[BUG FIX] [MER-4430] Cannot navigate pages in dataset

### DIFF
--- a/lib/oli_web/common/params.ex
+++ b/lib/oli_web/common/params.ex
@@ -4,6 +4,9 @@ defmodule OliWeb.Common.Params do
       nil ->
         default_value
 
+      value when is_integer(value) ->
+        value
+
       value ->
         case Integer.parse(value) do
           {num, _} -> num


### PR DESCRIPTION
This PR fixes a bug where in the "create dataset job" tab, a user cannot select course sections nested in other pages due to a pagination problem preventing navigating to other pages.