### PR TITLE
[ENHANCEMENT] [MER-4332] Improve efficiency of queries when retrieving LTI activity IDs by platform instance

### DIFF
--- a/lib/oli/lti/platform_external_tools.ex
+++ b/lib/oli/lti/platform_external_tools.ex
@@ -372,24 +372,21 @@ defmodule Oli.Lti.PlatformExternalTools do
 
     # Step 2: Get IDs of all section resources that are LTI activities
     lti_activity_ids =
-      from(sr in SectionResource,
-        join: r in Revision,
-        on: sr.revision_id == r.id,
+      from(r in Revision,
         where: r.activity_type_id in ^lti_activity_registrations,
-        select: r.resource_id
+        select: r.resource_id,
+        distinct: true
       )
       |> Repo.all()
 
     # Step 3: Find all sections that reference these LTI activities
-    page_type_id = ResourceType.id_for_page()
-
     from(sr in SectionResource,
       join: r in Revision,
       on: sr.revision_id == r.id,
       join: s in Section,
       on: sr.section_id == s.id,
       where:
-        r.resource_type_id == ^page_type_id and
+        r.resource_type_id == ^ResourceType.id_for_page() and
           fragment("? && ?", r.activity_refs, ^lti_activity_ids),
       distinct: true,
       select: s

--- a/test/oli/lti/platform_external_tools_test.exs
+++ b/test/oli/lti/platform_external_tools_test.exs
@@ -534,6 +534,63 @@ defmodule Oli.Lti.PlatformExternalToolsTest do
     end
   end
 
+  describe "get_sections_grouped_by_platform_instance_ids/1" do
+    test "returns sections grouped by platform_instance_id" do
+      section = insert(:section)
+      platform = insert(:platform_instance)
+      lti_deployment = insert(:lti_external_tool_activity_deployment, platform_instance: platform)
+
+      activity_registration =
+        insert(:activity_registration,
+          lti_external_tool_activity_deployment: lti_deployment
+        )
+
+      revision =
+        insert(:revision,
+          activity_type_id: activity_registration.id
+        )
+
+      insert(:section_resource,
+        section: section,
+        resource_id: revision.resource_id,
+        revision_id: revision.id,
+        activity_type_id: activity_registration.id
+      )
+
+      result =
+        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
+
+      assert Map.has_key?(result, platform.id)
+      assert Enum.any?(result[platform.id], fn s -> s.id == section.id end)
+    end
+
+    test "returns empty map when no deployments match" do
+      platform = insert(:platform_instance)
+
+      result =
+        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
+
+      assert result == %{}
+    end
+
+    test "excludes platforms with no linked sections" do
+      platform = insert(:platform_instance)
+
+      activity_registration = insert(:activity_registration)
+
+      _deployment =
+        insert(:lti_external_tool_activity_deployment,
+          platform_instance: platform,
+          activity_registration: activity_registration
+        )
+
+      result =
+        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
+
+      assert result == %{}
+    end
+  end
+
   describe "update_lti_external_tool_activity_deployment/2" do
     setup do
       deployment = insert(:lti_external_tool_activity_deployment)

--- a/test/oli/lti/platform_external_tools_test.exs
+++ b/test/oli/lti/platform_external_tools_test.exs
@@ -479,7 +479,7 @@ defmodule Oli.Lti.PlatformExternalToolsTest do
   end
 
   describe "get_sections_with_lti_activities_for_platform_instance_id/1" do
-    test "returns only sections that include pages referencing deployed LTI tools" do
+    test "returns only sections that include section resources referencing deployed LTI tools" do
       section = insert(:section)
       lti_deployment = insert(:lti_external_tool_activity_deployment)
 
@@ -498,19 +498,8 @@ defmodule Oli.Lti.PlatformExternalToolsTest do
       insert(:section_resource,
         section: section,
         resource_id: lti_activity_resource.id,
-        revision_id: lti_activity_revision.id
-      )
-
-      page_revision =
-        insert(:revision,
-          resource_type_id: ResourceType.id_for_page(),
-          activity_refs: [lti_activity_resource.id]
-        )
-
-      insert(:section_resource,
-        section: section,
-        resource_id: page_revision.resource_id,
-        revision_id: page_revision.id
+        revision_id: lti_activity_revision.id,
+        activity_type_id: activity_registration.id
       )
 
       result =

--- a/test/oli_web/live/admin/external_tools/usage_view_test.exs
+++ b/test/oli_web/live/admin/external_tools/usage_view_test.exs
@@ -27,31 +27,15 @@ defmodule OliWeb.Admin.ExternalTools.UsageViewTest do
       insert(:section_resource,
         section: section,
         resource_id: lti_activity_resource.id,
-        revision_id: lti_activity_revision.id
+        revision_id: lti_activity_revision.id,
+        activity_type_id: activity_registration.id
       )
 
       insert(:section_resource,
         section: section2,
         resource_id: lti_activity_resource.id,
-        revision_id: lti_activity_revision.id
-      )
-
-      page_revision =
-        insert(:revision,
-          resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-          activity_refs: [lti_activity_resource.id]
-        )
-
-      insert(:section_resource,
-        section: section,
-        resource_id: page_revision.resource_id,
-        revision_id: page_revision.id
-      )
-
-      insert(:section_resource,
-        section: section2,
-        resource_id: page_revision.resource_id,
-        revision_id: page_revision.id
+        revision_id: lti_activity_revision.id,
+        activity_type_id: activity_registration.id
       )
 
       %{


### PR DESCRIPTION
- Improved the query in `Oli.Lti.PlatformExternalTools.get_sections_with_lti_activities_for_platform_instance_id/1`
- Added new function `Oli.Lti.PlatformExternalTools.get_sections_grouped_by_platform_instance_ids/1` to enable retrieving sections for multiple platform instances. (This improves the efficiency when displaying the usage count `/admin/external_tools`)
- Fixed the sorting behaviour in `/admin/external_tools/:platform_instance_id/usage` and when sorting by _usage count_ in `/admin/external_tools`

See: https://eliterate.atlassian.net/browse/MER-4332