### PR TITLE
[ENHANCEMENT] [MER-4506] Updates aggregates mode calculation to include all students

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1328,9 +1328,7 @@ defmodule Oli.Delivery.Metrics do
   # users fall into a proficiency range for that container.
   defp bucket_into_container_mode(page_data, contained_pages, section_slug) do
     student_ids =
-      Sections.enrolled_students(section_slug)
-      |> Enum.reject(fn s -> s.user_role_id != 4 end)
-      |> Enum.map(fn s -> s.id end)
+      Sections.enrolled_student_ids(section_slug)
 
     contained_pages
     |> Enum.reduce(

--- a/test/oli/analytics/summary/metrics_v2_test.exs
+++ b/test/oli/analytics/summary/metrics_v2_test.exs
@@ -125,7 +125,7 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
 
       results = Metrics.proficiency_per_container(section, contained_pages)
       assert Map.keys(results) |> Enum.count() == 2
-      assert %{2 => "Low", 3 => "High"} = results
+      assert %{2 => "Low", 3 => "Medium"} = results
 
       results = Metrics.proficiency_per_student_across(section)
       assert Map.keys(results) |> Enum.count() == 2


### PR DESCRIPTION
This PR updates the insights in the content and objectives table to account for users who have not yet interacted with the content. It also ensures that, where there is more than one mode, the displayed value should be the highest value according to this hierarchy:

1. Low
2. Medium
3. High
4. Not enough information