### PR TITLE
[ENHANCEMENT] [MER-4511] Make logger filter more robust

### DIFF
--- a/lib/oli/logger_truncator.ex
+++ b/lib/oli/logger_truncator.ex
@@ -76,13 +76,17 @@ defmodule Oli.LoggerTruncator do
   end
 
   defp sanitize_msg(msg, max_length) when is_map(msg) do
-    msg
-    # truncate to first 50 keys if needed
-    |> Enum.take(50)
-    |> Enum.map(fn {k, v} ->
-      {k, sanitize_msg(v, max_length)}
-    end)
-    |> Enum.into(%{})
+    try do
+      msg
+      # truncate to first 50 keys if needed
+      |> Enum.take(50)
+      |> Enum.map(fn {k, v} ->
+        {k, sanitize_msg(v, max_length)}
+      end)
+      |> Enum.into(%{})
+    rescue
+      _error -> %{msg: "[TRUNCATED]"} # Log an error message if something goes wrong
+    end
   end
 
   defp sanitize_msg(other, _) do
@@ -90,10 +94,14 @@ defmodule Oli.LoggerTruncator do
   end
 
   defp truncate_if_needed(msg, max_length) when is_binary(msg) do
-    if byte_size(msg) > max_length do
-      String.slice(msg, 0, max_length) <> @truncate_msg
-    else
-      msg
+    try do
+      if byte_size(msg) > max_length do
+        String.slice(msg, 0, max_length) <> @truncate_msg
+      else
+        msg
+      end
+    rescue
+      _error -> "[TRUNCATED]" # If an error occurs during truncation, return a truncated message.
     end
   end
 end


### PR DESCRIPTION
This PR updates the `LoggerTruncator` to make it more robust - with the intent of preventing it from being removed by the Logging system if it encounters an error.  