### PR TITLE
[BUG FIX] [MER-3586] Resizing window will cause component icons to not appear in Advanced Author

### DIFF
--- a/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
@@ -171,7 +171,9 @@ const AddComponentToolbar: React.FC<{
             delay={{ show: 150, hide: 150 }}
             overlay={
               <Tooltip id="button-tooltip" style={{ fontSize: '12px' }}>
-                Paste Component
+                <strong>{part.title}</strong>
+                <br />
+                <em>{part.description}</em>
               </Tooltip>
             }
           >

--- a/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
@@ -115,7 +115,7 @@ const AddComponentToolbar: React.FC<{
     setPartsMenuTarget(event.target);
   };
   const handlePartPasteClick = () => {
-    //When a part is pasted, offset the new part component by 20px from the original part
+    // When a part is pasted, offset the new part component by 20px from the original part
     const pasteOffset = 20;
     let newPartData = {
       id: `${copiedPart.type}-${guid()}`,


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

This is a follow-up issue that I found due to the changes made https://github.com/Simon-Initiative/oli-torus/pull/5572/files.