### PR TITLE
[FEATURE] [MER-4308] LTI content type button

### DIFF
--- a/assets/src/components/content/add_resource_content/AddActivity.tsx
+++ b/assets/src/components/content/add_resource_content/AddActivity.tsx
@@ -35,7 +35,13 @@ export const AddActivity: React.FC<Props> = ({
             addActivity(editorDesc, resourceContext, onAddItem, editorMap, index);
             document.body.click();
           }}
-          onHoverStart={() => onSetTip(editorDesc.description)}
+          onHoverStart={() =>
+            onSetTip(
+              editorDesc.isLtiActivity
+                ? `Insert an instance of ${editorDesc.petiteLabel}`
+                : editorDesc.description,
+            )
+          }
           onHoverEnd={() => onResetTip()}
           disabled={false}
           icon={editorDesc.icon}

--- a/assets/src/data/content/editors.ts
+++ b/assets/src/data/content/editors.ts
@@ -10,6 +10,7 @@ export type EditorDesc = {
   enabledForProject: boolean;
   id: number;
   variables: any;
+  isLtiActivity: boolean;
 };
 
 export interface ActivityEditorMap {

--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -250,7 +250,7 @@ defmodule Oli.Activities do
       Enum.reduce(project.activity_registrations, MapSet.new(), fn a, m -> MapSet.put(m, a.id) end)
 
     activities_enabled =
-      list_activity_registrations_with_deployment_id()
+      list_activity_registrations()
       |> Enum.filter(fn a -> a.globally_visible || is_admin? end)
       |> Enum.reduce([], fn a, m ->
         enabled_for_project =
@@ -342,25 +342,11 @@ defmodule Oli.Activities do
 
   """
   def list_activity_registrations do
-    Repo.all(ActivityRegistration)
-  end
-
-  @doc """
-  Returns the list of activity_registrations with their deployment ids.
-
-  ## Examples
-
-      iex> list_activity_registrations()
-      [%ActivityRegistration{}, ...]
-
-  """
-  def list_activity_registrations_with_deployment_id do
-    fields = ActivityRegistration.__schema__(:fields)
-
     from(ar in ActivityRegistration,
       left_join: d in LtiExternalToolActivityDeployment,
       on: d.activity_registration_id == ar.id,
-      select: merge(map(ar, ^fields), %{deployment_id: d.deployment_id})
+      select: ar,
+      select_merge: %{deployment_id: d.deployment_id}
     )
     |> Repo.all()
   end

--- a/lib/oli/activities/activity_map_entry.ex
+++ b/lib/oli/activities/activity_map_entry.ex
@@ -13,6 +13,7 @@ defmodule Oli.Activities.ActivityMapEntry do
     :slug,
     :globallyAvailable,
     :variables,
+    :isLtiActivity,
     enabledForProject: false
   ]
 
@@ -26,7 +27,8 @@ defmodule Oli.Activities.ActivityMapEntry do
         authoring_element: authoring_element,
         delivery_element: delivery_element,
         globally_available: globally_available,
-        variables: variables
+        variables: variables,
+        deployment_id: deployment_id
       }) do
     %Oli.Activities.ActivityMapEntry{
       id: id,
@@ -39,7 +41,8 @@ defmodule Oli.Activities.ActivityMapEntry do
       deliveryElement: delivery_element,
       globallyAvailable: globally_available,
       enabledForProject: globally_available,
-      variables: Oli.Delivery.Page.ActivityContext.build_variables_map(variables, petite_label)
+      variables: Oli.Delivery.Page.ActivityContext.build_variables_map(variables, petite_label),
+      isLtiActivity: !is_nil(deployment_id)
     }
   end
 end

--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -18,6 +18,8 @@ defmodule Oli.Activities.ActivityRegistration do
     field :variables, {:array, :string}, default: []
     field :generates_report, :boolean, default: false
 
+    field :deployment_id, :string, virtual: true
+
     # Optionally, this activity registration can be associated with an LTI deployment.
     # If an LTI deployment is associated, the activity is considered an LTI activity.
     has_one :lti_external_tool_activity_deployment,

--- a/test/oli/activities_test.exs
+++ b/test/oli/activities_test.exs
@@ -2,7 +2,6 @@ defmodule Oli.ActivitiesTest do
   use Oli.DataCase
   import ExUnit.Assertions
   alias Oli.Activities
-  alias Oli.Lti.PlatformExternalTools
 
   setup [:author_project_fixture]
 
@@ -71,41 +70,6 @@ defmodule Oli.ActivitiesTest do
 
       image_coding = Map.get(editor_menu_items, "oli_image_coding")
       assert !image_coding.globallyAvailable and image_coding.enabledForProject
-    end
-  end
-
-  describe "list activities" do
-    test "list_activity_registrations_with_deployment_id/0 works correctly" do
-      # register a new lti external tool activity
-      params = %{
-        "name" => "External Tool Test 1",
-        "description" => "External Tool Description",
-        "client_id" => "new_tool_client_id_1",
-        "target_link_uri" => "https://example.com/launch",
-        "login_url" => "https://example.com/login",
-        "keyset_url" => "https://example.com/jwks",
-        "redirect_uris" => "https://example.com/redirect",
-        "custom_params" => "param1=value1&param2=value2"
-      }
-
-      {:ok, {_platform_instance, activity_registration, deployment}} =
-        PlatformExternalTools.register_lti_external_tool_activity(params)
-
-      # get activity registrations with deployment id
-      activities = Activities.list_activity_registrations_with_deployment_id()
-
-      # assert that all activities have the :deployment_id field
-      assert Enum.all?(activities, fn activity ->
-               Map.has_key?(activity, :deployment_id)
-             end)
-
-      # assert that the lti external tool activity is included in the list with their deployment id
-      new_activity_registered =
-        Enum.find(activities, fn activity ->
-          activity.id == activity_registration.id
-        end)
-
-      assert new_activity_registered.deployment_id == deployment.deployment_id
     end
   end
 end


### PR DESCRIPTION
[MER-4308](https://eliterate.atlassian.net/browse/MER-4308)

This PR verifies that an author can place an LTI tool on a page to have control over where students interact with the tool.

In addition, a small implementation is made so that when the user hovers over an LTI activity the correct text is displayed, i.e. “Insert an instance of [tool name]”.


https://github.com/user-attachments/assets/8d3763e5-25ae-45f0-bed1-c233b0f90f84




[MER-4308]: https://eliterate.atlassian.net/browse/MER-4308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ