### PR TITLE
[BUG FIX] [MER-4612] Various score as you go fixes

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyDelivery.tsx
@@ -37,6 +37,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
     onSubmitActivity,
     onResetActivity,
     onSaveActivity,
+    mode,
     model,
   } = useDeliveryElementContext<CATASchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
@@ -69,6 +70,7 @@ export const CheckAllThatApplyComponent: React.FC = () => {
       <SubmitResetConnected onReset={() => dispatch(resetAction(onResetActivity, resetInputs))} />
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/assets/src/components/activities/common/ScoreAsYouGoSubmitReset.tsx
+++ b/assets/src/components/activities/common/ScoreAsYouGoSubmitReset.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { DeliveryMode } from 'components/activities/types';
 import { Modal, ModalSize } from 'components/modal/Modal';
 import { modalActions } from 'actions/modal';
 import { ActivityDeliveryState, isEvaluated } from 'data/activities/DeliveryState';
@@ -8,6 +9,7 @@ import { ScoreAsYouGoIcon } from './utils';
 interface Props {
   onSubmit: () => void;
   onReset: () => void;
+  mode: DeliveryMode;
 }
 
 interface ModalProps {
@@ -61,19 +63,37 @@ function buildConfirmMessage(uiState: ActivityDeliveryState): any {
   );
 }
 
-export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset }) => {
+export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset, mode }) => {
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const { attemptState } = uiState;
+
+  const numberFormat = (value: number | null) => {
+    if (value === null) {
+      return '';
+    }
+    // If the number is an integer, return it as is
+    if (Number.isInteger(value)) {
+      return value.toString();
+    }
+    // Otherwise, return it with two decimal places
+    return value.toFixed(2);
+  };
 
   if (uiState.activityContext.graded) {
     if (isEvaluated(uiState)) {
       if (!uiState.activityContext.batchScoring) {
+        const pointsDisplay =
+          attemptState.score === undefined && mode === 'review'
+            ? null
+            : numberFormat(attemptState.score) + ' / ' + numberFormat(attemptState.outOf);
+
         return (
           <div className="mt-3 flex justify-between">
             <button
               disabled={
-                uiState.activityContext.maxAttempts > 0 &&
-                attemptState.attemptNumber >= uiState.activityContext.maxAttempts
+                mode != 'delivery' ||
+                (uiState.activityContext.maxAttempts > 0 &&
+                  attemptState.attemptNumber >= uiState.activityContext.maxAttempts)
               }
               onClick={() => {
                 window.oliDispatch(
@@ -98,7 +118,7 @@ export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset }) 
               <span>
                 <ScoreAsYouGoIcon /> Points:{' '}
               </span>
-              <span>{attemptState.score?.toFixed(2) + ' / ' + attemptState.outOf}</span>
+              <span>{pointsDisplay}</span>
             </div>
           </div>
         );
@@ -108,8 +128,9 @@ export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset }) 
         <div className="flex justify-center">
           <button
             disabled={
-              uiState.activityContext.maxAttempts > 0 &&
-              attemptState.attemptNumber > uiState.activityContext.maxAttempts
+              mode != 'delivery' ||
+              (uiState.activityContext.maxAttempts > 0 &&
+                attemptState.attemptNumber > uiState.activityContext.maxAttempts)
             }
             className="btn btn-primary"
             onClick={() => onSubmit()}

--- a/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
+++ b/assets/src/components/activities/custom_dnd/CustomDnDDelivery.tsx
@@ -188,6 +188,7 @@ export const CustomDnDComponent: React.FC = () => {
         )
       : working || (
           <ScoreAsYouGoSubmitReset
+            mode={mode}
             onSubmit={() => dispatch(submit(onSubmitActivity))}
             onReset={async () => {
               if (resetListener !== null) {

--- a/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotDelivery.tsx
@@ -44,6 +44,7 @@ const ImageHotspotComponent: React.FC = () => {
     state: activityState,
     context,
     model,
+    mode,
     writerContext,
     onSubmitActivity,
     onSaveActivity,
@@ -151,6 +152,7 @@ const ImageHotspotComponent: React.FC = () => {
       )
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/assets/src/components/activities/likert/LikertDelivery.tsx
+++ b/assets/src/components/activities/likert/LikertDelivery.tsx
@@ -35,6 +35,7 @@ const LikertComponent: React.FC = () => {
     state: activityState,
     context,
     model,
+    mode,
     writerContext,
     onSubmitActivity,
     onSaveActivity,
@@ -78,6 +79,7 @@ const LikertComponent: React.FC = () => {
       />
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -335,6 +335,7 @@ export const MultiInputComponent: React.FC = () => {
         )}
 
         <ScoreAsYouGoSubmitReset
+          mode={mode}
           onSubmit={() => dispatch(submit(onSubmitActivity))}
           onReset={() => dispatch(resetAction(onResetActivity, undefined))}
         />

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceDelivery.tsx
@@ -47,6 +47,7 @@ export const MultipleChoiceComponent: React.FC = () => {
     onSaveActivity,
     onResetActivity,
     model,
+    mode,
   } = useDeliveryElementContext<MCSchema>();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const dispatch = useDispatch();
@@ -122,6 +123,7 @@ export const MultipleChoiceComponent: React.FC = () => {
           context={writerContext}
         />
         <ScoreAsYouGoSubmitReset
+          mode={mode}
           onSubmit={() => dispatch(submit(onSubmitActivity))}
           onReset={() => dispatch(resetAction(onResetActivity, undefined))}
         />

--- a/assets/src/components/activities/ordering/OrderingDelivery.tsx
+++ b/assets/src/components/activities/ordering/OrderingDelivery.tsx
@@ -34,6 +34,7 @@ import { OrderingSchema } from './schema';
 export const OrderingComponent: React.FC = () => {
   const {
     model,
+    mode,
     context,
     state: activityState,
     onSubmitActivity,
@@ -145,6 +146,7 @@ export const OrderingComponent: React.FC = () => {
       />
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
@@ -390,6 +390,7 @@ export const ResponseMultiInputComponent: React.FC = () => {
         )}
 
         <ScoreAsYouGoSubmitReset
+          mode={mode}
           onSubmit={() => dispatch(submit(onSubmitActivity))}
           onReset={() => dispatch(resetAction(onResetActivity, undefined))}
         />

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -71,6 +71,7 @@ const Input = (props: InputProps) => {
 export const ShortAnswerComponent: React.FC = () => {
   const {
     model,
+    mode,
     state: activityState,
     context,
     onSubmitActivity,
@@ -144,6 +145,7 @@ export const ShortAnswerComponent: React.FC = () => {
       />
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/assets/src/components/activities/vlab/VlabDelivery.tsx
+++ b/assets/src/components/activities/vlab/VlabDelivery.tsx
@@ -38,6 +38,7 @@ export const VlabComponent: React.FC = () => {
     onSaveActivity,
     onResetActivity,
     model,
+    mode,
   } = useDeliveryElementContext<VlabSchema>();
 
   const uiState = useSelector((state: ActivityDeliveryState) => state);
@@ -240,6 +241,7 @@ export const VlabComponent: React.FC = () => {
       />
     ) : (
       <ScoreAsYouGoSubmitReset
+        mode={mode}
         onSubmit={() => dispatch(submit(onSubmitActivity))}
         onReset={() => dispatch(resetAction(onResetActivity, undefined))}
       />

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1135,19 +1135,19 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   attr :batch_scoring, :boolean, default: false
 
-  def submit_button(%{batch_scoring: false} = assigns) do
-    ~H"""
-    """
-  end
-
   def submit_button(assigns) do
+    button_style =
+      if assigns[:batch_scoring] do
+        "cursor-pointer px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded-[3px] shadow justify-center items-center gap-2.5 inline-flex text-white text-sm font-normal font-['Open Sans'] leading-tight"
+      else
+        "invisible"
+      end
+
+    assigns = assign(assigns, button_style: button_style)
+
     ~H"""
     <div class="flex w-full justify-center">
-      <button
-        id="submit_answers"
-        phx-hook="DelayedSubmit"
-        class="cursor-pointer px-5 py-2.5 hover:bg-opacity-40 bg-blue-600 rounded-[3px] shadow justify-center items-center gap-2.5 inline-flex text-white text-sm font-normal font-['Open Sans'] leading-tight"
-      >
+      <button id="submit_answers" phx-hook="DelayedSubmit" class={@button_style}>
         <span class="button-text">Submit Answers</span>
         <span class="spinner hidden ml-2 animate-spin">
           <svg


### PR DESCRIPTION
This PR fixes a few different issues with Score as you Go:

1. Client side auto submission was broke, due to the removal of the "Submit Assessment" button.  The fix here was to re-introduce its rendering into the DOM, but make it invisible during Score as you Go. 
2. The "Reset" button was still clickable during review mode.  This is now disabled during review mode.
3. The points display would display "undefined / null" in review mode when Feedback was disallowed.  This case has been handled. 
4. Certificates with SAYG pages could not be earned.  The fix here was to initiate the cert check during SAYG roll up. 