### PR TITLE
[BUG FIX] [MER-4742] [MER-4743] Fix issue when sorting by empty emails -- case: guess users

### DIFF
--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -337,7 +337,7 @@ defmodule OliWeb.Components.Delivery.Students do
         )
 
       :email ->
-        Enum.sort_by(students, fn student -> String.downcase(student.email) end, sort_order)
+        Enum.sort_by(students, fn student -> String.downcase("#{student.email}") end, sort_order)
 
       :last_interaction ->
         Enum.sort_by(students, & &1.last_interaction, {sort_order, DateTime})

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -582,7 +582,7 @@ defmodule OliWeb.DeliveryController do
   defp sort_data(results) do
     Enum.sort_by(
       results,
-      &{&1.status, String.downcase(&1.name), String.downcase(&1.email), &1.lms_id}
+      &{&1.status, String.downcase(&1.name), String.downcase("#{&1.email}"), &1.lms_id}
     )
   end
 


### PR DESCRIPTION
Tickets: [MER-4742](https://eliterate.atlassian.net/browse/MER-4742), [MER-4743](https://eliterate.atlassian.net/browse/MER-4743)

This PR fixes an issue where having empty emails on the Student Report page causes an error when sorting by that column or downloading the report. The error occurred because `String.downcase/2` expects a string as its first argument, but emails are `nil` for guest users.

https://github.com/user-attachments/assets/0217481f-05c7-4ecc-b7ab-1721f12f2d6b



[MER-4742]: https://eliterate.atlassian.net/browse/MER-4742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-4743]: https://eliterate.atlassian.net/browse/MER-4743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ