### PR TITLE
[FEATURE] [MER-4647] Text blob storage replacement for main DB extrinsic storage

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -85,7 +85,8 @@ const Delivery: React.FC<DeliveryProps> = ({
   const restartLesson = useSelector(selectRestartLesson);
   const screenIdleExpirationTime = useSelector(selectScreenIdleExpirationTime);
   const screenIdleTimeOutTriggered = useSelector(selectScreenIdleTimeOutTriggered);
-
+  console.log('Delivery component rendered');
+  console.log(blobStorageProvider);
   const [currentTheme, setCurrentTheme] = useState('auto');
   // Gives us the deadline for this assessment to be completed by.
   // We subtract out the server time and add in our local time in case the client system clock is off.

--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -85,8 +85,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   const restartLesson = useSelector(selectRestartLesson);
   const screenIdleExpirationTime = useSelector(selectScreenIdleExpirationTime);
   const screenIdleTimeOutTriggered = useSelector(selectScreenIdleTimeOutTriggered);
-  console.log('Delivery component rendered');
-  console.log(blobStorageProvider);
+
   const [currentTheme, setCurrentTheme] = useState('auto');
   // Gives us the deadline for this assessment to be completed by.
   // We subtract out the server time and add in our local time in case the client system clock is off.

--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -41,6 +41,7 @@ export interface DeliveryProps {
   graded: boolean;
   overviewURL: string;
   finalizeGradedURL: string;
+  blobStorageProvider: 'new' | 'deprecated';
   screenIdleTimeOutInSeconds?: number;
   reviewMode?: boolean;
   signoutUrl?: string;
@@ -70,6 +71,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   graded = false,
   overviewURL = '',
   finalizeGradedURL = '',
+  blobStorageProvider = 'deprecated',
   screenIdleTimeOutInSeconds = 1800,
   reviewMode = false,
   currentServerTime = 0,
@@ -189,6 +191,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         activeEverapp: 'none',
         overviewURL,
         finalizeGradedURL,
+        blobStorageProvider,
         screenIdleTimeOutInSeconds,
         reviewMode,
       }),

--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -58,7 +58,7 @@ interface ActivityRendererProps {
   onRequestLatestState?: any;
   adaptivityDomain?: string; // currently 'stage' or 'app'
   isEverApp?: boolean;
-  blobStorageProvider: 'deprecated' | 'new'
+  blobStorageProvider: 'deprecated' | 'new';
 }
 
 const defaultHandler = async () => {
@@ -91,7 +91,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
   onRequestLatestState = async () => ({ snapshot: {} }),
   adaptivityDomain = 'stage',
   isEverApp = false,
-  blobStorageProvider
+  blobStorageProvider,
 }) => {
   const isPreviewMode = useSelector(selectPreviewMode);
   const isReviewMode = useSelector(selectReviewMode);
@@ -103,7 +103,11 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
       return;
     }
     const { simId, key, value } = payload;
-    await Extrinsic.updateGlobalUserState(blobStorageProvider, { [simId]: { [key]: value } }, isPreviewMode);
+    await Extrinsic.updateGlobalUserState(
+      blobStorageProvider,
+      { [simId]: { [key]: value } },
+      isPreviewMode,
+    );
     try {
       // Review mode requires the ever app variable to be fetched from Resourse Attempt state so we need to update the variable in scripting so that
       // when trigger check happens, the extrinsic state get updated and sent to server. Adding it in try catch to avoid any failure during the scripting update which

--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -58,6 +58,7 @@ interface ActivityRendererProps {
   onRequestLatestState?: any;
   adaptivityDomain?: string; // currently 'stage' or 'app'
   isEverApp?: boolean;
+  blobStorageProvider: 'deprecated' | 'new'
 }
 
 const defaultHandler = async () => {
@@ -90,6 +91,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
   onRequestLatestState = async () => ({ snapshot: {} }),
   adaptivityDomain = 'stage',
   isEverApp = false,
+  blobStorageProvider
 }) => {
   const isPreviewMode = useSelector(selectPreviewMode);
   const isReviewMode = useSelector(selectReviewMode);
@@ -101,7 +103,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
       return;
     }
     const { simId, key, value } = payload;
-    await Extrinsic.updateGlobalUserState({ [simId]: { [key]: value } }, isPreviewMode);
+    await Extrinsic.updateGlobalUserState(blobStorageProvider, { [simId]: { [key]: value } }, isPreviewMode);
     try {
       // Review mode requires the ever app variable to be fetched from Resourse Attempt state so we need to update the variable in scripting so that
       // when trigger check happens, the extrinsic state get updated and sent to server. Adding it in try catch to avoid any failure during the scripting update which
@@ -123,7 +125,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
       }
       return undefined;
     }
-    const data = await Extrinsic.readGlobalUserState([simId], isPreviewMode);
+    const data = await Extrinsic.readGlobalUserState(blobStorageProvider, [simId], isPreviewMode);
     if (data) {
       const value = data[simId]?.[key];
       /* console.log('GOT DATA', { simId, key, value, data }); */
@@ -536,7 +538,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
         return data;
       }, {});
       /* console.log('updateGlobalState', { payloadData }); */
-      await Extrinsic.updateGlobalUserState(payloadData, isPreviewMode);
+      await Extrinsic.updateGlobalUserState(blobStorageProvider, payloadData, isPreviewMode);
     }
   };
 
@@ -635,7 +637,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
         return data;
       }, {});
       /* console.log('CHANGE EVENT EVERAPP', { changes, appChanges, updatePayload }); */
-      await Extrinsic.updateGlobalUserState(updatePayload, isPreviewMode);
+      await Extrinsic.updateGlobalUserState(blobStorageProvider, updatePayload, isPreviewMode);
     }
     // we send ALL of the changes to the components
     if (changes?.changed?.length > 1) {

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -26,6 +26,7 @@ import {
   selectLastCheckTriggered,
   selectLessonEnd,
   selectNextActivityId,
+
   setCurrentFeedbacks,
   setIsGoodFeedback,
   setMutationTriggered,
@@ -50,6 +51,7 @@ import {
   selectResourceAttemptGuid,
   selectReviewMode,
   selectSectionSlug,
+  selectBlobStorageProvider,
   setScore,
   setScreenIdleExpirationTime,
 } from '../../store/features/page/slice';
@@ -229,6 +231,7 @@ const DeckLayoutFooter: React.FC = () => {
   const isGoodFeedback = useSelector(selectIsGoodFeedback);
   const currentFeedbacks = useSelector(selectCurrentFeedbacks);
   const nextActivityId: string = useSelector(selectNextActivityId);
+  const blobStorageProvider = useSelector(selectBlobStorageProvider);
   const lastCheckTimestamp = useSelector(selectLastCheckTriggered);
   const lastCheckResults = useSelector(selectLastCheckResults);
   const initPhaseComplete = useSelector(selectInitPhaseComplete);
@@ -349,7 +352,7 @@ const DeckLayoutFooter: React.FC = () => {
       },
       {},
     );
-    writePageAttemptState(sectionSlug, resourceAttemptGuid, extrinsicSnapshot);
+    writePageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid, extrinsicSnapshot);
   };
 
   useEffect(() => {
@@ -441,7 +444,7 @@ const DeckLayoutFooter: React.FC = () => {
           acc[everAppId][op.target.replace(`app.${everAppId}.`, '')] = envState[op.target];
           return acc;
         }, {});
-        updateGlobalUserState(everAppState, isPreviewMode);
+        updateGlobalUserState(blobStorageProvider, everAppState, isPreviewMode);
       }
 
       const latestSnapshot = getLocalizedStateSnapshot(

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutFooter.tsx
@@ -26,7 +26,6 @@ import {
   selectLastCheckTriggered,
   selectLessonEnd,
   selectNextActivityId,
-
   setCurrentFeedbacks,
   setIsGoodFeedback,
   setMutationTriggered,
@@ -45,13 +44,13 @@ import {
   selectCurrentActivityTreeAttemptState,
 } from '../../store/features/groups/selectors/deck';
 import {
+  selectBlobStorageProvider,
   selectIsLegacyTheme,
   selectPageContent,
   selectPreviewMode,
   selectResourceAttemptGuid,
   selectReviewMode,
   selectSectionSlug,
-  selectBlobStorageProvider,
   setScore,
   setScreenIdleExpirationTime,
 } from '../../store/features/page/slice';

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -28,6 +28,7 @@ import {
   selectSequence,
 } from '../../store/features/groups/selectors/deck';
 import {
+  selectBlobStorageProvider,
   selectPageSlug,
   selectReviewMode,
   selectSectionSlug,
@@ -58,6 +59,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
   const currentLesson = useSelector(selectPageSlug);
   const sectionSlug = useSelector(selectSectionSlug);
   const currentUserId = useSelector(selectUserId);
+  const blobStorageProvider = useSelector(selectBlobStorageProvider);
   const currentUserName = useSelector(selectUserName);
   const historyModeNavigation = useSelector(selectHistoryNavigationActivity);
   const reviewMode = useSelector(selectReviewMode);
@@ -623,6 +625,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
           onActivitySubmitPart={handleActivitySubmitPart}
           onActivityReady={handleActivityReady}
           onRequestLatestState={handleActivityRequestLatestState}
+          blobStorageProvider={blobStorageProvider}
         />
       );
     });

--- a/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
@@ -11,7 +11,7 @@ import { getLocalizedCurrentStateSnapshot } from 'apps/delivery/store/features/a
 import { triggerCheck } from 'apps/delivery/store/features/adaptivity/actions/triggerCheck';
 import { selectCurrentActivityTree } from 'apps/delivery/store/features/groups/selectors/deck';
 import { toggleEverapp } from 'apps/delivery/store/features/page/actions/toggleEverapp';
-import { selectPreviewMode } from 'apps/delivery/store/features/page/slice';
+import { selectBlobStorageProvider, selectPreviewMode } from 'apps/delivery/store/features/page/slice';
 import { updateGlobalUserState } from 'data/persistence/extrinsic';
 import { getEverAppActivity, updateAttemptGuid } from '../EverApps';
 
@@ -36,7 +36,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
   const dispatch = useDispatch();
   const isPreviewMode = useSelector(selectPreviewMode);
   const [isOpen, setIsOpen] = useState<boolean>(props.open);
-
+  const blobStorageProvider = useSelector(selectBlobStorageProvider);
   const currentActivityTree = useSelector(selectCurrentActivityTree);
 
   useEffect(() => {
@@ -86,7 +86,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
 
     // because the everapp attemptGuid and partAttemptGuid are always made up
     // can't save it like normal, instead setData should cover it
-    const result = await updateGlobalUserState(updatedState, isPreviewMode);
+    const result = await updateGlobalUserState(blobStorageProvider, updatedState, isPreviewMode);
 
     /* console.log('EVERAPP SAVE PART', {
       activityId,
@@ -160,6 +160,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
           onRequestLatestState={handleRequestLatestState}
           adaptivityDomain="app"
           isEverApp={true}
+          blobStorageProvider={blobStorageProvider}
         />
       </div>
     </div>

--- a/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
@@ -11,7 +11,10 @@ import { getLocalizedCurrentStateSnapshot } from 'apps/delivery/store/features/a
 import { triggerCheck } from 'apps/delivery/store/features/adaptivity/actions/triggerCheck';
 import { selectCurrentActivityTree } from 'apps/delivery/store/features/groups/selectors/deck';
 import { toggleEverapp } from 'apps/delivery/store/features/page/actions/toggleEverapp';
-import { selectBlobStorageProvider, selectPreviewMode } from 'apps/delivery/store/features/page/slice';
+import {
+  selectBlobStorageProvider,
+  selectPreviewMode,
+} from 'apps/delivery/store/features/page/slice';
 import { updateGlobalUserState } from 'data/persistence/extrinsic';
 import { getEverAppActivity, updateAttemptGuid } from '../EverApps';
 

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -107,7 +107,12 @@ export const triggerCheck = createAsyncThunk(
         resourceAttemptGuid,
         extrnisicState,
       }); */
-      await writePageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid, extrnisicState);
+      await writePageAttemptState(
+        blobStorageProvider,
+        sectionSlug,
+        resourceAttemptGuid,
+        extrnisicState,
+      );
     }
 
     let checkResult;
@@ -473,7 +478,10 @@ export const triggerCheck = createAsyncThunk(
       }); */
       await writePageAttemptState(
         rootState.page.blobStorageProvider,
-        sectionSlug, resourceAttemptGuid, extrnisicState);
+        sectionSlug,
+        resourceAttemptGuid,
+        extrnisicState,
+      );
     }
     await dispatch(
       setLastCheckResults({

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -39,6 +39,7 @@ export const triggerCheck = createAsyncThunk(
     const rootState = getState() as DeliveryRootState;
     const isPreviewMode = selectPreviewMode(rootState);
     const sectionSlug = selectSectionSlug(rootState);
+    const blobStorageProvider = rootState.page.blobStorageProvider;
     const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
 
     const currentActivityTreeAttempts = selectCurrentActivityTreeAttemptState(rootState) || [];
@@ -106,7 +107,7 @@ export const triggerCheck = createAsyncThunk(
         resourceAttemptGuid,
         extrnisicState,
       }); */
-      await writePageAttemptState(sectionSlug, resourceAttemptGuid, extrnisicState);
+      await writePageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid, extrnisicState);
     }
 
     let checkResult;
@@ -470,7 +471,9 @@ export const triggerCheck = createAsyncThunk(
         resourceAttemptGuid,
         extrnisicState,
       }); */
-      await writePageAttemptState(sectionSlug, resourceAttemptGuid, extrnisicState);
+      await writePageAttemptState(
+        rootState.page.blobStorageProvider,
+        sectionSlug, resourceAttemptGuid, extrnisicState);
     }
     await dispatch(
       setLastCheckResults({

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -267,7 +267,12 @@ export const initializeActivity = createAsyncThunk(
       return { result: status };
     }
 
-    await writePageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid, sessionState);
+    await writePageAttemptState(
+      blobStorageProvider,
+      sectionSlug,
+      resourceAttemptGuid,
+      sessionState,
+    );
   },
 );
 
@@ -282,9 +287,11 @@ const getSessionVisitHistory = async (
     const allState = getEnvState(defaultGlobalEnv);
     pageAttemptState = allState;
   } else {
-    const { result } = await getPageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid);
-    console.log('session visit history')
-    console.log(result);
+    const { result } = await getPageAttemptState(
+      blobStorageProvider,
+      sectionSlug,
+      resourceAttemptGuid,
+    );
     pageAttemptState = result;
   }
   return Object.keys(pageAttemptState)
@@ -313,8 +320,6 @@ export const findNextSequenceId = createAsyncThunk(
       resourceAttemptGuid,
       isPreviewMode,
     );
-
-    console.log('visitHistory', visitHistory);
 
     const currentActivityId = selectCurrentActivityId(rootState);
     const currentIndex =
@@ -367,8 +372,7 @@ export const findNextSequenceId = createAsyncThunk(
     if (navError) {
       throw new Error(navError);
     }
-    console.log('end of sequence');
-    console.log(nextSequenceEntry?.custom.sequenceId);
+
     return nextSequenceEntry?.custom.sequenceId;
   },
 );

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -42,6 +42,7 @@ import {
 import { loadActivityAttemptState, updateExtrinsicState } from '../../attempt/slice';
 import {
   selectActivityTypes,
+  selectBlobStorageProvider,
   selectIsInstructor,
   selectNavigationSequence,
   selectPreviewMode,
@@ -63,6 +64,7 @@ export const initializeActivity = createAsyncThunk(
     const rootState = thunkApi.getState() as DeliveryRootState;
     const isPreviewMode = selectPreviewMode(rootState);
     const sectionSlug = selectSectionSlug(rootState);
+    const blobStorageProvider = selectBlobStorageProvider(rootState);
     const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
     const sequence = selectSequence(rootState);
     const isReviewMode = selectReviewMode(rootState);
@@ -265,11 +267,12 @@ export const initializeActivity = createAsyncThunk(
       return { result: status };
     }
 
-    await writePageAttemptState(sectionSlug, resourceAttemptGuid, sessionState);
+    await writePageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid, sessionState);
   },
 );
 
 const getSessionVisitHistory = async (
+  blobStorageProvider: 'deprecated' | 'new',
   sectionSlug: string,
   resourceAttemptGuid: string,
   isPreviewMode = false,
@@ -279,7 +282,9 @@ const getSessionVisitHistory = async (
     const allState = getEnvState(defaultGlobalEnv);
     pageAttemptState = allState;
   } else {
-    const { result } = await getPageAttemptState(sectionSlug, resourceAttemptGuid);
+    const { result } = await getPageAttemptState(blobStorageProvider, sectionSlug, resourceAttemptGuid);
+    console.log('session visit history')
+    console.log(result);
     pageAttemptState = result;
   }
   return Object.keys(pageAttemptState)
@@ -296,16 +301,20 @@ export const findNextSequenceId = createAsyncThunk(
     const rootState = thunkApi.getState() as DeliveryRootState;
     const isPreviewMode = selectPreviewMode(rootState);
     const sectionSlug = selectSectionSlug(rootState);
+    const blobStorageProvider = selectBlobStorageProvider(rootState);
     const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
     const sequence = selectSequence(rootState);
     let nextSequenceEntry: SequenceEntry<SequenceEntryType> | null = null;
     let navError = '';
 
     const visitHistory = await getSessionVisitHistory(
+      blobStorageProvider,
       sectionSlug,
       resourceAttemptGuid,
       isPreviewMode,
     );
+
+    console.log('visitHistory', visitHistory);
 
     const currentActivityId = selectCurrentActivityId(rootState);
     const currentIndex =
@@ -358,6 +367,8 @@ export const findNextSequenceId = createAsyncThunk(
     if (navError) {
       throw new Error(navError);
     }
+    console.log('end of sequence');
+    console.log(nextSequenceEntry?.custom.sequenceId);
     return nextSequenceEntry?.custom.sequenceId;
   },
 );

--- a/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
+++ b/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
@@ -67,7 +67,11 @@ export const loadInitialPageState = createAsyncThunk(
       //As per the current implementation, the readGlobalUserState gives the Ever App state of the logged in user. However, in review mode, we need to
       //state of the student whose attempt is being review by the instructor. We get this info from the resource attempt state so no need to call this method in REVIEW mode
       if (!isReviewMode && everAppIds && Array.isArray(everAppIds)) {
-        const userState = await readGlobalUserState(params.blobStorageProvider, everAppIds, params.previewMode);
+        const userState = await readGlobalUserState(
+          params.blobStorageProvider,
+          everAppIds,
+          params.previewMode,
+        );
         if (typeof userState === 'object') {
           const everAppState = Object.keys(userState).reduce((acc: any, key) => {
             const subState = userState[key];
@@ -104,7 +108,12 @@ export const loadInitialPageState = createAsyncThunk(
       const { result: _scriptResult } = evalScript(assignScript, defaultGlobalEnv);
       //No need to wite anything to server in REVIEW mode
       if (!params.previewMode && !isReviewMode) {
-        await writePageAttemptState(params.blobStorageProvider, params.sectionSlug, resourceAttemptGuid, sessionState);
+        await writePageAttemptState(
+          params.blobStorageProvider,
+          params.sectionSlug,
+          resourceAttemptGuid,
+          sessionState,
+        );
       }
 
       dispatch(setExtrinsicState({ state: sessionState }));
@@ -148,7 +157,12 @@ export const loadInitialPageState = createAsyncThunk(
         updateSessionState['session.currentQuestionScore'] = 0;
         //No need to wite anything to server in REVIEW mode
         if (!params.previewMode && !isReviewMode) {
-          await writePageAttemptState(params.blobStorageProvider, params.sectionSlug, resourceAttemptGuid, updateSessionState);
+          await writePageAttemptState(
+            params.blobStorageProvider,
+            params.sectionSlug,
+            resourceAttemptGuid,
+            updateSessionState,
+          );
         }
 
         let resumeSequenceId = sequence[0].custom.sequenceId;

--- a/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
+++ b/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
@@ -67,7 +67,7 @@ export const loadInitialPageState = createAsyncThunk(
       //As per the current implementation, the readGlobalUserState gives the Ever App state of the logged in user. However, in review mode, we need to
       //state of the student whose attempt is being review by the instructor. We get this info from the resource attempt state so no need to call this method in REVIEW mode
       if (!isReviewMode && everAppIds && Array.isArray(everAppIds)) {
-        const userState = await readGlobalUserState(everAppIds, params.previewMode);
+        const userState = await readGlobalUserState(params.blobStorageProvider, everAppIds, params.previewMode);
         if (typeof userState === 'object') {
           const everAppState = Object.keys(userState).reduce((acc: any, key) => {
             const subState = userState[key];

--- a/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
+++ b/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
@@ -104,7 +104,7 @@ export const loadInitialPageState = createAsyncThunk(
       const { result: _scriptResult } = evalScript(assignScript, defaultGlobalEnv);
       //No need to wite anything to server in REVIEW mode
       if (!params.previewMode && !isReviewMode) {
-        await writePageAttemptState(params.sectionSlug, resourceAttemptGuid, sessionState);
+        await writePageAttemptState(params.blobStorageProvider, params.sectionSlug, resourceAttemptGuid, sessionState);
       }
 
       dispatch(setExtrinsicState({ state: sessionState }));
@@ -148,7 +148,7 @@ export const loadInitialPageState = createAsyncThunk(
         updateSessionState['session.currentQuestionScore'] = 0;
         //No need to wite anything to server in REVIEW mode
         if (!params.previewMode && !isReviewMode) {
-          await writePageAttemptState(params.sectionSlug, resourceAttemptGuid, updateSessionState);
+          await writePageAttemptState(params.blobStorageProvider, params.sectionSlug, resourceAttemptGuid, updateSessionState);
         }
 
         let resumeSequenceId = sequence[0].custom.sequenceId;

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -24,6 +24,7 @@ export interface PageState {
   activeEverapp: string;
   overviewURL: string;
   finalizeGradedURL: string;
+  blobStorageProvider: 'new' | 'deprecated';
   screenIdleTimeOutInSeconds: number;
   screenIdleExpireTime?: number;
   reviewMode?: boolean;
@@ -50,6 +51,7 @@ const initialState: PageState = {
   activeEverapp: '',
   overviewURL: '',
   finalizeGradedURL: '',
+  blobStorageProvider: 'deprecated',
   screenIdleTimeOutInSeconds: 1800,
   reviewMode: false,
 };
@@ -79,6 +81,7 @@ const pageSlice = createSlice({
       state.graded = !!action.payload.graded;
       state.overviewURL = action.payload.overviewURL;
       state.finalizeGradedURL = action.payload.finalizeGradedURL;
+      state.blobStorageProvider = action.payload.blobStorageProvider || 'deprecated';
       state.screenIdleTimeOutInSeconds = action.payload.screenIdleTimeOutInSeconds;
       state.reviewMode = action.payload.reviewMode;
       if (state.previewMode && !state.resourceAttemptGuid) {
@@ -173,6 +176,11 @@ export const selectOverviewURL = createSelector(
 export const selectFinalizeGradedURL = createSelector(
   selectState,
   (state: PageState) => state.finalizeGradedURL,
+);
+
+export const selectBlobStorageProvider = createSelector(
+  selectState,
+  (state: PageState) => state.blobStorageProvider,
 );
 
 export default pageSlice.reducer;

--- a/assets/src/data/persistence/blob.ts
+++ b/assets/src/data/persistence/blob.ts
@@ -18,9 +18,7 @@ const lastSet = () => {
   return arr[arr.length - 1];
 };
 
-
-export const read = async(key: string) => {
-
+export const read = async (key: string) => {
   const params = {
     method: 'GET',
     url: '/blob/' + key,
@@ -40,10 +38,9 @@ export const read = async(key: string) => {
   });
 
   return { result };
-}
+};
 
 export const write = async (key: string, state: any) => {
-
   const body = JSON.stringify(state);
 
   const params = {
@@ -64,12 +61,9 @@ export const write = async (key: string, state: any) => {
   });
 
   return { result };
-}
-
-
+};
 
 function readGlobal(keys: string[] | null = null) {
-
   const promises = keys?.map((key) => {
     const params = {
       method: 'GET',
@@ -175,9 +169,7 @@ export const updateGlobalUserState = async (
 };
 
 export function upsertGlobal(keyValues: KeyValues) {
-
   const result = Object.keys(keyValues).map((key) => {
-
     const body = JSON.stringify((keyValues as any)[key]);
 
     const params = {

--- a/assets/src/data/persistence/blob.ts
+++ b/assets/src/data/persistence/blob.ts
@@ -1,0 +1,143 @@
+import { batchedBuffer } from 'utils/common';
+import { makeRequest } from './common';
+
+// eslint-disable-next-line
+export type ExtrinsicRead = String;
+
+// eslint-disable-next-line
+export type KeyValues = Object;
+export type ExtrinsicUpsert = {
+  result: 'success';
+};
+export type ExtrinsicDelete = {
+  result: 'success';
+};
+const setQ = new Set();
+const lastSet = () => {
+  const arr = Array.from(setQ);
+  return arr[arr.length - 1];
+};
+
+function readGlobal(keys: string[] | null = null) {
+
+  const promises = keys?.map((key) => {
+    const params = {
+      method: 'GET',
+      url: '/blob/user/' + key,
+    };
+
+    return makeRequest<ExtrinsicRead>(params);
+  });
+
+  if (!promises || promises.length === 0) {
+    return Promise.resolve({});
+  }
+
+  return Promise.all(promises).then((results) => {
+    return results.map((result) => {
+      if (typeof result === 'string') {
+        return JSON.parse(result);
+      }
+      return { type: 'ServerError', message: 'Invalid response from server' };
+    });
+  });
+}
+
+export const readGlobalUserState = async (
+  keys: string[] | null = null,
+  useLocalStorage = false,
+) => {
+  let result: any = {};
+  if (useLocalStorage) {
+    // localStorage API doesn't support the "get all" behavior, so we need to put everything into a single object
+    const storedUserState = JSON.parse(localStorage.getItem('torus.userState') || '{}');
+    if (keys) {
+      keys.forEach((key) => {
+        result[key] = storedUserState[key];
+      });
+    } else {
+      result = storedUserState;
+    }
+  } else {
+    if (lastSet()) {
+      await lastSet();
+    }
+    if (keys) {
+      //if cache does not have any of the requested keys, we should make the server call
+      const serverUserState = await readGlobal(keys);
+      // merge server state with result
+      if ((serverUserState as any).type !== 'ServerError') {
+        result = serverUserState;
+      }
+    }
+  }
+  return result;
+};
+
+export const internalUpdateGlobalUserState = async (
+  updates: { [topKey: string]: { [key: string]: any } },
+  useLocalStorage = false,
+) => {
+  /* console.log('updateGlobalUserState', updates); */
+  const topLevelKeys = Object.keys(updates);
+  const currentState = await readGlobalUserState(topLevelKeys, useLocalStorage);
+
+  const newState = { ...currentState };
+  topLevelKeys.forEach((topKey) => {
+    const actualKeys = Object.keys(updates[topKey]);
+    actualKeys.forEach((actualKey) => {
+      newState[topKey] = { ...newState[topKey], [actualKey]: updates[topKey][actualKey] };
+    });
+  });
+
+  if (useLocalStorage) {
+    const existingState = localStorage.getItem('torus.userState') || '{}';
+    const parsedState = JSON.parse(existingState);
+
+    const mergedState = { ...parsedState, ...newState };
+
+    localStorage.setItem('torus.userState', JSON.stringify(mergedState));
+  } else {
+    const op = upsertGlobal(newState);
+    setQ.add(op);
+    await op;
+    setQ.delete(op);
+  }
+  return newState;
+};
+
+const updateInterval = 300;
+const [batchedUpdate] = batchedBuffer(internalUpdateGlobalUserState, updateInterval);
+
+export const updateGlobalUserState = async (
+  updates: { [topKey: string]: { [key: string]: any } },
+  useLocalStorage = false,
+) => {
+  /*console.log('updateGlobalUserState called', { updates, useLocalStorage });*/
+  const result = await batchedUpdate(updates, useLocalStorage);
+  /* console.log('updateGlobalUserState result', { result, updates }); */
+  return result;
+};
+
+export function upsertGlobal(keyValues: KeyValues) {
+
+  const result = Object.keys(keyValues).map((key) => {
+
+    const params = {
+      method: 'PUT',
+      body: JSON.stringify((keyValues as any)[key]),
+      url: '/blob/user/' + key,
+    };
+
+    return makeRequest<ExtrinsicDelete>(params);
+  });
+
+  return Promise.all(result).then((results) => {
+    return results.map((result) => {
+      if (typeof result === 'string') {
+        return JSON.parse(result);
+      }
+      return { type: 'ServerError', message: 'Invalid response from server' };
+    });
+  });
+}

--- a/assets/src/data/persistence/blob.ts
+++ b/assets/src/data/persistence/blob.ts
@@ -18,12 +18,66 @@ const lastSet = () => {
   return arr[arr.length - 1];
 };
 
+
+export const read = async(key: string) => {
+
+  const params = {
+    method: 'GET',
+    url: '/blob/' + key,
+    hasTextResult: true,
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  };
+
+  const result = await makeRequest<ExtrinsicRead>(params).then((result) => {
+    if (typeof result === 'string') {
+      const json = JSON.parse(result);
+      return json;
+    } else {
+      return { type: 'ServerError', message: 'Invalid response from server' };
+    }
+  });
+
+  return { result };
+}
+
+export const write = async (key: string, state: any) => {
+
+  const body = JSON.stringify(state);
+
+  const params = {
+    method: 'PUT',
+    body,
+    url: '/blob/' + key,
+    hasTextResult: true,
+    headers: {
+      'Content-Type': 'text/plain',
+    },
+  };
+
+  const result = await makeRequest<ExtrinsicDelete>(params).then((result) => {
+    if (typeof result === 'string') {
+      return JSON.parse(result);
+    }
+    return { type: 'ServerError', message: 'Invalid response from server' };
+  });
+
+  return { result };
+}
+
+
+
 function readGlobal(keys: string[] | null = null) {
 
   const promises = keys?.map((key) => {
     const params = {
       method: 'GET',
       url: '/blob/user/' + key,
+      hasTextResult: true,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
     };
 
     return makeRequest<ExtrinsicRead>(params);
@@ -36,7 +90,8 @@ function readGlobal(keys: string[] | null = null) {
   return Promise.all(promises).then((results) => {
     return results.map((result) => {
       if (typeof result === 'string') {
-        return JSON.parse(result);
+        const json = JSON.parse(result);
+        return json;
       }
       return { type: 'ServerError', message: 'Invalid response from server' };
     });
@@ -123,10 +178,16 @@ export function upsertGlobal(keyValues: KeyValues) {
 
   const result = Object.keys(keyValues).map((key) => {
 
+    const body = JSON.stringify((keyValues as any)[key]);
+
     const params = {
       method: 'PUT',
-      body: JSON.stringify((keyValues as any)[key]),
+      body,
       url: '/blob/user/' + key,
+      hasTextResult: true,
+      headers: {
+        'Content-Type': 'text/plain',
+      },
     };
 
     return makeRequest<ExtrinsicDelete>(params);

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -1,6 +1,8 @@
 import { SectionSlug } from 'data/types';
 import { batchedBuffer } from 'utils/common';
 import { makeRequest } from './common';
+import * as Blob from './blob';
+
 
 // eslint-disable-next-line
 export type ExtrinsicRead = Object;
@@ -33,6 +35,17 @@ export function readGlobal(keys: string[] | null = null) {
 }
 
 export const readGlobalUserState = async (
+  provider: 'deprecated' | 'new',
+  keys: string[] | null = null,
+  useLocalStorage = false,
+) => {
+  if (provider === 'deprecated') {
+    return deprecatedReadGlobalUserState(keys, useLocalStorage);
+  }
+  return Blob.readGlobalUserState(keys, useLocalStorage);
+};
+
+const deprecatedReadGlobalUserState = async (
   keys: string[] | null = null,
   useLocalStorage = false,
 ) => {
@@ -69,7 +82,7 @@ export const internalUpdateGlobalUserState = async (
 ) => {
   /* console.log('updateGlobalUserState', updates); */
   const topLevelKeys = Object.keys(updates);
-  const currentState = await readGlobalUserState(topLevelKeys, useLocalStorage);
+  const currentState = await deprecatedReadGlobalUserState(topLevelKeys, useLocalStorage);
 
   const newState = { ...currentState };
   topLevelKeys.forEach((topKey) => {
@@ -98,7 +111,20 @@ export const internalUpdateGlobalUserState = async (
 const updateInterval = 300;
 const [batchedUpdate] = batchedBuffer(internalUpdateGlobalUserState, updateInterval);
 
+
 export const updateGlobalUserState = async (
+  provider: 'deprecated' | 'new',
+  updates: { [topKey: string]: { [key: string]: any } },
+  useLocalStorage = false,
+) => {
+
+  if (provider === 'deprecated') {
+    return deprecatedUpdateGlobalUserState(updates, useLocalStorage);
+  }
+  return Blob.updateGlobalUserState(updates, useLocalStorage);
+};
+
+export const deprecatedUpdateGlobalUserState = async (
   updates: { [topKey: string]: { [key: string]: any } },
   useLocalStorage = false,
 ) => {

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -1,8 +1,7 @@
 import { SectionSlug } from 'data/types';
 import { batchedBuffer } from 'utils/common';
-import { makeRequest } from './common';
 import * as Blob from './blob';
-
+import { makeRequest } from './common';
 
 // eslint-disable-next-line
 export type ExtrinsicRead = Object;
@@ -111,13 +110,11 @@ export const internalUpdateGlobalUserState = async (
 const updateInterval = 300;
 const [batchedUpdate] = batchedBuffer(internalUpdateGlobalUserState, updateInterval);
 
-
 export const updateGlobalUserState = async (
   provider: 'deprecated' | 'new',
   updates: { [topKey: string]: { [key: string]: any } },
   useLocalStorage = false,
 ) => {
-
   if (provider === 'deprecated') {
     return deprecatedUpdateGlobalUserState(updates, useLocalStorage);
   }

--- a/assets/src/data/persistence/state/intrinsic.ts
+++ b/assets/src/data/persistence/state/intrinsic.ts
@@ -1,5 +1,6 @@
 import { encodeFile, getFileName } from 'data/persistence/media';
 import { makeRequest } from '../common';
+import * as Blob from '../blob';
 
 export type BulkAttemptRetrieved = {
   result: 'success';
@@ -21,7 +22,37 @@ export const getBulkAttemptState = async (sectionSlug: string, attemptGuids: str
   return response.activityAttempts;
 };
 
-export const getPageAttemptState = async (sectionSlug: string, resourceAttemptGuid: string) => {
+
+export const getPageAttemptState = async (provider: 'deprecated' | 'new', sectionSlug: string, resourceAttemptGuid: string) => {
+  console.log('HERE READING', { sectionSlug, resourceAttemptGuid });
+
+  if (provider === 'deprecated') {
+    const result = deprecatedGetPageAttemptState(sectionSlug, resourceAttemptGuid);
+    return result;
+  }
+  const result = await Blob.read(resourceAttemptGuid);
+  console.log(result);
+  return result;
+};
+
+export const writePageAttemptState = async (
+  provider: 'deprecated' | 'new',
+  sectionSlug: string,
+  resourceAttemptGuid: string,
+  state: any,
+) => {
+  if (provider === 'deprecated') {
+    const result = deprecatedWritePageAttemptState(sectionSlug, resourceAttemptGuid, state);
+    console.log('deprecatedWritePageAttemptState', { sectionSlug, resourceAttemptGuid, state, result });
+    return result;
+  }
+  console.log("WRITING")
+  console.log(state)
+  return Blob.write(resourceAttemptGuid, state).then((result => result));
+
+};
+
+export const deprecatedGetPageAttemptState = async (sectionSlug: string, resourceAttemptGuid: string) => {
   const url = `/state/course/${sectionSlug}/resource_attempt/${resourceAttemptGuid}`;
   const result = await makeRequest({
     url,
@@ -30,7 +61,7 @@ export const getPageAttemptState = async (sectionSlug: string, resourceAttemptGu
   return { result };
 };
 
-export const writePageAttemptState = async (
+export const deprecatedWritePageAttemptState = async (
   sectionSlug: string,
   resourceAttemptGuid: string,
   state: any,

--- a/assets/src/data/persistence/state/intrinsic.ts
+++ b/assets/src/data/persistence/state/intrinsic.ts
@@ -1,6 +1,6 @@
 import { encodeFile, getFileName } from 'data/persistence/media';
-import { makeRequest } from '../common';
 import * as Blob from '../blob';
+import { makeRequest } from '../common';
 
 export type BulkAttemptRetrieved = {
   result: 'success';
@@ -22,16 +22,17 @@ export const getBulkAttemptState = async (sectionSlug: string, attemptGuids: str
   return response.activityAttempts;
 };
 
-
-export const getPageAttemptState = async (provider: 'deprecated' | 'new', sectionSlug: string, resourceAttemptGuid: string) => {
-  console.log('HERE READING', { sectionSlug, resourceAttemptGuid });
-
+export const getPageAttemptState = async (
+  provider: 'deprecated' | 'new',
+  sectionSlug: string,
+  resourceAttemptGuid: string,
+) => {
   if (provider === 'deprecated') {
     const result = deprecatedGetPageAttemptState(sectionSlug, resourceAttemptGuid);
     return result;
   }
   const result = await Blob.read(resourceAttemptGuid);
-  console.log(result);
+
   return result;
 };
 
@@ -43,16 +44,15 @@ export const writePageAttemptState = async (
 ) => {
   if (provider === 'deprecated') {
     const result = deprecatedWritePageAttemptState(sectionSlug, resourceAttemptGuid, state);
-    console.log('deprecatedWritePageAttemptState', { sectionSlug, resourceAttemptGuid, state, result });
     return result;
   }
-  console.log("WRITING")
-  console.log(state)
-  return Blob.write(resourceAttemptGuid, state).then((result => result));
-
+  return Blob.write(resourceAttemptGuid, state).then((result) => result);
 };
 
-export const deprecatedGetPageAttemptState = async (sectionSlug: string, resourceAttemptGuid: string) => {
+export const deprecatedGetPageAttemptState = async (
+  sectionSlug: string,
+  resourceAttemptGuid: string,
+) => {
   const url = `/state/course/${sectionSlug}/resource_attempt/${resourceAttemptGuid}`;
   const result = await makeRequest({
     url,
@@ -105,7 +105,6 @@ export const writePartAttemptState = async (
   input: any,
   finalize = false,
 ) => {
-  console.info('writePartAttemptState');
   const method = finalize ? 'PUT' : 'PATCH';
   const url = `/state/course/${sectionSlug}/activity_attempt/${attemptGuid}/part_attempt/${partAttemptGuid}`;
   const result = await makeRequest({

--- a/config/config.exs
+++ b/config/config.exs
@@ -83,6 +83,11 @@ config :oli,
     String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
   log_incomplete_requests: true
 
+config :oli, :blob_storage,
+  bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-storage-dev"),
+  use_deprecated_api:
+    get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
+
 config :oli, :dataset_generation,
   enabled: System.get_env("EMR_DATASET_ENABLED", "false") == "true",
   emr_application_name: System.get_env("EMR_DATASET_APPLICATION_NAME", "csv_job"),

--- a/config/config.exs
+++ b/config/config.exs
@@ -85,8 +85,7 @@ config :oli,
 
 config :oli, :blob_storage,
   bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-dev"),
-  use_deprecated_api:
-    get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
+  use_deprecated_api: get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
 
 config :oli, :dataset_generation,
   enabled: System.get_env("EMR_DATASET_ENABLED", "false") == "true",

--- a/config/config.exs
+++ b/config/config.exs
@@ -84,7 +84,7 @@ config :oli,
   log_incomplete_requests: true
 
 config :oli, :blob_storage,
-  bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-storage-dev"),
+  bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-dev"),
   use_deprecated_api:
     get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -211,7 +211,7 @@ if config_env() == :prod do
     log_incomplete_requests: get_env_as_boolean.("LOG_INCOMPLETE_REQUESTS", "true")
 
   config :oli, :blob_storage,
-    bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-storage-prod"),
+    bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-prod"),
     use_deprecated_api:
       get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -212,8 +212,7 @@ if config_env() == :prod do
 
   config :oli, :blob_storage,
     bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-prod"),
-    use_deprecated_api:
-      get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
+    use_deprecated_api: get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
 
   config :oli, :dataset_generation,
     enabled: System.get_env("EMR_DATASET_ENABLED", "false") == "true",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -210,6 +210,11 @@ if config_env() == :prod do
       String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
     log_incomplete_requests: get_env_as_boolean.("LOG_INCOMPLETE_REQUESTS", "true")
 
+  config :oli, :blob_storage,
+    bucket_name: System.get_env("BLOB_STORAGE_BUCKET_NAME", "torus-blob-storage-prod"),
+    use_deprecated_api:
+      get_env_as_boolean.("BLOB_STORAGE_USE_DEPRECATED_API", "true")
+
   config :oli, :dataset_generation,
     enabled: System.get_env("EMR_DATASET_ENABLED", "false") == "true",
     emr_aplication_name: System.get_env("EMR_DATASET_APPLICATION_NAME", "csv_job"),

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -492,7 +492,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   # Retrieving the extrinsic state of the resource attempt must take
   # into account if the blob storage API is in use for extrinsic state.
   defp fetch_extrinsic_state(resource_attempt) do
-
     if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] do
       resource_attempt.state
     else
@@ -511,7 +510,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
           %{}
       end
     end
-
   end
 
   defp assemble_full_adaptive_state(

--- a/lib/oli/delivery/text_blob.ex
+++ b/lib/oli/delivery/text_blob.ex
@@ -1,5 +1,4 @@
 defmodule Oli.Delivery.TextBlob do
-
   @moduledoc """
   A module for text blob storage, allowing for the storage and retrieval of text blobs
   keyed off of either a globally unique identifier or a user scoped unique identifier.
@@ -49,5 +48,4 @@ defmodule Oli.Delivery.TextBlob do
       _ -> "#{user.sub}/#{key}"
     end
   end
-
 end

--- a/lib/oli/delivery/text_blob.ex
+++ b/lib/oli/delivery/text_blob.ex
@@ -1,0 +1,53 @@
+defmodule Oli.Delivery.TextBlob do
+
+  @moduledoc """
+  A module for text blob storage, allowing for the storage and retrieval of text blobs
+  keyed off of either a globally unique identifier or a user scoped unique identifier.
+  """
+
+  @doc """
+  Reads a text blob from a user scoped key.
+
+  Returns {:ok, text_blob} if the blob exists, or {:ok, default_value}
+  if it does not.  An error tuple is returned if the read operation fails.
+  """
+  def read(user, key, default_value) do
+    build_user_key(user, key)
+    |> read(default_value)
+  end
+
+  @doc """
+  Reads a text blob from a globally unique key.
+
+  Returns {:ok, text_blob} if the blob exists, or {:ok, default_value}
+  if it does not.  An error tuple is returned if the read operation fails.
+  """
+  def read(key, default_value) do
+    Oli.Delivery.TextBlob.Storage.read(key, default_value)
+  end
+
+  @doc """
+  Writes a text blob to a user scoped key.
+  Returns :ok on success, or an error tuple on failure.
+  """
+  def write(user, key, text_blob) do
+    build_user_key(user, key)
+    |> write(text_blob)
+  end
+
+  @doc """
+  Writes a text blob to a globally unique key.
+  Returns :ok on success, or an error tuple on failure.
+  """
+  def write(key, text_blob) do
+    Oli.Delivery.TextBlob.Storage.write(key, text_blob)
+  end
+
+  defp build_user_key(user, key) do
+    case user.sub do
+      nil -> "#{user.id}/#{key}"
+      _ -> "#{user.sub}/#{key}"
+    end
+  end
+
+end

--- a/lib/oli/delivery/text_blob/storage.ex
+++ b/lib/oli/delivery/text_blob/storage.ex
@@ -1,5 +1,4 @@
 defmodule Oli.Delivery.TextBlob.Storage do
-
   alias ExAws.S3
   alias Oli.HTTP
 
@@ -18,17 +17,16 @@ defmodule Oli.Delivery.TextBlob.Storage do
   Returns `:ok` on success or an error tuple on failure.
   """
   def write(key, text_blob) do
-
     bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
 
     case S3.put_object(bucket_name, key, text_blob, [])
-    |> HTTP.aws().request() do
+         |> HTTP.aws().request() do
       {:ok, %{status_code: 200}} ->
         :ok
+
       {_, payload} ->
         {:error, payload}
     end
-
   end
 
   @doc """
@@ -38,17 +36,15 @@ defmodule Oli.Delivery.TextBlob.Storage do
   value as {:ok, default_value}.
   """
   def read(key, default_value) do
-
     bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
 
     case S3.get_object(bucket_name, key)
-    |> HTTP.aws().request() do
+         |> HTTP.aws().request() do
       {:ok, %{status_code: 200, body: text_blob}} ->
         {:ok, text_blob}
+
       {_, _} ->
         {:ok, default_value}
     end
-
   end
-
 end

--- a/lib/oli/delivery/text_blob/storage.ex
+++ b/lib/oli/delivery/text_blob/storage.ex
@@ -21,7 +21,7 @@ defmodule Oli.Delivery.TextBlob.Storage do
 
     bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
 
-    case S3.put_object(bucket_name, key, text_blob, [{:acl, :public_read}])
+    case S3.put_object(bucket_name, key, text_blob, [])
     |> HTTP.aws().request() do
       {:ok, %{status_code: 200}} ->
         :ok
@@ -35,18 +35,18 @@ defmodule Oli.Delivery.TextBlob.Storage do
   Reads a text blob from storage using the provided key.
   If the key exists, it returns `{:ok, text_blob}` where `text_blob` is the content
   associated with the key. If the key does not exist, it returns the specified
-  `not_found_value`.
+  value as {:ok, default_value}.
   """
   def read(key, default_value) do
 
     bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
 
-    case S3.put_object(bucket_name, key, text_blob, [{:acl, :public_read}])
+    case S3.get_object(bucket_name, key)
     |> HTTP.aws().request() do
       {:ok, %{status_code: 200, body: text_blob}} ->
         {:ok, text_blob}
       {_, _} ->
-        default_value
+        {:ok, default_value}
     end
 
   end

--- a/lib/oli/delivery/text_blob/storage.ex
+++ b/lib/oli/delivery/text_blob/storage.ex
@@ -1,0 +1,54 @@
+defmodule Oli.Delivery.TextBlob.Storage do
+
+  alias ExAws.S3
+  alias Oli.HTTP
+
+  @moduledoc """
+  A module for the raw text blob storage read and write operations.
+
+  This module is designed to provide a simple interface for storing and retrieving
+  potentially large text blobs in and out of files in S3.
+  """
+
+  @doc """
+  Writes an arbitrary text blob to storage, associated with a unique key.
+  The key can be any string that uniquely identifies the blob, and the text_blob
+  is the content to be stored.
+
+  Returns `:ok` on success or an error tuple on failure.
+  """
+  def write(key, text_blob) do
+
+    bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
+
+    case S3.put_object(bucket_name, key, text_blob, [{:acl, :public_read}])
+    |> HTTP.aws().request() do
+      {:ok, %{status_code: 200}} ->
+        :ok
+      {_, payload} ->
+        {:error, payload}
+    end
+
+  end
+
+  @doc """
+  Reads a text blob from storage using the provided key.
+  If the key exists, it returns `{:ok, text_blob}` where `text_blob` is the content
+  associated with the key. If the key does not exist, it returns the specified
+  `not_found_value`.
+  """
+  def read(key, default_value) do
+
+    bucket_name = Application.fetch_env!(:oli, :blob_storage)[:bucket_name]
+
+    case S3.put_object(bucket_name, key, text_blob, [{:acl, :public_read}])
+    |> HTTP.aws().request() do
+      {:ok, %{status_code: 200, body: text_blob}} ->
+        {:ok, text_blob}
+      {_, _} ->
+        default_value
+    end
+
+  end
+
+end

--- a/lib/oli_web/controllers/api/blob_storage_controller.ex
+++ b/lib/oli_web/controllers/api/blob_storage_controller.ex
@@ -1,0 +1,86 @@
+defmodule OliWeb.Api.BlobStorageController do
+
+  use OliWeb, :controller
+
+  alias Oli.Delivery.TextBlob
+  require Logger
+
+  @moduledoc """
+  Provides endpoints for reading and writing text blobs, both for user scoped
+  and globally scoped keys.
+
+  While this data is stored as text blobs, it is known that the content
+  being stored through this endpoint is actually stringified JSON objects (from
+  the adaptive page client-side implementation). This controller is designed to
+  provide a simple interface for reading and writing these blobs, with appropriate
+  default "JSON as string" values and error handling.
+
+  All of this exists to support the storing and retrieving of large JSON objects
+  without the need to serialize and deserialize them in the application layer
+  and without the need to store them in the database.
+  """
+
+
+  @doc """
+  Reads a text blob from a user scoped key.
+  """
+  def read_user_key(conn, params) do
+    read(conn, fn -> TextBlob.read(conn.assigns.current_user, params["key"], "{}") end)
+  end
+
+
+  @doc """
+  Reads a text blob from storage using the provided key.
+  """
+  def read_key(conn, params) do
+    read(conn, fn -> TextBlob.read(params["key"], "{}") end)
+  end
+
+  @doc """
+  Writes a text blob to a user scoped key.
+  """
+  def write_user_key(conn, params) do
+    write(conn, fn text ->
+      TextBlob.write(conn.assigns.current_user, params["key"], text)
+    end)
+  end
+
+  @doc """
+  Writes a text blob from storage using the provided guid as the key.
+  """
+  def write_key(conn, params) do
+    write(conn, fn text ->
+      TextBlob.write(params["key"], text)
+    end)
+  end
+
+  defp write(conn, write_fn) do
+
+    {:ok, text, _conn} = Plug.Conn.read_body(conn)
+
+    case write_fn.(text) do
+      :ok ->
+        text(conn, "success")
+      {:error, reason} ->
+        Logger.error("Failed to write blob with key #{key}: #{inspect(reason)}")
+        error(conn, 500, reason)
+    end
+
+  end
+
+  defp read(conn, read_fn) do
+    case read_fn.() do
+      {:ok, result} ->
+        text(conn, result)
+      {:error, reason} ->
+        error(conn, 500, reason)
+    end
+  end
+
+  defp error(conn, code, reason) do
+    conn
+    |> send_resp(code, reason)
+    |> halt()
+  end
+
+end

--- a/lib/oli_web/controllers/api/blob_storage_controller.ex
+++ b/lib/oli_web/controllers/api/blob_storage_controller.ex
@@ -60,9 +60,9 @@ defmodule OliWeb.Api.BlobStorageController do
 
     case write_fn.(text) do
       :ok ->
-        text(conn, "success")
+        text(conn, "{\"result\": \"success\"}")
       {:error, reason} ->
-        Logger.error("Failed to write blob with key #{key}: #{inspect(reason)}")
+        Logger.error("Failed to write blob: #{inspect(reason)}")
         error(conn, 500, reason)
     end
 

--- a/lib/oli_web/controllers/api/blob_storage_controller.ex
+++ b/lib/oli_web/controllers/api/blob_storage_controller.ex
@@ -1,5 +1,4 @@
 defmodule OliWeb.Api.BlobStorageController do
-
   use OliWeb, :controller
 
   alias Oli.Delivery.TextBlob
@@ -20,14 +19,12 @@ defmodule OliWeb.Api.BlobStorageController do
   and without the need to store them in the database.
   """
 
-
   @doc """
   Reads a text blob from a user scoped key.
   """
   def read_user_key(conn, params) do
     read(conn, fn -> TextBlob.read(conn.assigns.current_user, params["key"], "{}") end)
   end
-
 
   @doc """
   Reads a text blob from storage using the provided key.
@@ -55,23 +52,23 @@ defmodule OliWeb.Api.BlobStorageController do
   end
 
   defp write(conn, write_fn) do
-
     {:ok, text, _conn} = Plug.Conn.read_body(conn)
 
     case write_fn.(text) do
       :ok ->
         text(conn, "{\"result\": \"success\"}")
+
       {:error, reason} ->
         Logger.error("Failed to write blob: #{inspect(reason)}")
         error(conn, 500, reason)
     end
-
   end
 
   defp read(conn, read_fn) do
     case read_fn.() do
       {:ok, result} ->
         text(conn, result)
+
       {:error, reason} ->
         error(conn, 500, reason)
     end
@@ -82,5 +79,4 @@ defmodule OliWeb.Api.BlobStorageController do
     |> send_resp(code, reason)
     |> halt()
   end
-
 end

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -761,6 +761,11 @@ defmodule OliWeb.PageDeliveryController do
             conn,
             :transition
           ),
+        blobStorageProvider: if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
+          "new"
+        else
+          "deprecated"
+        end,
         screenIdleTimeOutInSeconds:
           String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
         isAuthor: !is_nil(author),

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -761,11 +761,12 @@ defmodule OliWeb.PageDeliveryController do
             conn,
             :transition
           ),
-        blobStorageProvider: if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
-          "new"
-        else
-          "deprecated"
-        end,
+        blobStorageProvider:
+          if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
+            "new"
+          else
+            "deprecated"
+          end,
         screenIdleTimeOutInSeconds:
           String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
         isAuthor: !is_nil(author),

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   import Phoenix.Component, only: [assign: 2, update: 3]
 
+  alias DBConnection.App
   alias Oli.Delivery.{Gating, Metrics, PreviousNextIndex, Settings}
   alias Oli.Delivery.Attempts.Core
   alias Oli.Delivery.Page.{PageContext, PrologueContext}
@@ -197,7 +198,12 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
           :transition
         ),
       screenIdleTimeOutInSeconds:
-        String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800"))
+        String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
+      blobStorageProvider: if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
+          "new"
+        else
+          "deprecated"
+        end
     }
 
     assign(socket, %{

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
 
   import Phoenix.Component, only: [assign: 2, update: 3]
 
-  alias DBConnection.App
   alias Oli.Delivery.{Gating, Metrics, PreviousNextIndex, Settings}
   alias Oli.Delivery.Attempts.Core
   alias Oli.Delivery.Page.{PageContext, PrologueContext}

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -198,7 +198,8 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
         ),
       screenIdleTimeOutInSeconds:
         String.to_integer(System.get_env("SCREEN_IDLE_TIMEOUT_IN_SECONDS", "1800")),
-      blobStorageProvider: if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
+      blobStorageProvider:
+        if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] == false do
           "new"
         else
           "deprecated"

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -39,7 +39,7 @@ defmodule OliWeb.Router do
     plug(OliWeb.Plugs.SessionContext)
   end
 
-  pipeline :raw_text_api do
+  pipeline :text_api do
     plug(:accepts, ["text/plain"])
     plug(:fetch_session)
     plug(:fetch_current_user)

--- a/test/oli_web/controllers/api/blob_storage_controller_test.exs
+++ b/test/oli_web/controllers/api/blob_storage_controller_test.exs
@@ -20,7 +20,6 @@ defmodule OliWeb.Api.BlobStorageControllerTest do
     test "can read regular keys as a pure text, but psuedo JSON API", %{
       conn: conn
     } do
-
       expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
         {:ok, %{status_code: 200, body: "{}"}}
       end)
@@ -34,7 +33,6 @@ defmodule OliWeb.Api.BlobStorageControllerTest do
     test "can read user scoped keys as a pure text, but psuedo JSON API", %{
       conn: conn
     } do
-
       expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
         {:ok, %{status_code: 200, body: "{}"}}
       end)
@@ -48,7 +46,6 @@ defmodule OliWeb.Api.BlobStorageControllerTest do
     test "can write regular keys as a pure text, but psuedo JSON API", %{
       conn: conn
     } do
-
       expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
         {:ok, %{status_code: 200, body: "{}"}}
       end)
@@ -65,7 +62,6 @@ defmodule OliWeb.Api.BlobStorageControllerTest do
     test "can write user scoped keys as a pure text, but psuedo JSON API", %{
       conn: conn
     } do
-
       expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
         {:ok, %{status_code: 200, body: "{}"}}
       end)
@@ -78,7 +74,6 @@ defmodule OliWeb.Api.BlobStorageControllerTest do
       text = text_response(conn, 200)
       assert text == "{\"result\": \"success\"}"
     end
-
   end
 
   defp setup_session(%{conn: conn}) do

--- a/test/oli_web/controllers/api/blob_storage_controller_test.exs
+++ b/test/oli_web/controllers/api/blob_storage_controller_test.exs
@@ -1,0 +1,118 @@
+defmodule OliWeb.Api.BlobStorageControllerTest do
+  use OliWeb.ConnCase
+
+  alias Oli.Seeder
+  import Mox
+
+  @moduledoc """
+  This module tests the BlobStorageController, which provides endpoints for reading
+  and writing text blobs by a client API that asserts the data is stored as JSON strings.
+
+  This isn't much of a test, but it does ensure that the controller is set up correctly
+  and that the expected behavior is implemented for reading and writing text blobs.
+  It uses Mox to mock the ExAws requests to S3, allowing us to test the controller
+  without actually making network requests.
+  """
+
+  describe "blob storage controller" do
+    setup [:setup_session]
+
+    test "can read regular keys as a pure text, but psuedo JSON API", %{
+      conn: conn
+    } do
+
+      expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
+        {:ok, %{status_code: 200, body: "{}"}}
+      end)
+
+      conn = get(conn, Routes.blob_storage_path(conn, :read_key, "some-key"))
+
+      text = text_response(conn, 200)
+      assert text == "{}"
+    end
+
+    test "can read user scoped keys as a pure text, but psuedo JSON API", %{
+      conn: conn
+    } do
+
+      expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
+        {:ok, %{status_code: 200, body: "{}"}}
+      end)
+
+      conn = get(conn, Routes.blob_storage_path(conn, :read_user_key, "some-key"))
+
+      text = text_response(conn, 200)
+      assert text == "{}"
+    end
+
+    test "can write regular keys as a pure text, but psuedo JSON API", %{
+      conn: conn
+    } do
+
+      expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
+        {:ok, %{status_code: 200, body: "{}"}}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "text/plain")
+        |> put(Routes.blob_storage_path(conn, :write_key, "some-key"), "raw text")
+
+      text = text_response(conn, 200)
+      assert text == "{\"result\": \"success\"}"
+    end
+
+    test "can write user scoped keys as a pure text, but psuedo JSON API", %{
+      conn: conn
+    } do
+
+      expect(Oli.Test.MockAws, :request, 1, fn %ExAws.Operation.S3{} ->
+        {:ok, %{status_code: 200, body: "{}"}}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "text/plain")
+        |> put(Routes.blob_storage_path(conn, :write_user_key, "some-key"), "raw text")
+
+      text = text_response(conn, 200)
+      assert text == "{\"result\": \"success\"}"
+    end
+
+  end
+
+  defp setup_session(%{conn: conn}) do
+    user = user_fixture()
+    user2 = user_fixture()
+
+    map = Seeder.base_project_with_resource2()
+
+    section =
+      section_fixture(%{
+        context_id: "some-context-id",
+        base_project_id: map.project.id,
+        institution_id: map.institution.id,
+        open_and_free: false
+      })
+
+    Oli.Lti.TestHelpers.all_default_claims()
+    |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], section.slug)
+    |> cache_lti_params(user.id)
+
+    conn =
+      Plug.Test.init_test_session(conn, lti_session: nil)
+      |> log_in_author(map.author)
+      |> log_in_user(user)
+
+    {:ok,
+     conn: conn,
+     map: map,
+     author: map.author,
+     institution: map.institution,
+     user: user,
+     user2: user2,
+     project: map.project,
+     publication: map.publication,
+     section: section}
+  end
+end


### PR DESCRIPTION
This PR introduces a (configurable, optional) replacement for the database backed storage for global and page attempt level.   Prior to this PR, the `users` and `resource_attempts` each used a `state` field to store arbitrary JSON blobs.  This feature is used by the Adaptive Player to store EverApp and Simulation data, but the large of amount of data being stored has proved to be a performance and scalability issue.   We solve these performance issues by 1) Storing these large JSON blobs in S3 storage and 2) Eliminating all of the server JSON encoding and decoding by providing a pure `plain/text` API and distributing the JSON encoding/decoding to the client browser.

To enable this new "text blob storage", we set a new run time environment variable `BLOB_STORAGE_USE_DEPRECATED_API=false`.  The default here is `true` which allows a server to continue to operate with the current DB backed extrinsic service.     **WE MUST SET THIS FOR PROTON, but NOT SET THIS FOR ETX PROD.** 

A change had to be made in this client facing API for pure text as we now must read and write individual keys instead of getting and upsertting a JSON object with potentially many keys. 

Also, this only affects the Adaptive Page use of extrinsic storage.  The basic page has a couple of uses of user and attempt level extrinsic storage (pagination, alternatives selection) that will continue to be stored in the DB record.  These usages do not at all contribute to the scaling and performance issues and can continue to operate this way. 