### PR TITLE
[BUG FIX] [MER-4490] Fix date comparison and submit page term - part 2

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -227,13 +227,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   end
 
   defp submit_term(
-         %{
-           effective_settings: %{
-             late_submit: :allow,
-             time_limit: time_limit,
-             scheduling_type: :due_by
-           }
-         } = assigns
+         %{effective_settings: %{late_submit: :allow, time_limit: time_limit}} = assigns
        )
        when time_limit not in ["nil", 0] do
     ~H"""

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -62,7 +62,7 @@ defmodule Oli.Delivery.SettingsTest do
     refute Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
   end
 
-  test "was_late/2 never returns true when scheduling type is :read_by" do
+  test "was_late/2 returns true for :read_by pages when there is a time limit + allow late submit, and student submits late" do
     ra = %ResourceAttempt{
       inserted_at: ~U[2020-01-15 00:00:00Z]
     }
@@ -70,6 +70,15 @@ defmodule Oli.Delivery.SettingsTest do
     settings = %Combined{
       late_submit: :allow,
       time_limit: 1,
+      scheduling_type: :read_by,
+      end_date: ~U[2020-01-12 00:00:00Z]
+    }
+
+    assert Settings.was_late?(ra, settings, DateTime.add(ra.inserted_at, 20, :minute))
+
+    settings = %Combined{
+      late_submit: :allow,
+      time_limit: 0,
       scheduling_type: :read_by,
       end_date: ~U[2020-01-12 00:00:00Z]
     }

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1148,7 +1148,7 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       refute has_element?(view, "#page_time_limit_term", "<li id=\"page_time_limit_term\">")
     end
 
-    test "page terms render a time limit late submit message only for a due by page",
+    test "page terms render a time limit late submit in both due_by and read_by scheduling types",
          ctx do
       %{conn: conn, user: user, section: section, page_2: page_2} = ctx
 
@@ -1169,7 +1169,8 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
-      refute view |> has_element?("#page_submit_term")
+      assert view |> element("#page_submit_term") |> render() =~
+               "<li id=\"page_submit_term\">\n  If you exceed this time, it will be marked late.\n</li>"
     end
 
     test "page terms render a late submit due date message only for pages with due date", ctx do


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4490?focusedCommentId=27024) to the comment in the ticket

When I opened the previous PR, I understood that none of the logic of the [Schedule and Assessment Settings](https://docs.google.com/drawings/d/1LDzW7DH6fX7BW6oFBYgPR9H2ZkqHn-YP5JuvcfSq1xw/edit) document had to be applied when the page had a scheduling type of `:read_by`. The note that made me confuse was: 
![image](https://github.com/user-attachments/assets/9fb044bb-ecf3-4acc-b465-a89732ecfc6f)

Amanda [explained](https://eliterate.atlassian.net/browse/MER-4490?focusedCommentId=27030) to me that `“Suggested by” date has no impact on the logic, meaning one should follow the logical path on the flow chart that exists when there is no due date”`.

That being clarified, then we should mark an attempt as late when the page has read_by + allow_late_submit + time_limit and the student submits after the countdown has finished.