### PR TITLE
[ENHANCEMENT] [MER-4621] Refine approach for determining student ids to ignore

### DIFF
--- a/lib/oli/analytics/datasets/utils.ex
+++ b/lib/oli/analytics/datasets/utils.ex
@@ -35,7 +35,6 @@ defmodule Oli.Analytics.Datasets.Utils do
   users that have opted out of research and users that are not students in the section.
   """
   def determine_ignored_student_ids(section_ids) do
-
     # The most robust way to calculate this is to get all user ids in the sections,
     # then subtract those that are students who have not opted out
 

--- a/lib/oli/analytics/datasets/utils.ex
+++ b/lib/oli/analytics/datasets/utils.ex
@@ -35,7 +35,20 @@ defmodule Oli.Analytics.Datasets.Utils do
   users that have opted out of research and users that are not students in the section.
   """
   def determine_ignored_student_ids(section_ids) do
-    query =
+
+    # The most robust way to calculate this is to get all user ids in the sections,
+    # then subtract those that are students who have not opted out
+
+    all_user_ids =
+      from(e in Oli.Delivery.Sections.Enrollment,
+        where: e.section_id in ^section_ids,
+        distinct: true,
+        select: e.user_id
+      )
+      |> Repo.all()
+      |> MapSet.new()
+
+    students_who_have_not_opted_out =
       from(e in Oli.Delivery.Sections.Enrollment,
         join: u in Oli.Accounts.User,
         on: u.id == e.user_id,
@@ -43,12 +56,17 @@ defmodule Oli.Analytics.Datasets.Utils do
         on: ecr.enrollment_id == e.id,
         where:
           e.section_id in ^section_ids and
-            (u.research_opt_out == true or ecr.context_role_id != @student_role),
+            u.research_opt_out == false and
+            ecr.context_role_id == @student_role,
         distinct: true,
         select: u.id
       )
+      |> Repo.all()
+      |> MapSet.new()
 
-    Repo.all(query)
+    # Return the difference between all user ids and students who have not opted out
+    MapSet.difference(all_user_ids, students_who_have_not_opted_out)
+    |> MapSet.to_list()
   end
 
   def context_sql(section_ids) do

--- a/test/oli/analytics/datasets/utils_test.exs
+++ b/test/oli/analytics/datasets/utils_test.exs
@@ -1,0 +1,89 @@
+defmodule Oli.Analytics.Datasets.UtilsTest do
+  use Oli.DataCase
+
+  alias Oli.Analytics.Datasets.Utils
+  alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Accounts.User
+  alias Oli.Delivery.Sections
+
+  def enroll(section, attrs, roles) do
+    {:ok, user} = User.noauth_changeset(
+      %User{
+        sub: UUID.uuid4(),
+        name: "Ms Jane Marie Doe",
+        given_name: "Jane",
+        family_name: "Doe",
+        middle_name: "Marie",
+        picture: "https://platform.example.edu/jane.jpg",
+        email: "jane#{System.unique_integer([:positive])}@platform.example.edu",
+        locale: "en-US",
+        independent_learner: false,
+        age_verified: true
+      },
+      attrs
+    )
+    |> Repo.insert()
+
+    Sections.enroll(user.id, section.id, roles)
+
+    user.id
+  end
+
+  describe "determining user ids to ignore" do
+    setup do
+      map = Seeder.base_project_with_resource2()
+
+      {:ok, section} =
+        Sections.create_section(%{
+          title: "Section Title",
+          registration_open: true,
+          open_and_free: true,
+          context_id: UUID.uuid4(),
+          institution_id: map.institution.id,
+          base_project_id: map.project.id
+        })
+        |> then(fn {:ok, section} -> section end)
+        |> Sections.create_section_resources(map.publication)
+
+      Map.put(map, :section, section)
+    end
+
+    test "with instructors and students", %{section: section} do
+
+      # Enroll an instructor
+      instructor_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
+
+      # Enroll a student who opts out
+      opt_out_student_id = enroll(section, %{research_opt_out: true}, [ContextRoles.get_role(:context_learner)])
+
+      # Enroll a student who does not opt out
+      student_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_learner)])
+
+      # Verify that only the instructor and opt-out student are ignored
+      results = Utils.determine_ignored_student_ids([section.id])
+      assert Enum.count(results) == 2
+      assert Enum.any?(results, fn id -> id == instructor_id end)
+      assert Enum.any?(results, fn id -> id == opt_out_student_id end)
+      refute Enum.any?(results, fn id -> id == student_id end)
+    end
+
+    test "with students that have both learner and member roles assigned", %{section: section} do
+
+      # Enroll an instructor
+      instructor_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
+
+      # Enroll a student who opts out
+      opt_out_student_id = enroll(section, %{research_opt_out: true}, [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_member)])
+
+      # Enroll a student who does not opt out
+      student_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_member)])
+
+      # Verify that only the instructor and opt-out student are ignored
+      results = Utils.determine_ignored_student_ids([section.id])
+      assert Enum.count(results) == 2
+      assert Enum.any?(results, fn id -> id == instructor_id end)
+      assert Enum.any?(results, fn id -> id == opt_out_student_id end)
+      refute Enum.any?(results, fn id -> id == student_id end)
+    end
+  end
+end

--- a/test/oli/analytics/datasets/utils_test.exs
+++ b/test/oli/analytics/datasets/utils_test.exs
@@ -7,22 +7,23 @@ defmodule Oli.Analytics.Datasets.UtilsTest do
   alias Oli.Delivery.Sections
 
   def enroll(section, attrs, roles) do
-    {:ok, user} = User.noauth_changeset(
-      %User{
-        sub: UUID.uuid4(),
-        name: "Ms Jane Marie Doe",
-        given_name: "Jane",
-        family_name: "Doe",
-        middle_name: "Marie",
-        picture: "https://platform.example.edu/jane.jpg",
-        email: "jane#{System.unique_integer([:positive])}@platform.example.edu",
-        locale: "en-US",
-        independent_learner: false,
-        age_verified: true
-      },
-      attrs
-    )
-    |> Repo.insert()
+    {:ok, user} =
+      User.noauth_changeset(
+        %User{
+          sub: UUID.uuid4(),
+          name: "Ms Jane Marie Doe",
+          given_name: "Jane",
+          family_name: "Doe",
+          middle_name: "Marie",
+          picture: "https://platform.example.edu/jane.jpg",
+          email: "jane#{System.unique_integer([:positive])}@platform.example.edu",
+          locale: "en-US",
+          independent_learner: false,
+          age_verified: true
+        },
+        attrs
+      )
+      |> Repo.insert()
 
     Sections.enroll(user.id, section.id, roles)
 
@@ -49,15 +50,17 @@ defmodule Oli.Analytics.Datasets.UtilsTest do
     end
 
     test "with instructors and students", %{section: section} do
-
       # Enroll an instructor
-      instructor_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
+      instructor_id =
+        enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
 
       # Enroll a student who opts out
-      opt_out_student_id = enroll(section, %{research_opt_out: true}, [ContextRoles.get_role(:context_learner)])
+      opt_out_student_id =
+        enroll(section, %{research_opt_out: true}, [ContextRoles.get_role(:context_learner)])
 
       # Enroll a student who does not opt out
-      student_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_learner)])
+      student_id =
+        enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_learner)])
 
       # Verify that only the instructor and opt-out student are ignored
       results = Utils.determine_ignored_student_ids([section.id])
@@ -68,15 +71,23 @@ defmodule Oli.Analytics.Datasets.UtilsTest do
     end
 
     test "with students that have both learner and member roles assigned", %{section: section} do
-
       # Enroll an instructor
-      instructor_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
+      instructor_id =
+        enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_instructor)])
 
       # Enroll a student who opts out
-      opt_out_student_id = enroll(section, %{research_opt_out: true}, [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_member)])
+      opt_out_student_id =
+        enroll(section, %{research_opt_out: true}, [
+          ContextRoles.get_role(:context_learner),
+          ContextRoles.get_role(:context_member)
+        ])
 
       # Enroll a student who does not opt out
-      student_id = enroll(section, %{research_opt_out: false}, [ContextRoles.get_role(:context_learner), ContextRoles.get_role(:context_member)])
+      student_id =
+        enroll(section, %{research_opt_out: false}, [
+          ContextRoles.get_role(:context_learner),
+          ContextRoles.get_role(:context_member)
+        ])
 
       # Verify that only the instructor and opt-out student are ignored
       results = Utils.determine_ignored_student_ids([section.id])


### PR DESCRIPTION
This PR adjusts the approach that Datasets infrastructure uses to determine which user ids to ignore.  The intent here is to ignore all "non students" and all students who opt out of research consent.  The previous impl was not robust against students having multiple roles (`:context_learner` and `:context_member`), which certain LMSes were assigning. 

The new approach handles this edge case.  