### PR TITLE
[FEATURE] [MER-4611] Remove type column from student progress report

### DIFF
--- a/lib/oli_web/live/sections/enrollments_table_model.ex
+++ b/lib/oli_web/live/sections/enrollments_table_model.ex
@@ -10,7 +10,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
   alias OliWeb.Common.Utils
   alias OliWeb.Common.FormatDateTime
   alias OliWeb.Delivery.InstructorDashboard.HTMLComponents
-  alias Lti_1p3.Roles.ContextRoles
 
   use Phoenix.Component
 
@@ -59,12 +58,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
           render_fn: &__MODULE__.render_overall_proficiency_column/3,
           tooltip:
             "For all students, or one specific student, proficiency for a learning objective will be calculated off the percentage of correct answers for first part attempts within first activity attempts - for those parts that have that learning objective or any of its sub-objectives attached to it."
-        },
-        %ColumnSpec{
-          name: :type,
-          label: "TYPE",
-          render_fn: &__MODULE__.render_type_column/3,
-          sortable: false
         }
       ] ++
         if section.requires_payment do
@@ -214,22 +207,6 @@ defmodule OliWeb.Delivery.Sections.EnrollmentsTableModel do
 
     ~H"""
     <div><%= @email %></div>
-    """
-  end
-
-  def render_type_column(assigns, user, _) do
-    assigns =
-      Map.merge(assigns, %{
-        type:
-          if(
-            user.user_role_id == ContextRoles.get_role(:context_instructor).id,
-            do: "Instructor",
-            else: "Student"
-          )
-      })
-
-    ~H"""
-    <div><%= @type %></div>
     """
   end
 


### PR DESCRIPTION
[MER-4611](https://eliterate.atlassian.net/browse/MER-4611)

This PR updates the student progress report under `Insights > Content` to remove the “Type” column from the on-screen view.

Since only students are shown in the report, the column wasn’t adding value and could cause confusion. This change helps simplify the view and make the information clearer for instructors.

- Before 

![type-column-before](https://github.com/user-attachments/assets/678a4227-b841-4a5a-a332-d347f90f83c7)


- After

![type-column-after](https://github.com/user-attachments/assets/a918a709-5854-4646-8231-c3548318c26c)


[MER-4611]: https://eliterate.atlassian.net/browse/MER-4611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ