### PR TITLE
[FEATURE] [MER-4268] Instructor schedule expand all - rework

### DIFF
--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -75,6 +75,7 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset,
   const dispatch = useDispatch();
   const someExpanded = useSelector(areSomeContainersExpanded);
   const canToggle = useSelector(hasContainers);
+
   const handleClick = () => {
     someExpanded ? dispatch(collapseAllContainers()) : dispatch(expandAllContainers());
   };
@@ -114,16 +115,19 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset,
         {/* Expand/Collapse All button */}
         <button
           id="toggle_expand_button"
-          className="flex space-x-3 dark:text-[#eeebf5] disabled:opacity-50 disabled:cursor-not-allowed items-center"
+          className={`flex items-center space-x-3 font-medium disabled:opacity-50 disabled:cursor-not-allowed
+                      ${
+                        someExpanded
+                          ? 'text-[#0062F2] dark:text-[#4CA6FF] font-bold'
+                          : 'text-[#353740] dark:text-[#EEEBF5]'
+                      }
+                      hover:text-[#1B67B2] dark:hover:text-[#99CCFF] hover:font-bold
+                    `}
           onClick={handleClick}
           title={!canToggle ? 'No expandable containers available' : undefined}
           disabled={!canToggle}
         >
-          {someExpanded ? (
-            <CollapseAllIcon className="text-[#353740] dark:text-white ml-2" />
-          ) : (
-            <ExpandAllIcon className="text-[#353740] dark:text-white ml-2" />
-          )}
+          {someExpanded ? <CollapseAllIcon className="ml-2" /> : <ExpandAllIcon className="ml-2" />}
           <span>{someExpanded ? 'Collapse All' : 'Expand All'}</span>
         </button>
 


### PR DESCRIPTION
[MER-4268](https://eliterate.atlassian.net/browse/MER-4268)

This PR fixes the styling of the button used to expand and collapse the schedule grid.

It adjusts the hover colors for both light and dark modes.

Also, the following rules are applied to the button styling:

- When the user clicks “expand all”: button is blue to show it is active

- When the user clicks “collapse all”: button is black again (back to default) to show it is not active 



https://github.com/user-attachments/assets/ad7af957-7b49-4b15-8e4c-534608278ad9





[MER-4268]: https://eliterate.atlassian.net/browse/MER-4268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ