### PR TITLE
[FEATURE] [MER-4312] Tool removal message

### DIFF
--- a/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
+++ b/assets/src/components/content/add_resource_content/AddResourceContent.modules.scss
@@ -5,7 +5,7 @@
   position: relative;
   padding: 10px 0;
   width: 90%;
-  margin: 0 auto;
+  margin: 6rem auto 0;
   cursor: pointer;
   opacity: 0;
 

--- a/assets/src/components/lti/LTIExternalToolFrame.tsx
+++ b/assets/src/components/lti/LTIExternalToolFrame.tsx
@@ -112,6 +112,26 @@ export const LTIExternalToolFrame = ({
           />
         </>
       )}
+      {['disabled', 'deleted'].includes(launchParams.status) && (
+        <div className="w-[769px] p-6 my-4 rounded-2xl shadow-[0px_2px_10px_0px_rgba(0,50,99,0.10)] inline-flex gap-3 items-end">
+          <div className="flex-1 flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <div className="p-1 rounded-lg flex justify-center items-center overflow-hidden">
+                <i className="fa-solid fa-triangle-exclamation text-[#c03a2b]"></i>
+              </div>
+              <span className="text-text-text-default text-lg font-semibold leading-normal">
+                Tool has been removed
+              </span>
+            </div>
+            <div className="pl-8 flex items-center gap-2">
+              <span className="text-text-text-neutral text-sm leading-none">
+                This tool is no longer registered in the system, and its functionality has been
+                disabled.
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/assets/src/data/persistence/lti_platform.ts
+++ b/assets/src/data/persistence/lti_platform.ts
@@ -6,6 +6,7 @@ export type LTIExternalToolDetails = {
     client_id: string;
     target_link_uri: string;
     login_url: string;
+    status: string;
   };
 };
 

--- a/lib/oli_web/controllers/api/lti_controller.ex
+++ b/lib/oli_web/controllers/api/lti_controller.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.Api.LtiController do
   def launch_details(conn, %{"project_slug" => project_slug, "activity_id" => activity_id}) do
     with %Oli.Resources.Revision{activity_type_id: activity_type_id} <-
            AuthoringResolver.from_resource_id(project_slug, activity_id),
-         %LtiExternalToolActivityDeployment{platform_instance: platform_instance} =
+         %LtiExternalToolActivityDeployment{platform_instance: platform_instance, status: status} =
            PlatformExternalTools.get_lti_external_tool_activity_deployment_by(
              activity_registration_id: activity_type_id
            ) do
@@ -65,7 +65,8 @@ defmodule OliWeb.Api.LtiController do
           login_hint: login_hint,
           client_id: platform_instance.client_id,
           target_link_uri: platform_instance.target_link_uri,
-          login_url: platform_instance.login_url
+          login_url: platform_instance.login_url,
+          status: status
         }
       })
     else


### PR DESCRIPTION
[MER-4312](https://eliterate.atlassian.net/browse/MER-4312)

This PR adds a warning message below the LTI activities that have been removed/deleted at the system level.

This warning message is intended for authors when they are editing any page of the curriculum and the page has in its content any LTI activity that has been removed or deleted at the system level.


https://github.com/user-attachments/assets/6ac8edee-66e0-4192-af2b-9cacb1d37261



[MER-4312]: https://eliterate.atlassian.net/browse/MER-4312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ