### PR TITLE
[ENHANCEMENT] [MER-4344] Re-add removed item to schedule

### DIFF
--- a/assets/src/apps/scheduler/PageScheduleLine.tsx
+++ b/assets/src/apps/scheduler/PageScheduleLine.tsx
@@ -83,19 +83,21 @@ export const PageScheduleLine: React.FC<ScheduleLineProps> = ({
   );
   const labelClasses = item.scheduling_type === 'due_by' ? 'font-bold' : '';
 
+  const removedBackgroundColor = item.removed_from_schedule ? { backgroundColor: '#FFE8E8' } : {};
+
   return (
     <>
       <tr style={rowSelectColor}>
         <td className="w-[1px] p-[2px] border-r-0" style={{ backgroundColor: rowColor }}></td>
-        <td className={`w-64 ${labelClasses}`} onClick={onSelect}>
+        <td className={`w-64 ${labelClasses}`} onClick={onSelect} style={removedBackgroundColor}>
           <div style={{ paddingLeft: 20 + (1 + indent) * 10 }}>{item.title}</div>
         </td>
 
-        <td className="relative p-0">
+        <td className="relative p-0" style={removedBackgroundColor}>
           <ScheduleHeader labels={false} dayGeometry={dayGeometry} />
 
           <PageDragBar
-            itemId={item.id}
+            item={item}
             onChange={onChange}
             onStartDrag={onSelect}
             startDate={item.startDate}

--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import { Dropdown } from 'react-bootstrap';
+import { Dropdown, Form } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import { useCallbackRef, useResizeObserver } from '@restart/hooks';
 import { DateWithoutTime } from 'epoq';
 import { modeIsDark } from 'components/misc/DarkModeSelector';
-import { ClearIcon, CollapseAllIcon, ExpandAllIcon, SearchIcon } from 'components/misc/icons/Icons';
+import { ClearIcon, CollapseAllIcon, ExpandAllIcon, SearchIcon, FilterIcon } from 'components/misc/icons/Icons';
 import { ViewMode } from './ScheduleEditor';
 import { ScheduleHeaderRow } from './ScheduleHeader';
 import { ScheduleLine } from './ScheduleLine';
@@ -23,6 +23,7 @@ import {
   expandVisibleContainers,
   hasContainers,
   setSearchQuery,
+  showHideRemoved,
 } from './scheduler-slice';
 
 interface GridProps {
@@ -90,6 +91,8 @@ export const ScheduleGrid: React.FC<GridProps> = ({
   const expandedContainers = useSelector(
     (state: SchedulerAppState) => state.scheduler.expandedContainers,
   );
+  const isShowRemoved = useSelector((state: SchedulerAppState) => state.scheduler.showRemoved);
+
   const canToggle = useSelector(hasContainers);
   const searchQuery = useSelector((state: SchedulerAppState) => state.scheduler.searchQuery || '');
   const prevSearchRef = useRef(searchQuery);
@@ -244,6 +247,29 @@ export const ScheduleGrid: React.FC<GridProps> = ({
             Clear
           </span>
         </button>
+
+        {/* Filter Dropdown */}
+        <Dropdown>
+          <Dropdown.Toggle
+            id="bottom-panel-add-context-trigger"
+            variant="button"
+            className="text-[#0062F2] dark:text-white btn btn-sm flex gap-1 items-center"
+          >
+            <FilterIcon className="text-[#0062F2] dark:text-white ml-2" />
+            <span className="justify-start text-sm font-bold dark:font-normal dark:text-[#eeebf5]">
+              Filter
+            </span>
+          </Dropdown.Toggle>
+
+          <Dropdown.Menu>
+            <Form.Check
+              type="checkbox"
+              label="  Show Removed"
+              checked={isShowRemoved}
+              onChange={() => dispatch(showHideRemoved(!isShowRemoved))}
+            />
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
       <div className="w-full px-4">
         <table className="select-none schedule_table border-t-0 border-l-0">
@@ -256,7 +282,7 @@ export const ScheduleGrid: React.FC<GridProps> = ({
           </thead>
           <tbody>
             {schedule
-              .filter((item) => !item.removed_from_schedule)
+              .filter((item) => isShowRemoved || !item.removed_from_schedule)
               .map((item, index) => (
                 <ScheduleLine
                   key={item.id}

--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -4,7 +4,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useCallbackRef, useResizeObserver } from '@restart/hooks';
 import { DateWithoutTime } from 'epoq';
 import { modeIsDark } from 'components/misc/DarkModeSelector';
-import { ClearIcon, CollapseAllIcon, ExpandAllIcon, SearchIcon, FilterIcon } from 'components/misc/icons/Icons';
+import {
+  ClearIcon,
+  CollapseAllIcon,
+  ExpandAllIcon,
+  EyeIcon,
+  FilterIcon,
+  SearchIcon,
+} from 'components/misc/icons/Icons';
 import { ViewMode } from './ScheduleEditor';
 import { ScheduleHeaderRow } from './ScheduleHeader';
 import { ScheduleLine } from './ScheduleLine';
@@ -212,7 +219,7 @@ export const ScheduleGrid: React.FC<GridProps> = ({
             variant="button"
             className="text-[#0062F2] dark:text-white btn btn-sm flex gap-1 items-center"
           >
-            <i className="fa-regular fa-eye" />
+            <EyeIcon className="text-[#0062F2] dark:text-white ml-2" />
             <span className="justify-start text-sm font-bold dark:font-normal dark:text-[#eeebf5]">
               View
             </span>

--- a/assets/src/apps/scheduler/ScheduleGrid.tsx
+++ b/assets/src/apps/scheduler/ScheduleGrid.tsx
@@ -19,6 +19,7 @@ import { generateDayGeometry } from './date-utils';
 import {
   VisibleHierarchyItem,
   getVisibleSchedule,
+  hasRemovedItems,
   isAnyVisibleContainerExpanded,
 } from './schedule-selectors';
 import { SchedulerAppState } from './scheduler-reducer';
@@ -82,6 +83,7 @@ export const ScheduleGrid: React.FC<GridProps> = ({
 
   const schedule = useSelector(getVisibleSchedule) as VisibleHierarchyItem[];
   const isScheduled = schedule.some((item: any) => item.startDateTime && item.endDateTime);
+  const hasRemoved = useSelector(hasRemovedItems);
   const dayGeometry = useMemo(
     () =>
       generateDayGeometry(
@@ -271,6 +273,7 @@ export const ScheduleGrid: React.FC<GridProps> = ({
           <Dropdown.Menu>
             <Form.Check
               type="checkbox"
+              disabled={!hasRemoved}
               label="  Show Removed"
               checked={isShowRemoved}
               onChange={() => dispatch(showHideRemoved(!isShowRemoved))}

--- a/assets/src/apps/scheduler/ScheduleLine.tsx
+++ b/assets/src/apps/scheduler/ScheduleLine.tsx
@@ -85,6 +85,8 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
     (state: SchedulerAppState) => state.scheduler.searchQuery?.toLowerCase().trim() || '',
   );
 
+  const isShowRemoved = useSelector((state: SchedulerAppState) => state.scheduler.showRemoved);
+
   const toggleExpanded = () => dispatch(toggleContainer(item.id));
   const isSelected = useSelector(getSelectedId) === item.id;
   const showNumbers = useSelector(shouldDisplayCurriculumItemNumbering);
@@ -101,14 +103,17 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
   );
 
   const childrenCount = item.children.filter((c) => {
-    return !c.removed_from_schedule;
+    return isShowRemoved || !c.removed_from_schedule;
   }).length;
 
   const containerChildren = item.children.filter(
-    (c) => !c.removed_from_schedule && c.resource_type_id === ScheduleItemType.Container,
+    (c) =>
+      (isShowRemoved || !c.removed_from_schedule) &&
+      c.resource_type_id === ScheduleItemType.Container,
   );
   const pageChildren = item.children.filter(
-    (c) => !c.removed_from_schedule && c.resource_type_id === ScheduleItemType.Page,
+    (c) =>
+      (isShowRemoved || !c.removed_from_schedule) && c.resource_type_id === ScheduleItemType.Page,
   );
 
   const filteredPageChildren = React.useMemo(() => {
@@ -135,13 +140,18 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
     : 'fa-regular fa-square-plus fa-lg';
   const chevronIcon = expanded ? 'fa-solid fa-chevron-up' : 'fa-solid fa-chevron-down';
 
+  const backgroundWithPadding = item.removed_from_schedule
+    ? { paddingLeft: (1 + indent) * 10, backgroundColor: '#FFE8E8' }
+    : { paddingLeft: (1 + indent) * 10 };
+
+  const removedBackgroundColor = item.removed_from_schedule ? { backgroundColor: '#FFE8E8' } : {};
   return (
     <>
       <tr style={rowSelectColor}>
         <td className="border-r-0 w-[1px] !p-[2px]" style={{ backgroundColor: rowColor }}></td>
         <td
           className={`w-48 ${labelClasses} font-bold`}
-          style={{ paddingLeft: (1 + indent) * 10 }}
+          style={backgroundWithPadding}
           onClick={onSelect}
         >
           <div className="flex flex-row justify-between items-center">
@@ -161,11 +171,11 @@ const ContainerScheduleLine: React.FC<ScheduleLineProps> = ({
             )}
           </div>
         </td>
-        <td className="relative p-0">
+        <td className="relative p-0" style={removedBackgroundColor}>
           <ScheduleHeader labels={false} dayGeometry={dayGeometry} />
           {item.startDate && item.endDate && (
             <DragBar
-              itemId={item.id}
+              item={item}
               onStartDrag={onStartDrag}
               onChange={onChange}
               startDate={item.startDate}

--- a/assets/src/apps/scheduler/schedule-selectors.ts
+++ b/assets/src/apps/scheduler/schedule-selectors.ts
@@ -67,6 +67,7 @@ export const shouldDisplayCurriculumItemNumbering = (state: SchedulerAppState) =
 export const hasUnsavedChanges = (state: SchedulerAppState) => state.scheduler.dirty.length > 0;
 export const isSaving = (state: SchedulerAppState) => state.scheduler.saving;
 export const getError = (state: SchedulerAppState) => state.scheduler.errorMessage;
+// const isShowRemoved = (state: SchedulerAppState) => state.scheduler.showRemoved;
 
 export const isSearching = (state: SchedulerAppState) => !!state.scheduler.searchQuery?.trim();
 
@@ -82,15 +83,17 @@ export const getVisibleSchedule = createSelector(
   [
     (state: SchedulerAppState) => state.scheduler.schedule,
     (state: SchedulerAppState) => state.scheduler.searchQuery?.toLowerCase().trim() || '',
+    (state: SchedulerAppState) => state.scheduler.showRemoved,
   ],
-  (schedule: HierarchyItem[], search: string): VisibleHierarchyItem[] => {
+  (schedule: HierarchyItem[], search: string, showRemoved: boolean): VisibleHierarchyItem[] => {
     const root = getScheduleRoot(schedule);
     if (!root) return [];
 
     const getItemById = (id: number): HierarchyItem | undefined =>
       getScheduleItem(id, schedule) as HierarchyItem | undefined;
+
     const matches = (item: HierarchyItem): boolean =>
-      !item.removed_from_schedule && item.title.toLowerCase().includes(search);
+      (showRemoved || !item.removed_from_schedule) && item.title.toLowerCase().includes(search);
 
     if (!search) {
       const buildTree = (item: HierarchyItem): VisibleHierarchyItem => ({

--- a/assets/src/apps/scheduler/schedule-selectors.ts
+++ b/assets/src/apps/scheduler/schedule-selectors.ts
@@ -67,7 +67,8 @@ export const shouldDisplayCurriculumItemNumbering = (state: SchedulerAppState) =
 export const hasUnsavedChanges = (state: SchedulerAppState) => state.scheduler.dirty.length > 0;
 export const isSaving = (state: SchedulerAppState) => state.scheduler.saving;
 export const getError = (state: SchedulerAppState) => state.scheduler.errorMessage;
-// const isShowRemoved = (state: SchedulerAppState) => state.scheduler.showRemoved;
+export const hasRemovedItems = (state: SchedulerAppState) =>
+  state.scheduler.schedule.some((item) => item.removed_from_schedule);
 
 export const isSearching = (state: SchedulerAppState) => !!state.scheduler.searchQuery?.trim();
 

--- a/assets/src/components/misc/icons/Icons.tsx
+++ b/assets/src/components/misc/icons/Icons.tsx
@@ -120,6 +120,32 @@ export const FilterIcon: React.FC<IconProps> = ({ className = '', width = 20, he
   </svg>
 );
 
+export const EyeIcon: React.FC<IconProps> = ({ className = '', width = 20, height = 22 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill="none"
+  >
+    <path
+      d="M10 12C10 12.5304 10.2107 13.0391 10.5858 13.4142C10.9609 13.7893 11.4696 14 12 14C12.5304 14 13.0391 13.7893 13.4142 13.4142C13.7893 13.0391 14 12.5304 14 12C14 11.4696 13.7893 10.9609 13.4142 10.5858C13.0391 10.2107 12.5304 10 12 10C11.4696 10 10.9609 10.2107 10.5858 10.5858C10.2107 10.9609 10 11.4696 10 12Z"
+      className="stroke-current"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M21 12C18.6 16 15.6 18 12 18C8.4 18 5.4 16 3 12C5.4 8 8.4 6 12 6C15.6 6 18.6 8 21 12Z"
+      className="stroke-current"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const CloseIcon: React.FC<IconProps> = ({
   className = '',
   width = 17,

--- a/assets/src/components/misc/icons/Icons.tsx
+++ b/assets/src/components/misc/icons/Icons.tsx
@@ -101,6 +101,25 @@ export const ClearIcon: React.FC<IconProps> = ({ className = '', width = 16, hei
   </svg>
 );
 
+export const FilterIcon: React.FC<IconProps> = ({ className = '', width = 20, height = 22 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    width={width}
+    height={height}
+    viewBox="0 0 24 24"
+    fill="none"
+  >
+    <path
+      d="M4 4H20V6.172C19.9999 6.70239 19.7891 7.21101 19.414 7.586L15 12V19L9 21V12.5L4.52 7.572C4.18545 7.20393 4.00005 6.7244 4 6.227V4Z"
+      className="stroke-current"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 export const CloseIcon: React.FC<IconProps> = ({
   className = '',
   width = 17,

--- a/assets/test/scheduler/agenda-visibility_test.tsx
+++ b/assets/test/scheduler/agenda-visibility_test.tsx
@@ -33,7 +33,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
-      showRemoved: false
+      showRemoved: false,
     };
 
     it('updates agenda to true when fulfilled', () => {
@@ -91,7 +91,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
-      showRemoved: false
+      showRemoved: false,
     };
 
     const createTestStore = (preloadedState: SchedulerState) =>

--- a/assets/test/scheduler/agenda-visibility_test.tsx
+++ b/assets/test/scheduler/agenda-visibility_test.tsx
@@ -33,6 +33,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
+      showRemoved: false
     };
 
     it('updates agenda to true when fulfilled', () => {
@@ -90,6 +91,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
+      showRemoved: false
     };
 
     const createTestStore = (preloadedState: SchedulerState) =>

--- a/assets/test/scheduler/expand-collapse-schedule_test.ts
+++ b/assets/test/scheduler/expand-collapse-schedule_test.ts
@@ -54,6 +54,7 @@ describe('expand/collapse containers', () => {
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
       searchQuery: '',
+      showRemoved: false,
     },
   };
 

--- a/lib/oli/delivery/sections/scheduling.ex
+++ b/lib/oli/delivery/sections/scheduling.ex
@@ -109,7 +109,7 @@ defmodule Oli.Delivery.Sections.Scheduling do
       |> Multi.update_all(
         :updated_resources,
         &get_section_resources_with_schedule(&1, section_id),
-        set: [start_date: nil, end_date: nil]
+        set: [start_date: nil, end_date: nil, removed_from_schedule: false]
       )
       |> Repo.transaction()
 


### PR DESCRIPTION
[MER-4344
](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4344)

This PR implements the ability for instructors to **view and restore previously removed items** from the course schedule, providing flexibility to experiment with and adjust scheduling decisions.

## Features

- Adds a **"Filter"** button to the scheduling tab toolbar.
- Introduces a **"Show Removed"** checkbox in the filter dropdown:
  - Disabled if no items have been removed.
  - Enabled if one or more items (pages, modules, sections, units) have been removed.
- When "Show Removed" is selected:
  - Removed items are displayed:
    - **Rows** of removed content are styled in **red**.
    - **Bars** of removed units/modules/sections use a **striped design** (per Figma spec).
  - The schedule layout updates to account for removed content.
  - Search and expand-all respect the current filter state (including removed items).
- Adds **context menu option** to "Re-add Item" when right-clicking on a removed item:
  - Restores the item to its original context in the schedule.
- Deselecting "Show Removed" hides removed content and restores the schedule view.