### PR TITLE
[BUG FIX] [MER-4793] Preserve selection id in new attempt creation

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -152,6 +152,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                      revision_id: revision.id,
                      resource_attempt_id: activity_attempt.resource_attempt_id,
                      survey_id: survey_id,
+                     selection_id: activity_attempt.selection_id,
                      out_of: activity_attempt.out_of,
                      aggregate_score: activity_attempt.aggregate_score,
                      aggregate_out_of: activity_attempt.aggregate_out_of

--- a/test/oli/delivery/attempts/attempt_reset_test.exs
+++ b/test/oli/delivery/attempts/attempt_reset_test.exs
@@ -198,5 +198,31 @@ defmodule Oli.Delivery.Attempts.ActivityResetTest do
       attempt = Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
       refute attempt.transformed_model == activity1_attempt.transformed_model
     end
+
+    test "ensure resetting preserves selection id", %{
+      ungraded_page_user1_activity1_attempt1: activity1_attempt,
+      section: section
+    } do
+      datashop_session_id_user1 = UUID.uuid4()
+
+      # Edit the attempt to set a selection_id
+      Core.update_activity_attempt(
+        activity1_attempt,
+        %{selection_id: "test_selection_id"}
+      )
+
+      # now reset the activity, this should not have a transform - we can softly assert
+      # that by ensuring that the transformed_models are the same
+      {:ok, {attempt_state, _}} =
+        ActivityLifecycle.reset_activity(
+          section.slug,
+          activity1_attempt.attempt_guid,
+          datashop_session_id_user1
+        )
+
+      attempt = Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
+      assert attempt.transformed_model == activity1_attempt.transformed_model
+      assert attempt.selection_id == "test_selection_id"
+    end
   end
 end


### PR DESCRIPTION
This PR changes the "reset attempt" logic to carry forward the `selection_id` of the original attempt in creating the new attempt.   Without this, Score as you Go activities that had multiple attempts could not be migrated to new page attempts correctly.  The migration logic basically would fail to pair up the corresponding attempt prototype for an activity bank selection, resulting in the creation of a different question instead of carrying forward the same question.  