### PR TITLE
[FEATURE] [MER-4270] Adds support for save and preview of schedule and agenda

### DIFF
--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -139,7 +139,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 
   const { Modal: unsavedModal, showModal: showUnsavedModal } = useBackdropModal(
     <div>
-      <p>Viewing your schedule requires that you save all changes first.</p>
+      <p>Please save your changes before viewing your schedule.</p>
     </div>,
     () => {},
     () => {

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -140,7 +140,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
   const { Modal: unsavedModal, showModal: showUnsavedModal } = useBackdropModal(
     <div>
       <p>
-        If you view without saving, you’ll see the last saved changes—not your most recent edits.
+        Previewing your schedule requires that you save all changes first.
       </p>
     </div>,
     () => {},

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -139,9 +139,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 
   const { Modal: unsavedModal, showModal: showUnsavedModal } = useBackdropModal(
     <div>
-      <p>
-        Previewing your schedule requires that you save all changes first.
-      </p>
+      <p>Previewing your schedule requires that you save all changes first.</p>
     </div>,
     () => {},
     () => {

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useBackdropModal } from 'components/misc/BackdropModal';
 import { Alert } from '../../components/misc/Alert';
 import { usePromptModal } from '../../components/misc/PromptModal';
@@ -7,6 +7,7 @@ import { ErrorDisplay } from './ErrorDisplay';
 import { ScheduleGrid } from './ScheduleGrid';
 import { ScheduleSaveBar } from './SchedulerSaveBar';
 import { WeekDayPicker } from './WeekdayPicker';
+import { hasUnsavedChanges } from './schedule-selectors';
 import { StringDate, resetSchedule } from './scheduler-slice';
 import {
   clearSectionSchedule,
@@ -25,6 +26,11 @@ export interface SchedulerProps {
   edit_section_details_url: string;
 }
 
+export enum ViewMode {
+  SCHEDULE = 'schedule',
+  AGENDA = 'agenda',
+}
+
 export const ScheduleEditor: React.FC<SchedulerProps> = ({
   start_date,
   end_date,
@@ -37,6 +43,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 }) => {
   const dispatch = useDispatch();
 
+  const unsavedChanges = useSelector(hasUnsavedChanges);
   const [validWeekdays, setValidWeekdays] = React.useState<boolean[]>([
     false,
     true,
@@ -46,6 +53,8 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
     true,
     false,
   ]);
+
+  const [viewMode, setViewMode] = React.useState<ViewMode | null>(null);
 
   const onModification = useCallback(() => {
     dispatch(scheduleAppFlushChanges());
@@ -57,6 +66,24 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 
   const onClear = () => {
     dispatch(clearSectionSchedule({ section_slug }));
+  };
+
+  const onViewSelected = (view: ViewMode) => {
+    setViewMode(view);
+    if (unsavedChanges) {
+      showUnsavedModal();
+      return;
+    }
+    changeView(view);
+  };
+
+  const changeView = (view: ViewMode) => {
+    const url = new URL(window.location.href);
+    url.pathname = `/sections/${section_slug}/preview/student_schedule`;
+    if (view === ViewMode.AGENDA) {
+      url.pathname = `/sections/${section_slug}/preview`;
+    }
+    window.open(url.href, '_blank');
   };
 
   // Set up a way the page can call into us to save, useful for the wizard mode when we don't have a save bar to click.
@@ -110,6 +137,22 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
     'Cancel',
   );
 
+  const { Modal: unsavedModal, showModal: showUnsavedModal } = useBackdropModal(
+    <div>
+      <p>
+        If you view without saving, you’ll see the last saved changes—not your most recent edits.
+      </p>
+    </div>,
+    () => {},
+    () => {
+      dispatch(scheduleAppFlushChanges());
+      changeView(viewMode || ViewMode.SCHEDULE);
+    },
+    'You have unsaved changes',
+    'Keep editing',
+    'View after saving',
+  );
+
   if (!start_date || !end_date) {
     return (
       <div className="container">
@@ -133,10 +176,12 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
           endDate={end_date}
           onReset={showModal}
           onClear={showClearModal}
+          onViewSelected={onViewSelected}
         />
 
         {Modal}
         {clearModal}
+        {unsavedModal}
       </div>
     </>
   );

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -139,7 +139,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 
   const { Modal: unsavedModal, showModal: showUnsavedModal } = useBackdropModal(
     <div>
-      <p>Previewing your schedule requires that you save all changes first.</p>
+      <p>Viewing your schedule requires that you save all changes first.</p>
     </div>,
     () => {},
     () => {

--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -1,9 +1,11 @@
 import React, { useMemo } from 'react';
+import { Dropdown } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallbackRef, useResizeObserver } from '@restart/hooks';
 import { DateWithoutTime } from 'epoq';
 import { modeIsDark } from 'components/misc/DarkModeSelector';
 import { ClearIcon, CollapseAllIcon, ExpandAllIcon, SearchIcon } from 'components/misc/icons/Icons';
+import { ViewMode } from './ScheduleEditor';
 import { ScheduleHeaderRow } from './ScheduleHeader';
 import { ScheduleLine } from './ScheduleLine';
 import { generateDayGeometry } from './date-utils';
@@ -20,6 +22,7 @@ interface GridProps {
   endDate: string;
   onReset: () => void;
   onClear: () => void;
+  onViewSelected: (view: ViewMode) => void;
 }
 
 const rowPalette = [
@@ -52,7 +55,13 @@ const rowPaletteDark = [
   '#33F1FF',
 ];
 
-export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset, onClear }) => {
+export const ScheduleGrid: React.FC<GridProps> = ({
+  startDate,
+  endDate,
+  onReset,
+  onClear,
+  onViewSelected,
+}) => {
   const [barContainer, attachBarContainer] = useCallbackRef<HTMLElement>();
   const rect = useResizeObserver(barContainer || null);
 
@@ -126,6 +135,37 @@ export const ScheduleGrid: React.FC<GridProps> = ({ startDate, endDate, onReset,
           )}
           <span>{someExpanded ? 'Collapse All' : 'Expand All'}</span>
         </button>
+
+        {/* View Dropdown */}
+        <Dropdown>
+          <Dropdown.Toggle
+            id="bottom-panel-add-context-trigger"
+            variant="button"
+            className="text-[#0062F2] dark:text-white btn btn-sm flex gap-1 items-center"
+          >
+            <i className="fa-regular fa-eye" />
+            <span className="justify-start text-sm font-bold dark:font-normal dark:text-[#eeebf5]">
+              View
+            </span>
+          </Dropdown.Toggle>
+
+          <Dropdown.Menu>
+            <Dropdown.Item
+              onClick={() => {
+                onViewSelected(ViewMode.AGENDA);
+              }}
+            >
+              View Agenda
+            </Dropdown.Item>
+            <Dropdown.Item
+              onClick={() => {
+                onViewSelected(ViewMode.SCHEDULE);
+              }}
+            >
+              View Schedule
+            </Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
 
         {/* Clear Schedule button */}
         <button

--- a/assets/src/components/misc/BackdropModal.tsx
+++ b/assets/src/components/misc/BackdropModal.tsx
@@ -97,7 +97,7 @@ export const BackdropModal: React.FC<BackdropModalProps> = ({
             <div className="flex justify-end p-6 space-x-2">
               <button
                 onClick={handleClose}
-                className="h-8 w-24 px-3 border rounded-md
+                className="h-8 px-3 border rounded-md inline-flex items-center
               bg-white text-[#006cd9] border-[#8ab8e5] hover:bg-[#0062F2] hover:text-white
               dark:bg-gray-800 dark:text-[#197adc] dark:border-[#197adc]
               dark:hover:bg-[#0062F2] dark:hover:text-white dark:hover:border-[#0062F2]"


### PR DESCRIPTION
[MER-4270](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4270)

This PR introduces a new **“View” button** to the scheduling toolbar, enabling instructors to preview how students will see the **Agenda** and **Schedule** based on the current scheduling configuration.

### Key Features

- Added **“View” button** between “Expand all” and “Clear” on the schedule tab toolbar.
- Clicking the button opens a **dropdown with two options**:
  - **View Agenda**
  - **View Schedule**
- Selecting an option opens the corresponding **student-facing view in a new tab** using the last saved schedule.
- If unsaved changes exist, a **confirmation modal** is shown:
  - **“Keep editing”** brings the user back to the scheduling tool.
  - **“View without saving”** proceeds with the last saved data.


[MER-4270]: https://eliterate.atlassian.net/browse/MER-4270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ