### PR TITLE
[FEATURE] [MER-4684] Add available dates to student assignment UI - rework

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1068,11 +1068,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
                 <%= @unit["title"] %>
               </h3>
-              <div
-                :if={@has_scheduled_resources?}
-                class="ml-auto flex items-center gap-3"
-                role="schedule_details"
-              >
+              <div class="ml-auto flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span>
                     Available: <%= get_available_date(
@@ -1146,11 +1142,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               <h3 class="text-[26px] leading-[32px] tracking-[0.02px] font-normal dark:text-[#DDD]">
                 <%= @unit["title"] %>
               </h3>
-              <div
-                :if={@has_scheduled_resources?}
-                class="flex items-center gap-3"
-                role="schedule_details"
-              >
+              <div class="flex items-center gap-3" role="schedule_details">
                 <div class="text-[14px] leading-[32px] tracking-[0.02px] font-semibold">
                   <span>
                     <span class="text-gray-400 opacity-80 dark:text-[#696974] dark:opacity-100 mr-1">
@@ -1306,12 +1298,9 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                 "title"
               ] %>
             </h2>
-            <span
-              :if={@has_scheduled_resources?}
-              class="opacity-50 dark:text-white text-xs font-normal"
-            >
+            <span class="opacity-50 dark:text-white text-xs font-normal">
               <span>
-                Available: <%= format_date(
+                Available: <%= get_available_date(
                   selected_module[
                     "section_resource"
                   ].start_date,
@@ -1510,7 +1499,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             </div>
             <div class="flex justify-between items-center mb-3 w-full">
               <div
-                :if={@has_scheduled_resources?}
                 role={"unit #{@row["resource_id"]} scheduling details"}
                 class="dark:text-[#eeebf5]/75 text-sm font-semibold font-['Open Sans'] leading-none"
               >
@@ -1706,7 +1694,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             </div>
             <div class="flex justify-between items-center h-6 mb-3 w-full">
               <div
-                :if={@has_scheduled_resources?}
                 role={"module #{@row["resource_id"]} scheduling details"}
                 class="dark:text-[#eeebf5]/75 text-sm font-semibold font-['Open Sans'] leading-none"
               >
@@ -1821,10 +1808,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                     data-completed={"#{Enum.all?(grouped_pages, fn p -> p["completed"] end)}"}
                     class="h-[19px] mb-5"
                   >
-                    <span
-                      :if={@has_scheduled_resources?}
-                      class="dark:text-white text-sm font-bold font-['Open Sans']"
-                    >
+                    <span :if={@has_scheduled_resources?} class="dark:text-white text-sm font-bold">
                       <%= "#{Utils.label_for_scheduling_type(grouped_scheduling_type)}#{format_date(grouped_due_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}")}" %>
                     </span>
                   </div>
@@ -1948,7 +1932,6 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             </div>
             <div :if={@row["graded"]} role="due date and score" class="flex">
               <span
-                :if={@has_scheduled_resources?}
                 role="page due date"
                 class="opacity-60 text-[13px] font-normal font-['Open Sans'] !font-normal opacity-60 dark:text-white"
               >
@@ -2306,10 +2289,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
             <Student.duration_in_minutes duration_minutes={@duration_minutes} graded={@graded} />
           </div>
           <div :if={@graded} role="due date and score" class="flex">
-            <span
-              :if={@has_scheduled_resources?}
-              class="opacity-60 text-[13px] font-normal !font-normal opacity-60 dark:text-white"
-            >
+            <span class="opacity-60 text-[13px] font-normal !font-normal opacity-60 dark:text-white">
               <span>
                 Available: <%= get_available_date(
                   @available_date,
@@ -3268,7 +3248,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     Map.get(student_available_date_exceptions_per_resource_id, resource_id, start_date)
   end
 
-  defp format_date("Not yet scheduled", _context, _format), do: "Not yet scheduled"
+  defp format_date(date, _context, _format) when date in [nil, "", "Not yet scheduled"],
+    do: "None"
 
   defp format_date(due_date, context, format) do
     FormatDateTime.to_formatted_datetime(due_date, context, format)
@@ -3486,6 +3467,8 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     |> JS.dispatch("click", to: "#show_completed_button")
   end
 
-  defp get_available_date(nil, _ctx, _format), do: "Now"
+  defp get_available_date(date, _ctx, _format) when date in [nil, "", "Not yet scheduled"],
+    do: "Now"
+
   defp get_available_date(start_date, ctx, format), do: format_date(start_date, ctx, format)
 end

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -1795,7 +1795,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
                     Enum.filter(@row["children"], fn row ->
                       case {row["section_resource"].end_date, grouped_due_date,
                             row["section_resource"].scheduling_type, grouped_scheduling_type} do
-                        {nil, "Not yet scheduled", _, _} ->
+                        {nil, "Not yet scheduled", _, nil} ->
                           true
 
                         {end_date, grouped_due_date, sch_type, grouped_sch_type} ->
@@ -2998,7 +2998,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
 
   defp display_module_item?(
          _grouped_due_date,
-         "Not yet scheduled" = _grouped_scheduling_type,
+         nil = _grouped_scheduling_type,
          _student_end_date_exceptions_per_resource_id,
          %{"section_resource" => %{end_date: end_date}} = _child,
          _ctx
@@ -3063,7 +3063,7 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         scheduling_type_date_keywords
         |> Enum.reject(fn {_st, date} -> is_nil(date) end)
         |> Enum.sort_by(fn {_st, date} -> date end, {:asc, Date})
-        |> Enum.concat([{"Not yet scheduled", "Not yet scheduled"}])
+        |> Enum.concat([{nil, "Not yet scheduled"}])
       else
         Enum.sort_by(scheduling_type_date_keywords, fn {_st, date} -> date end, {:asc, Date})
       end

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -388,7 +388,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   def container_label_for_scheduling_type([:read_by]), do: "Read by: "
   def container_label_for_scheduling_type(_), do: "Due by: "
 
-  def label_for_scheduling_type(:due_by), do: "Due by: "
+  def label_for_scheduling_type(type) when type in [:due_by, "Not yet scheduled"], do: "Due by: "
   def label_for_scheduling_type(:read_by), do: "Read by: "
   def label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "
   def label_for_scheduling_type(_), do: ""

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -388,7 +388,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   def container_label_for_scheduling_type([:read_by]), do: "Read by: "
   def container_label_for_scheduling_type(_), do: "Due by: "
 
-  def label_for_scheduling_type(type) when type in [:due_by, "Not yet scheduled"], do: "Due by: "
+  def label_for_scheduling_type(type) when type in [:due_by, nil], do: "Due by: "
   def label_for_scheduling_type(:read_by), do: "Read by: "
   def label_for_scheduling_type(:inclass_activity), do: "In-class activity by: "
   def label_for_scheduling_type(_), do: ""

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2001,7 +2001,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       group_by_due_by_date_div = element(view, ~s{div[id="pages_grouped_by_due_by_2023-11-03"]})
 
       group_by_not_yet_scheduled_div =
-        element(view, ~s{div[id="pages_grouped_by_Not yet scheduled_Not yet scheduled"]})
+        element(view, ~s{div[id="pages_grouped_by__Not yet scheduled"]})
 
       assert render(group_by_read_by_date_div) =~ "Read by: Fri Nov 3, 2023"
       assert render(group_by_read_by_date_div) =~ "Page 11"
@@ -2009,7 +2009,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert render(group_by_due_by_date_div) =~ "Due by: Fri Nov 3, 2023"
       assert render(group_by_due_by_date_div) =~ "Page 12"
 
-      assert render(group_by_not_yet_scheduled_div) =~ "Not yet scheduled"
+      assert render(group_by_not_yet_scheduled_div) =~ "None"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 13"
       assert render(group_by_not_yet_scheduled_div) =~ "Page 14"
     end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -1546,10 +1546,10 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert view
              |> element(~s{div[role="unit_2"] div[role="schedule_details"]})
              |> render() =~
-               "Due by:\n              </span><span class=\"whitespace-nowrap\">\n                Not yet scheduled"
+               "Due by:\n              </span><span class=\"whitespace-nowrap\">\n                None"
     end
 
-    test "can not see the 'Not yet scheduled' label when the instructor has not set a schedule",
+    test "can see the 'None' label when the instructor has not set a schedule",
          %{conn: conn, user: user} do
       %{section: section_without_schedule} = create_elixir_project(%{}, false)
 
@@ -1561,8 +1561,9 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section_without_schedule.slug))
 
-      refute has_element?(view, ~s{div[role="unit_1"] div[role="schedule_details"]})
-      refute has_element?(view, ~s{div[role="unit_2"] div[role="schedule_details"]})
+      assert has_element?(view, ~s{div[role="unit_1"] div[role="schedule_details"]}, "None")
+
+      assert has_element?(view, ~s{div[role="unit_2"] div[role="schedule_details"]}, "None")
     end
 
     @tag :flaky
@@ -1734,7 +1735,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              |> element(
                ~s{div[id="top_level_page_#{top_level_page.resource_id}"] div[role="schedule_details"]}
              )
-             |> render() =~ "Not yet scheduled"
+             |> render() =~ "None"
 
       assert view
              |> element(~s{div[id="page_#{top_level_page.resource_id}"][role="resource card 1"]})
@@ -2534,7 +2535,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       assert view
              |> element(~s{div[role="unit #{unit_2.resource_id} scheduling details"]})
-             |> render() =~ "Not yet scheduled"
+             |> render() =~ "None"
 
       assert view
              |> element(~s{div[role="module #{module_1.resource_id} scheduling details"]})
@@ -2547,7 +2548,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
              |> render() =~ "Read by: Fri Nov 3, 2023"
     end
 
-    test "does not see scheduling details when course has no scheduled resources", %{
+    test "does see scheduling details when course has no scheduled resources", %{
       conn: conn,
       user: user
     } do
@@ -2560,16 +2561,16 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(conn, Utils.learn_live_path(section_without_schedule.slug, selected_view: :outline))
 
-      refute view
+      assert view
              |> has_element?(~s{div[role="unit #{unit_1.resource_id} scheduling details"]})
 
-      refute view
+      assert view
              |> has_element?(~s{div[role="unit #{unit_2.resource_id} scheduling details"]})
 
-      refute view
+      assert view
              |> has_element?(~s{div[role="module #{module_1.resource_id} scheduling details"]})
 
-      refute view
+      assert view
              |> has_element?(
                ~s{button[role="page 4 details"] div[role="due date and score"] span[role="page due date"]}
              )


### PR DESCRIPTION
[MER-4684](https://eliterate.atlassian.net/browse/MER-4684)

This PR introduces changes to ensure that due and available dates are always displayed, regardless of whether the course resources have a schedule set or not.

If the resources don’t have a schedule set, it will display:

`Available: Now         Due by: None`

- Gallery view

<img width="1913" height="957" alt="gallery-view-dates" src="https://github.com/user-attachments/assets/0507e8ed-530d-49e9-bb17-53ebd8cf6b48" />


- Outline view

<img width="1915" height="959" alt="outline-view-dates" src="https://github.com/user-attachments/assets/5ece1edf-235d-40bb-af4e-3a57dcaada60" />


[MER-4684]: https://eliterate.atlassian.net/browse/MER-4684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ