### PR TITLE
[BUG FIX] [MER-4663] Change default value of AWS lambda generation function

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -80,8 +80,7 @@ config :oli, :user_auth_providers,
      end)
 
 config :oli, :certificates,
-  generate_pdf_lambda:
-    System.get_env("CERTIFICATES_GENERATE_PDF_LAMBDA", "generate-certificate"),
+  generate_pdf_lambda: System.get_env("CERTIFICATES_GENERATE_PDF_LAMBDA", "generate-certificate"),
   s3_pdf_bucket: System.get_env("CERTIFICATES_S3_PDF_URL", "torus-pdf-certificates")
 
 ####################### Production-only configurations ########################


### PR DESCRIPTION
The default value for the Lambda function used to generate certificate PDFs is outdated. Failures occur only when the CERTIFICATES_GENERATE_PDF_LAMBDA environment variable is not explicitly set, as the system falls back to this outdated default. Update the default to prevent unexpected behavior in such cases.