### PR TITLE
[ENHANCEMENT] [MER-4752] change precourse survey intro text

### DIFF
--- a/lib/oli_web/live/delivery/student_onboarding/survey.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/survey.ex
@@ -131,7 +131,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Survey do
                 <%= @title %>
               </h2>
               <span class="text-[14px] leading-[20px] tracking-[0.02px] dark:text-white">
-              Please complete this required survey before beginning your course.
+                Please complete this required survey before beginning your course.
               </span>
             </div>
           </div>


### PR DESCRIPTION
This changes the required precourse survey intro text to remove the confusing and false reference to pulling in info from an LMS. Text now just "Please complete this required survey before beginning your course."