### PR TITLE
[BUG FIX] [MER-4446] assessments are being marked late when submitting after suggested date

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -238,7 +238,7 @@ defmodule Oli.Delivery.Settings do
     |> Repo.update()
   end
 
-  def was_late?(_, %Combined{late_submit: :disallow}, _now), do: false
+  def was_late?(%ResourceAttempt{}, %Combined{late_submit: :disallow}, _now), do: false
 
   def was_late?(%ResourceAttempt{}, %Combined{scheduling_type: :read_by}, _now), do: false
 

--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -240,6 +240,8 @@ defmodule Oli.Delivery.Settings do
 
   def was_late?(_, %Combined{late_submit: :disallow}, _now), do: false
 
+  def was_late?(%ResourceAttempt{}, %Combined{scheduling_type: :read_by}, _now), do: false
+
   def was_late?(
         %ResourceAttempt{} = resource_attempt,
         %Combined{late_submit: :allow} = effective_settings,

--- a/test/oli/delivery/attempts/was_late_test.exs
+++ b/test/oli/delivery/attempts/was_late_test.exs
@@ -66,9 +66,17 @@ defmodule Oli.Delivery.Attempts.WasLateTest do
       Oli.Delivery.Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       datashop_session_id_user1 = UUID.uuid4()
 
-      effective_settings = %Oli.Delivery.Settings.Combined{time_limit: 5}
+      effective_settings = %Oli.Delivery.Settings.Combined{
+        time_limit: 5,
+        scheduling_type: :due_by
+      }
+
       sr = Oli.Delivery.Sections.get_section_resource(section.id, page.resource.id)
-      Oli.Delivery.Sections.update_section_resource(sr, %{time_limit: 5})
+
+      Oli.Delivery.Sections.update_section_resource(sr, %{
+        time_limit: 5,
+        scheduling_type: :due_by
+      })
 
       Oli.Delivery.Attempts.Core.track_access(page.resource.id, section.id, user.id)
 
@@ -143,6 +151,51 @@ defmodule Oli.Delivery.Attempts.WasLateTest do
     end
 
     @tag isolation: "serializable"
+    test "finalization after end date doesn't set was_late if read_by", %{
+      section: section,
+      graded_page1: page,
+      user1: user
+    } do
+      Oli.Delivery.Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      datashop_session_id_user1 = UUID.uuid4()
+
+      yesterday = DateTime.utc_now() |> DateTime.add(-1, :day)
+
+      effective_settings = %Oli.Delivery.Settings.Combined{
+        end_date: yesterday,
+        scheduling_type: :read_by
+      }
+
+      sr = Oli.Delivery.Sections.get_section_resource(section.id, page.resource.id)
+
+      Oli.Delivery.Sections.update_section_resource(sr, %{
+        end_date: yesterday,
+        scheduling_type: :read_by
+      })
+
+      Oli.Delivery.Attempts.Core.track_access(page.resource.id, section.id, user.id)
+
+      activity_provider = &Oli.Delivery.ActivityProvider.provide/6
+
+      {:ok, %AttemptState{resource_attempt: ra}} =
+        PageLifecycle.start(
+          page.revision.slug,
+          section.slug,
+          datashop_session_id_user1,
+          user,
+          effective_settings,
+          activity_provider
+        )
+
+      {:ok, %FinalizationSummary{resource_access: resource_access}} =
+        PageLifecycle.finalize(section.slug, ra.attempt_guid, datashop_session_id_user1)
+
+      ra1 = Core.get_resource_attempt_by(attempt_guid: ra.attempt_guid)
+      refute ra1.was_late
+      refute resource_access.was_late
+    end
+
+    @tag isolation: "serializable"
     test "finalization after end date sets was_late", %{
       section: section,
       graded_page1: page,
@@ -152,9 +205,18 @@ defmodule Oli.Delivery.Attempts.WasLateTest do
       datashop_session_id_user1 = UUID.uuid4()
 
       yesterday = DateTime.utc_now() |> DateTime.add(-1, :day)
-      effective_settings = %Oli.Delivery.Settings.Combined{end_date: yesterday}
+
+      effective_settings = %Oli.Delivery.Settings.Combined{
+        end_date: yesterday,
+        scheduling_type: :due_by
+      }
+
       sr = Oli.Delivery.Sections.get_section_resource(section.id, page.resource.id)
-      Oli.Delivery.Sections.update_section_resource(sr, %{end_date: yesterday})
+
+      Oli.Delivery.Sections.update_section_resource(sr, %{
+        end_date: yesterday,
+        scheduling_type: :due_by
+      })
 
       Oli.Delivery.Attempts.Core.track_access(page.resource.id, section.id, user.id)
 

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -70,13 +70,15 @@ defmodule Oli.Delivery.SettingsTest do
     settings_with_grace_period = %Combined{
       end_date: nil,
       time_limit: 30,
-      grace_period: 5
+      grace_period: 5,
+      scheduling_type: :due_by
     }
 
     settings_with_no_grace_period = %Combined{
       end_date: nil,
       time_limit: 30,
-      grace_period: 0
+      grace_period: 0,
+      scheduling_type: :due_by
     }
 
     refute Settings.was_late?(
@@ -133,12 +135,14 @@ defmodule Oli.Delivery.SettingsTest do
 
     settings_with_grace_period = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
-      grace_period: 5
+      grace_period: 5,
+      scheduling_type: :due_by
     }
 
     settings_with_no_grace_period = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
-      grace_period: 0
+      grace_period: 0,
+      scheduling_type: :due_by
     }
 
     refute Settings.was_late?(
@@ -178,6 +182,7 @@ defmodule Oli.Delivery.SettingsTest do
     }
 
     settings = %Combined{
+      scheduling_type: :due_by,
       end_date: ~U[2020-01-01 02:00:00Z],
       time_limit: 30
     }


### PR DESCRIPTION
Ticket: [MER-4446](https://eliterate.atlassian.net/browse/MER-4446)

This PR fixes an issue where an instructor sets a graded page with a suggested "read by" date, but it is not honored.

The fix can be found in commit e4508cce38e6815f549f66d6f8ae992b3dba5da3 , where the `Oli.Delivery.Settings.was_late?/3` function was not considering the case when `%Combined{scheduling_type: :read_by}`. This case is used to determine that the grade page is not late.

[MER-4446]: https://eliterate.atlassian.net/browse/MER-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ