### PR TITLE
[BUG FIX] [MER-4759] Add section_id to get_delivery_setting_by/1 to fetch correct delivery settings

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -894,7 +894,8 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
 
     Delivery.get_delivery_setting_by(%{
       resource_id: socket.assigns.params.selected_assessment_id,
-      user_id: user_id
+      user_id: user_id,
+      section_id: socket.assigns.section.id
     })
     |> StudentException.changeset(changes)
     |> Repo.update()

--- a/priv/repo/migrations/20250703151227_add_unique_constraint_to_delivery_settings_table.exs
+++ b/priv/repo/migrations/20250703151227_add_unique_constraint_to_delivery_settings_table.exs
@@ -1,0 +1,7 @@
+defmodule Oli.Repo.Migrations.AddUniqueConstraintToDeliverySettingsTable do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:delivery_settings, [:section_id, :resource_id, :user_id])
+  end
+end


### PR DESCRIPTION
Ticket: [MER-4759](https://eliterate.atlassian.net/browse/MER-4759)

This PR adds the `section_id` field to the `get_delivery_setting_by/1` function to fetch the correct delivery settings. This is necessary when two different course sections from the same project have student exceptions for the same student.

This PR also adds a unique constraint to the `delivery_settings` table on the `[:section_id, :resource_id, :user_id]` combination to ensure data consistency.