### PR TITLE
[BUG FIX] [MER-4551] Cannot add activity to bank

### DIFF
--- a/assets/src/apps/bank/CreateActivity.tsx
+++ b/assets/src/apps/bank/CreateActivity.tsx
@@ -27,7 +27,7 @@ const create = (
   allowTriggers: boolean,
 ) => {
   let model: any;
-  invokeCreationFunc(editorDesc.slug, {} as any)
+  invokeCreationFunc(editorDesc.authoringElement, {} as any)
     .then((createdModel) => {
       model = createdModel;
       return Persistence.createBanked(projectSlug, editorDesc.slug, createdModel, []);
@@ -130,7 +130,9 @@ const createBulk = async (
   for (const data of bulkImportData) {
     const editorDesc = editorForData(data, editorMap);
     if (editorDesc) {
-      const model = await invokeCreationFunc(editorDesc.slug, { creationData: data } as any)
+      const model = await invokeCreationFunc(editorDesc.authoringElement, {
+        creationData: data,
+      } as any)
         .then((createdModel) => {
           return createdModel;
         })
@@ -211,7 +213,7 @@ export const CreateActivity = (props: CreateActivityProps) => {
         onClick={handleAdd.bind(this, editorDesc)}
         className="dropdown-item"
         href="#"
-        key={editorDesc.slug}
+        key={editorDesc.authoringElement}
       >
         {editorDesc.friendlyName}
       </a>

--- a/assets/src/components/activities/creation.ts
+++ b/assets/src/components/activities/creation.ts
@@ -24,16 +24,16 @@ export function registerCreationFunc(manifest: Manifest, fn: creationFn) {
 }
 
 export function invokeCreationFunc(
-  id: string,
+  authoringElement: string,
   context: ResourceContext,
 ): Promise<ActivityModelSchema> {
   if (window.oliCreationFuncs !== undefined) {
-    const fn = window.oliCreationFuncs[id];
+    const fn = window.oliCreationFuncs[authoringElement];
     if (typeof fn === 'function') {
       return fn.apply(undefined, [context]);
     }
   }
-  return Promise.reject('could not invoke creation function for ' + id);
+  return Promise.reject('could not invoke creation function for ' + authoringElement);
 }
 
 declare global {


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4551

This PR fixes an issue where authors cannot add activities to the activity bank. The issue was caused by a change made in LTI external tools groundwork which modified the invokeCreationFunc to register activities using their authoringElement, instead of activity slug, in order to support multiple registered activities under the same authoring element (for LTI activities).

The fix here is to update activity bank to use authoringElement for the key in invokeCreationFunc.