### PR TITLE
[BUG FIX] [MER-4686] Can leave names empty on account editing

### DIFF
--- a/lib/oli/accounts/schemas/author.ex
+++ b/lib/oli/accounts/schemas/author.ex
@@ -284,6 +284,7 @@ defmodule Oli.Accounts.Author do
       :email_confirmed_at
     ])
     |> cast_embed(:preferences)
+    |> common_name_validations()
     |> unique_constraint(:email)
     |> default_system_role()
     |> maybe_hash_password([])

--- a/lib/oli/accounts/schemas/user.ex
+++ b/lib/oli/accounts/schemas/user.ex
@@ -334,7 +334,7 @@ defmodule Oli.Accounts.User do
       :hidden
     ])
     |> cast_embed(:preferences)
-    |> validate_required([:given_name, :family_name])
+    |> common_name_validations()
     |> maybe_name_from_given_and_family()
   end
 
@@ -376,6 +376,7 @@ defmodule Oli.Accounts.User do
       :hidden
     ])
     |> cast_embed(:preferences)
+    |> common_name_validations()
     |> validate_email_if(&is_independent_learner_and_not_guest/1)
     |> maybe_name_from_given_and_family()
   end

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -533,4 +533,34 @@ defmodule Oli.Utils do
 
   defp compare(f, t, true), do: f <= t
   defp compare(f, t, false), do: f < t
+
+  @doc """
+  Validates the given_name and family_name fields.
+
+  ## Examples
+
+      iex> common_name_validations(changeset)
+      %Ecto.Changeset{data: %Author{}}
+
+      iex> common_name_validations(changeset)
+      %Ecto.Changeset{data: %User{}}
+
+  """
+  @spec common_name_validations(Ecto.Changeset.t()) :: Ecto.Changeset.t()
+  def common_name_validations(changeset) do
+    changeset
+    |> update_change(:given_name, &maybe_trim/1)
+    |> update_change(:family_name, &maybe_trim/1)
+    |> validate_length(:given_name, min: 1, message: "Please enter a First Name.")
+    |> validate_length(:family_name,
+      min: 2,
+      message: "Please enter a Last Name that is at least two characters long."
+    )
+  end
+
+  defp maybe_trim(nil), do: ""
+  defp maybe_trim(val) when is_binary(val), do: String.trim(val)
+
+  def input_value(%Phoenix.HTML.FormField{value: val}), do: val
+  def input_value(_), do: nil
 end

--- a/lib/oli_web/live/author_settings_live.ex
+++ b/lib/oli_web/live/author_settings_live.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.AuthorSettingsLive do
   use OliWeb, :live_view
 
+  import Oli.Utils
+
   alias Oli.Accounts
   alias Oli.Accounts.Author
   alias Oli.AssentAuth.AuthorAssentAuth
@@ -21,7 +23,13 @@ defmodule OliWeb.AuthorSettingsLive do
               phx-submit="update_author"
               phx-change="validate_author"
             >
-              <.input field={@author_form[:name]} type="text" label="Full name" readonly />
+              <.input
+                field={@author_form[:name]}
+                type="text"
+                label="Full name"
+                value={@author_form[:name].value}
+                readonly
+              />
               <.input field={@author_form[:given_name]} type="text" label="First name" />
               <.input field={@author_form[:family_name]} type="text" label="Last name" />
 
@@ -208,16 +216,22 @@ defmodule OliWeb.AuthorSettingsLive do
     {:ok, socket}
   end
 
-  def handle_event("validate_author", params, socket) do
-    %{"author" => author_params} = params
+  def handle_event("validate_author", %{"author" => author_params}, socket) do
+    %{author_form: author_form} = socket.assigns
+
+    author_data = %Author{
+      name: input_value(author_form[:name]),
+      given_name: input_value(author_form[:given_name]),
+      family_name: input_value(author_form[:family_name])
+    }
 
     author_form =
-      socket.assigns.current_author
+      author_data
       |> Accounts.change_author_details(author_params)
       |> Map.put(:action, :validate)
       |> to_form()
 
-    {:noreply, assign(socket, author_form: author_form)}
+    {:noreply, assign(socket, author_form: author_form) |> clear_flash()}
   end
 
   def handle_event("update_author", params, socket) do

--- a/lib/oli_web/live/user_settings_live.ex
+++ b/lib/oli_web/live/user_settings_live.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.UserSettingsLive do
   use OliWeb, :live_view
 
+  import Oli.Utils
+
   alias Oli.Accounts
   alias Oli.Accounts.{User, Author}
   alias Oli.AssentAuth.UserAssentAuth
@@ -21,7 +23,13 @@ defmodule OliWeb.UserSettingsLive do
               phx-submit="update_user"
               phx-change="validate_user"
             >
-              <.input field={@user_form[:name]} type="text" label="Full name" readonly />
+              <.input
+                field={@user_form[:name]}
+                type="text"
+                label="Full name"
+                value={@user_form[:name].value}
+                readonly
+              />
               <.input field={@user_form[:given_name]} type="text" label="First name" />
               <.input field={@user_form[:family_name]} type="text" label="Last name" />
 
@@ -199,16 +207,22 @@ defmodule OliWeb.UserSettingsLive do
     {:ok, socket}
   end
 
-  def handle_event("validate_user", params, socket) do
-    %{"user" => user_params} = params
+  def handle_event("validate_user", %{"user" => user_params}, socket) do
+    %{user_form: user_form} = socket.assigns
+
+    user_data = %User{
+      name: input_value(user_form[:name]),
+      given_name: input_value(user_form[:given_name]),
+      family_name: input_value(user_form[:family_name])
+    }
 
     user_form =
-      socket.assigns.current_user
+      user_data
       |> Accounts.change_user_details(user_params)
       |> Map.put(:action, :validate)
       |> to_form()
 
-    {:noreply, assign(socket, user_form: user_form)}
+    {:noreply, assign(socket, user_form: user_form) |> clear_flash()}
   end
 
   def handle_event("update_user", params, socket) do

--- a/lib/oli_web/live/users/author_detail_view.ex
+++ b/lib/oli_web/live/users/author_detail_view.ex
@@ -58,10 +58,11 @@ defmodule OliWeb.Users.AuthorsDetailView do
            current_author: socket.assigns.current_author,
            breadcrumbs: set_breadcrumbs(author),
            author: author,
-           changeset: author_changeset(author),
            disabled_edit: true,
            author_roles: SystemRole.role_id(),
-           password_reset_link: ""
+           password_reset_link: "",
+           author_name: author.name,
+           form: author_form(author)
          )}
     end
   end
@@ -71,10 +72,12 @@ defmodule OliWeb.Users.AuthorsDetailView do
   attr(:title, :string, default: "Author Details")
   attr(:author, Author, required: true)
   attr(:modal, :any, default: nil)
-  attr(:changeset, :map)
   attr(:disabled_edit, :boolean, default: true)
+  attr(:disabled_submit, :boolean, default: false)
   attr(:author_roles, :map, default: %{})
   attr(:password_reset_link, :string)
+  attr(:author_name, :string)
+  attr(:form, :map)
 
   def render(assigns) do
     ~H"""
@@ -84,42 +87,41 @@ defmodule OliWeb.Users.AuthorsDetailView do
       <Groups.render>
         <Group.render label="Details" description="User details">
           <.form
-            :let={f}
             id="edit_author"
-            for={@changeset}
+            for={@form}
             phx-change="change"
             phx-submit="submit"
             autocomplete="off"
           >
-            <ReadOnly.render label="Name" value={@author.name} />
+            <ReadOnly.render label="Name" value={@author_name} />
             <div class="form-group">
               <label for="given_name">First Name</label>
               <.input
-                value={fetch_field(@changeset, :given_name)}
+                field={@form[:given_name]}
                 id="given_name"
-                name="author[given_name]"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:bottom}
               />
             </div>
             <div class="form-group">
               <label for="family_name">Last Name</label>
               <.input
-                value={fetch_field(@changeset, :family_name)}
+                field={@form[:family_name]}
                 id="family_name"
-                name="author[family_name]"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:bottom}
               />
             </div>
             <div class="form-group">
               <label for="email">Email</label>
               <.input
-                value={fetch_field(@changeset, :email)}
+                field={@form[:email]}
                 id="email"
-                name="author[email]"
                 class="form-control"
                 disabled={@disabled_edit}
+                error_position={:bottom}
               />
             </div>
             <div class="form-group">
@@ -127,7 +129,7 @@ defmodule OliWeb.Users.AuthorsDetailView do
               <.input
                 type="select"
                 class="form-control"
-                field={f[:system_role_id]}
+                field={@form[:system_role_id]}
                 options={
                   Enum.map(@author_roles, fn {_type, id} ->
                     {role(id), id}
@@ -143,6 +145,7 @@ defmodule OliWeb.Users.AuthorsDetailView do
                 variant={:primary}
                 type="submit"
                 class="float-right btn btn-md btn-primary mt-2"
+                disabled={@disabled_submit}
               >
                 Save
               </.button>
@@ -362,7 +365,15 @@ defmodule OliWeb.Users.AuthorsDetailView do
   end
 
   def handle_event("change", %{"author" => params}, socket) do
-    {:noreply, assign(socket, changeset: author_changeset(socket.assigns.author, params))}
+    form = author_form(socket.assigns.author, params)
+
+    socket =
+      socket
+      |> assign(form: form)
+      |> assign(disabled_submit: !Enum.empty?(form.errors))
+      |> assign(author_name: "#{params["given_name"]} #{params["family_name"]}")
+
+    {:noreply, socket}
   end
 
   def handle_event("submit", %{"author" => params}, socket) do
@@ -373,12 +384,19 @@ defmodule OliWeb.Users.AuthorsDetailView do
          |> put_flash(:info, "Author successfully updated.")
          |> assign(
            author: author,
-           changeset: author_changeset(author, params),
-           disabled_edit: true
+           form: author_form(author, params),
+           disabled_edit: true,
+           author_name: author.name
          )}
 
-      {:error, _error} ->
-        {:noreply, put_flash(socket, :error, "Author couldn't be updated.")}
+      {:error, error} ->
+        form = to_form(error)
+
+        {:noreply,
+         socket
+         |> assign(form: form)
+         |> assign(disabled_submit: !Enum.empty?(form.errors))
+         |> put_flash(:error, "Author couldn't be updated.")}
     end
   end
 
@@ -386,9 +404,11 @@ defmodule OliWeb.Users.AuthorsDetailView do
     {:noreply, socket |> assign(disabled_edit: false)}
   end
 
-  defp author_changeset(author, attrs \\ %{}) do
-    Author.noauth_changeset(author, attrs)
+  defp author_form(author, attrs \\ %{}) do
+    author
+    |> Author.noauth_changeset(attrs)
     |> Map.put(:action, :update)
+    |> to_form()
   end
 
   defp role(system_role_id) do

--- a/test/oli/delivery/sections/enrollments_browse_test.exs
+++ b/test/oli/delivery/sections/enrollments_browse_test.exs
@@ -28,7 +28,7 @@ defmodule Oli.Delivery.Sections.EnrollmentsBrowseTest do
         sub: UUID.uuid4(),
         name: "#{v}",
         given_name: "#{v}",
-        family_name: "#{v}",
+        family_name: "name_#{v}",
         middle_name: "",
         picture: "https://platform.example.edu/jane.jpg",
         email: "test#{v}@example.edu",

--- a/test/oli_web/live/admin_live_test.exs
+++ b/test/oli_web/live/admin_live_test.exs
@@ -1204,5 +1204,72 @@ defmodule OliWeb.AdminLiveTest do
              |> element("input[value=\"#{new_first_name} #{new_last_name}\"][disabled]")
              |> render() =~ "#{new_first_name} #{new_last_name}"
     end
+
+    test "shows error message when First Name is empty", %{conn: conn, author: author} do
+      {:ok, view, _html} = live(conn, live_view_author_detail_route(author.id))
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "author" => %{
+          "given_name" => "",
+          "family_name" => author.family_name,
+          "email" => author.email
+        }
+      })
+
+      assert render(view) =~ "Please enter a First Name"
+    end
+
+    test "shows error message when Last Name is shorter than 2 characters", %{
+      conn: conn,
+      author: author
+    } do
+      {:ok, view, _html} = live(conn, live_view_author_detail_route(author.id))
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "author" => %{
+          "given_name" => author.given_name,
+          "family_name" => "A",
+          "email" => author.email
+        }
+      })
+
+      assert render(view) =~ "Please enter a Last Name that is at least two characters long."
+    end
+
+    test "shows both error messages when First Name is empty and Last Name has less than 2 characters on form submit",
+         %{conn: conn, author: author} do
+      {:ok, view, _html} = live(conn, live_view_author_detail_route(author.id))
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "author" => %{
+          "given_name" => "",
+          "family_name" => "A",
+          "email" => author.email
+        }
+      })
+
+      html = render(view)
+
+      assert html =~ "Please enter a First Name"
+      assert html =~ "Please enter a Last Name that is at least two characters long."
+    end
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
@@ -1793,7 +1793,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         sub: UUID.uuid4(),
         name: "#{v}",
         given_name: "#{v}",
-        family_name: "#{v}",
+        family_name: "name_#{v}",
         middle_name: "",
         picture: "https://platform.example.edu/jane.jpg",
         email: "test#{v}@example.edu",

--- a/test/oli_web/live/user_settings_live_test.exs
+++ b/test/oli_web/live/user_settings_live_test.exs
@@ -37,6 +37,123 @@ defmodule OliWeb.UserSettingsLiveTest do
     end
   end
 
+  describe "update name form" do
+    test "shows error message when First Name is empty", %{conn: conn} do
+      user = user_fixture()
+
+      {:ok, lv, _html} =
+        conn
+        |> log_in_user(user)
+        |> live(~p"/users/settings")
+
+      result =
+        lv
+        |> element("#user_form")
+        |> render_change(%{
+          "user" => %{
+            "given_name" => "",
+            "family_name" => "Doe"
+          }
+        })
+
+      assert result =~ "Please enter a First Name."
+    end
+
+    test "shows error message when Last Name is less than two characters", %{conn: conn} do
+      user = user_fixture()
+
+      {:ok, lv, _html} =
+        conn
+        |> log_in_user(user)
+        |> live(~p"/users/settings")
+
+      result =
+        lv
+        |> element("#user_form")
+        |> render_change(%{
+          "user" => %{
+            "given_name" => "John",
+            "family_name" => "D"
+          }
+        })
+
+      assert result =~ "Please enter a Last Name that is at least two characters long."
+    end
+
+    test "shows both error messages when First Name is empty and Last Name has less than 2 characters on form submit",
+         %{conn: conn} do
+      user = user_fixture(%{given_name: "John", family_name: "Doe"})
+
+      {:ok, lv, _html} =
+        conn
+        |> log_in_user(user)
+        |> live(~p"/users/settings")
+
+      invalid_params = %{
+        "given_name" => "",
+        "family_name" => "A"
+      }
+
+      result =
+        lv
+        |> form("#user_form", %{"user" => invalid_params})
+        |> render_submit()
+
+      assert result =~ "Please enter a First Name."
+      assert result =~ "Please enter a Last Name that is at least two characters long."
+    end
+
+    test "shows correct full name when first name or last name change", %{conn: conn} do
+      user = user_fixture(%{given_name: "John", family_name: "Doe"})
+
+      {:ok, lv, _html} =
+        conn
+        |> log_in_user(user)
+        |> live(~p"/users/settings")
+
+      # Simulate user changing first name
+      result =
+        lv
+        |> element("#user_form")
+        |> render_change(%{"user" => %{"given_name" => "Jane", "family_name" => "Doe"}})
+
+      assert result =~ "Full name"
+      assert result =~ "Jane Doe"
+
+      # Simulate user changing last name
+      result =
+        lv
+        |> element("#user_form")
+        |> render_change(%{"user" => %{"given_name" => "Jane", "family_name" => "Smith"}})
+
+      assert result =~ "Full name"
+      assert result =~ "Jane Smith"
+    end
+
+    test "shows flash message when first name or last name are successfully updated", %{
+      conn: conn
+    } do
+      user = user_fixture(%{given_name: "John", family_name: "Doe"})
+
+      {:ok, lv, _html} =
+        conn
+        |> log_in_user(user)
+        |> live(~p"/users/settings")
+
+      updated_params = %{
+        "given_name" => "Jane",
+        "family_name" => "Smith"
+      }
+
+      result =
+        lv
+        |> form("#user_form", %{"user" => updated_params})
+        |> render_submit()
+
+      assert result =~ "Account details successfully updated."
+    end
+  end
+
   describe "update email form" do
     setup %{conn: conn} do
       password = valid_user_password()

--- a/test/oli_web/live/users/user_detail_view_test.exs
+++ b/test/oli_web/live/users/user_detail_view_test.exs
@@ -214,6 +214,110 @@ defmodule OliWeb.Users.UsersDetailViewTest do
              |> element("input[value=\"#{new_given_name} #{new_last_name}\"][disabled]")
              |> render() =~ "#{new_given_name} #{new_last_name}"
     end
+
+    test "shows error message when First Name is empty", %{
+      conn: conn,
+      admin: admin,
+      independent_student: independent_student
+    } do
+      conn =
+        Plug.Test.init_test_session(conn, %{})
+        |> log_in_author(admin)
+
+      conn =
+        get(
+          conn,
+          ~p"/admin/users/#{independent_student.id}"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "user" => %{
+          "given_name" => "",
+          "family_name" => independent_student.family_name,
+          "email" => independent_student.email
+        }
+      })
+
+      assert render(view) =~ "Please enter a First Name"
+    end
+
+    test "shows error message when Last Name is shorter than 2 characters", %{
+      conn: conn,
+      admin: admin,
+      independent_student: independent_student
+    } do
+      conn =
+        Plug.Test.init_test_session(conn, %{})
+        |> log_in_author(admin)
+
+      conn =
+        get(
+          conn,
+          ~p"/admin/users/#{independent_student.id}"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "user" => %{
+          "given_name" => independent_student.given_name,
+          "family_name" => "A",
+          "email" => independent_student.email
+        }
+      })
+
+      assert render(view) =~ "Please enter a Last Name that is at least two characters long."
+    end
+
+    test "shows both error messages when First Name is empty and Last Name has less than 2 characters on form submit",
+         %{
+           conn: conn,
+           admin: admin,
+           independent_student: independent_student
+         } do
+      conn =
+        Plug.Test.init_test_session(conn, %{})
+        |> log_in_author(admin)
+
+      conn =
+        get(
+          conn,
+          ~p"/admin/users/#{independent_student.id}"
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click=\"start_edit\"]", "Edit")
+      |> render_click()
+
+      view
+      |> element("form[phx-submit=\"submit\"")
+      |> render_submit(%{
+        "user" => %{
+          "given_name" => "",
+          "family_name" => "A",
+          "email" => independent_student.email
+        }
+      })
+
+      assert render(view) =~ "Please enter a First Name"
+      assert render(view) =~ "Please enter a Last Name that is at least two characters long."
+    end
   end
 
   describe "user cannot access when is not logged in" do


### PR DESCRIPTION
[MER-4686](https://eliterate.atlassian.net/browse/MER-4686)

This PR fixes the bug  view that allowed leaving the First Name and Last Name fields empty and saving the changes in the Account Settings. Now, the First Name cannot be empty and the Last Name must have at least two non-whitespace characters.

Additionally, the Full Name is automatically updated on the screen as the First Name or Last Name fields are edited. If the entered values do not meet the validation requirements, error messages are shown on the corresponding fields.

Both the First Name and Last Name are saved without leading or trailing spaces, as was already the case. This applies both when a user edits their own account and when an administrator edits another user’s account.

Author Account Settings


https://github.com/user-attachments/assets/9ac30013-a681-48af-a608-8279bf14be60



User Account Settings


https://github.com/user-attachments/assets/6619d7ca-e048-4471-a823-6a48265bd8cd





[MER-4686]: https://eliterate.atlassian.net/browse/MER-4686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ