### PR TITLE
[BUG FIX] [MER-4294] Do not show disabled activities in the project overview page

### DIFF
--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -251,7 +251,9 @@ defmodule Oli.Activities do
 
     activities_enabled =
       list_activity_registrations()
-      |> Enum.filter(fn a -> a.globally_visible || is_admin? end)
+      |> Enum.filter(fn a ->
+        (a.globally_visible || is_admin?) and (is_nil(a.status) or a.status == :enabled)
+      end)
       |> Enum.reduce([], fn a, m ->
         enabled_for_project =
           a.globally_available === true or MapSet.member?(project_activities, a.id)
@@ -346,7 +348,7 @@ defmodule Oli.Activities do
       left_join: d in LtiExternalToolActivityDeployment,
       on: d.activity_registration_id == ar.id,
       select: ar,
-      select_merge: %{deployment_id: d.deployment_id}
+      select_merge: %{deployment_id: d.deployment_id, status: d.status}
     )
     |> Repo.all()
   end

--- a/lib/oli/activities/activity_registration.ex
+++ b/lib/oli/activities/activity_registration.ex
@@ -19,6 +19,7 @@ defmodule Oli.Activities.ActivityRegistration do
     field :generates_report, :boolean, default: false
 
     field :deployment_id, :string, virtual: true
+    field :status, Ecto.Enum, values: [:enabled, :disabled], virtual: true
 
     # Optionally, this activity registration can be associated with an LTI deployment.
     # If an LTI deployment is associated, the activity is considered an LTI activity.


### PR DESCRIPTION
[MER-4294](https://eliterate.atlassian.net/browse/MER-4294)

Do not list disabled LTI External Tools in the Activities section in the Project Overview page.


https://github.com/user-attachments/assets/6036d467-6587-4cf2-a202-798627808c6b



[MER-4294]: https://eliterate.atlassian.net/browse/MER-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ