### PR TITLE
[BUG FIX] [MER-4429] Instructor Dashboard search: ignore nil instructor names

### DIFF
--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -317,20 +317,18 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   defp maybe_filter_by_text(sections, nil), do: sections
   defp maybe_filter_by_text(sections, ""), do: sections
 
+  # Filters sections by section title or instructor name
   defp maybe_filter_by_text(sections, text_search) do
     normalized_text_search = String.downcase(text_search)
 
     sections
     |> Enum.filter(fn section ->
-      # searchs by course name or instructor name
+      instructor_names = Enum.map(section.instructors, &to_string/1)
 
-      String.contains?(String.downcase(section.title), normalized_text_search) ||
-        Enum.find(section.instructors, false, fn name ->
-          String.contains?(
-            String.downcase(name),
-            normalized_text_search
-          )
-        end)
+      searchable_text =
+        [section.title, instructor_names] |> IO.iodata_to_binary() |> String.downcase()
+
+      String.contains?(searchable_text, normalized_text_search)
     end)
   end
 


### PR DESCRIPTION
If for any given reason the instructors of a section end up in a inconsistent state and they do not have a name associated, when filtering the sections list (specifically when downcasing the instructor names, see: [Appsignal Incident](https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/62/samples/618539ab2cf81d7e3cd051ca-477208838546314286517424913201)) it would fail returning a 500.

I will add a log to detect these cases in a separate PR, related to this same bug, since the other ticket also involves work in the "Manage Source Materials" section.


See: https://eliterate.atlassian.net/jira/software/c/projects/MER/issues/MER-4429