### PR TITLE
[BUG FIX] [MER-4762] Fix broken redirect when canceling section creation

### DIFF
--- a/lib/oli_web/live/new_course/new_course.ex
+++ b/lib/oli_web/live/new_course/new_course.ex
@@ -456,14 +456,14 @@ defmodule OliWeb.Delivery.NewCourse do
   end
 
   def handle_event("redirect_to_courses", _, socket) do
-    {:noreply,
-     redirect(socket,
-       to:
-         if(socket.assigns.lti_params,
-           do: Routes.delivery_path(socket, :index),
-           else: Routes.live_path(socket, OliWeb.Workspaces.Instructor)
-         )
-     )}
+    redirect_path =
+      cond do
+        socket.assigns.lti_params -> ~p"/sections"
+        socket.assigns.current_author -> ~p"/admin/sections"
+        true -> ~p"/workspaces/instructor"
+      end
+
+    {:noreply, push_navigate(socket, to: redirect_path)}
   end
 
   def handle_event("source_selection", %{"id" => source}, socket) do


### PR DESCRIPTION
Ticket: [MER-4762](https://eliterate.atlassian.net/browse/MER-4762)

This PR fixes the redirect bug when canceling the creation of a section. The issue was caused by a route that no longer exists.


https://github.com/user-attachments/assets/b2a108cf-9331-4503-beea-fefe0bfe7ae0

