### PR TITLE
[BUG FIX] [MER-4757] Fix ability to set custom incorrect points [MER-4792] [MER-4801]

### DIFF
--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -22,8 +22,10 @@ export const ScoringActions = {
         model.scoringStrategy = ScoringStrategy.average;
         model.authoring?.parts?.forEach((part: Part) => {
           const oldCorrectScore = getOutOfPoints(model, part.id);
-          part.outOf = 1;
-          part.incorrectScore = 0;
+          // code part same as for single-part default scoring. Needed by TargetedFeedback
+          // on part which doesn't know if it is part of single or multi part activity.
+          part.outOf = null;
+          part.incorrectScore = null;
           part.responses?.forEach((response) => {
             response.score = response.score === oldCorrectScore ? 1 : 0;
           });

--- a/assets/src/components/activities/common/authoring/actions/scoringActions.ts
+++ b/assets/src/components/activities/common/authoring/actions/scoringActions.ts
@@ -1,22 +1,16 @@
 import { ActivityLevelScoring, Part, Response, ScoringStrategy } from 'components/activities/types';
 import {
-  getCorrectResponse,
-  getIncorrectResponse,
+  getIncorrectPoints,
   getOutOfPoints,
+  multiHasCustomScoring,
 } from 'data/activities/model/responses';
-
-// Migrated qs may have non-default point values but no customScoring attribute. To allow for this,
-// this method should be used rather than checking attribute. Attribute will get set if toggled
-export const usesCustomScoring = (model: ActivityLevelScoring) =>
-  model.customScoring ||
-  model.authoring.parts.some((part: Part) => part.responses.some((r: Response) => r.score > 1));
 
 export const ScoringActions = {
   toggleActivityDefaultScoring() {
-    // This toggles an activity-level default scoring flag, currently only used for multi input questions.
+    // This toggles an activity-level default scoring flag, used for potentially multipart questions
     return (model: ActivityLevelScoring) => {
       // attribute may not exist on migrated qs; this will set it
-      model.customScoring = !usesCustomScoring(model);
+      model.customScoring = !multiHasCustomScoring(model);
 
       if (model.customScoring) {
         // going from default to custom, so all responses should already be 1 or 0.
@@ -58,7 +52,7 @@ export const ScoringActions = {
 
   editPartScore(
     partId: string,
-    correctScore: number | null,
+    correctScore: number | null, // non-null if custom; null => set default scoring
     incorrectScore: number | null,
     scoringStrategy: string | undefined = undefined,
   ) {
@@ -68,42 +62,42 @@ export const ScoringActions = {
         console.warn('Could not set score for part', partId);
         return;
       }
-      // outOf attribute may not exist on migrated questions
-      const oldCorrectScore = getOutOfPoints(model, part.id);
+
+      // reject any change that violates consistency requirements
+      const newCorrectPoints = correctScore || 1;
+      const newIncorrectPoints = incorrectScore || 0;
+      if (!(newCorrectPoints > newIncorrectPoints)) return;
+
+      // fetch current special point values before modifying anything
+      const oldCorrectPoints = getOutOfPoints(model, partId);
+      const oldIncorrectPoints = getIncorrectPoints(model, partId);
+
+      // update correct/incorrect scores in all responses, using score
+      // match to hit alternate correct/incorrect in targeted feedbacks
+      part.responses?.forEach((response: Response) => {
+        if (response.score === oldCorrectPoints) response.score = newCorrectPoints;
+        else if (response.score === oldIncorrectPoints) response.score = newIncorrectPoints;
+        else {
+          // Partial credit response. Ensure score remains within possibly new range
+          if (correctScore === null) {
+            // Going to default scoring. No more partial credit, so just treat
+            // all non-correct as wrong.
+            response.score = newIncorrectPoints;
+          } else {
+            // adjust score by scaling, preserving fraction of score range width
+            const fraction =
+              (response.score - oldIncorrectPoints) / (oldCorrectPoints - oldIncorrectPoints);
+            response.score =
+              newIncorrectPoints + fraction * (newCorrectPoints - newIncorrectPoints);
+          }
+        }
+      });
+
+      // update part-wide scoring params. nullish outOf codes for default scoring
       part.outOf = correctScore;
       part.incorrectScore = incorrectScore;
-
       if (scoringStrategy) {
         part.scoringStrategy = scoringStrategy;
-      }
-
-      // if changing to default, reset the scores for each part to 1 or 0
-      if (part.outOf == null) {
-        model.authoring?.parts?.forEach((part: Part) => {
-          part.responses?.forEach((response) => {
-            response.score = response.score === oldCorrectScore ? 1 : 0;
-          });
-        });
-      } else {
-        // When we change the correct & incorrect scores, we also need to update the responses for the correct & incorrect answers
-
-        try {
-          const correctResponse = getCorrectResponse(model, partId);
-          if (correctResponse) {
-            correctResponse.score = correctScore ?? 1;
-          }
-        } catch (e) {
-          console.warn('Could not find correct response for part', partId);
-        }
-
-        try {
-          const incorrectResponse = getIncorrectResponse(model, partId);
-          if (incorrectResponse) {
-            incorrectResponse.score = incorrectScore ?? 0;
-          }
-        } catch (e) {
-          console.warn('Could not find incorrect response for part', partId);
-        }
       }
     };
   },

--- a/assets/src/components/activities/common/responses/ActivityScoring.tsx
+++ b/assets/src/components/activities/common/responses/ActivityScoring.tsx
@@ -23,11 +23,10 @@ export const ActivityScoring: React.FC<ActivityScoreProps> = ({ partId, promptFo
   const { model, dispatch, editMode } = useAuthoringElementContext<HasParts>();
   const checkboxInputId = useMemo(() => guid(), []);
   const outOfPoints = getOutOfPoints(model, partId);
-  const incorrect = getIncorrectPoints(model, partId);
+  const incorrectPoints = getIncorrectPoints(model, partId);
   const [useDefaultScoring, setDefaultScoring] = useState(
     !hasCustomScoring(model) && promptForDefault,
   );
-  const incorrectPoints = incorrect || 0;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {
     setDefaultScoring(e.target.checked);

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -14,6 +14,7 @@ import {
 } from 'components/activities/types';
 import {
   ResponseMapping,
+  getCorrectResponse,
   getTargetedResponseMappings,
   hasCustomScoring,
 } from 'data/activities/model/responses';
@@ -24,6 +25,7 @@ import { ShowPage } from './ShowPage';
 
 interface Props {
   choices?: Choice[];
+  partId?: string;
   toggleChoice: (id: ChoiceId, mapping: ResponseMapping) => void;
   addTargetedResponse: () => void;
   selectedIcon: React.ReactNode;
@@ -82,8 +84,8 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
   // only show feedbacks for relevant choice set, presumably current part's on multipart
   const partMappings = getFeedbackForChoices(props.choices || model.choices, hook.targetedMappings);
   // some migrated qs erroneously included correct answer in targeted feedback map: ignore
-  const firstCorrect = partMappings.find((m) => m.response.score > 0);
-  const mappings = partMappings.filter((m) => m !== firstCorrect);
+  const correctResponse = getCorrectResponse(model, props.partId || model.authoring.parts[0].id);
+  const mappings = partMappings.filter((m) => m.response !== correctResponse);
 
   const customScoring = hasCustomScoring(model);
 

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -12,6 +12,9 @@ import {
 } from 'components/activities/types';
 import {
   RESPONSES_PATH,
+  findResponsePartId,
+  getIncorrectPoints,
+  getMaxPoints,
   getResponseBy,
   getResponseId,
   getResponsesByPartId,
@@ -51,7 +54,14 @@ export const ResponseActions = {
 
   editResponseScore(responseId: ResponseId, score: number) {
     return (model: HasParts) => {
-      getResponseBy(model, (r) => r.id === responseId).score = score;
+      // ensure score is within allowed range
+      const partId = findResponsePartId(model, responseId);
+      if (
+        partId &&
+        getIncorrectPoints(model, partId) <= score &&
+        score <= getMaxPoints(model, partId)
+      )
+        getResponseBy(model, (r) => r.id === responseId).score = score;
     };
   },
 

--- a/assets/src/components/activities/common/responses/responseActions.ts
+++ b/assets/src/components/activities/common/responses/responseActions.ts
@@ -12,9 +12,6 @@ import {
 } from 'components/activities/types';
 import {
   RESPONSES_PATH,
-  findResponsePartId,
-  getIncorrectPoints,
-  getMaxPoints,
   getResponseBy,
   getResponseId,
   getResponsesByPartId,
@@ -54,14 +51,7 @@ export const ResponseActions = {
 
   editResponseScore(responseId: ResponseId, score: number) {
     return (model: HasParts) => {
-      // ensure score is within allowed range
-      const partId = findResponsePartId(model, responseId);
-      if (
-        partId &&
-        getIncorrectPoints(model, partId) <= score &&
-        score <= getMaxPoints(model, partId)
-      )
-        getResponseBy(model, (r) => r.id === responseId).score = score;
+      getResponseBy(model, (r) => r.id === responseId).score = score;
     };
   },
 

--- a/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputScoringMethod.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import { Card } from 'components/misc/Card';
+import { multiHasCustomScoring } from 'data/activities/model/responses';
 import guid from 'utils/guid';
 import { useAuthoringElementContext } from '../AuthoringElementProvider';
-import { ScoringActions, usesCustomScoring } from '../common/authoring/actions/scoringActions';
+import { ScoringActions } from '../common/authoring/actions/scoringActions';
 import { ScoringStrategy } from '../types';
 import { MultiInputSchema } from './schema';
 
@@ -11,7 +12,7 @@ interface MultiInputScoringMethodProps {}
 export const MultiInputScoringMethod: React.FC<MultiInputScoringMethodProps> = () => {
   const { model, dispatch, editMode } = useAuthoringElementContext<MultiInputSchema>();
   const checkboxInputId = useMemo(guid, []);
-  const defaultScoring = !usesCustomScoring(model);
+  const defaultScoring = !multiHasCustomScoring(model);
   const scoringStrategy = model.scoringStrategy || ScoringStrategy.total;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -3,7 +3,6 @@ import { useAuthoringElementContext } from 'components/activities/AuthoringEleme
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
 import { GradingApproachDropdown } from 'components/activities/common/authoring/GradingApproachDropdown';
 import { MCActions } from 'components/activities/common/authoring/actions/multipleChoiceActions';
-import { usesCustomScoring } from 'components/activities/common/authoring/actions/scoringActions';
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { ActivityScoring } from 'components/activities/common/responses/ActivityScoring';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
@@ -23,7 +22,7 @@ import { InputEntry } from 'components/activities/short_answer/sections/InputEnt
 import { getTargetedResponses } from 'components/activities/short_answer/utils';
 import { GradingApproach, Response, RichText, makeResponse } from 'components/activities/types';
 import { Radio } from 'components/misc/icons/radio/Radio';
-import { getCorrectResponse } from 'data/activities/model/responses';
+import { getCorrectResponse, multiHasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule } from 'data/activities/model/rules';
 import { getPartById } from 'data/activities/model/utils';
 import { defaultWriterContext } from 'data/content/writers/context';
@@ -79,7 +78,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
         <SimpleFeedback partId={props.input.partId} />
 
         <MultiInputScoringMethod />
-        {usesCustomScoring(model) && (
+        {multiHasCustomScoring(model) && (
           <ActivityScoring partId={props.input.partId} promptForDefault={false} />
         )}
 
@@ -87,6 +86,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           choices={model.choices.filter((choice) =>
             (props.input as Dropdown).choiceIds.includes(choice.id),
           )}
+          partId={props.input.partId}
           toggleChoice={(choiceId, mapping) => {
             dispatch(MCActions.editTargetedFeedbackChoice(mapping.response.id, choiceId));
           }}
@@ -120,7 +120,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
       />
       <SimpleFeedback partId={props.input.partId} />
       <MultiInputScoringMethod />
-      {usesCustomScoring(model) && (
+      {multiHasCustomScoring(model) && (
         <ActivityScoring partId={props.input.partId} promptForDefault={false} />
       )}
       {getTargetedResponses(model, props.input.partId).map((response: Response) => (
@@ -142,7 +142,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           updateScore={(_id, score) =>
             dispatch(ResponseActions.editResponseScore(response.id, score))
           }
-          customScoring={usesCustomScoring(model)}
+          customScoring={multiHasCustomScoring(model)}
           removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
           key={response.id}
         >

--- a/assets/src/components/activities/response_multi/ResponseMultiInputScoringMethod.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputScoringMethod.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import { Card } from 'components/misc/Card';
+import { multiHasCustomScoring } from 'data/activities/model/responses';
 import guid from 'utils/guid';
 import { useAuthoringElementContext } from '../AuthoringElementProvider';
-import { ScoringActions, usesCustomScoring } from '../common/authoring/actions/scoringActions';
+import { ScoringActions } from '../common/authoring/actions/scoringActions';
 import { ScoringStrategy } from '../types';
 import { ResponseMultiInputSchema } from './schema';
 
@@ -13,7 +14,7 @@ export const ResponseMultiInputScoringMethod: React.FC<
 > = () => {
   const { model, dispatch, editMode } = useAuthoringElementContext<ResponseMultiInputSchema>();
   const checkboxInputId = useMemo(guid, []);
-  const defaultScoring = !usesCustomScoring(model);
+  const defaultScoring = !multiHasCustomScoring(model);
   const scoringStrategy = model.scoringStrategy || ScoringStrategy.total;
 
   const onChangeDefault = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/assets/src/components/activities/response_multi/sections/PartsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/PartsTab.tsx
@@ -3,7 +3,6 @@ import { Editor } from 'slate';
 import { ReactEditor } from 'slate-react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { AuthoringButtonConnected } from 'components/activities/common/authoring/AuthoringButton';
-import { usesCustomScoring } from 'components/activities/common/authoring/actions/scoringActions';
 import { ActivityScoring } from 'components/activities/common/responses/ActivityScoring';
 import { ResponseActions } from 'components/activities/common/responses/responseActions';
 import { Dropdown, FillInTheBlank, MultiInput } from 'components/activities/multi_input/schema';
@@ -11,7 +10,7 @@ import { ResponseMultiInputSchema } from 'components/activities/response_multi/s
 import { ResponseTab } from 'components/activities/response_multi/sections/ResponseTab';
 import { Part, Response, makeResponse } from 'components/activities/types';
 import { Card } from 'components/misc/Card';
-import { getMaxScoreResponse } from 'data/activities/model/responses';
+import { getMaxScoreResponse, multiHasCustomScoring } from 'data/activities/model/responses';
 import { containsRule, eqRule, equalsRule, matchRule } from 'data/activities/model/rules';
 import { getPartById } from 'data/activities/model/utils';
 import { ResponseMultiInputScoringMethod } from '../ResponseMultiInputScoringMethod';
@@ -65,7 +64,7 @@ export const PartsTab: React.FC<Props> = (props) => {
         title={title}
         response={response}
         partId={part.id}
-        customScoring={usesCustomScoring(model)}
+        customScoring={multiHasCustomScoring(model)}
         removeResponse={(id) => dispatch(ResponseActions.removeResponse(id))}
         updateScore={(_id, score) =>
           dispatch(ResponseActions.editResponseScore(response.id, score))
@@ -102,7 +101,9 @@ export const PartsTab: React.FC<Props> = (props) => {
           Add targeted feedback
         </AuthoringButtonConnected>
         <ResponseMultiInputScoringMethod />
-        {usesCustomScoring(model) && <ActivityScoring partId={part.id} promptForDefault={false} />}
+        {multiHasCustomScoring(model) && (
+          <ActivityScoring partId={part.id} promptForDefault={false} />
+        )}
       </Card.Content>
     </Card.Card>
   );

--- a/assets/src/data/activities/model/responses.ts
+++ b/assets/src/data/activities/model/responses.ts
@@ -46,13 +46,6 @@ export const getResponsesByPartId = (model: HasParts, partId: string): Response[
 export const getResponseBy = (model: HasParts, predicate: (x: Response) => boolean) =>
   getByUnsafe(getResponses(model), predicate);
 
-export const findResponsePartId = (model: HasParts, responseId: string): string | undefined => {
-  const part = model.authoring.parts.find((p: Part) =>
-    p.responses.map((r) => r.id).includes(responseId),
-  );
-  return part?.id;
-};
-
 // Use of custom scoring is explicitly flagged to authoring differently in
 // single-part and multi-part activities. However, older migrations did not set
 // these flags, so these routines also allow it to be implicit in the use of


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4757 The ability to set custom incorrect points when using custom activity scoring was broken; attempting to do so rendered the question uneditable. The error occurred because custom incorrect points broke the way the catchall incorrect response was being found, by looking for a response of .* with a score of zero. The score test was added for a reason - to allow for cases which actually occurred where authors set a *correct* response to .* in order to make every answer correct. That broke finding correct answer, also rendering question uneditable. The fix is simply to test against the current incorrect point value rather than 0. But getting this to work also required updates to the code that handle scoring mode changes to work.

This also fixes two other minor glitches that were found to arise when custom scoring is used:

- Targeted Feedbacks could disappear from the interface when partial credit points were assigned. This arose from the implementation of some defensive code against having the correct answer included in the targeted feedbacks, which was done by the migration tool at one point. https://eliterate.atlassian.net/browse/MER-4792

- On multi-input questions, changing from custom scoring back to default did not reset targeted feedback from showing a points box to showing a Correct checkbox. https://eliterate.atlassian.net/browse/MER-4801

This PR also renames and relocates a routine and add some comments to try to highlight for the reader the messy detail that custom scoring is flagged differently for single-part and multi-part questions.