### PR TITLE
[BUG FIX] [MER-4575] Rework: tools not showing on products

### DIFF
--- a/lib/oli/delivery/sections/section_resource_migration.ex
+++ b/lib/oli/delivery/sections/section_resource_migration.ex
@@ -6,17 +6,9 @@ defmodule Oli.Delivery.Sections.SectionResourceMigration do
   def requires_migration?(section_id) do
     query =
       from sr in SectionResource,
-        where: sr.section_id == ^section_id,
-        select: sr.graded,
-        limit: 1
+        where: sr.section_id == ^section_id and is_nil(sr.graded)
 
-    case Oli.Repo.all(query) do
-      [nil] ->
-        true
-
-      _ ->
-        false
-    end
+    Repo.exists?(query)
   end
 
   def migrate(section_id) do

--- a/test/oli/delivery/sections/section_resource_migration_test.exs
+++ b/test/oli/delivery/sections/section_resource_migration_test.exs
@@ -1,0 +1,35 @@
+defmodule Oli.Delivery.Sections.SectionResourceMigrationTest do
+  use Oli.DataCase
+
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections.SectionResourceMigration
+
+  describe "requires_migration?/1" do
+    test "returns true when section has section resources not yet migrated" do
+      section = insert(:section)
+
+      insert(:section_resource, section: section, graded: nil)
+
+      assert SectionResourceMigration.requires_migration?(section.id)
+    end
+
+    test "returns false when section has all section resources migrated" do
+      section = insert(:section)
+
+      insert(:section_resource, section: section, graded: true)
+      insert(:section_resource, section: section, graded: false)
+
+      refute SectionResourceMigration.requires_migration?(section.id)
+    end
+
+    test "returns true when section has mix of resources migrated and not yet migrated" do
+      section = insert(:section)
+
+      insert(:section_resource, section: section, graded: true)
+      insert(:section_resource, section: section, graded: nil)
+
+      assert SectionResourceMigration.requires_migration?(section.id)
+    end
+  end
+end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4575?focusedCommentId=28576) to the comment in the ticket

## Fix section resource migration detection to handle partial migration states

### Problem
On [MER-4332](https://github.com/Simon-Initiative/oli-torus/pull/5600#issuecomment-2913884490), we discovered that some queries fail when section resources were still not migrated. Specifically, queries that join with the `revisions` table using the `revision_id` field (such as `get_section_resources_with_lti_activities/1`) fail when `revision_id` is `nil` for unmigrated section resources.

### Root Cause
The issue occurs when:
1. A section has existing section resources that have already been migrated (`revision_id` and other fields populated)
2. New section resources are added (e.g., when an author adds an LTI activity to a page and publishes updates)
3. These new section resources are created without the migrated fields populated (`revision_id = nil`, `graded = nil`, etc.)
4. When `DepotCoordinator.refresh/3` is triggered, it calls `SectionResourceDepot.process_table_creation/1`
5. The migration check (`SectionResourceMigration.requires_migration?/1`) incorrectly returns `false` because it finds **at least one** migrated section resource, even though newly added resources still need migration

### Solution
This PR fixes `requires_migration?/1` to check if **ANY** section resource still needs migration (has `graded = nil`), rather than assuming all are migrated if any single one has been migrated.




#### **Before:** Migration skipped if any section resource was already migrated

https://github.com/user-attachments/assets/a044704e-5655-4d23-b350-7be293b6d272

The new LTI tool section_resource record has its `revision_id` field null.

<img width="718" alt="Screenshot 2025-06-10 at 10 00 01 AM" src="https://github.com/user-attachments/assets/e70e757d-a949-4bbd-bb9f-47de7202790a" />


#### **After:** Migration runs if any section resource still needs migration

https://github.com/user-attachments/assets/9d56c2d2-93c8-4c0f-9d9f-dea0c0ff0092

<img width="723" alt="Screenshot 2025-06-10 at 10 03 23 AM" src="https://github.com/user-attachments/assets/581412aa-23fc-4331-9d59-0aab4f7cc930" />


[MER-4332]: https://eliterate.atlassian.net/browse/MER-4332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ