### PR TITLE
[ENHANCEMENT] [MER-4595] Add crontab configuration to dev environment.

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,6 +10,8 @@ get_env_as_boolean = fn key, default ->
   end
 end
 
+config :oli, Oban, plugins: [Oban.Plugins.Pruner, {Oban.Plugins.Cron, crontab: []}]
+
 config :oli,
   env: :dev,
   s3_xapi_bucket_name: System.get_env("S3_XAPI_BUCKET_NAME"),

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -10,7 +10,11 @@ get_env_as_boolean = fn key, default ->
   end
 end
 
-config :oli, Oban, plugins: [Oban.Plugins.Pruner, {Oban.Plugins.Cron, crontab: []}]
+if System.get_env("ADD_OBAN_CRONTAB_IN_DEV", "false") == "true" do
+  config :oli, Oban, plugins: [Oban.Plugins.Pruner, {Oban.Plugins.Cron, crontab: []}]
+else
+  nil
+end
 
 config :oli,
   env: :dev,


### PR DESCRIPTION
Ticket: [MER-4595](https://eliterate.atlassian.net/browse/MER-4595)

This PR adds a configuration to the development environment to prevent cron jobs from running and cluttering the IEx session console.


[MER-4595]: https://eliterate.atlassian.net/browse/MER-4595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ