### PR TITLE
[BUG FIX] [MER-4756] Targeted retake not persisting from project to section

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2817,7 +2817,8 @@ defmodule Oli.Delivery.Sections do
         assessment_mode: revision.assessment_mode,
         batch_scoring: revision.batch_scoring,
         replacement_strategy: revision.replacement_strategy,
-        section_id: section.id
+        section_id: section.id,
+        retake_mode: revision.retake_mode
       }
       |> SectionResource.to_map()
       |> Map.delete(:id)


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4756) to the ticket

The issue was that the retake mode was not being copied into the section resource insert when creating a new course