### PR TITLE
[BUG FIX] [MER-4602] fix browser tab title in delivery template

### DIFF
--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <Phoenix.Component.live_title>
-      <%= assigns[:page_title] || assigns[:title] || "Delivery" %>
+      <%= assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name() %>
     </Phoenix.Component.live_title>
 
     <link


### PR DESCRIPTION
#5565 addressing MER-4536 adjusted page titles shown in browser tabs. This had an error causing "Delivery" to be shown as browser tab page title on pages using the delivery template. This corrects to show product short name from vendor properties just as in other cases addressed in that PR.