### PR TITLE
[FEATURE] [MER-4275] Update student exceptions late policy

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -560,29 +560,6 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
       {:password, user_id, new_value} ->
         do_update(:password, user_id, new_value, socket)
 
-      {:late_submit, user_id, :allow} ->
-        result =
-          Repo.transaction(fn ->
-            AutoSubmitCustodian.cancel(
-              socket.assigns.section.id,
-              socket.assigns.params.selected_assessment_id,
-              user_id
-            )
-
-            do_update(:late_submit, user_id, :allow, socket)
-          end)
-
-        case result do
-          {:ok, return} ->
-            return
-
-          {:error, _} ->
-            {:noreply,
-             socket
-             |> flash_to_liveview(:error, "ERROR: Student Exception could not be updated")
-             |> assign(modal_assigns: %{show: false})}
-        end
-
       {key, user_id, new_value} when new_value != "" ->
         do_update(key, user_id, new_value, socket)
 
@@ -888,8 +865,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
             :available_date,
             :max_attempts,
             :time_limit,
-            :late_submit,
-            :late_start,
+            :late_policy,
             :scoring,
             :grace_period,
             :retake_mode,
@@ -906,11 +882,17 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   end
 
   defp do_update(key, user_id, new_value, socket) do
+    changes =
+      case key do
+        :late_policy -> determine_late_policy(new_value)
+        _ -> Map.new([{key, new_value}])
+      end
+
     Delivery.get_delivery_setting_by(%{
       resource_id: socket.assigns.params.selected_assessment_id,
       user_id: user_id
     })
-    |> StudentException.changeset(Map.new([{key, new_value}]))
+    |> StudentException.changeset(changes)
     |> Repo.update()
     |> case do
       {:error, _changeset} ->
@@ -958,6 +940,17 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
         Enum.sort_by(
           student_exceptions,
           fn se -> if se.scheduling_type == :due_by, do: se.end_date, else: nil end,
+          sort_order
+        )
+
+      :late_policy ->
+        Enum.sort_by(
+          student_exceptions,
+          fn
+            %{late_start: :allow, late_submit: :allow} -> 1
+            %{late_start: :disallow, late_submit: :allow} -> 2
+            %{late_start: :disallow, late_submit: :disallow} -> 3
+          end,
           sort_order
         )
 
@@ -1042,8 +1035,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
       case {key, Map.get(params, target_str)} do
         {key, value}
         when key in [
-               "late_submit",
-               "late_start",
+               "late_policy",
                "retake_mode",
                "assessment_mode",
                "feedback_mode",
@@ -1069,4 +1061,13 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
     send(self(), {:flash_message, type, message})
     socket
   end
+
+  defp determine_late_policy(:allow_late_start_and_late_submit),
+    do: %{late_start: :allow, late_submit: :allow}
+
+  defp determine_late_policy(:allow_late_submit_but_not_late_start),
+    do: %{late_start: :disallow, late_submit: :allow}
+
+  defp determine_late_policy(:disallow_late_start_and_late_submit),
+    do: %{late_start: :disallow, late_submit: :disallow}
 end

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table_model.ex
@@ -22,98 +22,91 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
       %ColumnSpec{
         name: :student,
         label: "STUDENT",
-        render_fn: &__MODULE__.render_student_column/3,
+        render_fn: &render_student_column/3,
         th_class: "pl-10 !sticky left-0 bg-white dark:bg-neutral-800 z-10",
         td_class: "sticky left-0 bg-white dark:bg-neutral-800 z-10 whitespace-nowrap"
       },
       %ColumnSpec{
         name: :available_date,
         label: "AVAILABLE DATE",
-        render_fn: &__MODULE__.render_available_date_column/3,
+        render_fn: &render_available_date_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:available_date)
       },
       %ColumnSpec{
         name: :due_date,
         label: "DUE DATE",
-        render_fn: &__MODULE__.render_due_date_column/3,
+        render_fn: &render_due_date_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:due_date)
       },
       %ColumnSpec{
         name: :max_attempts,
         label: "# ATTEMPTS",
-        render_fn: &__MODULE__.render_attempts_column/3,
+        render_fn: &render_attempts_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:max_attempts)
       },
       %ColumnSpec{
         name: :time_limit,
         label: "TIME LIMIT",
-        render_fn: &__MODULE__.render_time_limit_column/3,
+        render_fn: &render_time_limit_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:time_limit)
       },
       %ColumnSpec{
-        name: :late_submit,
-        label: "LATE SUBMIT",
-        render_fn: &__MODULE__.render_late_submit_column/3,
+        name: :late_policy,
+        label: "LATE POLICY",
+        render_fn: &render_late_policy_column/3,
         th_class: "whitespace-nowrap",
-        tooltip: Tooltips.for(:late_submit)
-      },
-      %ColumnSpec{
-        name: :late_start,
-        label: "LATE START",
-        render_fn: &__MODULE__.render_late_start_column/3,
-        th_class: "whitespace-nowrap",
-        tooltip: Tooltips.for(:late_start)
+        tooltip: Tooltips.for(:late_policy)
       },
       %ColumnSpec{
         name: :scoring_strategy_id,
         label: "SCORING",
-        render_fn: &__MODULE__.render_scoring_column/3,
+        render_fn: &render_scoring_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:scoring_strategy_id)
       },
       %ColumnSpec{
         name: :grace_period,
         label: "GRACE PERIOD",
-        render_fn: &__MODULE__.render_grace_period_column/3,
+        render_fn: &render_grace_period_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:grace_period)
       },
       %ColumnSpec{
         name: :retake_mode,
         label: "RETAKE MODE",
-        render_fn: &__MODULE__.render_retake_mode_column/3,
+        render_fn: &render_retake_mode_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:retake_mode)
       },
       %ColumnSpec{
         name: :assessment_mode,
         label: "PRESENTATION",
-        render_fn: &__MODULE__.render_assessment_mode_column/3,
+        render_fn: &render_assessment_mode_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:assessment_mode)
       },
       %ColumnSpec{
         name: :feedback_mode,
         label: "VIEW FEEDBACK",
-        render_fn: &__MODULE__.render_view_feedback_column/3,
+        render_fn: &render_view_feedback_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:feedback_mode)
       },
       %ColumnSpec{
         name: :review_submission,
         label: "VIEW ANSWERS",
-        render_fn: &__MODULE__.render_view_answers_column/3,
+        render_fn: &render_view_answers_column/3,
         th_class: "whitespace-nowrap",
         tooltip: Tooltips.for(:review_submission)
       },
       %ColumnSpec{
         name: :password,
         label: "PASSWORD",
-        render_fn: &__MODULE__.render_password_column/3,
+        render_fn: &render_password_column/3,
         th_class: "pt-3 whitespace-nowrap",
         sortable: false,
         tooltip: Tooltips.for(:password)
@@ -264,39 +257,35 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTableModel do
     """
   end
 
-  def render_late_submit_column(assigns, student_exception, _) do
+  def render_late_policy_column(assigns, student_exception, _) do
     assigns =
       Map.merge(assigns, %{
+        late_start: student_exception.late_start,
         late_submit: student_exception.late_submit,
         id: student_exception.user_id
       })
 
     ~H"""
-    <div class={data_class(@selected_assessment.late_submit, @late_submit)}>
-      <select class="torus-select pr-32" name={"late_submit-#{@id}"}>
-        <option disabled selected={@late_submit == nil} hidden value="">-</option>
-        <option selected={@late_submit == :allow} value={:allow}>Allow</option>
-        <option selected={@late_submit == :disallow} value={:disallow}>Disallow</option>
-      </select>
-    </div>
-    """
-  end
-
-  def render_late_start_column(assigns, student_exception, _) do
-    assigns =
-      Map.merge(assigns, %{
-        late_start: student_exception.late_start,
-        id: student_exception.user_id
-      })
-
-    ~H"""
-    <div class={data_class(@selected_assessment.late_start, @late_start)}>
-      <select class="torus-select pr-32" name={"late_start-#{@id}"}>
-        <option disabled selected={@late_start == nil} hidden value="">-</option>
-        <option selected={@late_start == :allow} value={:allow}>Allow</option>
-        <option selected={@late_start == :disallow} value={:disallow}>Disallow</option>
-      </select>
-    </div>
+    <select class="torus-select pr-32" name={"late_policy-#{@id}"}>
+      <option
+        selected={@late_start == :allow && @late_submit == :allow}
+        value={:allow_late_start_and_late_submit}
+      >
+        Allow late start and late submit
+      </option>
+      <option
+        selected={@late_start == :disallow && @late_submit == :allow}
+        value={:allow_late_submit_but_not_late_start}
+      >
+        Allow late submit but not late start
+      </option>
+      <option
+        selected={@late_start == :disallow && @late_submit == :disallow}
+        value={:disallow_late_start_and_late_submit}
+      >
+        Disallow late start and late submit
+      </option>
+    </select>
     """
   end
 

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -445,8 +445,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
             :due_date,
             :max_attempts,
             :time_limit,
-            :late_submit,
-            :late_start,
+            :late_policy,
             :scoring_strategy_id,
             :grace_period,
             :retake_mode,
@@ -2055,18 +2054,18 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
 
       [student_exception_1] = table_as_list_of_maps(view, :student_exceptions)
 
-      assert student_exception_1.late_submit == "-"
+      assert student_exception_1.scoring_strategy_id == "-"
 
       view
       |> form(~s{form[for="student_exceptions_table"]})
       |> render_change(%{
-        "_target" => ["late_submit-#{student_1.id}"],
-        "late_submit-#{student_1.id}" => "disallow"
+        "_target" => ["scoring_strategy_id-#{student_1.id}"],
+        "scoring_strategy_id-#{student_1.id}" => "2"
       })
 
       [updated_student_exception_1] = table_as_list_of_maps(view, :student_exceptions)
 
-      assert updated_student_exception_1.late_submit == "Disallow"
+      assert updated_student_exception_1.scoring_strategy_id == "Best"
       assert student_exception_1.student == updated_student_exception_1.student
     end
 
@@ -2101,8 +2100,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       view
       |> form(~s{form[for="student_exceptions_table"]})
       |> render_change(%{
-        "_target" => ["late_submit-#{student_1.id}"],
-        "late_submit-#{student_1.id}" => "disallow"
+        "_target" => ["scoring_strategy_id-#{student_1.id}"],
+        "scoring_strategy_id-#{student_1.id}" => "1"
       })
 
       assert has_element?(
@@ -2115,8 +2114,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       view
       |> form(~s{form[for="student_exceptions_table"]})
       |> render_change(%{
-        "_target" => ["late_submit-#{student_2.id}"],
-        "late_submit-#{student_2.id}" => "disallow"
+        "_target" => ["scoring_strategy_id-#{student_2.id}"],
+        "scoring_strategy_id-#{student_2.id}" => "2"
       })
 
       assert has_element?(
@@ -2619,6 +2618,72 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
                "table.instructor_dashboard_table > tbody > tr:nth-child(4) > td > div",
                "#{student_1.name}"
              )
+    end
+
+    test "late policy setting is set correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      student_1: student_1
+    } do
+      set_student_exception(section, page_1.resource, student_1)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      [student_exception_1] = table_as_list_of_maps(view, :student_exceptions)
+
+      assert student_exception_1.late_policy == ""
+
+      # set late start and late submit allowed
+      view
+      |> form(~s{form[for="student_exceptions_table"]})
+      |> render_change(%{
+        "_target" => ["late_policy-#{student_1.id}"],
+        "late_policy-#{student_1.id}" => "allow_late_start_and_late_submit"
+      })
+
+      [updated_student_exception_1] = table_as_list_of_maps(view, :student_exceptions)
+
+      assert updated_student_exception_1.late_policy == "Allow late start and late submit"
+
+      # verify that values are stored correctly
+      exception =
+        Delivery.get_delivery_setting_by(%{
+          resource_id: page_1.resource.id,
+          user_id: student_1.id
+        })
+
+      assert exception.late_start == :allow
+      assert exception.late_submit == :allow
+
+      # set late start and late submit disallowed
+      view
+      |> form(~s{form[for="student_exceptions_table"]})
+      |> render_change(%{
+        "_target" => ["late_policy-#{student_1.id}"],
+        "late_policy-#{student_1.id}" => "disallow_late_start_and_late_submit"
+      })
+
+      [updated_student_exception_2] = table_as_list_of_maps(view, :student_exceptions)
+      assert updated_student_exception_2.late_policy == "Disallow late start and late submit"
+
+      # Verify that values are stored correctly
+      exception =
+        Delivery.get_delivery_setting_by(%{
+          resource_id: page_1.resource.id,
+          user_id: student_1.id
+        })
+
+      assert exception.late_start == :disallow
+      assert exception.late_submit == :disallow
     end
   end
 end


### PR DESCRIPTION
[MER-4275](https://eliterate.atlassian.net/browse/MER-4275)

This PR updates the Student Exceptions tab by replacing the separate `Late Submit` and `Late Start` settings with a unified `Late Policy` setting, ensuring consistency with the Assessment Settings. 

This change provides instructors with a clearer understanding of which settings are applied to student exceptions, avoiding confusion. 

The `Late Policy` setting in the Student Exceptions tab now mirrors the options and behavior found in the Assessment Settings.


https://github.com/user-attachments/assets/2376addf-80b6-4397-90b9-bd6eaeb884b3



[MER-4275]: https://eliterate.atlassian.net/browse/MER-4275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ