### PR TITLE
[ENHANCEMENT] [MER-4606] rename and update assessment scores

### DIFF
--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -97,7 +97,7 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
       section_id,
       query_conditions
     )
-    |> Enum.sort_by(& &1.numbering_index)
+    |> Enum.sort_by(&{&1.numbering_index, &1.title})
   end
 
   @doc """

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -164,7 +164,8 @@ defmodule Oli.Grading do
   @doc """
   Returns a tuple containing a list of GradebookRow for every enrolled user and an ordered list of column labels.
 
-  `{[%GradebookRow{user: %User{}, scores: [%GradebookScore{}, ...]}, ...], ["Quiz 1 - Points Earned", "Quiz 1 - Points Possible", "Quiz 1 - Percentage"]}`
+  `{[%GradebookRow{user: %User{}, scores: [%GradebookScore{}, ...]}, ...], ["Assessment 1 - Points Earned", "Assessment 1 - Points Possible", "Assessment 1 - Percentage"]}`
+
   """
   def generate_gradebook_for_section(%Section{} = section) do
     # get publication page resources, filtered by graded: true and ordered by numbering index

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -278,7 +278,9 @@ defmodule Oli.Grading do
           label: rev.title,
           score: ra.score,
           out_of: ra.out_of,
-          was_late: ra.was_late
+          was_late: ra.was_late,
+          index: sr.numbering_index,
+          title: sr.title
         }
       )
     )

--- a/lib/oli/grading/gradebook_score.ex
+++ b/lib/oli/grading/gradebook_score.ex
@@ -1,12 +1,14 @@
 defmodule Oli.Grading.GradebookScore do
   @enforce_keys [:resource_id, :label, :out_of]
-  defstruct [:resource_id, :label, :score, :out_of, :was_late]
+  defstruct [:resource_id, :label, :score, :out_of, :was_late, :index, :title]
 
   @type t() :: %__MODULE__{
           resource_id: integer,
           label: String.t(),
           score: float | nil,
           out_of: float | nil,
-          was_late: boolean | nil
+          was_late: boolean | nil,
+          index: integer | nil,
+          title: String.t()
         }
 end

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -242,8 +242,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
   def handle_event("paged_table_sort", %{"sort_by" => sort_by} = _params, socket) do
     patch_url_type = socket.assigns.patch_url_type
     sort_by = String.to_existing_atom(sort_by)
-    updated_params = update_params(socket.assigns.params, %{sort_by: sort_by})
-    {:noreply, push_patch(socket, to: route_for(socket, updated_params, patch_url_type))}
+    {:noreply, push_patch(socket, to: route_for(socket, %{sort_by: sort_by}, patch_url_type))}
   end
 
   def handle_event("show_all_links", _params, socket) do
@@ -334,7 +333,6 @@ defmodule OliWeb.Components.Delivery.QuizScores do
 
   defp purge_default_params(params) do
     Map.filter(params, fn
-      {:sort_by, _value} -> true
       {key, value} -> @default_params[key] != value
     end)
   end

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -64,10 +64,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
         >
           <div>
             <h4 class="torus-h4 !py-0 sm:mr-auto mb-2">Assessment Scores</h4>
-            <a
-              href={Routes.delivery_path(OliWeb.Endpoint, :download_quiz_scores, @section_slug)}
-              class="self-end"
-            >
+            <a href={~p"/sections/#{@section_slug}/grades/export"} class="self-end">
               <i class="fa-solid fa-download ml-1" /> Download
             </a>
           </div>

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -63,7 +63,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
           class="flex justify-between sm:items-end px-4 sm:px-9 py-4 instructor_dashboard_table"
         >
           <div>
-            <h4 class="torus-h4 !py-0 sm:mr-auto mb-2">Quiz Scores</h4>
+            <h4 class="torus-h4 !py-0 sm:mr-auto mb-2">Assessment Scores</h4>
             <a
               href={Routes.delivery_path(OliWeb.Endpoint, :download_quiz_scores, @section_slug)}
               class="self-end"

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -114,7 +114,7 @@ defmodule OliWeb.Components.Delivery.QuizScores do
             overflow_class="block scrollbar"
           />
         <% else %>
-          <h6 class="text-center py-4">There are no quiz scores to show</h6>
+          <h6 class="text-center py-4">There are no assessment scores to show</h6>
         <% end %>
       </div>
     </div>

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -21,28 +21,22 @@ defmodule OliWeb.Components.Delivery.QuizScores do
     show_all_links: false
   }
 
-  def update(
-        %{
-          params: params,
-          section: section
-        } = assigns,
-        socket
-      ) do
-    params = decode_params(params)
+  def update(%{params: params, section: section} = assigns, socket) do
+    params = decode_params(params, assigns[:student_id])
 
-    if is_nil(assigns[:student_id]),
-      do:
-        get_grades_all_students(section, assigns[:view], assigns[:patch_url_type], params, socket),
-      else:
-        get_scores_for_student(
-          assigns[:scores].scores,
-          assigns[:student_id],
-          section,
-          assigns[:view],
-          assigns[:patch_url_type],
-          params,
-          socket
-        )
+    if is_nil(assigns[:student_id]) do
+      get_grades_all_students(section, assigns[:view], assigns[:patch_url_type], params, socket)
+    else
+      get_scores_for_student(
+        assigns[:scores].scores,
+        assigns[:student_id],
+        section,
+        assigns[:view],
+        assigns[:patch_url_type],
+        params,
+        socket
+      )
+    end
   end
 
   attr(:params, :map, required: true)
@@ -264,13 +258,18 @@ defmodule OliWeb.Components.Delivery.QuizScores do
      )}
   end
 
-  defp decode_params(params) do
+  defp decode_params(params, student_id) do
+    default_params =
+      if student_id,
+        do: @default_params,
+        else: %{@default_params | sort_by: :name}
+
     %{
       offset: Params.get_int_param(params, "offset", @default_params.offset),
       limit: Params.get_int_param(params, "limit", @default_params.limit),
       sort_order:
         Params.get_atom_param(params, "sort_order", [:asc, :desc], @default_params.sort_order),
-      sort_by: Params.get_atom_param(params, "sort_by", [:index, :name], @default_params.sort_by),
+      sort_by: Params.get_atom_param(params, "sort_by", [:index, :name], default_params.sort_by),
       text_search: Params.get_param(params, "text_search", @default_params.text_search),
       show_all_links:
         Params.get_boolean_param(params, "show_all_links", @default_params.show_all_links)

--- a/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
+++ b/lib/oli_web/components/delivery/quiz_scores/quiz_scores.ex
@@ -297,9 +297,8 @@ defmodule OliWeb.Components.Delivery.QuizScores do
     {length(scores), scores |> Enum.drop(params.offset) |> Enum.take(params.limit)}
   end
 
-  defp sort_by(scores, sort_order) do
-    Enum.sort_by(scores, fn score -> score.label end, sort_order)
-  end
+  defp sort_by(scores, :desc), do: Enum.reverse(scores)
+  defp sort_by(scores, _sort_order), do: scores
 
   defp maybe_filter_by_text(scores, nil), do: scores
   defp maybe_filter_by_text(scores, ""), do: scores

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -411,7 +411,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         active: is_active_tab?(:students, active_tab)
       },
       %TabLink{
-        label: "Quiz Scores",
+        label: "Assessment Scores",
         path: path_for(:overview, :quiz_scores, section_slug, preview_mode),
         badge: nil,
         active: is_active_tab?(:quiz_scores, active_tab)

--- a/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/components/helpers.ex
@@ -88,7 +88,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.Helpers do
         <%= for {label, href, badge, active, hidden} <- [
             {"Content", path_for(:content, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:content, @active_tab), is_hidden?(:content, @hidden_tabs)},
             {"Learning Objectives", path_for(:learning_objectives, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:learning_objectives, @active_tab), is_hidden?(:learning_objectives, @hidden_tabs)},
-            {"Quiz Scores", path_for(:quizz_scores, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:quizz_scores, @active_tab), is_hidden?(:quizz_scores, @hidden_tabs)},
+            {"Assessment Scores", path_for(:quizz_scores, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:quizz_scores, @active_tab), is_hidden?(:quizz_scores, @hidden_tabs)},
             {"Progress", path_for(:progress, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:progress, @active_tab), is_hidden?(:progress, @hidden_tabs)},
             {"Actions", path_for(:actions, @section_slug, @student_id, @preview_mode), nil, is_active_tab?(:actions, @active_tab), is_hidden?(:actions, @hidden_tabs)},
           ] do %>

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -288,7 +288,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
         %{
           resource_id: node.revision.resource_id,
           node: node,
-          index: index,
+          index: index + 1,
           title: node.revision.title,
           type: if(node.revision.graded, do: "Scored", else: "Practice"),
           was_late: if(is_nil(ra), do: false, else: ra.was_late),

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -57,6 +57,12 @@ defmodule OliWeb.Grades.GradebookTableModel do
   def new(graded_pages, section_slug, student_id) do
     column_specs = [
       %ColumnSpec{
+        name: :index,
+        label: "Order",
+        render_fn: &__MODULE__.render_grade_order/3,
+        th_class: "pl-10"
+      },
+      %ColumnSpec{
         name: :name,
         label: "Assessment",
         render_fn: &__MODULE__.render_grade/3,
@@ -78,6 +84,16 @@ defmodule OliWeb.Grades.GradebookTableModel do
       id_field: [:id],
       data: %{section_slug: section_slug, student_id: student_id}
     )
+  end
+
+  def render_grade_order(assigns, row, _) do
+    assigns = Map.merge(assigns, %{row: row})
+
+    ~H"""
+    <div class="ml-8">
+      <%= @row.index %>
+    </div>
+    """
   end
 
   def render_grade(assigns, row, _) do

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -58,7 +58,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
     column_specs = [
       %ColumnSpec{
         name: :name,
-        label: "Quiz",
+        label: "Assessment",
         render_fn: &__MODULE__.render_grade/3,
         th_class: "pl-10"
       },

--- a/lib/oli_web/live/grades/gradebook_view.ex
+++ b/lib/oli_web/live/grades/gradebook_view.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.Grades.GradebookView do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "Gradebook",
+          full_title: "Assessment Scores",
           link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
         })
       ]

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -338,7 +338,7 @@ defmodule OliWeb.Sections.OverviewView do
               }
               class="text-[#006CD9] hover:text-[#1B67B2] dark:text-[#4CA6FF] dark:hover:text-[#99CCFF] hover:underline"
             >
-              Score Manually Graded Activities
+              Manual Scoring
               <%= if @has_submitted_attempts do %>
                 <span class="badge badge-primary">*</span>
               <% end %>
@@ -349,15 +349,7 @@ defmodule OliWeb.Sections.OverviewView do
               href={Routes.live_path(OliWeb.Endpoint, OliWeb.Grades.GradebookView, @section.slug)}
               class="text-[#006CD9] hover:text-[#1B67B2] dark:text-[#4CA6FF] dark:hover:text-[#99CCFF] hover:underline"
             >
-              View all Scores
-            </a>
-          </li>
-          <li>
-            <a
-              href={Routes.page_delivery_path(OliWeb.Endpoint, :export_gradebook, @section.slug)}
-              class="text-[#006CD9] hover:text-[#1B67B2] dark:text-[#4CA6FF] dark:hover:text-[#99CCFF] hover:underline"
-            >
-              Download Gradebook as <code>.csv</code> file
+              Assessment Scores
             </a>
           </li>
 

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -358,7 +358,7 @@ defmodule OliWeb.Workspaces.Utils do
             parent_view: :overview
           },
           %SubMenuItem{
-            text: "Quiz Scores",
+            text: "Assessment Scores",
             view: :quiz_scores,
             parent_view: :overview
           },

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/quiz_scores_tab_test.exs
@@ -67,7 +67,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       assert has_element?(
                view,
                ~s{a[href="#{live_view_quiz_scores_route(section.slug)}"].border-b-2},
-               "Quiz Scores"
+               "Assessment Scores"
              )
 
       # QuizScores tab content gets rendered
@@ -114,7 +114,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
 
       {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
 
-      assert has_element?(view, "h4", "Quiz Scores")
+      assert has_element?(view, "h4", "Assessment Scores")
     end
 
     test "applies searching", %{

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/quiz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/quiz_scores_tab_test.exs
@@ -71,14 +71,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
              )
 
       # QuizScores tab content gets rendered
-      assert has_element?(view, "h6", "There are no quiz scores to show")
+      assert has_element?(view, "h6", "There are no assessment scores to show")
     end
   end
 
-  describe "quiz scores" do
+  describe "assessment scores" do
     setup [:instructor_conn, :section_with_gating_conditions]
 
-    test "loads correctly when there are no quiz scores", %{
+    test "loads correctly when there are no assessment scores", %{
       conn: conn,
       instructor: instructor
     } do
@@ -92,10 +92,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.QuizScoreTabTest do
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
       {:ok, view, _html} = live(conn, live_view_quiz_scores_route(section.slug))
 
-      assert has_element?(view, "h6", "There are no quiz scores to show")
+      assert has_element?(view, "h6", "There are no assessment scores to show")
     end
 
-    test "loads correctly when a student has not yet finished a quiz", %{
+    test "loads correctly when a student has not yet finished an assessment", %{
       conn: conn,
       section: section,
       instructor: instructor,

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -114,8 +114,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
       assert has_element?(view, "a.active", "Course Content")
       assert has_element?(view, "a", "Students")
       refute has_element?(view, "a.active", "Students")
-      assert has_element?(view, "a", "Quiz Scores")
-      refute has_element?(view, "a.active", "Quiz Scores")
+      assert has_element?(view, "a", "Assessment Scores")
+      refute has_element?(view, "a.active", "Assessment Scores")
       assert has_element?(view, "a", "Recommended Actions")
       refute has_element?(view, "a.active", "Recommended Actions")
     end

--- a/test/oli_web/live/delivery/student_dashboard/components/progress_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/progress_tab_test.exs
@@ -257,38 +257,41 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
       )
 
       {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_progress_route(
-            section.slug,
-            student.id,
-            :progress
-          )
-        )
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress))
+
+      titles =
+        [
+          graded_page_1.title,
+          graded_page_2.title,
+          graded_page_3.title,
+          graded_page_4.title,
+          graded_page_5.title,
+          graded_page_6.title
+        ]
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:first-child")
-             |> render() =~ graded_page_1.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "A Graded page 5") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
-             |> render() =~ graded_page_2.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "B Graded page 4") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
-             |> render() =~ graded_page_3.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "C Graded page 3") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
-             |> render() =~ graded_page_4.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "D Graded page 2") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
-             |> render() =~ graded_page_5.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "E Graded page 1") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:last-child")
-             |> render() =~ graded_page_6.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "Z Graded page 6") end)
 
       ## sorting by student
       params = %{
@@ -296,39 +299,31 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
       }
 
       {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_progress_route(
-            section.slug,
-            student.id,
-            :progress,
-            params
-          )
-        )
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress, params))
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:last-child")
-             |> render() =~ graded_page_1.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "A Graded page 5") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
-             |> render() =~ graded_page_2.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "B Graded page 4") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
-             |> render() =~ graded_page_3.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "C Graded page 3") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
-             |> render() =~ graded_page_4.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "D Graded page 2") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
-             |> render() =~ graded_page_5.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "E Graded page 1") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:first-child")
-             |> render() =~ graded_page_6.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "Z Graded page 6") end)
     end
 
     test "applies pagination", %{
@@ -337,7 +332,10 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
       student: student,
       graded_page_1: graded_page_1,
       graded_page_2: graded_page_2,
-      graded_page_3: graded_page_3
+      graded_page_3: graded_page_3,
+      graded_page_4: graded_page_4,
+      graded_page_5: graded_page_5,
+      graded_page_6: graded_page_6
     } do
       insert_resource_access(
         graded_page_1,
@@ -348,103 +346,58 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ProgressTabTest do
       )
 
       {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_progress_route(
-            section.slug,
-            student.id,
-            :progress
-          )
-        )
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress))
 
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_1.title}"
-             )
-
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_2.title}"
-             )
-
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_3.title}"
-             )
+      assert has_element?(view, "div", "#{graded_page_1.title}")
+      assert has_element?(view, "div", "#{graded_page_2.title}")
+      assert has_element?(view, "div", "#{graded_page_3.title}")
 
       ## aplies limit
-      params = %{
-        limit: 2,
-        sort_order: "asc"
-      }
+      params = %{limit: 2, sort_order: "asc"}
 
       {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_progress_route(
-            section.slug,
-            student.id,
-            :progress,
-            params
-          )
-        )
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress, params))
 
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_1.title}"
-             )
+      titles = [
+        graded_page_1.title,
+        graded_page_2.title,
+        graded_page_3.title,
+        graded_page_4.title,
+        graded_page_5.title,
+        graded_page_6.title
+      ]
 
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_2.title}"
-             )
+      assert view
+             |> render()
+             |> Floki.find("table.instructor_dashboard_table > tbody > tr")
+             |> Enum.count() == 2
 
-      refute has_element?(
-               view,
-               "div",
-               "#{graded_page_3.title}"
-             )
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "A Graded page 5") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "B Graded page 4") end)
 
       ## aplies pagination
-      params = %{
-        limit: 2,
-        offset: 2,
-        sort_order: "asc"
-      }
+      params = %{limit: 2, offset: 2, sort_order: "asc"}
 
       {:ok, view, _html} =
-        live(
-          conn,
-          live_view_students_progress_route(
-            section.slug,
-            student.id,
-            :progress,
-            params
-          )
-        )
+        live(conn, live_view_students_progress_route(section.slug, student.id, :progress, params))
 
-      refute has_element?(
-               view,
-               "div",
-               "#{graded_page_1.title}"
-             )
+      assert view
+             |> render()
+             |> Floki.find("table.instructor_dashboard_table > tbody > tr")
+             |> Enum.count() == 2
 
-      refute has_element?(
-               view,
-               "div",
-               "#{graded_page_2.title}"
-             )
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "C Graded page 3") end)
 
-      assert has_element?(
-               view,
-               "div",
-               "#{graded_page_3.title}"
-             )
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "D Graded page 2") end)
     end
   end
 

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -356,17 +356,20 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       conn: conn,
       instructor: instructor,
       section: section,
-      student_with_gating_condition: student_with_gating_condition,
+      student_with_gating_condition: student,
       graded_page_1: graded_page_1,
+      graded_page_2: graded_page_2,
       graded_page_3: graded_page_3,
-      graded_page_5: graded_page_5
+      graded_page_4: graded_page_4,
+      graded_page_5: graded_page_5,
+      graded_page_6: graded_page_6
     } do
       insert_resource_access(
         graded_page_1,
         graded_page_3,
         graded_page_5,
         section,
-        student_with_gating_condition
+        student
       )
 
       Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
@@ -376,50 +379,77 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
           conn,
           live_view_students_dashboard_route(
             section.slug,
-            student_with_gating_condition.id,
+            student.id,
             :quizz_scores
           )
         )
 
+      titles =
+        [
+          graded_page_1.title,
+          graded_page_2.title,
+          graded_page_3.title,
+          graded_page_4.title,
+          graded_page_5.title,
+          graded_page_6.title
+        ]
+
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:first-child")
-             |> render() =~ graded_page_1.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "E Graded page 1") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "D Graded page 2") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
-             |> render() =~ graded_page_3.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "C Graded page 3") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "B Graded page 4") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
-             |> render() =~ graded_page_5.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "A Graded page 5") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(6)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "Z Graded page 6") end)
 
       ## sorting by student
-      params = %{
-        sort_order: :desc
-      }
+      params = %{sort_order: :desc}
 
       {:ok, view, _html} =
         live(
           conn,
-          live_view_students_dashboard_route(
-            section.slug,
-            student_with_gating_condition.id,
-            :quizz_scores,
-            params
-          )
+          live_view_students_dashboard_route(section.slug, student.id, :quizz_scores, params)
         )
 
       assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "Z Graded page 6") end)
+
+      assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
-             |> render() =~ graded_page_5.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "A Graded page 5") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(3)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "B Graded page 4") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(4)")
-             |> render() =~ graded_page_3.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "C Graded page 3") end)
+
+      assert view
+             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(5)")
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "D Graded page 2") end)
 
       assert view
              |> element("table.instructor_dashboard_table > tbody > tr:nth-child(6)")
-             |> render() =~ graded_page_1.title
+             |> render() =~ Enum.find(titles, fn t -> String.contains?(t, "E Graded page 1") end)
     end
 
     test "applies pagination", %{

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -116,7 +116,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       assert has_element?(
                view,
                ~s{a[href="#{live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)}"].border-b-2},
-               "Quiz Scores"
+               "Assessment Scores"
              )
 
       # QuizScores tab content gets rendered
@@ -153,7 +153,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       assert has_element?(
                view,
                ~s{a[href="#{live_view_students_dashboard_route(section.slug, student.id, :quizz_scores)}"].border-b-2},
-               "Quiz Scores"
+               "Assessment Scores"
              )
 
       assert has_element?(

--- a/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/quizz_scores_tab_test.exs
@@ -266,7 +266,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.QuizzScoresTabTest do
       assert has_element?(
                view,
                "h6",
-               "There are no quiz scores to show"
+               "There are no assessment scores to show"
              )
     end
 

--- a/test/oli_web/live/workspaces/instructor/dashboard_live_test.exs
+++ b/test/oli_web/live/workspaces/instructor/dashboard_live_test.exs
@@ -26,7 +26,7 @@ defmodule OliWeb.Workspaces.Instructor.DashboardLiveTest do
           {"Students",
            "/workspaces/instructor/#{section.slug}/overview/students?sidebar_expanded=true"},
         3 =>
-          {"Quiz Scores",
+          {"Assessment Scores",
            "/workspaces/instructor/#{section.slug}/overview/quiz_scores?sidebar_expanded=true"},
         4 =>
           {"Recommended Actions",

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2149,7 +2149,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 1 - Level 1 (w/ no date)",
+        title: "E Graded page 1 - Level 1 (w/ no date)",
         graded: true,
         resource: graded_page_1_resource
       )
@@ -2158,7 +2158,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 2 - Level 0 (w/ date)",
+        title: "D Graded page 2 - Level 0 (w/ date)",
         graded: true,
         purpose: :application,
         resource: graded_page_2_resource
@@ -2168,7 +2168,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 3 - Level 1 (w/ no date)",
+        title: "C Graded page 3 - Level 1 (w/ no date)",
         graded: true,
         resource: graded_page_3_resource,
         relates_to: [graded_page_1_resource.id, graded_page_2_resource.id]
@@ -2178,7 +2178,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 4 - Level 0 (w/ gating condition)",
+        title: "B Graded page 4 - Level 0 (w/ gating condition)",
         graded: true,
         resource: graded_page_4_resource
       )
@@ -2187,7 +2187,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 5 - Level 0 (w/ student gating condition)",
+        title: "A Graded page 5 - Level 0 (w/ student gating condition)",
         graded: true,
         resource: graded_page_5_resource,
         relates_to: [graded_page_4_resource.id]
@@ -2197,7 +2197,7 @@ defmodule Oli.TestHelpers do
       insert(
         :revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
-        title: "Graded page 6 - Level 0 (w/o student gating condition)",
+        title: "Z Graded page 6 - Level 0 (w/o student gating condition)",
         graded: true,
         resource: graded_page_6_resource
       )


### PR DESCRIPTION
Ticket: [MER-4606](https://eliterate.atlassian.net/browse/MER-4606)

This PR replaces many occurrences of **_Quiz_** with **_Assessment_**.


## Overview → Quiz Scores
### Before
![image](https://github.com/user-attachments/assets/3ec0fb71-b6e4-4752-bbe9-b175a8031f42)
### After
<img width="530" alt="Screenshot 2025-06-18 at 11 02 05 AM" src="https://github.com/user-attachments/assets/cf867ba1-3bf5-4c93-9fef-3c131f7f8968" />

### Overview → Students → select a student → Quiz Scores
### Before
![image](https://github.com/user-attachments/assets/d2dad56a-983f-4b67-8f87-0057b260d7d0)
### After
<img width="510" alt="Screenshot 2025-06-18 at 11 02 39 AM" src="https://github.com/user-attachments/assets/e5197efa-e63b-4142-8e92-6fe946f7e6c8" />

#### Manage Page
### Before
![image](https://github.com/user-attachments/assets/a8f8d864-8f7f-4609-b632-41f23ab1c6e5)
### After
<img width="617" alt="Screenshot 2025-06-18 at 11 03 03 AM" src="https://github.com/user-attachments/assets/03e71aa0-cf67-49bd-8d86-2c377ab1c913" />

#### Manage → Assessment Scores
### Before
![image](https://github.com/user-attachments/assets/895bcd43-85ce-4c07-bbc6-06a23e68fdf1)
### After
<img width="682" alt="Screenshot 2025-06-18 at 11 04 36 AM" src="https://github.com/user-attachments/assets/a2a8473e-a124-4ecd-b762-023b020d0787" />



[MER-4606]: https://eliterate.atlassian.net/browse/MER-4606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ