### PR TITLE
[FEATURE] [MER-4263] Remove mentions of not yet scheduled - part 2

### DIFF
--- a/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
+++ b/lib/oli_web/live/delivery/student/home/components/schedule_component.ex
@@ -28,6 +28,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
   attr(:section_start_date, :string, required: true)
   attr(:section_slug, :string, required: true)
   attr(:expanded_items, :list, default: [])
+  attr(:has_scheduled_resources?, :boolean, required: true)
 
   def render(assigns) do
     ~H"""
@@ -58,6 +59,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
                 section_slug={@section_slug}
                 expanded={item.id in @expanded_items}
                 target={@myself}
+                has_scheduled_resources?={@has_scheduled_resources?}
               />
             </div>
           </div>
@@ -73,6 +75,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
   attr :section_slug, :string, required: true
   attr :target, :any, required: true
   attr :expanded, :boolean, default: false
+  attr :has_scheduled_resources?, :boolean, required: true
 
   defp schedule_item(%{item: item} = assigns) when length(item.resources) > 1 do
     ~H"""
@@ -117,6 +120,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
         expanded={@expanded}
         target={@target}
         section_slug={@section_slug}
+        has_scheduled_resources?={@has_scheduled_resources?}
       />
     </div>
     """
@@ -174,6 +178,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
           ctx={@ctx}
           target={@target}
           section_slug={@section_slug}
+          has_scheduled_resources?={@has_scheduled_resources?}
         />
       </div>
     </.link>
@@ -202,7 +207,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
   attr :target, :any, required: true
   attr :expanded, :boolean, default: false
   attr :section_slug, :string, required: true
-
+  attr :has_scheduled_resources?, :boolean, required: true
   # Graded pages with existing attempts for simple schedule items
   defp schedule_item_details(
          %{
@@ -288,9 +293,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
       <div class="pr-2 pl-1 self-end">
         <div class="flex items-end gap-1">
           <div class="text-right dark:text-white text-opacity-90 text-xs font-semibold h-5">
-            <%= if @completed do %>
-              Completed
-            <% else %>
+            <span :if={@completed}>Completed</span>
+            <span :if={!@completed and @has_scheduled_resources?} role="schedule details">
               <%= if is_nil(hd(@resources).effective_settings),
                 do:
                   Utils.days_difference(
@@ -302,7 +306,7 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponent do
                   Utils.coalesce(hd(@resources).effective_settings.end_date, hd(@resources).end_date)
                   |> Utils.coalesce(hd(@resources).effective_settings.start_date)
                   |> Utils.days_difference(grouped_scheduling_type(@resources), @ctx) %>
-            <% end %>
+            </span>
           </div>
           <Icons.check :if={@completed} progress={1.0} />
         </div>

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -1087,6 +1087,7 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           grouped_agenda_resources={@grouped_agenda_resources}
           section_start_date={@section_start_date}
           section_slug={@section_slug}
+          has_scheduled_resources?={@has_scheduled_resources?}
         />
       </div>
     </div>

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -327,7 +327,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
           ctx: session_context,
           grouped_agenda_resources: grouped_agenda_resources,
           section_start_date: section.start_date,
-          section_slug: section.slug
+          section_slug: section.slug,
+          has_scheduled_resources?: true
         })
 
       ## Displays current week
@@ -407,7 +408,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
           ctx: session_context,
           grouped_agenda_resources: grouped_agenda_resources,
           section_start_date: section.start_date,
-          section_slug: section.slug
+          section_slug: section.slug,
+          has_scheduled_resources?: true
         })
 
       # Practice 2 is completed
@@ -440,7 +442,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
           ctx: session_context,
           grouped_agenda_resources: grouped_agenda_resources,
           section_start_date: section.start_date,
-          section_slug: section.slug
+          section_slug: section.slug,
+          has_scheduled_resources?: true
         })
 
       # Graded 1 is completed and displays attempts info
@@ -472,7 +475,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
           ctx: session_context,
           grouped_agenda_resources: grouped_agenda_resources,
           section_start_date: section.start_date,
-          section_slug: section.slug
+          section_slug: section.slug,
+          has_scheduled_resources?: true
         })
 
       lcd
@@ -498,6 +502,27 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
                "Graded 2"
              )
     end
+
+    test "does render the schedule details label", %{
+      conn: conn,
+      section: section,
+      user: user,
+      session_context: session_context
+    } do
+      stub_current_time(~U[2024-05-07 20:00:00Z])
+      grouped_agenda_resources = Utils.grouped_agenda_resources(section, nil, user.id, true)
+
+      {:ok, lcd, _html} =
+        live_component_isolated(conn, ScheduleComponent, %{
+          ctx: session_context,
+          grouped_agenda_resources: grouped_agenda_resources,
+          section_start_date: section.start_date,
+          section_slug: section.slug,
+          has_scheduled_resources?: true
+        })
+
+      assert has_element?(lcd, ~s{span[role="schedule details"]})
+    end
   end
 
   describe "live component without schedule" do
@@ -517,7 +542,8 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
           ctx: session_context,
           grouped_agenda_resources: grouped_agenda_resources,
           section_start_date: section.start_date,
-          section_slug: section.slug
+          section_slug: section.slug,
+          has_scheduled_resources?: false
         })
 
       ## Does not display current week (no schedule)
@@ -534,6 +560,27 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       Enum.each(5..11, fn x ->
         refute render(lcd) =~ "Unit #{x}"
       end)
+    end
+
+    test "does not render the schedule details ('Not yet scheduled' label)", %{
+      conn: conn,
+      section: section,
+      user: user,
+      session_context: session_context
+    } do
+      # no schedule
+      grouped_agenda_resources = Utils.grouped_agenda_resources(section, nil, user.id, false)
+
+      {:ok, lcd, _html} =
+        live_component_isolated(conn, ScheduleComponent, %{
+          ctx: session_context,
+          grouped_agenda_resources: grouped_agenda_resources,
+          section_start_date: section.start_date,
+          section_slug: section.slug,
+          has_scheduled_resources?: false
+        })
+
+      refute has_element?(lcd, ~s{span[role="schedule details"]})
     end
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4263?focusedCommentId=27883) to the comment in the ticket

In a refactor, I accidentally removed that implementation.

#### Before
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/7cc9cc6a-5d89-4b06-a38e-d832db23b415" />



#### After
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/c430461c-ba90-4075-bdea-8c53aa02574b" />
