### PR TITLE
[FEATURE] [MER-4683] Critical information missing from my courses page

### DIFF
--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -85,4 +85,19 @@ defmodule OliWeb.Components.Utils do
     </div>
     """
   end
+
+  @doc """
+  Given a list of instructors, returns a comma-separated string of their names
+
+  ## Examples
+
+      iex> list_instructors([%{name: "John Doe"}, %{name: "Jane Smith"}])
+      "John Doe, Jane Smith"
+  """
+  @spec list_instructors(list(map())) :: String.t()
+  def list_instructors(instructors) do
+    instructors
+    |> Enum.map(& &1.name)
+    |> Enum.join(", ")
+  end
 end

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -3,7 +3,6 @@ defmodule OliWeb.Common.Utils do
 
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Common.SessionContext
-  alias OliWeb.Common.FormatDateTime
 
   require Logger
 
@@ -26,19 +25,6 @@ defmodule OliWeb.Common.Utils do
       {true, _, _} -> name
       _ -> "Unknown"
     end
-  end
-
-  @doc """
-  Formats a date using the given format.
-
-  ## Examples
-
-      iex> format_date(~U[2023-09-06 13:28:00Z], %{SessionContext.init() | local_tz: "America/Montevideo"}, "{0M}/{0D}/{YY}")
-      "09/06/23"
-  """
-  @spec format_date(DateTime.t(), map(), String.t()) :: String.t()
-  def format_date(date, context, format) do
-    FormatDateTime.to_formatted_datetime(date, context, format)
   end
 
   def render_date(item, attr_name, %SessionContext{} = ctx) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.Common.Utils do
 
   alias Oli.Accounts.{User, Author}
   alias OliWeb.Common.SessionContext
+  alias OliWeb.Common.FormatDateTime
 
   require Logger
 
@@ -25,6 +26,19 @@ defmodule OliWeb.Common.Utils do
       {true, _, _} -> name
       _ -> "Unknown"
     end
+  end
+
+  @doc """
+  Formats a date using the given format.
+
+  ## Examples
+
+      iex> format_date(~U[2023-09-06 13:28:00Z], %{SessionContext.init() | local_tz: "America/Montevideo"}, "{0M}/{D}/{YY}")
+      "09/06/23"
+  """
+  @spec format_date(DateTime.t(), map(), String.t()) :: String.t()
+  def format_date(date, context, format) do
+    FormatDateTime.to_formatted_datetime(date, context, format)
   end
 
   def render_date(item, attr_name, %SessionContext{} = ctx) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -33,7 +33,7 @@ defmodule OliWeb.Common.Utils do
 
   ## Examples
 
-      iex> format_date(~U[2023-09-06 13:28:00Z], %{SessionContext.init() | local_tz: "America/Montevideo"}, "{0M}/{D}/{YY}")
+      iex> format_date(~U[2023-09-06 13:28:00Z], %{SessionContext.init() | local_tz: "America/Montevideo"}, "{0M}/{0D}/{YY}")
       "09/06/23"
   """
   @spec format_date(DateTime.t(), map(), String.t()) :: String.t()

--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -3,10 +3,10 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
 
   alias Oli.Delivery.Sections
   alias OliWeb.Backgrounds
-  alias OliWeb.Common.{Params, SearchInput}
+  alias OliWeb.Common.{FormatDateTime, Params, SearchInput}
   alias OliWeb.Icons
 
-  import OliWeb.Common.{SourceImage, Utils}
+  import OliWeb.Common.SourceImage
   import OliWeb.Components.Utils
 
   @default_params %{text_search: "", sidebar_expanded: true}
@@ -321,7 +321,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
           class="justify-center text-[#757682] text-xs font-bold uppercase leading-3"
           role="start_end_date"
         >
-          <%= format_date(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= format_date(
+          <%= FormatDateTime.to_formatted_datetime(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= FormatDateTime.to_formatted_datetime(
             @section.end_date,
             @ctx,
             "{Mshort} {YYYY}"

--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -6,8 +6,8 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   alias OliWeb.Common.{Params, SearchInput}
   alias OliWeb.Icons
 
-  import Ecto.Query, warn: false
-  import OliWeb.Common.SourceImage
+  import OliWeb.Common.{SourceImage, Utils}
+  import OliWeb.Components.Utils
 
   @default_params %{text_search: "", sidebar_expanded: true}
 
@@ -16,7 +16,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   ]
 
   @impl Phoenix.LiveView
-  def mount(_params, _session, %{assigns: %{current_user: current_user}} = socket)
+  def mount(_params, _session, %{assigns: %{current_user: current_user, ctx: ctx}} = socket)
       when not is_nil(current_user) do
     sections =
       current_user.id
@@ -27,7 +27,8 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
      assign(socket,
        sections: sections,
        filtered_sections: sections,
-       active_workspace: :instructor
+       active_workspace: :instructor,
+       ctx: ctx
      )}
   end
 
@@ -53,13 +54,14 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _uri, %{assigns: %{sections: sections}} = socket) do
+  def handle_params(params, _uri, %{assigns: %{sections: sections, ctx: ctx}} = socket) do
     params = decode_params(params)
 
     {:noreply,
      assign(socket,
        filtered_sections: maybe_filter_by_text(sections, params.text_search),
-       params: params
+       params: params,
+       ctx: ctx
      )}
   end
 
@@ -279,6 +281,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
                 index={index}
                 section={section}
                 params={@params}
+                ctx={@ctx}
               />
               <p :if={length(@filtered_sections) == 0} class="mt-4">
                 No course found matching <strong>"<%= @params.text_search %>"</strong>
@@ -294,6 +297,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   attr :section, :map
   attr :index, :integer
   attr :params, :map
+  attr :ctx, :map
 
   def instructor_course_card(assigns) do
     ~H"""
@@ -312,7 +316,17 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
         style={"background-image: url('#{cover_image(@section)}');"}
       >
       </div>
-      <div class="flex-col justify-start items-start gap-6 inline-flex p-8">
+      <div class="flex-col justify-start items-start gap-2 inline-flex p-8">
+        <div
+          class="justify-center text-[#757682] text-xs font-bold uppercase leading-3"
+          role="start_end_date"
+        >
+          <%= format_date(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= format_date(
+            @section.end_date,
+            @ctx,
+            "{Mshort} {YYYY}"
+          ) %>
+        </div>
         <h5
           class="text-black text-base font-bold font-['Inter'] leading-normal overflow-hidden"
           style="display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical;"
@@ -320,6 +334,17 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
         >
           <%= @section.title %>
         </h5>
+        <div
+          class="justify-center text-[#757682] text-base font-bold leading-normal"
+          role="instructors"
+        >
+          <%= if length(Sections.get_instructors_for_section(@section.id)) == 1 do %>
+            Instructor:
+          <% else %>
+            Instructors:
+          <% end %>
+          <%= list_instructors(Sections.get_instructors_for_section(@section.id)) %>
+        </div>
         <div class="text-black text-base font-normal leading-normal h-[100px] overflow-hidden">
           <p
             role="course description"

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -4,11 +4,10 @@ defmodule OliWeb.Workspaces.Student do
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Sections
   alias OliWeb.Backgrounds
-  alias OliWeb.Common.{Params, SearchInput}
+  alias OliWeb.Common.{FormatDateTime, Params, SearchInput}
   alias OliWeb.Common.SourceImage
 
   import Ecto.Query, warn: false
-  import OliWeb.Common.Utils
   import OliWeb.Components.Utils
   import OliWeb.Components.Delivery.Layouts
 
@@ -240,7 +239,7 @@ defmodule OliWeb.Workspaces.Student do
             class="justify-center text-[#bab8bf] text-xs font-bold uppercase leading-3"
             role="start_end_date"
           >
-            <%= format_date(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= format_date(
+            <%= FormatDateTime.to_formatted_datetime(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= FormatDateTime.to_formatted_datetime(
               @section.end_date,
               @ctx,
               "{Mshort} {YYYY}"

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -8,6 +8,8 @@ defmodule OliWeb.Workspaces.Student do
   alias OliWeb.Common.SourceImage
 
   import Ecto.Query, warn: false
+  import OliWeb.Common.Utils
+  import OliWeb.Components.Utils
   import OliWeb.Components.Delivery.Layouts
 
   @default_params %{
@@ -25,7 +27,7 @@ defmodule OliWeb.Workspaces.Student do
   end
 
   @impl Phoenix.LiveView
-  def mount(params, _session, %{assigns: %{current_user: current_user}} = socket)
+  def mount(params, _session, %{assigns: %{current_user: current_user, ctx: ctx}} = socket)
       when not is_nil(current_user) do
     sections =
       current_user.id
@@ -38,7 +40,8 @@ defmodule OliWeb.Workspaces.Student do
        sections: sections,
        params: params,
        filtered_sections: sections,
-       active_workspace: :student
+       active_workspace: :student,
+       ctx: ctx
      )}
   end
 
@@ -58,13 +61,18 @@ defmodule OliWeb.Workspaces.Student do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _uri, %{assigns: %{sections: sections}} = socket) do
+  def handle_params(
+        params,
+        _uri,
+        %{assigns: %{sections: sections, ctx: ctx}} = socket
+      ) do
     params = decode_params(params)
 
     {:noreply,
      assign(socket,
        filtered_sections: maybe_filter_by_text(sections, params.text_search),
-       params: params
+       params: params,
+       ctx: ctx
      )}
   end
 
@@ -184,6 +192,7 @@ defmodule OliWeb.Workspaces.Student do
               index={index}
               section={section}
               params={@params}
+              ctx={@ctx}
             />
             <p :if={length(@filtered_sections) == 0} class="mt-4">
               No course found matching <strong>"<%= @params.text_search %>"</strong>
@@ -198,6 +207,7 @@ defmodule OliWeb.Workspaces.Student do
   attr :index, :integer
   attr :section, :map
   attr :params, :map
+  attr :ctx, :map
 
   def course_card(assigns) do
     ~H"""
@@ -211,7 +221,7 @@ defmodule OliWeb.Workspaces.Student do
         )
         |> JS.remove_class("opacity-100 translate-x-0")
       }
-      class="opacity-0 relative flex items-center self-stretch md:h-[200px] w-full bg-cover py-4 md:py-12 px-6 md:px-24 text-white hover:text-white rounded-xl shadow-lg hover:no-underline transition-all hover:translate-x-3"
+      class="opacity-0 relative flex items-center self-stretch w-full bg-cover py-4 md:py-12 px-6 md:px-24 text-white hover:text-white rounded-xl shadow-lg hover:no-underline transition-all hover:translate-x-3"
       style={"background-image: url('#{SourceImage.cover_image(@section)}');"}
     >
       <div class="top-0 left-0 rounded-xl absolute w-full h-full mix-blend-difference bg-[linear-gradient(180deg,rgba(0,0,0,0.00)_0%,rgba(0,0,0,0.80)_100%),linear-gradient(90deg,rgba(0,0,0,0.80)_0%,rgba(0,0,0,0.40)_100%)]" />
@@ -225,15 +235,36 @@ defmodule OliWeb.Workspaces.Student do
         Complete
       </span>
       <div class="z-10 flex w-full items-center">
-        <div class="flex flex-col items-start gap-6">
+        <div class="flex flex-col items-start gap-2">
+          <div
+            class="justify-center text-[#bab8bf] text-xs font-bold uppercase leading-3"
+            role="start_end_date"
+          >
+            <%= format_date(@section.start_date, @ctx, "{Mshort} {YYYY}") %> - <%= format_date(
+              @section.end_date,
+              @ctx,
+              "{Mshort} {YYYY}"
+            ) %>
+          </div>
           <h5 class="text-2xl md:text-[36px] md:leading-[49px] font-semibold drop-shadow-md">
             <%= @section.title %>
           </h5>
           <div
-            class="flex flex-col md:flex-row drop-shadow-md"
+            class="justify-center text-[#bab8bf] text-base font-bold leading-normal"
+            role="instructors"
+          >
+            <%= if length(Sections.get_instructors_for_section(@section.id)) == 1 do %>
+              Instructor:
+            <% else %>
+              Instructors:
+            <% end %>
+            <%= list_instructors(Sections.get_instructors_for_section(@section.id)) %>
+          </div>
+          <div
+            class="flex flex-col md:flex-row items-center drop-shadow-md md:mt-4"
             role={"progress_for_section_#{@section.id}"}
           >
-            <h4 class="text-sm md:text-[16px] md:leading-[32px] tracking-[1.28px] uppercase mr-9">
+            <h4 class="text-sm md:text-[16px] md:leading-[32px] tracking-[1.28px] uppercase mr-9 whitespace-nowrap">
               Course Progress
             </h4>
             <.progress_bar percent={@section.progress} show_percent={true} width="100px" />

--- a/test/oli_web/live/workspaces/instructor_test.exs
+++ b/test/oli_web/live/workspaces/instructor_test.exs
@@ -359,5 +359,39 @@ defmodule OliWeb.Workspaces.InstructorTest do
                author.email
              )
     end
+
+    test "can see title, description, start date, end date and instructors in instructor workspace",
+         %{
+           conn: conn,
+           instructor: instructor
+         } do
+      section =
+        insert(:section, %{
+          open_and_free: true,
+          title: "The best course ever!",
+          description: "This is a description",
+          start_date: ~U[2025-01-01 00:00:00Z],
+          end_date: ~U[2026-01-01 00:00:00Z]
+        })
+
+      instructor_1 = insert(:user, %{name: "Lionel Messi"})
+      instructor_2 = insert(:user, %{name: "Angel Di Maria"})
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(instructor_1.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.enroll(instructor_2.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, ~p"/workspaces/instructor")
+
+      assert has_element?(view, "h5", "The best course ever!")
+      assert has_element?(view, "p", "This is a description")
+      assert has_element?(view, "div[role='start_end_date']", "Jan 2025 - Jan 2026")
+
+      assert has_element?(
+               view,
+               "div[role='instructors']",
+               ~r/Instructors:\s*#{instructor.name},\s*Lionel Messi,\s*Angel Di Maria/
+             )
+    end
   end
 end


### PR DESCRIPTION
[MER-4683](https://eliterate.atlassian.net/browse/MER-4683)

This PR adds the display of the course start and end dates, as well as instructor names, on the “My Courses” page for both students and instructors. 

This information is now visible directly on each course card.

**Instructor view**

<img width="1904" height="948" alt="instructor-view" src="https://github.com/user-attachments/assets/e5110e99-ec4b-4577-8e45-77a3939eb5bb" />

**Student view**

<img width="1550" height="950" alt="student-view" src="https://github.com/user-attachments/assets/7592b40c-f2af-44a5-a542-2b55c33b25c1" />


[MER-4683]: https://eliterate.atlassian.net/browse/MER-4683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ