### PR TITLE
[BUG FIX] [MER-3114] Fix license selection resetting other project attributes in form

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -35,6 +35,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
       |> Enum.map(fn {k, v} -> {v.text, k} end)
       |> Enum.sort(:desc)
 
+    custom_license? = project.attributes.license.license_type === :custom
+
     {project_export_status, project_export_url, project_export_timestamp} =
       case ProjectExportWorker.project_export_status(project) do
         {:available, url, timestamp} -> {:available, url, timestamp}
@@ -61,6 +63,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
        attributes: project.attributes,
        language_codes: LanguageCodesIso639.codes(),
        license_opts: cc_options,
+       custom_license: custom_license?,
        collab_space_config: collab_space_config,
        revision_slug: revision_slug,
        latest_publication: latest_publication,
@@ -199,11 +202,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
               <%= inputs_for fp, :license, fn fpp -> %>
                 <%= label(fpp, :license_type, "License (optional)", class: "control-label") %>
                 <%= select(fpp, :license_type, @license_opts,
-                  phx_change: "on_selected",
+                  phx_change: "on_select_license_type",
                   class: "form-control",
                   required: false
                 ) %>
-                <div :if={open_custom_type?(@changeset)} class="form-label-group mb-3">
+                <div :if={@custom_license} class="form-label-group mb-3">
                   <%= label(fpp, :custom_license_details, "Custom license (URL)",
                     class: "control-label"
                   ) %>
@@ -516,16 +519,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
     """
   end
 
-  defp open_custom_type?(changeset) do
-    with %Ecto.Changeset{} = changeset <- Ecto.Changeset.get_embed(changeset, :attributes),
-         %Ecto.Changeset{} = changeset <- Ecto.Changeset.get_embed(changeset, :license),
-         :custom <- Ecto.Changeset.get_field(changeset, :license_type) do
-      true
-    else
-      _ -> false
-    end
-  end
-
   defp get_collab_space_config_and_revision(project_slug) do
     %{slug: revision_slug} = AuthoringResolver.root_container(project_slug)
 
@@ -539,9 +532,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("on_selected", %{"project" => project_attrs}, socket) do
-    project = socket.assigns.project
-    {:noreply, assign(socket, changeset: Project.changeset(project, project_attrs))}
+  def handle_event(
+        "on_select_license_type",
+        %{"project" => %{"attributes" => %{"license" => %{"license_type" => license_type}}}},
+        socket
+      ) do
+    {:noreply, socket |> assign(custom_license: license_type === "custom")}
   end
 
   def handle_event("update", %{"project" => project_params}, socket) do

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -35,7 +35,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
       |> Enum.map(fn {k, v} -> {v.text, k} end)
       |> Enum.sort(:desc)
 
-    custom_license? = project.attributes.license.license_type === :custom
+    custom_license? =
+      project.attributes && project.attributes.license &&
+        project.attributes.license.license_type === :custom
 
     {project_export_status, project_export_url, project_export_timestamp} =
       case ProjectExportWorker.project_export_status(project) do


### PR DESCRIPTION
Selecting a license type in the Project Attributes section of the Project Overview page was having the effect of resetting any other unsaved attribute values in that section (Language and, for admins, Calculate Embeddings on Publish). This issue posed a nuisance for automated QA testing.

The bug was caused by an error in the state management in the event handler for selections from the license type dropdown, which is needed to maintain state to show/hide the input box for custom license details. 

This recodes to use a simple `custom_license` flag in the assigns to show/hide the details, setting on mount and updating on changes to license type. This avoids the problem of trying to do this by manipulating the involved changeset structure. 