### PR TITLE
[BUG FIX] [MER-4660] fix an issue where resource_link id is double nested

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -196,15 +196,11 @@ defmodule OliWeb.LtiController do
             platform_instance_id: platform_instance.id
           )
 
-        resource_link = %{
-          id: resource_id
-        }
-
         claims = [
           Lti_1p3.Claims.DeploymentId.deployment_id(deployment.deployment_id),
           Lti_1p3.Claims.MessageType.message_type(:lti_resource_link_request),
           Lti_1p3.Claims.Version.version("1.3.0"),
-          Lti_1p3.Claims.ResourceLink.resource_link(resource_link),
+          Lti_1p3.Claims.ResourceLink.resource_link(resource_id),
           Lti_1p3.Claims.TargetLinkUri.target_link_uri(platform_instance.target_link_uri),
           Lti_1p3.Claims.Roles.roles(roles)
         ]


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4660

When performing an LTI external tools launch, the launch was failing for some tools because the resource_link id claim payload was double nested under the "id" key.

This PR resolves the issue by removing the outer "id" key that was causing the issue.