### PR TITLE
[BUG FIX] [MER-4758] change "Last" to "Most Recent" in assessment settings to match authoring

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -325,7 +325,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       <option disabled selected={@scoring_strategy_id == nil} hidden value="">-</option>
       <option selected={@scoring_strategy_id == 1} value={1}>Average</option>
       <option selected={@scoring_strategy_id == 2} value={2}>Best</option>
-      <option selected={@scoring_strategy_id == 3} value={3}>Last</option>
+      <option selected={@scoring_strategy_id == 3} value={3}>Most Recent</option>
     </select>
     """
   end


### PR DESCRIPTION
In the table used in Manage Section/Assessment Settings, the scoring strategy shown as "Last" was inconsistent with the label used in authoring, leading to confusion. This changes the label there to "Most Recent" to match the label used in authoring. 