### PR TITLE
[FEATURE] [MER-4290] Fix breadcrumb text in external tools liveview

### DIFF
--- a/lib/oli_web/live/admin/external_tools/external_tools_view.ex
+++ b/lib/oli_web/live/admin/external_tools/external_tools_view.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Admin.ExternalToolsView do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "LTI 1.3 External Tools",
+          full_title: "Manage LTI 1.3 External Tools",
           link: Routes.live_path(OliWeb.Endpoint, __MODULE__)
         })
       ]


### PR DESCRIPTION
[MER-4290](https://eliterate.atlassian.net/browse/MER-4290)

This PR fixes the breadcrumb text in the `Manage LTI 1.3 External Tools` view by changing it from the wrong text “LTI 1.3 External Tools” to the correct text “Manage LTI 1.3 External Tools”. 

![Captura de pantalla 2025-04-25 a la(s) 2 06 37 p  m](https://github.com/user-attachments/assets/ffd925b9-5d27-46c9-a626-c321770bd451)


[MER-4290]: https://eliterate.atlassian.net/browse/MER-4290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ