### PR TITLE
[ENHANCEMENT] [MER-4642] Update scoring statement for assesments

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -341,22 +341,18 @@ defmodule OliWeb.Delivery.Student.Utils do
   defp to_hours(hours), do: "#{hours} hours"
 
   defp page_scoring_term(effective_settings) do
-    # Determine the scoring policy text
     policy_text =
       if effective_settings.batch_scoring, do: "this assignment", else: "each question"
 
-    # Determine the scoring strategy text
     strategy_text =
       case effective_settings.scoring_strategy_id do
         1 -> "the average of your attempts"
         2 -> "your best attempt"
         3 -> "your last attempt"
         4 -> "the total sum of your attempts"
-        # Default to best (strategy 2)
         _ -> "your best attempt"
       end
 
-    # Generate the final message
     "For #{policy_text}, your score will be determined by #{strategy_text}."
   end
 

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -347,13 +347,13 @@ defmodule OliWeb.Delivery.Student.Utils do
     strategy_text =
       case effective_settings.scoring_strategy_id do
         1 -> "the average of your attempts"
-        2 -> "your best attempt"
-        3 -> "your last attempt"
-        4 -> "the total sum of your attempts"
-        _ -> "your best attempt"
+        2 -> "determined by your best attempt"
+        3 -> "determined by your last attempt"
+        4 -> "determined by the total sum of your attempts"
+        _ -> "determined by your best attempt"
       end
 
-    "For #{policy_text}, your score will be determined by #{strategy_text}."
+    "For #{policy_text}, your score will be #{strategy_text}."
   end
 
   @doc """

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -195,7 +195,7 @@ defmodule OliWeb.Delivery.Student.Utils do
           <%= score_as_you_go(@effective_settings) %>
         </li>
         <li id="page_scoring_terms">
-          <%= page_scoring_term(@effective_settings.scoring_strategy_id) %>
+          <%= page_scoring_term(@effective_settings) %>
         </li>
         <li :if={!@effective_settings.batch_scoring} id="question_attempts">
           <%= question_attempts(@effective_settings) %>
@@ -340,18 +340,25 @@ defmodule OliWeb.Delivery.Student.Utils do
   defp to_hours(1), do: "1 hour"
   defp to_hours(hours), do: "#{hours} hours"
 
-  defp page_scoring_term(1 = _scoring_strategy_id),
-    do: "Your overall score for this assignment will be the average score of your attempts."
+  defp page_scoring_term(effective_settings) do
+    # Determine the scoring policy text
+    policy_text =
+      if effective_settings.batch_scoring, do: "this assignment", else: "each question"
 
-  defp page_scoring_term(3 = _scoring_strategy_id),
-    do: "Your overall score for this assignment will be the score of your last attempt."
+    # Determine the scoring strategy text
+    strategy_text =
+      case effective_settings.scoring_strategy_id do
+        1 -> "the average of your attempts"
+        2 -> "your best attempt"
+        3 -> "your last attempt"
+        4 -> "the total sum of your attempts"
+        # Default to best (strategy 2)
+        _ -> "your best attempt"
+      end
 
-  defp page_scoring_term(4 = _scoring_strategy_id),
-    do: "Your overall score for this assignment will be the total sum of your attempts."
-
-  # scoring strategy 2 is the default scoring strategy
-  defp page_scoring_term(_scoring_strategy_id),
-    do: "Your overall score for this assignment will be the score of your best attempt."
+    # Generate the final message
+    "For #{policy_text}, your score will be determined by #{strategy_text}."
+  end
 
   @doc """
   Returns the scheduling type label for the container.
@@ -371,9 +378,9 @@ defmodule OliWeb.Delivery.Student.Utils do
       assign(assigns, %{
         proficiency_levels: [
           {"Not enough data", "Not enough information",
-           "You haven’t completed enough activities for the system to calculate learning proficiency."},
+           "You haven't completed enough activities for the system to calculate learning proficiency."},
           {"Low", "Beginning Proficiency",
-           "You’re beginning to understand key ideas, but there is room to grow."},
+           "You're beginning to understand key ideas, but there is room to grow."},
           {"Medium", "Growing Proficiency",
            "Your understanding and skills are clearly strengthening and expanding."},
           {"High", "Establishing Proficiency",

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1155,7 +1155,7 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
       assert view |> element("#page_scoring_terms") |> render() =~
-               "For this assignment, your score will be determined by the average of your attempts."
+               "For this assignment, your score will be the average of your attempts."
     end
 
     test "page terms show correct scoring messages for different policies and strategies", ctx do
@@ -1166,14 +1166,12 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       # Test score at the end (batch_scoring: true) with different strategies
       test_cases = [
         # {batch_scoring, scoring_strategy_id, expected_message}
-        {true, 1,
-         "For this assignment, your score will be determined by the average of your attempts."},
+        {true, 1, "For this assignment, your score will be the average of your attempts."},
         {true, 2, "For this assignment, your score will be determined by your best attempt."},
         {true, 3, "For this assignment, your score will be determined by your last attempt."},
         {true, 4,
          "For this assignment, your score will be determined by the total sum of your attempts."},
-        {false, 1,
-         "For each question, your score will be determined by the average of your attempts."},
+        {false, 1, "For each question, your score will be the average of your attempts."},
         {false, 2, "For each question, your score will be determined by your best attempt."},
         {false, 3, "For each question, your score will be determined by your last attempt."},
         {false, 4,

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1155,7 +1155,39 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 
       assert view |> element("#page_scoring_terms") |> render() =~
-               "Your overall score for this assignment will be the average score of your attempts."
+               "For this assignment, your score will be determined by the average of your attempts."
+    end
+
+    test "page terms show correct scoring messages for different policies and strategies", ctx do
+      %{conn: conn, user: user, section: section, page_2: page_2} = ctx
+
+      enroll_and_mark_visited(user, section)
+
+      # Test score at the end (batch_scoring: true) with different strategies
+      test_cases = [
+        # {batch_scoring, scoring_strategy_id, expected_message}
+        {true, 1,
+         "For this assignment, your score will be determined by the average of your attempts."},
+        {true, 2, "For this assignment, your score will be determined by your best attempt."},
+        {true, 3, "For this assignment, your score will be determined by your last attempt."},
+        {true, 4,
+         "For this assignment, your score will be determined by the total sum of your attempts."},
+        {false, 1,
+         "For each question, your score will be determined by the average of your attempts."},
+        {false, 2, "For each question, your score will be determined by your best attempt."},
+        {false, 3, "For each question, your score will be determined by your last attempt."},
+        {false, 4,
+         "For each question, your score will be determined by the total sum of your attempts."}
+      ]
+
+      Enum.each(test_cases, fn {batch_scoring, scoring_strategy_id, expected_message} ->
+        params = %{batch_scoring: batch_scoring, scoring_strategy_id: scoring_strategy_id}
+        get_and_update_section_resource(section.id, page_2.resource_id, params)
+
+        {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+        assert view |> element("#page_scoring_terms") |> render() =~ expected_message
+      end)
     end
 
     test "page terms render a time limit message", ctx do


### PR DESCRIPTION
Scoring statement message considers both the scoring policy (batch_scoring) and scoring strategy (scoring_strategy_id)

Follows new format: "For [this assignment / each question], your score will be determined by [your best attempt / your last attempt / the average of your attempts]"

---

The new implementation generates messages based on:


Scoring Policy:
- batch_scoring: true → "this assignment" (score at the end)
- batch_scoring: false → "each question" (score as you go)

Scoring Strategy:
- Strategy ID 1 → "the average of your attempts"
- Strategy ID 2 → "your best attempt"
- Strategy ID 3 → "your last attempt"
- Strategy ID 4 → "the total sum of your attempts"

--- 

See: https://eliterate.atlassian.net/browse/MER-4642