### PR TITLE
[ENHANCEMENT] [MER-4639] add static page providing EBSCO access link w/referrer

### DIFF
--- a/assets/static/ebsco/login.html
+++ b/assets/static/ebsco/login.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Use referrer policy of origin only. Not essential given modern browser default -->
+    <meta name="referrer" content="origin" />
+
+    <title>OLI Torus EBSCO Access Page</title>
+    <script>
+      window.onload = () => {
+        // build ebsco login link with same search parameters as we got
+        const link = document.createElement("a");
+        link.href = `//search.ebscohost.com/login.aspx${window.location.search}`;
+        link.textContent = "Click here to access this EBSCO resource";
+        // noopener is weaker than noreferrer, allowing referer header to be sent
+        link.rel = "noopener";
+        // link.target = "_blank";
+        document.body.appendChild(link);
+
+        // Immediately simulate a click of the link. Pop-up blocker may suppress
+        link.click();
+      };
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/assets/static/ebsco/login.html
+++ b/assets/static/ebsco/login.html
@@ -12,17 +12,7 @@
 
     <title>OLI Torus EBSCO Access Page</title>
     <script>
-      window.onload = () => {
-        // build ebsco login link with same search parameters as we got
-        const link = document.createElement("a");
-        link.href = `//search.ebscohost.com/login.aspx${window.location.search}`;
-        link.rel = "noopener";
-        link.textContent = "click here to access the specified EBSCO database";
-        document.body.appendChild(link);
-
-        // Simulate a click of the link to effect immediate redirect
-        link.click();
-      };
+      window.location.replace(`//search.ebscohost.com/login.aspx${window.location.search}`);
     </script>
   </head>
   <body></body>

--- a/assets/static/ebsco/login.html
+++ b/assets/static/ebsco/login.html
@@ -1,7 +1,13 @@
 <!DOCTYPE html>
+<!--
+  Proxy page providing links to access to resources on EBSCO research database site
+  from torus courses.  Allows referrer header, normally suppressed on torus links, to
+  be sent for loginless access to EBSCO from origins whitelisted on EBSCO.
+-->
 <html lang="en">
   <head>
-    <!-- Use referrer policy of origin only. Not essential given modern browser default -->
+    <!-- Specify referrer policy to only send origin part of url. Modern browsers
+     default to this anyway for cross-origin links, but doesn't hurt to be safe -->
     <meta name="referrer" content="origin" />
 
     <title>OLI Torus EBSCO Access Page</title>
@@ -10,13 +16,11 @@
         // build ebsco login link with same search parameters as we got
         const link = document.createElement("a");
         link.href = `//search.ebscohost.com/login.aspx${window.location.search}`;
-        link.textContent = "Click here to access this EBSCO resource";
-        // noopener is weaker than noreferrer, allowing referer header to be sent
         link.rel = "noopener";
-        // link.target = "_blank";
+        link.textContent = "click here to access the specified EBSCO database";
         document.body.appendChild(link);
 
-        // Immediately simulate a click of the link. Pop-up blocker may suppress
+        // Simulate a click of the link to effect immediate redirect
         link.click();
       };
     </script>

--- a/lib/oli_web/endpoint.ex
+++ b/lib/oli_web/endpoint.ex
@@ -24,7 +24,8 @@ defmodule OliWeb.Endpoint do
     at: "/",
     from: :oli,
     gzip: true,
-    only: ~w(assets css fonts images js custom branding vlab favicon.ico robots.txt flame_graphs)
+    only:
+      ~w(assets css fonts images js custom branding vlab favicon.ico robots.txt flame_graphs ebsco)
   )
 
   plug Plug.Static, at: "/schemas", from: {:oli, "priv/schemas"}, gzip: true


### PR DESCRIPTION
The Evidence Based Management course makes use of links to research databases hosted on a site called EBSCO for various exercises. These rely on a feature of EBSCO to allow loginless access via the referrer header for origins that are whitelsted at EBSCO. However, torus links use rel="noreferrer" to suppress the referrer header for security and privacy reasons. 

This provides a wrapper or proxy page hosted on the torus server to work around this. The idea is that EBSCO links in courses will be rewritten to link instead to the proxy page, which then uses script to construct a link to EBSCO that can be clicked while not suppressing referrer. For convenience, the proxy page is coded to automatically redirect to the EBSCO site, so clicking an ebsco access page link from a course will take one directly to EBSCO. 

As implemented, the access page has URL`https://[torus-host]/ebsco/login.html` followed by URL query parameters. As an example, an original EBSCO URL is 
`https://search.ebscohost.com/login.aspx?authtype=url&custid=ns214597&groupid=main&profile=ehost&defaultdb=bsh
`
the rewritten URL for use in a course on proton would be 
`https://proton.oli.cmu.edu/ebsco/login.html?authtype=url&custid=ns214597&groupid=main&profile=ehost&defaultdb=bsh
`

It will only fully work from sites currently whitelisted for referrer access at EBSCO. This  includes proton and tokamak from past requests but not stellarator. On non-whitelisted servers or a development environment it can be tested to at least confirm the referrer header and appropriate parameters are being sent (visible in network tab of browser developer tools). 

Note this functionality might alternatively be implemented entirely by haproxy configuration to add the referrer header to a torus URL we define and then forward to the EBSCO site. That method would avoid need to serve a page or modify the torus codebase at all. However, this torus-hosted access page solution was chosen in discussions.