### PR TITLE
[BUG FIX] [MER-4575] Rework: tools not showing on products

### DIFF
--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -315,6 +315,119 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
     end
   end
 
+  describe "create_blueprint/5" do
+    setup do
+      Seeder.base_project_with_resource2()
+    end
+
+    test "successfully creates a blueprint from a valid project", %{
+      project: project,
+      author: author
+    } do
+      {:ok, _publication} = Publishing.publish_project(project, "initial publication", author.id)
+
+      custom_labels = %{"unit" => "Module", "lesson" => "Section"}
+
+      attrs = %{
+        "requires_payment" => true,
+        "payment_options" => "direct",
+        "amount" => %{"currency" => "USD", "amount" => "50.00"}
+      }
+
+      {:ok, blueprint} =
+        Blueprint.create_blueprint(
+          project.slug,
+          "Test Blueprint",
+          custom_labels,
+          nil,
+          attrs
+        )
+
+      # Verify blueprint basic properties
+      assert blueprint.type == :blueprint
+      assert blueprint.status == :active
+      assert blueprint.title == "Test Blueprint"
+      assert blueprint.base_project_id == project.id
+      assert blueprint.requires_payment == true
+      assert blueprint.payment_options == :direct
+      assert blueprint.amount == Money.new(:USD, "50.00")
+      assert blueprint.customizations.unit == "Module"
+      refute blueprint.open_and_free
+
+      # Verify section resources were created
+      section_resources = Sections.get_section_resources(blueprint.id)
+      assert length(section_resources) > 0
+
+      # Verify root section resource is set
+      assert blueprint.root_section_resource_id != nil
+
+      # Verify section project publication was created
+      section_project_publications =
+        from(spp in Oli.Delivery.Sections.SectionsProjectsPublications,
+          where: spp.section_id == ^blueprint.id,
+          select: spp
+        )
+        |> Repo.all()
+
+      assert length(section_project_publications) == 1
+      assert Enum.at(section_project_publications, 0).project_id == project.id
+    end
+
+    test "creates blueprint with default values when attrs not provided", %{
+      project: project,
+      author: author
+    } do
+      {:ok, _publication} = Publishing.publish_project(project, "initial publication", author.id)
+
+      {:ok, blueprint} =
+        Blueprint.create_blueprint(
+          project.slug,
+          "Default Blueprint",
+          %{}
+        )
+
+      # Verify default values
+      assert blueprint.requires_payment == false
+      assert blueprint.payment_options == :direct_and_deferred
+      assert blueprint.pay_by_institution == false
+      assert blueprint.registration_open == false
+      assert blueprint.grace_period_days == 1
+      assert blueprint.amount == Money.new(:USD, "25.00")
+      assert blueprint.certificate_enabled == false
+    end
+
+    test "returns error when project does not exist" do
+      assert {:error, {:invalid_project}} =
+               Blueprint.create_blueprint(
+                 "non-existent-project",
+                 "Test Blueprint",
+                 %{}
+               )
+    end
+
+    test "spawns task to initialize depot coordinator", %{
+      project: project,
+      author: author
+    } do
+      {:ok, _publication} = Publishing.publish_project(project, "initial publication", author.id)
+
+      # Get the number of children before creating the blueprint
+      children_before = Task.Supervisor.children(Oli.TaskSupervisor) |> length()
+
+      {:ok, _blueprint} =
+        Blueprint.create_blueprint(
+          project.slug,
+          "Depot Test Blueprint",
+          %{}
+        )
+
+      # Verify that a task was spawned by checking the children count increased
+      children_after = Task.Supervisor.children(Oli.TaskSupervisor) |> length()
+
+      assert children_after == children_before + 1
+    end
+  end
+
   describe "blueprint availability based on visibility" do
     setup do
       Seeder.base_project_with_resource2()


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4575?focusedCommentId=29101) to the comment in the ticket

The [previous PR](https://github.com/Simon-Initiative/oli-torus/pull/5662) fixed a bug where some section resources where not migrated if other records where already migrated (for instance, this made that adding an LTI tool to a already existing page was not reflected correctly on the `LTI External Tools` page).

This PR continues the rework by guaranteeing the migration of the section resource records is done in the same process of creating or duplicating a blueprint. 
With this changes an author/instructor can see the tools listed on the `LTI External Tools` page _**as soon as the product/course is created**_, without having to previously visiting the course to trigger an async process that runs the migration.

### Author visits `LTI 1.3 External Tools` page after creating a product

https://github.com/user-attachments/assets/860d722b-4885-433c-be03-949523ed24a6



### Instructor visits `LTI 1.3 External Tools` page after creating a course based on a blueprint

https://github.com/user-attachments/assets/266e95c3-cec2-4ea1-930a-acbf9b05484b



### No more page crash when visiting/previewing the course for the first time
This PR also fixes [MER-4643](https://eliterate.atlassian.net/browse/MER-4643). The issue was that the section resource depot for that blueprint was being generated in an async task within the same Repo.transaction that creates the blueprint. So, the depot ended up being generated when that blueprint was not fully yet created (and failed). 
Now we let the section resource depot creation to be triggered when a user enters the course for the first time (as before this Task approach was implemented), while ensuring the section resource migration is applied (the one that is needed to allow an instructor see all the LTI tools listed even when no user has yet visited the course)

#### Instructor first preview

https://github.com/user-attachments/assets/12d26d4d-da13-4de7-8d1b-8b854c1b9683


#### Student first visit


https://github.com/user-attachments/assets/e9f7244f-62ce-46a7-8d11-64421ef4fe86








[MER-4643]: https://eliterate.atlassian.net/browse/MER-4643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ