### PR TITLE
[BUG FIX] [MER-4519] ingestion: don't force bank selection operator to Equals

### DIFF
--- a/lib/oli/interop/ingest/processor/rewiring.ex
+++ b/lib/oli/interop/ingest/processor/rewiring.ex
@@ -62,7 +62,13 @@ defmodule Oli.Interop.Ingest.Processing.Rewiring do
         case e do
           %{"type" => "selection", "logic" => logic} = ref ->
             case logic do
-              %{"conditions" => %{"children" => [%{"fact" => "tags", "value" => originals, "operator" => operator}]}} ->
+              %{
+                "conditions" => %{
+                  "children" => [
+                    %{"fact" => "tags", "value" => originals, "operator" => operator}
+                  ]
+                }
+              } ->
                 Enum.reduce(originals, {[], {:ok, []}}, fn o, {ids, {status, invalid_ids}} ->
                   case retrieve(tag_map, o) do
                     nil ->


### PR DESCRIPTION
The bank selection rewiring step during course ingestion forced the operator in all activity bank selections by tag to a harcoded value of “Equals”. This is harmless when activities have only one tag associated, as is the case in migrated courses which only contain a single tag for the legacy pool, because in this case Equals and Contains are equivalent. But this breaks selections where authors have attached multiple tags to an activity and want to select it by a single tag, in which case only a Contains operator will work. 

PR changes to capture and preserve the original operator during this step.