### PR TITLE
[BUG FIX] [MER-4507] Branding isnt working on course pages as expected

### DIFF
--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -22,7 +22,8 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
          :lti_1p3_deployment,
          :contains_discussions,
          :contains_explorations,
-         :contains_deliberate_practice
+         :contains_deliberate_practice,
+         :open_and_free
        ], %Section{}},
     current_user: {[:id, :name, :email, :sub], %User{}}
   }

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -32,7 +32,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   # this is an optimization to reduce the memory footprint of the liveview process
   @required_keys_per_assign %{
     section:
-      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :customizations], %Sections.Section{}},
+      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :customizations, :open_and_free],
+       %Sections.Section{}},
     current_user: {[:id, :name, :email, :sub], %User{}}
   }
 

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -23,8 +23,16 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   # this is an optimization to reduce the memory footprint of the liveview process
   @required_keys_per_assign %{
     section:
-      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :resource_gating_index, :customizations],
-       %Sections.Section{}},
+      {[
+         :id,
+         :slug,
+         :title,
+         :brand,
+         :lti_1p3_deployment,
+         :resource_gating_index,
+         :customizations,
+         :open_and_free
+       ], %Sections.Section{}},
     current_user: {[:id, :name, :email, :sub], %User{}}
   }
 

--- a/lib/oli_web/live/delivery/student/review_live.ex
+++ b/lib/oli_web/live/delivery/student/review_live.ex
@@ -15,7 +15,8 @@ defmodule OliWeb.Delivery.Student.ReviewLive do
   # this is an optimization to reduce the memory footprint of the liveview process
   @required_keys_per_assign %{
     section:
-      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :customizations], %Sections.Section{}}
+      {[:id, :slug, :title, :brand, :lti_1p3_deployment, :customizations, :open_and_free],
+       %Sections.Section{}}
   }
 
   def mount(

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -737,6 +737,28 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert element(view, "#header_logo_button") |> render() =~ "www.logo.com"
     end
 
+    test "see default brand logo if the section is not open and free", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{open_and_free: false, lti_1p3_deployment_id: nil})
+
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, page_1.slug))
+      ensure_content_is_visible(view)
+
+      # assert that the section has a brand
+      assert is_struct(section.brand, Oli.Branding.Brand)
+
+      # assert that the default logo is shown because the section is not open and free even if the brand is set
+      assert element(view, "#header_logo_button") |> render() =~ "/images/oli_torus_logo.png"
+    end
+
     test "can access when enrolled to course", %{
       conn: conn,
       user: user,

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -512,6 +512,27 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       assert element(view, "#header_logo_button") |> render() =~ "www.logo.com"
     end
 
+    test "see default brand logo if the section is not open and free", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_1: page_1
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{open_and_free: false, lti_1p3_deployment_id: nil})
+
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_1.slug))
+
+      # assert that the section has a brand
+      assert is_struct(section.brand, Oli.Branding.Brand)
+
+      # assert that the default logo is shown because the section is not open and free even if the brand is set
+      assert element(view, "#header_logo_button") |> render() =~ "/images/oli_torus_logo.png"
+    end
+
     test "can see prologue on graded pages with no attempt in progress", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
[MER-4507](https://eliterate.atlassian.net/browse/MER-4507)

This PR updates the `required_keys_per_assign` configuration to include the `:open_and_free` key in the section assign. This makes sure that the open_and_free value stays in the LiveView socket after calling slim_assigns/1, which is used to reduce memory usage.

Before this change, open_and_free was not included in the slimmed version of section. Because of that, some logic depending on this flag—like the branding logic that decides which logo to show—did not work correctly.

As a result, even when a section had a custom brand with its own logo, the system was always showing the default logo, since section.open_and_free was missing and treated as false.

With this fix, the open_and_free value is kept, and the branding logic can now use the correct value from the section data.

[MER-4507]: https://eliterate.atlassian.net/browse/MER-4507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ