### PR TITLE
[FEATURE] [MER-4077] Add ability to remove password in assessment settings

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -592,6 +592,10 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
            }
          )}
 
+      {key = :password, assessment_setting_id, new_value} ->
+        AssessmentSettings.do_update(key, assessment_setting_id, new_value, resources)
+        |> process_updated_result(socket, assessment_setting_id, key, new_value)
+
       {key, assessment_setting_id, new_value} when new_value != "" ->
         AssessmentSettings.do_update(key, assessment_setting_id, new_value, resources)
         |> process_updated_result(socket, assessment_setting_id, key, new_value)

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -762,6 +762,34 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       |> has_element?()
     end
 
+    test "can remove password", ctx do
+      %{conn: conn, section: section, page_1: %{resource_id: resource_id}} = ctx
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      # Set a password to page 1
+      set_password(view, resource_id, "strong_password!")
+
+      # Verify change of password
+      assert view |> element("input[type=password][value='****************']") |> has_element?()
+
+      # Remove password - Set to ""
+      set_password(view, resource_id, "")
+
+      assert view
+             |> element("input[placeholder='Enter password'][name='password-#{resource_id}]")
+             |> has_element?()
+    end
+
+    defp set_password(view, resource_id, password) do
+      view
+      |> form(~s{form[for="settings_table"]})
+      |> render_change(%{
+        "_target" => ["password-#{resource_id}"],
+        "password-#{resource_id}" => password
+      })
+    end
+
     test "exception count links to corresponding student exceptions for that assessment",
          %{
            conn: conn,
@@ -1681,12 +1709,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert Settings.fetch_all_settings_changes() == []
 
       # we change page 3 password setting to "asdf"
-      view
-      |> form(~s{form[for="settings_table"]})
-      |> render_change(%{
-        "_target" => ["password-#{page_3.resource.id}"],
-        "password-#{page_3.resource.id}" => "asdf"
-      })
+      set_password(view, page_3.resource_id, "asdf")
 
       changes = Settings.fetch_all_settings_changes()
       change_for_page_3 = hd(changes)


### PR DESCRIPTION
Ticket: [MER-4077](https://eliterate.atlassian.net/browse/MER-4077)

This PR adds the ability to remove an assessment’s password by leaving the input field empty.

https://github.com/user-attachments/assets/0698b4fc-680b-47b7-be6c-fe08a27eca9f



[MER-4077]: https://eliterate.atlassian.net/browse/MER-4077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ