### PR TITLE
[BUGFIX] [MER-4664] Error When Manually Grading Adaptive Page

### DIFF
--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -238,6 +238,8 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
   If this activity is the last activity remaining in a graded page, this will finalize that graded page attempt,
   recalculate a resource access level score, and trigger LMS grade passback (if this is an LMS section and that
   section has gradepassback enabled)
+
+  It returns a tuple of `{:ok, part_attempt_guids}` if successful, or `{:error, reason}` if there was an error.
   """
   def apply_manual_scoring(
         %Section{slug: section_slug} = section,
@@ -271,6 +273,8 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
         {:ok, _} ->
           maybe_finalize_resource_attempt(section, graded, resource_attempt_guid)
 
+          Enum.map(mocked_part_attempts, & &1.attempt_guid)
+
         {:error, error} ->
           Repo.rollback(error)
       end
@@ -290,7 +294,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
           input =
             case Map.get(pa, :response) do
               %{input: input} -> input
-              nil -> %{}
+              _ -> %{}
             end
 
           %{

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -499,13 +499,12 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     } = socket.assigns
 
     case ManualGrading.apply_manual_scoring(section, attempt, score_feedbacks) do
-      {:ok, finalized_part_attempts} ->
+      {:ok, finalized_part_attempt_guids} ->
         pid = self()
 
         send(
           pid,
-          {:purge_score_feedbacks,
-           Enum.map(finalized_part_attempts, fn pa -> pa.attempt_guid end)}
+          {:purge_score_feedbacks, finalized_part_attempt_guids}
         )
 
         put_flash(socket, :info, "Student attempt scored.")


### PR DESCRIPTION
[https://eliterate.atlassian.net/browse/MER-4664](https://eliterate.atlassian.net/browse/MER-4664)

Fixes a bug that caused a match error when applying manual scores to adaptive pages.
Now the `ManualGrading.apply_manual_scoring/3` function returns a list of part attempt guids, which is expected when calling this function on the manual grading view.

https://github.com/user-attachments/assets/76c437f7-8076-4335-9744-30c1cff72899

