### PR TITLE
[BUG FIX] [MER-4451] canvas embed view refuses to connect

### DIFF
--- a/lib/oli_web/common/assent_auth_web.ex
+++ b/lib/oli_web/common/assent_auth_web.ex
@@ -201,7 +201,7 @@ defmodule OliWeb.Common.AssentAuthWeb do
   defp provider_config!(provider, config) do
     provider = ensure_atom_key(provider)
 
-    config.authentication_providers()
+    config.authentication_providers
     |> Keyword.get(provider)
     |> Assent.Config.put(
       :redirect_uri,

--- a/lib/oli_web/plugs/allow_iframe.ex
+++ b/lib/oli_web/plugs/allow_iframe.ex
@@ -1,0 +1,13 @@
+defmodule OliWeb.Plugs.AllowIframe do
+  @moduledoc """
+  Allows ressources to be loaded in an iframe.
+  """
+
+  alias Plug.Conn
+
+  def init(opts \\ %{}), do: opts
+
+  def call(conn, _opts) do
+    Conn.delete_resp_header(conn, "x-frame-options")
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -76,6 +76,7 @@ defmodule OliWeb.Router do
 
   pipeline :delivery do
     plug(Oli.Plugs.SetVrAgentValue)
+    plug(OliWeb.Plugs.AllowIframe)
   end
 
   # set the layout to be workspace
@@ -275,7 +276,12 @@ defmodule OliWeb.Router do
   end
 
   scope "/", OliWeb do
-    pipe_through [:browser, :require_authenticated_user, :fetch_current_author]
+    pipe_through [
+      :browser,
+      :delivery,
+      :require_authenticated_user,
+      :fetch_current_author
+    ]
 
     live "/users/link_account", LinkAccountLive, :link_account
   end
@@ -975,7 +981,7 @@ defmodule OliWeb.Router do
   ###
 
   scope "/sections", OliWeb do
-    pipe_through([:browser])
+    pipe_through([:browser, :delivery, :delivery_layout])
 
     # Resolve root /sections route using the DeliveryController index action
     get("/", DeliveryController, :index)


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4451

Fixes an issue where trying to load a section directly in an iframe within an LMS refused to connect. The root issue was the x-frame-options header was implicitly being set by phoenix. I am not sure what actually changed between v29 and v30 to introduce this issue but adding an explicit plug to unset this header fixes the problem.

This only enables iframe embedding for delivery routes. Authoring and other non-delivery routes will still be prohibited from being loaded in an iframe.