### PR TITLE
[BUG FIX] [MER-4034] improvements to the torus support modal rework 2

### DIFF
--- a/assets/src/hooks/submit_tech_support_form.ts
+++ b/assets/src/hooks/submit_tech_support_form.ts
@@ -35,7 +35,6 @@ export const SubmitTechSupportForm = {
         const json = await res.json();
         this.pushEvent('form_response', json);
       } catch (err) {
-        console.log('Something went wrong when trying to request help', err);
         this.pushEvent('form_response', { error: err });
       }
     });

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,7 +35,8 @@ config :oli,
 config :oli, :vendor_property,
   workspace_logo:
     System.get_env("VENDOR_PROPERTY_WORKSPACE_LOGO", "/branding/dev/oli_torus_icon.png"),
-  support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL", "support@example.com")
+  support_email: System.get_env("VENDOR_PROPERTY_SUPPORT_EMAIL", "support@example.com"),
+  knowledgebase_url: System.get_env("KNOWLEDGEBASE_URL", "#")
 
 # Configure your database
 config :oli, Oli.Repo,

--- a/lib/oli/help/requester_data.ex
+++ b/lib/oli/help/requester_data.ex
@@ -35,6 +35,6 @@ defmodule Oli.Help.RequesterData do
       end)
       |> Enum.join(" and ")
 
-    {:error, "Help requester data is incomplete. Required field: #{required_fields}"}
+    {:error, "Requester data is incomplete. Required field(s): #{required_fields}"}
   end
 end

--- a/lib/oli/help/requester_data.ex
+++ b/lib/oli/help/requester_data.ex
@@ -26,7 +26,15 @@ defmodule Oli.Help.RequesterData do
     {:ok, help_requester_data}
   end
 
-  def parse(_) do
-    {:error, "Help requester data is incomplete."}
+  def parse(requester_data) do
+    required_fields =
+      Enum.reduce(requester_data, [], fn
+        {"requester_email", nil}, acc -> acc ++ ["email"]
+        {"requester_name", nil}, acc -> acc ++ ["name"]
+        _, acc -> acc
+      end)
+      |> Enum.join(" and ")
+
+    {:error, "Help requester data is incomplete. Required field: #{required_fields}"}
   end
 end

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -1261,25 +1261,6 @@ defmodule OliWeb.Components.Common do
     """
   end
 
-  attr :recaptcha_error, :string, required: true
-  attr :class, :string, default: "w-80 mx-auto"
-
-  def render_recaptcha(assigns) do
-    ~H"""
-    <div class={@class}>
-      <div
-        id="recaptcha"
-        phx-hook="Recaptcha"
-        data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}
-        data-theme="light"
-        phx-update="ignore"
-      >
-      </div>
-      <.error :if={@recaptcha_error}><%= @recaptcha_error %></.error>
-    </div>
-    """
-  end
-
   attr :id, :string, required: true
   attr :class, :string, default: ""
   attr :show_text, :boolean, default: true

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -142,9 +142,20 @@ defmodule OliWeb.TechSupportLive do
               &times;
             </a>
           </div>
-
           <div class="w-full flex flex-col lg:flex-row gap-2 md:justify-between">
-            <.render_recaptcha recaptcha_error={@recaptcha_error} class="md:m-0 m-auto" />
+            <%!-- Start Captcha --%>
+            <div class="w-80 mx-auto">
+              <div
+                id="recaptcha"
+                phx-hook="Recaptcha"
+                data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}
+                data-theme="dark"
+                phx-update="ignore"
+              >
+              </div>
+
+              <.error :if={@recaptcha_error}><%= @recaptcha_error %></.error>
+            </div>
 
             <div class="flex w-full justify-around lg:justify-end items-center">
               <.button type="link" variant={:link} phx-click={Modal.hide_modal(@modal_id)}>

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -21,6 +21,7 @@ defmodule OliWeb.TechSupportLive do
       |> assign(modal_id: @modal_id)
       |> assign(recaptcha_error: false)
       |> assign(:session, session)
+      |> assign(tech_support_flash: %{})
       |> assign(uploaded_files: [])
       |> allow_upload(:attached_screenshots,
         accept: ~w(.jpg .jpeg .png),
@@ -36,7 +37,7 @@ defmodule OliWeb.TechSupportLive do
   def render(assigns) do
     ~H"""
     <div class="mx-auto z-50 top-0 absolute right-0">
-      <.flash_group flash={@flash} />
+      <.flash_group flash={@tech_support_flash} />
     </div>
     <button
       id="trigger-tech-support-modal"
@@ -206,7 +207,7 @@ defmodule OliWeb.TechSupportLive do
   end
 
   def handle_event("form_response", %{"info" => info}, socket) do
-    socket = put_flash(socket, :info, info)
+    socket = assign(socket, tech_support_flash: %{"info" => info})
     {:noreply, socket}
   end
 

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -3,10 +3,11 @@ defmodule OliWeb.TechSupportLive do
   alias Oli.Help.HelpContent
   alias Oli.Help.HelpRequest
   alias OliWeb.Components.Modal
-  alias OliWeb.Icons
 
   @modal_id "tech-support-modal"
   @base_url Oli.Utils.get_base_url()
+
+  require Logger
 
   @impl true
   def mount(_params, session, socket) do
@@ -27,7 +28,6 @@ defmodule OliWeb.TechSupportLive do
         auto_upload: true,
         max_file_size: 10_000_000
       )
-      |> assign(custom_flash: nil)
 
     {:ok, socket, layout: false}
   end
@@ -35,7 +35,9 @@ defmodule OliWeb.TechSupportLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <%= render_custom_flash(@custom_flash) %>
+    <div class="mx-auto z-50 top-0 absolute right-0">
+      <.flash_group flash={@flash} />
+    </div>
     <button
       id="trigger-tech-support-modal"
       class="hidden"
@@ -204,18 +206,15 @@ defmodule OliWeb.TechSupportLive do
   end
 
   def handle_event("form_response", %{"info" => info}, socket) do
-    socket = assign(socket, :custom_flash, %{type: :success, message: info})
+    socket = put_flash(socket, :info, info)
     {:noreply, socket}
   end
 
-  def handle_event("form_response", %{"error" => _error}, socket) do
-    message = "We are unable to forward your help request at the moment."
-    socket = assign(socket, :custom_flash, %{type: :error, message: message})
+  def handle_event("form_response", %{"error" => error}, socket) do
+    Logger.error("Error requesting support help: #{inspect(error, pretty: true)}")
+    message = "We are unable to forward your help request at the moment"
+    socket = put_flash(socket, :error, message)
     {:noreply, socket}
-  end
-
-  def handle_event("clear-custom-flash", _params, socket) do
-    {:noreply, assign(socket, custom_flash: nil)}
   end
 
   defp add_metadata(socket, params, changeset) do
@@ -327,44 +326,5 @@ defmodule OliWeb.TechSupportLive do
         "#{@base_url}/admin/authors/#{user.id}"
       end
     end
-  end
-
-  defp render_custom_flash(nil), do: nil
-
-  defp render_custom_flash(%{type: type, message: message}) do
-    {bg_class, text_color, label} =
-      case type do
-        :success -> {"bg-[#F2F9FF]", "#1b67b2", "Success!"}
-        :error -> {"bg-[#FEEBED]", "#ce2c31", "Error!"}
-      end
-
-    assigns = %{
-      bg_class: bg_class,
-      text_color: text_color,
-      label: label,
-      type: type,
-      message: message
-    }
-
-    ~H"""
-    <div id="flash" class={"#{@bg_class} px-6 py-4 rounded-md relative mb-8"}>
-      <div class="flex items-start justify-between gap-4">
-        <div class="flex items-center gap-2 font-semibold">
-          <Icons.check :if={@type == :success} stroke_class="stroke-blue-600" />
-          <Icons.alert :if={@type == :error} />
-          <span class={"text-[#{@text_color}] text-base font-semibold"}>
-            <%= @label %>
-          </span>
-        </div>
-        <button
-          phx-click="clear-custom-flash"
-          class={"text-sm hover:opacity-70 text-[#{@text_color}]"}
-        >
-          ✕
-        </button>
-      </div>
-      <p class="mt-1 text-[#353740] text-sm font-normal"><%= @message %></p>
-    </div>
-    """
   end
 end

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -94,6 +94,7 @@ defmodule OliWeb.TechSupportLive do
           <.input
             label="Questions or Comments:"
             field={@form[:message]}
+            phx-debounce="500"
             type="textarea"
             class="w-full dark:placeholder:text-zinc-300 pl-6 dark:bg-stone-900 rounded-md border dark:border-zinc-300 dark:text-zinc-300 leading-snug"
             required

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -213,8 +213,8 @@ defmodule OliWeb.TechSupportLive do
 
   def handle_event("form_response", %{"error" => error}, socket) do
     Logger.error("Error requesting support help: #{inspect(error, pretty: true)}")
-    message = "We are unable to forward your help request at the moment"
-    socket = put_flash(socket, :error, message)
+    message = "We are unable to forward your help request at the moment."
+    socket = assign(socket, tech_support_flash: %{"error" => message})
     {:noreply, socket}
   end
 

--- a/lib/oli_web/components/tech_support_live.ex
+++ b/lib/oli_web/components/tech_support_live.ex
@@ -46,7 +46,9 @@ defmodule OliWeb.TechSupportLive do
     />
     <Modal.modal id={@modal_id} class="md:w-8/12">
       <:title>Tech Support</:title>
-      <a href={@knowledgebase_url}>Find answers quickly in the Torus knowledge base.</a>
+      <a href={@knowledgebase_url} target="_blank">
+        Find answers quickly in the Torus knowledge base.
+      </a>
       <div class="w-auto">
         <.form
           id="tech-support-modal-form"

--- a/lib/oli_web/controllers/help_controller.ex
+++ b/lib/oli_web/controllers/help_controller.ex
@@ -17,12 +17,12 @@ defmodule OliWeb.HelpController do
          {:ok, _} <- Oli.Help.Dispatcher.dispatch(dispatcher, help_content) do
       json(conn, %{
         "result" => "success",
-        "info" => "Your help request has been successfully submitted"
+        "info" => "Your help request has been successfully submitted."
       })
     else
       {:error, message} ->
-        Logger.error("Error when processing help message #{inspect(message)}")
-        error(conn, 500, "We are unable to forward your help request at the moment")
+        Logger.error("Error when processing help message. #{inspect(message)}")
+        error(conn, 500, "We are unable to forward your help request at the moment.")
     end
   end
 

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -160,8 +160,7 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      },
-      container: {:div, class: "absolute top-0 right-0 z-[999]"}
+      }
     ) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -160,7 +160,8 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      }
+      },
+      container: {:div, class: "absolute top-0 right-0 z-[999]"}
     ) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -159,7 +159,7 @@
     <%= live_render(@conn, OliWeb.TechSupportLive,
       session: %{
         "section" => Map.get(@conn.assigns, :section),
-        "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
+        "user" => Map.get(@conn.assigns, :current_author) || Map.get(@conn.assigns, :current_user)
       }
     ) %>
   </body>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -166,8 +166,7 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      },
-      container: {:div, class: "absolute top-0 right-0 z-[999]"}
+      }
     ) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -165,7 +165,7 @@
     <%= live_render(@conn, OliWeb.TechSupportLive,
       session: %{
         "section" => Map.get(@conn.assigns, :section),
-        "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
+        "user" => Map.get(@conn.assigns, :current_author) || Map.get(@conn.assigns, :current_user)
       }
     ) %>
   </body>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -166,7 +166,8 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      }
+      },
+      container: {:div, class: "absolute top-0 right-0 z-[999]"}
     ) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/lti.html.heex
+++ b/lib/oli_web/templates/layout/lti.html.heex
@@ -78,7 +78,7 @@
     <%= live_render(@conn, OliWeb.TechSupportLive,
       session: %{
         "section" => Map.get(@conn.assigns, :section),
-        "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
+        "user" => Map.get(@conn.assigns, :current_author) || Map.get(@conn.assigns, :current_user)
       }
     ) %>
   </body>

--- a/lib/oli_web/templates/layout/lti.html.heex
+++ b/lib/oli_web/templates/layout/lti.html.heex
@@ -79,7 +79,8 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      }
+      },
+      container: {:div, class: "absolute top-0 right-0 z-[999]"}
     ) %>
   </body>
 </html>

--- a/lib/oli_web/templates/layout/lti.html.heex
+++ b/lib/oli_web/templates/layout/lti.html.heex
@@ -79,8 +79,7 @@
       session: %{
         "section" => Map.get(@conn.assigns, :section),
         "user" => Map.get(@conn.assigns, :current_user) || Map.get(@conn.assigns, :current_author)
-      },
-      container: {:div, class: "absolute top-0 right-0 z-[999]"}
+      }
     ) %>
   </body>
 </html>

--- a/test/oli_web/controllers/help_controller_test.exs
+++ b/test/oli_web/controllers/help_controller_test.exs
@@ -27,7 +27,7 @@ defmodule OliWeb.HelpControllerTest do
         "student_report_url" => nil
       }
 
-      assert {:error, "Help requester data is incomplete. Required field: email and name"} ==
+      assert {:error, "Requester data is incomplete. Required field(s): email and name"} ==
                Oli.Help.RequesterData.parse(requester_data)
 
       requester_data = %{

--- a/test/oli_web/controllers/help_controller_test.exs
+++ b/test/oli_web/controllers/help_controller_test.exs
@@ -27,7 +27,7 @@ defmodule OliWeb.HelpControllerTest do
         "student_report_url" => nil
       }
 
-      assert {:error, "Help requester data is incomplete."} ==
+      assert {:error, "Help requester data is incomplete. Required field: email and name"} ==
                Oli.Help.RequesterData.parse(requester_data)
 
       requester_data = %{


### PR DESCRIPTION
Ticket: [MER-4034](https://eliterate.atlassian.net/browse/MER-4034)

This PR adds the captcha directly to the TechSupport LiveView, as AppSignal logs indicate the error originates there:

```
05-19-2025 10:15:41.950[application][ERROR][tokamak.oli.cmu.edu][phoenix]Error when processing help message "reCaptcha failure"
```

Additionally, this PR includes a fix for the flash message rendering twice. A custom flash implementation was added, inspired by PR: https://github.com/Simon-Initiative/oli-torus/pull/5595.

Finally, this PR updates the `knowledgebase_url` to open in a new tab (see commit: 01b6d68c748a7cf32c737049db283984ca02475a) and removes the `console.log` added in PR: https://github.com/Simon-Initiative/oli-torus/pull/5614, as it was not providing useful information. (see commit: a62bd51dc6cc8f839d4f03648d078efa53131757)

Note: The last commit adds a debounce to the textarea input.

[MER-4034]: https://eliterate.atlassian.net/browse/MER-4034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ