### PR TITLE
[FEATURE] [MER-4268] Instructor schedule expand all

### DIFF
--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useCallbackRef, useResizeObserver } from '@restart/hooks';
 import { DateWithoutTime } from 'epoq';
 import { modeIsDark } from 'components/misc/DarkModeSelector';
@@ -8,6 +8,12 @@ import { ScheduleHeaderRow } from './ScheduleHeader';
 import { ScheduleLine } from './ScheduleLine';
 import { generateDayGeometry } from './date-utils';
 import { getTopLevelSchedule } from './schedule-selectors';
+import {
+  areSomeContainersExpanded,
+  collapseAllContainers,
+  expandAllContainers,
+  hasContainers,
+} from './scheduler-slice';
 
 interface GridProps {
   startDate: string;
@@ -66,6 +72,13 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset,
     [rect?.width, startDate, endDate],
   );
 
+  const dispatch = useDispatch();
+  const someExpanded = useSelector(areSomeContainersExpanded);
+  const canToggle = useSelector(hasContainers);
+  const handleClick = () => {
+    someExpanded ? dispatch(collapseAllContainers()) : dispatch(expandAllContainers());
+  };
+
   return (
     <div className="pb-20">
       <div className="flex flex-row justify-between gap-x-4 mb-6 px-6 bg-[#F2F9FF] dark:bg-[#1F1D23]">
@@ -99,17 +112,20 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset,
         </div>
 
         {/* Expand/Collapse All button */}
-        <div className="flex flex-row items-center justify-start w-auto px-2 text-sm text-[#353740] ">
-          <button id="expand_all_button" className="flex space-x-3 dark:text-[#eeebf5]">
-            <ExpandAllIcon className="text-[#353740] dark:text-white ml-2" />
-            <span>Expand All</span>
-          </button>
-
-          <button id="collapse_all_button" className="hidden space-x-3 dark:text-[#eeebf5]">
+        <button
+          id="toggle_expand_button"
+          className="flex space-x-3 dark:text-[#eeebf5] disabled:opacity-50 disabled:cursor-not-allowed items-center"
+          onClick={handleClick}
+          title={!canToggle ? 'No expandable containers available' : undefined}
+          disabled={!canToggle}
+        >
+          {someExpanded ? (
             <CollapseAllIcon className="text-[#353740] dark:text-white ml-2" />
-            <span>Collapse All</span>
-          </button>
-        </div>
+          ) : (
+            <ExpandAllIcon className="text-[#353740] dark:text-white ml-2" />
+          )}
+          <span>{someExpanded ? 'Collapse All' : 'Expand All'}</span>
+        </button>
 
         {/* Clear Schedule button */}
         <button

--- a/assets/src/apps/scheduler/ScheduleLine.tsx
+++ b/assets/src/apps/scheduler/ScheduleLine.tsx
@@ -2,7 +2,6 @@ import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { DateWithoutTime } from 'epoq';
 import { modeIsDark } from 'components/misc/DarkModeSelector';
-import { useToggle } from '../../components/hooks/useToggle';
 import { DragBar } from './DragBar';
 import { PageScheduleLine } from './PageScheduleLine';
 import { ScheduleHeader } from './ScheduleHeader';
@@ -20,7 +19,6 @@ import {
   moveScheduleItem,
   selectItem,
   toggleContainer,
-  unlockScheduleItem,
 } from './scheduler-slice';
 
 interface ScheduleLineProps {
@@ -64,7 +62,6 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
   rowColor,
   dayGeometry,
 }) => {
-  const [expanded, toggleExpanded] = useToggle(false);
   const dispatch = useDispatch();
   const expanded = useSelector((state) => isContainerExpanded(state, item.id));
   const toggleExpanded = () => dispatch(toggleContainer(item.id));

--- a/assets/src/apps/scheduler/ScheduleLine.tsx
+++ b/assets/src/apps/scheduler/ScheduleLine.tsx
@@ -16,8 +16,11 @@ import {
   HierarchyItem,
   ScheduleItemType,
   getScheduleItem,
+  isContainerExpanded,
   moveScheduleItem,
   selectItem,
+  toggleContainer,
+  unlockScheduleItem,
 } from './scheduler-slice';
 
 interface ScheduleLineProps {
@@ -63,6 +66,8 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
 }) => {
   const [expanded, toggleExpanded] = useToggle(false);
   const dispatch = useDispatch();
+  const expanded = useSelector((state) => isContainerExpanded(state, item.id));
+  const toggleExpanded = () => dispatch(toggleContainer(item.id));
   const isSelected = useSelector(getSelectedId) === item.id;
   const schedule = useSelector(getSchedule);
   const showNumbers = useSelector(shouldDisplayCurriculumItemNumbering);

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -443,12 +443,12 @@ export const schedulerSliceReducer = schedulerSlice.reducer;
 export const isContainerExpanded = (state: any, id: number) =>
   !!state.scheduler.expandedContainers[id];
 
-export const areSomeContainersExpanded = (state: any) => {
-  const containers: HierarchyItem[] = state.scheduler.schedule.filter(
-    (item: HierarchyItem) => item.resource_type_id === ScheduleItemType.Container,
+export const areSomeContainersExpanded = (state: any) =>
+  state.scheduler.schedule.some(
+    (item: HierarchyItem) =>
+      item.resource_type_id === ScheduleItemType.Container &&
+      state.scheduler.expandedContainers[item.id],
   );
-  return containers.some((item) => state.scheduler.expandedContainers[item.id]);
-};
 
 export const hasContainers = (state: any) =>
   state.scheduler.schedule.some(

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -60,6 +60,7 @@ export interface SchedulerState {
   errorMessage: string | null;
   weekdays: boolean[];
   preferredSchedulingTime: TimeParts;
+  expandedContainers: Record<number, boolean>;
 }
 
 export const initSchedulerState = (): SchedulerState => ({
@@ -80,6 +81,7 @@ export const initSchedulerState = (): SchedulerState => ({
     minute: 59,
     second: 59,
   },
+  expandedContainers: {},
 });
 
 const toDateTime = (str: string, preferredSchedulingTime: TimeParts) => {
@@ -333,6 +335,21 @@ const schedulerSlice = createSlice({
     dismissError(state) {
       state.errorMessage = null;
     },
+    toggleContainer(state, action: PayloadAction<number>) {
+      const id = action.payload;
+      state.expandedContainers[id] = !state.expandedContainers[id];
+    },
+    expandAllContainers(state) {
+      const containers = state.schedule.filter(
+        (item) => item.resource_type_id === ScheduleItemType.Container,
+      );
+      containers.forEach((item) => {
+        state.expandedContainers[item.id] = true;
+      });
+    },
+    collapseAllContainers(state) {
+      state.expandedContainers = {};
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(clearSectionSchedule.pending, (state, action) => {
@@ -416,6 +433,25 @@ export const {
   unlockScheduleItem,
   changeScheduleType,
   dismissError,
+  toggleContainer,
+  expandAllContainers,
+  collapseAllContainers,
 } = schedulerSlice.actions;
 
 export const schedulerSliceReducer = schedulerSlice.reducer;
+
+export const isContainerExpanded = (state: any, id: number) =>
+  !!state.scheduler.expandedContainers[id];
+
+export const areSomeContainersExpanded = (state: any) => {
+  const containers: HierarchyItem[] = state.scheduler.schedule.filter(
+    (item: HierarchyItem) => item.resource_type_id === ScheduleItemType.Container,
+  );
+  return containers.some((item) => state.scheduler.expandedContainers[item.id]);
+};
+
+export const hasContainers = (state: any) =>
+  state.scheduler.schedule.some(
+    (item: HierarchyItem) =>
+      item.resource_type_id === ScheduleItemType.Container && item.numbering_level !== 0,
+  );

--- a/assets/test/scheduler/expand-collapse-schedule_test.ts
+++ b/assets/test/scheduler/expand-collapse-schedule_test.ts
@@ -1,0 +1,130 @@
+import {
+  HierarchyItem,
+  ScheduleItemType,
+  areSomeContainersExpanded,
+  collapseAllContainers,
+  expandAllContainers,
+  hasContainers,
+  isContainerExpanded,
+  schedulerSliceReducer,
+  toggleContainer,
+} from '../../src/apps/scheduler/scheduler-slice';
+
+describe('expand/collapse containers', () => {
+  const container1: HierarchyItem = {
+    id: 1,
+    resource_id: 1,
+    resource_type_id: ScheduleItemType.Container,
+    title: 'Container 1',
+    numbering_level: 1,
+    numbering_index: 1,
+    scheduling_type: 'read_by',
+    manually_scheduled: false,
+    graded: false,
+    children: [],
+    startDate: null,
+    endDate: null,
+    startDateTime: null,
+    endDateTime: null,
+    start_date: '',
+    end_date: '',
+  };
+
+  const rootContainer: HierarchyItem = {
+    ...container1,
+    id: 0,
+    numbering_level: 0,
+    numbering_index: 1,
+  };
+
+  const baseState = {
+    scheduler: {
+      schedule: [rootContainer, container1],
+      expandedContainers: {},
+      startDate: null,
+      endDate: null,
+      selectedId: null,
+      appLoading: false,
+      saving: false,
+      title: '',
+      displayCurriculumItemNumbering: true,
+      dirty: [],
+      sectionSlug: '',
+      errorMessage: null,
+      weekdays: [false, true, true, true, true, true, false],
+      preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
+    },
+  };
+
+  it('should toggle a container', () => {
+    const nextState = schedulerSliceReducer(baseState.scheduler, toggleContainer(1));
+    expect(nextState.expandedContainers[1]).toBe(true);
+
+    const revertedState = schedulerSliceReducer(nextState, toggleContainer(1));
+    expect(revertedState.expandedContainers[1]).toBeFalsy();
+  });
+
+  it('should expand all containers', () => {
+    const nextState = schedulerSliceReducer(baseState.scheduler, expandAllContainers());
+    expect(Object.keys(nextState.expandedContainers)).toHaveLength(2);
+    expect(nextState.expandedContainers).toEqual({ 0: true, 1: true });
+  });
+
+  it('should collapse all containers', () => {
+    const expandedState = schedulerSliceReducer(baseState.scheduler, expandAllContainers());
+    const collapsedState = schedulerSliceReducer(expandedState, collapseAllContainers());
+    expect(collapsedState.expandedContainers).toEqual({});
+  });
+
+  it('isContainerExpanded selector should return true if container is expanded', () => {
+    const stateWithExpanded = {
+      ...baseState,
+      scheduler: {
+        ...baseState.scheduler,
+        expandedContainers: { 1: true },
+      },
+    };
+    expect(isContainerExpanded(stateWithExpanded, 1)).toBe(true);
+    expect(isContainerExpanded(stateWithExpanded, 999)).toBe(false);
+  });
+
+  it('areSomeContainersExpanded should return true if any container is expanded', () => {
+    const stateWithExpanded = {
+      ...baseState,
+      scheduler: {
+        ...baseState.scheduler,
+        expandedContainers: { 1: true },
+      },
+    };
+    expect(areSomeContainersExpanded(stateWithExpanded)).toBe(true);
+
+    const stateCollapsed = {
+      ...baseState,
+      scheduler: {
+        ...baseState.scheduler,
+        expandedContainers: {},
+      },
+    };
+    expect(areSomeContainersExpanded(stateCollapsed)).toBe(false);
+  });
+
+  it('hasContainers should return true only if there are non-root containers', () => {
+    const withOnlyRoot = {
+      ...baseState,
+      scheduler: {
+        ...baseState.scheduler,
+        schedule: [rootContainer],
+      },
+    };
+    expect(hasContainers(withOnlyRoot)).toBe(false);
+
+    const withSubContainer = {
+      ...baseState,
+      scheduler: {
+        ...baseState.scheduler,
+        schedule: [rootContainer, container1],
+      },
+    };
+    expect(hasContainers(withSubContainer)).toBe(true);
+  });
+});


### PR DESCRIPTION
[MER-4268](https://eliterate.atlassian.net/browse/MER-4268)

This PR adds functionality to the button that collapses and expands the schedule grid in the instructor’s schedule view.

- When the user clicks Expand All, all containers in the grid will be expanded, and the button text and icon will switch to Collapse All.

- When the user clicks Collapse All, all containers in the grid will be collapsed, and the button text and icon will switch to Expand All.

Additionally, if there are no expandable or collapsible containers in the grid, the button will be disabled and a tooltip will show  **"No expandable containers available."**

https://github.com/user-attachments/assets/202966ae-6884-4713-a63a-d444a9ee088d



[MER-4268]: https://eliterate.atlassian.net/browse/MER-4268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ