### PR TITLE
[BUG FIX] [MER-4682] Instructor Quiz Scores: Format scores up to 2 decimal places

### DIFF
--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -94,9 +94,18 @@ defmodule OliWeb.Grades.GradebookTableModel do
     perc = score(row.score) / out_of_score(row.out_of) * 100
     has_score? = row.score != nil
     was_late = row.was_late
+    score = if has_score?, do: Utils.format_score(row.score)
+    out_of = Utils.format_score(row.out_of)
 
     assigns =
-      Map.merge(assigns, %{perc: perc, has_score?: has_score?, was_late: was_late, row: row})
+      Map.merge(assigns, %{
+        perc: perc,
+        has_score?: has_score?,
+        was_late: was_late,
+        row: row,
+        score: score,
+        out_of: out_of
+      })
 
     ~H"""
     <div>
@@ -114,7 +123,7 @@ defmodule OliWeb.Grades.GradebookTableModel do
         }
       >
         <%= if @has_score? do %>
-          <%= "#{@row.score}/#{@row.out_of}" %>
+          <%= "#{@score}/#{@out_of}" %>
         <% else %>
           Not Finished
         <% end %>

--- a/test/oli_web/live/grades/gradebook_table_model_test.exs
+++ b/test/oli_web/live/grades/gradebook_table_model_test.exs
@@ -1,0 +1,68 @@
+defmodule OliWeb.Grades.GradebookTableModelTest do
+  use ExUnit.Case, async: true
+
+  alias OliWeb.Grades.GradebookTableModel
+
+  describe "render_grade_score/3" do
+    test "formats scores to 2 decimal places" do
+      row = %{
+        score: 8.123456789,
+        out_of: 10.987654321,
+        resource_id: 1,
+        was_late: false
+      }
+
+      assigns = %{
+        section_slug: "test_section",
+        student_id: 1
+      }
+
+      # Render the score
+      html =
+        Phoenix.HTML.Safe.to_iodata(GradebookTableModel.render_grade_score(assigns, row, %{}))
+        |> IO.iodata_to_binary()
+
+      assert html =~ "8.12/10.99"
+    end
+
+    test "handles integer scores correctly" do
+      row = %{
+        score: 8,
+        out_of: 10,
+        resource_id: 1,
+        was_late: false
+      }
+
+      assigns = %{
+        section_slug: "test_section",
+        student_id: 1
+      }
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(GradebookTableModel.render_grade_score(assigns, row, %{}))
+        |> IO.iodata_to_binary()
+
+      assert html =~ "8/10"
+    end
+
+    test "handles nil scores correctly" do
+      row = %{
+        score: nil,
+        out_of: 10,
+        resource_id: 1,
+        was_late: false
+      }
+
+      assigns = %{
+        section_slug: "test_section",
+        student_id: 1
+      }
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(GradebookTableModel.render_grade_score(assigns, row, %{}))
+        |> IO.iodata_to_binary()
+
+      assert html =~ "Not Finished"
+    end
+  end
+end


### PR DESCRIPTION
Fix the formatting of the score when viewing it inside the Student Report page (`/sections/:course_section/student_dashboard/:id/quizz_scores`)

<img width="1917" alt="image" src="https://github.com/user-attachments/assets/f3c1a337-4470-4a57-9285-bcf99f933b27" />
