### PR TITLE
[BUG FIX] [MER-4664] Fix Scientific Notation Failure On Very Small Floats

### DIFF
--- a/lib/oli/delivery/evaluation/rule.ex
+++ b/lib/oli/delivery/evaluation/rule.ex
@@ -148,7 +148,7 @@ defmodule Oli.Delivery.Evaluation.Rule do
 
         # The comparison is successful if the difference is within the calculated tolerance
         # and the precision (number of significant figures) matches the expected value.
-        abs_diff < tolerance && check_precision(left, r_precision)
+        abs_diff <= tolerance && check_precision(left, r_precision)
 
       true ->
         l_value = parse_number(left)

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -290,5 +290,8 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
     assert eval("attemptNumber = {1} && input < {4#1}", "3")
     assert eval("attemptNumber = {1} && input > {3#2}", "3.1")
     assert eval("attemptNumber = {1} && input > {3#1}", "4")
+
+    # Ensures small scientific notation floats are not incorrectly considered equal
+    refute eval("input = {2.2e-10}", "2.2e-11")
   end
 end

--- a/test/oli/delivery/evaluation/rule_eval_test.exs
+++ b/test/oli/delivery/evaluation/rule_eval_test.exs
@@ -293,5 +293,8 @@ defmodule Oli.Delivery.Evaluation.RuleEvalTest do
 
     # Ensures small scientific notation floats are not incorrectly considered equal
     refute eval("input = {2.2e-10}", "2.2e-11")
+
+    # Ensures 0.0 is considered equal to 0.0
+    assert eval("input = {0.0}", "0.0")
   end
 end


### PR DESCRIPTION
[MER-4733](https://eliterate.atlassian.net/browse/MER-4733)

### Problem
Previously, the evaluation logic for numeric answers in scientific notation used only an absolute tolerance (`0.00001`) when comparing floating-point values. This approach caused a bug where, for very small numbers (e.g., `2.2e-10`), the absolute tolerance was much larger than the actual values being compared. As a result, answers with different exponents (such as `2.2e-10` and `2.2e-11`) were incorrectly considered equal, allowing students to submit answers with the wrong exponent and still be marked correct.

**Example of the bug:**
- Expected answer: `2.2e-10`
- Student input: `2.2e-11`
- Result: Marked as correct (incorrect behavior)

### Solution
This PR updates the float comparison logic to use only a relative tolerance when comparing floating-point values. The allowed error is now always a fixed percentage of the largest value being compared. This ensures that answers with different exponents are never considered equal, regardless of how small the numbers are, and that the comparison remains robust for all representable float values.

**How it works:**
- The absolute difference between the expected and input values is compared to a relative tolerance (e.g., `1.0e-10 * max(|expected|, |input|)`).
- If the difference is less than the tolerance, the values are considered equal.
- This approach prevents false positives for answers with different exponents, while still allowing for minor floating-point imprecision.
- 
**Example (now works as intended):**
- Expected answer: `2.2e-10`
- Student input: `2.2e-11`
- Result: Marked as incorrect (correct behavior)

### Summary
- Removes absolute tolerance from float comparison.
- Uses only relative tolerance for robust and accurate scientific notation evaluation.
- Adds a regression test to ensure answers with different exponents are not considered equal.



https://github.com/user-attachments/assets/f54e9bd1-f571-4b3d-8f1a-5842f39ea44c



[MER-4733]: https://eliterate.atlassian.net/browse/MER-4733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ