### PR TITLE
[ENHANCEMENT] [MER-4487] [MER-4500] Collection of Trigger point updates

### DIFF
--- a/assets/src/apps/page-editor/PageTriggerEditor.tsx
+++ b/assets/src/apps/page-editor/PageTriggerEditor.tsx
@@ -35,7 +35,7 @@ export const PageTriggerEditor: React.FC<{
       <div className="flex justify-between">
         <h4>
           <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-          DOT AI Page Trigger Point
+          DOT AI Page Activation Point
         </h4>
         <button onClick={() => onEdit(undefined)} className="btn btn-primary">
           Disable
@@ -77,7 +77,7 @@ export const PageTriggerEditor: React.FC<{
       <div className="flex justify-between">
         <h4>
           <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-          DOT AI Page Trigger Point
+          DOT AI Page Activation Point
         </h4>
         <button
           onClick={() => onEdit({ id: 'page', type: 'trigger', trigger_type: 'page', prompt: '' })}

--- a/assets/src/components/TriggerButton.tsx
+++ b/assets/src/components/TriggerButton.tsx
@@ -32,12 +32,18 @@ export const TriggerButton: React.FC<{
     <div className="flex justify-center">
       <button
         disabled={disabled}
-        className={`px-2 py-1 text-sm text-white ${
-          disabled ? '' : 'active:scale-95 transition-transform'
+        className={`px-3 py-3 text-base text-white ${
+          disabled
+            ? 'opacity-50 cursor-not-allowed'
+            : 'hover:bg-gray-300 hover:scale-105 active:scale-95 transition-transform duration-150 cursor-pointer'
         } rounded`}
         onClick={onClick}
       >
-        <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
+        <img
+          src="/images/icons/icon-AI.svg"
+          style={{ marginBottom: 0 }}
+          className="block w-6 h-6 m-0 p-0"
+        />
       </button>
     </div>
   );

--- a/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
@@ -75,10 +75,10 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
   const NewTriggerForm = () => (
     <div className="mt-2">
       <p>
-        <b>Trigger</b>
+        <b>Activation Point</b>
       </p>
       <p>
-        An AI trigger is when our AI assistant, DOT, responds to something a learner does, like
+        An AI activation point is when our AI assistant, DOT, responds to something a learner does, like
         giving feedback or extra help based on their actions.
       </p>
 
@@ -154,7 +154,7 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
     <>
       <h4>
         <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-        DOT AI Activity Trigger Point
+        DOT AI Activity Point
       </h4>
       <p className="mt-2">
         Customize a prompt for our AI assistant, DOT, to follow based on learner actions within this
@@ -170,7 +170,7 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
         <>
           <div className="mt-2 flex justify-center py-4">
             <Button onClick={(_e) => setAddMode(true)} disabled={!editMode}>
-              + Create New Trigger
+              + Create New Activation Point
             </Button>
           </div>
 

--- a/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
@@ -78,8 +78,8 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
         <b>Activation Point</b>
       </p>
       <p>
-        An AI activation point is when our AI assistant, DOT, responds to something a learner does, like
-        giving feedback or extra help based on their actions.
+        An AI activation point is when our AI assistant, DOT, responds to something a learner does,
+        like giving feedback or extra help based on their actions.
       </p>
 
       <select defaultValue="" onChange={onTriggerChange}>

--- a/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerAuthoring.tsx
@@ -154,7 +154,7 @@ export const TriggerAuthoring: React.FC<Props> = ({ partId }) => {
     <>
       <h4>
         <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-        DOT AI Activity Point
+        DOT AI Activation Point
       </h4>
       <p className="mt-2">
         Customize a prompt for our AI assistant, DOT, to follow based on learner actions within this

--- a/assets/src/components/activities/common/triggers/TriggerUtils.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerUtils.tsx
@@ -56,7 +56,7 @@ export const describeTrigger = (t: ActivityTrigger, part: Part, maxchars: number
 
     case 'explanation':
       const explanation = part.explanation!.content;
-      return addContent('Student triggers explanation', explanation);
+      return addContent('Student activates explanation', explanation);
 
     case 'hint':
       const hint = part.hints[t.ref_id - 1].content;
@@ -65,10 +65,10 @@ export const describeTrigger = (t: ActivityTrigger, part: Part, maxchars: number
     case 'targeted_feedback':
       const response = part.responses.find((r) => r.id == t.ref_id);
       const feedback = response?.feedback.content;
-      return addContent('Student triggers targeted feedback', feedback);
+      return addContent('Student activates targeted feedback', feedback);
 
     default:
-      console.error('unrecognized activity trigger type');
+      console.error('unrecognized activation point type');
       return '[unknown]';
   }
 };

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -23,7 +23,7 @@ import { ImageCodeEditor } from './sections/ImageCodeEditor';
 import { lastPart } from './utils';
 
 const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
-  const { dispatch, model, onRequestMedia, authoringContext } =
+  const { dispatch, model, onRequestMedia } =
     useAuthoringElementContext<ImageCodingModelSchema>();
 
   const { projectSlug } = props;

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -23,8 +23,7 @@ import { ImageCodeEditor } from './sections/ImageCodeEditor';
 import { lastPart } from './utils';
 
 const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
-  const { dispatch, model, onRequestMedia } =
-    useAuthoringElementContext<ImageCodingModelSchema>();
+  const { dispatch, model, onRequestMedia } = useAuthoringElementContext<ImageCodingModelSchema>();
 
   const { projectSlug } = props;
 

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -14,7 +14,6 @@ import guid from 'utils/guid';
 import { AuthoringElement, AuthoringElementProps } from '../AuthoringElement';
 import { AuthoringElementProvider, useAuthoringElementContext } from '../AuthoringElementProvider';
 import { Explanation } from '../common/explanation/ExplanationAuthoring';
-import { TriggerAuthoring, TriggerLabel } from '../common/triggers/TriggerAuthoring';
 import * as ActivityTypes from '../types';
 import { MediaItemRequest } from '../types';
 import { ICActions } from './actions';
@@ -214,12 +213,6 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
             <TabbedNavigation.Tab label="Explanation">
               <Explanation partId={model.authoring.parts[0].id} />
             </TabbedNavigation.Tab>
-
-            {authoringContext?.optionalContentTypes?.triggers && (
-              <TabbedNavigation.Tab label={TriggerLabel()}>
-                <TriggerAuthoring partId={model.authoring.parts[0].id} />
-              </TabbedNavigation.Tab>
-            )}
           </TabbedNavigation.Tabs>
         </div>
       )}

--- a/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
+++ b/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
@@ -55,7 +55,7 @@ export const TriggerEditorCore = ({
       <div className="flex justify-between">
         <h4>
           <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-          DOT AI Group Activation Point
+          DOT AI Activation Point
         </h4>
         {showDelete ? <DeleteButton onClick={() => onDelete()} editMode={true} /> : null}
       </div>

--- a/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
+++ b/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
@@ -10,7 +10,7 @@ import * as ContentModel from 'data/content/model/elements/types';
 export const insertTrigger = createButtonCommandDesc({
   icon: <img src="/images/icons/icon-AI.svg" className="inline mr-1" />,
   category: 'General',
-  description: 'DOT Trigger',
+  description: 'DOT Activation Point',
   execute: (_context, editor) => {
     const at = editor.selection;
     if (!at) return;
@@ -55,17 +55,17 @@ export const TriggerEditorCore = ({
       <div className="flex justify-between">
         <h4>
           <img src="/images/icons/icon-AI.svg" className="inline mr-1" />
-          DOT AI Group Trigger Point
+          DOT AI Group Activation Point
         </h4>
         {showDelete ? <DeleteButton onClick={() => onDelete()} editMode={true} /> : null}
       </div>
       <p className="mt-2">
-        Customize a prompt for our AI assistant, DOT, to follow the student clicks this trigger
+        Customize a prompt for our AI assistant, DOT, to follow the student clicks this
         button.
       </p>
 
       <h6 className="mt-2">
-        <strong>Trigger</strong>
+        <strong>Activation Point</strong>
       </h6>
 
       {instructions}

--- a/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
+++ b/assets/src/components/editing/elements/trigger/TriggerEditor.tsx
@@ -60,8 +60,7 @@ export const TriggerEditorCore = ({
         {showDelete ? <DeleteButton onClick={() => onDelete()} editMode={true} /> : null}
       </div>
       <p className="mt-2">
-        Customize a prompt for our AI assistant, DOT, to follow the student clicks this
-        button.
+        Customize a prompt for our AI assistant, DOT, to follow the student clicks this button.
       </p>
 
       <h6 className="mt-2">

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,11 +3,10 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
-
     const chatMessages = document.querySelectorAll('.chat-message');
-    const elements : any = [];
+    const elements: any = [];
 
-    chatMessages.forEach(el => {
+    chatMessages.forEach((el) => {
       elements.push(el);
     });
 
@@ -16,7 +15,6 @@ export const EvaluateMathJaxExpressions = {
       let lastPromise = window?.MathJax?.startup?.promise;
       /* istanbul ignore next */
       if (!lastPromise) {
-
         typeof jest === 'undefined' &&
           console.warn(
             'Load the MathJax script before this one or unpredictable rendering might occur.',

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,14 +3,20 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
-    const elements = document.querySelectorAll('.formula, .formula-inline');
+
+    const chatMessages = document.querySelectorAll('.chat-message');
+    const elements : any = [];
+
+    chatMessages.forEach(el => {
+      elements.push(el);
+    });
 
     const getGlobalLastPromise = () => {
       /* istanbul ignore next */
       let lastPromise = window?.MathJax?.startup?.promise;
       /* istanbul ignore next */
       if (!lastPromise) {
-        console.info('NO LAST PROMISE');
+
         typeof jest === 'undefined' &&
           console.warn(
             'Load the MathJax script before this one or unpredictable rendering might occur.',

--- a/lib/oli/activities/model/response.ex
+++ b/lib/oli/activities/model/response.ex
@@ -1,4 +1,6 @@
 defmodule Oli.Activities.Model.Response do
+
+  @derive Jason.Encoder
   defstruct [:id, :rule, :score, :feedback, :show_page]
 
   def parse(%{"id" => id, "rule" => rule, "score" => score, "feedback" => feedback} = response) do

--- a/lib/oli/activities/model/response.ex
+++ b/lib/oli/activities/model/response.ex
@@ -1,5 +1,4 @@
 defmodule Oli.Activities.Model.Response do
-
   @derive Jason.Encoder
   defstruct [:id, :rule, :score, :feedback, :show_page]
 

--- a/lib/oli/conversation/dialogue.ex
+++ b/lib/oli/conversation/dialogue.ex
@@ -9,6 +9,7 @@ defmodule Oli.Conversation.Dialogue do
   alias Oli.Conversation.Functions
   alias Oli.Conversation.Model
 
+
   defstruct [
     :model,
     :rendered_messages,

--- a/lib/oli/conversation/dialogue.ex
+++ b/lib/oli/conversation/dialogue.ex
@@ -9,7 +9,6 @@ defmodule Oli.Conversation.Dialogue do
   alias Oli.Conversation.Functions
   alias Oli.Conversation.Model
 
-
   defstruct [
     :model,
     :rendered_messages,

--- a/lib/oli/conversation/dialogue_handler.ex
+++ b/lib/oli/conversation/dialogue_handler.ex
@@ -80,19 +80,20 @@ defmodule Oli.Conversation.DialogueHandler do
                 true
               end
 
+            # Here we check if there are any triggers in the queue
+            # and if so, we process the first one
+            # and remove it from the queue
             case socket.assigns.trigger_queue do
               [] ->
-
                 {:noreply,
-                  assign(socket,
-                    dialogue: dialogue,
-                    streaming: false,
-                    active_message: nil,
-                    allow_submission?: allow_submission?
-                  )}
+                 assign(socket,
+                   dialogue: dialogue,
+                   streaming: false,
+                   active_message: nil,
+                   allow_submission?: allow_submission?
+                 )}
 
               [trigger | rest] ->
-
                 prompt = Oli.Conversation.Triggers.assemble_trigger_prompt(trigger)
 
                 dialogue =
@@ -112,11 +113,11 @@ defmodule Oli.Conversation.DialogueHandler do
                 end)
 
                 {:noreply,
-                  assign(socket,
-                    dialogue: dialogue,
-                    active_message: socket.assigns.active_message <> "\n\n",
-                    trigger_queue: rest
-                  )}
+                 assign(socket,
+                   dialogue: dialogue,
+                   active_message: socket.assigns.active_message <> "\n\n",
+                   trigger_queue: rest
+                 )}
             end
 
           fc ->

--- a/lib/oli/conversation/functions.ex
+++ b/lib/oli/conversation/functions.ex
@@ -17,16 +17,15 @@ defmodule Oli.Conversation.Functions do
   @functions [
     %{
       name: "course_sequence",
-      description:
-        """
-        Returns the full sequence of units, modules, sections and learning pages in this course as a
-        list of objects with the following keys: [resource_id, title, url, is_page, graded, level] where
-        resource_id is the unique identifier of the page or container, and
-        title is the title of the page or container, url is the url to the page, is_page is a boolean
-        indicating if the object is a page or a container, graded is a boolean indicating if the
-        page is graded or is practice, and level is the level of the page or container in the hierarchy.
-        The level is a number starting from 1 for the first level of the hierarchy.
-        """,
+      description: """
+      Returns the full sequence of units, modules, sections and learning pages in this course as a
+      list of objects with the following keys: [resource_id, title, url, is_page, graded, level] where
+      resource_id is the unique identifier of the page or container, and
+      title is the title of the page or container, url is the url to the page, is_page is a boolean
+      indicating if the object is a page or a container, graded is a boolean indicating if the
+      page is graded or is practice, and level is the level of the page or container in the hierarchy.
+      The level is a number starting from 1 for the first level of the hierarchy.
+      """,
       parameters: %{
         type: "object",
         properties: %{
@@ -162,7 +161,7 @@ defmodule Oli.Conversation.Functions do
         title: node.revision.title,
         is_page: node.revision.resource_type_id == Oli.Resources.ResourceType.id_for_page(),
         level: node.numbering.level,
-        graded: node.revision.graded,
+        graded: node.revision.graded
       }
     end)
   end

--- a/lib/oli/conversation/functions.ex
+++ b/lib/oli/conversation/functions.ex
@@ -10,10 +10,34 @@ defmodule Oli.Conversation.Functions do
   @lookup_table %{
     "avg_score_for" => "Elixir.Oli.Conversation.Functions.avg_score_for",
     "up_next" => "Elixir.Oli.Conversation.Functions.up_next",
-    "relevant_course_content" => "Elixir.Oli.Conversation.Functions.relevant_course_content"
+    "relevant_course_content" => "Elixir.Oli.Conversation.Functions.relevant_course_content",
+    "course_sequence" => "Elixir.Oli.Conversation.Functions.course_sequence"
   }
 
   @functions [
+    %{
+      name: "course_sequence",
+      description:
+        """
+        Returns the full sequence of units, modules, sections and learning pages in this course as a
+        list of objects with the following keys: [resource_id, title, url, is_page, graded, level] where
+        resource_id is the unique identifier of the page or container, and
+        title is the title of the page or container, url is the url to the page, is_page is a boolean
+        indicating if the object is a page or a container, graded is a boolean indicating if the
+        page is graded or is practice, and level is the level of the page or container in the hierarchy.
+        The level is a number starting from 1 for the first level of the hierarchy.
+        """,
+      parameters: %{
+        type: "object",
+        properties: %{
+          section_id: %{
+            type: "integer",
+            description: "The current course section's id"
+          }
+        },
+        required: ["section_id"]
+      }
+    },
     %{
       name: "up_next",
       description:
@@ -125,6 +149,22 @@ defmodule Oli.Conversation.Functions do
 
   def up_next(%{"current_user_id" => user_id, "section_id" => section_id}) do
     get_next_activities_for_student(section_id, user_id)
+  end
+
+  def course_sequence(%{"section_id" => section_id}) do
+    section = Oli.Delivery.Sections.get_section!(section_id)
+
+    Oli.Delivery.Sections.SectionResourceDepot.get_delivery_resolver_full_hierarchy(section)
+    |> Oli.Delivery.Hierarchy.flatten_hierarchy()
+    |> Enum.map(fn node ->
+      %{
+        url: Routes.page_delivery_url(OliWeb.Endpoint, :page, section.slug, node.revision.slug),
+        title: node.revision.title,
+        is_page: node.revision.resource_type_id == Oli.Resources.ResourceType.id_for_page(),
+        level: node.numbering.level,
+        graded: node.revision.graded,
+      }
+    end)
   end
 
   def relevant_course_content(%{"student_input" => input, "section_id" => section_id}) do

--- a/lib/oli/delivery/evaluation/evaluator.ex
+++ b/lib/oli/delivery/evaluation/evaluator.ex
@@ -40,6 +40,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
              Triggers.check_for_response_trigger(
                relevant_triggers_by_type,
                response,
+               part.id,
                out_of,
                context
              )
@@ -71,6 +72,7 @@ defmodule Oli.Delivery.Evaluation.Evaluator do
              Triggers.check_for_response_trigger(
                relevant_triggers_by_type,
                %Response{score: 0},
+               part.id,
                adjusted_out_of,
                context
              )

--- a/lib/oli_web/components/delivery/dialogue.ex
+++ b/lib/oli_web/components/delivery/dialogue.ex
@@ -37,7 +37,8 @@ defmodule OliWeb.Components.Delivery.Dialogue do
             <div class="grow shrink basis-0 self-stretch flex-col justify-start items-start gap-3 inline-flex">
               <div
                 id={"message_#{@index}_content"}
-                class="self-stretch dark:text-white text-sm font-normal font-['Open Sans'] tracking-tight"
+                class="chat-message self-stretch dark:text-white text-sm font-normal font-['Open Sans'] tracking-tight"
+                phx-hook="EvaluateMathJaxExpressions"
               >
                 <%= raw(@content) %>
               </div>

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -670,16 +670,17 @@ defmodule OliWeb.Dialogue.WindowLive do
       "Handlng trigger for section #{socket.assigns.section.id}, resource #{socket.assigns.resource_id}, user #{socket.assigns.current_user.id}"
     )
 
+    # If there is currently a trigger or direct student interaction
+    # streaming, we must queue the trigger and process it after
+    # the current one is finished
     case socket.assigns.streaming do
-
       true ->
         {:noreply,
-          assign(socket,
-            trigger_queue: socket.assigns.trigger_queue ++ [trigger]
-          )}
+         assign(socket,
+           trigger_queue: socket.assigns.trigger_queue ++ [trigger]
+         )}
 
       false ->
-
         prompt = Triggers.assemble_trigger_prompt(trigger)
 
         dialogue =
@@ -698,18 +699,14 @@ defmodule OliWeb.Dialogue.WindowLive do
           send(pid, {:reply_finished})
         end)
 
-        # socket = push_event(socket, "show_teaser", %{})
-
         {:noreply,
-        assign(socket,
-          dialogue: dialogue,
-          streaming: true,
-          teaser_message: nil,
-          teaser_visible: true
-        )}
-
+         assign(socket,
+           dialogue: dialogue,
+           streaming: true,
+           teaser_message: nil,
+           teaser_visible: true
+         )}
     end
-
   end
 
   use Oli.Conversation.DialogueHandler

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -747,7 +747,7 @@ defmodule OliWeb.Sections.OverviewView do
         />
       </div>
       <div class="flex py-2 mb-2">
-        <div>Enable Assistant Triggers</div>
+        <div>Enable AI Activation Points</div>
         <.toggle_switch
           class="ml-4"
           checked={@section.triggers_enabled}

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -506,7 +506,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
           When AI Activation Points are enabled as an authoring feature, authors can insert an activation point at the page level, group level, paragraph level, or question level.
         </p>
 
-        <p class="mt-3">AI Activation Points are currently <strong>enabled</strong> for this project.</p>
+        <p class="mt-3">
+          AI Activation Points are currently <strong>enabled</strong> for this project.
+        </p>
 
         <p class="mt-3">
           Note: AI Activation Points will only work for course sections that have DOT AI enabled.  This must be enabled section by section by a system administrator.

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -325,8 +325,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
       ) %>
 
       <Overview.section
-        title="AI Triggers"
-        description="Enable AI triggers for your project to include in your curriculum."
+        title="AI Activation Points"
+        description="Enable AI activation points for your project to include in your curriculum."
       >
         <%= render_ai_triggers(assigns) %>
       </Overview.section>
@@ -474,24 +474,24 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     <div class="flex items-center">
       <div>
         <p class="mt-3">
-          When AI Trigger Points are enabled as an authoring feature, authors can insert a trigger point at the page level, group level, paragraph level, or question level.
+          When AI Activation Points are enabled as an authoring feature, authors can insert an activation point at the page level, group level, paragraph level, or question level.
         </p>
 
         <p class="mt-3">
-          AI Trigger Points are currently <strong>disabled</strong> for this project.
+          AI Activation Points are currently <strong>disabled</strong> for this project.
         </p>
 
-        <%= button("Enable AI Triggers",
+        <%= button("Enable AI Activation Points",
           to: Routes.project_path(@socket, :enable_triggers, @project),
           method: :post,
           class:
             "text-[#006CD9] hover:text-[#1B67B2] dark:text-[#4CA6FF] dark:hover:text-[#99CCFF] hover:underline pr-3 py-2",
           data_confirm:
-            "The AI Trigger Points authoring feature cannot be disabled once it is enabled. Do you want to proceed with enabling AI Trigger Points??"
+            "The AI Activation Points authoring feature cannot be disabled once it is enabled. Do you want to proceed with enabling AI Activation Points??"
         ) %>
 
         <p class="mt-3">
-          Note: AI Trigger Points will only work for course sections that have DOT AI enabled.  This must be enabled section by section by a system administrator.
+          Note: AI Activation Points will only work for course sections that have DOT AI enabled.  This must be enabled section by section by a system administrator.
         </p>
       </div>
     </div>
@@ -503,13 +503,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     <div class="flex items-center">
       <div>
         <p class="mt-3">
-          When AI Trigger Points are enabled as an authoring feature, authors can insert a trigger point at the page level, group level, paragraph level, or question level.
+          When AI Activation Points are enabled as an authoring feature, authors can insert an activation point at the page level, group level, paragraph level, or question level.
         </p>
 
-        <p class="mt-3">AI Trigger Points are currently <strong>enabled</strong> for this project.</p>
+        <p class="mt-3">AI Activation Points are currently <strong>enabled</strong> for this project.</p>
 
         <p class="mt-3">
-          Note: AI Trigger Points will only work for course sections that have DOT AI enabled.  This must be enabled section by section by a system administrator.
+          Note: AI Activation Points will only work for course sections that have DOT AI enabled.  This must be enabled section by section by a system administrator.
         </p>
       </div>
     </div>

--- a/test/oli/conversation/triggers_test.exs
+++ b/test/oli/conversation/triggers_test.exs
@@ -29,7 +29,7 @@ defmodule Oli.Conversation.TriggersTest do
     }
 
     trigger =
-      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, 2.0, context)
+      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, "1", 2.0, context)
 
     assert trigger.prompt == "correct prompt"
     assert trigger.trigger_type == :correct_answer
@@ -66,7 +66,7 @@ defmodule Oli.Conversation.TriggersTest do
     }
 
     trigger =
-      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, 2.0, context)
+      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, "1", 2.0, context)
 
     assert trigger.prompt == "incorrect prompt"
     assert trigger.trigger_type == :incorrect_answer
@@ -103,7 +103,7 @@ defmodule Oli.Conversation.TriggersTest do
     }
 
     trigger =
-      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, 2.0, context)
+      Triggers.check_for_response_trigger(relevant_triggers_by_type, response, "1", 2.0, context)
 
     assert trigger.prompt == "targeted prompt"
     assert trigger.trigger_type == :targeted_feedback


### PR DESCRIPTION
This PR fixes the following issues:

### TRIAGE-1483   Page level trigger + another make it act weird

The fix here is to queue for later processing any trigger that arrives when DOT is currently streaming a response. This effectively "serializes" DOT's operation, ensuring that it can never interleave the streaming results of multiple triggers.

### TRIAGE-1495   Student response missing from context

This was addressed in another ticket, but it actually was including the activity `Response` object and not the student's actual response (from the part attempt).  Changes were made to encode into the context the `:response` from the part attempt.

### TRIAGE-1496   Course sequence missing from context

This is addressed by providing a new `course_sequence` function to DOT - so that it can get a full listing of the containers and pages in the course. 

### TRIAGE-1497    Multi-Input questions not isolated to part

This was handled by adjusting the prompt, giving access to the specific part id that was triggered, and instructing DOT to only converse about that specific part. 

### TRIAGE-1482   Page reset needed for MCQs with multiple triggers 

After making all of the above changes, this problem was no longer observable. 

### MER-4487 Latex does not render in DOT

Added a call to invoke MathJax typesetting and DOT can now render Latex.  We must update the base prompt to include the following paragraph about proper escaping: 

```
The current course section's unique id (section_id) is <%= section_id %>.

You can render inline Latex but you ABSOLUTELY MUST surround it with the \\( \\) escape sequence and
block latex surrounded by the $$ $$ sequence.  For example: \\( /frac{2}{3} \\) and $$ /frac{2}{3} $$

Your assistance is being requested within the context of a particular lesson with this course.
Please pay attention to this specific lesson content when providing assistance. The content of
the lesson is:
```

### TRIAGE-1518 renaming to “Activation Points”

Renamed. 

### MER-4500 AI Activation Points breaks Image Coding Authoring

Removed trigger authoring from Image Coding.

### No ticket:  Content block trigger button is too small

Increased the size (and corrected aspect ratio) of the content block trigger button

