### PR TITLE
[BUG FIX] [MER-4721] [MER-4722] Fix bugs on Manual Scoring page

### DIFF
--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -219,7 +219,7 @@ defmodule Oli.Rendering.Activity.Html do
       |> HtmlEntities.encode()
 
     [
-      ~s|<#{tag} id="activity-#{resource_id}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+      ~s|<#{tag} id="activity-#{resource_id}-#{Ecto.UUID.generate()}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -218,8 +218,13 @@ defmodule Oli.Rendering.Activity.Html do
       |> Poison.encode!()
       |> HtmlEntities.encode()
 
+    activity_resource_id =
+      if mode == :review,
+        do: "activity-#{resource_id}-#{Ecto.UUID.generate()}}",
+        else: "activity-#{resource_id}"
+
     [
-      ~s|<#{tag} id="activity-#{resource_id}-#{Ecto.UUID.generate()}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
+      ~s|<#{tag} id="#{activity_resource_id}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
 

--- a/lib/oli_web/live/manual_grading/rendering.ex
+++ b/lib/oli_web/live/manual_grading/rendering.ex
@@ -17,6 +17,12 @@ defmodule OliWeb.ManualGrading.Rendering do
 
     effective_settings = Oli.Delivery.Settings.get_combined_settings(resource_attempt)
 
+    content_for_ordinal_assignment =
+      case resource_attempt.content do
+        nil -> resource_attempt.revision.content
+        content -> content
+      end
+
     %Context{
       user: attempt.user,
       section_slug: section_slug,
@@ -30,7 +36,8 @@ defmodule OliWeb.ManualGrading.Rendering do
           nil,
           nil,
           effective_settings,
-          prune: false
+          prune: false,
+          assign_ordinals_from: content_for_ordinal_assignment
         ),
       activity_types_map: activity_types_map,
       resource_attempt: resource_attempt


### PR DESCRIPTION
Tickets: [MER-4721](https://eliterate.atlassian.net/browse/MER-4721), [MER-4722](https://eliterate.atlassian.net/browse/MER-4722)

his PR includes two commits, each addressing one of the bugs described in the tickets above.

- Commit ddcac643a599a66fdf35ab00bc8ddaa037e6594c forces the re-rendering of the response attempt.
- Commit 60e20932fa634333c9283b0b2f4930406cc21516 adds a missing argument needed to calculate the order of the questions.

https://github.com/user-attachments/assets/db327c40-08b6-4546-af9f-e29c2311e5c2

