### PR TITLE
[ENHANCEMENT] [MER-4644] Limit score as you go to 1 completed attempt

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -286,6 +286,9 @@ defmodule Oli.Delivery.Settings do
   defp check_blocking_gates([]), do: {:allowed}
   defp check_blocking_gates(_), do: {:blocking_gates}
 
+  defp check_num_attempts(%Combined{batch_scoring: false}, 0), do: {:allowed}
+  defp check_num_attempts(%Combined{batch_scoring: false}, _), do: {:score_as_you_go_completed}
+
   defp check_num_attempts(settings, num_attempts_taken) do
     if max(settings.max_attempts - num_attempts_taken, 0) > 0 or settings.max_attempts == 0 do
       {:allowed}

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -313,6 +313,9 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
             format_datetime: format_datetime_fn(socket.assigns.ctx)
           )
 
+        {{:score_as_you_go_completed}, _max_attempts} ->
+          "This score as you go assessment has already been completed."
+
         {{:no_attempts_remaining}, max_attempts} ->
           "You have no attempts remaining out of #{max_attempts} total attempt#{plural(max_attempts)}."
 


### PR DESCRIPTION
Score as you go assessments (i.e., those with `batch_score: false`) use the `:max_attempts` to control the number of times a student can retry each activity with in the single page attempt.  Given that time limits and hard deadlines with auto submit can finalize a score as you attempt - we needed a way to prevent the student from starting another attempt (as the original prologue logic was still applying `:max_attempts` to the number of page attempts).  

This PR adjusts the logic used to determine if a new page attempt can be started, taking into account our desire to limit Score as you go to 1 page attempt.  