### PR TITLE
[BUG FIX] [MER-4690] Student search field does not work for specific users

### DIFF
--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -177,6 +177,8 @@ defmodule OliWeb.Workspaces.Student do
               placeholder="Search by course or instructor name"
               text={@params.text_search}
             />
+
+            <button class="hidden" name="submit" value="disabled" disabled />
           </.form>
         </div>
       </div>
@@ -317,20 +319,18 @@ defmodule OliWeb.Workspaces.Student do
   defp maybe_filter_by_text(sections, nil), do: sections
   defp maybe_filter_by_text(sections, ""), do: sections
 
+  # Filters sections by section title or instructor name
   defp maybe_filter_by_text(sections, text_search) do
     normalized_text_search = String.downcase(text_search)
 
     sections
     |> Enum.filter(fn section ->
-      # searchs by course name or instructor name
+      instructor_names = Enum.map(section.instructors, &to_string/1)
 
-      String.contains?(String.downcase(section.title), normalized_text_search) ||
-        Enum.find(section.instructors, false, fn name ->
-          String.contains?(
-            String.downcase(name),
-            normalized_text_search
-          )
-        end)
+      searchable_text =
+        [section.title, instructor_names] |> IO.iodata_to_binary() |> String.downcase()
+
+      String.contains?(searchable_text, normalized_text_search)
     end)
   end
 


### PR DESCRIPTION
Prevent search input submission to avoid LiveView reloads
The search is already handled on each keystroke (with debounce), so form submission via Enter is unnecessary and causes a full LiveView reload.

Also ignore nil fields in sections' instructors / titles (See: https://github.com/Simon-Initiative/oli-torus/pull/5511)