### PR TITLE
[BUG FIX] [MER-4437] Progress for practice page not counting on homepage

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1211,7 +1211,7 @@ defmodule Oli.Delivery.Metrics do
             GREATEST(
               (
                 SELECT
-                  completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100) + 0.0001))
+                  completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100)))
                 FROM (
                   SELECT
                     COUNT(aa2.id) FILTER (WHERE aa2.lifecycle_state = 'evaluated' OR aa2.lifecycle_state = 'submitted')::float AS completed_count,

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1211,7 +1211,7 @@ defmodule Oli.Delivery.Metrics do
             GREATEST(
               (
                 SELECT
-                  completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100)))
+                  completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100.0)))
                 FROM (
                   SELECT
                     COUNT(aa2.id) FILTER (WHERE aa2.lifecycle_state = 'evaluated' OR aa2.lifecycle_state = 'submitted')::float AS completed_count,

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1176,7 +1176,7 @@ defmodule Oli.Delivery.Metrics do
 
   Can return one of:
   {:ok, :updated} -> Progress calculated and set
-  {:ok, :noop} -> Noting needed to be done, since the attempt number was greater than 1
+  {:ok, :noop} -> Nothing needed to be done, since the attempt number was greater than 1
   {:error, :unexpected_update_count} -> 0 or more than 1 record would have been updated, rolled back
   {:error, e} -> An other error occurred, rolled back
   """

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -263,6 +263,9 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       # because it can never go lower
       ra = Oli.Repo.get(ResourceAccess, map.attempt2.resource_access_id)
       assert_in_delta 0.75, ra.progress, 0.0001
+
+      # TODO: test the case where we submit all the 4 scorable activities
+      # and assert the progress is 1.0
     end
 
     test "progress_for_page/3 calculates correctly", %{


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4437) to the ticket

The issue was that we were calculating the progress in a way that it could never reach 1.0, since the denominator was always slightly larger than the numerator (because we were adding 0.0001 to the denominator):

### Before

```
completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100) + 0.0001))
```

### After

```
completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100.0)))
```

### Before

https://github.com/user-attachments/assets/236ac93d-eca6-4024-9d33-14d4193dcac7



### After

https://github.com/user-attachments/assets/f5805475-01e2-4cd4-bd7a-2df2bcccc301

