### PR TITLE
[BUG FIX] [MER-4440] No paragraph spacing for long questions

### DIFF
--- a/assets/src/data/content/writers/renderer.tsx
+++ b/assets/src/data/content/writers/renderer.tsx
@@ -15,7 +15,7 @@ interface Props {
 export const HtmlContentModelRenderer: React.FC<Props> = (props) => {
   // Support content persisted when RichText had a `model` property.
   const content = (props.content as any).model ? (props.content as any).model : props.content;
-  const className = props.inline ? 'inline' : '';
+  const className = props.inline ? 'inline content' : 'content';
 
   const dispatchPageContentChange = useCallback(
     () => Events.dispatch(Events.Registry.PageContentChange, Events.makePageContentChangeEvent({})),


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4440?atlOrigin=eyJpIjoiOTlkZTlhOTQzM2YwNDU2OThhNzRjZDI3YzRiZTkzYzQiLCJwIjoiaiJ9) to the ticket

The issue was that the HtmlContentModelRenderer component did not have the required [`content`](https://github.com/Simon-Initiative/oli-torus/blob/cab4c4a84b19e152bb0baa7bf35cc1435d14c071/assets/styles/common/elements.scss#L49) class that adds spacing between p tags (line height and margin bottom)

#### Authoring
<img width="1432" alt="Screenshot 2025-07-07 at 1 43 30 PM" src="https://github.com/user-attachments/assets/eb233bbb-9296-47b1-a223-8026e7a75007" />



#### Delivery (before)
<img width="1432" alt="Screenshot 2025-07-07 at 1 44 04 PM" src="https://github.com/user-attachments/assets/d6df07e1-6774-4fd1-8527-fd35d72ebff9" />


#### Delivery (after)
<img width="1432" alt="Screenshot 2025-07-07 at 1 44 24 PM" src="https://github.com/user-attachments/assets/d25427dc-13d1-4e65-a85c-5a900ac60563" />
