### PR TITLE
[ENHANCEMENT] [MER-4272] Schedule preferences modal update

### DIFF
--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useBackdropModal } from 'components/misc/BackdropModal';
+import { useMultiStepModal } from 'components/misc/MultiStepModal';
 import { Alert } from '../../components/misc/Alert';
-import { usePromptModal } from '../../components/misc/PromptModal';
+// import { usePromptModal } from '../../components/misc/PromptModal';
 import { ContextMenuProvider } from './ContextMenuController';
 import { ErrorDisplay } from './ErrorDisplay';
 import { ScheduleGrid } from './ScheduleGrid';
@@ -112,17 +113,44 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
     );
   }, [dispatch, display_curriculum_item_numbering, end_date, section_slug, start_date, title]);
 
-  const { Modal, showModal } = usePromptModal(
-    <div>
+  const steps = [
+    <div key="step-1">
       <p>
         This will reset all timelines to the default. Select the week days you want to consider for
         that schedule.
       </p>
       <WeekDayPicker weekdays={validWeekdays} onChange={setValidWeekdays} />
     </div>,
+    <div key="step-2">This feature development is still in progress</div>,
+    <div key="step-3">Step 3 content</div>,
+  ];
+  const stepTitles = ['Set Default Timeline', 'Identify Breaks', 'Set Default Layout'];
 
-    onReset,
+  const { showModal, Modal } = useMultiStepModal(
+    steps,
+    stepTitles,
+    () => onReset(),
+    () => console.log('Cancelled!'),
+    {
+      title: 'Schedule Preferences',
+      finishText: 'Complete',
+      nextText: 'Continue',
+      backText: 'Back',
+      allowBack: false,
+    },
   );
+
+  // const { Modal, showModal } = usePromptModal(
+  //   <div>
+  //     <p>
+  //       This will reset all timelines to the default. Select the week days you want to consider for
+  //       that schedule.
+  //     </p>
+  //     <WeekDayPicker weekdays={validWeekdays} onChange={setValidWeekdays} />
+  //   </div>,
+
+  //   onReset,
+  // );
 
   const { Modal: clearModal, showModal: showClearModal } = useBackdropModal(
     <div>

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -9,8 +9,8 @@ import { ErrorDisplay } from './ErrorDisplay';
 import { ScheduleGrid } from './ScheduleGrid';
 import { ScheduleSaveBar } from './SchedulerSaveBar';
 import { WeekDayPicker } from './WeekdayPicker';
-import { hasUnsavedChanges } from './schedule-selectors';
-import { StringDate, resetSchedule } from './scheduler-slice';
+import { assessmentLayoutType, hasUnsavedChanges } from './schedule-selectors';
+import { StringDate, resetSchedule, setAssessmentLayoutType } from './scheduler-slice';
 import {
   clearSectionSchedule,
   scheduleAppFlushChanges,
@@ -48,6 +48,8 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
   const dispatch = useDispatch();
 
   const unsavedChanges = useSelector(hasUnsavedChanges);
+  const assessmentLayout = useSelector(assessmentLayoutType);
+
   const [validWeekdays, setValidWeekdays] = React.useState<boolean[]>([
     false,
     true,
@@ -118,14 +120,59 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
 
   const steps = [
     <div key="step-1">
-      <p>
-        This will reset all timelines to the default. Select the week days you want to consider for
-        that schedule.
-      </p>
+      <div className="font-bold mb-4">Set Default Timeline</div>
+      <div className="mb-4">Select the week days you want to consider for that schedule.</div>
       <WeekDayPicker weekdays={validWeekdays} onChange={setValidWeekdays} />
     </div>,
-    <div key="step-2">This feature development is still in progress</div>,
-    <div key="step-3">Step 3 content</div>,
+    <div key="step-2">
+      <div className="font-bold mb-4">Identify Breaks</div>
+      <div className="mb-4">This feature is currently under development.</div>
+    </div>,
+    <div key="step-3">
+      <div className="font-bold mb-4">Set Default Layout</div>
+      <div className="mb-4">
+        Choose the default layout of your course schedule. You can later customize the schedule by
+        interacting with the timeline or visiting the assessment settings.
+      </div>
+      <div className="flex flex-col space-y-4 mt-4 pl-2">
+        <label className="flex items-start space-x-3 text-gray-700">
+          <input
+            type="radio"
+            name="assessmentLayoutType"
+            className="mt-1"
+            checked={assessmentLayout === 'no_due_dates'}
+            onChange={() => dispatch(setAssessmentLayoutType('no_due_dates'))}
+          />
+          <span className="leading-snug font-bold">Do not set assessment due dates</span>
+        </label>
+
+        <label className="flex items-start space-x-3 text-gray-700">
+          <input
+            type="radio"
+            name="assessmentLayoutType"
+            className="mt-1"
+            checked={assessmentLayout === 'content_sequence'}
+            onChange={() => dispatch(setAssessmentLayoutType('content_sequence'))}
+          />
+          <span className="leading-snug font-bold">
+            Set assessment due dates according to the sequence of course content.
+          </span>
+        </label>
+
+        <label className="flex items-start space-x-3 text-gray-700">
+          <input
+            type="radio"
+            name="assessmentLayoutType"
+            className="mt-1"
+            checked={assessmentLayout === 'end_of_each_section'}
+            onChange={() => dispatch(setAssessmentLayoutType('end_of_each_section'))}
+          />
+          <span className="leading-snug font-bold">
+            Set assessment due dates to the end of each section.
+          </span>
+        </label>
+      </div>
+    </div>,
   ];
   const stepTitles = ['Set Default Timeline', 'Identify Breaks', 'Set Default Layout'];
 

--- a/assets/src/apps/scheduler/ScheduleEditor.tsx
+++ b/assets/src/apps/scheduler/ScheduleEditor.tsx
@@ -124,10 +124,6 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
       <div className="mb-4">Select the week days you want to consider for that schedule.</div>
       <WeekDayPicker weekdays={validWeekdays} onChange={setValidWeekdays} />
     </div>,
-    <div key="step-2">
-      <div className="font-bold mb-4">Identify Breaks</div>
-      <div className="mb-4">This feature is currently under development.</div>
-    </div>,
     <div key="step-3">
       <div className="font-bold mb-4">Set Default Layout</div>
       <div className="mb-4">
@@ -174,7 +170,7 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
       </div>
     </div>,
   ];
-  const stepTitles = ['Set Default Timeline', 'Identify Breaks', 'Set Default Layout'];
+  const stepTitles = ['Set Default Timeline', 'Set Default Layout'];
 
   const { showModal, Modal } = useMultiStepModal(
     steps,
@@ -189,18 +185,6 @@ export const ScheduleEditor: React.FC<SchedulerProps> = ({
       allowBack: false,
     },
   );
-
-  // const { Modal, showModal } = usePromptModal(
-  //   <div>
-  //     <p>
-  //       This will reset all timelines to the default. Select the week days you want to consider for
-  //       that schedule.
-  //     </p>
-  //     <WeekDayPicker weekdays={validWeekdays} onChange={setValidWeekdays} />
-  //   </div>,
-
-  //   onReset,
-  // );
 
   const { Modal: clearModal, showModal: showClearModal } = useBackdropModal(
     <div>

--- a/assets/src/apps/scheduler/schedule-selectors.ts
+++ b/assets/src/apps/scheduler/schedule-selectors.ts
@@ -67,6 +67,8 @@ export const shouldDisplayCurriculumItemNumbering = (state: SchedulerAppState) =
 export const hasUnsavedChanges = (state: SchedulerAppState) => state.scheduler.dirty.length > 0;
 export const isSaving = (state: SchedulerAppState) => state.scheduler.saving;
 export const getError = (state: SchedulerAppState) => state.scheduler.errorMessage;
+export const assessmentLayoutType = (state: SchedulerAppState) =>
+  state.scheduler.assessmentLayoutType;
 
 export const isSearching = (state: SchedulerAppState) => !!state.scheduler.searchQuery?.trim();
 

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -48,6 +48,8 @@ export interface HierarchyItem extends HierarchyItemSrc {
   startDateTime: Date | null; // This is only used for the available-from which includes a date and time.
 }
 
+export type AssessmentLayoutType = 'no_due_dates' | 'content_sequence' | 'end_of_each_section';
+
 export interface SchedulerState {
   schedule: HierarchyItem[];
   startDate: DateWithoutTime | null;
@@ -65,6 +67,7 @@ export interface SchedulerState {
   expandedContainers: Record<number, boolean>;
   searchQuery: string;
   agenda: boolean;
+  assessmentLayoutType: AssessmentLayoutType;
 }
 
 export const initSchedulerState = (): SchedulerState => ({
@@ -88,6 +91,7 @@ export const initSchedulerState = (): SchedulerState => ({
   expandedContainers: {},
   searchQuery: '',
   agenda: false,
+  assessmentLayoutType: 'end_of_each_section',
 });
 
 const toDateTime = (str: string, preferredSchedulingTime: TimeParts) => {
@@ -405,6 +409,9 @@ const schedulerSlice = createSlice({
     setSearchQuery: (state, action) => {
       state.searchQuery = action.payload;
     },
+    setAssessmentLayoutType: (state, action: PayloadAction<AssessmentLayoutType>) => {
+      state.assessmentLayoutType = action.payload;
+    },
   },
   extraReducers: (builder) => {
     builder.addCase(clearSectionSchedule.pending, (state, action) => {
@@ -507,6 +514,7 @@ export const {
   toggleContainer,
   expandAllContainers,
   collapseAllContainers,
+  setAssessmentLayoutType,
 } = schedulerSlice.actions;
 
 export const schedulerSliceReducer = schedulerSlice.reducer;

--- a/assets/src/apps/scheduler/scheduler-slice.ts
+++ b/assets/src/apps/scheduler/scheduler-slice.ts
@@ -93,7 +93,7 @@ export const initSchedulerState = (): SchedulerState => ({
   searchQuery: '',
   showRemoved: false,
   agenda: false,
-  assessmentLayoutType: 'end_of_each_section',
+  assessmentLayoutType: 'content_sequence',
 });
 
 const toDateTime = (str: string, preferredSchedulingTime: TimeParts) => {
@@ -280,6 +280,7 @@ const schedulerSlice = createSlice({
               true,
               state.weekdays,
               state.preferredSchedulingTime,
+              state.assessmentLayoutType,
             );
           state.dirty = state.schedule.map((item) => item.id);
         }
@@ -303,6 +304,7 @@ const schedulerSlice = createSlice({
               true,
               state.weekdays,
               state.preferredSchedulingTime,
+              state.assessmentLayoutType,
             );
           state.dirty = state.schedule.map((item) => item.id);
         }
@@ -413,6 +415,7 @@ const schedulerSlice = createSlice({
             false,
             state.weekdays,
             state.preferredSchedulingTime,
+            state.assessmentLayoutType,
           );
 
           state.dirty.push(...descendentIds(mutableItem, state.schedule));
@@ -438,6 +441,7 @@ const schedulerSlice = createSlice({
             true,
             action.payload.weekdays,
             state.preferredSchedulingTime,
+            state.assessmentLayoutType,
           );
         state.dirty = state.schedule.map((item) => item.id);
       }
@@ -561,6 +565,7 @@ const schedulerSlice = createSlice({
             true,
             state.weekdays,
             state.preferredSchedulingTime,
+            state.assessmentLayoutType,
           );
         state.dirty = state.schedule.map((item) => item.id);
       }

--- a/assets/src/components/misc/MultiStepModal.tsx
+++ b/assets/src/components/misc/MultiStepModal.tsx
@@ -108,7 +108,7 @@ export const MultiStepModal: React.FC<MultiStepModalProps> = ({
 
         {/* Footer buttons */}
         <div className="flex justify-end space-x-4">
-          <Button onClick={onCancel} variant="secondary">
+          <Button className="border-[1px] border-blue-600" onClick={onCancel} variant="secondary">
             {cancelText}
           </Button>
           {allowBack && !isFirstStep && (

--- a/assets/src/components/misc/MultiStepModal.tsx
+++ b/assets/src/components/misc/MultiStepModal.tsx
@@ -6,7 +6,7 @@ import { Card } from './Card';
 interface MultiStepModalProps {
   title: string;
   steps: ReactNode[];
-  stepTitles: string[];    // NEW PROP
+  stepTitles: string[]; // NEW PROP
   onFinish: () => void;
   onCancel: () => void;
   finishText?: string;
@@ -54,72 +54,65 @@ export const MultiStepModal: React.FC<MultiStepModalProps> = ({
     >
       <Card.Title>
         {/* Modal Title */}
-      <div className="text-center text-xl font-semibold mb-4">{title}</div>
+        <div className="text-center text-xl font-semibold mb-4">{title}</div>
       </Card.Title>
 
       <Card.Content>
         {/* Stepper */}
         <hr className="mb-6 border-gray-200 dark:border-gray-600" />
-        <div className="flex justify-center items-center mb-10 w-full max-w-3xl mx-auto" >
-  {stepTitles.map((label, index) => {
-    const isCompleted = index < currentStep;
-    const isCurrent = index === currentStep;
+        <div className="flex justify-center items-center mb-10 w-full max-w-3xl mx-auto">
+          {stepTitles.map((label, index) => {
+            const isCurrent = index === currentStep;
 
-    return (
-      <React.Fragment key={index}>
-        <div className="flex flex-col items-center flex-shrink-0">
-          <div
-            className={`flex items-center justify-center w-8 h-8 rounded-full border-2 text-sm font-medium ${
-              isCompleted
-                ? 'bg-blue-600 border-blue-600 text-white'
-                : isCurrent
-                ? 'bg-white border-blue-600 text-blue-600'
-                : 'bg-white border-gray-300 text-gray-500'
-            }`}
-          >
-            {index + 1}
-          </div>
-          <div
-            className={`text-xs mt-2 text-center ${
-              isCurrent ? 'text-black font-medium' : 'text-gray-500'
-            }`}
-          >
-            {label}
-          </div>
+            return (
+              <React.Fragment key={index}>
+                <div className="flex flex-col items-center flex-shrink-0">
+                  <div
+                    className={`flex items-center justify-center w-8 h-8 rounded-full border-2 text-sm font-medium ${
+                      isCurrent
+                        ? 'bg-blue-600 border-blue-600 text-white'
+                        : 'bg-white border-gray-300 text-gray-500'
+                    }`}
+                  >
+                    {index + 1}
+                  </div>
+                  <div
+                    className={`text-xs mt-2 text-center ${
+                      isCurrent ? 'text-black font-medium' : 'text-gray-500'
+                    }`}
+                  >
+                    {label}
+                  </div>
+                </div>
+
+                {/* Line connector */}
+                {index < stepTitles.length - 1 && (
+                  <div className={'flex-1 h-[2px] mx-2 bg-gray-300'}></div>
+                )}
+              </React.Fragment>
+            );
+          })}
         </div>
 
-        {/* Line connector */}
-        {index < stepTitles.length - 1 && (
-          <div
-            className={`flex-1 h-[2px] mx-2 ${
-              isCompleted ? 'bg-blue-600' : 'bg-gray-300'
-            }`}
-          ></div>
-        )}
-      </React.Fragment>
-    );
-  })}
-</div>
+        {/* Step Content */}
+        <div className="mb-8">{steps[currentStep]}</div>
 
-      {/* Step Content */}
-      <div className="mb-8">{steps[currentStep]}</div>
-
-      {/* Footer buttons */}
-      <div className="flex justify-end space-x-4">
-        <Button onClick={onCancel} variant="secondary">
-          {cancelText}
-        </Button>
-        {allowBack && !isFirstStep && (
-          <Button onClick={handleBack} variant="secondary">
-            {backText}
+        {/* Footer buttons */}
+        <div className="flex justify-end space-x-4">
+          <Button onClick={onCancel} variant="secondary">
+            {cancelText}
           </Button>
-        )}
-        {!isLastStep ? (
-          <Button onClick={handleNext}>{nextText}</Button>
-        ) : (
-          <Button onClick={handleFinish}>{finishText}</Button>
-        )}
-      </div>
+          {allowBack && !isFirstStep && (
+            <Button onClick={handleBack} variant="secondary">
+              {backText}
+            </Button>
+          )}
+          {!isLastStep ? (
+            <Button onClick={handleNext}>{nextText}</Button>
+          ) : (
+            <Button onClick={handleFinish}>{finishText}</Button>
+          )}
+        </div>
       </Card.Content>
     </Card.Card>
   );
@@ -147,7 +140,7 @@ export const useMultiStepModal = (
     backText?: string;
     allowBack?: boolean;
     className?: string;
-  }
+  },
 ) => {
   const [isOpen, , showModal, hideModal] = useToggle();
 

--- a/assets/src/components/misc/MultiStepModal.tsx
+++ b/assets/src/components/misc/MultiStepModal.tsx
@@ -1,0 +1,186 @@
+import React, { ReactNode, useCallback, useState } from 'react';
+import { useToggle } from '../hooks/useToggle';
+import { Button } from './Button';
+import { Card } from './Card';
+
+interface MultiStepModalProps {
+  title: string;
+  steps: ReactNode[];
+  stepTitles: string[];    // NEW PROP
+  onFinish: () => void;
+  onCancel: () => void;
+  finishText?: string;
+  cancelText?: string;
+  nextText?: string;
+  backText?: string;
+  allowBack?: boolean;
+  className?: string;
+}
+
+export const MultiStepModal: React.FC<MultiStepModalProps> = ({
+  title,
+  steps,
+  stepTitles,
+  onFinish,
+  onCancel,
+  finishText,
+  cancelText,
+  nextText,
+  backText,
+  allowBack,
+  className,
+}) => {
+  const [currentStep, setCurrentStep] = useState(0);
+  const totalSteps = steps.length;
+
+  const isLastStep = currentStep === totalSteps - 1;
+  const isFirstStep = currentStep === 0;
+
+  const handleNext = () => {
+    if (!isLastStep) setCurrentStep((prev) => prev + 1);
+  };
+
+  const handleBack = () => {
+    if (!isFirstStep) setCurrentStep((prev) => prev - 1);
+  };
+
+  const handleFinish = () => {
+    onFinish();
+  };
+
+  return (
+    <Card.Card
+      className={`w-[32rem] fixed top-1/3 inset-x-0 mx-auto border-[1px] border-gray-100 dark:border-gray-500 ${className} z-50`}
+    >
+      <Card.Title>
+        {/* Modal Title */}
+      <div className="text-center text-xl font-semibold mb-4">{title}</div>
+      </Card.Title>
+
+      <Card.Content>
+        {/* Stepper */}
+        <hr className="mb-6 border-gray-200 dark:border-gray-600" />
+        <div className="flex justify-center items-center mb-10 w-full max-w-3xl mx-auto" >
+  {stepTitles.map((label, index) => {
+    const isCompleted = index < currentStep;
+    const isCurrent = index === currentStep;
+
+    return (
+      <React.Fragment key={index}>
+        <div className="flex flex-col items-center flex-shrink-0">
+          <div
+            className={`flex items-center justify-center w-8 h-8 rounded-full border-2 text-sm font-medium ${
+              isCompleted
+                ? 'bg-blue-600 border-blue-600 text-white'
+                : isCurrent
+                ? 'bg-white border-blue-600 text-blue-600'
+                : 'bg-white border-gray-300 text-gray-500'
+            }`}
+          >
+            {index + 1}
+          </div>
+          <div
+            className={`text-xs mt-2 text-center ${
+              isCurrent ? 'text-black font-medium' : 'text-gray-500'
+            }`}
+          >
+            {label}
+          </div>
+        </div>
+
+        {/* Line connector */}
+        {index < stepTitles.length - 1 && (
+          <div
+            className={`flex-1 h-[2px] mx-2 ${
+              isCompleted ? 'bg-blue-600' : 'bg-gray-300'
+            }`}
+          ></div>
+        )}
+      </React.Fragment>
+    );
+  })}
+</div>
+
+      {/* Step Content */}
+      <div className="mb-8">{steps[currentStep]}</div>
+
+      {/* Footer buttons */}
+      <div className="flex justify-end space-x-4">
+        <Button onClick={onCancel} variant="secondary">
+          {cancelText}
+        </Button>
+        {allowBack && !isFirstStep && (
+          <Button onClick={handleBack} variant="secondary">
+            {backText}
+          </Button>
+        )}
+        {!isLastStep ? (
+          <Button onClick={handleNext}>{nextText}</Button>
+        ) : (
+          <Button onClick={handleFinish}>{finishText}</Button>
+        )}
+      </div>
+      </Card.Content>
+    </Card.Card>
+  );
+};
+
+MultiStepModal.defaultProps = {
+  finishText: 'Finish',
+  cancelText: 'Cancel',
+  nextText: 'Next',
+  backText: 'Back',
+  allowBack: true,
+  className: '',
+};
+
+export const useMultiStepModal = (
+  steps: ReactNode[],
+  stepTitles: string[],
+  onFinish?: () => void,
+  onCancel?: () => void,
+  options?: {
+    title?: string;
+    finishText?: string;
+    cancelText?: string;
+    nextText?: string;
+    backText?: string;
+    allowBack?: boolean;
+    className?: string;
+  }
+) => {
+  const [isOpen, , showModal, hideModal] = useToggle();
+
+  const onFinishHandler = useCallback(() => {
+    hideModal();
+    onFinish && onFinish();
+  }, [hideModal, onFinish]);
+
+  const onCancelHandler = useCallback(() => {
+    hideModal();
+    onCancel && onCancel();
+  }, [hideModal, onCancel]);
+
+  const Modal = isOpen ? (
+    <MultiStepModal
+      steps={steps}
+      stepTitles={stepTitles}
+      onFinish={onFinishHandler}
+      onCancel={onCancelHandler}
+      title={options?.title ?? 'Multi-Step Process'}
+      finishText={options?.finishText}
+      cancelText={options?.cancelText}
+      nextText={options?.nextText}
+      backText={options?.backText}
+      allowBack={options?.allowBack}
+      className={options?.className}
+    />
+  ) : null;
+
+  return {
+    isOpen,
+    showModal,
+    hideModal,
+    Modal,
+  };
+};

--- a/assets/src/components/misc/MultiStepModal.tsx
+++ b/assets/src/components/misc/MultiStepModal.tsx
@@ -6,7 +6,7 @@ import { Card } from './Card';
 interface MultiStepModalProps {
   title: string;
   steps: ReactNode[];
-  stepTitles: string[]; // NEW PROP
+  stepTitles: string[];
   onFinish: () => void;
   onCancel: () => void;
   finishText?: string;
@@ -60,15 +60,20 @@ export const MultiStepModal: React.FC<MultiStepModalProps> = ({
       <Card.Content>
         {/* Stepper */}
         <hr className="mb-6 border-gray-200 dark:border-gray-600" />
-        <div className="flex justify-center items-center mb-10 w-full max-w-3xl mx-auto">
+        <div className="flex justify-center items-center mb-8 w-full max-w-3xl mx-auto">
           {stepTitles.map((label, index) => {
             const isCurrent = index === currentStep;
 
             return (
-              <React.Fragment key={index}>
-                <div className="flex flex-col items-center flex-shrink-0">
+              <div className="flex flex-col w-full mb-2" key={index}>
+                {/* Top row */}
+                <div className="flex w-full space-x-2 items-center">
+                  {/* Left connector */}
+                  <div className={`flex-grow h-[2px] ${index > 0 ? 'bg-gray-300' : ''}`}></div>
+
+                  {/* Middle dot (step number) */}
                   <div
-                    className={`flex items-center justify-center w-8 h-8 rounded-full border-2 text-sm font-medium ${
+                    className={`flex items-center justify-center w-8 h-8 rounded-full border-2 text-sm font-medium flex-shrink-0 ${
                       isCurrent
                         ? 'bg-blue-600 border-blue-600 text-white'
                         : 'bg-white border-gray-300 text-gray-500'
@@ -76,20 +81,24 @@ export const MultiStepModal: React.FC<MultiStepModalProps> = ({
                   >
                     {index + 1}
                   </div>
+
+                  {/* Right connector */}
                   <div
-                    className={`text-xs mt-2 text-center ${
-                      isCurrent ? 'text-black font-medium' : 'text-gray-500'
+                    className={`flex-grow h-[2px] ${
+                      index < stepTitles.length - 1 ? 'bg-gray-300' : ''
                     }`}
-                  >
-                    {label}
-                  </div>
+                  ></div>
                 </div>
 
-                {/* Line connector */}
-                {index < stepTitles.length - 1 && (
-                  <div className={'flex-1 h-[2px] mx-2 bg-gray-300'}></div>
-                )}
-              </React.Fragment>
+                {/* Bottom row: Step title */}
+                <div
+                  className={`w-full text-xs mt-2 text-center ${
+                    isCurrent ? 'text-black font-medium' : 'text-gray-500'
+                  }`}
+                >
+                  {label}
+                </div>
+              </div>
             );
           })}
         </div>

--- a/assets/test/scheduler/agenda-visibility_test.tsx
+++ b/assets/test/scheduler/agenda-visibility_test.tsx
@@ -33,6 +33,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
+      assessmentLayoutType: 'no_due_dates',
     };
 
     it('updates agenda to true when fulfilled', () => {
@@ -90,6 +91,7 @@ describe('Agenda Visibility Toggle', () => {
       errorMessage: null,
       weekdays: [false, true, true, true, true, true, false],
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
+      assessmentLayoutType: 'no_due_dates',
     };
 
     const createTestStore = (preloadedState: SchedulerState) =>

--- a/assets/test/scheduler/expand-collapse-schedule_test.ts
+++ b/assets/test/scheduler/expand-collapse-schedule_test.ts
@@ -55,6 +55,7 @@ describe('expand/collapse containers', () => {
       preferredSchedulingTime: { hour: 23, minute: 59, second: 59 },
       searchQuery: '',
       agenda: true,
+      assessmentLayoutType: 'end_of_each_section',
     },
   };
 


### PR DESCRIPTION
[MER-4272](https://eliterate.atlassian.net/jira/software/c/projects/MER/boards/2?selectedIssue=MER-4272)

This PR enhances the **"Set Schedule"** modal in the **Scheduling** tab with updated UI and new logic for assigning assessment due dates.

---

## What’s New

- Updated modal layout per [Figma design].
- **Set Default Timeline** section:  
  - Behavior remains unchanged.
- **Set Default Layout** section:  
  - Displays 3 options assessment due date options.

---

## Assessment Due Date Options

Users can choose one of the following when setting a schedule:

1. **Do not set assessment due dates**  
   → No due dates applied to assessments.

2. **Set due dates to the end of each section**  
   → Each assessment due at the end of its parent container’s range.

3. **Set due dates based on content sequence**  
   → Default behavior; due dates follow schedule placement.