### PR TITLE
[BUG FIX] [MER-4645] Minor updates to FITB

### DIFF
--- a/assets/src/components/parts/janus-text-flow/QuillFIBOptionEditor.tsx
+++ b/assets/src/components/parts/janus-text-flow/QuillFIBOptionEditor.tsx
@@ -180,10 +180,10 @@ export const QuillFIBOptionEditor: React.FC<QuillFIBOptionEditorProps> = ({
             </Modal.Header>
             <Modal.Body className="px-8" style={{ backgroundColor: 'lightgray' }}>
               <div style={{ display: 'flex', marginBottom: '10px', alignItems: 'center' }}>
-                <label className="form-label">“Select FITB Item</label>
+                <label className="form-label">Select FITB Item</label>
                 <select
                   className="form-control"
-                  style={{ width: '71%', marginLeft: '13px' }}
+                  style={{ width: '69%', marginLeft: '13px' }}
                   value={selectedKey}
                   onChange={(e) => {
                     setCurrentSelectedIndex(e.target.selectedIndex);
@@ -268,7 +268,10 @@ export const QuillFIBOptionEditor: React.FC<QuillFIBOptionEditorProps> = ({
                         }}
                       >
                         {item.correct ? (
-                          <i className="fa-solid fa-circle-check fa-lg"></i>
+                          <i
+                            style={{ color: '#3B76D3' }}
+                            className="fa-solid fa-circle-check fa-lg"
+                          ></i>
                         ) : (
                           <i className="fa-regular fa-circle-check fa-lg"></i>
                         )}


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

This PR contains 2 changes mentioned in the comment:
-> can the correct check also get that blue color?
-> Can the quotation mark be removed? Also is there any way this can be one line? Maybe make the dropdown just a little narrower (where “blank 2” is in the image)?  Maybe removing the quotation mark is enough.

![image](https://github.com/user-attachments/assets/f37a12fc-8bc3-4b41-99c2-56ce44cf60ee)
