### PR TITLE
[BUG FIX] [MER-4453] Late label not showing

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -329,9 +329,12 @@ defmodule Oli.Delivery.Settings do
 
         # both an end date and a time limit, use the earlier of the two
         {end_date, time_limit} ->
-          if end_date < DateTime.add(resource_attempt.inserted_at, time_limit, :minute),
-            do: end_date,
-            else: DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
+          if DateTime.compare(
+               end_date,
+               DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
+             ) == :lt,
+             do: end_date,
+             else: DateTime.add(resource_attempt.inserted_at, time_limit, :minute)
       end
 
     case deadline do

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -62,6 +62,52 @@ defmodule Oli.Delivery.SettingsTest do
     refute Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
   end
 
+  test "was_late/2 never returns true when scheduling type is :read_by" do
+    ra = %ResourceAttempt{
+      inserted_at: ~U[2020-01-15 00:00:00Z]
+    }
+
+    settings = %Combined{
+      late_submit: :allow,
+      time_limit: 1,
+      scheduling_type: :read_by,
+      end_date: ~U[2020-01-12 00:00:00Z]
+    }
+
+    refute Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
+  end
+
+  #   iex(12)> today = DateTime.utc_now
+  # ~U[2025-03-27 18:52:09.691707Z]
+  # iex(13)> next_week = DateTime.add(today, 7, :day)
+  # ~U[2025-04-03 18:52:09.691707Z]
+  # iex(14)> today < next_week
+  # false
+  # iex(15)> DateTime.compare(today, next_week)
+  # :lt
+  test "was_late/2 correctly compares datetimes" do
+    today = ~U[2025-03-27 18:52:09.00Z]
+    next_week = DateTime.add(today, 7, :day)
+
+    # a bad date comparison
+    refute today < next_week
+
+    ra = %ResourceAttempt{
+      inserted_at: today
+    }
+
+    settings = %Combined{
+      late_submit: :allow,
+      time_limit: 1,
+      scheduling_type: :due_by,
+      end_date: next_week
+    }
+
+    # inside its logic the was_late function compares datetimes using DateTime.compare
+    # and not "<" sign
+    assert Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
+  end
+
   test "was_late/2 determines lateness correctly when only a time limit" do
     ra = %ResourceAttempt{
       inserted_at: ~U[2020-01-01 00:00:00Z]


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4453) to the ticket

The issue happened randomly depending on the due date, since we were using the `<` operator to compare two DateTimes instead of using `DateTime.compare/2`, which may lead to wrong results like the following ones:

```
iex(12)> today = DateTime.utc_now
~U[2025-03-27 18:52:09.691707Z]
iex(13)> next_week = DateTime.add(today, 7, :day)
~U[2025-04-03 18:52:09.691707Z]
iex(14)> today < next_week
false
iex(15)> DateTime.compare(today, next_week)
:lt
```

Comparison operators (>, <, >=, <=, min, and max) perform structural and not semantic comparison. Comparing with a struct won't give meaningful results. Structs that can be compared typically define a compare/2 function within their modules that can be used for semantic comparison.