### PR TITLE
[BUG FIX] [MER-4035] Add support link to lesson pages - part 2

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -781,7 +781,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       id={@id}
       onclick="window.showHelpModal();"
       class={[
-        "w-full h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white",
+        "w-24 h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white",
         @class
       ]}
     >

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -781,7 +781,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       id={@id}
       onclick="window.showHelpModal();"
       class={[
-        "w-24 h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white",
+        "w-auto mr-auto h-11 px-3 py-3 flex-col justify-center items-start inline-flex text-black/70 hover:text-black/90 dark:text-gray-400 hover:dark:text-white stroke-black/70 hover:stroke-black/90 dark:stroke-[#B8B4BF] hover:dark:stroke-white",
         @class
       ]}
     >

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -789,7 +789,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
         <div class="w-5 h-5 flex items-center justify-center">
           <Icons.support class="" />
         </div>
-        <div :if={@sidebar_expanded} class="text-sm font-medium tracking-tight">Support</div>
+        <div :if={@sidebar_expanded} class="text-sm font-medium tracking-tight">
+          Support
+        </div>
       </div>
     </button>
     """

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -119,7 +119,16 @@
           </div>
           <OliWeb.Components.Delivery.Layouts.tech_support_button
             id="tech-support"
-            class="z-[999] fixed bottom-20 left-4 lg:bottom-2 lg:left-[70px]"
+            class="z-[999] fixed hidden lg:block lg:bottom-2 lg:left-[70px]"
+          />
+          <%!--
+          this is the mobile version of the tech support button,
+          to avoid showing the "Support" text that overlaps with the page text content
+          --%>
+          <OliWeb.Components.Delivery.Layouts.tech_support_button
+            id="tech-support-2"
+            class="z-[999] fixed bottom-20 left-4 lg:hidden"
+            sidebar_expanded={false}
           />
         </div>
 

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -119,7 +119,7 @@
           </div>
           <OliWeb.Components.Delivery.Layouts.tech_support_button
             id="tech-support"
-            class="z-[999] fixed bottom-2 left-[70px]"
+            class="z-[999] fixed bottom-20 left-4 lg:bottom-2 lg:left-[70px]"
           />
         </div>
 


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4035) to the ticket

The issue was that the width of the support button was set to `full`, and since its `z-index` was bigger than the one for the previous-next navigation bar, whenever we tried to click on the navigation bar, we ended up clicking on the support button.
By setting a width to the support button, we do not have the overlay issue between those 2 elements.



https://github.com/user-attachments/assets/dec2179f-db4e-49a4-abc3-5354d307d525


