### PR TITLE
[BUG FIX] [MER-4446] Revert assessments are being marked late when submitting after suggested date

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -238,9 +238,7 @@ defmodule Oli.Delivery.Settings do
     |> Repo.update()
   end
 
-  def was_late?(%ResourceAttempt{}, %Combined{late_submit: :disallow}, _now), do: false
-
-  def was_late?(%ResourceAttempt{}, %Combined{scheduling_type: :read_by}, _now), do: false
+  def was_late?(_, %Combined{late_submit: :disallow}, _now), do: false
 
   def was_late?(
         %ResourceAttempt{} = resource_attempt,

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -70,15 +70,13 @@ defmodule Oli.Delivery.SettingsTest do
     settings_with_grace_period = %Combined{
       end_date: nil,
       time_limit: 30,
-      grace_period: 5,
-      scheduling_type: :due_by
+      grace_period: 5
     }
 
     settings_with_no_grace_period = %Combined{
       end_date: nil,
       time_limit: 30,
-      grace_period: 0,
-      scheduling_type: :due_by
+      grace_period: 0
     }
 
     refute Settings.was_late?(
@@ -135,14 +133,12 @@ defmodule Oli.Delivery.SettingsTest do
 
     settings_with_grace_period = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
-      grace_period: 5,
-      scheduling_type: :due_by
+      grace_period: 5
     }
 
     settings_with_no_grace_period = %Combined{
       end_date: ~U[2020-01-01 02:00:00Z],
-      grace_period: 0,
-      scheduling_type: :due_by
+      grace_period: 0
     }
 
     refute Settings.was_late?(
@@ -182,7 +178,6 @@ defmodule Oli.Delivery.SettingsTest do
     }
 
     settings = %Combined{
-      scheduling_type: :due_by,
       end_date: ~U[2020-01-01 02:00:00Z],
       time_limit: 30
     }


### PR DESCRIPTION
[MER-4446](https://eliterate.atlassian.net/browse/MER-4446)

This PR reverts the changes made by @Francisco-Castro in [this other PR](https://github.com/Simon-Initiative/oli-torus/pull/5517) in order to keep the functionality identical to how it is currently in Proton.


[MER-4446]: https://eliterate.atlassian.net/browse/MER-4446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ