### PR TITLE
[BUG FIX] [MER-4726] Student Exceptions: Default to first assessment when none selected

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -26,7 +26,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   end
 
   def update(assigns, socket) do
-    params = decode_params(assigns.params)
+    params = decode_params(assigns.params, assigns.assessments)
 
     selected_assessment =
       Enum.find(assigns.assessments, fn a -> a.resource_id == params.selected_assessment_id end)
@@ -846,7 +846,14 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
     })
   end
 
-  def decode_params(params) do
+  defp default_selected_assesment_id(params, assesments) do
+    case {Params.get_int_param(params, "assessment_id", 0), assesments} do
+      {0, [%{resource_id: assesment_id} | _]} -> assesment_id
+      {assesment_id, _} -> assesment_id
+    end
+  end
+
+  defp decode_params(params, assesments) do
     %{
       offset: Params.get_int_param(params, "offset", @default_params.offset),
       limit: Params.get_int_param(params, "limit", @default_params.limit),
@@ -874,7 +881,7 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
           ],
           @default_params.sort_by
         ),
-      selected_assessment_id: Params.get_int_param(params, "assessment_id", 0)
+      selected_assessment_id: default_selected_assesment_id(params, assesments)
     }
   end
 

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -2697,5 +2697,37 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert exception.late_start == :disallow
       assert exception.late_submit == :disallow
     end
+
+    test "defaults to first assessment when none is selected", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      student_2: student_2
+    } do
+      # set up one exception on each of two assessments
+      set_student_exception(section, page_1.resource, student_1)
+      set_student_exception(section, page_2.resource, student_2)
+
+      # load the student_exceptions tab with no specific assessment selected
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(section.slug, "student_exceptions", "all")
+        )
+
+      # verify the first assessment (page_1) is selected by default
+      selected =
+        view
+        |> element(~s{select[id="assessment_select_assessment_id"] option[selected]})
+        |> render()
+
+      assert selected =~ page_1.title
+
+      # and only exceptions for that first assessment are shown
+      [se] = table_as_list_of_maps(view, :student_exceptions)
+      assert se.student =~ student_1.name
+    end
   end
 end


### PR DESCRIPTION
When opening the student‐exceptions view without an explicit assessment, automatically select the first assessment in the dropdown.


https://github.com/user-attachments/assets/1a73c147-26a6-4639-890a-75772d042f52



See: https://eliterate.atlassian.net/browse/MER-4726