### PR TITLE
[BUG FIX] [MER-4537] Allow triggers to display when Explanation fires

### DIFF
--- a/lib/oli/delivery/evaluation/explanation.ex
+++ b/lib/oli/delivery/evaluation/explanation.ex
@@ -43,7 +43,12 @@ defmodule Oli.Delivery.Evaluation.Explanation do
         # will replace any other response driven trigger (thus giving explanation
         # triggers higher priority)
         trigger =
-          Oli.Conversation.Triggers.check_for_explanation_trigger(part, part.explanation, context)
+          case Oli.Conversation.Triggers.check_for_explanation_trigger(part, part.explanation, context) do
+            nil ->
+              feedback_action.trigger
+            trigger ->
+              trigger
+          end
 
         {:ok, %FeedbackAction{feedback_action | explanation: part.explanation, trigger: trigger}}
 


### PR DESCRIPTION
This PR makes an adjustment to the logic that checks to see if an explanation trigger exists, when an explanation has fired.  Previously, it simply took the result of the `Triggers. check_for_explanation_trigger` function and overwrote the `trigger` attribute of the feedback action.  When there is no explanation trigger (that is, when this function returns `nil`) this effectively overwrites a non-explanation trigger that would have already been set. 

The change here is to preserve the previously set trigger, and only replace it with the explanation trigger if there is actually an explanation trigger.  This gives us the original intent that Explanation triggers have higher priority than non explanation triggers, when an explanation has been tripped.  