### PR TITLE
[FEATURE] [MER-3452] Bottom bar improvement lesson pages

### DIFF
--- a/assets/src/hooks/fixed_navigation_bar.ts
+++ b/assets/src/hooks/fixed_navigation_bar.ts
@@ -1,0 +1,34 @@
+export const FixedNavigationBar = {
+  mounted() {
+    const bottomBar = document.getElementById('bottom-bar');
+    if (!bottomBar) return;
+
+    const updateBarVisibility = () => {
+      const { scrollTop, scrollHeight } = document.documentElement;
+      const windowHeight = window.innerHeight;
+      const atBottom = scrollTop + windowHeight >= scrollHeight - 5;
+      const noScroll = scrollHeight <= windowHeight;
+
+      if (atBottom || noScroll) {
+        bottomBar.classList.add('translate-y-0', 'opacity-100');
+        bottomBar.classList.remove('translate-y-full', 'opacity-0');
+      } else {
+        bottomBar.classList.remove('translate-y-0', 'opacity-100');
+        bottomBar.classList.add('translate-y-full', 'opacity-0');
+      }
+    };
+
+    window.addEventListener('scroll', updateBarVisibility);
+    window.addEventListener('resize', updateBarVisibility); // por si cambia el alto
+    requestAnimationFrame(updateBarVisibility); // correr al montar
+
+    this.cleanup = () => {
+      window.removeEventListener('scroll', updateBarVisibility);
+      window.removeEventListener('resize', updateBarVisibility);
+    };
+  },
+
+  destroyed() {
+    this.cleanup?.();
+  },
+};

--- a/assets/src/hooks/fixed_navigation_bar.ts
+++ b/assets/src/hooks/fixed_navigation_bar.ts
@@ -19,8 +19,8 @@ export const FixedNavigationBar = {
     };
 
     window.addEventListener('scroll', updateBarVisibility);
-    window.addEventListener('resize', updateBarVisibility); // por si cambia el alto
-    requestAnimationFrame(updateBarVisibility); // correr al montar
+    window.addEventListener('resize', updateBarVisibility);
+    requestAnimationFrame(updateBarVisibility);
 
     this.cleanup = () => {
       window.removeEventListener('scroll', updateBarVisibility);

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -15,6 +15,7 @@ import { DragSource, DropTarget } from './dragdrop';
 import { EmailList } from './email_list';
 import { EndDateTimer } from './end_date_timer';
 import { EvaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
+import { FixedNavigationBar } from './fixed_navigation_bar';
 import { GraphNavigation } from './graph';
 import { HierarchySelector } from './hierarchy_selector';
 import { InputAutoSelect } from './input_auto_select';
@@ -99,4 +100,5 @@ export const Hooks = {
   DisableSubmitted,
   Recaptcha,
   OnMountAndUpdate,
+  FixedNavigationBar,
 };

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -214,6 +214,26 @@ defmodule Oli.Delivery.Metrics do
   end
 
   @doc """
+  Calculate the progress for a given student for a list of pages.
+  """
+
+  def progress_for_pages(section_id, user_id, page_ids) do
+    from(ra in ResourceAccess,
+      where:
+        ra.resource_id in ^page_ids and
+          ra.section_id == ^section_id and
+          ra.user_id == ^user_id,
+      group_by: ra.resource_id,
+      select: {
+        ra.resource_id,
+        fragment("COALESCE(SUM(?), 0)", ra.progress)
+      }
+    )
+    |> Repo.all()
+    |> Enum.into(%{})
+  end
+
+  @doc """
   Calculate the percentage of students that have completed a container or page
   """
   def completion_for(section_id, container_id) do

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -850,6 +850,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:previous_page, :map)
   attr(:next_page, :map)
   attr(:section_slug, :string)
+  attr(:pages_progress, :map)
   attr(:request_path, :string)
   attr(:selected_view, :string, doc: "The selected view for the Learn page (gallery or outline)")
 
@@ -861,87 +862,103 @@ defmodule OliWeb.Components.Delivery.Layouts do
     # ("working" loader kept spinning after interacting with an activity)
     ~H"""
     <div
-      :if={!is_nil(@current_page)}
-      class="fixed bottom-0 left-1/2 -translate-x-1/2 h-[74px] lg:py-4 shadow-lg bg-white dark:bg-black lg:rounded-tl-[40px] lg:rounded-tr-[40px] flex items-center gap-3 lg:w-[720px] w-full"
+      id="bottom-bar-wrapper"
+      phx-hook="FixedNavigationBar"
+      class="group fixed bottom-0 left-1/2 -translate-x-1/2 w-full lg:w-[720px] z-50 h-[10px] lg:h-[74px]"
     >
-      <div class="hidden lg:block absolute -left-[114px] z-0">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="170"
-          height="74"
-          viewBox="0 0 170 74"
-          fill="none"
-        >
-          <path
-            class="fill-white dark:fill-black"
-            d="M170 0H134C107 0 92.5 13 68.5 37C44.5 61 24.2752 74 0 74H170V0Z"
-          />
-        </svg>
-      </div>
-
       <div
-        :if={!is_nil(@previous_page)}
-        class="grow shrink basis-0 h-10 justify-start items-center lg:gap-6 flex z-10 overflow-hidden whitespace-nowrap"
-        role="prev_page"
+        :if={!is_nil(@current_page)}
+        id="bottom-bar"
+        class="translate-y-full opacity-0 group-hover:translate-y-0 group-hover:opacity-100 absolute bottom-0 left-1/2 -translate-x-1/2 h-[74px] lg:py-4 shadow-lg bg-white dark:bg-black lg:rounded-tl-[40px] lg:rounded-tr-[40px] flex items-center gap-3 lg:w-[720px] w-full z-50 transition-all duration-500 ease-in-out"
       >
-        <div class="px-2 lg:px-6 rounded justify-end items-center gap-2 flex">
-          <.link
-            href={
-              resource_navigation_url(
-                @previous_page,
-                @section_slug,
-                assigns[:request_path],
-                assigns[:selected_view]
-              )
-            }
-            class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center"
+        <div class="hidden lg:block absolute -left-[114px] z-0">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="170"
+            height="74"
+            viewBox="0 0 170 74"
+            fill="none"
           >
-            <.left_arrow />
-          </.link>
+            <path
+              class="fill-white dark:fill-black"
+              d="M170 0H134C107 0 92.5 13 68.5 37C44.5 61 24.2752 74 0 74H170V0Z"
+            />
+          </svg>
         </div>
-        <div class="grow shrink basis-0 dark:text-white text-xs font-normal overflow-hidden text-ellipsis">
-          <%= @previous_page["title"] %>
-        </div>
-      </div>
 
-      <div
-        :if={!is_nil(@next_page)}
-        class="grow shrink basis-0 h-10 justify-end items-center lg:gap-6 flex z-10 overflow-hidden whitespace-nowrap"
-        role="next_page"
-      >
-        <div class="grow shrink basis-0 text-right dark:text-white text-xs font-normal overflow-hidden text-ellipsis">
-          <%= @next_page["title"] %>
-        </div>
-        <div class="px-2 lg:px-6 py-2 rounded justify-end items-center gap-2 flex">
-          <.link
-            href={
-              resource_navigation_url(
-                @next_page,
-                @section_slug,
-                assigns[:request_path],
-                assigns[:selected_view]
-              )
-            }
-            class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-blue-600 flex items-center justify-center"
-          >
-            <.right_arrow />
-          </.link>
-        </div>
-      </div>
-
-      <div class="hidden lg:block absolute -right-[114px] z-0">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="170"
-          height="74"
-          viewBox="0 0 170 74"
-          fill="none"
+        <div
+          :if={!is_nil(@previous_page)}
+          class="grow shrink basis-0 h-10 justify-start items-center flex z-10 overflow-hidden whitespace-nowrap"
+          role="prev_page"
         >
-          <path
-            class="fill-white dark:fill-black"
-            d="M0 0H36C63 0 77.5 13 101.5 37C125.5 61 145.725 74 170 74H0V0Z"
-          />
-        </svg>
+          <div
+            class="px-2 lg:px-6 rounded justify-end items-center gap-2 flex"
+            tooltip="Previous Page"
+          >
+            <.link
+              href={
+                resource_navigation_url(
+                  @previous_page,
+                  @section_slug,
+                  assigns[:request_path],
+                  assigns[:selected_view]
+                )
+              }
+              class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-[#0062F2]/50 flex items-center justify-center"
+            >
+              <.left_arrow />
+            </.link>
+          </div>
+          <div class="flex flex-row gap-x-1 justify-start items-center grow shrink basis-0 dark:text-white text-xs font-normal overflow-hidden text-ellipsis">
+            <%= maybe_add_icon(@previous_page, @pages_progress) %>
+            <span class="overflow-hidden text-ellipsis" title={@previous_page["title"]}>
+              <%= @previous_page["title"] %>
+            </span>
+          </div>
+        </div>
+
+        <div
+          :if={!is_nil(@next_page)}
+          class="grow shrink basis-0 h-10 justify-end items-center flex z-10 overflow-hidden whitespace-nowrap"
+          role="next_page"
+        >
+          <div class="flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 text-right dark:text-white text-xs font-normal overflow-hidden text-ellipsis">
+            <%= maybe_add_icon(@next_page, @pages_progress) %>
+            <span class="overflow-hidden text-ellipsis" title={@next_page["title"]}>
+              <%= @next_page["title"] %>
+            </span>
+          </div>
+          <div class="px-2 lg:px-6 py-2 rounded justify-end items-center gap-2 flex">
+            <.link
+              href={
+                resource_navigation_url(
+                  @next_page,
+                  @section_slug,
+                  assigns[:request_path],
+                  assigns[:selected_view]
+                )
+              }
+              class="w-[72px] h-10 opacity-90 hover:opacity-100 bg-[#0062F2] flex items-center justify-center"
+            >
+              <.right_arrow />
+            </.link>
+          </div>
+        </div>
+
+        <div class="hidden lg:block absolute -right-[114px] z-0">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="170"
+            height="74"
+            viewBox="0 0 170 74"
+            fill="none"
+          >
+            <path
+              class="fill-white dark:fill-black"
+              d="M0 0H36C63 0 77.5 13 101.5 37C125.5 61 145.725 74 170 74H0V0Z"
+            />
+          </svg>
+        </div>
       </div>
     </div>
     """
@@ -1125,5 +1142,17 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   defp section_has_assignments?(section_id) do
     section_id |> SectionResourceDepot.graded_pages(hidden: false) |> Enum.any?()
+  end
+
+  defp maybe_add_icon(page, pages_progress) do
+    page_id = String.to_integer(page["id"])
+    progress = Map.get(pages_progress, page_id, nil)
+
+    case {progress, page["graded"]} do
+      {1.0, "false"} -> apply(OliWeb.Icons, :check, [%{}])
+      {1.0, "true"} -> apply(OliWeb.Icons, :square_checked, [%{}])
+      {progress, "true"} when progress < 1.0 -> apply(OliWeb.Icons, :flag, [%{}])
+      _ -> nil
+    end
   end
 end

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -1146,12 +1146,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   defp maybe_add_icon(page, pages_progress) do
     page_id = String.to_integer(page["id"])
-    progress = Map.get(pages_progress, page_id, nil)
+    progress = Map.get(pages_progress, page_id)
 
     case {progress, page["graded"]} do
       {1.0, "false"} -> apply(OliWeb.Icons, :check, [%{}])
       {1.0, "true"} -> apply(OliWeb.Icons, :square_checked, [%{}])
-      {progress, "true"} when progress < 1.0 -> apply(OliWeb.Icons, :flag, [%{}])
+      {_, "true"} -> apply(OliWeb.Icons, :flag, [%{}])
       _ -> nil
     end
   end

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -112,6 +112,7 @@
               previous_page={@previous_page}
               next_page={@next_page}
               section_slug={@section.slug}
+              pages_progress={@pages_progress}
               request_path={assigns[:request_path]}
               selected_view={assigns[:selected_view]}
             />

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   import Phoenix.Component, only: [assign: 2, update: 3]
 
-  alias Oli.Delivery.{PreviousNextIndex, Settings}
+  alias Oli.Delivery.{Metrics, PreviousNextIndex, Settings}
   alias Oli.Delivery.Page.{PageContext, PrologueContext}
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -82,11 +82,19 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
             socket
         end
 
+      pages_progress =
+        Metrics.progress_for_pages(
+          assigns.section.id,
+          assigns.ctx.user.id,
+          [previous["id"], next["id"]]
+        )
+
       {:cont,
        assign(socket,
          previous_page: previous,
          next_page: next,
-         current_page: current
+         current_page: current,
+         pages_progress: pages_progress
        )}
     else
       {:cont, socket}

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -341,5 +341,53 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       assert progress_2[p1.resource.id] == 0.75
       assert progress_2[p2.resource.id] == 0.5
     end
+
+    test "progress_for_pages/3 calculates correctly", %{
+      mod1_pages: mod1_pages,
+      this_user: this_user,
+      section: section
+    } do
+      [p1, p2, p3] = mod1_pages
+
+      Sections.enroll(this_user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      ## set progress for the user in p1
+      set_progress(
+        section.id,
+        p1.resource.id,
+        this_user.id,
+        0.0,
+        p1.revision
+      )
+
+      ## set progress for the user in p2
+      set_progress(
+        section.id,
+        p2.resource.id,
+        this_user.id,
+        0.5,
+        p2.revision
+      )
+
+      ## set progress for the user in p3
+      set_progress(
+        section.id,
+        p3.resource.id,
+        this_user.id,
+        1.0,
+        p3.revision
+      )
+
+      progress =
+        Metrics.progress_for_pages(section.id, this_user.id, [
+          p1.resource.id,
+          p2.resource.id,
+          p3.resource.id
+        ])
+
+      assert progress[p1.resource.id] == 0.0
+      assert progress[p2.resource.id] == 0.5
+      assert progress[p3.resource.id] == 1.0
+    end
   end
 end


### PR DESCRIPTION
[MER-3452](https://eliterate.atlassian.net/browse/MER-3452)

This PR introduces changes and improvements to the navigation bar displayed at the bottom of the `Lesson Pages`.

It improves the way the navigation bar is displayed, leaving it hidden by default and showing it when the user hovers on it. 
Also, when the user navigates to the bottom of the page, the bar will be fixed at the bottom. 

On the other hand, icons are added next to the title of the previous page and the next page, indicating what type of page they are and if they are completed or not. 

For the icons, the same logic used in the `Learn View` is maintained, i.e.: 

- Scored pages completed ---> Square check icon
- Scored pages not completed ---> Orange flag icon
- Practice pages completed ---> Check icon
- Practice pages not completed ---> No icon

Additionally the text of the previous and next pages is truncated, adding ellipses if the text is too long. In this case a tooltip is also added over the title to show it completely. 


https://github.com/user-attachments/assets/9bed1615-c3b2-4fd1-b4c5-6e7be92f8632



[MER-3452]: https://eliterate.atlassian.net/browse/MER-3452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ