### PR TITLE
[BUG FIX] [MER-4648] Autosubmission not working correctly

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -149,8 +149,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       attempt_expired_auto_submit =
         with true <- now > effective_end_time,
              true <- auto_submit,
-             false <- page_context.review_mode,
-             :due_by <- page_context.effective_settings.scheduling_type do
+             false <- page_context.review_mode do
           true
         else
           _ ->


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4648) to the ticket

### How does auto-submission work?
  - When a student is in the browser and the time limit is reached, a js script auto-triggers a click on the submit button.
  - When the student closes the browser and the time limit is reached, an oban job auto-submits the attempt (one minute after the time limit is reached)

So, there was a one-minute window that allowed the student to re-enter the assessment and make changes to the responses. That bug was fixed on [MER-3931](https://github.com/Simon-Initiative/oli-torus/pull/5223)

### Issue
The logic for determining the deadline was considering a soft end date as part of the logic. According to the [Schedule and Assessment Settings Logic](https://docs.google.com/drawings/d/1LDzW7DH6fX7BW6oFBYgPR9H2ZkqHn-YP5JuvcfSq1xw/edit) only hard end dates (scheduling type = :due_by) should be considered in the logic `EARLIEST(due date, start time + time limit) + grace period`

### Fix
This PR changes the `determine_effective_deadline` function to consider only hard end dates.




### Before

https://github.com/user-attachments/assets/3c85b3a8-b00d-418f-b1f8-0752b175846e



### After

https://github.com/user-attachments/assets/5f65ccba-20dc-486e-8483-aee79e107d03



[MER-3931]: https://eliterate.atlassian.net/browse/MER-3931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ