### PR TITLE
[BUG FIX] [MER-4453] Late attempts not being marked as late when there is a time limit

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -215,7 +215,10 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
-  defp submit_term(%{effective_settings: %{late_submit: :allow, time_limit: 0}} = assigns) do
+  defp submit_term(
+         %{effective_settings: %{late_submit: :allow, time_limit: 0, scheduling_type: :due_by}} =
+           assigns
+       ) do
     ~H"""
     <li id="page_submit_term">
       If you submit after the due date, it will be marked late.
@@ -223,7 +226,10 @@ defmodule OliWeb.Delivery.Student.Utils do
     """
   end
 
-  defp submit_term(%{effective_settings: %{late_submit: :allow}} = assigns) do
+  defp submit_term(
+         %{effective_settings: %{late_submit: :allow, time_limit: time_limit}} = assigns
+       )
+       when time_limit > 0 do
     ~H"""
     <li id="page_submit_term">
       If you exceed this time, it will be marked late.

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1148,12 +1148,13 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       refute has_element?(view, "#page_time_limit_term", "<li id=\"page_time_limit_term\">")
     end
 
-    test "page terms render a late submit message", ctx do
+    test "page terms render a late submit message when time limit is set (no matter the scheduling type)",
+         ctx do
       %{conn: conn, user: user, section: section, page_2: page_2} = ctx
 
       enroll_and_mark_visited(user, section)
 
-      params = %{late_submit: :allow, time_limit: 10}
+      params = %{late_submit: :allow, time_limit: 10, scheduling_type: :due_by}
 
       get_and_update_section_resource(section.id, page_2.resource_id, params)
 
@@ -1161,6 +1162,31 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       assert view |> element("#page_submit_term") |> render() =~
                "<li id=\"page_submit_term\">\n  If you exceed this time, it will be marked late.\n</li>"
+
+      params = %{late_submit: :allow, time_limit: 10, scheduling_type: :read_by}
+
+      get_and_update_section_resource(section.id, page_2.resource_id, params)
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+      assert view |> element("#page_submit_term") |> render() =~
+               "<li id=\"page_submit_term\">\n  If you exceed this time, it will be marked late.\n</li>"
+    end
+
+    test "page terms render a late submit message warning when due date is set with no time limit",
+         ctx do
+      %{conn: conn, user: user, section: section, page_2: page_2} = ctx
+
+      enroll_and_mark_visited(user, section)
+
+      params = %{late_submit: :allow, time_limit: 0, scheduling_type: :due_by}
+
+      get_and_update_section_resource(section.id, page_2.resource_id, params)
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+      assert view |> element("#page_submit_term") |> render() =~
+               "<li id=\"page_submit_term\">\n  If you submit after the due date, it will be marked late.\n</li>"
     end
 
     test "page terms render no message when late submit is disallowed", ctx do


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4453) to the ticket

On [MER-4446](https://eliterate.atlassian.net/browse/MER-4446), the "late" logic was changed not to mark as late any attempt on pages with a suggested_by date (as the ticket's expected behavior requested)
This PR slightly modifies that logic to consider this edge case: when a page with a suggested_by date AND a time limit is submitted, then the attempt is marked as "late" if the `submission_date_time > start_attempt_date_time + time limit + grace period`


https://github.com/user-attachments/assets/a3d3cb26-6a37-4d20-9f1a-f04069908e08




## Another fix
A page with a suggested_by date, late-submit allowed, and no time limit used to show this submit term message on the prologue page:

`If you submit after the due date, it will be marked late.`

With the changes made, that warning will only be shown for pages with due-date set, late-submit allowed and not time limit.






[MER-4446]: https://eliterate.atlassian.net/browse/MER-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ