### PR TITLE
[BUG FIX] [MER-4438] My Assignments text formatting is wonky

### DIFF
--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -822,21 +822,24 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         "flex h-full px-2.5 py-3.5 rounded-xl border flex-col justify-start items-start hover:cursor-pointer relative overflow-hidden z-0 before:content-[''] before:absolute before:left-0 before:top-0 before:w-0.5 before:h-full before:z-10"
       ]}>
         <div class="self-stretch justify-between items-start flex pl-2">
-          <div class="grow shrink basis-0 self-stretch flex-col justify-start items-start gap-2.5 flex">
-            <div role="container_label" class="justify-start items-start gap-2 flex uppercase">
-              <div class="dark:text-white text-opacity-60 text-xs font-bold whitespace-nowrap">
+          <div class="flex flex-col justify-start items-start gap-2.5 flex-grow min-w-0 overflow-hidden pr-2">
+            <div
+              role="container_label"
+              class="uppercase w-full min-w-0 dark:text-white text-opacity-60 text-xs font-bold break-words"
+            >
+              <span class="break-words">
                 <%= @unit["label"] %>
-              </div>
-
-              <div :if={@module} class="flex items-center gap-2">
-                <div class="dark:text-white text-opacity-60 text-xs font-bold">•</div>
-                <div class="dark:text-white text-opacity-60 text-xs font-bold whitespace-nowrap">
-                  <%= @module["label"] %>
-                </div>
-              </div>
+                <%= if @module do %>
+                  <span class="mx-2">•</span><%= @module["label"] %>
+                <% end %>
+              </span>
             </div>
-            <div role="title" class="self-stretch pb-2.5 justify-start items-start gap-2.5 flex">
-              <div class="grow shrink basis-0 dark:text-white text-opacity-90 text-lg font-semibold">
+
+            <div
+              role="title"
+              class="self-stretch pb-2.5 justify-start items-start gap-2.5 flex min-w-0"
+            >
+              <div class="grow shrink basis-0 dark:text-white text-opacity-90 text-lg font-semibold break-words">
                 <%= @lesson.title %>
               </div>
             </div>


### PR DESCRIPTION
[MER-4438](https://eliterate.atlassian.net/browse/MER-4438)

This PR fixes a visual issue in the `My Assignments` section on the student’s home page, where the Unit and Module texts were overflowing the container and hiding content and icons. 

Now, the texts respect the maximum width defined, wrapping to a new line if necessary to prevent overlapping or content going outside the container. 

Additionally, the container height adjusts automatically to display the full content.

- Before

![my-assignments-before](https://github.com/user-attachments/assets/bf44b9fd-c65a-4c1f-8f0e-08ec20966d6b)

- After

![my-assignments-after](https://github.com/user-attachments/assets/63e6864a-3711-4803-be15-26b49c0c0591)


[MER-4438]: https://eliterate.atlassian.net/browse/MER-4438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ