### PR TITLE
[FEATURE] [MER-4469] Track LTI activities

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -660,7 +660,21 @@ defmodule Oli.Authoring.Editing.PageEditor do
 
   # Applies the update to the revision
   defp update_revision({revision, activity_revisions}, update, _) do
-    {:ok, updated} = Oli.Resources.update_revision(revision, update)
+    # Extract activity references from content if present
+    update_with_activity_refs =
+      case Map.get(update, "content") do
+        nil ->
+          update
+
+        content ->
+          activity_ids =
+            Oli.Authoring.Editing.Utils.activity_references(content)
+            |> MapSet.to_list()
+
+          Map.put(update, "activity_refs", activity_ids)
+      end
+
+    {:ok, updated} = Oli.Resources.update_revision(revision, update_with_activity_refs)
     {updated, activity_revisions}
   end
 end

--- a/lib/oli/resources.ex
+++ b/lib/oli/resources.ex
@@ -347,7 +347,8 @@ defmodule Oli.Resources do
           collab_space_config: previous_revision.collab_space_config,
           purpose: previous_revision.purpose,
           relates_to: previous_revision.relates_to,
-          full_progress_pct: previous_revision.full_progress_pct
+          full_progress_pct: previous_revision.full_progress_pct,
+          activity_refs: previous_revision.activity_refs
         },
         convert_strings_to_atoms(attrs)
       )

--- a/lib/oli/resources/revision.ex
+++ b/lib/oli/resources/revision.ex
@@ -25,7 +25,8 @@ defmodule Oli.Resources.Revision do
              :poster_image,
              :intro_content,
              :duration_minutes,
-             :id
+             :id,
+             :activity_refs
            ]}
   schema "revisions" do
     #
@@ -47,6 +48,7 @@ defmodule Oli.Resources.Revision do
     field :content, :map, default: %{}
     field :children, {:array, :id}, default: []
     field :tags, {:array, :id}, default: []
+    field :activity_refs, {:array, :id}, default: []
     field :objectives, :map, default: %{}
     field :graded, :boolean, default: false
     field :duration_minutes, :integer, default: nil
@@ -129,7 +131,8 @@ defmodule Oli.Resources.Revision do
       :activity_type_id,
       :purpose,
       :relates_to,
-      :full_progress_pct
+      :full_progress_pct,
+      :activity_refs
     ])
     |> cast_embed(:legacy)
     |> cast_embed(:explanation_strategy)

--- a/priv/repo/migrations/20250428195108_add_activity_refs_to_revisions.exs
+++ b/priv/repo/migrations/20250428195108_add_activity_refs_to_revisions.exs
@@ -1,0 +1,9 @@
+defmodule Oli.Repo.Migrations.AddActivityRefsToRevisions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:revisions) do
+      add :activity_refs, {:array, :id}, default: [], null: false
+    end
+  end
+end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -2140,4 +2140,169 @@ defmodule Oli.SectionsTest do
       refute Sections.get_latest_visited_page(section.slug, student.id)
     end
   end
+
+  describe "get_section_resources_with_lti_activities/1" do
+    setup do
+      section = insert(:section)
+
+      lti_deployment = insert(:lti_external_tool_activity_deployment)
+
+      activity_registration =
+        insert(:activity_registration,
+          lti_external_tool_activity_deployment: lti_deployment
+        )
+
+      lti_activity_revision =
+        insert(:revision,
+          activity_type_id: activity_registration.id
+        )
+
+      lti_activity_resource = lti_activity_revision.resource
+
+      lti_section_resource =
+        insert(:section_resource,
+          section: section,
+          resource_id: lti_activity_resource.id,
+          revision_id: lti_activity_revision.id
+        )
+
+      page_revision =
+        insert(:revision,
+          resource_type_id: ResourceType.id_for_page(),
+          activity_refs: [lti_activity_resource.id]
+        )
+
+      page_section_resource =
+        insert(:section_resource,
+          section: section,
+          resource_id: page_revision.resource_id,
+          revision_id: page_revision.id
+        )
+
+      %{
+        section: section,
+        lti_activity_resource: lti_activity_resource,
+        lti_section_resource: lti_section_resource,
+        page_section_resource: page_section_resource
+      }
+    end
+
+    test "returns empty map when section has no LTI activities" do
+      empty_section = insert(:section)
+
+      result = Sections.get_section_resources_with_lti_activities(empty_section)
+
+      assert result == %{}
+    end
+
+    test "returns map of LTI activity IDs to section resources", %{
+      section: section,
+      lti_activity_resource: lti_activity_resource,
+      page_section_resource: page_section_resource
+    } do
+      result = Sections.get_section_resources_with_lti_activities(section)
+
+      assert is_map(result)
+      assert map_size(result) == 1
+      assert Map.has_key?(result, lti_activity_resource.id)
+
+      section_resources = result[lti_activity_resource.id]
+      assert is_list(section_resources)
+      assert length(section_resources) == 1
+      assert hd(section_resources).id == page_section_resource.id
+    end
+
+    test "handles multiple pages referencing the same LTI activity", %{
+      section: section,
+      lti_activity_resource: lti_activity_resource
+    } do
+      another_page_revision =
+        insert(:revision,
+          resource_type_id: ResourceType.id_for_page(),
+          activity_refs: [lti_activity_resource.id]
+        )
+
+      another_page_section_resource =
+        insert(:section_resource,
+          section: section,
+          resource_id: another_page_revision.resource_id,
+          revision_id: another_page_revision.id
+        )
+
+      result = Sections.get_section_resources_with_lti_activities(section)
+
+      section_resources = result[lti_activity_resource.id]
+      assert length(section_resources) == 2
+
+      section_resource_ids = Enum.map(section_resources, & &1.id)
+      assert Enum.member?(section_resource_ids, another_page_section_resource.id)
+    end
+
+    test "handles multiple LTI activities referenced by pages", %{
+      section: section
+    } do
+      lti_deployment2 = insert(:lti_external_tool_activity_deployment)
+
+      activity_registration2 =
+        insert(:activity_registration,
+          lti_external_tool_activity_deployment: lti_deployment2
+        )
+
+      lti_activity_revision2 =
+        insert(:revision,
+          activity_type_id: activity_registration2.id
+        )
+
+      lti_activity_resource2 = lti_activity_revision2.resource
+
+      insert(:section_resource,
+        section: section,
+        resource_id: lti_activity_resource2.id,
+        revision_id: lti_activity_revision2.id
+      )
+
+      page_revision =
+        insert(:revision,
+          resource_type_id: ResourceType.id_for_page(),
+          activity_refs: [lti_activity_resource2.id]
+        )
+
+      page_section_resource =
+        insert(:section_resource,
+          section: section,
+          resource_id: page_revision.resource_id,
+          revision_id: page_revision.id
+        )
+
+      result = Sections.get_section_resources_with_lti_activities(section)
+
+      assert map_size(result) == 2
+      assert Map.has_key?(result, lti_activity_resource2.id)
+
+      section_resources = result[lti_activity_resource2.id]
+      assert length(section_resources) == 1
+      assert hd(section_resources).id == page_section_resource.id
+    end
+
+    test "ignores pages that don't reference LTI activities", %{
+      section: section
+    } do
+      page_revision =
+        insert(:revision,
+          resource_type_id: ResourceType.id_for_page(),
+          activity_refs: []
+        )
+
+      insert(:section_resource,
+        section: section,
+        resource_id: page_revision.resource_id,
+        revision_id: page_revision.id
+      )
+
+      result = Sections.get_section_resources_with_lti_activities(section)
+
+      assert is_map(result)
+      assert map_size(result) == 1
+    end
+  end
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -167,6 +167,7 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "a", product_2.title)
     end
 
+    @tag :flaky
     test "applies sorting by creation date", %{conn: conn, product: product} do
       product_2 =
         insert(:section,

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -724,7 +724,7 @@ defmodule Oli.Factory do
 
   def platform_instance_factory() do
     %Lti_1p3.DataProviders.EctoProvider.PlatformInstance{
-      id: System.unique_integer([:positive])
+      id: System.unique_integer([:positive]),
       name: sequence("Platform Instance"),
       description: sequence("Platform Instance Description"),
       client_id: sequence("client_id"),
@@ -740,7 +740,7 @@ defmodule Oli.Factory do
     %Oli.Lti.PlatformExternalTools.LtiExternalToolActivityDeployment{
       deployment_id: Ecto.UUID.generate(),
       activity_registration: build(:activity_registration),
-      platform_instance: build(:platform_instance)
+      platform_instance: build(:platform_instance),
       status: :enabled
     }
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -704,6 +704,39 @@ defmodule Oli.Factory do
     }
   end
 
+  def activity_registration_factory() do
+    %Oli.Activities.ActivityRegistration{
+      slug: sequence("exampleactivityregistration"),
+      authoring_script: "<script>authoring</script>",
+      delivery_script: "<script>delivery</script>",
+      description: "Sample activity description",
+      authoring_element: "AuthoringElement",
+      delivery_element: "DeliveryElement",
+      icon: "icon.png",
+      title: "Sample Activity",
+      petite_label: "Sample",
+      allow_client_evaluation: false,
+      globally_available: true,
+      globally_visible: true,
+      variables: [],
+      generates_report: false
+    }
+  end
+
+  def platform_instance_factory() do
+    %Lti_1p3.DataProviders.EctoProvider.PlatformInstance{
+      id: System.unique_integer([:positive])
+    }
+  end
+
+  def lti_external_tool_activity_deployment_factory() do
+    %Oli.Lti.PlatformExternalTools.LtiExternalToolActivityDeployment{
+      deployment_id: Ecto.UUID.generate(),
+      activity_registration: build(:activity_registration),
+      platform_instance: build(:platform_instance)
+    }
+  end
+
   # HELPERS
 
   defp anonymous_build(entity_name, attrs \\ %{}),


### PR DESCRIPTION
## Add support for tracking activity references in pages and querying LTI usage by section
- Added `activity_refs` array field to the revisions table to track the list of activity resource IDs referenced within a page.

- Updated the `PageEditor` logic to recompute and persist the `activity_refs` field on every page edit.

- Implemented `Oli.Delivery.Sections.get_section_resources_with_lti_activities/1` which:
  - Accepts a course section
  - Identifies all LTI activities in the section via the activity_registrations table.
  - Locates all pages (via section resources) whose activity_refs include any of the LTI activity resource IDs.
  - Returns results grouped by activity resource ID.


See: https://eliterate.atlassian.net/browse/MER-4469