### PR TITLE
[BUG FIX] [MER-4640] Remove protect_from_forgery plug from LTI pipeline

### DIFF
--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -46,7 +46,6 @@ defmodule OliWeb.Router do
     plug(:fetch_current_user)
     plug(:fetch_live_flash)
     plug(:put_root_layout, {OliWeb.LayoutView, :lti})
-    plug(:protect_from_forgery)
     plug(OliWeb.Plugs.SessionContext)
   end
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4640

This reverts a change that breaks LTI launch. With this plug in place, any LTI launch returns a 403 forbidden.