### PR TITLE
[FEATURE] [MER-4294] Enable/Disable a tool at system level - rework

### DIFF
--- a/lib/oli/activities.ex
+++ b/lib/oli/activities.ex
@@ -175,6 +175,9 @@ defmodule Oli.Activities do
         end)
 
       list_activity_registrations()
+      |> Enum.filter(fn a ->
+        is_nil(a.status) or a.status == :enabled
+      end)
       |> Enum.map(&ActivityMapEntry.from_registration/1)
       |> Enum.reduce(%{}, fn e, m ->
         e =


### PR DESCRIPTION
[MER-4294](https://eliterate.atlassian.net/browse/MER-4294)

This PR excludes LTI tools that were disabled or removed at the system level, showing only LTI tools enabled to be added to a curriculum page. 


https://github.com/user-attachments/assets/cc92e9d9-9b1d-4583-9097-e0e4032e51ea



[MER-4294]: https://eliterate.atlassian.net/browse/MER-4294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ