### PR TITLE
[BUG FIX] [MER-4536] make instructor sign-in page use same page title as student and author sign-in

### DIFF
--- a/lib/oli_web/live/user_login_live.ex
+++ b/lib/oli_web/live/user_login_live.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.UserLoginLive do
 
   @impl Phoenix.LiveView
   def mount(_, session, socket) do
-    title = session["title"] || brand_name()
+    title = session["title"] || product_short_name()
 
     email = Phoenix.Flash.get(socket.assigns.flash, :email)
     form = to_form(%{"email" => email}, as: "user")

--- a/lib/oli_web/live/user_login_live.ex
+++ b/lib/oli_web/live/user_login_live.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.UserLoginLive do
 
   @impl Phoenix.LiveView
   def mount(_, session, socket) do
-    title = session["title"] || "Sign in"
+    title = session["title"] || brand_name()
 
     email = Phoenix.Flash.get(socket.assigns.flash, :email)
     form = to_form(%{"email" => email}, as: "user")

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || brand_name() %>
+      <%= assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name() %>
     </Phoenix.Component.live_title>
 
     <link rel="apple-touch-icon" sizes="180x180" href={favicons("apple-touch-icon.png")} />

--- a/lib/oli_web/templates/layout/chromeless.html.heex
+++ b/lib/oli_web/templates/layout/chromeless.html.heex
@@ -11,7 +11,7 @@
     <%= csrf_meta_tag() %>
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || brand_name() %>
+      <%= assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name() %>
     </Phoenix.Component.live_title>
 
     <link

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || brand_name() %>
+      <%= assigns[:page_title] || assigns[:title] || "Delivery" %>
     </Phoenix.Component.live_title>
 
     <link

--- a/lib/oli_web/templates/layout/error.html.heex
+++ b/lib/oli_web/templates/layout/error.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || brand_name() %>
+      <%= assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name() %>
     </Phoenix.Component.live_title>
 
     <link rel="apple-touch-icon" sizes="180x180" href={favicons("apple-touch-icon.png")} />

--- a/lib/oli_web/templates/layout/lti.html.heex
+++ b/lib/oli_web/templates/layout/lti.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || brand_name() %>
+      <%= assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name() %>
     </Phoenix.Component.live_title>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />


### PR DESCRIPTION
Instructor sign-in page was defaulting to hard-coded page title of "Sign in", which was inconsistent with other sign-in pages which have page title taken from brand name, coming out as "OLI Torus" under default branding. This inconsistency was interfering with automating QA testing. This PR changes to use the ~~name from branding~~ short name from vendor properties consistently for page title in all cases.

Note "page title" here means the title shown in the browser tab, obtained from meta information in the HTML head element. It is not part of the page body content. 