### PR TITLE
[BUG FIX] [MER-4436] 500 error when accessing student quizz attempts

### DIFF
--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -4,6 +4,8 @@ defmodule OliWeb.Common.Utils do
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Common.SessionContext
 
+  require Logger
+
   def name(%User{guest: true}) do
     "Guest Student"
   end
@@ -239,12 +241,13 @@ defmodule OliWeb.Common.Utils do
   """
   def extract_feedback_text(activity_attempts) do
     activity_attempts
-    |> Enum.flat_map(&extract_from_activity_attempt/1)
+    |> Enum.map(&extract_from_activity_attempt/1)
+    |> List.flatten()
   end
 
   defp extract_from_activity_attempt(%{part_attempts: part_attempts}) do
     part_attempts
-    |> Enum.flat_map(&extract_from_part_attempt/1)
+    |> Enum.map(&extract_from_part_attempt/1)
   end
 
   defp extract_from_part_attempt(%{feedback: %{"content" => content}}) do
@@ -258,5 +261,14 @@ defmodule OliWeb.Common.Utils do
     children
     |> Enum.map(& &1["text"])
     |> Enum.join(" ")
+  end
+
+  defp extract_text({"model", model}) do
+    Enum.map(model, &extract_text/1)
+  end
+
+  defp extract_text(_other_case = other) do
+    Logger.error("Could not parse feedback text from #{inspect(other)}")
+    []
   end
 end

--- a/test/oli_web/live/common/utils_test.exs
+++ b/test/oli_web/live/common/utils_test.exs
@@ -1,0 +1,81 @@
+defmodule OliWeb.Common.UtilsTest do
+  use OliWeb.ConnCase
+
+  alias OliWeb.Common.Utils
+
+  import ExUnit.CaptureLog
+
+  describe "extract_feedback_text/1" do
+    test "extracts the feedback text from an attempt and logs an error if it can not be parsed" do
+      activity_attempts = [
+        %{
+          part_attempts: [
+            %{
+              feedback: %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => "First Feedback"}],
+                    "id" => "7brHHbLfce3qYbdU8rkk23",
+                    "type" => "p"
+                  }
+                ]
+              }
+            },
+            %{
+              feedback: %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => "Second Feedback"}],
+                    "id" => "7brHHbLfce3qYbdU8rkk23",
+                    "type" => "p"
+                  }
+                ]
+              }
+            },
+            %{
+              feedback: %{
+                "content" => %{
+                  "model" => [
+                    %{
+                      "children" => [%{"text" => "Third Feedback"}],
+                      "id" => "7brHHbLfce3qYbdU8rkk23",
+                      "type" => "p"
+                    }
+                  ]
+                }
+              }
+            },
+            %{
+              feedback: %{
+                "content" => %{
+                  "some_other_case" => [
+                    %{
+                      "children" => [
+                        %{
+                          "text" =>
+                            "This feedback does not match any known case, so a Log error should be triggered"
+                        }
+                      ],
+                      "id" => "7brHHbLfce3qYbdU8rkk23",
+                      "type" => "p"
+                    }
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ]
+
+      {result, log} =
+        with_log(fn ->
+          Utils.extract_feedback_text(activity_attempts)
+        end)
+
+      assert result == ["First Feedback", "Second Feedback", "Third Feedback"]
+
+      assert log =~
+               "[error] Could not parse feedback text from {\"some_other_case\", [%{\"children\" => [%{\"text\" => \"This feedback does not match any known case, so a Log error should be triggered\"}], \"id\" => \"7brHHbLfce3qYbdU8rkk23\", \"type\" => \"p\"}]}"
+    end
+  end
+end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4436) to the ticket

The issue was that the recently added `extract_text` helper function did not consider the case where the feedback text might be contained within the `model` key. An activity part attempt may have the feedback in two ways:

```
%Oli.Delivery.Attempts.Core.PartAttempt{
  __meta__: #Ecto.Schema.Metadata<:loaded, "part_attempts">,
  id: 1275,
  ...
  feedback: %{
    "content" => [
      %{
        "children" => [
          %{
            "text" => "Incorrect. A liquid has a definite volume and takes the shape of its container."
          }
        ],
        "id" => "dd888118ccd946a49ba0d2bf0dee6c2d",
        "type" => "p"
      }
    ],
    "id" => "3295844819"
  },
  ...
}
```
```
%Oli.Delivery.Attempts.Core.PartAttempt{
  __meta__: #Ecto.Schema.Metadata<:loaded, "part_attempts">,
  id: 1249,
  ...
  feedback: %{
    "content" => %{
      "model" => [
        %{
          "children" => [%{"text" => "Incorrect"}],
          "id" => "fZnVDjDPugE5mfBP7iYkih",
          "type" => "p"
        }
      ]
    },
    "id" => "hvm3PgQfbmmsV4FHpSpYUg"
  },
  ...
}
```


### Before

https://github.com/user-attachments/assets/c5b3971a-49ef-439d-ad76-a75b466ed4dd



### After

https://github.com/user-attachments/assets/be6eac37-d563-4b85-b127-f7e5474741b9


