### PR TITLE
[ENHANCEMENT] [MER-3983] Flaky Tests (Part 1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,10 @@ jobs:
         run: mix format --check-formatted
 
       - name: ▶️ Run unit tests
-        run: set -a;source oli.env && MIX_ENV=test mix ecto.reset && mix test
+        run: |
+          set -a;source oli.env
+          MIX_ENV=test mix ecto.reset
+          mix test || if [[ $? = 2  ]]; then mix test --failed; else false; fi # https://angelika.me/2024/01/08/do-not-run-mix-test-failed/
 
       - name: 📦 Install node_module dependencies
         run: yarn --cwd assets --frozen-lockfile

--- a/lib/oli/branding.ex
+++ b/lib/oli/branding.ex
@@ -248,9 +248,13 @@ defmodule Oli.Branding do
 
   defp ensure_preloaded(section, associations) do
     Logger.warning(
-      "The section association #{Kernel.inspect(associations)} has not been preloaded for branding. " <>
+      "The section association #{inspect(associations)} has not been preloaded for branding. " <>
         "The association will be loaded now but may result in performance issues."
     )
+
+    if Mix.env() == :test do
+      raise "Branding associations must be preloaded"
+    end
 
     section
     |> Repo.preload(associations)

--- a/lib/oli/delivery/sections/certificates/workers/generate_pdf.ex
+++ b/lib/oli/delivery/sections/certificates/workers/generate_pdf.ex
@@ -25,7 +25,12 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.GeneratePdf do
       {:ok, granted_certificate} ->
         if send_email do
           granted_certificate =
-            Repo.preload(granted_certificate, [:user, certificate: [:section]])
+            Repo.preload(granted_certificate, [
+              :user,
+              certificate: [
+                section: [:brand, lti_1p3_deployment: [institution: [:default_brand]]]
+              ]
+            ])
 
           section = granted_certificate.certificate.section
 

--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
          :customizations,
          :title,
          :brand,
+         :lti_1p3_deployment,
          :contains_discussions,
          :contains_explorations,
          :contains_deliberate_practice

--- a/test/oli/analytics/datasets_test.exs
+++ b/test/oli/analytics/datasets_test.exs
@@ -40,6 +40,7 @@ defmodule Oli.Analytics.Datasets.Test do
       Seeder.base_project_with_resource2()
     end
 
+    @tag :flaky
     test "multiple jobs, but all from same application id", %{
       project: project,
       author: author1,
@@ -533,6 +534,7 @@ defmodule Oli.Analytics.Datasets.Test do
       assert result == [%{id: project.id, title: project.title}]
     end
 
+    @tag :flaky
     test "initiator values", %{project: project, author: author1, author2: author2} do
       job(%{
         status: :pending,

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -52,7 +52,6 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
       assert body == "fail"
     end
 
-    @tag :skip
     test "test that a single batcher honors batch keys", map do
       bundle1a = make_bundle("1", map.upload_directory)
       bundle1b = make_bundle("1", map.upload_directory)

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -52,6 +52,7 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
       assert body == "fail"
     end
 
+    @tag :flaky
     test "test that a single batcher honors batch keys", map do
       bundle1a = make_bundle("1", map.upload_directory)
       bundle1b = make_bundle("1", map.upload_directory)

--- a/test/oli/analytics/xapi/pipeline_test.exs
+++ b/test/oli/analytics/xapi/pipeline_test.exs
@@ -53,6 +53,7 @@ defmodule Oli.Analytics.XAPI.PipelineTest do
     end
 
     @tag :flaky
+    @tag :skip
     test "test that a single batcher honors batch keys", map do
       bundle1a = make_bundle("1", map.upload_directory)
       bundle1b = make_bundle("1", map.upload_directory)

--- a/test/oli/branding_test.exs
+++ b/test/oli/branding_test.exs
@@ -113,6 +113,9 @@ defmodule Oli.BrandingTest do
           lti_1p3_deployment_id: deployment.id
         })
 
+      section =
+        Repo.preload(section, [:brand, lti_1p3_deployment: [institution: [:default_brand]]])
+
       oaf_section =
         section_fixture(%{
           context_id: UUID.uuid4(),
@@ -120,6 +123,9 @@ defmodule Oli.BrandingTest do
           open_and_free: true,
           registration_open: true
         })
+
+      oaf_section =
+        Repo.preload(oaf_section, [:brand, lti_1p3_deployment: [institution: [:default_brand]]])
 
       %{
         section: section,
@@ -147,6 +153,8 @@ defmodule Oli.BrandingTest do
         |> Institution.changeset(%{default_brand_id: institution_brand.id})
         |> Repo.update()
 
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
+
       assert Branding.brand_name(section) == "Institution Brand"
 
       # create section brand
@@ -156,6 +164,8 @@ defmodule Oli.BrandingTest do
         section
         |> Oli.Delivery.Sections.Section.changeset(%{brand_id: section_brand.id})
         |> Repo.update()
+
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
 
       assert Branding.brand_name(section) == "Section Brand"
 
@@ -167,6 +177,8 @@ defmodule Oli.BrandingTest do
         |> Oli.Delivery.Sections.Section.changeset(%{brand_id: oaf_brand.id})
         |> Repo.update()
 
+      oaf_section = Oli.Delivery.Sections.get_section_by_slug(oaf_section.slug)
+
       assert Branding.brand_name(oaf_section) == "Open and Free Brand"
     end
 
@@ -176,6 +188,8 @@ defmodule Oli.BrandingTest do
 
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
 
       assert Branding.brand_logo_path(section) == "/some_logo"
     end
@@ -187,6 +201,8 @@ defmodule Oli.BrandingTest do
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
+
       assert Branding.brand_logo_path_dark(section) == "/some_logo_dark"
     end
 
@@ -197,6 +213,8 @@ defmodule Oli.BrandingTest do
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
 
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
+
       assert Branding.brand_logo_url(section) == "#{Oli.Utils.get_base_url()}/some_logo"
     end
 
@@ -206,6 +224,8 @@ defmodule Oli.BrandingTest do
 
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
 
       assert Branding.brand_logo_url_dark(section) == "#{Oli.Utils.get_base_url()}/some_logo_dark"
     end
@@ -229,6 +249,8 @@ defmodule Oli.BrandingTest do
 
       {:ok, section} =
         Oli.Delivery.Sections.update_section(section, %{brand_id: section_brand.id})
+
+      section = Oli.Delivery.Sections.get_section_by_slug(section.slug)
 
       assert Branding.favicons("icon.png", section) == "/some_favicons/icon.png"
     end

--- a/test/oli/delivery/section_cache_test.exs
+++ b/test/oli/delivery/section_cache_test.exs
@@ -16,6 +16,7 @@ defmodule Oli.Delivery.Sections.SectionCacheTest do
     assert value == nil
   end
 
+  @tag :flaky
   test "get_or_compute/3 calculates and stores the value if it is not present" do
     Phoenix.PubSub.subscribe(Oli.PubSub, SectionCache.cache_topic())
     slug = "test_slug"

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -253,6 +253,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
                )
     end
 
+    @tag :flaky
     test "browse/3 lists products and applies searching by amount" do
       product_id_1 = insert(:section, requires_payment: true, amount: Money.new(:USD, 500)).id
       _product_id_2 = insert(:section, requires_payment: true, amount: Money.new(:USD, 100)).id

--- a/test/oli/publishing/authoring_resolver_test.exs
+++ b/test/oli/publishing/authoring_resolver_test.exs
@@ -12,6 +12,7 @@ defmodule Oli.Publishing.AuthoringResolverTest do
       Seeder.base_project_with_resource4()
     end
 
+    @tag :flaky
     test "find_parent_objectives/2 returns parents", %{
       project: project,
       child1: child1,

--- a/test/oli/search/embeddings_test.exs
+++ b/test/oli/search/embeddings_test.exs
@@ -191,7 +191,6 @@ defmodule Oli.Search.EmbeddingsTest do
     end
 
     # MER-3983
-    @tag :skip
     test "inserts the revision_embeddings for each revision id when the third argument is true",
          %{
            publication: publication,

--- a/test/oli_web/controllers/api/xapi_controller_test.exs
+++ b/test/oli_web/controllers/api/xapi_controller_test.exs
@@ -1,6 +1,8 @@
 defmodule OliWeb.XAPIControllerTest do
   use OliWeb.ConnCase
 
+  import ExUnit.CaptureLog
+
   alias Oli.Seeder
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -40,8 +42,10 @@ defmodule OliWeb.XAPIControllerTest do
         Plug.Test.init_test_session(conn, lti_session: nil)
         |> log_in_user(map.user2)
 
-      conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
-      assert %{"result" => "failure"} = json_response(conn, 200)
+      assert capture_log([level: :error], fn ->
+               conn = post(conn, Routes.xapi_path(conn, :emit), %{"event" => event, "key" => key})
+               assert %{"result" => "failure"} = json_response(conn, 200)
+             end) =~ "Error constructing xapi bundle: \"user id mismatch\""
     end
 
     test "can emit video played event", %{

--- a/test/oli_web/controllers/legacy_superactivity_controller_test.exs
+++ b/test/oli_web/controllers/legacy_superactivity_controller_test.exs
@@ -13,9 +13,9 @@ defmodule OliWeb.LegacySuperactivityControllerTest do
   describe "legacy superactivity" do
     setup [:setup_session]
 
-    @tag :skip
     # this test should be migrated to a liveview approach since now we
     # are not rendering any content on the first response (we render when websocket is connected)
+    @tag :skip
     test "deliver legacy superactivity", %{
       user: user,
       conn: conn,

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -1,6 +1,7 @@
-@moduletag :skip
 defmodule OliWeb.PageDeliveryControllerTest do
   use OliWeb.ConnCase
+
+  @moduletag :skip
 
   import Mox
   import Oli.Factory

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -1,3 +1,4 @@
+@moduletag :skip
 defmodule OliWeb.PageDeliveryControllerTest do
   use OliWeb.ConnCase
 
@@ -235,7 +236,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
-    @tag :skip
     test "shows the related exploration pages for a given page", %{
       conn: conn,
       user: user,
@@ -253,7 +253,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
-    @tag :skip
     test "shows a 'no exploration pages' message when the page doesn't have any related exploration pages",
          %{
            conn: conn,
@@ -271,7 +270,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
-    @tag :skip
     test "handles student adaptive page access by an enrolled student", %{
       conn: conn,
       map: %{adaptive_page_revision: revision},
@@ -381,7 +379,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "shows the prologue page on an assessment", %{
       user: user,
@@ -553,7 +550,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker.get_jobs() |> length() == 1
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "requires correct password to start an attempt", %{
       user: user,
@@ -626,7 +622,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
-    @tag :skip
     test "renders custom license in footer for started page", %{
       conn: conn,
       user: user,
@@ -654,7 +649,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "This is a custom license"
     end
 
-    @tag :skip
     test "renders :none license case in footer for started page", %{
       conn: conn,
       user: user,
@@ -682,7 +676,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "Non-CC / Copyrighted / Other"
     end
 
-    @tag :skip
     test "renders custom license in footer for a not_started page -- prologue", %{
       conn: conn,
       user: user,
@@ -710,7 +703,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
              |> Floki.text() =~ "This is a custom license"
     end
 
-    @tag :skip
     test "renders creative commons license in footer for a not_started page -- prologue", %{
       conn: conn,
       user: user,
@@ -747,7 +739,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert Floki.find(license, "img") |> Floki.attribute("src") == ["/images/cc_logos/by.svg"]
     end
 
-    @tag :skip
     # This tests the edge case for when a student goes to a page that is available to start and the instructor changes the start date
     # to a future date simultaneously and before the student refreshes the page.
     # The student should be redirected back to the page and see a message that the page is not yet available when trying to start an attempt.
@@ -793,7 +784,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "This assessment is not yet available. It will be available on #{FormatDateTime.date(tomorrow, conn: conn, precision: :minutes)}."
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "shows 'Start Attempt' button when start date has passed", %{
       user: user,
@@ -837,7 +827,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
-    @tag :skip
     test "does not show 'Start Attempt' button when start date has not passed yet", %{
       user: user,
       conn: conn,
@@ -860,7 +849,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response =~ "Start Attempt"
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "changing a page from graded to ungraded allows the graded attempt to continue", %{
       map: map,
@@ -974,7 +962,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "Submit Answers"
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "changing a page from ungraded to graded shows the prologue even with an ungraded attempt present",
          %{
@@ -1078,7 +1065,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Submit Answers"
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "multiple requests to start attempt only results in single active attempt record", %{
       user: user,
@@ -1143,7 +1129,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                Core.get_resource_attempt_history(page_revision.resource_id, section.slug, user.id)
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "page with content breaks renders pagination controls", %{
       map: map,
@@ -1216,7 +1201,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ ~s|<div data-react-class="Components.PaginationControls"|
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "page renders learning objectives in ungraded pages but not graded, except for review mode",
          %{
@@ -1266,7 +1250,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "objective one"
     end
 
-    @tag :skip
     test "render student's upcoming activities if any exists", %{
       conn: conn,
       user: user
@@ -1312,7 +1295,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       refute html_response(conn, 200) =~ "A graded container?"
     end
 
-    @tag :skip
     test "shows page index based navigation", %{
       conn: conn,
       revision: revision,
@@ -1329,7 +1311,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "id=\"bottom_page_navigator\""
     end
 
-    @tag :skip
     @tag isolation: "serializable"
     test "timer will be shown it if revision is graded", %{
       conn: conn,
@@ -1381,7 +1362,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 404) =~ "The section you are trying to view does not exist"
     end
 
-    @tag :skip
     test "shows 'Where you left off' card when student has visited a page before", %{
       conn: conn,
       user: user,
@@ -1549,7 +1529,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 302) =~ Routes.delivery_path(conn, :show_enroll, section.slug)
     end
 
-    @tag :skip
     test "handles independent learner user access after author and another user have been deleted",
          %{
            conn: conn,
@@ -1650,7 +1629,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
   describe "displaying unit numbers" do
     setup [:setup_tags, :base_project_with_curriculum]
 
-    @tag :skip
     test "does not display unit numbers if setting is set to false", %{
       conn: conn,
       project: project,
@@ -1693,7 +1671,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert response =~ "Unit: The first unit"
     end
 
-    @tag :skip
     test "does display unit numbers if setting is set to true", %{
       conn: conn,
       project: project,
@@ -1962,7 +1939,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
   end
 
   describe "preview redirects to student view when is enrolled" do
-    @describetag :skip
     setup [:setup_lti_session, :section_with_assessment, :enroll_as_student]
 
     test "index preview redirects ok", %{
@@ -1978,7 +1954,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Course Content"
     end
 
-    @tag :skip
     test "index preview redirects ok when section slug ends with 'preview'", %{
       conn: conn,
       section: section
@@ -2009,7 +1984,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                Routes.page_delivery_path(conn, :container, section.slug, unit_one_revision)
     end
 
-    @tag :skip
     test "page preview redirects ok", %{
       conn: conn,
       section: section,
@@ -2153,7 +2127,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
   describe "exploration" do
     setup [:project_section_revisions]
 
-    @tag :skip
     test "student can access if is enrolled in the section", %{conn: conn, section: section} do
       user = insert(:user)
       enroll_as_student(%{section: section, user: user})
@@ -2179,7 +2152,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200)
     end
 
-    @tag :skip
     test "user logged in as system admin can access to exploration preview", %{
       conn: conn,
       section: section
@@ -2206,7 +2178,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "You are being <a href=\"/sections/#{section.slug}/enroll\">redirected</a>."
     end
 
-    @tag :skip
     test "page renders a list of exploration pages", %{
       conn: conn,
       section: section,
@@ -2224,7 +2195,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Your Exploration Activities"
     end
 
-    @tag :skip
     test "page renders a message when there are no exploration pages available", %{
       conn: conn
     } do
@@ -2318,7 +2288,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200)
     end
 
-    @tag :skip
     test "user logged in as system admin can access to discussion preview", %{
       conn: conn,
       section: section
@@ -2330,7 +2299,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ "Your Latest Discussion Activity"
     end
 
-    @tag :skip
     test "page renders a list of posts of current user", %{
       conn: conn,
       section: section,
@@ -2353,7 +2321,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       end
     end
 
-    @tag :skip
     test "page renders a list of posts of all users", %{
       conn: conn,
       section: section,
@@ -2376,7 +2343,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
       end
     end
 
-    @tag :skip
     test "page renders a message when there are no posts to show", %{
       conn: conn
     } do
@@ -2402,7 +2368,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
   describe "assignments" do
     setup [:section_with_gating_conditions]
 
-    @tag :skip
     test "student can access if is enrolled in the section", %{conn: conn, section: section} do
       user = insert(:user)
       enroll_as_student(%{section: section, user: user})
@@ -2420,7 +2385,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "Find all your assignments, quizzes and activities associated with graded material."
     end
 
-    @tag :skip
     test "user logged in as system admin can access to assignments preview", %{
       conn: conn,
       section: section
@@ -2435,7 +2399,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "Find all your assignments, quizzes and activities associated with graded material."
     end
 
-    @tag :skip
     test "related activities get rendered", %{conn: conn, section: section} do
       user = insert(:user)
       enroll_as_student(%{section: section, user: user})

--- a/test/oli_web/live/certificates/components/certificates_issued_tab_test.exs
+++ b/test/oli_web/live/certificates/components/certificates_issued_tab_test.exs
@@ -15,6 +15,7 @@ defmodule OliWeb.Certificates.Components.CertificatesIssuedTabTest do
   describe "certificates issued component" do
     setup [:setup_data]
 
+    @tag :flaky
     test "renders table", ctx do
       %{conn: conn, session_context: session_context, section: section} = ctx
       id = "certificates_issued_component"

--- a/test/oli_web/live/delivery/student/discussions_live_test.exs
+++ b/test/oli_web/live/delivery/student/discussions_live_test.exs
@@ -702,6 +702,7 @@ defmodule OliWeb.Delivery.Student.DiscussionsLiveTest do
       )
     end
 
+    @tag :flaky
     test "triggers CheckCertification when creating a child post",
          ctx do
       %{conn: conn, student: student, section: section, root_container: root_container} = ctx

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1276,8 +1276,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              )
     end
 
-    @tag :skip
     # This feature was disabled in ticket NG-201 but will be reactivated with NG23-199
+    @tag :skip
     test "can see module learning objectives (if any) in the tooltip", %{
       conn: conn,
       section: section
@@ -1427,7 +1427,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     end
 
     # TODO: finish this test when the handle event for the "Let's discuss" button is implemented
-    @tag :skip
     test "can click on let's discuss button to open DOT AI Bot interface", %{
       conn: conn,
       section: section
@@ -1549,7 +1548,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     end
 
     @tag :flaky
-    @tag :skip
     test "can see units, modules and page (at module level) progresses", %{
       conn: conn,
       user: user,
@@ -2213,7 +2211,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
     end
 
     @tag :flaky
-    @tag :skip
     test "can see checked square icon and score details for attempted graded pages in the module index details",
          %{
            conn: conn,

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2210,55 +2210,6 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              )
     end
 
-    @tag :flaky
-    test "can see checked square icon and score details for attempted graded pages in the module index details",
-         %{
-           conn: conn,
-           user: user,
-           section: section,
-           mcq_1: mcq_1,
-           page_4: page_4_revision,
-           project: project,
-           publication: publication
-         } do
-      set_progress(section.id, page_4_revision.resource_id, user.id, 1.0, page_4_revision)
-
-      set_activity_attempt(
-        page_4_revision,
-        mcq_1,
-        user,
-        section,
-        project.id,
-        publication.id,
-        "id_for_option_a",
-        true
-      )
-
-      set_activity_attempt(
-        page_4_revision,
-        mcq_1,
-        user,
-        section,
-        project.id,
-        publication.id,
-        "id_for_option_a",
-        false
-      )
-
-      {:ok, view, _html} =
-        live(conn, Utils.learn_live_path(section.slug, selected_view: :outline))
-
-      # when the garbage collection message is recieved we know the async metrics were loaded
-      # since the gc message is sent from the handle_info that loads the async metrics
-      assert_receive(:gc, 2_000)
-
-      # graded page with title "Page 4" in the hierarchy has the correct icon
-      assert has_element?(
-               view,
-               ~s{button[role="page 4 details"] div[role="square check icon"]}
-             )
-    end
-
     test "sees a clock icon beside the duration in minutes for graded pages", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1320,6 +1320,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(learning_objectives_tooltip) =~ "Objective 4"
     end
 
+    @tag :flaky
     test "can see unit correct progress when all pages are completed",
          %{
            conn: conn,
@@ -1547,6 +1548,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
                "Due by:\n              </span><span class=\"whitespace-nowrap\">\n                Not yet scheduled"
     end
 
+    @tag :flaky
+    @tag :skip
     test "can see units, modules and page (at module level) progresses", %{
       conn: conn,
       user: user,
@@ -2209,6 +2212,8 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              )
     end
 
+    @tag :flaky
+    @tag :skip
     test "can see checked square icon and score details for attempted graded pages in the module index details",
          %{
            conn: conn,

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1646,6 +1646,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert like_button_html =~ "<path class=\"stroke-primary\""
     end
 
+    @tag :flaky
     test "skips CheckCertification if require_certification_check is false when creating a student note",
          ctx do
       %{conn: conn, section: section, user: user, page_1: page_1} = ctx

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1744,7 +1744,6 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       )
     end
 
-    @tag :skip
     test "posts a note", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -448,6 +448,7 @@ defmodule OliWeb.GradesLiveTest do
   describe "fetching invalid access token" do
     setup [:admin_conn, :create_section_with_invalid_registration]
 
+    @tag :flaky
     test "test connection - shows error on failure to obtain access token", %{
       conn: conn,
       section: section

--- a/test/oli_web/live/grades_live_test.exs
+++ b/test/oli_web/live/grades_live_test.exs
@@ -448,7 +448,6 @@ defmodule OliWeb.GradesLiveTest do
   describe "fetching invalid access token" do
     setup [:admin_conn, :create_section_with_invalid_registration]
 
-    @tag :skip
     test "test connection - shows error on failure to obtain access token", %{
       conn: conn,
       section: section

--- a/test/oli_web/live/ingest_live_test.exs
+++ b/test/oli_web/live/ingest_live_test.exs
@@ -32,7 +32,6 @@ defmodule OliWeb.IngestLiveTest do
   describe "ingest project" do
     setup [:admin_conn]
 
-    @tag :skip
     test "show error message when no file is attached", %{conn: conn} do
       {:ok, view, _html} = live(conn, @live_view_ingest_route)
 

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -1,4 +1,3 @@
-@moduletag :skip
 defmodule OliWeb.NewCourse.CourseDetailsTest do
   use ExUnit.Case, async: true
   alias Oli.Delivery.Sections
@@ -17,6 +16,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "Admin - Course Details" do
     setup [:admin_conn]
 
+    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -37,6 +37,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
+    @tag :skip
     test "doesn't render the class days if class never meets", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -57,6 +58,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
+    @tag :skip
     test "can't go to next step unless all required fields are filled and valid",
          %{conn: conn} = context do
       %{section: section} = create_source(context)
@@ -90,6 +92,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
              )
     end
 
+    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -115,6 +118,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
                assert_redirect(view, ~p"/sections/new_admin_course")
     end
 
+    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} = create_source(context, %{type: :blueprint})
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -144,6 +148,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "Instructor - Course Details" do
     setup [:instructor_conn]
 
+    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -178,6 +183,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, ".alert-danger", "Some fields require your attention")
     end
 
+    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -203,6 +209,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
                assert_redirect(view, ~p"/sections/new_instructor_course")
     end
 
+    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} = create_source(context, %{type: :blueprint})
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -232,6 +239,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "LMS - Course Details" do
     setup [:lms_instructor_conn]
 
+    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -252,6 +260,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
+    @tag :skip
     test "can't go to next step unless all required fields are filled", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -266,6 +275,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, ".alert-danger", "Some fields require your attention")
     end
 
+    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -289,6 +299,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/sections")
     end
 
+    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} =
         create_source(context, %{type: :blueprint, contains_explorations: true})
@@ -322,6 +333,7 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/sections")
     end
 
+    @tag :skip
     test "creates a section with analytics_version :v2 ", %{conn: conn} = context do
       # Factory has a default analytics_version ==  :v1
       %{section: section} = create_source(context)

--- a/test/oli_web/live/new_course/course_details_test.exs
+++ b/test/oli_web/live/new_course/course_details_test.exs
@@ -1,3 +1,4 @@
+@moduletag :skip
 defmodule OliWeb.NewCourse.CourseDetailsTest do
   use ExUnit.Case, async: true
   alias Oli.Delivery.Sections
@@ -16,7 +17,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "Admin - Course Details" do
     setup [:admin_conn]
 
-    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -37,7 +37,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
-    @tag :skip
     test "doesn't render the class days if class never meets", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -58,7 +57,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
-    @tag :skip
     test "can't go to next step unless all required fields are filled and valid",
          %{conn: conn} = context do
       %{section: section} = create_source(context)
@@ -92,7 +90,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
              )
     end
 
-    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -118,7 +115,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
                assert_redirect(view, ~p"/sections/new_admin_course")
     end
 
-    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} = create_source(context, %{type: :blueprint})
       {:ok, view, _html} = live(conn, @live_view_admin_route)
@@ -148,7 +144,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "Instructor - Course Details" do
     setup [:instructor_conn]
 
-    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -169,7 +164,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
-    @tag :skip
     test "can't go to next step unless all required fields are filled", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -184,7 +178,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, ".alert-danger", "Some fields require your attention")
     end
 
-    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -210,7 +203,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
                assert_redirect(view, ~p"/sections/new_instructor_course")
     end
 
-    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} = create_source(context, %{type: :blueprint})
       {:ok, view, _html} = live(conn, @live_view_independent_learner_route)
@@ -240,7 +232,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
   describe "LMS - Course Details" do
     setup [:lms_instructor_conn]
 
-    @tag :skip
     test "renders the \"course details\" form", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -261,7 +252,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, "input[type=\"time\"]#section_preferred_scheduling_time")
     end
 
-    @tag :skip
     test "can't go to next step unless all required fields are filled", %{conn: conn} = context do
       %{section: section} = create_source(context)
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -276,7 +266,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert has_element?(view, ".alert-danger", "Some fields require your attention")
     end
 
-    @tag :skip
     test "successfully creates a section from a project publication", %{conn: conn} = context do
       %{publication: publication} = create_source(context, %{type: :enrollable})
       {:ok, view, _html} = live(conn, @live_view_lms_instructor_route)
@@ -300,7 +289,6 @@ defmodule OliWeb.NewCourse.CourseDetailsTest do
       assert %{"info" => "Section successfully created."} == assert_redirect(view, ~p"/sections")
     end
 
-    @tag :skip
     test "successfully creates a section from a product", %{conn: conn} = context do
       %{section: section} =
         create_source(context, %{type: :blueprint, contains_explorations: true})

--- a/test/oli_web/live/objectives_live_test.exs
+++ b/test/oli_web/live/objectives_live_test.exs
@@ -154,6 +154,8 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
+    @tag :flaky
+    @tag :skip
     test "applies searching", %{conn: conn, project: project, publication: publication} do
       {:ok, first_obj} = create_objective(project, publication, "first_obj", "First Objective")
       {:ok, second_obj} = create_objective(project, publication, "second_obj", "Second Objective")
@@ -242,6 +244,8 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
+    @tag :flaky
+    @tag :skip
     test "show objective", %{conn: conn, project: project, publication: publication} do
       {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
       {:ok, sub_obj_2} = create_objective(project, publication, "sub_obj_2", "Sub Objective 2")
@@ -287,6 +291,8 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
+    @tag :flaky
+    @tag :skip
     test "new objective", %{conn: conn, project: project} do
       title = "New Objective"
 
@@ -584,6 +590,8 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
+    @tag :flaky
+    @tag :skip
     test "remove sub objective with one parent", %{
       conn: conn,
       project: project,
@@ -619,6 +627,8 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
+    @tag :flaky
+    @tag :skip
     test "remove sub objective with more than one parent", %{
       conn: conn,
       project: project,

--- a/test/oli_web/live/objectives_live_test.exs
+++ b/test/oli_web/live/objectives_live_test.exs
@@ -154,7 +154,6 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
-    @tag :flaky
     @tag :skip
     test "applies searching", %{conn: conn, project: project, publication: publication} do
       {:ok, first_obj} = create_objective(project, publication, "first_obj", "First Objective")
@@ -244,7 +243,6 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
-    @tag :flaky
     @tag :skip
     test "show objective", %{conn: conn, project: project, publication: publication} do
       {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
@@ -292,7 +290,6 @@ defmodule OliWeb.ObjectivesLiveTest do
     end
 
     @tag :flaky
-    @tag :skip
     test "new objective", %{conn: conn, project: project} do
       title = "New Objective"
 
@@ -522,7 +519,6 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
-    @tag :skip
     test "new sub objective", %{conn: conn, project: project, publication: publication} do
       title = "Sub Objective"
       {:ok, obj} = create_objective(project, publication, "obj", "Objective")
@@ -590,7 +586,6 @@ defmodule OliWeb.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
-    @tag :flaky
     @tag :skip
     test "remove sub objective with one parent", %{
       conn: conn,
@@ -628,7 +623,6 @@ defmodule OliWeb.ObjectivesLiveTest do
     end
 
     @tag :flaky
-    @tag :skip
     test "remove sub objective with more than one parent", %{
       conn: conn,
       project: project,

--- a/test/oli_web/live/payments_live_test.exs
+++ b/test/oli_web/live/payments_live_test.exs
@@ -215,7 +215,6 @@ defmodule OliWeb.PaymentsLiveTest do
       assert has_element?(view, "div", product.title)
     end
 
-    @tag :skip
     test "applies sorting", %{conn: conn, product: product} do
       {_, _product, payment1} = create_payment_code(product)
       {_, _product, payment2} = create_payment_code(product)

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -138,7 +138,6 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "a", product_2.base_project.title)
     end
 
-    @tag :skip
     @tag :flaky
     test "search product by amount", %{conn: conn, product: product} do
       [{_, product_2} | _] = create_product(conn)

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -138,6 +138,8 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "a", product_2.base_project.title)
     end
 
+    @tag :skip
+    @tag :flaky
     test "search product by amount", %{conn: conn, product: product} do
       [{_, product_2} | _] = create_product(conn)
 
@@ -166,7 +168,6 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "a", product_2.title)
     end
 
-    @tag :skip
     test "applies sorting by creation date", %{conn: conn, product: product} do
       product_2 =
         insert(:section,
@@ -358,7 +359,6 @@ defmodule OliWeb.ProductsLiveTest do
              |> render() =~ "<img id=\"current-product-img\""
     end
 
-    @tag :skip
     test "canceling an upload restores previous rendered image", %{conn: conn} do
       current_image = "https://example.com/some-image-url.png"
       product = insert(:section, type: :blueprint, cover_image: current_image)

--- a/test/oli_web/live/sections/gating_and_scheduling_test.exs
+++ b/test/oli_web/live/sections/gating_and_scheduling_test.exs
@@ -440,6 +440,7 @@ defmodule OliWeb.Sections.GatingAndSchedulingTest do
              ) == input_end_date
     end
 
+    @tag :flaky
     test "create student exceptions for more than one student works correctly", %{
       conn: conn,
       section_1: section,

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -237,7 +237,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
 
-    @tag :skip
     test "show objective", %{conn: conn, project: project, publication: publication} do
       {:ok, sub_obj} = create_objective(project, publication, "sub_obj", "Sub Objective")
       {:ok, sub_obj_2} = create_objective(project, publication, "sub_obj_2", "Sub Objective 2")

--- a/test/oli_web/plugs/header_size_logger_test.exs
+++ b/test/oli_web/plugs/header_size_logger_test.exs
@@ -20,6 +20,7 @@ defmodule OliWeb.Plugs.HeaderSizeLoggerTest do
     |> Keyword.get(:max_header_value_length, 4096)
   end
 
+  @tag :flaky
   test "does not log when request headers are below threshold" do
     opts = HeaderSizeLogger.init(capture_module: Oli.Utils.AppsignalMock)
 

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -3646,7 +3646,7 @@ defmodule Oli.TestHelpers do
 
   defp wait_while_helper(f, interval, timeout, start) do
     if :os.system_time(:millisecond) - start > timeout do
-      throw("Timeout waiting for condition to be true. Timeout: #{timeout} ms.")
+      ExUnit.Assertions.flunk("Timeout waiting for condition to be true. Timeout: #{timeout} ms.")
     else
       case f.() do
         true ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,8 @@
 Application.ensure_all_started(:ex_machina)
-ExUnit.start(exclude: [:skip])
+
+ExUnit.start(
+  exclude: [:skip],
+  failures_manifest_path: "/Users/martin/work/oli-torus/failures_manifest.txt"
+)
+
 Ecto.Adapters.SQL.Sandbox.mode(Oli.Repo, :manual)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,8 +1,3 @@
 Application.ensure_all_started(:ex_machina)
-
-ExUnit.start(
-  exclude: [:skip],
-  failures_manifest_path: "/Users/martin/work/oli-torus/failures_manifest.txt"
-)
-
+ExUnit.start(exclude: [:skip])
 Ecto.Adapters.SQL.Sandbox.mode(Oli.Repo, :manual)


### PR DESCRIPTION
Now flaky tests are tagged as such, and tests that _always_ fail are marked as skipped (we need to get into those and try to fix them and remove the ones that are related to legacy features)

The Github action that runs the tests, now reruns the initial failed tests once more in order to avoid having to retrigger the CI because of flaky tests.

See: https://eliterate.atlassian.net/browse/MER-3983


----

## Skipped tests

| File                                                                                             | Count |
|--------------------------------------------------------------------------------------------------------|----------------|
| test/oli_web/controllers/page_delivery_controller_test.exs                                             | 38             |
| test/oli_web/live/new_course/course_details_test.exs                                                  | 13             |
| test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs             | 3              |
| test/oli_web/live/delivery/student/learn_live_test.exs                                                | 3              |
| test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs              | 3              |
| test/oli_web/live/ingest_live_test.exs                                                                | 3              |
| test/oli_web/live/objectives_live_test.exs                                                            | 3              |
| test/oli_web/controllers/legacy_superactivity_controller_test.exs                                     | 1              |
| test/oli_web/live/sections/gating_and_scheduling_test.exs                                             | 1              |
| test/oli_web/live/workspaces/course_author/curriculum_live_test.exs                                   | 1              |

## Flaky tests
| Test File                                                                                     | Count |
|-----------------------------------------------------------------------------------------------|----------------|
| test/oli/analytics/datasets_test.exs                                                          | 2              |
| test/oli_web/live/objectives_live_test.exs                                                    | 2              |
| test/oli_web/live/delivery/student/learn_live_test.exs                                        | 2              |
| test/oli/delivery/section_cache_test.exs                                                      | 1              |
| test/oli/delivery/sections/blueprint_test.exs                                                 | 1              |
| test/oli/publishing/authoring_resolver_test.exs                                               | 1              |
| test/oli_web/live/certificates/components/certificates_issued_tab_test.exs                    | 1              |
| test/oli_web/live/delivery/student/discussions_live_test.exs                                  | 1              |
| test/oli_web/live/delivery/student/lesson_live_test.exs                                       | 1              |
| test/oli_web/live/grades_live_test.exs                                                        | 1              |
| test/oli_web/live/products_test.exs                                                           | 1              |
| test/oli_web/live/sections/gating_and_scheduling_test.exs                                     | 1              |
| test/oli_web/plugs/header_size_logger_test.exs                                                | 1              |
