### PR TITLE
[BUG FIX] [MER-4604] Fix spelling issues in defined Datasets job shortcuts

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/datasets/job_shortcuts.ex
+++ b/lib/oli_web/live/workspaces/course_author/datasets/job_shortcuts.ex
@@ -68,9 +68,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.Datasets.JobShortcuts do
        chunk_size: 50_000,
        event_type: "attempt_evaluated",
        event_sub_types: [
-         "part_attempt_evaluted",
+         "part_attempt_evaluated",
          "activity_attempt_evaluated",
-         "page_attempt_evaluted"
+         "page_attempt_evaluated"
        ],
        page_ids: [],
        ignored_student_ids: [],
@@ -85,9 +85,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.Datasets.JobShortcuts do
        chunk_size: 5_000,
        event_type: "attempt_evaluated",
        event_sub_types: [
-         "part_attempt_evaluted",
+         "part_attempt_evaluated",
          "activity_attempt_evaluated",
-         "page_attempt_evaluted"
+         "page_attempt_evaluated"
        ],
        page_ids: [],
        ignored_student_ids: [],
@@ -127,7 +127,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Datasets.JobShortcuts do
        section_ids: section_ids,
        chunk_size: 5_000,
        event_type: "attempt_evaluated",
-       event_sub_types: ["part_attempt_evaluted"],
+       event_sub_types: ["part_attempt_evaluated"],
        page_ids: [],
        ignored_student_ids: [],
        excluded_fields: ["feedback", "hints"]


### PR DESCRIPTION
This PR fixes a datasets problem where the defined job shortcuts contained misspellings of the event subtypes for both `part_attempt_evaluated` and `page_attempt_evaluated`.  This was causing certain Dataset jobs to run and miss some results.   A workaround has been deployed on the Datasets side - which significantly lowers the priority of this issue. 

