### PR TITLE
[ENHANCEMENT] [MER-4035] Add Support link to lesson pages

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -194,7 +194,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
           />
         </div>
         <div class="p-2 flex-col justify-center items-center gap-4 inline-flex">
-          <.tech_support_button id="tech-support" ctx={@ctx} sidebar_expanded={@sidebar_expanded} />
+          <.tech_support_button id="tech-support" sidebar_expanded={@sidebar_expanded} />
           <.exit_course_button
             :if={is_independent_learner?(@ctx.user)}
             sidebar_expanded={@sidebar_expanded}
@@ -219,7 +219,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       >
         <div class="px-4 py-2 flex flex-row items-center align-center justify-between border-b border-gray-300 dark:border-gray-800">
           <div class="flex items-center">
-            <.tech_support_button id="mobile-tech-support" ctx={@ctx} />
+            <.tech_support_button id="mobile-tech-support" />
           </div>
           <UserAccount.menu
             id="mobile-user-account-menu-sidebar"
@@ -382,7 +382,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
           />
         </div>
         <div class="p-2 flex-col justify-center items-center gap-4 inline-flex h-[var(--footer-buttons-height)]">
-          <.tech_support_button id="tech-support" ctx={@ctx} sidebar_expanded={@sidebar_expanded} />
+          <.tech_support_button id="tech-support" sidebar_expanded={@sidebar_expanded} />
           <.exit_workspace_button
             :if={@resource_slug}
             sidebar_expanded={@sidebar_expanded}
@@ -409,7 +409,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       >
         <div class="px-4 py-2 flex flex-row items-center align-center justify-between border-b border-gray-300 dark:border-gray-800">
           <div class="flex items-center">
-            <.tech_support_button id="mobile-tech-support" ctx={@ctx} />
+            <.tech_support_button id="mobile-tech-support" />
           </div>
           <UserAccount.menu
             id="mobile-user-account-menu-workspace-sidebar"
@@ -772,14 +772,18 @@ defmodule OliWeb.Components.Delivery.Layouts do
   end
 
   attr(:id, :string)
-  attr(:ctx, SessionContext)
+  attr(:class, :string, default: "")
   attr(:sidebar_expanded, :boolean, default: true)
 
   def tech_support_button(assigns) do
     ~H"""
     <button
+      id={@id}
       onclick="window.showHelpModal();"
-      class="w-full h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white"
+      class={[
+        "w-full h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white",
+        @class
+      ]}
     >
       <div class="justify-start items-end gap-3 inline-flex">
         <div class="w-5 h-5 flex items-center justify-center">

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -116,6 +116,10 @@
               selected_view={assigns[:selected_view]}
             />
           </div>
+          <OliWeb.Components.Delivery.Layouts.tech_support_button
+            id="tech-support"
+            class="z-[999] fixed bottom-2 left-[70px]"
+          />
         </div>
 
         <%= if @section && !@page_context.page.graded do %>

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -803,6 +803,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
       ensure_content_is_visible(view)
       assert has_element?(view, "div[role='page content'] p", "Here's some practice page content")
+
+      # Support link is visible
+      assert has_element?(view, "#tech-support", "Support")
     end
 
     @tag isolation: "serializable"
@@ -876,6 +879,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
                view,
                "div[data-live-react-class='Components.References']"
              )
+
+      # Support link is visible
+      assert has_element?(view, "#tech-support", "Support")
     end
 
     test "does not see prologue but graded page when an attempt is in progress", %{
@@ -974,6 +980,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert html_response(conn, 200) =~ ~s{<div id=\"delivery_container\">}
       # It loads the adaptive themes
       assert html_response(conn, 200) =~ "/css/delivery_adaptive_themes_default_light.css"
+
+      # Support link is not visible on adaptive pages
+      refute html_response(conn, 200) =~ "Support"
     end
 
     test "back button of an adaptive page (NOT an exploration one) points to the provided url param 'request_path'",


### PR DESCRIPTION
[MER-4035](https://eliterate.atlassian.net/browse/MER-4035)

Add missing Support link to lesson pages:
1. It is displayed in both practice and graded pages.
2. It is not displayed on adaptive pages.

https://github.com/user-attachments/assets/563ab371-aa9c-4a1c-b914-f4ef6e52b1fb



[MER-4035]: https://eliterate.atlassian.net/browse/MER-4035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ