### PR TITLE
[ENHANCEMENT] [MER-4468] Include student response in context for response based triggers

### DIFF
--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -48,7 +48,8 @@ defmodule Oli.Conversation.Triggers do
     do: "Received the explanation (id: #{data["ref_id"]}) from question: #{data["question"]}"
 
   def description(:targeted_feedback, data),
-    do: "Received targeted feedback (id: #{data["ref_id"]}) from question: #{data["question"]}. The student's response was #{data["response"]}"
+    do:
+      "Received targeted feedback (id: #{data["ref_id"]}) from question: #{data["question"]}. The student's response was #{data["response"]}"
 
   @doc """
   Verify that the user is enrolled in a section with


### PR DESCRIPTION
This PR adds in the `:response` from the part attempt into the context for response based triggers (those triggers related to "answered a question correctly", "answered a question incorrectly" and "answered to a targeted feedback"