### PR TITLE
[BUG FIX] [MER-4510] Fix Bypass Paywall logic

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -294,6 +294,9 @@ defmodule Oli.Delivery.Paywall do
       [] ->
         {:ok, amount}
 
+      [%Discount{bypass_paywall: true}] ->
+        {:ok, nil}
+
       [%Discount{type: :percentage, percentage: percentage}] ->
         {:ok, discount_amount} =
           amount

--- a/lib/oli/delivery/paywall/discount.ex
+++ b/lib/oli/delivery/paywall/discount.ex
@@ -9,6 +9,7 @@ defmodule Oli.Delivery.Paywall.Discount do
 
     field :percentage, :float
     field :amount, Money.Ecto.Map.Type
+    field :bypass_paywall, :boolean, default: false
 
     belongs_to :section, Oli.Delivery.Sections.Section
     belongs_to :institution, Oli.Institutions.Institution
@@ -23,6 +24,7 @@ defmodule Oli.Delivery.Paywall.Discount do
       :type,
       :percentage,
       :amount,
+      :bypass_paywall,
       :section_id,
       :institution_id
     ])
@@ -30,14 +32,47 @@ defmodule Oli.Delivery.Paywall.Discount do
     |> validate_required([:type, :institution_id])
     |> validate_required_if([:percentage], &is_percentage_type?/1)
     |> validate_required_if([:amount], &is_amount_type?/1)
-    |> validate_number_if(:percentage, &is_percentage_type?/1, 0, 100)
+    |> validate_number_if(:percentage, &is_percentage_type?/1, 0.1, 99.9)
+    |> validate_amount_if(:amount, &is_amount_type?/1, 1)
     |> unique_constraint([:section_id, :institution_id],
       name: :index_discount_section_institution
     )
     |> foreign_key_constraint(:institution_id)
   end
 
-  defp is_percentage_type?(changeset), do: get_field(changeset, :type) == :percentage
+  @doc """
+  Checks if the discount type is percentage, unless bypass_paywall is enabled,
+  in which case the validation is skipped.
+  """
+  @spec is_percentage_type?(Ecto.Changeset.t()) :: boolean()
+  def is_percentage_type?(changeset) do
+    if get_field(changeset, :bypass_paywall) do
+      false
+    else
+      get_field(changeset, :type) == :percentage
+    end
+  end
 
-  defp is_amount_type?(changeset), do: get_field(changeset, :type) == :fixed_amount
+  @doc """
+  Checks if the discount type is fixed amount, unless bypass_paywall is enabled,
+  in which case the validation is skipped.
+  """
+  @spec is_amount_type?(Ecto.Changeset.t()) :: boolean()
+  def is_amount_type?(changeset) do
+    if get_field(changeset, :bypass_paywall) do
+      false
+    else
+      get_field(changeset, :type) == :fixed_amount
+    end
+  end
+
+  defp validate_amount_if(changeset, field, condition, min) do
+    with true <- condition.(changeset),
+         amount = %Money{} <- get_field(changeset, field),
+         :lt <- Money.compare(amount, Money.new(:USD, min)) do
+      add_error(changeset, field, "must be greater than or equal to #{min}")
+    else
+      _ -> changeset
+    end
+  end
 end

--- a/lib/oli_web/live/products/payments/discounts/form.ex
+++ b/lib/oli_web/live/products/payments/discounts/form.ex
@@ -30,36 +30,46 @@ defmodule OliWeb.Products.Payments.Discounts.Form do
         </div>
       <% end %>
 
+      <% bypass_paywall? = @form[:bypass_paywall].value in [true, "true"] %>
+
       <div class="form-group">
         <.input
           type="select"
           field={@form[:type]}
           label="Type"
-          class="form-control"
+          class={"form-control #{if(bypass_paywall?, do: "cursor-not-allowed", else: "")}"}
           options={[Percentage: "percentage", "Fixed price": "fixed_amount"]}
         />
       </div>
 
       <div class="form-group">
+        <% price_disabled? =
+          @form[:type].value in [:percentage, "percentage"] or bypass_paywall? %>
         <.input
           field={@form[:amount]}
           label="Price"
-          class="form-control"
-          disabled={@form[:type].value in [:percentage, "percentage"]}
+          class={"form-control #{if(price_disabled?, do: "cursor-not-allowed", else: "")}"}
+          disabled={price_disabled?}
         />
       </div>
 
       <div class="form-group">
+        <% percentage_disabled? =
+          @form[:type].value in [:fixed_amount, "fixed_amount"] or bypass_paywall? %>
         <.input
           type="number"
           field={@form[:percentage]}
           label="Percentage"
-          class="form-control"
-          min={0}
-          max={100}
+          class={"form-control #{if(percentage_disabled?, do: "cursor-not-allowed", else: "")}"}
+          min={0.1}
+          max={99.9}
           step={0.1}
-          disabled={@form[:type].value in [:fixed_amount, "fixed_amount"]}
+          disabled={percentage_disabled?}
         />
+      </div>
+
+      <div class="form-group">
+        <.input field={@form[:bypass_paywall]} type="checkbox" label="Turn Off Paywall Entirely" />
       </div>
 
       <button type="submit" class="form-button btn btn-md btn-primary btn-block mt-3">Save</button>

--- a/lib/oli_web/live/products/payments/discounts/show_view.ex
+++ b/lib/oli_web/live/products/payments/discounts/show_view.ex
@@ -173,7 +173,8 @@ defmodule OliWeb.Products.Payments.Discounts.ShowView do
         ),
       percentage: params["percentage"],
       amount: params["amount"],
-      type: params["type"]
+      type: params["type"],
+      bypass_paywall: params["bypass_paywall"] == "true"
     }
 
     case Paywall.create_or_update_discount(attrs) do
@@ -217,9 +218,18 @@ defmodule OliWeb.Products.Payments.Discounts.ShowView do
       params
       |> Map.put(
         "percentage",
-        if(params["type"] == "percentage", do: params["percentage"], else: nil)
+        if(params["type"] == "percentage" and params["bypass_paywall"] != "true",
+          do: params["percentage"],
+          else: nil
+        )
       )
-      |> Map.put("amount", if(params["type"] == "fixed_amount", do: params["amount"], else: nil))
+      |> Map.put(
+        "amount",
+        if(params["type"] == "fixed_amount" and params["bypass_paywall"] != "true",
+          do: params["amount"],
+          else: nil
+        )
+      )
 
     {:noreply,
      assign(socket,

--- a/lib/oli_web/live/products/payments/discounts/table_model.ex
+++ b/lib/oli_web/live/products/payments/discounts/table_model.ex
@@ -25,6 +25,11 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
           sort_fn: &__MODULE__.sort_value_column/2
         },
         %ColumnSpec{
+          name: :bypass_paywall,
+          label: "Paywall Turned Off",
+          render_fn: &__MODULE__.render_bypass_paywall_column/3
+        },
+        %ColumnSpec{
           name: :inserted_at,
           label: "Created",
           render_fn: &OliWeb.Common.Table.Common.render_date/3
@@ -42,6 +47,9 @@ defmodule OliWeb.Products.Payments.Discounts.TableModel do
       }
     )
   end
+
+  def render_bypass_paywall_column(_assigns, %{bypass_paywall: true}, _), do: "Yes"
+  def render_bypass_paywall_column(_assigns, _, _), do: "No"
 
   def render_institution_column(_assigns, item, _), do: item.institution.name
 

--- a/priv/repo/migrations/20250428165356_add_bypass_paywall_field_to_discounts.exs
+++ b/priv/repo/migrations/20250428165356_add_bypass_paywall_field_to_discounts.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddBypassPaywallFieldToDiscounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:discounts) do
+      add(:bypass_paywall, :boolean, default: false)
+    end
+  end
+end

--- a/test/oli/delivery/paywall/discount_test.exs
+++ b/test/oli/delivery/paywall/discount_test.exs
@@ -1,0 +1,103 @@
+defmodule Oli.Delivery.Paywall.DiscountTest do
+  use Oli.DataCase, async: true
+
+  alias Oli.Delivery.Paywall.Discount
+
+  import Oli.Factory
+
+  describe "Discount changeset validations" do
+    setup do
+      institution = insert(:institution)
+      {:ok, institution: institution}
+    end
+
+    test "valid percentage discount", %{institution: institution} do
+      attrs = %{
+        type: :percentage,
+        percentage: 10.0,
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "percentage discount fails if percentage is missing", %{institution: institution} do
+      attrs = %{
+        type: :percentage,
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      refute changeset.valid?
+      assert %{percentage: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "percentage discount fails if percentage is out of range", %{institution: institution} do
+      attrs = %{
+        type: :percentage,
+        percentage: 0.05,
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      refute changeset.valid?
+      assert %{percentage: ["must be greater than or equal to 0.1"]} = errors_on(changeset)
+    end
+
+    test "valid fixed amount discount", %{institution: institution} do
+      attrs = %{
+        type: :fixed_amount,
+        amount: Money.new(:USD, 20),
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "fixed amount discount fails if amount is missing", %{institution: institution} do
+      attrs = %{
+        type: :fixed_amount,
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      refute changeset.valid?
+      assert %{amount: ["can't be blank"]} = errors_on(changeset)
+    end
+
+    test "fixed amount discount fails if amount is too small", %{institution: institution} do
+      attrs = %{
+        type: :fixed_amount,
+        amount: Money.new(:USD, 0.5),
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      refute changeset.valid?
+      assert %{amount: ["is invalid"]} = errors_on(changeset)
+    end
+
+    test "bypass_paywall disables type-specific validations", %{institution: institution} do
+      attrs = %{
+        bypass_paywall: true,
+        institution_id: institution.id
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      assert changeset.valid?
+    end
+
+    test "requires institution_id" do
+      attrs = %{
+        type: :percentage,
+        percentage: 10.0
+      }
+
+      changeset = Discount.changeset(%Discount{}, attrs)
+      refute changeset.valid?
+      assert %{institution_id: ["can't be blank"]} = errors_on(changeset)
+    end
+  end
+end

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -430,6 +430,22 @@ defmodule Oli.Delivery.PaywallTest do
       assert {:ok, Money.new(:USD, 80)} == Paywall.section_cost_from_product(paid, institution)
     end
 
+    test "section_cost_from_product/2 returns nil amount when paywall is bypassed",
+         %{
+           paid: paid,
+           institution: institution
+         } do
+      {:ok, _} =
+        Paywall.create_discount(%{
+          institution_id: institution.id,
+          section_id: nil,
+          type: :fixed_amount,
+          bypass_paywall: true
+        })
+
+      assert {:ok, nil} == Paywall.section_cost_from_product(paid, institution)
+    end
+
     percentage_discounts = [
       %{discount: 50, expected: 50},
       %{discount: 20, expected: 80},


### PR DESCRIPTION
[MER-4510](https://eliterate.atlassian.net/browse/MER-4510)

This PR fixes the case when an admin or instructor wants to give students a 100% discount (meaning $0 cost) for a given product or institution. A new field is added to the `discounts` table and the "Create Discounts" form.

**Before:** 

https://github.com/user-attachments/assets/b3b55908-a838-4024-979f-f885d57a4d8c

**After:**


https://github.com/user-attachments/assets/e7045505-7370-4cfe-be6b-b17a25737db7

NOTE:
I added to our tech debt list that we need to add tests for the Paywall and Discounts integrated logic (there are no test files for this flow) and for the section creation logic (create from product and project). Since this is a bug that needs to be addressed ASAP, I didn't add those test cases in this PR.


[MER-4510]: https://eliterate.atlassian.net/browse/MER-4510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ