### PR TITLE
[BUG FIX] [MER-4547] More robust trigger type determination for ResponseMult

### DIFF
--- a/assets/src/components/activities/common/triggers/TriggerUtils.tsx
+++ b/assets/src/components/activities/common/triggers/TriggerUtils.tsx
@@ -17,9 +17,17 @@ export const getPossibleTriggers = (model: HasParts, partId: string): ActivityTr
 
   const triggers = [makeTrigger('correct_answer'), makeTrigger('incorrect_answer')];
   const hint_triggers = part.hints.filter(nonBlank).map((_h, i) => makeHintTrigger(i + 1));
-  const targeted_triggers = findTargetedResponses(model, partId).map((r: any) =>
-    makeTargetedTrigger(r.id),
-  );
+
+  let targeted_triggers = [] as ActivityTrigger[];
+
+  try {
+    targeted_triggers = findTargetedResponses(model, partId).map((r: any) =>
+      makeTargetedTrigger(r.id),
+    ) as ActivityTrigger[];
+  } catch (e) {
+    console.log(e);
+  }
+
   const explanation_triggers =
     part.explanation && nonBlank(part.explanation) ? [makeTrigger('explanation')] : [];
 


### PR DESCRIPTION
The ResponseMult activity type can break trigger type detection code - as when parts are linked there are then less parts than there are inputs. 

The change here is to catch the exception that `findTargetedResponses` throws in this case, and omit this activity instance from including targeted triggers. 