### PR TITLE
[BUG FIX] [MER-4724] Fix data types of section resource fields

### DIFF
--- a/priv/repo/migrations/20250625153539_change_sr_datatypes.exs
+++ b/priv/repo/migrations/20250625153539_change_sr_datatypes.exs
@@ -1,0 +1,10 @@
+defmodule Oli.Repo.Migrations.ChangeSrDatatypes do
+  use Ecto.Migration
+
+  def change do
+    execute("ALTER TABLE section_resources ALTER COLUMN title type text")
+    execute("ALTER TABLE section_resources ALTER COLUMN poster_image type text")
+    execute("ALTER TABLE section_resources ALTER COLUMN intro_video type text")
+  end
+end
+3

--- a/priv/repo/migrations/20250625153539_change_sr_datatypes.exs
+++ b/priv/repo/migrations/20250625153539_change_sr_datatypes.exs
@@ -7,4 +7,3 @@ defmodule Oli.Repo.Migrations.ChangeSrDatatypes do
     execute("ALTER TABLE section_resources ALTER COLUMN intro_video type text")
   end
 end
-3

--- a/test/oli/delivery/sections/data_types_test.exs
+++ b/test/oli/delivery/sections/data_types_test.exs
@@ -1,0 +1,48 @@
+defmodule Oli.Delivery.Sections.DataTypeTest do
+  use Oli.DataCase
+
+  alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Repo
+
+  defp setup_section(_) do
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_objective("objective one", :o1)
+
+    Seeder.ensure_published(map.publication.id)
+
+    Seeder.create_section_resources(map)
+  end
+
+  describe "data type length" do
+    setup [:setup_section]
+
+    @tag isolation: "serializable"
+    test "data type length of section resources",
+         %{
+           o1: o1,
+           section: section
+         } do
+      # read the current section resource record
+      sr = Oli.Delivery.Sections.get_section_resource(section.id, o1.resource.id)
+
+      # verfiy that for the title, poster_image, and intro_video fields that we can persist
+      # a string of length 1000
+      attrs = %{
+        title: String.duplicate("a", 1000),
+        poster_image: String.duplicate("b", 1000),
+        intro_video: String.duplicate("c", 1000)
+      }
+
+      {:ok, _} =
+        SectionResource.changeset(sr, attrs)
+        |> Repo.update()
+
+      sr = Oli.Delivery.Sections.get_section_resource(section.id, o1.resource.id)
+      assert sr.title == String.duplicate("a", 1000)
+      assert sr.poster_image == String.duplicate("b", 1000)
+      assert sr.intro_video == String.duplicate("c", 1000)
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the data type of the `title`, `poster_image` and `intro_video` fields of the `section_resources` table from `VARCHAR(255)` to `TEXT`, thus matching the same type for those fields from the `revisions` table.  

This prevents project resources with titles greater than 255 characters from breaking the publication process.

The added unit test fails without the migration.  With the migration in place it succeeds.  

