### PR TITLE
[BUG FIX] [MER-4328] Page edits not attributed to correct author

### DIFF
--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -37,7 +37,6 @@ defmodule OliWeb.Curriculum.ContainerLive do
   alias OliWeb.Common.Breadcrumb
   alias Oli.Delivery.Hierarchy
   alias Oli.Resources.Revision
-  alias Oli.Resources
   alias Oli.Delivery.Hierarchy.HierarchyNode
   alias OliWeb.Components.Modal
   alias OliWeb.Curriculum.Container.ContainerLiveHelpers
@@ -255,45 +254,11 @@ defmodule OliWeb.Curriculum.ContainerLive do
   end
 
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
-
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
-
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
-      |> to_form()
-
-    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
+    ContainerLiveHelpers.handle_validate_options(socket, revision_params)
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{
-      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
-      project: project,
-      author: author
-    } =
-      socket.assigns
-
-    revision_params =
-      revision_params
-      |> Map.put("author_id", author.id)
-      |> ContainerLiveHelpers.decode_revision_params()
-
-    case ContainerEditor.edit_page(project, revision.slug, revision_params) do
-      {:ok, _} ->
-        {:noreply,
-         socket
-         |> put_flash(
-           :info,
-           "#{resource_type_label(revision) |> String.capitalize()} options saved"
-         )
-         |> push_navigate(to: redirect_url)}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
-    end
+    ContainerLiveHelpers.handle_save_options(socket, revision_params)
   end
 
   def handle_event("show_move_modal", %{"slug" => slug}, socket) do

--- a/lib/oli_web/live/curriculum/container/container_live.ex
+++ b/lib/oli_web/live/curriculum/container/container_live.ex
@@ -269,10 +269,17 @@ defmodule OliWeb.Curriculum.ContainerLive do
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
+    %{
+      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
+      project: project,
+      author: author
+    } =
       socket.assigns
 
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+    revision_params =
+      revision_params
+      |> Map.put("author_id", author.id)
+      |> ContainerLiveHelpers.decode_revision_params()
 
     case ContainerEditor.edit_page(project, revision.slug, revision_params) do
       {:ok, _} ->

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -180,13 +180,12 @@ defmodule OliWeb.Resources.PagesView do
           ctx={@ctx}
           redirect_url={@options_modal_assigns.redirect_url}
           revision={@options_modal_assigns.revision}
-          changeset={@options_modal_assigns.changeset}
           project={@project}
           project_hierarchy={@project_hierarchy}
           validate={JS.push("validate-options")}
           submit={JS.push("save-options")}
           cancel={Modal.hide_modal("options_modal") |> JS.push("restart_options_modal")}
-          form={to_form(@options_modal_assigns.changeset)}
+          form={@options_modal_assigns.form}
         />
       <% end %>
       <div id="options-modal-assigns-trigger" data-show_modal={Modal.show_modal("options_modal")}>
@@ -445,7 +444,7 @@ defmodule OliWeb.Resources.PagesView do
           }
         ),
       revision: revision,
-      changeset: Resources.change_revision(revision),
+      form: to_form(Resources.change_revision(revision)),
       title: "#{resource_type_label(revision) |> String.capitalize()} Options"
     }
 
@@ -462,37 +461,11 @@ defmodule OliWeb.Resources.PagesView do
   end
 
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
-
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
-
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
-
-    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | changeset: changeset})}
+    ContainerLiveHelpers.handle_validate_options(socket, revision_params)
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
-      socket.assigns
-
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
-
-    case ContainerEditor.edit_page(project, revision.slug, revision_params) do
-      {:ok, _} ->
-        {:noreply,
-         socket
-         |> put_flash(
-           :info,
-           "#{resource_type_label(revision) |> String.capitalize()} options saved"
-         )
-         |> push_navigate(to: redirect_url)}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
-    end
+    ContainerLiveHelpers.handle_save_options(socket, revision_params)
   end
 
   def handle_event("show_move_modal", %{"slug" => slug}, socket) do

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -175,10 +175,17 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
+    %{
+      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
+      project: project,
+      author: author
+    } =
       socket.assigns
 
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+    revision_params =
+      revision_params
+      |> Map.put("author_id", author.id)
+      |> ContainerLiveHelpers.decode_revision_params()
 
     case ContainerEditor.edit_page(project, revision.slug, revision_params) do
       {:ok, _} ->

--- a/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/curriculum_live.ex
@@ -33,7 +33,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
   alias OliWeb.Common.Breadcrumb
   alias Oli.Delivery.Hierarchy
   alias Oli.Resources.Revision
-  alias Oli.Resources
   alias Oli.Delivery.Hierarchy.HierarchyNode
   alias OliWeb.Components.Modal
   alias OliWeb.Curriculum.Container.ContainerLiveHelpers
@@ -161,45 +160,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLive do
   end
 
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
-
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
-
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
-      |> to_form()
-
-    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
+    ContainerLiveHelpers.handle_validate_options(socket, revision_params)
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{
-      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
-      project: project,
-      author: author
-    } =
-      socket.assigns
-
-    revision_params =
-      revision_params
-      |> Map.put("author_id", author.id)
-      |> ContainerLiveHelpers.decode_revision_params()
-
-    case ContainerEditor.edit_page(project, revision.slug, revision_params) do
-      {:ok, _} ->
-        {:noreply,
-         socket
-         |> put_flash(
-           :info,
-           "#{resource_type_label(revision) |> String.capitalize()} options saved"
-         )
-         |> push_navigate(to: redirect_url)}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
-    end
+    ContainerLiveHelpers.handle_save_options(socket, revision_params)
   end
 
   def handle_event("show_move_modal", %{"slug" => slug}, socket) do

--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -237,7 +237,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
           }
         ),
       revision: revision,
-      changeset: Resources.change_revision(revision),
+      form: to_form(Resources.change_revision(revision)),
       title: "#{resource_type_label(revision) |> String.capitalize()} Options"
     }
 
@@ -254,44 +254,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
   end
 
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
-
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
-
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
-
-    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | changeset: changeset})}
+    ContainerLiveHelpers.handle_validate_options(socket, revision_params)
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{
-      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
-      project: project,
-      author: author
-    } =
-      socket.assigns
-
-    revision_params =
-      revision_params
-      |> Map.put("author_id", author.id)
-      |> ContainerLiveHelpers.decode_revision_params()
-
-    case ContainerEditor.edit_page(project, revision.slug, revision_params) do
-      {:ok, _} ->
-        {:noreply,
-         socket
-         |> put_flash(
-           :info,
-           "#{resource_type_label(revision) |> String.capitalize()} options saved"
-         )
-         |> push_navigate(to: redirect_url)}
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        {:noreply, assign(socket, :changeset, changeset)}
-    end
+    ContainerLiveHelpers.handle_save_options(socket, revision_params)
   end
 
   def handle_event("show_move_modal", %{"slug" => slug}, socket) do
@@ -514,13 +481,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
           ctx={@ctx}
           redirect_url={@options_modal_assigns.redirect_url}
           revision={@options_modal_assigns.revision}
-          changeset={@options_modal_assigns.changeset}
           project={@project}
           project_hierarchy={@project_hierarchy}
           validate={JS.push("validate-options")}
           submit={JS.push("save-options")}
           cancel={Modal.hide_modal("options_modal") |> JS.push("restart_options_modal")}
-          form={to_form(@options_modal_assigns.changeset)}
+          form={@options_modal_assigns.form}
         />
       <% end %>
       <div id="options-modal-assigns-trigger" data-show_modal={Modal.show_modal("options_modal")}>

--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -267,10 +267,17 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{redirect_url: redirect_url, revision: revision}, project: project} =
+    %{
+      options_modal_assigns: %{redirect_url: redirect_url, revision: revision},
+      project: project,
+      author: author
+    } =
       socket.assigns
 
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+    revision_params =
+      revision_params
+      |> Map.put("author_id", author.id)
+      |> ContainerLiveHelpers.decode_revision_params()
 
     case ContainerEditor.edit_page(project, revision.slug, revision_params) do
       {:ok, _} ->


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4689) to the ticket

The issue was that the `author_id` was not being updated when editing a revision.

In this PR I also refactored some code to avoid event-handling logic duplication between different liveviews


#### Before (revision author does not update correctly)

https://github.com/user-attachments/assets/8241d106-0aef-4766-ad9e-0539ecee29b9



#### After (revision author matches the user who updated the page)

https://github.com/user-attachments/assets/e7977b81-0093-4daa-a41d-5102167f5efd

