### PR TITLE
[BUG FIX] [MER-3990] Add Text Option to Slider Component

### DIFF
--- a/assets/src/components/parts/janus-text-slider/SliderTextAuthor.tsx
+++ b/assets/src/components/parts/janus-text-slider/SliderTextAuthor.tsx
@@ -34,7 +34,8 @@ const SliderTextAuthor: React.FC<AuthorPartComponentProps<SliderTextModel>> = (p
   useEffect(() => {
     if (!isEqual(prevSliderOptionLabelsRef.current?.length, sliderOptionLabels?.length)) {
       const modelClone = clone(model);
-      modelClone.maximum = sliderOptionLabels.length;
+      //The max range will be the total text items - 1.
+      modelClone.maximum = sliderOptionLabels?.length - 1;
       onSaveConfigure({ id, snapshot: modelClone });
       prevSliderOptionLabelsRef.current = sliderOptionLabels;
     }


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks


The issues here was the slider text is showing the same Max number as labels. The max value should be labels minus 1. (e.g., 5 labels, max is 4). 