### PR TITLE
[FEATURE] [MER-4693] Insights content table UI

### DIFF
--- a/assets/css/bootstrap-shims.css
+++ b/assets/css/bootstrap-shims.css
@@ -523,7 +523,7 @@ table {
   @apply min-w-full border dark:border-gray-600 dark:text-gray-300;
 }
 table thead th {
-  @apply border-b border-r p-2 bg-gray-100 font-semibold dark:bg-gray-600 dark:border-gray-600;
+  @apply border-b border-r p-2 bg-gray-100 font-semibold dark:bg-gray-600 dark:border-[#3B3740];
 }
 table tr {
   @apply border-b dark:border-gray-600;

--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -3,7 +3,7 @@
 }
 
 .instructor_dashboard_table th {
-  @apply h-[50px] border-r-0 border-l-0 bg-white dark:bg-[#000000] text-[#353740] dark:text-[#EEEBF5] text-left font-normal text-xs sm:text-sm relative;
+  @apply h-[50px] border-r-0 border-l-0 bg-white dark:bg-[#000000] text-[#353740] dark:text-[#EEEBF5] border-b border-[#CED1D9] dark:border-[#3B3740] text-left font-normal text-xs sm:text-sm relative;
 }
 
 .instructor_dashboard_table th[data-sort-column='true'] {
@@ -15,7 +15,7 @@
 }
 
 .instructor_dashboard_table tr {
-  @apply h-[50px] text-gray-500 dark:text-white font-semibold text-xs sm:text-sm;
+  @apply h-[50px] text-gray-500 dark:text-white font-semibold text-xs sm:text-sm border-t border-[#CED1D9] dark:border-[#3B3740];
 }
 
 .instructor_dashboard_table td {
@@ -59,7 +59,7 @@ div:has(.instructor_dashboard_table) #header_paging {
 }
 
 div:has(.instructor_dashboard_table) #footer_paging {
-  @apply sticky left-0 dark:bg-[#0D0C0F];
+  @apply sticky left-0 dark:bg-[#262626];
 }
 
 div:has(.remix_materials_table) {

--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -3,7 +3,7 @@
 }
 
 .instructor_dashboard_table th {
-  @apply h-[50px] border-r-0 border-l-0 bg-white dark:bg-[#000000] dark:text-[#EEEBF5] text-left font-normal text-xs sm:text-sm relative;
+  @apply h-[50px] border-r-0 border-l-0 bg-white dark:bg-[#000000] text-[#353740] dark:text-[#EEEBF5] text-left font-normal text-xs sm:text-sm relative;
 }
 
 .instructor_dashboard_table th[data-sort-column='true'] {
@@ -59,7 +59,7 @@ div:has(.instructor_dashboard_table) #header_paging {
 }
 
 div:has(.instructor_dashboard_table) #footer_paging {
-  @apply sticky left-0 dark:bg-neutral-800;
+  @apply sticky left-0 dark:bg-[#0D0C0F];
 }
 
 div:has(.remix_materials_table) {

--- a/assets/css/table.css
+++ b/assets/css/table.css
@@ -3,11 +3,11 @@
 }
 
 .instructor_dashboard_table th {
-  @apply h-16 border-r-0 border-l-0 bg-white dark:bg-gray-800 text-left font-normal text-xs sm:text-sm relative;
+  @apply h-[50px] border-r-0 border-l-0 bg-white dark:bg-[#000000] dark:text-[#EEEBF5] text-left font-normal text-xs sm:text-sm relative;
 }
 
 .instructor_dashboard_table th[data-sort-column='true'] {
-  @apply font-bold text-gray-800 dark:text-white;
+  @apply font-bold text-gray-800 dark:text-[#EEEBF5];
 }
 
 .instructor_dashboard_table_link {
@@ -15,7 +15,7 @@
 }
 
 .instructor_dashboard_table tr {
-  @apply h-14 text-gray-500 dark:text-white font-semibold text-xs sm:text-sm;
+  @apply h-[50px] text-gray-500 dark:text-white font-semibold text-xs sm:text-sm;
 }
 
 .instructor_dashboard_table td {
@@ -50,7 +50,7 @@
   @apply bg-[#F3F4F8] dark:bg-[#0D0C0F];
 }
 
-.schedule_table tbody tr{
+.schedule_table tbody tr {
   @apply hover:bg-[#F2F9FF] hover:dark:bg-[#0A203A];
 }
 

--- a/lib/oli_web/components/delivery/buttons.ex
+++ b/lib/oli_web/components/delivery/buttons.ex
@@ -130,10 +130,18 @@ defmodule OliWeb.Components.Delivery.Buttons do
     ~H"""
     <div>
       <div id={"#{@id}-down-icon"}>
-        <Icons.chevron_down class={"dark:fill-white " <> if @map_values != %{}, do: "fill-blue-400 dark:fill-blue-400", else: ""} />
+        <Icons.chevron_down
+          class={"dark:fill-white " <> if @map_values not in [%{}, nil], do: "fill-blue-400 dark:fill-blue-400", else: ""}
+          width="16"
+          height="16"
+        />
       </div>
       <div class="hidden" id={"#{@id}-up-icon"}>
-        <Icons.chevron_down class={"rotate-180 dark:fill-white " <> if(@map_values != %{}, do: "fill-blue-400 dark:fill-blue-400", else: "")} />
+        <Icons.chevron_down
+          class={"rotate-180 dark:fill-white " <> if(@map_values not in [%{}, nil], do: "fill-blue-400 dark:fill-blue-400", else: "")}
+          width="16"
+          height="16"
+        />
       </div>
     </div>
     """

--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -13,29 +13,39 @@ defmodule OliWeb.Components.Delivery.CardHighlights do
     <div
       phx-click={@on_click}
       phx-value-selected={@value}
-      class={"w-56 h-auto rounded-md dark:bg-gray-800 flex-col justify-start items-start px-4 py-3 hover:cursor-pointer #{if @is_selected, do: "shadow border-2 border-blue-500 bg-slate-50", else: "bg-white border border-blue-500/30 hover:border-blue-500/80 dark:border-white"}"}
+      class={
+        "inline-flex flex-col justify-start items-start gap-3 p-6 h-32 rounded-2xl shadow-[0px_2px_10px_0px_rgba(0,50,99,0.10)]
+        outline outline-1 outline-offset-[-1px] outline-gray-300 cursor-pointer transition-colors dark:bg-[#000000] dark:outline-[#3B3740] " <>
+        if @is_selected, do: "bg-slate-50 outline-blue-500", else: "bg-white hover:outline-blue-500/70"
+      }
     >
-      <div class="text-slate-500 text-xs font-normal leading-none dark:text-white">
+      <div class="text-gray-700 text-base font-semibold leading-normal dark:text-[#EEEBF5]">
         <%= @title %>
       </div>
-      <div class="flex items-baseline space-x-2 mt-2">
-        <div class={"text-3xl font-semibold leading-10 dark:text-white #{if @is_selected, do: "text-blue-500", else: "text-slate-800"}"}>
+
+      <div class="flex justify-start items-end gap-2 w-full">
+        <div class="text-[32px] font-bold leading-[44px] text-gray-800 dark:text-[#EEEBF5]">
           <%= @count %>
         </div>
-        <div class="text-gray-400 text-xs font-normal leading-none dark:text-white">
-          <%= case @container_filter_by do %>
-            <% :units -> %>
-              Units
-            <% :modules -> %>
-              Modules
-            <% :students -> %>
-              Students
-            <% _ -> %>
-              <%= @container_filter_by %>
-          <% end %>
+        <div class="flex-1 py-2 flex justify-start items-center gap-1">
+          <div class="text-sm text-[#45464c] font-normal leading-none dark:text-[#EEEBF5]">
+            <%= label_for(@container_filter_by, @count) %>
+          </div>
         </div>
       </div>
     </div>
     """
+  end
+
+  defp label_for(type, count) do
+    base =
+      case type do
+        :units -> "Unit"
+        :modules -> "Module"
+        :students -> "Student"
+        _ -> to_string(type || "")
+      end
+
+    if count == 1, do: base, else: "#{base}s"
   end
 end

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -159,8 +159,8 @@ defmodule OliWeb.Components.Delivery.Content do
           Modules
         </button>
       </div>
-      <div class="bg-white dark:bg-[#0D0C0F] shadow-sm">
-        <div class="flex justify-between gap-2 items-center px-4 pt-8 pb-4 instructor_dashboard_table dark:bg-[#0D0C0F]">
+      <div class="bg-white dark:bg-[#262626] shadow-sm">
+        <div class="flex justify-between gap-2 items-center px-4 pt-8 pb-4 instructor_dashboard_table dark:bg-[#262626]">
           <div class="text-zinc-700 text-lg font-bold leading-none tracking-tight dark:bg-gray-800 dark:text-white">
             Course <%= if @params.container_filter_by == :units, do: "Units", else: "Modules" %>
           </div>

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -1,8 +1,6 @@
 defmodule OliWeb.Components.Delivery.Content do
   use OliWeb, :live_component
 
-  import OliWeb.Components.Delivery.Buttons, only: [toggle_chevron: 1]
-
   alias Phoenix.LiveView.JS
 
   alias Oli.Delivery.Metrics
@@ -10,7 +8,7 @@ defmodule OliWeb.Components.Delivery.Content do
   alias OliWeb.Components.Delivery.{CardHighlights, ContentTableModel}
   alias OliWeb.Common.{StripedPagedTable, Params}
   alias OliWeb.Router.Helpers, as: Routes
-  alias OliWeb.Delivery.Content.Progress
+  alias OliWeb.Delivery.Content.{MultiSelect, Progress}
 
   alias Phoenix.LiveView.JS
   alias OliWeb.Icons
@@ -139,10 +137,10 @@ defmodule OliWeb.Components.Delivery.Content do
   def render(assigns) do
     ~H"""
     <div class="flex flex-col mb-10">
-      <div class="w-full h-9 relative my-7">
+      <div class="w-full h-10 relative my-7">
         <button
           id="filter_units_button"
-          class={"w-[6.5rem] h-9 left-0 top-0 absolute rounded-tl-lg rounded-bl-lg border border-slate-300 #{set_button_background(@params.container_filter_by, :units)} text-xs #{set_button_text(@params.container_filter_by, :units)}"}
+          class={"w-24 h-10 left-0 top-0 absolute rounded-tl-lg rounded-bl-lg border border-[#CED1D9] dark:border-[#3B3740] #{set_button_background(@params.container_filter_by, :units)} text-xs #{set_button_text(@params.container_filter_by, :units)}"}
           phx-click="filter_container"
           phx-value-filter="units"
           phx-target={@myself}
@@ -152,7 +150,7 @@ defmodule OliWeb.Components.Delivery.Content do
         </button>
         <button
           id="filter_modules_button"
-          class={"w-28 h-9 left-[100.52px] top-0 absolute rounded-tr-lg rounded-br-lg border border-slate-300 #{set_button_background(@params.container_filter_by, :modules)} text-xs #{set_button_text(@params.container_filter_by, :modules)}"}
+          class={"w-24 h-10 left-[95px] top-0 absolute rounded-tr-lg rounded-br-lg border border-[#CED1D9] dark:border-[#3B3740] #{set_button_background(@params.container_filter_by, :modules)} text-xs #{set_button_text(@params.container_filter_by, :modules)}"}
           phx-click="filter_container"
           phx-value-filter="modules"
           phx-target={@myself}
@@ -161,8 +159,8 @@ defmodule OliWeb.Components.Delivery.Content do
           Modules
         </button>
       </div>
-      <div class="bg-white dark:bg-gray-800 shadow-sm">
-        <div class="flex justify-between gap-2 items-center px-4 pt-8 pb-4 instructor_dashboard_table">
+      <div class="bg-white dark:bg-[#0D0C0F] shadow-sm">
+        <div class="flex justify-between gap-2 items-center px-4 pt-8 pb-4 instructor_dashboard_table dark:bg-[#0D0C0F]">
           <div class="text-zinc-700 text-lg font-bold leading-none tracking-tight dark:bg-gray-800 dark:text-white">
             Course <%= if @params.container_filter_by == :units, do: "Units", else: "Modules" %>
           </div>
@@ -174,7 +172,7 @@ defmodule OliWeb.Components.Delivery.Content do
                 )
               }
               download="course_content.csv"
-              class="flex items-center justify-center gap-x-2"
+              class="flex items-center justify-center gap-x-2 text-[#006CD9] dark:text-[#4CA6FF] font-bold"
             >
               Download CSV <Icons.download />
             </a>
@@ -211,7 +209,7 @@ defmodule OliWeb.Components.Delivery.Content do
               params_from_url={@params_from_url}
             />
 
-            <.multi_select
+            <MultiSelect.render
               id="proficiency_select"
               options={@proficiency_options}
               selected_values={@selected_proficiency_options}
@@ -243,106 +241,6 @@ defmodule OliWeb.Components.Delivery.Content do
           limit_change={JS.push("paged_table_limit_change", target: @myself)}
           show_limit_change={true}
         />
-      </div>
-    </div>
-    """
-  end
-
-  attr :placeholder, :string, default: "Select an option"
-  attr :disabled, :boolean, default: false
-  attr :options, :list, default: []
-  attr :id, :string
-  attr :target, :map, default: %{}
-  attr :selected_values, :map, default: %{}
-  attr :selected_proficiency_ids, :list, default: []
-
-  def multi_select(assigns) do
-    ~H"""
-    <div class={"flex flex-col relative rounded h-9 #{if @selected_values != %{}, do: "border border-blue-500", else: "outline outline-1 outline-[#ced1d9] dark:outline-[#3B3740]"}"}>
-      <div
-        phx-click={
-          if(!@disabled,
-            do:
-              JS.toggle(to: "##{@id}-options-container")
-              |> JS.toggle(to: "##{@id}-down-icon")
-              |> JS.toggle(to: "##{@id}-up-icon")
-          )
-        }
-        class={[
-          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
-          if(@disabled, do: "bg-gray-300 hover:cursor-not-allowed")
-        ]}
-        id={"#{@id}-selected-options-container"}
-      >
-        <div class="flex gap-1 flex-wrap">
-          <span
-            :if={@selected_values == %{}}
-            class="text-[#353740] text-xs font-semibold leading-none dark:text-[#EEEBF5]"
-          >
-            <%= @placeholder %>
-          </span>
-          <span :if={@selected_values != %{}} class="text-blue-500 text-xs font-semibold leading-none">
-            Proficiency is <%= show_proficiency_selected_values(@selected_values) %>
-          </span>
-        </div>
-        <.toggle_chevron id={@id} map_values={@selected_values} />
-      </div>
-      <div class="relative">
-        <div
-          class="py-4 hidden z-50 absolute dark:bg-gray-800 bg-white w-48 border overflow-y-scroll top-1 rounded"
-          id={"#{@id}-options-container"}
-          phx-click-away={
-            JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")
-          }
-        >
-          <div>
-            <.form
-              :let={_f}
-              class="flex flex-column gap-y-3 px-4"
-              for={%{}}
-              as={:options}
-              phx-change="toggle_selected"
-              phx-target={@target}
-            >
-              <.input
-                :for={option <- @options}
-                name={option.id}
-                value={option.selected}
-                label={option.name}
-                checked={option.id in @selected_proficiency_ids}
-                type="checkbox"
-                label_class="text-zinc-900 text-xs font-normal leading-none dark:text-white"
-              />
-            </.form>
-          </div>
-          <div class="w-full border border-gray-200 my-4"></div>
-          <div class="flex flex-row items-center justify-end px-4 gap-x-4">
-            <button
-              class="text-center text-neutral-600 text-xs font-semibold leading-none dark:text-white"
-              phx-click={
-                JS.hide(to: "##{@id}-options-container")
-                |> JS.hide(to: "##{@id}-up-icon")
-                |> JS.show(to: "##{@id}-down-icon")
-              }
-            >
-              Cancel
-            </button>
-            <button
-              class="px-4 py-2 bg-blue-500 rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
-              phx-click={
-                JS.push("apply_proficiency_filter")
-                |> JS.hide(to: "##{@id}-options-container")
-                |> JS.hide(to: "##{@id}-up-icon")
-                |> JS.show(to: "##{@id}-down-icon")
-              }
-              phx-target={@target}
-              phx-value={@selected_proficiency_ids}
-              disabled={@disabled}
-            >
-              Apply
-            </button>
-          </div>
-        </div>
       </div>
     </div>
     """
@@ -739,15 +637,19 @@ defmodule OliWeb.Components.Delivery.Content do
   defp set_button_background(:pages, _filter), do: "bg-gray-100 dark:bg-gray-800"
 
   defp set_button_background(container_filter_by, filter),
-    do: if(container_filter_by == filter, do: "bg-blue-500 dark:bg-gray-800", else: "bg-white")
+    do:
+      if(container_filter_by == filter,
+        do: "bg-[#0080FF] dark:bg-[#0062F2]",
+        else: "bg-[#F3F4F8] dark:bg-[#0D0C0F]"
+      )
 
   defp set_button_text(:pages, _filter), do: "text-gray-700 dark:text-white cursor-not-allowed"
 
   defp set_button_text(container_filter_by, filter),
     do:
       if(container_filter_by == filter,
-        do: "text-white font-bold",
-        else: "text-zinc-700 font-normal"
+        do: "text-[#FFFFFF] font-semibold",
+        else: "text-[#45464C] font-normal dark:text-[#BAB8BF]"
       )
 
   defp containers_count(containers, container_filter) do
@@ -789,10 +691,6 @@ defmodule OliWeb.Components.Delivery.Content do
       |> Map.put(:was_filtered, MapSet.member?(rows_ids, container.id))
       |> Map.drop([:progress, :student_proficiency, :numbering_index, :numbering_level])
     end)
-  end
-
-  defp show_proficiency_selected_values(values) do
-    Enum.map_join(values, ", ", fn {_id, values} -> values end)
   end
 
   defp update_proficiency_options(selected_proficiency_ids, proficiency_options) do

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -8,7 +8,7 @@ defmodule OliWeb.Components.Delivery.Content do
   alias Oli.Delivery.Metrics
   alias OliWeb.Common.SearchInput
   alias OliWeb.Components.Delivery.{CardHighlights, ContentTableModel}
-  alias OliWeb.Common.{InstructorDashboardPagedTable, Params}
+  alias OliWeb.Common.{StripedPagedTable, Params}
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Delivery.Content.Progress
 
@@ -25,7 +25,7 @@ defmodule OliWeb.Components.Delivery.Content do
     container_filter_by: :units,
     selected_card_value: nil,
     progress_percentage: 100,
-    progress_selector: :is_less_than_or_equal,
+    progress_selector: nil,
     selected_proficiency_ids: Jason.encode!([])
   }
 
@@ -162,10 +162,7 @@ defmodule OliWeb.Components.Delivery.Content do
         </button>
       </div>
       <div class="bg-white dark:bg-gray-800 shadow-sm">
-        <div
-          style="min-height: 83px;"
-          class="flex justify-between gap-2 items-center px-4 sm:px-9 py-4 instructor_dashboard_table"
-        >
+        <div class="flex justify-between gap-2 items-center px-4 pt-8 pb-4 instructor_dashboard_table">
           <div class="text-zinc-700 text-lg font-bold leading-none tracking-tight dark:bg-gray-800 dark:text-white">
             Course <%= if @params.container_filter_by == :units, do: "Units", else: "Modules" %>
           </div>
@@ -184,7 +181,7 @@ defmodule OliWeb.Components.Delivery.Content do
           </div>
         </div>
 
-        <div class="flex flex-row mx-9 gap-x-4">
+        <div class="flex flex-row mx-4 gap-x-4">
           <%= for card <- @card_props do %>
             <CardHighlights.render
               title={card.title}
@@ -197,42 +194,44 @@ defmodule OliWeb.Components.Delivery.Content do
           <% end %>
         </div>
 
-        <div class="flex gap-2 mx-9 mt-4 mb-10">
-          <.form for={%{}} phx-target={@myself} phx-change="search_container" class="w-56">
-            <SearchInput.render
-              id="content_search_input"
-              name="container_name"
-              text={@params.text_search}
+        <div class="flex w-fit gap-2 mx-4 mt-4 mb-4 shadow-[0px_2px_6.099999904632568px_0px_rgba(0,0,0,0.10)] border border-[#ced1d9] dark:border-[#3B3740] dark:bg-[#000000]">
+          <div class="flex p-2 gap-2">
+            <.form for={%{}} phx-target={@myself} phx-change="search_container" class="w-56">
+              <SearchInput.render
+                id="content_search_input"
+                name="container_name"
+                text={@params.text_search}
+              />
+            </.form>
+
+            <Progress.render
+              target={@myself}
+              progress_percentage={@params.progress_percentage}
+              progress_selector={@params.progress_selector}
+              params_from_url={@params_from_url}
             />
-          </.form>
 
-          <Progress.render
-            target={@myself}
-            progress_percentage={@params.progress_percentage}
-            progress_selector={@params.progress_selector}
-            params_from_url={@params_from_url}
-          />
+            <.multi_select
+              id="proficiency_select"
+              options={@proficiency_options}
+              selected_values={@selected_proficiency_options}
+              selected_proficiency_ids={@selected_proficiency_ids}
+              target={@myself}
+              disabled={@selected_proficiency_ids == %{}}
+              placeholder="Proficiency"
+            />
 
-          <.multi_select
-            id="proficiency_select"
-            options={@proficiency_options}
-            selected_values={@selected_proficiency_options}
-            selected_proficiency_ids={@selected_proficiency_ids}
-            target={@myself}
-            disabled={@selected_proficiency_ids == %{}}
-            placeholder="Proficiency"
-          />
-
-          <button
-            class="text-center text-blue-500 text-xs font-semibold underline leading-none"
-            phx-click="clear_all_filters"
-            phx-target={@myself}
-          >
-            Clear All Filters
-          </button>
+            <button
+              class="ml-2 mr-6 text-center text-[#353740] dark:text-[#EEEBF5] text-sm font-normal leading-none flex items-center gap-x-2"
+              phx-click="clear_all_filters"
+              phx-target={@myself}
+            >
+              <Icons.trash class="stroke-[#353740] dark:stroke-[#EEEBF5]" /> Clear All Filters
+            </button>
+          </div>
         </div>
 
-        <InstructorDashboardPagedTable.render
+        <StripedPagedTable.render
           table_model={@table_model}
           total_count={@total_count}
           offset={@params.offset}
@@ -259,7 +258,7 @@ defmodule OliWeb.Components.Delivery.Content do
 
   def multi_select(assigns) do
     ~H"""
-    <div class={"flex flex-col border relative rounded-md h-9 #{if @selected_values != %{}, do: "border-blue-500", else: "border-zinc-400"}"}>
+    <div class={"flex flex-col relative rounded h-9 #{if @selected_values != %{}, do: "border border-blue-500", else: "outline outline-1 outline-[#ced1d9] dark:outline-[#3B3740]"}"}>
       <div
         phx-click={
           if(!@disabled,
@@ -270,7 +269,7 @@ defmodule OliWeb.Components.Delivery.Content do
           )
         }
         class={[
-          "flex gap-x-4 px-4 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
+          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
           if(@disabled, do: "bg-gray-300 hover:cursor-not-allowed")
         ]}
         id={"#{@id}-selected-options-container"}
@@ -278,7 +277,7 @@ defmodule OliWeb.Components.Delivery.Content do
         <div class="flex gap-1 flex-wrap">
           <span
             :if={@selected_values == %{}}
-            class="text-zinc-900 text-xs font-semibold leading-none dark:text-white"
+            class="text-[#353740] text-xs font-semibold leading-none dark:text-[#EEEBF5]"
           >
             <%= @placeholder %>
           </span>
@@ -400,7 +399,7 @@ defmodule OliWeb.Components.Delivery.Content do
   def handle_event("filter_container", %{"filter" => filter}, socket) do
     socket =
       update(socket, :params, fn params ->
-        %{params | progress_percentage: 100, progress_selector: :is_less_than_or_equal}
+        %{params | progress_percentage: 100, progress_selector: nil}
       end)
 
     {:noreply,
@@ -577,7 +576,7 @@ defmodule OliWeb.Components.Delivery.Content do
           |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
           |> sort_by(params.sort_by, params.sort_order)
 
-        {length(modules), "MODULES",
+        {length(modules), "Modules",
          modules |> Enum.drop(params.offset) |> Enum.take(params.limit)}
 
       :units ->
@@ -590,7 +589,7 @@ defmodule OliWeb.Components.Delivery.Content do
           |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
           |> sort_by(params.sort_by, params.sort_order)
 
-        {length(units), "UNITS", units |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+        {length(units), "Units", units |> Enum.drop(params.offset) |> Enum.take(params.limit)}
 
       :pages ->
         pages =
@@ -601,7 +600,7 @@ defmodule OliWeb.Components.Delivery.Content do
           |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
           |> sort_by(params.sort_by, params.sort_order)
 
-        {length(pages), "PAGES", pages |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+        {length(pages), "Pages", pages |> Enum.drop(params.offset) |> Enum.take(params.limit)}
     end
   end
 

--- a/lib/oli_web/components/delivery/content/content_table_model.ex
+++ b/lib/oli_web/components/delivery/content/content_table_model.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
   alias OliWeb.Common.Table.ColumnSpec
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Delivery.InstructorDashboard.HTMLComponents
+  alias OliWeb.Common.Chip
 
   alias OliWeb.Router.Helpers, as: Routes
 
@@ -11,24 +12,26 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
     column_specs = [
       %ColumnSpec{
         name: :numbering_index,
-        label: "ORDER",
+        label: "Order",
         th_class: "pl-10",
-        td_class: "pl-10"
+        td_class: "pl-10 text-[#353740] dark:text-[#EEEBF5]"
       },
       %ColumnSpec{
         name: :container_name,
         label: container_column_name,
+        th_class: "text-[#353740]",
         render_fn: &__MODULE__.render_name_column/3
       },
       %ColumnSpec{
         name: :student_completion,
-        th_class: "flex items-center gap-1 border-b-0",
-        label: HTMLComponents.student_progress_label(%{title: "STUDENT PROGRESS"}),
+        th_class: "flex items-center gap-1 border-b-0 text-[#353740]",
+        label: HTMLComponents.student_progress_label(%{title: "Class Progress"}),
         render_fn: &__MODULE__.render_student_completion/3
       },
       %ColumnSpec{
         name: :student_proficiency,
-        label: "STUDENT PROFICIENCY",
+        label: "Class Proficiency",
+        th_class: "text-[#353740]",
         tooltip:
           "For all students, or one specific student, proficiency for a learning objective will be calculated off the percentage of correct answers for first part attempts within first activity attempts - for those parts that have that learning objective or any of its sub-objectives attached to it.",
         render_fn: &__MODULE__.render_student_proficiency/3
@@ -56,7 +59,7 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
       ) do
     url_params =
       case column_spec.label do
-        "PAGES" -> %{page_id: container.id}
+        "Pages" -> %{page_id: container.id}
         _ -> %{container_id: container.id}
       end
 
@@ -73,11 +76,9 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
 
     ~H"""
     <div class="flex items-center">
-      <div class={"flex flex-shrink-0 rounded-full w-2 h-2 #{if @progress < 50, do: "bg-red-600", else: "bg-gray-500"}"}>
-      </div>
       <%= if @patch_url_type == :instructor_dashboard do %>
         <.link
-          class="ml-6 underline"
+          class="justify-start text-[#1B67B2] dark:text-[#4CA6FF] text-base font-medium leading-normal"
           patch={
             Routes.live_path(
               OliWeb.Endpoint,
@@ -105,7 +106,7 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
 
     ~H"""
     <div
-      class={if @progress < 50, do: "text-red-600 font-bold"}
+      class={"font-bold #{if @progress < 50, do: "text-[#ce2c31]", else: "text-[#353740] dark:text-[#EEEBF5]"}"}
       data-progress-check={if @progress >= 50, do: "true", else: "false"}
     >
       <%= @progress %>%
@@ -114,12 +115,23 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
   end
 
   def render_student_proficiency(assigns, container, _) do
-    assigns = Map.merge(assigns, %{container: container})
+    {bg_color, text_color} =
+      case container.student_proficiency do
+        "High" -> {"bg-[#e6fcf2] dark:bg-[#3D4F47]", "text-[#175a3d] dark:text-[#39E581]"}
+        "Medium" -> {"bg-[#ffecde] dark:bg-[#4C3F39]", "text-[#91450e] dark:text-[#FFB387]"}
+        "Low" -> {"bg-[#feebed] dark:bg-[#33181A]", "text-[#ce2c31] dark:text-[#FF8787]"}
+        _ -> {"bg-[#ced1d9] dark:bg-[#353740]", "text-[#000000] dark:text-[#FFFFFF]"}
+      end
+
+    assigns =
+      Map.merge(assigns, %{
+        label: container.student_proficiency,
+        bg_color: bg_color,
+        text_color: text_color
+      })
 
     ~H"""
-    <div class={if @container.student_proficiency == "Low", do: "text-red-600 font-bold"}>
-      <%= @container.student_proficiency %>
-    </div>
+    <Chip.render {assigns} />
     """
   end
 

--- a/lib/oli_web/components/delivery/content/content_table_model.ex
+++ b/lib/oli_web/components/delivery/content/content_table_model.ex
@@ -12,29 +12,24 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
     column_specs = [
       %ColumnSpec{
         name: :numbering_index,
-        label: "Order",
-        th_class: "pl-10",
-        td_class: "pl-10 text-[#353740] dark:text-[#EEEBF5]"
+        label: "Order"
       },
       %ColumnSpec{
         name: :container_name,
         label: container_column_name,
-        th_class: "text-[#353740]",
-        render_fn: &__MODULE__.render_name_column/3
+        render_fn: &render_name_column/3
       },
       %ColumnSpec{
         name: :student_completion,
-        th_class: "flex items-center gap-1 border-b-0 text-[#353740]",
         label: HTMLComponents.student_progress_label(%{title: "Class Progress"}),
-        render_fn: &__MODULE__.render_student_completion/3
+        render_fn: &render_student_completion/3
       },
       %ColumnSpec{
         name: :student_proficiency,
         label: "Class Proficiency",
-        th_class: "text-[#353740]",
         tooltip:
           "For all students, or one specific student, proficiency for a learning objective will be calculated off the percentage of correct answers for first part attempts within first activity attempts - for those parts that have that learning objective or any of its sub-objectives attached to it.",
-        render_fn: &__MODULE__.render_student_proficiency/3
+        render_fn: &render_student_proficiency/3
       }
     ]
 
@@ -106,7 +101,7 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
 
     ~H"""
     <div
-      class={"font-bold #{if @progress < 50, do: "text-[#ce2c31]", else: "text-[#353740] dark:text-[#EEEBF5]"}"}
+      class={"font-bold #{if @progress < 50, do: "text-[#FF8787]", else: "text-[#353740] dark:text-[#EEEBF5]"}"}
       data-progress-check={if @progress >= 50, do: "true", else: "false"}
     >
       <%= @progress %>%

--- a/lib/oli_web/components/delivery/content/multi_select.ex
+++ b/lib/oli_web/components/delivery/content/multi_select.ex
@@ -45,7 +45,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
       </div>
       <div class="relative">
         <div
-          class="py-4 hidden z-50 absolute dark:bg-gray-800 bg-white w-48 border overflow-y-scroll top-1 rounded"
+          class="py-4 px-4 hidden z-50 absolute dark:bg-gray-800 bg-white w-48 border overflow-y-scroll top-1 rounded"
           id={"#{@id}-options-container"}
           phx-click-away={
             JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")
@@ -54,7 +54,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
           <div>
             <.form
               :let={_f}
-              class="flex flex-column gap-y-3 px-4"
+              class="flex flex-column gap-y-3"
               for={%{}}
               as={:options}
               phx-change="toggle_selected"
@@ -74,7 +74,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
           <div class="w-full border border-gray-200 my-4"></div>
           <div class="flex flex-row items-center justify-end px-4 gap-x-4">
             <button
-              class="text-center text-neutral-600 text-xs font-semibold leading-none dark:text-white"
+              class="text-center text-[#006CD9] text-xs font-semibold leading-none dark:text-white"
               phx-click={
                 JS.hide(to: "##{@id}-options-container")
                 |> JS.hide(to: "##{@id}-up-icon")
@@ -84,7 +84,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
               Cancel
             </button>
             <button
-              class="px-4 py-2 bg-blue-500 rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
+              class="px-4 py-2 bg-[#0080FF] rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
               phx-click={
                 JS.push("apply_proficiency_filter")
                 |> JS.hide(to: "##{@id}-options-container")

--- a/lib/oli_web/components/delivery/content/multi_select.ex
+++ b/lib/oli_web/components/delivery/content/multi_select.ex
@@ -1,0 +1,110 @@
+defmodule OliWeb.Delivery.Content.MultiSelect do
+  use OliWeb, :html
+
+  import OliWeb.Components.Delivery.Buttons, only: [toggle_chevron: 1]
+  alias Phoenix.LiveView.JS
+
+  attr :placeholder, :string, default: "Select an option"
+  attr :disabled, :boolean, default: false
+  attr :options, :list, default: []
+  attr :id, :string
+  attr :target, :map, default: %{}
+  attr :selected_values, :map, default: %{}
+  attr :selected_proficiency_ids, :list, default: []
+
+  def render(assigns) do
+    ~H"""
+    <div class={"flex flex-col relative rounded h-9 #{if @selected_values != %{}, do: "border border-blue-500", else: "outline outline-1 outline-[#ced1d9] dark:outline-[#3B3740]"}"}>
+      <div
+        phx-click={
+          if(!@disabled,
+            do:
+              JS.toggle(to: "##{@id}-options-container")
+              |> JS.toggle(to: "##{@id}-down-icon")
+              |> JS.toggle(to: "##{@id}-up-icon")
+          )
+        }
+        class={[
+          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
+          if(@disabled, do: "bg-gray-300 hover:cursor-not-allowed")
+        ]}
+        id={"#{@id}-selected-options-container"}
+      >
+        <div class="flex gap-1 flex-wrap">
+          <span
+            :if={@selected_values == %{}}
+            class="text-[#353740] text-xs font-semibold leading-none dark:text-[#EEEBF5]"
+          >
+            <%= @placeholder %>
+          </span>
+          <span :if={@selected_values != %{}} class="text-blue-500 text-xs font-semibold leading-none">
+            Proficiency is <%= show_proficiency_selected_values(@selected_values) %>
+          </span>
+        </div>
+        <.toggle_chevron id={@id} map_values={@selected_values} />
+      </div>
+      <div class="relative">
+        <div
+          class="py-4 hidden z-50 absolute dark:bg-gray-800 bg-white w-48 border overflow-y-scroll top-1 rounded"
+          id={"#{@id}-options-container"}
+          phx-click-away={
+            JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")
+          }
+        >
+          <div>
+            <.form
+              :let={_f}
+              class="flex flex-column gap-y-3 px-4"
+              for={%{}}
+              as={:options}
+              phx-change="toggle_selected"
+              phx-target={@target}
+            >
+              <.input
+                :for={option <- @options}
+                name={option.id}
+                value={option.selected}
+                label={option.name}
+                checked={option.id in @selected_proficiency_ids}
+                type="checkbox"
+                label_class="text-zinc-900 text-xs font-normal leading-none dark:text-white"
+              />
+            </.form>
+          </div>
+          <div class="w-full border border-gray-200 my-4"></div>
+          <div class="flex flex-row items-center justify-end px-4 gap-x-4">
+            <button
+              class="text-center text-neutral-600 text-xs font-semibold leading-none dark:text-white"
+              phx-click={
+                JS.hide(to: "##{@id}-options-container")
+                |> JS.hide(to: "##{@id}-up-icon")
+                |> JS.show(to: "##{@id}-down-icon")
+              }
+            >
+              Cancel
+            </button>
+            <button
+              class="px-4 py-2 bg-blue-500 rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
+              phx-click={
+                JS.push("apply_proficiency_filter")
+                |> JS.hide(to: "##{@id}-options-container")
+                |> JS.hide(to: "##{@id}-up-icon")
+                |> JS.show(to: "##{@id}-down-icon")
+              }
+              phx-target={@target}
+              phx-value={@selected_proficiency_ids}
+              disabled={@disabled}
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp show_proficiency_selected_values(values) do
+    Enum.map_join(values, ", ", fn {_id, values} -> values end)
+  end
+end

--- a/lib/oli_web/components/delivery/content/progress.ex
+++ b/lib/oli_web/components/delivery/content/progress.ex
@@ -46,7 +46,7 @@ defmodule OliWeb.Delivery.Content.Progress do
           |> JS.hide(to: "#progress-up-icon")
           |> JS.show(to: "#progress-down-icon")
         }
-        class="hidden bg-white dark:bg-gray-800 mt-1 rounded border flex flex-col p-2 absolute w-auto"
+        class="hidden bg-white dark:bg-gray-800 mt-1 rounded border flex flex-col p-2 px-4 absolute w-auto"
         phx-submit="apply_progress_filter"
         id="progress_form"
         phx-target={@target}
@@ -91,7 +91,7 @@ defmodule OliWeb.Delivery.Content.Progress do
                 |> JS.hide(to: "#progress-up-icon")
                 |> JS.show(to: "#progress-down-icon")
               }
-              class="text-center text-neutral-600 text-xs font-semibold leading-none dark:text-white"
+              class="text-center text-[#006CD9] text-xs font-semibold leading-none dark:text-white"
             >
               Cancel
             </button>
@@ -101,7 +101,7 @@ defmodule OliWeb.Delivery.Content.Progress do
                 |> JS.hide(to: "#progress-up-icon")
                 |> JS.show(to: "#progress-down-icon")
               }
-              class="px-4 py-2 bg-blue-500 rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
+              class="px-4 py-2 bg-[#0080FF] rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
             >
               Apply
             </button>

--- a/lib/oli_web/components/delivery/content/progress.ex
+++ b/lib/oli_web/components/delivery/content/progress.ex
@@ -12,8 +12,7 @@ defmodule OliWeb.Delivery.Content.Progress do
   )
 
   def render(assigns) do
-    progress_selector = assigns.progress_selector || :is_less_than_or_equal
-    assigns = assign(assigns, :progress_selector, progress_selector)
+    assigns = assign(assigns, :progress_selector, assigns.progress_selector)
 
     ~H"""
     <div class="relative z-10">
@@ -27,7 +26,7 @@ defmodule OliWeb.Delivery.Content.Progress do
       >
         <button
           data-dropdown-toggle="dropdown"
-          class={"h-full flex-shrink-0 rounded-md z-10 inline-flex items-center py-2.5 px-4 text-zinc-900 text-xs font-semibold leading-none dark:text-white border border-[#B0B0B0] #{if @progress_selector not in ["", nil], do: "!text-blue-500 text-xs font-semibold leading-none"}"}
+          class={"h-full flex-shrink-0 rounded z-10 inline-flex items-center py-2.5 px-2 text-[#353740] text-xs font-semibold leading-none dark:text-[#EEEBF5] outline outline-1 outline-[#ced1d9] dark:outline-[#3B3740] #{if @progress_selector not in ["", nil], do: "!text-blue-500 text-xs font-semibold leading-none"}"}
           type="button"
         >
           Progress <%= progress_filter_text(
@@ -35,7 +34,7 @@ defmodule OliWeb.Delivery.Content.Progress do
             @progress_selector,
             @progress_percentage
           ) %>
-          <div class="ml-3">
+          <div class="ml-2">
             <.toggle_chevron id="progress" map_values={@progress_selector} />
           </div>
         </button>

--- a/lib/oli_web/icons.ex
+++ b/lib/oli_web/icons.ex
@@ -1194,12 +1194,14 @@ defmodule OliWeb.Icons do
     """
   end
 
+  attr :stroke_class, :string, default: "stroke-[#006CD9] dark:stroke-[#4CA6FF]"
+
   def download(assigns) do
     ~H"""
     <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M3.56934 14.9318V16.6791C3.56934 17.1425 3.75343 17.587 4.08111 17.9147C4.4088 18.2423 4.85324 18.4264 5.31666 18.4264H15.8006C16.264 18.4264 16.7084 18.2423 17.0361 17.9147C17.3638 17.587 17.5479 17.1425 17.5479 16.6791V14.9318M6.19032 9.68984L10.5586 14.0581M10.5586 14.0581L14.9269 9.68984M10.5586 14.0581V3.57422"
-        stroke="#5B8FF9"
+        class={@stroke_class}
         stroke-width="1.74732"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/lib/oli_web/live/common/chip.ex
+++ b/lib/oli_web/live/common/chip.ex
@@ -1,0 +1,19 @@
+defmodule OliWeb.Common.Chip do
+  use Phoenix.Component
+
+  attr :label, :string, required: true
+  attr :bg_color, :string, required: true
+  attr :text_color, :string, required: true
+
+  def render(assigns) do
+    ~H"""
+    <div class="inline-flex items-center">
+      <div class={"px-2 py-1 rounded-full shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] flex items-center overflow-hidden #{@bg_color}"}>
+        <div class="px-2 flex items-center">
+          <div class={"text-base font-semibold text-center #{@text_color}"}><%= @label %></div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/common/paging.ex
+++ b/lib/oli_web/live/common/paging.ex
@@ -34,9 +34,9 @@ defmodule OliWeb.Common.Paging do
     ~H"""
     <div
       id={@id}
-      class={"d-flex justify-content-between items-center py-2 " <> if Map.get(@params, :rendered_pages_count) == 1, do: "justify-end", else: ""}
+      class={"flex justify-between items-center py-2 " <> if Map.get(@params, :rendered_pages_count) == 1, do: "justify-end", else: ""}
     >
-      <div :if={@show_pagination}><%= @params.label %></div>
+      <div :if={@show_pagination} class="ml-4"><%= @params.label %></div>
       <div :if={@should_add_empty_flex} class="flex-1"></div>
       <.form
         :if={!@is_page_size_right}
@@ -122,7 +122,10 @@ defmodule OliWeb.Common.Paging do
         for={%{}}
         phx-change={@limit_change}
       >
-        <div :if={@show_limit_change} class="inline-flex flex-col gap-1 mr-2">
+        <div
+          :if={@show_limit_change}
+          class={"inline-flex flex-col gap-1 mr-4 #{if @is_page_size_right, do: "ml-4"}"}
+        >
           <small class="torus-small uppercase">
             Page size
           </small>

--- a/lib/oli_web/live/common/search_input.ex
+++ b/lib/oli_web/live/common/search_input.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Common.SearchInput do
   def render(assigns) do
     ~H"""
     <div class={[
-      "w-56 h-[35px] inline-flex items-center gap-2 px-2 py-1 rounded-md outline outline-1 outline-[#ced1d9] bg-[#ffffff] dark:bg-[#2B282E] dark:outline-[#2B282E]",
+      "w-56 h-[35px] inline-flex items-center gap-2 px-2 py-1 rounded-md outline outline-1 outline-[#ced1d9] bg-[#ffffff] dark:bg-[#2A282E] dark:outline-[#2A282E]",
       @class
     ]}>
       <i class="fa-solid fa-magnifying-glass text-[#757682] w-4 h-4 dark:text-[#BAB8BF]"></i>

--- a/lib/oli_web/live/common/search_input.ex
+++ b/lib/oli_web/live/common/search_input.ex
@@ -9,13 +9,16 @@ defmodule OliWeb.Common.SearchInput do
 
   def render(assigns) do
     ~H"""
-    <div class="w-full">
-      <i id={"#{@id}-icon"} class="absolute fa-solid fa-magnifying-glass pl-3 pt-3 h-4 w-4 "></i>
+    <div class={[
+      "w-56 h-[35px] inline-flex items-center gap-2 px-2 py-1 rounded-md outline outline-1 outline-[#ced1d9] bg-[#ffffff] dark:bg-[#2B282E] dark:outline-[#2B282E]",
+      @class
+    ]}>
+      <i class="fa-solid fa-magnifying-glass text-[#757682] w-4 h-4 dark:text-[#BAB8BF]"></i>
       <input
         id={"#{@id}-input"}
         phx-debounce="300"
         type="text"
-        class="h-9 w-full rounded border pl-9 focus:ring-1 focus:ring-delivery-primary animate-none focus:outline-2 dark:bg-[#0F0D0F] dark:text-violet-100 text-base font-normal font-['Roboto']"
+        class="w-full p-0 bg-transparent border-none outline-none ring-0 focus:outline-none focus:ring-0 text-[#353740] text-base font-normal placeholder:text-[#757682]"
         placeholder={@placeholder}
         value={@text}
         name={@name}

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -1,22 +1,22 @@
 defmodule OliWeb.Common.SortableTable.StripedTable do
   use Phoenix.Component
 
+  require Integer
+
   alias OliWeb.Common.Table.ColumnSpec
 
   @spec id_field(any, %{:id_field => any, optional(any) => any}) :: any
   def id_field(row, %{id_field: id_field}) when is_list(id_field) do
     id_field
-    |> Enum.reduce("", fn field, acc ->
-      cond do
-        is_atom(field) ->
-          "#{acc}-#{Map.get(row, field)}"
+    |> Enum.reduce("", fn
+      field, acc when is_atom(field) ->
+        "#{acc}-#{Map.get(row, field)}"
 
-        is_binary(field) ->
-          "#{acc}-#{field}"
+      field, acc when is_binary(field) ->
+        "#{acc}-#{field}"
 
-        true ->
-          acc
-      end
+      _field, acc ->
+        acc
     end)
     |> String.trim("-")
   end
@@ -157,7 +157,7 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
                 select: @select,
                 additional_table_class: @additional_table_class,
                 additional_row_class:
-                  if(rem(index, 2) == 0,
+                  if(Integer.is_even(index),
                     do: "bg-[#f3f4f8] dark:bg-[#0D0C0F]",
                     else: "bg-[#e3e7eb] dark:bg-[#201D21]"
                   )

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -37,7 +37,7 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
 
     ~H"""
     <th
-      class={"#{@column_spec.th_class} border-b border-r p-2 bg-gray-100 font-semibold #{if @column_spec.sortable, do: "cursor-pointer"}"}
+      class={"#{@column_spec.th_class} pl-2.5 border-b border-r p-2 bg-gray-100 font-semibold #{if @column_spec.sortable, do: "cursor-pointer"}"}
       phx-click={if @column_spec.sortable, do: @sort, else: nil}
       phx-value-sort_by={@column_spec.name}
       data-sortable={if @column_spec.sortable == false, do: "false", else: "true"}
@@ -48,21 +48,23 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
           else: "desc"
       }
     >
-      <%= if @column_spec.tooltip do %>
-        <span id={@column_spec.name} title={@column_spec.tooltip} phx-hook="TooltipInit">
+      <div class="flex items-center gap-1">
+        <%= if @column_spec.tooltip do %>
+          <span id={@column_spec.name} title={@column_spec.tooltip} phx-hook="TooltipInit">
+            <%= @column_spec.label %>
+          </span>
+        <% else %>
           <%= @column_spec.label %>
-        </span>
-      <% else %>
-        <%= @column_spec.label %>
-      <% end %>
+        <% end %>
 
-      <%= if @column_spec.sortable do %>
-        <OliWeb.Icons.chevron_down
-          width="16"
-          height="16"
-          class={"inline fill-black dark:fill-white " <> if @sort_direction_cls == "up", do: "", else: "rotate-180 "}
-        />
-      <% end %>
+        <%= if @column_spec.sortable do %>
+          <OliWeb.Icons.chevron_down
+            width="16"
+            height="16"
+            class={"inline fill-black dark:fill-white " <> if @sort_direction_cls == "up", do: "", else: "rotate-180 "}
+          />
+        <% end %>
+      </div>
     </th>
     """
   end
@@ -92,7 +94,7 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
       phx-value-id={id_field(@row, @model)}
     >
       <%= for column_spec <- @model.column_specs do %>
-        <td class={"#{column_spec.td_class} border-r p-2"}>
+        <td class={"#{column_spec.td_class} border-r p-2 pl-2.5"}>
           <div class={if Map.get(@model.data, :fade_data, false), do: "fade-text", else: ""}>
             <%= if is_nil(column_spec.render_fn) do %>
               <%= ColumnSpec.default_render_fn(column_spec, @row) %>
@@ -127,7 +129,7 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
   def render(assigns) do
     ~H"""
     <table class={"min-w-full border " <> @additional_table_class}>
-      <thead class="sticky top-0 z-10 bg-white dark:bg-[#000000]">
+      <thead class="sticky top-0 bg-white dark:bg-[#000000]">
         <tr>
           <%= for column_spec <- @model.column_specs do %>
             <%= render_th(
@@ -156,8 +158,8 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
                 additional_table_class: @additional_table_class,
                 additional_row_class:
                   if(rem(index, 2) == 0,
-                    do: "bg-[#f3f4f8] dark:bg-[#201D21]",
-                    else: "bg-[#e3e7eb] dark:bg-[#0D0C0F]"
+                    do: "bg-[#f3f4f8] dark:bg-[#0D0C0F]",
+                    else: "bg-[#e3e7eb] dark:bg-[#201D21]"
                   )
               },
               @model.data

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -1,0 +1,176 @@
+defmodule OliWeb.Common.SortableTable.StripedTable do
+  use Phoenix.Component
+
+  alias OliWeb.Common.Table.ColumnSpec
+
+  @spec id_field(any, %{:id_field => any, optional(any) => any}) :: any
+  def id_field(row, %{id_field: id_field}) when is_list(id_field) do
+    id_field
+    |> Enum.reduce("", fn field, acc ->
+      cond do
+        is_atom(field) ->
+          "#{acc}-#{Map.get(row, field)}"
+
+        is_binary(field) ->
+          "#{acc}-#{field}"
+
+        true ->
+          acc
+      end
+    end)
+    |> String.trim("-")
+  end
+
+  def id_field(row, %{id_field: id_field}) do
+    Map.get(row, id_field)
+  end
+
+  defp render_th(assigns, column_spec) do
+    sort_direction_cls =
+      case assigns.model.sort_order do
+        :asc -> "up"
+        _ -> "down"
+      end
+
+    assigns =
+      Map.merge(assigns, %{sort_direction_cls: sort_direction_cls, column_spec: column_spec})
+
+    ~H"""
+    <th
+      class={"#{@column_spec.th_class} border-b border-r p-2 bg-gray-100 font-semibold #{if @column_spec.sortable, do: "cursor-pointer"}"}
+      phx-click={if @column_spec.sortable, do: @sort, else: nil}
+      phx-value-sort_by={@column_spec.name}
+      data-sortable={if @column_spec.sortable == false, do: "false", else: "true"}
+      data-sort-column={if @model.sort_by_spec == @column_spec, do: "true", else: "false"}
+      data-sort-order={
+        if @model.sort_by_spec == @column_spec,
+          do: to_string(@model.sort_order || :desc),
+          else: "desc"
+      }
+    >
+      <%= if @column_spec.tooltip do %>
+        <span id={@column_spec.name} title={@column_spec.tooltip} phx-hook="TooltipInit">
+          <%= @column_spec.label %>
+        </span>
+      <% else %>
+        <%= @column_spec.label %>
+      <% end %>
+
+      <%= if @column_spec.sortable do %>
+        <OliWeb.Icons.chevron_down
+          width="16"
+          height="16"
+          class={"inline fill-black dark:fill-white " <> if @sort_direction_cls == "up", do: "", else: "rotate-180 "}
+        />
+      <% end %>
+    </th>
+    """
+  end
+
+  defp render_row(assigns, row) do
+    row_class =
+      if id_field(row, assigns.model) == assigns.model.selected do
+        "border-b table-active"
+      else
+        if assigns.select != nil do
+          "border-b selectable"
+        else
+          "border-b"
+        end
+      end
+
+    row_class = row_class <> " #{assigns[:additional_row_class]}"
+
+    assigns = Map.merge(assigns, %{row: row, row_class: row_class})
+
+    ~H"""
+    <tr
+      id={id_field(@row, @model)}
+      class={@row_class <> if Map.get(@row, :selected) || id_field(@row, @model) == @model.selected, do: " bg-delivery-primary-100 shadow-inner dark:bg-gray-700 dark:text-black", else: ""}
+      aria-selected={if Map.get(@row, :selected), do: "true", else: "false"}
+      phx-click={@select}
+      phx-value-id={id_field(@row, @model)}
+    >
+      <%= for column_spec <- @model.column_specs do %>
+        <td class={"#{column_spec.td_class} border-r p-2"}>
+          <div class={if Map.get(@model.data, :fade_data, false), do: "fade-text", else: ""}>
+            <%= if is_nil(column_spec.render_fn) do %>
+              <%= ColumnSpec.default_render_fn(column_spec, @row) %>
+            <% else %>
+              <%= column_spec.render_fn.(
+                with_data(
+                  %{
+                    model: @model,
+                    sort: @sort,
+                    select: @select,
+                    additional_table_class: @additional_table_class
+                  },
+                  @model.data
+                ),
+                @row,
+                column_spec
+              ) %>
+            <% end %>
+          </div>
+        </td>
+      <% end %>
+    </tr>
+    """
+  end
+
+  attr :model, :map, required: true
+  attr :sort, :string, required: true
+  attr :select, :string, default: ""
+  attr :additional_table_class, :string, default: "table-sm"
+  attr :additional_row_class, :string, default: ""
+
+  def render(assigns) do
+    ~H"""
+    <table class={"min-w-full border " <> @additional_table_class}>
+      <thead class="sticky top-0 z-10 bg-white dark:bg-[#000000]">
+        <tr>
+          <%= for column_spec <- @model.column_specs do %>
+            <%= render_th(
+              with_data(
+                %{
+                  model: @model,
+                  sort: @sort,
+                  select: @select,
+                  additional_table_class: @additional_table_class
+                },
+                @model.data
+              ),
+              column_spec
+            ) %>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for {row, index} <- Enum.with_index(@model.rows) do %>
+          <%= render_row(
+            with_data(
+              %{
+                model: @model,
+                sort: @sort,
+                select: @select,
+                additional_table_class: @additional_table_class,
+                additional_row_class:
+                  if(rem(index, 2) == 0,
+                    do: "bg-[#f3f4f8] dark:bg-[#201D21]",
+                    else: "bg-[#e3e7eb] dark:bg-[#0D0C0F]"
+                  )
+              },
+              @model.data
+            ),
+            row
+          ) %>
+        <% end %>
+      </tbody>
+    </table>
+    """
+  end
+
+  defp with_data(assigns, data) do
+    Map.merge(assigns, data)
+  end
+end

--- a/lib/oli_web/live/common/table/striped_paged_table.ex
+++ b/lib/oli_web/live/common/table/striped_paged_table.ex
@@ -1,0 +1,159 @@
+defmodule OliWeb.Common.StripedPagedTable do
+  use Phoenix.Component
+  alias OliWeb.Common.SortableTable.StripedTable
+  alias OliWeb.Common.Paging
+
+  attr :total_count, :integer, required: true
+  attr :filter, :string, default: ""
+  attr :limit, :integer, required: true
+  attr :offset, :integer, required: true
+  attr :table_model, :map, required: true
+  attr :allow_selection, :boolean, required: false, default: false
+  attr :sort, :string, default: "paged_table_sort"
+  attr :page_change, :string, default: "paged_table_page_change"
+  attr :selection_change, :string, default: "paged_table_selection_change"
+  attr :limit_change, :string, default: "paged_table_limit_change"
+  attr :show_bottom_paging, :boolean, default: true
+
+  attr :additional_table_class, :string, default: ""
+  attr :render_top_info, :boolean, default: true
+  attr :scrollable, :boolean, default: true
+  attr :show_limit_change, :boolean, default: false
+  attr :no_records_message, :string, default: "None exist"
+  attr :overflow_class, :string, default: "inline"
+
+  def render(assigns) do
+    ~H"""
+    <div class={if @scrollable, do: "overflow-x-auto #{@overflow_class}"}>
+      <%= if @filter != "" and @render_top_info do %>
+        <strong>Results filtered on &quot;<%= @filter %>&quot;</strong>
+      <% end %>
+
+      <%= if @total_count > 0 do %>
+        <div :if={@total_count <= @limit and @render_top_info} class="px-5 py-2">
+          Showing all results (<%= @total_count %> total)
+        </div>
+        <div class="relative max-h-[650px] overflow-y-auto overflow-x-auto mx-4">
+          <%= render_table(%{
+            allow_selection: @allow_selection,
+            table_model: @table_model,
+            sort: @sort,
+            selection_change: @selection_change,
+            additional_table_class: @additional_table_class
+          }) %>
+        </div>
+        <Paging.render
+          id="footer_paging"
+          total_count={@total_count}
+          offset={@offset}
+          limit={@limit}
+          click={@page_change}
+          limit_change={@limit_change}
+          has_shorter_label={true}
+          show_limit_change={true}
+          should_add_empty_flex={false}
+          is_page_size_right={true}
+        />
+      <% else %>
+        <div class="bg-white dark:bg-gray-800 dark:text-white px-10 my-5">
+          <p><%= @no_records_message %></p>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  def render_table(assigns) do
+    if assigns.allow_selection do
+      ~H"""
+      <StripedTable.render
+        model={@table_model}
+        sort={@sort}
+        select={@selection_change}
+        additional_table_class={@additional_table_class}
+      />
+      """
+    else
+      ~H"""
+      <StripedTable.render
+        model={@table_model}
+        sort={@sort}
+        additional_table_class={@additional_table_class}
+      />
+      """
+    end
+  end
+
+  @spec handle_delegated(<<_::64, _::_*8>>, map, any, (any, any -> any), any) :: any
+  def handle_delegated(event, params, socket, patch_fn, model_key \\ :table_model) do
+    delegate_handle_event(event, params, socket, patch_fn, model_key)
+  end
+
+  def delegate_handle_event("paged_table_page_change", %{"offset" => offset}, socket, patch_fn, _) do
+    patch_fn.(socket, %{offset: offset})
+  end
+
+  def delegate_handle_event(
+        "paged_table_limit_change",
+        params,
+        %{assigns: %{params: current_params}} = socket,
+        patch_fn,
+        _
+      ) do
+    new_limit = OliWeb.Common.Params.get_int_param(params, "limit", 20)
+
+    new_offset =
+      if socket.assigns.total_count < new_limit do
+        0
+      else
+        OliWeb.Common.PagingParams.calculate_new_offset(
+          current_params.offset,
+          new_limit,
+          socket.assigns.total_count
+        )
+      end
+
+    patch_fn.(socket, %{limit: new_limit, offset: new_offset})
+  end
+
+  def delegate_handle_event(
+        "paged_table_selection_change",
+        %{"id" => selected},
+        socket,
+        patch_fn,
+        _
+      ) do
+    patch_fn.(socket, %{selected: selected})
+  end
+
+  # handle change of selection
+  def delegate_handle_event(
+        "paged_table_sort",
+        %{"sort_by" => sort_by},
+        socket,
+        patch_fn,
+        model_key
+      ) do
+    sort_order =
+      case Atom.to_string(socket.assigns[model_key].sort_by_spec.name) do
+        ^sort_by ->
+          if socket.assigns[model_key].sort_order == :asc do
+            :desc
+          else
+            :asc
+          end
+
+        _ ->
+          socket.assigns[model_key].sort_order
+      end
+
+    patch_fn.(socket, %{
+      sort_by: sort_by,
+      sort_order: sort_order
+    })
+  end
+
+  def delegate_handle_event(_, _, _, _) do
+    :not_handled
+  end
+end

--- a/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
@@ -233,7 +233,9 @@ defmodule OliWeb.Delivery.InstructorDashboard.HTMLComponents do
         <Icons.info />
       </button>
     </div>
-    <%= @title %>
+    <div class="ml-1">
+      <%= @title %>
+    </div>
     """
   end
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
@@ -194,7 +194,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.HTMLComponents do
     ~H"""
     <div
       id="student_progress_tooltip_container"
-      class="flex relative cursor-auto"
+      class="flex relative cursor-auto z-9999999999"
       phx-hook="HoverAway"
       mouse-leave-js={
         JS.hide(
@@ -208,7 +208,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.HTMLComponents do
       <div
         id="student_progress_tooltip"
         onclick="event.stopPropagation()"
-        class="absolute z-10 hidden -translate-x-[140px] -translate-y-[73px] w-max flex-col items-start p-3 border border-[#3a3740] rounded-md shadow bg-white dark:bg-[#0d0c0f] font-normal"
+        class="absolute z-50 hidden translate-x-[-10px] translate-y-[2rem] w-max flex-col items-start p-3 border border-[#3a3740] rounded-md shadow bg-white dark:bg-[#0d0c0f] font-normal"
       >
         <span style="text-[#353740] dark:text-[#eeebf5] text-sm leading-normal">
           This is an estimate of student progress.

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/content_tab_test.exs
@@ -320,10 +320,11 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       assert filtered_links == expected_links
 
       ### "units" button is selected
-      assert has_element?(view, "button.bg-blue-500", "Units")
-      refute has_element?(view, "button.bg-white", "Units")
-      assert has_element?(view, "button.bg-white", "Modules")
-      refute has_element?(view, "button.bg-blue-500", "Modules")
+      assert button_has_class?(view, "filter_units_button", "bg-[#0080FF]")
+      refute button_has_class?(view, "filter_units_button", "bg-white")
+
+      assert button_has_class?(view, "filter_modules_button", "bg-[#F3F4F8]")
+      refute button_has_class?(view, "filter_modules_button", "bg-[#0080FF]")
     end
 
     test "content table gets rendered given a section with only pages",
@@ -486,14 +487,15 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       ## filtering by modules
       element(view, "#filter_modules_button") |> render_click()
 
-      assert has_element?(view, "button.bg-blue-500", "Modules")
+      assert button_has_class?(view, "filter_modules_button", "bg-[#0080FF]")
+      refute button_has_class?(view, "filter_units_button", "bg-[#0080FF]")
 
       [module_for_tr_1, module_for_tr_2, module_for_tr_3] =
         view
         |> render()
         |> Floki.parse_fragment!()
         |> Floki.find(~s{.instructor_dashboard_table tr a})
-        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+        |> Enum.map(&Floki.text/1)
 
       assert module_for_tr_1 =~ "Module 1"
       assert module_for_tr_2 =~ "Module 2"
@@ -502,14 +504,15 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
       ## filtering by units
       element(view, "#filter_units_button") |> render_click()
 
-      assert has_element?(view, "button.bg-blue-500", "Units")
+      assert button_has_class?(view, "filter_units_button", "bg-[#0080FF]")
+      refute button_has_class?(view, "filter_modules_button", "bg-[#0080FF]")
 
       [unit_for_tr_1, unit_for_tr_2] =
         view
         |> render()
         |> Floki.parse_fragment!()
         |> Floki.find(~s{.instructor_dashboard_table tr a})
-        |> Enum.map(fn a_tag -> Floki.text(a_tag) end)
+        |> Enum.map(&Floki.text/1)
 
       assert unit_for_tr_1 =~ "Unit 1"
       assert unit_for_tr_2 =~ "Unit 2"
@@ -792,5 +795,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.ContentTabTest do
     filtered_query_params = Map.drop(query_params, ["navigation_data"])
     new_query = URI.encode_query(filtered_query_params)
     URI.to_string(%{uri | query: new_query})
+  end
+
+  defp button_has_class?(view, button_id, expected_class) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find("##{button_id}")
+    |> Floki.attribute("class")
+    |> List.first()
+    |> to_string()
+    |> String.contains?(expected_class)
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/students_tab_test.exs
@@ -81,7 +81,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
       assert has_element?(
                view,
                "th[phx-value-sort_by=\"student_completion\"]",
-               "STUDENT PROGRESS"
+               "Class Progress"
              )
 
       # Link that triggers the opening of the modal
@@ -946,7 +946,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.StudentsTabTest do
         container_filter_by: :units,
         selected_card_value: :zero_student_progress,
         progress_percentage: 100,
-        progress_selector: :is_less_than_or_equal,
         selected_proficiency_ids: Jason.encode!([])
       }
 

--- a/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/student_dashboard_live_test.exs
@@ -178,7 +178,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLiveTest do
       assert has_element?(
                view,
                "th[phx-value-sort_by=\"student_completion\"]",
-               "STUDENT PROGRESS"
+               "Class Progress"
              )
 
       # Link that triggers the opening of the modal


### PR DESCRIPTION
[MER-4693](https://eliterate.atlassian.net/browse/MER-4693)

This PR introduces a set of UI improvements to the `Content` tab in the instructor `Insights` view.

A new reusable table component was created, implementing zebra striping and following the visual style defined in Figma. This component is intended to be used across future views.

Additionally, several components were created or improved to promote reusability in upcoming tickets:

- A chip component to visually represent proficiency levels (green for high, orange for medium, red for low, gray for not enough data)

- An updated search input component (OliWeb.Common.SearchInput).

- An improved progress filter component (OliWeb.Delivery.Content.Progress) to align with the new filtering interface

- A new multi-select component (OliWeb.Delivery.Content.MultiSelect), extracted from inline logic and currently used to filter by proficiency

- An improved filter card component matching the visual design in Figma

Note that the previous table components were not removed, as they are still being used in other parts of the codebase. The new component was introduced alongside them, with the goal of progressively migrating other views in the future.


**Screenshots**

<img width="1610" height="817" alt="content-light-1" src="https://github.com/user-attachments/assets/f3e87938-4ec1-4f0c-96d6-3bfcc7031a09" />

<img width="1305" height="886" alt="content-light-2" src="https://github.com/user-attachments/assets/2e8d9396-21bc-4382-8dfa-3615885ad14f" />

<img width="1627" height="830" alt="content-dark-1" src="https://github.com/user-attachments/assets/ddd55b4c-8fc2-4b05-ac4d-05f23d8691c9" />

<img width="1335" height="900" alt="content-dark-2" src="https://github.com/user-attachments/assets/b44f31a1-36af-4217-bae4-01ddb48414bc" />



[MER-4693]: https://eliterate.atlassian.net/browse/MER-4693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ