### PR TITLE
[BUG FIX] [MER-4321] Rework: Student LTI tool opens in a new window

### DIFF
--- a/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
+++ b/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
@@ -29,7 +29,11 @@ const LTIExternalTool: React.FC = () => {
     [activityIdStr],
   );
 
-  const resourceId = model.id as string;
+  if (activityIdStr == undefined) {
+    console.error('LTIExternalTool: activityId is undefined');
+
+    return <Alert variant="error">Failed to load LTI activity</Alert>;
+  }
 
   return ltiToolDetailsLoader.caseOf({
     loading: () => <LoadingSpinner />,
@@ -39,9 +43,10 @@ const LTIExternalTool: React.FC = () => {
         <div className="activity lti-external-tool-activity">
           <div className="activity-content">
             <LTIExternalToolFrame
+              mode="authoring"
               name={ltiToolDetails.name}
               launchParams={ltiToolDetails.launch_params}
-              resourceId={resourceId}
+              resourceId={activityIdStr}
               openInNewTab={model.openInNewTab}
               height={model.height}
               onEditHeight={(height: number | undefined) => onEdit({ ...model, height })}

--- a/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
+++ b/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
@@ -16,15 +16,18 @@ import { LTIExternalToolSchema } from './schema';
 const store = configureStore();
 
 const LTIExternalTool: React.FC = () => {
-  const { model, projectSlug, activityId, onEdit } =
+  const { model, projectSlug, authoringContext, activityId, onEdit } =
     useAuthoringElementContext<LTIExternalToolSchema>();
 
   const activityIdStr = activityId ? `${activityId}` : undefined;
 
+  const projectsOrSections =
+    authoringContext?.previewMode === 'instructor' ? 'sections' : 'projects';
+
   const ltiToolDetailsLoader = useLoader(
     () =>
       activityIdStr
-        ? getLtiExternalToolDetails('projects', projectSlug, activityIdStr)
+        ? getLtiExternalToolDetails(projectsOrSections, projectSlug, activityIdStr)
         : Promise.resolve(null),
     [activityIdStr],
   );

--- a/assets/src/components/activities/lti_external_tool/LTIExternalToolDelivery.tsx
+++ b/assets/src/components/activities/lti_external_tool/LTIExternalToolDelivery.tsx
@@ -24,8 +24,6 @@ const LTIExternalTool: React.FC = () => {
     [state.activityId],
   );
 
-  const resourceId = model.id as string;
-
   return ltiToolDetailsLoader.caseOf({
     loading: () => <LoadingSpinner />,
     failure: (error) => <Alert variant="error">{error}</Alert>,
@@ -34,12 +32,12 @@ const LTIExternalTool: React.FC = () => {
         <div className="activity lti-external-tool-activity">
           <div className="activity-content">
             <LTIExternalToolFrame
+              mode="delivery"
               name={ltiToolDetails.name}
               launchParams={ltiToolDetails.launch_params}
-              resourceId={resourceId}
+              resourceId={`${context.resourceId}`}
               openInNewTab={model.openInNewTab}
               height={model.height}
-              launchOnMount={true}
             />
           </div>
         </div>

--- a/assets/src/components/lti/LTIExternalToolFrame.tsx
+++ b/assets/src/components/lti/LTIExternalToolFrame.tsx
@@ -3,12 +3,12 @@ import React, { useEffect, useState } from 'react';
 const DEFAULT_FRAME_HEIGHT = 600;
 
 type LTIExternalToolFrameProps = {
+  mode: 'authoring' | 'delivery';
   name: string;
   launchParams: Record<string, string>;
   resourceId: string;
   openInNewTab?: boolean;
   height?: number;
-  launchOnMount?: boolean;
   onEditHeight?: (height: number | undefined) => void;
 };
 
@@ -17,29 +17,32 @@ type LTIExternalToolFrameProps = {
  * an iframe.
  */
 export const LTIExternalToolFrame = ({
+  mode,
   name,
   launchParams,
   resourceId,
   openInNewTab,
   height,
-  launchOnMount,
   onEditHeight,
 }: LTIExternalToolFrameProps) => {
   const frameName = `tool-content-${resourceId}`;
   const target = openInNewTab ? '_blank' : frameName;
 
-  const [showFrame, setShowFrame] = useState(launchOnMount || false);
+  const [showFrame, setShowFrame] = useState(mode === 'delivery' && !openInNewTab);
 
   const frameRef = React.useRef<HTMLIFrameElement>(null);
   const formRef = React.useRef<HTMLFormElement>(null);
 
-  // If the launchOnMount prop is true, we submit the form immediately after the component mounts.
+  const autoLaunch = mode === 'delivery' && !openInNewTab;
+
+  const showLaunchButton = mode === 'authoring' || openInNewTab;
+
+  // If the autoLaunch prop is true, we submit the form immediately after the component mounts.
   // This is used in delvery mode to automatically open the tool when configured as a frame in the
   // page.
   useEffect(() => {
-    if (launchOnMount) {
+    if (autoLaunch) {
       if (formRef.current) {
-        console.log('Submitting form:', formRef.current);
         formRef.current.submit();
       }
     }
@@ -47,7 +50,7 @@ export const LTIExternalToolFrame = ({
 
   // Reset the iframe any time the openInNewTab setting changes
   useEffect(() => {
-    if (!launchOnMount) {
+    if (!autoLaunch) {
       setShowFrame(false);
     }
   }, [openInNewTab]);
@@ -75,7 +78,7 @@ export const LTIExternalToolFrame = ({
             ></input>
           ))}
 
-        {!launchOnMount && (
+        {showLaunchButton && (
           <div className="flex flex-row">
             <button
               className="w-full shadow-lg px-4 py-3 mb-4 bg-white rounded-lg border-2 border-gray-100 text-left text-primary font-semibold hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"

--- a/assets/src/data/persistence/lti_platform.ts
+++ b/assets/src/data/persistence/lti_platform.ts
@@ -11,11 +11,11 @@ export type LTIExternalToolDetails = {
 };
 
 export function getLtiExternalToolDetails(
-  projectOrCourse: 'projects' | 'sections',
+  projectsOrSections: 'projects' | 'sections',
   slug: string,
   activityId: string,
 ): Promise<LTIExternalToolDetails> {
-  return fetch(`/api/v1/lti/${projectOrCourse}/${slug}/launch_details/${activityId}`, {
+  return fetch(`/api/v1/lti/${projectsOrSections}/${slug}/launch_details/${activityId}`, {
     method: 'GET',
   }).then((response) => {
     if (!response.ok) return Promise.reject(new Error('Failed to fetch external tool details'));

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -219,7 +219,7 @@ defmodule Oli.Rendering.Activity.Html do
       |> HtmlEntities.encode()
 
     [
-      ~s|<#{tag} phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+      ~s|<#{tag} id="activity-#{resource_id}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -83,7 +83,8 @@ defmodule Oli.Rendering.Activity.Html do
 
         activity_context =
           %{
-            variables: variables
+            variables: variables,
+            previewMode: "instructor"
           }
           |> Poison.encode!()
           |> HtmlEntities.encode()

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -94,7 +94,7 @@ defmodule Oli.Rendering.Activity.Html do
 
       :review ->
         if is_adaptive?(tag) do
-          render_single_activity_html(tag, context, summary, bib_params, model_json)
+          render_single_activity_html(tag, context, summary, bib_params, model_json, activity_id)
         else
           [
             render_historical_attempts(
@@ -103,12 +103,19 @@ defmodule Oli.Rendering.Activity.Html do
               section_slug,
               context
             ),
-            render_single_activity_html(tag, context, summary, bib_params, model_json)
+            render_single_activity_html(
+              tag,
+              context,
+              summary,
+              bib_params,
+              model_json,
+              activity_id
+            )
           ]
         end
 
       _ ->
-        render_single_activity_html(tag, context, summary, bib_params, model_json)
+        render_single_activity_html(tag, context, summary, bib_params, model_json, activity_id)
     end
   end
 
@@ -169,10 +176,12 @@ defmodule Oli.Rendering.Activity.Html do
            ordinal: ordinal
          },
          bib_params,
-         model_json
+         model_json,
+         resource_id
        ) do
     activity_context =
       %{
+        resourceId: resource_id,
         graded: graded,
         batchScoring: effective_settings && effective_settings.batch_scoring,
         oneAtATime: effective_settings && effective_settings.assessment_mode == :one_at_a_time,
@@ -209,7 +218,7 @@ defmodule Oli.Rendering.Activity.Html do
       |> HtmlEntities.encode()
 
     [
-      ~s|<#{tag} phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}" id=#{UUID.uuid4()}></#{tag}>\n|
+      ~s|<#{tag} phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -48,7 +48,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~
-               ~s|<oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
+               ~s|<oli-multiple-choice-delivery id="activity-1" phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}"|
     end
 
     test "renders malformed activity gracefully", %{author: author} do

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -159,7 +159,7 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       # renders activity embedded in R alternative
       assert rendered_html_string =~
-               ~s|<oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="author_preview"|
+               ~s|<oli-multiple-choice-delivery id="activity-1" phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="author_preview"|
 
       # renders Excel alternative
       assert rendered_html_string =~

--- a/test/oli/rendering/survey/html_test.exs
+++ b/test/oli/rendering/survey/html_test.exs
@@ -69,7 +69,7 @@ defmodule Oli.Content.Survey.HtmlTest do
                ~s|<div id="1855946510" class="survey"><div class="survey-label">Survey</div><div class="survey-content">|
 
       assert rendered_html_string =~
-               ~s|<p data-point-marker=\"3166489545\">Please complete the following survey:</p>\n</div><oli-multiple-choice-delivery phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
+               ~s|<p data-point-marker=\"3166489545\">Please complete the following survey:</p>\n</div><oli-multiple-choice-delivery id="activity-1" phx-update="ignore" class="activity-container" state="{ "active": true }" model="{ "choices": [ "A", "B", "C", "D" ], "feedback": [ "A", "B", "C", "D" ], "stem": ""}" mode="delivery"|
 
       assert rendered_html_string =~
                ~s|</oli-multiple-choice-delivery>|

--- a/test/oli_web/controllers/user_session_controller_test.exs
+++ b/test/oli_web/controllers/user_session_controller_test.exs
@@ -19,7 +19,7 @@ defmodule OliWeb.UserSessionControllerTest do
 
       # Now do a logged in request and assert on the menu
       conn = get(conn, ~p"/")
-      response = html_response(conn, 200)
+      _response = html_response(conn, 200)
     end
 
     test "logs the user in with remember me", %{conn: conn, user: user} do

--- a/test/oli_web/plugs/header_size_logger_test.exs
+++ b/test/oli_web/plugs/header_size_logger_test.exs
@@ -1,9 +1,9 @@
 defmodule OliWeb.Plugs.HeaderSizeLoggerTest do
   use ExUnit.Case, async: true
-  use Plug.Test
 
   import Mox
   import ExUnit.CaptureLog
+  import Plug.Test
   import Plug.Conn
 
   alias OliWeb.Plugs.HeaderSizeLogger

--- a/test/oli_web/plugs/maybe_gated_resource_test.exs
+++ b/test/oli_web/plugs/maybe_gated_resource_test.exs
@@ -2,12 +2,10 @@ defmodule Oli.Plugs.MaybeGatedResourceTest do
   use OliWeb.ConnCase
 
   import Oli.Factory
-  import Phoenix.LiveViewTest
 
   alias Oli.Delivery.Attempts.Core.ResourceAccess
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Gating
-  alias Oli.Delivery.Attempts.Core
   alias Lti_1p3.Roles.ContextRoles
 
   describe "maybe_gated_resource plug" do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4321

Fixes several issues uncovered while testing the LTI tool launch as a student. The root cause of the issue was that there was no "id" on the model, this really should have been reading the resource ID (or activity ID) to uniquely identify the tool within the page. This is also the ID that gets passed along to the tool as part of the LTI claims. There was a little bit of work required to expose this to the LTI External Tool activity from the rendering code.

![2025-05-20 21 38 01](https://github.com/user-attachments/assets/143a3d74-7f4b-47b5-b651-99095c8f50c8)


I also identified and fixed an issue where LTI tools would not load in the Instructor Preview.