### PR TITLE
[BUG FIX] [MER-4483] Improve Certificates signatures font stack

### DIFF
--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -44,6 +44,7 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
     .signature {
       margin: 0;
       font-family: 'Alex Brush', 'Segoe Script', 'Brush Script MT', 'Lucida Handwriting', cursive;
+      font-weight: bold;
       font-size: 20px;
     }
   </style>

--- a/lib/oli/delivery/certificates/certificate_renderer.ex
+++ b/lib/oli/delivery/certificates/certificate_renderer.ex
@@ -40,6 +40,12 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
       font-family: Arial, sans-serif;
       background-color: white;
     }
+
+    .signature {
+      margin: 0;
+      font-family: 'Alex Brush', 'Segoe Script', 'Brush Script MT', 'Lucida Handwriting', cursive;
+      font-size: 20px;
+    }
   </style>
   <body>
     <div class="frame-container">
@@ -56,7 +62,7 @@ defmodule Oli.Delivery.Certificates.CertificateRenderer do
             <div style="display: flex; justify-content: space-around;">
               <%= for {admin_name, admin_description} <- @administrators do %>
                 <div>
-                  <p style="margin: 0; font-weight: bold; font-family: 'Alex Brush', cursive; font-size: 20px;">
+                  <p class="signature">
                     <%= admin_name %>
                   </p>
                   <p style="margin: 0; font-size: small;"><%= admin_description %></p>


### PR DESCRIPTION
Add cursive paragraph style with cross-platform font stack because in certain operating systems/browsers where the font was not available signatures were rendered in Comic Sans.

See: https://eliterate.atlassian.net/browse/MER-4483
