### PR TITLE
[BUG FIX] [MER-4387] Update Single-line feedback to Multi line feedback input in Simple Author

### DIFF
--- a/assets/src/components/parts/janus-mcq/schema.ts
+++ b/assets/src/components/parts/janus-mcq/schema.ts
@@ -166,15 +166,13 @@ export const simpleUiSchema = {
     },
   },
   incorrectFeedback: {
-    'ui:widget': 'MCQCustomErrorFeedbackAuthoring',
+    'ui:widget': 'textarea',
+    'ui:options': {
+      rows: 2,
+    },
   },
   commonErrorFeedback: {
-    items: {
-      'ui:widget': 'textarea',
-      'ui:options': {
-        rows: 2,
-      },
-    },
+    'ui:widget': 'MCQCustomErrorFeedbackAuthoring',
   },
 };
 


### PR DESCRIPTION
Hey @bsparks could you please look at the PR? Thanks

This PR contains fix for a follow-up issue that came in this ticket. 

The correct UI schema was

 ```
 correctFeedback: {
    'ui:widget': 'textarea',
    'ui:options': {
      rows: 2,
    },
  },
  incorrectFeedback: {
    'ui:widget': 'textarea',
    'ui:options': {
      rows: 2,
    },
  },
  commonErrorFeedback: {
    'ui:widget': 'MCQCustomErrorFeedbackAuthoring',
  },
```
but by mistake, in my previous [PR](https://github.com/Simon-Initiative/oli-torus/pull/5509), I made it like this when changing the UI widget from text to text-area: 

```
correctFeedback: {
    'ui:widget': 'textarea',
    'ui:options': {
      rows: 2,
    },
  },
  incorrectFeedback: {
    'ui:widget': 'MCQCustomErrorFeedbackAuthoring',
  },
  commonErrorFeedback: {
    items: {
      'ui:widget': 'textarea',
      'ui:options': {
        rows: 2,
      },
    },
  },
```

