### PR TITLE
[BUG FIX] [MER-4430] Fixes email cleared on any action in the create dataset ui

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/create_job_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/create_job_live.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
 
   @max_selected 5
 
-  @limit 25
+  @limit 5
   @default_options %BrowseOptions{
     institution_id: nil,
     blueprint_id: nil,
@@ -162,6 +162,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
           type="text"
           id="emails"
           name="emails"
+          value={Enum.join(@emails, ",")}
           class="form-control mb-2"
           form="job_form"
           phx-hook="TextInputListener"

--- a/lib/oli_web/live/workspaces/course_author/create_job_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/create_job_live.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CreateJobLive do
 
   @max_selected 5
 
-  @limit 5
+  @limit 25
   @default_options %BrowseOptions{
     institution_id: nil,
     blueprint_id: nil,


### PR DESCRIPTION
This PR addresses an issue where the email list in the "Enter additional emails" field on the "create dataset job" tab gets cleared every time a user interacts with the courses table