### PR TITLE
[FEATURE] [MER-4292] Fix success icon color - rework

### DIFF
--- a/lib/oli_web/live/admin/external_tools/new_external_tool_view.ex
+++ b/lib/oli_web/live/admin/external_tools/new_external_tool_view.ex
@@ -227,7 +227,7 @@ defmodule OliWeb.Admin.ExternalTools.NewExternalToolView do
         <div class="flex items-center gap-2 font-semibold">
           <%= case @type do %>
             <% :success -> %>
-              <Icons.check stroke_class={"stroke-[#{@text_color}]"} />
+              <Icons.check stroke_class="stroke-[#1b67b2]" />
             <% t when t in [:error, :duplicate] -> %>
               <Icons.alert />
           <% end %>


### PR DESCRIPTION
[MER-4292](https://eliterate.atlassian.net/browse/MER-4292)

This PR fixes the color of the success flash message icon


https://github.com/user-attachments/assets/bf7bd402-9d7d-421d-91e2-403c102ac7c5



[MER-4292]: https://eliterate.atlassian.net/browse/MER-4292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ