### PR TITLE
[BUG FIX] [MER-4214] Fix popover positioning offset issue

### DIFF
--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -3,6 +3,7 @@ import { ArrowContainer, Popover } from 'react-tiny-popover';
 import { Popup as PopupModel } from 'data/content/model/elements/types';
 import { isEmptyContent } from '../../data/content/utils';
 import { useAudio } from '../hooks/useAudio';
+import { positionRect } from '../../data/content/utils';
 
 interface Props {
   children: React.ReactNode;
@@ -71,6 +72,7 @@ export const Popup: React.FC<Props> = ({ children, popupContent, popup }) => {
       isOpen={isPopoverOpen}
       onClickOutside={() => (setIsPopoverOpen(false), pauseAudio())}
       positions={['top', 'bottom', 'left', 'right']}
+      reposition={false}
       content={({ position, childRect, popoverRect }) => (
         <ArrowContainer
           position={position}

--- a/assets/src/components/content/Popup.tsx
+++ b/assets/src/components/content/Popup.tsx
@@ -3,7 +3,6 @@ import { ArrowContainer, Popover } from 'react-tiny-popover';
 import { Popup as PopupModel } from 'data/content/model/elements/types';
 import { isEmptyContent } from '../../data/content/utils';
 import { useAudio } from '../hooks/useAudio';
-import { positionRect } from '../../data/content/utils';
 
 interface Props {
   children: React.ReactNode;


### PR DESCRIPTION
Ticket: [MER-4214](https://eliterate.atlassian.net/browse/MER-4214)

This PR resolves the positioning offset issue affecting popovers. From the [documentation](https://www.npmjs.com/package/react-tiny-popover):

```
reposition={false} // prevents automatic readjustment of content position that keeps your popover content within its parent's bounds
```

[MER-4214]: https://eliterate.atlassian.net/browse/MER-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ