### PR TITLE
[ENHANCEMENT] [MER-4738] student name sorting in customer reports is case insensitive

### DIFF
--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -158,7 +158,7 @@ defmodule Oli.Grading do
   def format_score(score) when is_number(score), do: StudentUtils.parse_score(score)
 
   defp sort_data(results) do
-    Enum.sort_by(results, &{&1["Status"], &1["Name"], &1["Email"], &1["LMS ID"]})
+    Enum.sort_by(results, &{&1["Status"], String.downcase(&1["Name"]), &1["Email"], &1["LMS ID"]})
   end
 
   @doc """

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -330,12 +330,14 @@ defmodule OliWeb.Components.Delivery.Students do
       :name ->
         Enum.sort_by(
           students,
-          fn student -> Utils.name(student.name, student.given_name, student.family_name) end,
+          fn student ->
+            String.downcase(Utils.name(student.name, student.given_name, student.family_name))
+          end,
           sort_order
         )
 
       :email ->
-        Enum.sort_by(students, fn student -> student.email end, sort_order)
+        Enum.sort_by(students, fn student -> String.downcase(student.email) end, sort_order)
 
       :last_interaction ->
         Enum.sort_by(students, & &1.last_interaction, {sort_order, DateTime})

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -580,7 +580,10 @@ defmodule OliWeb.DeliveryController do
   end
 
   defp sort_data(results) do
-    Enum.sort_by(results, &{&1.status, &1.name, &1.email, &1.lms_id})
+    Enum.sort_by(
+      results,
+      &{&1.status, String.downcase(&1.name), String.downcase(&1.email), &1.lms_id}
+    )
   end
 
   defp convert_to_percentage(%{progress: nil}), do: 0

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
@@ -203,6 +203,56 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
                |> Timex.format!("{Mshort}. {0D}, {YYYY} - {h12}:{m} {AM}")
     end
 
+    test "students table sorting case insensitive", %{instructor: instructor, conn: conn} do
+      %{section: section} = Oli.Seeder.base_project_with_larger_hierarchy()
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      [{"Zach", "zhu"}, {"zach", "Zhao"}, {"Alex", "Bill"}, {"alex", "bell"}, {"Will", "Smith"}]
+      |> Enum.shuffle()
+      |> Enum.each(fn {given_name, family_name} ->
+        insert(:user, %{given_name: given_name, family_name: family_name})
+        |> Map.get(:id)
+        |> Sections.enroll(section.id, [ContextRoles.get_role(:context_learner)])
+      end)
+
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+
+      params = %{sort_order: :asc, sort_by: :name}
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      [student_for_tr_1, student_for_tr_2, student_for_tr_3, student_for_tr_4, student_for_tr_5] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert student_for_tr_1 =~ "bell, alex"
+      assert student_for_tr_2 =~ "Bill, Alex"
+      assert student_for_tr_3 =~ "Smith, Will"
+      assert student_for_tr_4 =~ "Zhao, zach"
+      assert student_for_tr_5 =~ "zhu, Zach"
+
+      params = %{sort_order: :desc, sort_by: :name}
+
+      {:ok, view, _html} = live(conn, live_view_students_route(section.slug, params))
+
+      [student_for_tr_1, student_for_tr_2, student_for_tr_3, student_for_tr_4, student_for_tr_5] =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{.instructor_dashboard_table tr a})
+        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+
+      assert student_for_tr_5 =~ "bell, alex"
+      assert student_for_tr_4 =~ "Bill, Alex"
+      assert student_for_tr_3 =~ "Smith, Will"
+      assert student_for_tr_2 =~ "Zhao, zach"
+      assert student_for_tr_1 =~ "zhu, Zach"
+    end
+
     test "students table gets rendered considering the given url params", %{
       instructor: instructor,
       conn: conn


### PR DESCRIPTION
Ticket: [MER-4738](https://eliterate.atlassian.net/browse/MER-4738)

This PR makes student name and email sorting case-insensitive in customer reports and UI tables, in the areas specified in the ticket.

Note: The approach used here doesn't prevent a random order when names are identical. For example, having `Smith, Joe` and `smith, joe `could result in:

```
[Smith, Joe, smith, joe]
or
[smith, joe, Smith, Joe]
```
[MER-4738]: https://eliterate.atlassian.net/browse/MER-4738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ