### PR TITLE
[ENHANCEMENT] [MER-4625] remove teaser window from DOT

### DIFF
--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -49,8 +49,10 @@ import { ToggleReadMore } from './toggle_read_more';
 import { AutoHideTooltip, TooltipInit, TooltipWithTarget } from './tooltip';
 import { VideoPlayer } from './video_player';
 import { PauseOthersOnSelected, VideoPreview } from './video_preview';
+import { WakeUpDot } from './wakeup_dot';
 
 export const Hooks = {
+  WakeUpDot,
   ExpandContainers,
   ShowTeaser,
   FirePageTrigger,

--- a/assets/src/hooks/wakeup_dot.ts
+++ b/assets/src/hooks/wakeup_dot.ts
@@ -1,0 +1,10 @@
+export const WakeUpDot = {
+  mounted() {
+    window.addEventListener('phx:wakeup-dot', (_e) => {
+      const button = document.querySelector('#ai_bot_collapsed_button') as HTMLButtonElement;
+      if (button) {
+        button.click();
+      }
+    });
+  },
+};

--- a/lib/oli/conversation/dialogue_handler.ex
+++ b/lib/oli/conversation/dialogue_handler.ex
@@ -31,10 +31,8 @@ defmodule Oli.Conversation.DialogueHandler do
 
           :content ->
             active_message = "#{socket.assigns.active_message}#{content}"
-            teaser_message = active_message |> Floki.text()
 
-            {:noreply,
-             assign(socket, active_message: active_message, teaser_message: teaser_message)}
+            {:noreply, assign(socket, active_message: active_message)}
         end
       end
 


### PR DESCRIPTION
This PR removes the "teaser window" - the smaller, less obtrusive popup window that displayed when a ~trigger~ activation point fired.  