### PR TITLE
[BUG FIX] [MER-4493] Change the text on the banner after updating AI settings

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -668,7 +668,7 @@ defmodule OliWeb.Sections.OverviewView do
 
     socket =
       socket
-      |> put_flash(:info, "Assistant settings updated successfully")
+      |> put_flash(:info, "AI assistant settings updated successfully")
 
     {:noreply, assign(socket, section: section)}
   end
@@ -682,7 +682,7 @@ defmodule OliWeb.Sections.OverviewView do
 
     socket =
       socket
-      |> put_flash(:info, "Assistant trigger settings updated successfully")
+      |> put_flash(:info, "AI assistant activation settings updated successfully")
 
     {:noreply, assign(socket, section: section)}
   end


### PR DESCRIPTION
Ticket: [MER-4493](https://eliterate.atlassian.net/browse/MER-4493)

This PR changes the banner message after updating the AI settings.

Note: I added the word 'AI' to match the group section.

[MER-4493]: https://eliterate.atlassian.net/browse/MER-4493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ