### PR TITLE
[MER-4345] [FEATURE] Instructor schedule: Save warning

### DIFF
--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useBackdropModal } from 'components/misc/BackdropModal';
 import { Alert } from '../../components/misc/Alert';
@@ -58,6 +58,9 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
   ]);
 
   const [viewMode, setViewMode] = React.useState<ViewMode | null>(null);
+  const pendingNavigationUrl = useRef<string | null>(null);
+  const navigationEventListener = useRef<((e: Event) => void) | null>(null);
+  const showNavigationWarningModalRef = useRef<(() => void) | null>(null);
 
   const onModification = useCallback(() => {
     dispatch(scheduleAppFlushChanges());
@@ -88,6 +91,107 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
     }
     window.open(url.href, '_blank');
   };
+
+  const handlePendingNavigation = () => {
+    if (pendingNavigationUrl.current) {
+      window.location.href = pendingNavigationUrl.current;
+      pendingNavigationUrl.current = null;
+    }
+  };
+
+      const interceptNavigation = useCallback((e: Event) => {
+    if (!unsavedChanges) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    const target = e.target as HTMLElement;
+    const link = target.closest('a');
+
+    if (link) {
+      pendingNavigationUrl.current = link.href;
+      if (showNavigationWarningModalRef.current) {
+        showNavigationWarningModalRef.current();
+      }
+    }
+  }, [unsavedChanges]);
+
+  // Set up navigation interception for tabs and breadcrumbs
+  useEffect(() => {
+    const setupNavigationGuards = () => {
+      // Find tab navigation elements
+      const tabLinks = document.querySelectorAll('#tabs-tab a');
+      const breadcrumbLinks = document.querySelectorAll('.breadcrumb a');
+
+            // Remove existing listeners
+      if (navigationEventListener.current) {
+        Array.from(tabLinks).forEach(link => {
+          link.removeEventListener('click', navigationEventListener.current as EventListener);
+        });
+        Array.from(breadcrumbLinks).forEach(link => {
+          link.removeEventListener('click', navigationEventListener.current as EventListener);
+        });
+      }
+
+      // Add new listeners
+      navigationEventListener.current = interceptNavigation;
+      Array.from(tabLinks).forEach(link => {
+        // Skip the current schedule tab
+        if (link.getAttribute('href')?.includes('/schedule')) return;
+
+        link.addEventListener('click', navigationEventListener.current as EventListener);
+      });
+      Array.from(breadcrumbLinks).forEach(link => {
+        link.addEventListener('click', navigationEventListener.current as EventListener);
+      });
+    };
+
+    // Setup navigation guards after a short delay to ensure DOM is ready
+    const timer = setTimeout(setupNavigationGuards, 100);
+
+    return () => {
+      clearTimeout(timer);
+      if (navigationEventListener.current) {
+        const tabLinks = document.querySelectorAll('#tabs-tab a');
+        const breadcrumbLinks = document.querySelectorAll('.breadcrumb a');
+        Array.from(tabLinks).forEach(link => {
+          link.removeEventListener('click', navigationEventListener.current as EventListener);
+        });
+        Array.from(breadcrumbLinks).forEach(link => {
+          link.removeEventListener('click', navigationEventListener.current as EventListener);
+        });
+      }
+    };
+  }, [interceptNavigation]);
+
+  // Handle browser back button and other navigation
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (unsavedChanges) {
+        e.preventDefault();
+        e.returnValue = '';
+        return '';
+      }
+    };
+
+    const handlePopState = (e: PopStateEvent) => {
+      if (unsavedChanges) {
+        e.preventDefault();
+        pendingNavigationUrl.current = window.location.href;
+        showNavigationWarningModal();
+        // Push the current state back to prevent navigation
+        history.pushState(null, '', window.location.href);
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [unsavedChanges]);
 
   // Set up a way the page can call into us to save, useful for the wizard mode when we don't have a save bar to click.
   useEffect(() => {
@@ -155,6 +259,36 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
     'View after saving',
   );
 
+  const { Modal: navigationWarningModal, showModal: showNavigationWarningModal } = useBackdropModal(
+    <div>
+      <p>You have unsaved changes that will be lost if you leave this page.</p>
+    </div>,
+    () => {
+      // Keep editing - just close the modal
+      pendingNavigationUrl.current = null;
+    },
+    () => {
+      // Leave without saving
+      handlePendingNavigation();
+    },
+    'You have unsaved changes',
+    'Keep editing',
+    'Leave without saving',
+  );
+
+  // Set the ref so it can be used in the interceptNavigation callback
+  useEffect(() => {
+    showNavigationWarningModalRef.current = showNavigationWarningModal;
+  }, [showNavigationWarningModal]);
+
+  // Update the data-saved attribute for BeforeUnloadListener integration
+  useEffect(() => {
+    const container = document.getElementById('schedule-container');
+    if (container) {
+      container.setAttribute('data-saved', unsavedChanges ? 'false' : 'true');
+    }
+  }, [unsavedChanges]);
+
   if (!start_date || !end_date) {
     return (
       <div className="container">
@@ -185,6 +319,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
         {Modal}
         {clearModal}
         {unsavedModal}
+        {navigationWarningModal}
       </div>
     </ContextMenuProvider>
   );

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -58,8 +58,6 @@ defmodule OliWeb.Sections.ScheduleView do
 
     <div
       id="schedule-container"
-      data-saved="true"
-      phx-hook="BeforeUnloadListener"
       phx-update="ignore"
     >
       <div id="schedule-app">

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -56,8 +56,15 @@ defmodule OliWeb.Sections.ScheduleView do
     ~H"""
     <script type="text/javascript" src={@js_path} />
 
-    <div id="schedule-app" phx-update="ignore">
-      <%= ReactPhoenix.ClientSide.react_component("Components.ScheduleEditor", @appConfig) %>
+    <div
+      id="schedule-container"
+      data-saved="true"
+      phx-hook="BeforeUnloadListener"
+      phx-update="ignore"
+    >
+      <div id="schedule-app">
+        <%= ReactPhoenix.ClientSide.react_component("Components.ScheduleEditor", @appConfig) %>
+      </div>
     </div>
     """
   end


### PR DESCRIPTION
Add navigation guards to schedule editor.


It works in two different ways:
- When intercepting a browser navigation (e.g: page refresh, tab close, typing new URL, browser home button) it will display the default browser warning modal "Changes you made may not be saved.". This uses the same approach as when remixing and manually grading a submission.
- When intercepting an "internal" navigation (e.g: schedule editor tab change, breadcrumb navigation, etc) it will display the backdrop modal as shown on the figma design.

See: https://eliterate.atlassian.net/browse/MER-4345

---

https://github.com/user-attachments/assets/92a34971-79f9-465b-8c12-8c489717a856


