### PR TITLE
[BUG FIX] [MER-4593] Missing header in LTI tools view

### DIFF
--- a/lib/oli_web/live/admin/external_tools/external_tools_view.ex
+++ b/lib/oli_web/live/admin/external_tools/external_tools_view.ex
@@ -90,30 +90,33 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
 
   def render(assigns) do
     ~H"""
-    <div class="flex flex-row items-center justify-between mt-4">
-      <TextSearch.render
-        id="text-search"
-        class="lg:!max-w-[33%] w-full"
-        text={@options.text_search}
-        event_target={nil}
-      />
-      <.link
-        id="button-new-tool"
-        href={~p"/admin/external_tools/new"}
-        class="h-8 w-32 px-5 py-3 hover:no-underline rounded-md justify-center items-center gap-2 inline-flex bg-[#0062F2] hover:bg-[#0075EB] dark:bg-[#0062F2] dark:hover:bg-[#0D70FF]"
-      >
-        <div class="w-3 h-5 relative">
-          <Icons.plus
-            class="w-5 h-5 left-[-8px] top-0 absolute font-semibold"
-            path_class="stroke-white"
-          />
-        </div>
-        <div class="text-center justify-center text-white text-sm font-semibold leading-none">
-          Add Tool
-        </div>
-      </.link>
+    <div class="flex flex-col mt-4 space-y-4">
+      <h1 class="text-2xl font-normal leading-9">LTI 1.3 External Tools</h1>
+      <div class="flex flex-row items-center justify-between">
+        <TextSearch.render
+          id="text-search"
+          class="lg:!max-w-[33%] w-full"
+          text={@options.text_search}
+          event_target={nil}
+        />
+        <.link
+          id="button-new-tool"
+          href={~p"/admin/external_tools/new"}
+          class="h-8 w-32 px-5 py-3 hover:no-underline rounded-md justify-center items-center gap-2 inline-flex bg-[#0062F2] hover:bg-[#0075EB] dark:bg-[#0062F2] dark:hover:bg-[#0D70FF]"
+        >
+          <div class="w-3 h-5 relative">
+            <Icons.plus
+              class="w-5 h-5 left-[-8px] top-0 absolute font-semibold"
+              path_class="stroke-white"
+            />
+          </div>
+          <div class="text-center justify-center text-white text-sm font-semibold leading-none">
+            Add Tool
+          </div>
+        </.link>
+      </div>
     </div>
-    <div>
+    <div class="mt-4">
       <Check.render
         class="mr-4"
         checked={@options.include_disabled}

--- a/lib/oli_web/live/common/check.ex
+++ b/lib/oli_web/live/common/check.ex
@@ -11,7 +11,7 @@ defmodule OliWeb.Common.Check do
     ~H"""
     <div class={"form-check #{@class}"} style="display: inline;">
       <input id={@id} type="checkbox" class="form-check-input" checked={@checked} phx-click={@click} />
-      <label for={@id} class="form-check-label" phx-click={@click}>
+      <label for={@id} class="form-check-label">
         <%= render_slot(@inner_block) %>
       </label>
     </div>

--- a/test/oli_web/live/admin/external_tools/external_tools_view_test.exs
+++ b/test/oli_web/live/admin/external_tools/external_tools_view_test.exs
@@ -106,6 +106,8 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsViewTest do
       # Check that at least one platform is shown
       assert has_element?(view, "td", platform1.name)
       assert has_element?(view, "td", platform1.description)
+
+      assert has_element?(view, "h1", "LTI 1.3 External Tools")
     end
 
     test "the view matches the url params", %{conn: conn} do


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4593) to the ticket


This PR also fixes a small bug on the `Common.Check` component, where having two `phx-click` attributes (on the label and the input) ended up dispatching two clicks when clicking on the label, making it impossible to check/uncheck when clicking on the label:

#### Before

https://github.com/user-attachments/assets/addc95f4-0513-4c0e-83d8-825daeea3eaa




#### After

https://github.com/user-attachments/assets/6eb3b9b4-c1c0-41f4-85bd-4a288f929748

