### PR TITLE
[BUG FIX] [MER-4461] user registration creates user with null sub

### DIFF
--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -121,6 +121,7 @@ defmodule Oli.Accounts.User do
     user
     |> cast(attrs, [
       :email,
+      :sub,
       :password,
       :given_name,
       :family_name,
@@ -132,6 +133,7 @@ defmodule Oli.Accounts.User do
     |> validate_password(opts)
     |> put_change(:independent_learner, true)
     |> maybe_name_from_given_and_family()
+    |> maybe_generate_unique_sub()
   end
 
   defp validate_email(changeset, opts) do
@@ -181,6 +183,15 @@ defmodule Oli.Accounts.User do
         name: :users_email_independent_learner_index,
         message: "Email has already been taken by another independent learner"
       )
+    else
+      changeset
+    end
+  end
+
+  def maybe_generate_unique_sub(changeset) do
+    if changeset.valid? && is_nil(get_field(changeset, :sub)) do
+      sub = UUID.uuid4()
+      put_change(changeset, :sub, sub)
     else
       changeset
     end

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -520,6 +520,7 @@ defmodule Oli.Accounts.User do
     |> cast(attrs, [:email])
     |> validate_required([:email])
     |> validate_email(opts)
+    |> maybe_generate_unique_sub()
   end
 
   def invite_changeset(user, attrs, opts) do

--- a/priv/repo/migrations/20250401140659_ensure_user_sub.exs
+++ b/priv/repo/migrations/20250401140659_ensure_user_sub.exs
@@ -1,0 +1,26 @@
+defmodule Oli.Repo.Migrations.EnsureUserUniqueSub do
+  use Ecto.Migration
+
+  def up do
+    execute "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+
+    # Generate unique subs for users with nil sub
+    execute("""
+      UPDATE users
+      SET sub = gen_random_uuid()
+      WHERE sub IS NULL
+    """)
+
+    # Ensure the sub field is not null
+    alter table(:users) do
+      modify :sub, :string, null: false
+    end
+  end
+
+  def down do
+    # Allow null values in the sub field
+    alter table(:users) do
+      modify :sub, :string, null: true
+    end
+  end
+end

--- a/test/oli_web/live/user_registration_live_test.exs
+++ b/test/oli_web/live/user_registration_live_test.exs
@@ -65,6 +65,11 @@ defmodule OliWeb.UserRegistrationLiveTest do
 
       assert response =~ email
       assert response =~ "Access my courses"
+
+      # Assert that the new user has a unique sub generated
+      user = Oli.Accounts.get_independent_user_by_email(email)
+
+      refute is_nil(user.sub)
     end
 
     test "renders errors for duplicated email", %{conn: conn} do


### PR DESCRIPTION
Fixes an issue where new direct delivery user registrations that aren't social login accounts were creating the accounts with a null sub. There are also a number of existing accounts in production that have a null sub.

This PR addresses the account creation issue as well as adds a migration to add a unique sub to all existing user accounts without one and adds a new database constraint to ensure a sub is set.