### PR TITLE
[FEATURE] [MER-4482] Prevent LTI external tool creation in the activity bank

### DIFF
--- a/lib/oli/authoring/editing/bank_editor.ex
+++ b/lib/oli/authoring/editing/bank_editor.ex
@@ -44,7 +44,7 @@ defmodule Oli.Authoring.Editing.BankEditor do
            ) do
       editor_map =
         Activities.create_registered_activity_map(project_slug)
-        |> Enum.filter(fn {_key, entry} -> entry.isLtiActivity == false end)
+        |> Enum.reject(fn {_key, entry} -> entry.isLtiActivity end)
         |> Enum.into(%{})
 
       project = Oli.Authoring.Course.get_project_by_slug(project_slug)

--- a/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/activity_bank_live_test.exs
@@ -84,14 +84,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLiveTest do
       {:ok, props} = Jason.decode(props_json)
       editor_map = props["editorMap"]
 
-      # 1. Ensure that LTI activities exist in the database
-      lti_activities = Oli.Activities.list_activity_registrations()
-
-      assert Enum.all?([lti_activity1.slug, lti_activity2.slug], fn slug ->
-               Enum.any?(lti_activities, &(&1.slug == slug))
-             end)
-
-      # 2. Ensure that they are NOT present in the editorMap (React props)
+      # Ensure that they are NOT present in the editorMap (React props)
       editor_map_slugs = Map.keys(editor_map)
 
       assert Enum.all?([lti_activity1.slug, lti_activity2.slug], fn slug ->
@@ -121,15 +114,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.ActivityBankLiveTest do
       })
 
     insert(:lti_external_tool_activity_deployment, %{
-      activity_registration: lti_activity1,
-      deployment_id: Ecto.UUID.generate(),
-      status: :enabled
+      activity_registration: lti_activity1
     })
 
     insert(:lti_external_tool_activity_deployment, %{
-      activity_registration: lti_activity2,
-      deployment_id: Ecto.UUID.generate(),
-      status: :enabled
+      activity_registration: lti_activity2
     })
 
     # root container


### PR DESCRIPTION
[MER-4482](https://eliterate.atlassian.net/browse/MER-4482)

This PR updates the activity bank authoring interface to exclude LTI external tool activities, ensuring only supported (non-LTI) activities appear as options for authors.


- Before

<img width="1440" alt="before" src="https://github.com/user-attachments/assets/cbb436f5-f403-4c18-b684-75c3d4f05bd6" />



- After

<img width="1440" alt="after" src="https://github.com/user-attachments/assets/401adb01-18d3-481e-810e-73b238eee3fc" />


[MER-4482]: https://eliterate.atlassian.net/browse/MER-4482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ