### PR TITLE
[ENHANCEMENT] [MER-4506] Switches aggregate student proficiency for content and objectives the using mode instead of average

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1322,7 +1322,8 @@ defmodule Oli.Delivery.Metrics do
   # Given a map of page data, and a list of ContainedPage records,
   # return a map of container ids where the keys are the container and the values are
   # the level of proficiency for that container.
-  # The proficiency is calculated by finding the mode, wi
+  # The proficiency is calculated by finding the mode where the highest number of
+  # users fall into a proficiency range for that container.
   defp bucket_into_container_mode(page_data, contained_pages) do
     contained_pages
     |> Enum.reduce(

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1342,27 +1342,16 @@ defmodule Oli.Delivery.Metrics do
               Map.get(page_data, page_id, %{})
               |> Enum.reduce(
                 Map.get(map, container_id, %{}),
-                fn {user_id,
-                    {num_first_attempts_correct, num_first_attempts, num_correct, num_attempts}},
-                   acc ->
-                  if Map.has_key?(acc, user_id) do
-                    {old_num_first_attempts_correct, old_num_first_attempts, old_num_correct,
-                     old_num_attempts} = Map.get(acc, user_id)
-
-                    Map.put(acc, user_id, {
-                      old_num_first_attempts_correct + num_first_attempts_correct,
-                      old_num_first_attempts + num_first_attempts,
-                      old_num_correct + num_correct,
-                      old_num_attempts + num_attempts
-                    })
-                  else
-                    Map.put(acc, user_id, {
-                      num_first_attempts_correct,
-                      num_first_attempts,
-                      num_correct,
-                      num_attempts
-                    })
-                  end
+                fn {user_id, stats}, acc ->
+                  Map.update(acc, user_id, stats, fn {old_correct, old_total, old_correct_all,
+                                                      old_total_all} ->
+                    {
+                      old_correct + elem(stats, 0),
+                      old_total + elem(stats, 1),
+                      old_correct_all + elem(stats, 2),
+                      old_total_all + elem(stats, 3)
+                    }
+                  end)
                 end
               )
 

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -123,20 +123,18 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
 
   defp custom_render(
          assigns,
-         %{section_id: section_id, resource_id: objective_id},
+         %{
+           resource_id: objective_id,
+           student_proficiency_obj_dist: student_proficiency_obj_dist
+         },
          %ColumnSpec{
            name: :student_proficiency_distribution
          }
        ) do
-    proficiency_distribution =
-      section_id
-      |> Oli.Delivery.Metrics.proficiency_per_student_for_objective(objective_id)
-      |> Enum.frequencies_by(fn {_student_id, proficiency} -> proficiency end)
-
     assigns =
       Map.merge(assigns, %{
         objective_id: objective_id,
-        proficiency_distribution: proficiency_distribution
+        proficiency_distribution: student_proficiency_obj_dist
       })
 
     ~H"""

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -383,14 +383,14 @@ defmodule OliWeb.DeliveryController do
       section ->
         contents =
           Sections.get_objectives_and_subobjectives(section)
-          |> Enum.map(
-            &%{
-              objective: &1.objective,
-              subojective: &1.subobjective,
-              student_proficiency_obj: &1.student_proficiency_obj,
-              student_proficiency_subobj: &1.student_proficiency_subobj
+          |> Enum.map(fn objective ->
+            %{
+              objective: objective.objective,
+              subobjective: objective.subobjective,
+              student_proficiency_obj: objective.student_proficiency_obj,
+              student_proficiency_subobj: objective.student_proficiency_subobj
             }
-          )
+          end)
           |> DataTable.new()
           |> DataTable.headers([
             :objective,

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -78,7 +78,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
       )
       |> assign_new(:objectives_tab, fn ->
         %{
-          objectives: Sections.get_objectives_and_subobjectives(socket.assigns.section),
+          objectives:
+            Sections.get_objectives_and_subobjectives(socket.assigns.section,
+              exclude_sub_objectives: true
+            ),
           filter_options:
             Sections.get_units_and_modules_from_a_section(socket.assigns.section.slug)
         }

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
           objectives:
             Sections.get_objectives_and_subobjectives(
               socket.assigns.section,
-              socket.assigns.student.id
+              student_id: socket.assigns.student.id
             ),
           filter_options:
             Sections.get_units_and_modules_from_a_section(socket.assigns.section.slug)

--- a/test/oli/analytics/summary/metrics_v2_test.exs
+++ b/test/oli/analytics/summary/metrics_v2_test.exs
@@ -125,7 +125,7 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
 
       results = Metrics.proficiency_per_container(section, contained_pages)
       assert Map.keys(results) |> Enum.count() == 2
-      assert %{2 => "Low", 3 => "Medium"} = results
+      assert %{2 => "Low", 3 => "High"} = results
 
       results = Metrics.proficiency_per_student_across(section)
       assert Map.keys(results) |> Enum.count() == 2

--- a/test/oli/analytics/summary/metrics_v2_test.exs
+++ b/test/oli/analytics/summary/metrics_v2_test.exs
@@ -234,16 +234,21 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
       ]
       |> Enum.each(fn v -> add_resource_summary(v) end)
 
-      proficiencies_objective1 = Metrics.proficiency_per_student_for_objective(section.id, id)
-      proficiencies_objective2 = Metrics.proficiency_per_student_for_objective(section.id, id2)
-      proficiencies_objective3 = Metrics.proficiency_per_student_for_objective(section.id, id3)
+      proficiencies_objective1 =
+        Map.get(Metrics.proficiency_per_student_for_objective(section.id, [id]), id)
 
-      assert proficiencies_objective1[user1.id] == "Low"
-      assert proficiencies_objective1[user2.id] == "Not enough data"
-      assert proficiencies_objective2[user1.id] == "Medium"
-      assert proficiencies_objective2[user2.id] == "Medium"
-      assert proficiencies_objective3[user1.id] == "High"
-      refute proficiencies_objective3[user2.id]
+      proficiencies_objective2 =
+        Map.get(Metrics.proficiency_per_student_for_objective(section.id, [id2]), id2)
+
+      proficiencies_objective3 =
+        Map.get(Metrics.proficiency_per_student_for_objective(section.id, [id3]), id3)
+
+      assert Map.get(proficiencies_objective1, user1.id) == "Low"
+      assert Map.get(proficiencies_objective1, user2.id) == "Not enough data"
+      assert Map.get(proficiencies_objective2, user1.id) == "Medium"
+      assert Map.get(proficiencies_objective2, user2.id) == "Medium"
+      assert Map.get(proficiencies_objective3, user1.id) == "High"
+      refute Map.get(proficiencies_objective3, user2.id)
     end
   end
 end


### PR DESCRIPTION
This PR updates aggregate student proficiency calculations for both content containers (Units, Modules) and Learning objectives to use the **mode**, meaning the proficiency category (Low, Medium, High, Not enough data) that describes the largest number of students. 

Refer to the ticket for details and examples. [MER-4506](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4506)


[MER-4506]: https://eliterate.atlassian.net/browse/MER-4506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ