### PR TITLE
[BUG FIX] [MER-4487] Restore latex page rendering

### DIFF
--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,12 +3,7 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
-    const chatMessages = document.querySelectorAll('.chat-message');
-    const elements: any = [];
-
-    chatMessages.forEach((el) => {
-      elements.push(el);
-    });
+    const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
 
     const getGlobalLastPromise = () => {
       /* istanbul ignore next */

--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -129,7 +129,6 @@ defmodule Oli.Conversation.Triggers do
 
     #{trigger.prompt}
     """
-    |> IO.inspect()
   end
 
   # Given certain classes of triggers, augment the data context with additional


### PR DESCRIPTION
This restores the typesetting on pages, this `EvaluateMathJaxExpressions` hook is actually called from `lib/oli_web/components/layouts/student_delivery_lesson.html.heex`.  In my original PR, I did a search through `*.ex` files and didn't see it being used - and changed it in a way that precluded it from working on formulas.   This PR restores `.formula` and `.formula-inline` - adding in `.chat-message` which after testing shows both page Latex and DOT messages now correctly rendering Latex.

I also saw an `IO.inspect()` call that should have been removed from Triggers code.