### PR TITLE
[FEATURE] [MER-4290] Adding admin manage lti 1.3 external tools

### DIFF
--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -4,7 +4,6 @@ defmodule OliWeb.Admin.AdminView do
   alias Oli.Accounts
   alias OliWeb.Common.Properties.{Groups, Group}
   alias OliWeb.Common.Breadcrumb
-  alias OliWeb.Router.Helpers, as: Routes
 
   on_mount {OliWeb.AuthorAuth, :ensure_authenticated}
   on_mount OliWeb.LiveSessionPlugs.SetCtx
@@ -34,12 +33,12 @@ defmodule OliWeb.Admin.AdminView do
         <Group.render label="Account Management" description="Access and manage all users and authors">
           <ul class="link-list">
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}>
+              <a href={~p"/admin/users"}>
                 Manage Students and Instructor Accounts
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}>
+              <a href={~p"/admin/authors"}>
                 Manage Authoring Accounts
               </a>
             </li>
@@ -51,19 +50,19 @@ defmodule OliWeb.Admin.AdminView do
                 ) %>
               </a>
             </li>
-            <li><a href={Routes.invite_path(OliWeb.Endpoint, :index)}>Invite New Authors</a></li>
+            <li><a href={~p"/admin/invite"}>Invite New Authors</a></li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}>
+              <a href={~p"/authoring/communities"}>
                 Manage Communities
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}>
+              <a href={~p"/admin/registrations"}>
                 Manage LTI 1.3 Registrations
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}>
+              <a href={~p"/admin/external_tools"}>
                 Manage LTI 1.3 External Tools
               </a>
             </li>
@@ -74,32 +73,32 @@ defmodule OliWeb.Admin.AdminView do
         <Group.render label="Content Management" description="Access and manage created content">
           <ul class="link-list">
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}>
+              <a href={~p"/authoring/projects"}>
                 Browse all Projects
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}>
+              <a href={~p"/admin/products"}>
                 Browse all Products
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}>
+              <a href={~p"/admin/sections"}>
                 Browse all Course Sections
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}>Ingest Project</a>
+              <a href={~p"/admin/ingest"}>Ingest Project</a>
             </li>
-            <li><a href={Routes.ingest_path(OliWeb.Endpoint, :index)}>V2 Ingest Project</a></li>
-            <li><a href={Routes.brand_path(OliWeb.Endpoint, :index)}>Manage Branding</a></li>
+            <li><a href={~p"/admin/ingest/upload"}>V2 Ingest Project</a></li>
+            <li><a href={~p"/admin/brands"}>Manage Branding</a></li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}>
+              <a href={~p"/admin/publishers"}>
                 Manage Publishers
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Workspaces.CourseAuthor.DatasetsLive)}>
+              <a href={~p"/admin/datasets"}>
                 Manage Dataset Jobs
               </a>
             </li>
@@ -113,21 +112,21 @@ defmodule OliWeb.Admin.AdminView do
         >
           <ul class="link-list">
             <li>
-              <a href={Routes.activity_manage_path(OliWeb.Endpoint, :index)}>Manage Activities</a>
+              <a href={~p"/admin/manage_activities"}>Manage Activities</a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}>
+              <a href={~p"/admin/system_messages"}>
                 Manage System Message Banner
               </a>
             </li>
 
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}>
+              <a href={~p"/admin/features"}>
                 Feature Flags and Logging
               </a>
             </li>
             <li>
-              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}>
+              <a href={~p"/admin/api_keys"}>
                 Manage Third-Party API Keys
               </a>
             </li>
@@ -142,7 +141,7 @@ defmodule OliWeb.Admin.AdminView do
               </a>
             </li>
             <li>
-              <a href={Routes.live_dashboard_path(OliWeb.Endpoint, :home)} target="_blank">
+              <a href={~p"/admin/dashboard/home"} target="_blank">
                 <span>View System Performance Dashboard</span>
                 <i class="fas fa-external-link-alt self-center ml-1"></i>
               </a>
@@ -170,6 +169,6 @@ defmodule OliWeb.Admin.AdminView do
 
   def breadcrumb(),
     do: [
-      Breadcrumb.new(%{link: Routes.live_path(OliWeb.Endpoint, __MODULE__), full_title: "Admin"})
+      Breadcrumb.new(%{link: ~p"/admin", full_title: "Admin"})
     ]
 end

--- a/lib/oli_web/live/admin/admin_view.ex
+++ b/lib/oli_web/live/admin/admin_view.ex
@@ -62,6 +62,11 @@ defmodule OliWeb.Admin.AdminView do
                 Manage LTI 1.3 Registrations
               </a>
             </li>
+            <li>
+              <a href={Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}>
+                Manage LTI 1.3 External Tools
+              </a>
+            </li>
           </ul>
         </Group.render>
       <% end %>

--- a/lib/oli_web/live/admin/external_tools/external_tools_view.ex
+++ b/lib/oli_web/live/admin/external_tools/external_tools_view.ex
@@ -1,0 +1,33 @@
+defmodule OliWeb.Admin.ExternalToolsView do
+  use OliWeb, :live_view
+
+  alias OliWeb.Common.Breadcrumb
+  alias OliWeb.Router.Helpers, as: Routes
+
+  defp set_breadcrumbs() do
+    OliWeb.Admin.AdminView.breadcrumb()
+    |> breadcrumb()
+  end
+
+  def breadcrumb(previous) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "LTI 1.3 External Tools",
+          link: Routes.live_path(OliWeb.Endpoint, __MODULE__)
+        })
+      ]
+  end
+
+  def mount(_, _session, socket) do
+    {:ok,
+     assign(socket,
+       breadcrumbs: set_breadcrumbs()
+     )}
+  end
+
+  def render(assigns) do
+    ~H"""
+    """
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1582,6 +1582,9 @@ defmodule OliWeb.Router do
       resources("/registrations", RegistrationController, except: [:index]) do
         resources("/deployments", DeploymentController, except: [:index, :show])
       end
+
+      # External tools
+      live("/external_tools", Admin.ExternalToolsView)
     end
 
     # System admin

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -146,6 +146,11 @@ defmodule OliWeb.AdminLiveTest do
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]"
              )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]"
+             )
     end
 
     test "loads content management links correctly", %{conn: conn} do
@@ -266,6 +271,12 @@ defmodule OliWeb.AdminLiveTest do
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
                "Manage LTI 1.3 Registrations"
+             )
+
+      assert has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]",
+               "Manage LTI 1.3 External Tools"
              )
     end
 
@@ -404,6 +415,12 @@ defmodule OliWeb.AdminLiveTest do
                view,
                "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
                "Manage LTI 1.3 Registrations"
+             )
+
+      refute has_element?(
+               view,
+               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]",
+               "Manage LTI 1.3 External Tools"
              )
     end
 

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -14,13 +14,9 @@ defmodule OliWeb.AdminLiveTest do
   @live_view_users_route Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)
   @live_view_authors_route Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)
 
-  defp live_view_user_detail_route(user_id) do
-    Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersDetailView, user_id)
-  end
+  defp live_view_user_detail_route(user_id), do: ~p"/admin/users/#{user_id}"
 
-  defp live_view_author_detail_route(author_id) do
-    Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsDetailView, author_id)
-  end
+  defp live_view_author_detail_route(author_id), do: ~p"/admin/authors/#{author_id}"
 
   defp create_user(_conn) do
     user = insert(:user)
@@ -119,12 +115,12 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}\"]"
+               "a[href=\"#{~p"/admin/users"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}\"]"
+               "a[href=\"#{~p"/admin/authors"}\"]"
              )
 
       assert has_element?(
@@ -134,22 +130,22 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.invite_path(OliWeb.Endpoint, :index)}\"]"
+               "a[href=\"#{~p"/admin/invite"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]"
+               "a[href=\"#{~p"/authoring/communities"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]"
+               "a[href=\"#{~p"/admin/registrations"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]"
+               "a[href=\"#{~p"/admin/external_tools"}\"]"
              )
     end
 
@@ -161,27 +157,27 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}\"]"
+               "a[href=\"#{~p"/authoring/projects"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}\"]"
+               "a[href=\"#{~p"/admin/products"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}\"]"
+               "a[href=\"#{~p"/admin/sections"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}\"]"
+               "a[href=\"#{~p"/admin/ingest"}\"]"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.brand_path(OliWeb.Endpoint, :index)}\"]"
+               "a[href=\"#{~p"/admin/brands"}\"]"
              )
     end
 
@@ -193,31 +189,31 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/manage_activities"}\"]",
                "Manage Activities"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "a[href=\"#{~p"/admin/system_messages"}\"]",
                "Manage System Message Banner"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "a[href=\"#{~p"/admin/features"}\"]",
                "Feature Flags and Logging"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "a[href=\"#{~p"/admin/api_keys"}\"]",
                "Manage Third-Party API Keys"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{~p"/admin/dashboard"}\"]",
+               "a[href=\"#{~p"/admin/dashboard/home"}\"]",
                "View System Performance Dashboard"
              )
     end
@@ -239,13 +235,13 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}\"]",
+               "a[href=\"#{~p"/admin/users"}\"]",
                "Manage Students and Instructor Accounts"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}\"]",
+               "a[href=\"#{~p"/admin/authors"}\"]",
                "Manage Authoring Accounts"
              )
 
@@ -257,25 +253,25 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.invite_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/invite"}\"]",
                "Invite New Authors"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]",
+               "a[href=\"#{~p"/authoring/communities"}\"]",
                "Manage Communities"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
+               "a[href=\"#{~p"/admin/registrations"}\"]",
                "Manage LTI 1.3 Registrations"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]",
+               "a[href=\"#{~p"/admin/external_tools"}\"]",
                "Manage LTI 1.3 External Tools"
              )
     end
@@ -288,25 +284,25 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}\"]",
+               "a[href=\"#{~p"/authoring/projects"}\"]",
                "Browse all Projects"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}\"]",
+               "a[href=\"#{~p"/admin/products"}\"]",
                "Browse all Products"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}\"]",
+               "a[href=\"#{~p"/admin/sections"}\"]",
                "Browse all Course Sections"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}\"]",
+               "a[href=\"#{~p"/admin/ingest"}\"]",
                "Ingest Project"
              )
 
@@ -318,13 +314,13 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.brand_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/brands"}\"]",
                "Manage Branding"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}\"]",
+               "a[href=\"#{~p"/admin/publishers"}\"]",
                "Manage Publishers"
              )
     end
@@ -337,31 +333,31 @@ defmodule OliWeb.AdminLiveTest do
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/manage_activities"}\"]",
                "Manage Activities"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "a[href=\"#{~p"/admin/system_messages"}\"]",
                "Manage System Message Banner"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "a[href=\"#{~p"/admin/features"}\"]",
                "Feature Flags and Logging"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "a[href=\"#{~p"/admin/api_keys"}\"]",
                "Manage Third-Party API Keys"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{~p"/admin/dashboard"}\"]",
+               "a[href=\"#{~p"/admin/dashboard/home"}\"]",
                "View System Performance Dashboard "
              )
     end
@@ -383,13 +379,13 @@ defmodule OliWeb.AdminLiveTest do
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.UsersView)}\"]",
+               "a[href=\"#{~p"/admin/users"}\"]",
                "Manage Students and Instructor Accounts"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Users.AuthorsView)}\"]",
+               "a[href=\"#{~p"/admin/authors"}\"]",
                "Manage Authoring Accounts"
              )
 
@@ -401,25 +397,25 @@ defmodule OliWeb.AdminLiveTest do
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.invite_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/invite"}\"]",
                "Invite New Authors"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.CommunityLive.IndexView)}\"]",
+               "a[href=\"#{~p"/authoring/communities"}\"]",
                "Manage Communities"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.RegistrationsView)}\"]",
+               "a[href=\"#{~p"/admin/registrations"}\"]",
                "Manage LTI 1.3 Registrations"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.ExternalToolsView)}\"]",
+               "a[href=\"#{~p"/admin/external_tools"}\"]",
                "Manage LTI 1.3 External Tools"
              )
     end
@@ -432,25 +428,25 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Projects.ProjectsLive)}\"]",
+               "a[href=\"#{~p"/authoring/projects"}\"]",
                "Browse all Projects"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Products.ProductsView)}\"]",
+               "a[href=\"#{~p"/admin/products"}\"]",
                "Browse all Products"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.SectionsView)}\"]",
+               "a[href=\"#{~p"/admin/sections"}\"]",
                "Browse all Course Sections"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Admin.Ingest)}\"]",
+               "a[href=\"#{~p"/admin/ingest"}\"]",
                "Ingest Project"
              )
 
@@ -462,13 +458,13 @@ defmodule OliWeb.AdminLiveTest do
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.brand_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/brands"}\"]",
                "Manage Branding"
              )
 
       assert has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.PublisherLive.IndexView)}\"]",
+               "a[href=\"#{~p"/admin/publishers"}\"]",
                "Manage Publishers"
              )
     end
@@ -481,25 +477,25 @@ defmodule OliWeb.AdminLiveTest do
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.activity_manage_path(OliWeb.Endpoint, :index)}\"]",
+               "a[href=\"#{~p"/admin/manage_activities"}\"]",
                "Manage Activities"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.SystemMessageLive.IndexView)}\"]",
+               "a[href=\"#{~p"/admin/system_messages"}\"]",
                "Manage System Message Banner"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.Features.FeaturesLive)}\"]",
+               "a[href=\"#{~p"/admin/features"}\"]",
                "Feature Flags and Logging"
              )
 
       refute has_element?(
                view,
-               "a[href=\"#{Routes.live_path(OliWeb.Endpoint, OliWeb.ApiKeys.ApiKeysLive)}\"]",
+               "a[href=\"#{~p"/admin/api_keys"}\"]",
                "Manage Third-Party API Keys"
              )
 


### PR DESCRIPTION
[MER-4290](https://eliterate.atlassian.net/browse/MER-4290)

This PR adds a link to navigate to the view that will manage the `LTI 1.3 external tools` within the account management section of the admin panel. 

It also creates the view that will be used to manage the `LTI 1.3 external tools`.


https://github.com/user-attachments/assets/9551e062-dc2a-46f4-864e-37a5b4528e0b



[MER-4290]: https://eliterate.atlassian.net/browse/MER-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ