### PR TITLE
[BUG FIX] [MER-4685] sub objectives missing from instructor insights tab

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -4932,15 +4932,9 @@ defmodule Oli.Delivery.Sections do
   directly attached to them.
   """
   def get_objectives_and_subobjectives(%Section{slug: section_slug} = section, opts \\ []) do
-    student_id =
-      if opts[:student_id],
-        do: opts[:student_id],
-        else: nil
+    student_id = if opts[:student_id], do: opts[:student_id], else: nil
 
-    exclude_sub_objectives =
-      if opts[:exclude_sub_objectives],
-        do: true,
-        else: false
+    exclude_sub_objectives = if opts[:exclude_sub_objectives], do: true, else: false
 
     # get the minimal fields for all objectives from the database
     objective_id = Oli.Resources.ResourceType.id_for_objective()
@@ -4956,20 +4950,10 @@ defmodule Oli.Delivery.Sections do
       })
       |> Repo.all()
 
-    id_list =
-      objectives
-      |> Enum.map(& &1.resource_id)
+    id_list = Enum.map(objectives, & &1.resource_id)
 
     proficiencies_for_objectives =
-      case student_id do
-        nil ->
-          Metrics.proficiency_per_student_for_objective(section.id, id_list)
-
-        student_id ->
-          Metrics.proficiency_per_student_for_objective(section.id, id_list,
-            student_id: student_id
-          )
-      end
+      Metrics.proficiency_per_student_for_objective(section.id, id_list, student_id: student_id)
 
     student_ids =
       Sections.enrolled_student_ids(section_slug)
@@ -4985,8 +4969,9 @@ defmodule Oli.Delivery.Sections do
           end)
 
         proficiency_dist =
-          student_proficiency
-          |> Enum.frequencies_by(fn {_student_id, proficiency} -> proficiency end)
+          Enum.frequencies_by(student_proficiency, fn {_student_id, proficiency} ->
+            proficiency
+          end)
 
         proficiency_mode =
           proficiency_dist
@@ -5060,9 +5045,9 @@ defmodule Oli.Delivery.Sections do
               objective_resource_id: objective.resource_id,
               student_proficiency_obj: student_proficiency_obj,
               student_proficiency_obj_dist: student_proficiency_obj_dist,
-              subobjective: "",
+              subobjective: nil,
               subobjective_resource_id: nil,
-              student_proficiency_subobj: ""
+              student_proficiency_subobj: nil
             })
 
           case exclude_sub_objectives do
@@ -5081,14 +5066,14 @@ defmodule Oli.Delivery.Sections do
 
                   Map.merge(sub_objective, %{
                     section_id: section.id,
-                    objective: objective.title,
-                    objective_resource_id: objective.resource_id,
-                    student_proficiency_obj: student_proficiency_obj,
-                    student_proficiency_obj_dist: student_proficiency_obj_dist,
-                    subobjective: sub_objective.title,
-                    subobjective_resource_id: sub_objective.resource_id,
+                    objective: sub_objective.title,
+                    objective_resource_id: sub_objective.resource_id,
+                    student_proficiency_obj: student_proficiency_subobj,
+                    student_proficiency_obj_dist: student_proficiency_subobj_dist,
+                    subobjective: sub_objective,
+                    subobjective_resource_id: nil,
                     student_proficiency_subobj: student_proficiency_subobj,
-                    student_proficiency_subobj_dist: student_proficiency_subobj_dist
+                    student_proficiency_subobj_dist: nil
                   })
                 end)
 
@@ -5100,7 +5085,7 @@ defmodule Oli.Delivery.Sections do
           end
 
         # this is a subobjective, we do nothing as it will be handled in the context of its parent(s)
-        _ ->
+        _true ->
           all
       end
     end)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5066,14 +5066,14 @@ defmodule Oli.Delivery.Sections do
 
                   Map.merge(sub_objective, %{
                     section_id: section.id,
-                    objective: sub_objective.title,
-                    objective_resource_id: sub_objective.resource_id,
-                    student_proficiency_obj: student_proficiency_subobj,
-                    student_proficiency_obj_dist: student_proficiency_subobj_dist,
-                    subobjective: sub_objective,
-                    subobjective_resource_id: nil,
+                    objective: objective.title,
+                    objective_resource_id: objective.resource_id,
+                    student_proficiency_obj: student_proficiency_obj,
+                    student_proficiency_obj_dist: student_proficiency_obj_dist,
+                    subobjective: sub_objective.title,
+                    subobjective_resource_id: sub_objective.resource_id,
                     student_proficiency_subobj: student_proficiency_subobj,
-                    student_proficiency_subobj_dist: nil
+                    student_proficiency_subobj_dist: student_proficiency_subobj_dist
                   })
                 end)
 

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -367,12 +367,18 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   end
 
   def handle_event("clear_all_filters", _params, socket) do
-    %{section_slug: section_slug} = socket.assigns
+    section_slug = socket.assigns.section_slug
 
-    {:noreply,
-     push_patch(socket,
-       to: ~p"/sections/#{section_slug}/instructor_dashboard/insights/learning_objectives"
-     )}
+    path =
+      case Map.get(socket.assigns, :student_id) do
+        nil ->
+          ~p"/sections/#{section_slug}/instructor_dashboard/insights/learning_objectives"
+
+        student_id ->
+          ~p"/sections/#{section_slug}/student_dashboard/#{student_id}/learning_objectives"
+      end
+
+    {:noreply, push_navigate(socket, to: path)}
   end
 
   def handle_event("filter_by", %{"filter" => filter}, socket) do
@@ -512,6 +518,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
           "sort_by",
           [
             :objective,
+            :objective_instructor_dashboard,
             :subobjective,
             :student_proficiency_obj,
             :student_proficiency_subobj
@@ -589,8 +596,47 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
                     |> Enum.with_index()
                     |> Enum.into(%{})
 
+  @proficiency_rank_desc [nil, "High", "Medium", "Low", "Not enough data"]
+                         |> Enum.with_index()
+                         |> Enum.into(%{})
+
   defp sort_by(objectives, :student_proficiency_obj, sort_order) do
-    Enum.sort_by(objectives, &{@proficiency_rank[&1.student_proficiency_obj]}, sort_order)
+    Enum.sort_by(
+      objectives,
+      fn objective ->
+        case Map.get(objective, :subobjective) do
+          nil -> @proficiency_rank[objective.student_proficiency_obj]
+          _ -> @proficiency_rank[objective.student_proficiency_subobj]
+        end
+      end,
+      sort_order
+    )
+  end
+
+  defp sort_by(objectives, :objective, sort_order) do
+    Enum.sort_by(objectives, &{&1.title}, sort_order)
+  end
+
+  defp sort_by(objectives, :objective_instructor_dashboard, sort_order) do
+    Enum.sort_by(objectives, &{&1.title}, sort_order)
+  end
+
+  defp sort_by(objectives, :student_proficiency_subobj, sort_order) do
+    case sort_order do
+      :desc ->
+        Enum.sort_by(
+          objectives,
+          &{@proficiency_rank_desc[&1.student_proficiency_subobj]},
+          sort_order
+        )
+
+      :asc ->
+        Enum.sort_by(
+          objectives,
+          &{@proficiency_rank[&1.student_proficiency_subobj]},
+          sort_order
+        )
+    end
   end
 
   defp sort_by(objectives, sort_by, sort_order) do

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -378,7 +378,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
           ~p"/sections/#{section_slug}/student_dashboard/#{student_id}/learning_objectives"
       end
 
-    {:noreply, push_navigate(socket, to: path)}
+    {:noreply, push_patch(socket, to: path)}
   end
 
   def handle_event("filter_by", %{"filter" => filter}, socket) do

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -585,6 +585,14 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     {total_count, rows}
   end
 
+  @proficiency_rank ["High", "Medium", "Low", "Not enough data"]
+                    |> Enum.with_index()
+                    |> Enum.into(%{})
+
+  defp sort_by(objectives, :student_proficiency_obj, sort_order) do
+    Enum.sort_by(objectives, &{@proficiency_rank[&1.student_proficiency_obj]}, sort_order)
+  end
+
   defp sort_by(objectives, sort_by, sort_order) do
     Enum.sort_by(objectives, fn obj -> obj[sort_by] end, sort_order)
   end

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -110,16 +110,6 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     """
   end
 
-  defp custom_render(assigns, objective, %ColumnSpec{name: :objective}) do
-    assigns = Map.merge(assigns, %{objective: objective.objective})
-
-    ~H"""
-    <div class="flex items-center ml-8 gap-x-4">
-      <span><%= @objective %></span>
-    </div>
-    """
-  end
-
   defp custom_render(assigns, objective, %ColumnSpec{name: :objective_instructor_dashboard}) do
     objective =
       case Map.get(objective, :subobjective) do

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -14,7 +14,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
   def new(objectives, :instructor_dashboard) do
     column_specs = [
       %ColumnSpec{
-        name: :objective,
+        name: :objective_instructor_dashboard,
         label: "LEARNING OBJECTIVE",
         render_fn: &custom_render/3,
         th_class: "pl-10"
@@ -22,6 +22,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
       %ColumnSpec{
         name: :student_proficiency_obj,
         label: "STUDENT PROFICIENCY",
+        render_fn: &custom_render/3,
         tooltip:
           "For all students, or one specific student, proficiency for a learning objective will be calculated off the percentage of correct answers for first part attempts within first activity attempts - for those parts that have that learning objective or any of its sub-objectives attached to it."
       },
@@ -76,15 +77,26 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     )
   end
 
-  defp custom_render(
-         assigns,
-         %{objective: objective, student_proficiency: student_proficiency} = _objectives,
-         %ColumnSpec{
-           name: :objective
-         }
-       ) do
+  defp custom_render(assigns, objectives, %ColumnSpec{name: :student_proficiency_obj}) do
+    student_proficiency =
+      case Map.get(objectives, :student_proficiency_subobj) do
+        nil -> objectives.student_proficiency_obj
+        _ -> objectives.student_proficiency_subobj
+      end
+
+    assigns = Map.put(assigns, :student_proficiency, student_proficiency)
+
+    ~H"""
+    <%= @student_proficiency %>
+    """
+  end
+
+  defp custom_render(assigns, objective, %ColumnSpec{name: :objective}) do
     assigns =
-      Map.merge(assigns, %{objective: objective, student_proficiency: student_proficiency})
+      Map.merge(assigns, %{
+        objective: objective.objective,
+        student_proficiency: Map.get(objective, :student_proficiency)
+      })
 
     ~H"""
     <div
@@ -98,43 +110,54 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     """
   end
 
-  defp custom_render(assigns, %{objective: objective} = _objectives, %ColumnSpec{
-         name: :objective
-       }) do
-    assigns = Map.merge(assigns, %{objective: objective})
+  defp custom_render(assigns, objective, %ColumnSpec{name: :objective}) do
+    assigns = Map.merge(assigns, %{objective: objective.objective})
 
     ~H"""
     <div class="flex items-center ml-8 gap-x-4">
-      <span></span>
       <span><%= @objective %></span>
     </div>
     """
   end
 
-  defp custom_render(assigns, %{subobjective: subobjective} = _objectives, %ColumnSpec{
-         name: :subobjective
-       }) do
-    assigns = Map.merge(assigns, %{subobjective: subobjective})
+  defp custom_render(assigns, objective, %ColumnSpec{name: :objective_instructor_dashboard}) do
+    objective =
+      case Map.get(objective, :subobjective) do
+        nil -> objective.objective
+        subobjective -> subobjective
+      end
+
+    assigns = Map.merge(assigns, %{objective: objective})
+
+    ~H"""
+    <div class="flex items-center ml-8 gap-x-4">
+      <span><%= @objective %></span>
+    </div>
+    """
+  end
+
+  defp custom_render(assigns, objectives, %ColumnSpec{name: :subobjective}) do
+    assigns = Map.merge(assigns, %{subobjective: objectives[:subobjective]})
 
     ~H"""
     <div><%= if is_nil(@subobjective), do: "-", else: @subobjective %></div>
     """
   end
 
-  defp custom_render(
-         assigns,
-         %{
-           resource_id: objective_id,
-           student_proficiency_obj_dist: student_proficiency_obj_dist
-         },
-         %ColumnSpec{
-           name: :student_proficiency_distribution
-         }
-       ) do
+  defp custom_render(assigns, objective, %ColumnSpec{name: :student_proficiency_distribution}) do
+    %{resource_id: objective_id, student_proficiency_obj_dist: student_proficiency_obj_dist} =
+      objective
+
+    proficiency_distribution =
+      case Map.get(objective, :student_proficiency_subobj_dist) do
+        nil -> student_proficiency_obj_dist
+        student_proficiency_subobj_dist -> student_proficiency_subobj_dist
+      end
+
     assigns =
       Map.merge(assigns, %{
         objective_id: objective_id,
-        proficiency_distribution: student_proficiency_obj_dist
+        proficiency_distribution: proficiency_distribution
       })
 
     ~H"""

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -399,7 +399,7 @@ defmodule OliWeb.DeliveryController do
 
             %{
               objective: (!subobjective && objective.title) || nil,
-              subobjective: subobjective && subobjective.title,
+              subobjective: subobjective && subobjective,
               student_proficiency_obj:
                 (!student_proficiency_subobj && student_proficiency_obj) || nil,
               student_proficiency_subobj: student_proficiency_subobj

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -399,7 +399,7 @@ defmodule OliWeb.DeliveryController do
 
             %{
               objective: (!subobjective && objective.title) || nil,
-              subobjective: subobjective && subobjective,
+              subobjective: subobjective,
               student_proficiency_obj:
                 (!student_proficiency_subobj && student_proficiency_obj) || nil,
               student_proficiency_subobj: student_proficiency_subobj

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -388,19 +388,27 @@ defmodule OliWeb.DeliveryController do
 
       section ->
         contents =
-          Sections.get_objectives_and_subobjectives(section)
+          Sections.get_objectives_and_subobjectives(section, exclude_sub_objectives: false)
           |> Enum.map(fn objective ->
             %{
-              objective: objective.objective,
-              subobjective: objective.subobjective,
-              student_proficiency_obj: objective.student_proficiency_obj,
-              student_proficiency_subobj: objective.student_proficiency_subobj
+              subobjective: subobjective,
+              student_proficiency_subobj: student_proficiency_subobj,
+              student_proficiency_obj: student_proficiency_obj
+            } =
+              objective
+
+            %{
+              objective: (!subobjective && objective.title) || nil,
+              subobjective: subobjective && subobjective.title,
+              student_proficiency_obj:
+                (!student_proficiency_subobj && student_proficiency_obj) || nil,
+              student_proficiency_subobj: student_proficiency_subobj
             }
           end)
           |> DataTable.new()
           |> DataTable.headers([
             :objective,
-            :subojective,
+            :subobjective,
             :student_proficiency_obj,
             :student_proficiency_subobj
           ])

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -80,7 +80,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         %{
           objectives:
             Sections.get_objectives_and_subobjectives(socket.assigns.section,
-              exclude_sub_objectives: true
+              exclude_sub_objectives: false
             ),
           filter_options:
             Sections.get_units_and_modules_from_a_section(socket.assigns.section.slug)

--- a/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
@@ -88,71 +88,15 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
         )
 
       # Row 1
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(1) [data-proficiency-check='true'] > span:last-child"
-             )
-             |> render() =~ obj_revision_1.title
-
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(1) > td:nth-child(2) > div > div"
-             )
-             |> render() ==
-               "<div>-</div>"
-
+      assert [obj_revision_1.title, "-"] == pull_data_from_table(view, 1)
       # Row 2
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(2) [data-proficiency-check='true'] > span:last-child"
-             )
-             |> render() =~ obj_revision_2.title
-
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(2) > td:nth-child(2) > div > div"
-             )
-             |> render() ==
-               "<div>-</div>"
-
+      assert [obj_revision_2.title, "-"] == pull_data_from_table(view, 2)
       # Row 3 - has subobjective 1
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(3) [data-proficiency-check='true'] > span:last-child"
-             )
-             |> render() =~ obj_revision_1.title
-
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(3) > td:nth-child(2) > div > div"
-             )
-             |> render() =~ subobj_rev_1.title
-
+      assert [obj_revision_1.title, subobj_rev_1.title] == pull_data_from_table(view, 3)
       # Row 4 - has subobjective 2 (We also check here the order)
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(4) [data-proficiency-check='true'] > span:last-child"
-             )
-             |> render() =~ obj_revision_1.title
-
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(4) > td:nth-child(2) > div > div"
-             )
-             |> render() =~ subobj_rev_3.title
-
+      assert [obj_revision_1.title, subobj_rev_3.title] == pull_data_from_table(view, 4)
       # Row 5 - has subobjective 2 (We also check here the order)
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(5) [data-proficiency-check='true'] > span:last-child"
-             )
-             |> render() =~ obj_revision_1.title
-
-      assert view
-             |> element(
-               "table.instructor_dashboard_table > tbody > tr:nth-child(5) > td:nth-child(2) > div > div"
-             )
-             |> render() =~ subobj_rev_2.title
+      assert [obj_revision_1.title, subobj_rev_2.title] == pull_data_from_table(view, 5)
     end
 
     test "gets rendered correctly", %{
@@ -612,5 +556,27 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       refute has_element?(view, "span", "#{revisions.obj_revision_e.title}")
       refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
     end
+  end
+
+  defp pull_data_from_table(view, row) do
+    col_1 =
+      view
+      |> element(
+        "table.instructor_dashboard_table > tbody > tr:nth-child(#{row}) [data-proficiency-check='true'] > span:last-child"
+      )
+      |> render()
+      |> Floki.parse_document!()
+      |> Floki.text()
+
+    col_2 =
+      view
+      |> element(
+        "table.instructor_dashboard_table > tbody > tr:nth-child(#{row}) > td:nth-child(2) > div > div"
+      )
+      |> render()
+      |> Floki.parse_document!()
+      |> Floki.text()
+
+    [col_1, col_2]
   end
 end


### PR DESCRIPTION
Ticket: [MER-4685](https://eliterate.atlassian.net/browse/MER-4685)

This PR restores the subobjectives on both the Section Learning Objectives page (Insight Tab) and the Student Learning Objectives page (Overview Tab).


https://github.com/user-attachments/assets/1aef234a-8958-4e3a-9ccc-ff9942712cd5


Note: For the following URL: http://localhost/sections/coursesection2/student_dashboard/3/learning_objectives?limit=10&sort_by=student_proficiency_obj the page crashes. This bug already exists in master. It **only** happens when the application starts, not when we visit the page.

Here is a snippet of the error trace:
```
[error] GenServer #PID<0.1186.0> terminating
** (FunctionClauseError) no function clause matching in OliWeb.Delivery.StudentDashboard.StudentDashboardLive.handle_event/3
    (oli 0.31.0) lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex:3: OliWeb.Delivery.StudentDashboard.StudentDashboardLive.handle_event("[[\"push\",{\"target\":2,\"event\":\"paged_table_limit_change\"}]]", %{"_target" => ["limit"], "limit" => "10"}, #Phoenix.LiveView.Socket<id: "phx-GFFQhlK74j6QUnVB", endpoint: OliWeb.Endpoint, view: OliWeb.Delivery.StudentDashboard.StudentDashboardLive, parent_pid: nil, root_pid: #PID<0.1186.0>, router: OliWeb.Router, assigns: %{params: %{"active_tab" => "learning_objectives", "limit" => "10", "section_slug" => "coursesection2", "sort_by" => "student_proficiency_obj", "student_id" => "3"}, user_token: "SFMyNTY.g2gDbQAAACRmNWFmOTg0ZS1hMmJjLTRmMmItYjk5YS02NGJmMjRjMWM5YzNuBgDShnL7lwFiAAFRgA.lFfzIZ7u3Sq7TU8GA1fuNRoEiCfPAzJ-1FQp-iE8irE", __changed__: %{}, preview_mode: false, is_admin: true, ctx: %OliWeb.Common.SessionContext{browser_timezone: "America/New_York",
```

[MER-4685]: https://eliterate.atlassian.net/browse/MER-4685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ