### PR TITLE
[ENHANCEMENT] [MER-4552] add data attribute marking activity editors for automated tests

### DIFF
--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -190,7 +190,10 @@ export class InlineActivityEditor extends React.Component<
     );
 
     return (
-      <div className={classNames(styles.inlineActivityEditor, 'activity-editor')}>
+      <div
+        className={classNames(styles.inlineActivityEditor, 'activity-editor')}
+        data-qa="activity"
+      >
         <div className="d-flex align-items-baseline flex-grow-1 mr-2">
           <TextEditor
             onEdit={onTitleEdit}


### PR DESCRIPTION
This adds marker attribute `data-qa='activity'` to inline activity editor container so automated QA tests have something to reliably key on to identify activities in the authoring UI. 