### PR TITLE
[BUG FIX] [MER-4614] Fix issue where checkbox label affects other LTI activity on page

### DIFF
--- a/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
+++ b/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
@@ -58,7 +58,7 @@ const LTIExternalTool: React.FC = () => {
             <div>
               <AuthoringCheckbox
                 label="Launch tool in new window"
-                id="launchInNewWindow"
+                id={`open-in-new-tab-${activityIdStr}`}
                 value={model.openInNewTab}
                 onChange={(value) => onEdit({ ...model, openInNewTab: value })}
                 editMode={true}


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4614

This PR fixes an issue in authoring where changing the value of the "Launch tool in new window"  by clicking the label would non-deterministically affect other LTI activities on the page.

The issue was the htmlFor prop for the label was a static string and therefore pointed to all activities of this type. The fix here is to append a unique identifier to the id so that all checkboxes are unique on the page.