### PR TITLE
[BUG FIX] [MER-4562] Refactor Mount.for to use auth socket assigns instead of session ids

### DIFF
--- a/lib/oli_web/common/session_context.ex
+++ b/lib/oli_web/common/session_context.ex
@@ -98,4 +98,39 @@ defmodule OliWeb.Common.SessionContext do
       is_liveview: true
     }
   end
+
+  @doc """
+  Returns the current author from the session context.
+  """
+  def get_author(%__MODULE__{author: author}) do
+    author
+  end
+
+  @doc """
+  Returns the current user from the session context.
+  """
+  def get_user(%__MODULE__{user: user}) do
+    user
+  end
+
+  @doc """
+  Returns the browser timezone from the session context.
+  """
+  def get_browser_timezone(%__MODULE__{browser_timezone: browser_timezone}) do
+    browser_timezone
+  end
+
+  @doc """
+  Returns the local timezone from the session context.
+  """
+  def get_local_tz(%__MODULE__{local_tz: local_tz}) do
+    local_tz
+  end
+
+  @doc """
+  Returns true if the current session context is in a LiveView, false otherwise.
+  """
+  def is_liveview?(%__MODULE__{is_liveview: is_liveview}) do
+    is_liveview
+  end
 end

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -29,8 +29,8 @@ defmodule OliWeb.Attempt.AttemptLive do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug, "attempt_guid" => attempt_guid}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug, "attempt_guid" => attempt_guid}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -15,27 +15,29 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
   alias OliWeb.Common.Params
   alias OliWeb.Sections.Mount
 
+  on_mount {OliWeb.AuthorAuth, :mount_current_author}
+  on_mount {OliWeb.UserAuth, :mount_current_user}
   on_mount OliWeb.LiveSessionPlugs.SetCtx
   on_mount OliWeb.LiveSessionPlugs.SetRouteName
   on_mount OliWeb.LiveSessionPlugs.SetUri
 
-  def mount(params, session, socket) do
+  def mount(params, _session, socket) do
     slug = params["product_id"] || params["section_slug"]
     socket = assigns_for(socket, :page)
 
-    case Mount.for(slug, session) do
+    case Mount.for(slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 
       {_, _, section} ->
         certificate = Certificates.get_certificate_by(%{section_id: section.id})
 
-        socket
-        |> assign(section: section)
-        |> assign(section_changeset: Section.changeset(section))
-        |> assign(certificate: certificate)
+        {:ok,
+         socket
+         |> assign(section: section)
+         |> assign(section_changeset: Section.changeset(section))
+         |> assign(certificate: certificate)}
     end
-    |> ok_wrapper()
   end
 
   def handle_params(params, url, socket) do

--- a/lib/oli_web/live/collaboration_live/index_view.ex
+++ b/lib/oli_web/live/collaboration_live/index_view.ex
@@ -38,11 +38,11 @@ defmodule OliWeb.CollaborationLive.IndexView do
       ]
   end
 
-  def mount(params, session, socket) do
+  def mount(params, _session, socket) do
     ctx = socket.assigns.ctx
     section_slug = params["section_slug"]
 
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/initial_assigns.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InitialAssigns do
   end
 
   def on_mount(:default, %{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, error} ->
         {:halt, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, error))}
 

--- a/lib/oli_web/live/delivery/manage_source_materials.ex
+++ b/lib/oli_web/live/delivery/manage_source_materials.ex
@@ -39,7 +39,7 @@ defmodule OliWeb.Delivery.ManageSourceMaterials do
         _ -> Map.get(params, "section_slug")
       end
 
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/initial_assigns.ex
@@ -24,7 +24,7 @@ defmodule OliWeb.Delivery.StudentDashboard.InitialAssigns do
         session,
         socket
       ) do
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, error} ->
         {:halt, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, error))}
 

--- a/lib/oli_web/live/grades/browse_updates_view.ex
+++ b/lib/oli_web/live/grades/browse_updates_view.ex
@@ -38,8 +38,8 @@ defmodule OliWeb.Grades.BrowseUpdatesView do
     }
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/grades/failed_grade_sync.ex
+++ b/lib/oli_web/live/grades/failed_grade_sync.ex
@@ -44,8 +44,8 @@ defmodule OliWeb.Grades.FailedGradeSyncLive do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -21,8 +21,8 @@ defmodule OliWeb.Grades.GradebookView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/grades/grades.ex
+++ b/lib/oli_web/live/grades/grades.ex
@@ -28,8 +28,8 @@ defmodule OliWeb.Grades.GradesLive do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/grades/observe_grade_updates.ex
+++ b/lib/oli_web/live/grades/observe_grade_updates.ex
@@ -27,8 +27,8 @@ defmodule OliWeb.Grades.ObserveGradeUpdatesView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -62,8 +62,8 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -28,10 +28,10 @@ defmodule OliWeb.Products.DetailsView do
 
   def mount(
         %{"product_id" => product_slug},
-        session,
+        _session,
         socket
       ) do
-    case Mount.for(product_slug, session) do
+    case Mount.for(product_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/progress/student_resource_view.ex
+++ b/lib/oli_web/live/progress/student_resource_view.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Progress.StudentResourceView do
 
   def mount(
         %{"section_slug" => section_slug, "user_id" => user_id, "resource_id" => resource_id},
-        session,
+        _session,
         socket
       ) do
     case get_user_and_revision(section_slug, user_id, resource_id) do
@@ -36,7 +36,7 @@ defmodule OliWeb.Progress.StudentResourceView do
         Mount.handle_error(socket, {:error, e})
 
       {:ok, user, revision} ->
-        case Mount.for(section_slug, session) do
+        case Mount.for(section_slug, socket) do
           {:error, e} ->
             Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/progress/student_view.ex
+++ b/lib/oli_web/live/progress/student_view.ex
@@ -28,7 +28,7 @@ defmodule OliWeb.Progress.StudentView do
 
   def mount(
         %{"section_slug" => section_slug, "user_id" => user_id},
-        session,
+        _session,
         socket
       ) do
     case get_user(user_id) do
@@ -38,7 +38,7 @@ defmodule OliWeb.Progress.StudentView do
       {:ok, user} ->
         ctx = socket.assigns.ctx
 
-        case Mount.for(section_slug, session) do
+        case Mount.for(section_slug, socket) do
           {:error, e} ->
             Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -9,8 +9,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   alias OliWeb.Sections.Mount
 
   @impl true
-  def mount(%{"section_slug" => section_slug} = _params, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug} = _params, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, error} ->
         {:ok, redirect(socket, to: Routes.static_page_path(OliWeb.Endpoint, error))}
 

--- a/lib/oli_web/live/sections/assistant/student_conversations.ex
+++ b/lib/oli_web/live/sections/assistant/student_conversations.ex
@@ -39,9 +39,9 @@ defmodule OliWeb.Sections.Assistant.StudentConversationsLive do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
     # only allow admins to access this page for now
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -36,8 +36,8 @@ defmodule OliWeb.Sections.EditView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
 
   def mount(
         %{"section_slug" => section_slug} = params,
-        session,
+        _session,
         socket
       ) do
     {parent_gate, title} =
@@ -98,7 +98,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
           {Gating.get_gating_condition!(int_id), "Student Exceptions"}
       end
 
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -9,10 +9,10 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
 
   def mount(
         %{"id" => gating_condition_id, "section_slug" => section_slug},
-        session,
+        _session,
         socket
       ) do
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -8,10 +8,10 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
 
   def mount(
         %{"section_slug" => section_slug} = params,
-        session,
+        _session,
         socket
       ) do
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/invite_view.ex
+++ b/lib/oli_web/live/sections/invite_view.ex
@@ -24,8 +24,8 @@ defmodule OliWeb.Sections.InviteView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -48,7 +48,7 @@ defmodule OliWeb.Sections.OverviewView do
         _ -> Map.get(params, "section_slug")
       end
 
-    case Mount.for(section_slug, session) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -20,8 +20,8 @@ defmodule OliWeb.Sections.ScheduleView do
       ]
   end
 
-  def mount(%{"section_slug" => section_slug}, session, socket) do
-    case Mount.for(section_slug, session) do
+  def mount(%{"section_slug" => section_slug}, _session, socket) do
+    case Mount.for(section_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 

--- a/lib/oli_web/live/workspaces/course_author/products/details_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products/details_live.ex
@@ -23,8 +23,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
   on_mount {OliWeb.AuthorAuth, :ensure_authenticated}
   on_mount OliWeb.LiveSessionPlugs.SetCtx
 
-  def mount(%{"product_id" => product_slug}, session, socket) do
-    case Mount.for(product_slug, session) do
+  def mount(%{"product_id" => product_slug}, _session, socket) do
+    case Mount.for(product_slug, socket) do
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4562

Fixes the root cause of an issue identified during smoke testing where deleting an author who was logged in would crash liveviews being accessed by instructor if that author session was still also active. In general, this `Mount.for` module used by a number of LiveViews was not pulled forward as part of the phx.gen.auth migration to use socket assigns for current author/user and instead relied on the session ids to load these users itself.

By using the assigns in the socket set by the new auth mount plugs, we can have a single source of truth for user sessions and these records only need to be loaded and preloaded a single time for a request. This PR updates this module to use the already loaded assigns instead of trying to re-load the users from the session id.