### PR TITLE
[BUG FIX] [MER-4754] Cannot Set Incorrect Value Points in Activities

### DIFF
--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -80,10 +80,9 @@ export const getIncorrectResponse = (model: HasParts, partId: string) => {
   return Maybe.maybe(
     getResponsesByPartId(model, partId).find((r) => {
       return (
-        r.score === 0 &&
-        (r.rule === matchRule('.*') ||
-          // Allow for special rule form used by ResponseMulti
-          (r.rule.startsWith('input_ref') && MultiRule.ruleIsCatchAll(r.rule)))
+        r.rule === matchRule('.*') ||
+        // Allow for special rule form used by ResponseMulti
+        (r.rule.startsWith('input_ref') && MultiRule.ruleIsCatchAll(r.rule))
       );
     }),
   ).valueOrThrow(new Error('Could not find incorrect response'));


### PR DESCRIPTION
[MER-4757](https://eliterate.atlassian.net/browse/MER-4757)

### Problem
Previously, the code assumed that the "incorrect" response for an activity part always had a score of `0`. This caused errors when using custom scoring, where an "incorrect" response could have a different score (e.g., `1`). As a result, the system failed to identify the catch-all incorrect response and threw an exception.

### Solution
The logic for finding the "incorrect" response was updated to match only the catch-all rule (e.g., `input like {.*}`), regardless of its score. This makes the code compatible with custom scoring scenarios and prevents runtime errors when the score is not zero.


https://github.com/user-attachments/assets/66b99505-983e-48ff-b314-b8d3bc3db3b5



[MER-4757]: https://eliterate.atlassian.net/browse/MER-4757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ