### PR TITLE
[BUG FIX] [MER-4548] Stop AI trigger tab from breaking ResponseMulti authoring

### DIFF
--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -1,4 +1,5 @@
 import { Maybe } from 'tsmonad';
+import { ruleIsCatchAll } from 'components/activities/response_multi/rules';
 import {
   ChoiceId,
   ChoiceIdsToResponseId,
@@ -84,11 +85,11 @@ export const getCorrectResponse = (model: HasParts, partId: string) => {
 export const getIncorrectResponse = (model: HasParts, partId: string) => {
   return Maybe.maybe(
     getResponsesByPartId(model, partId).find((r) => {
-      const rule: string = matchRule('.*');
-      const incorrectValue: string = ruleValue(rule);
-      const valueToCheck: string = ruleValue(r.rule);
-
-      return valueToCheck === incorrectValue;
+      return (
+        (r.rule === matchRule('.*') && r.score === 0) ||
+        // Allow for special rule form used by ResponseMulti
+        (r.rule.startsWith('input_ref') && ruleIsCatchAll(r.rule))
+      );
     }),
   ).valueOrThrow(new Error('Could not find incorrect response'));
 };

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -1,5 +1,5 @@
 import { Maybe } from 'tsmonad';
-import { ruleIsCatchAll } from 'components/activities/response_multi/rules';
+import * as MultiRule from 'components/activities/response_multi/rules';
 import {
   ChoiceId,
   ChoiceIdsToResponseId,
@@ -86,9 +86,10 @@ export const getIncorrectResponse = (model: HasParts, partId: string) => {
   return Maybe.maybe(
     getResponsesByPartId(model, partId).find((r) => {
       return (
-        (r.rule === matchRule('.*') && r.score === 0) ||
-        // Allow for special rule form used by ResponseMulti
-        (r.rule.startsWith('input_ref') && ruleIsCatchAll(r.rule))
+        r.score === 0 &&
+        (r.rule === matchRule('.*') ||
+          // Allow for special rule form used by ResponseMulti
+          (r.rule.startsWith('input_ref') && MultiRule.ruleIsCatchAll(r.rule)))
       );
     }),
   ).valueOrThrow(new Error('Could not find incorrect response'));


### PR DESCRIPTION
ReponseMulti authoring was crashing with an exception from `getIncorrectResponse` when AI triggers were in effect. A hotfix was implemented to avoid that error by catching and disabling targeted feedback triggers in this activity This PR fixes the underlying cause to prevent the exception from occurring at all.

The bug arose because the default incorrect (catchall) response for responseMulti's has rule of the form
`input_ref_136853124 like {.*} && (input_ref_1282200811 like {.*})`
but the generic `getIncorrectResponse` routine was not prepared for a rule with this structure. It looked only for a catchall rule of form ... like {.*} assuming one argument only and so failed to find responseMulti catchAlls rules. (More precisely, it used the `ruleValue` utility function to find the rule pattern. That extracts everything between the first { and last }, which is too much in case of a ResponseMulti rule like above)

This was OK because the generic `getIncorrectResponse` was NOT used within ResponseMulti authoring. That module uses a `ruleIsCatchAll` predicate that works on rules of the special form used there (called "MultiRules" in the code).

But the AI trigger authoring tab relies on functions using the generic routine while getting targeted feedback, invoked via another generic routine that expects to partition all responses into [correct, incorrect, targeted]. So in that case only it tripped the exception. 

This recodes `getIncorrectResponse` to work also on the case of responseMulti-form rules. 
