### PR TITLE
[ENHANCEMENT] [MER-4419] Allow Image to be used for Navigation button

### DIFF
--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -15,6 +15,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
     enabled = true,
     ariaLabel,
     transparent,
+    src,
   } = model;
 
   const styles: CSSProperties = {
@@ -59,8 +60,28 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
 
   return (
     <div className={`navigation-button`}>
-      <button data-janus-type={tagName} {...buttonProps} style={styles}>
-        {title}
+      <button
+        data-janus-type={tagName}
+        {...buttonProps}
+        style={{
+          ...styles,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
+        }}
+      >
+        {src && (
+          <img
+            draggable="false"
+            src={src}
+            style={{
+              height: '100%',
+              width: 'auto',
+              objectFit: 'contain',
+            }}
+          />
+        )}
+        <span>{title}</span>
       </button>
     </div>
   );

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -37,6 +37,23 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
   if (buttonColor) {
     styles.backgroundColor = buttonColor;
   }
+  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
+
+  //Apply these style only if button have image
+  if (imageSource?.length) {
+    styles.display = 'flex';
+    styles.flexDirection = isVertical
+      ? imagePosition === 'Top'
+        ? 'column'
+        : 'column-reverse'
+      : imagePosition === 'Left'
+      ? 'row'
+      : 'row-reverse';
+
+    styles.alignItems = 'center';
+    styles.gap = isVertical ? '1px' : '4px';
+  }
+
   const handleStylingChanges = () => {
     const styleChanges: any = {};
     if (width !== undefined) {
@@ -58,26 +75,9 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
     'aria-label': ariaLabel,
     disabled: false,
   };
-  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
   return (
     <div className={`navigation-button`}>
-      <button
-        data-janus-type={tagName}
-        {...buttonProps}
-        style={{
-          ...styles,
-          display: 'flex',
-          flexDirection: isVertical
-            ? imagePosition === 'Top'
-              ? 'column'
-              : 'column-reverse'
-            : imagePosition === 'Left'
-            ? 'row'
-            : 'row-reverse',
-          alignItems: 'center',
-          gap: isVertical ? '1px' : '4px',
-        }}
-      >
+      <button data-janus-type={tagName} {...buttonProps} style={styles}>
         {imageSource?.length > 0 && (
           <img
             draggable="false"

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -15,7 +15,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
     enabled = true,
     ariaLabel,
     transparent,
-    src,
+    imageSource,
   } = model;
 
   const styles: CSSProperties = {
@@ -70,10 +70,10 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
           gap: '6px',
         }}
       >
-        {src && (
+        {imageSource && (
           <img
             draggable="false"
-            src={src}
+            src={imageSource}
             style={{
               height: '100%',
               width: 'auto',

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -16,6 +16,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
     ariaLabel,
     transparent,
     imageSource,
+    imagePosition,
   } = model;
 
   const styles: CSSProperties = {
@@ -57,7 +58,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
     'aria-label': ariaLabel,
     disabled: false,
   };
-
+  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
   return (
     <div className={`navigation-button`}>
       <button
@@ -66,22 +67,28 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
         style={{
           ...styles,
           display: 'flex',
+          flexDirection: isVertical
+            ? imagePosition === 'Top'
+              ? 'column'
+              : 'column-reverse'
+            : imagePosition === 'Left'
+            ? 'row'
+            : 'row-reverse',
           alignItems: 'center',
-          gap: '6px',
+          gap: isVertical ? '1px' : '8px',
         }}
       >
-        {imageSource && (
+        {imageSource?.length > 0 && (
           <img
             draggable="false"
             src={imageSource}
             style={{
-              height: '100%',
-              width: 'auto',
-              objectFit: 'contain',
+              height: isVertical && title ? '60%' : '100%',
+              width: isVertical && title ? '90%' : 'auto',
             }}
           />
         )}
-        <span>{title}</span>
+        {title && <span>{title}</span>}
       </button>
     </div>
   );

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -84,7 +84,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
             src={imageSource}
             style={{
               height: isVertical && title ? '60%' : '100%',
-              width: isVertical && title ? '90%' : 'auto',
+              width: title ? '90%' : 'auto',
             }}
           />
         )}

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -75,7 +75,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
             ? 'row'
             : 'row-reverse',
           alignItems: 'center',
-          gap: isVertical ? '1px' : '8px',
+          gap: isVertical ? '1px' : '4px',
         }}
       >
         {imageSource?.length > 0 && (
@@ -84,7 +84,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
             src={imageSource}
             style={{
               height: isVertical && title ? '60%' : '100%',
-              width: title ? 'auto' : '90%',
+              width: title ? '50%' : '100%',
             }}
           />
         )}

--- a/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavButtonAuthor.tsx
@@ -84,7 +84,7 @@ const NavButtonAuthor: React.FC<AuthorPartComponentProps<NavButtonModel>> = (pro
             src={imageSource}
             style={{
               height: isVertical && title ? '60%' : '100%',
-              width: title ? '90%' : 'auto',
+              width: title ? 'auto' : '90%',
             }}
           />
         )}

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -25,6 +25,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   const [buttonTransparent, setButtonTransparent] = useState('');
   const [buttonEnabled, setButtonEnabled] = useState(true);
   const [buttonTitle, setButtonTitle] = useState('');
+  const [buttonImageSrc, setButtonImageSrc] = useState('');
   const [_cssClass, setCssClass] = useState('');
 
   const initialize = useCallback(async (pModel) => {
@@ -40,6 +41,9 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
 
     const dTitle = pModel.title || '';
     setButtonTitle(dTitle);
+
+    const dSrc = pModel.src || '';
+    setButtonImageSrc(dSrc);
 
     const dAccessibilityText = pModel.ariaLabel || accessibilityText;
     setAccessibilityText(dAccessibilityText);
@@ -125,6 +129,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     const sVisible = currentStateSnapshot[`stage.${id}.visible`];
     if (sVisible !== undefined) {
       setButtonVisible(sVisible);
+    }
+
+    const src = currentStateSnapshot[`stage.${id}.src`];
+    if (src?.length) {
+      setButtonImageSrc(src);
     }
 
     const sTitle = currentStateSnapshot[`stage.${id}.title`];
@@ -244,6 +253,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
                 setButtonTitle(sTitle);
               }
 
+              const src = changes[`stage.${id}.src`];
+              if (src?.length) {
+                setButtonImageSrc(src);
+              }
+
               const sTitles = changes[`stage.${id}.buttonTitles`];
               if (sTitles !== undefined) {
                 setButtonTitle(sTitles[0]);
@@ -294,6 +308,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
               const sTitle = changes[`stage.${id}.title`];
               if (sTitle !== undefined) {
                 setButtonTitle(sTitle);
+              }
+
+              const src = changes[`stage.${id}.src`];
+              if (src?.length) {
+                setButtonImageSrc(src);
               }
 
               const sTitles = changes[`stage.${id}.buttonTitles`];
@@ -429,8 +448,28 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   };
 
   return ready && buttonVisible ? (
-    <button data-janus-type={tagName} {...buttonProps} style={styles}>
-      {buttonTitle}
+    <button
+      data-janus-type={tagName}
+      {...buttonProps}
+      style={{
+        ...styles,
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+      }}
+    >
+      {buttonImageSrc?.length && (
+        <img
+          draggable="false"
+          src={buttonImageSrc}
+          style={{
+            height: '100%',
+            width: 'auto',
+            objectFit: 'contain',
+          }}
+        />
+      )}
+      <span>{buttonTitle}</span>
     </button>
   ) : null;
 };

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -42,7 +42,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     const dTitle = pModel.title || '';
     setButtonTitle(dTitle);
 
-    const dSrc = pModel.src || '';
+    const dSrc = pModel.imageSource || '';
     setButtonImageSrc(dSrc);
 
     const dAccessibilityText = pModel.ariaLabel || accessibilityText;
@@ -131,9 +131,9 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       setButtonVisible(sVisible);
     }
 
-    const src = currentStateSnapshot[`stage.${id}.src`];
-    if (src?.length) {
-      setButtonImageSrc(src);
+    const imageSource = currentStateSnapshot[`stage.${id}.imageSource`];
+    if (imageSource?.length) {
+      setButtonImageSrc(imageSource);
     }
 
     const sTitle = currentStateSnapshot[`stage.${id}.title`];
@@ -253,9 +253,9 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
                 setButtonTitle(sTitle);
               }
 
-              const src = changes[`stage.${id}.src`];
-              if (src?.length) {
-                setButtonImageSrc(src);
+              const imageSource = changes[`stage.${id}.imageSource`];
+              if (imageSource?.length) {
+                setButtonImageSrc(imageSource);
               }
 
               const sTitles = changes[`stage.${id}.buttonTitles`];
@@ -310,9 +310,9 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
                 setButtonTitle(sTitle);
               }
 
-              const src = changes[`stage.${id}.src`];
-              if (src?.length) {
-                setButtonImageSrc(src);
+              const imageSource = changes[`stage.${id}.imageSource`];
+              if (imageSource?.length) {
+                setButtonImageSrc(imageSource);
               }
 
               const sTitles = changes[`stage.${id}.buttonTitles`];

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -26,6 +26,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   const [buttonEnabled, setButtonEnabled] = useState(true);
   const [buttonTitle, setButtonTitle] = useState('');
   const [buttonImageSrc, setButtonImageSrc] = useState('');
+  const [imagePosition, setImagePosition] = useState('');
   const [_cssClass, setCssClass] = useState('');
 
   const initialize = useCallback(async (pModel) => {
@@ -44,6 +45,9 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
 
     const dSrc = pModel.imageSource || '';
     setButtonImageSrc(dSrc);
+
+    const dImagePosition = pModel.imagePosition || 'Left';
+    setImagePosition(dImagePosition);
 
     const dAccessibilityText = pModel.ariaLabel || accessibilityText;
     setAccessibilityText(dAccessibilityText);
@@ -134,6 +138,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     const imageSource = currentStateSnapshot[`stage.${id}.imageSource`];
     if (imageSource?.length) {
       setButtonImageSrc(imageSource);
+    }
+
+    const imagePosition = currentStateSnapshot[`stage.${id}.imagePosition`];
+    if (imagePosition?.length) {
+      setImagePosition(imagePosition);
     }
 
     const sTitle = currentStateSnapshot[`stage.${id}.title`];
@@ -258,6 +267,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
                 setButtonImageSrc(imageSource);
               }
 
+              const imagePosition = changes[`stage.${id}.imagePosition`];
+              if (imagePosition?.length) {
+                setImagePosition(imagePosition);
+              }
+
               const sTitles = changes[`stage.${id}.buttonTitles`];
               if (sTitles !== undefined) {
                 setButtonTitle(sTitles[0]);
@@ -313,6 +327,11 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
               const imageSource = changes[`stage.${id}.imageSource`];
               if (imageSource?.length) {
                 setButtonImageSrc(imageSource);
+              }
+
+              const imagePosition = changes[`stage.${id}.imagePosition`];
+              if (imagePosition?.length) {
+                setImagePosition(imagePosition);
               }
 
               const sTitles = changes[`stage.${id}.buttonTitles`];
@@ -446,7 +465,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     'aria-label': ariaLabel,
     disabled: !buttonEnabled,
   };
-
+  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
   return ready && buttonVisible ? (
     <button
       data-janus-type={tagName}
@@ -454,22 +473,28 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       style={{
         ...styles,
         display: 'flex',
+        flexDirection: isVertical
+          ? imagePosition === 'Top'
+            ? 'column'
+            : 'column-reverse'
+          : imagePosition === 'Left'
+          ? 'row'
+          : 'row-reverse',
         alignItems: 'center',
-        gap: '6px',
+        gap: isVertical ? '1px' : '4px',
       }}
     >
-      {buttonImageSrc?.length && (
+      {buttonImageSrc?.length > 0 && (
         <img
           draggable="false"
           src={buttonImageSrc}
           style={{
-            height: '100%',
-            width: 'auto',
-            objectFit: 'contain',
+            height: isVertical && buttonTitle ? '60%' : '100%',
+            width: buttonTitle ? '50%' : '100%',
           }}
         />
       )}
-      <span>{buttonTitle}</span>
+      {buttonTitle && <span>{buttonTitle}</span>}
     </button>
   ) : null;
 };

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -415,7 +415,21 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     styles.backgroundColor = backgroundColor;
     janusButtonStyle.backgroundColor = backgroundColor;
   }
+  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
+  //Apply these style only if button have image
+  if (buttonImageSrc?.length) {
+    styles.display = 'flex';
+    styles.flexDirection = isVertical
+      ? imagePosition === 'Top'
+        ? 'column'
+        : 'column-reverse'
+      : imagePosition === 'Left'
+      ? 'row'
+      : 'row-reverse';
 
+    styles.alignItems = 'center';
+    styles.gap = isVertical ? '1px' : '4px';
+  }
   const handleButtonPress = () => {
     props.onSubmit({
       id: `${id}`,
@@ -465,25 +479,8 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     'aria-label': ariaLabel,
     disabled: !buttonEnabled,
   };
-  const isVertical = imagePosition === 'Top' || imagePosition === 'Bottom';
   return ready && buttonVisible ? (
-    <button
-      data-janus-type={tagName}
-      {...buttonProps}
-      style={{
-        ...styles,
-        display: 'flex',
-        flexDirection: isVertical
-          ? imagePosition === 'Top'
-            ? 'column'
-            : 'column-reverse'
-          : imagePosition === 'Left'
-          ? 'row'
-          : 'row-reverse',
-        alignItems: 'center',
-        gap: isVertical ? '1px' : '4px',
-      }}
-    >
+    <button data-janus-type={tagName} {...buttonProps} style={styles}>
       {buttonImageSrc?.length > 0 && (
         <img
           draggable="false"

--- a/assets/src/components/parts/janus-navigation-button/schema.ts
+++ b/assets/src/components/parts/janus-navigation-button/schema.ts
@@ -17,6 +17,10 @@ export const schema: JSONSchema7Object = {
   title: {
     type: 'string',
   },
+  src: {
+    title: 'Source',
+    type: 'string',
+  },
   ariaLabel: {
     type: 'string',
   },
@@ -59,6 +63,9 @@ export const uiSchema = {
   buttonColor: {
     'ui:widget': 'ColorPicker',
   },
+  src: {
+    'ui:widget': 'TorusImageBrowser',
+  },
 };
 
 export const adaptivitySchema = {
@@ -71,6 +78,7 @@ export const adaptivitySchema = {
   transparent: CapiVariableTypes.BOOLEAN,
   accessibilityText: CapiVariableTypes.STRING,
   customCssClass: CapiVariableTypes.STRING,
+  src: CapiVariableTypes.STRING,
 };
 
 export const createSchema = (): Partial<NavButtonModel> => ({
@@ -82,4 +90,5 @@ export const createSchema = (): Partial<NavButtonModel> => ({
   height: 30,
   title: 'Nav Button',
   ariaLabel: 'Nav Button',
+  src: '',
 });

--- a/assets/src/components/parts/janus-navigation-button/schema.ts
+++ b/assets/src/components/parts/janus-navigation-button/schema.ts
@@ -17,7 +17,7 @@ export const schema: JSONSchema7Object = {
   title: {
     type: 'string',
   },
-  src: {
+  imageSource: {
     title: 'Source',
     type: 'string',
   },
@@ -63,7 +63,7 @@ export const uiSchema = {
   buttonColor: {
     'ui:widget': 'ColorPicker',
   },
-  src: {
+  imageSource: {
     'ui:widget': 'TorusImageBrowser',
   },
 };
@@ -78,7 +78,7 @@ export const adaptivitySchema = {
   transparent: CapiVariableTypes.BOOLEAN,
   accessibilityText: CapiVariableTypes.STRING,
   customCssClass: CapiVariableTypes.STRING,
-  src: CapiVariableTypes.STRING,
+  imageSource: CapiVariableTypes.STRING,
 };
 
 export const createSchema = (): Partial<NavButtonModel> => ({
@@ -90,5 +90,5 @@ export const createSchema = (): Partial<NavButtonModel> => ({
   height: 30,
   title: 'Nav Button',
   ariaLabel: 'Nav Button',
-  src: '',
+  imageSource: '',
 });

--- a/assets/src/components/parts/janus-navigation-button/schema.ts
+++ b/assets/src/components/parts/janus-navigation-button/schema.ts
@@ -11,6 +11,8 @@ export interface NavButtonModel extends JanusAbsolutePositioned, JanusCustomCss 
   buttonColor: string;
   transparent: boolean;
   selected: boolean;
+  imagePosition: string;
+  imageSource: string;
 }
 
 export const schema: JSONSchema7Object = {
@@ -20,6 +22,12 @@ export const schema: JSONSchema7Object = {
   imageSource: {
     title: 'Source',
     type: 'string',
+  },
+  imagePosition: {
+    title: 'Image position',
+    type: 'string',
+    enum: ['Left', 'Right', 'Top', 'Bottom'],
+    default: 'Left',
   },
   ariaLabel: {
     type: 'string',
@@ -79,6 +87,7 @@ export const adaptivitySchema = {
   accessibilityText: CapiVariableTypes.STRING,
   customCssClass: CapiVariableTypes.STRING,
   imageSource: CapiVariableTypes.STRING,
+  imagePosition: CapiVariableTypes.STRING,
 };
 
 export const createSchema = (): Partial<NavButtonModel> => ({
@@ -91,4 +100,5 @@ export const createSchema = (): Partial<NavButtonModel> => ({
   title: 'Nav Button',
   ariaLabel: 'Nav Button',
   imageSource: '',
+  imagePosition: 'Left',
 });


### PR DESCRIPTION
Hey @bsparks could you please look at the PR? Thanks

This is an extend version of the earlier approved PR -> https://github.com/Simon-Initiative/oli-torus/pull/5514. This PR contains the ability to let user define where they want to place the image -> Left, Right, Top, Bottom. If there is not text on the button, then image takes the entire space.