### PR TITLE
[BUG FIX] [MER-4428] Update Num Input component to include Significant Figures capi property

### DIFF
--- a/assets/src/utils/common.ts
+++ b/assets/src/utils/common.ts
@@ -310,15 +310,16 @@ export function isDefined<T>(value: T | undefined): value is T {
 /**
  * Calculates the number of significant figures in a numeric string input.
  *
- * Rules handled:
- * - Leading zeros are not significant.
- * - All non-zero digits are significant.
- * - Zeros between non-zero digits are significant.
- * - Trailing zeros in decimal numbers are significant.
- * - Trailing zeros in whole numbers are not significant unless followed by a decimal point (e.g., "100.").
- * - Scientific notation is parsed correctly (e.g., "1.23e4" has 3 sig figs).
+ * ✅ Rules handled:
+ * - Leading zeros are **not significant** (e.g., "0.003" → 1 sig fig).
+ * - All **non-zero digits** are significant.
+ * - Zeros **between non-zero digits** are significant (e.g., "1002" → 4 sig figs).
+ * - Trailing zeros in **decimal numbers** are significant (e.g., "5.00" → 3 sig figs).
+ * - Trailing zeros in **whole numbers** are **not significant** unless a decimal point is present (e.g., "100" → 1, "100." → 3).
+ * - **Scientific notation** is handled correctly (e.g., "1.20e4" → 3 sig figs).
+ * - Handles both signed numbers and numbers without leading digits (e.g., "-.003").
  *
- * @param input - The number input as a string (e.g., "0.01230", "100", "1.23e4").
+ * @param input - The number input as a string (e.g., "0.01230", "100", "3.00", "1.23e4").
  * @returns The count of significant figures as a number.
  */
 export const countSigFigs = (input: string): number => {
@@ -326,23 +327,31 @@ export const countSigFigs = (input: string): number => {
 
   const trimmed = input.trim();
 
-  // Handle scientific notation like "1.23e4"
-  const sciMatch = trimmed.match(/^(-)?(\d+(\.\d+)?)(e[-+]?\d+)?$/i);
-  if (sciMatch) {
-    const [base] = trimmed.split(/e/i);
-    return base.replace('.', '').replace(/^0+/, '').length;
+  // Handle scientific notation
+  if (/e/i.test(trimmed)) {
+    const [base] = trimmed.toLowerCase().split('e');
+    const cleaned = base.replace(/^[-+]?0+/, ''); // Remove leading zeros
+    const digits = cleaned.replace('.', '');
+    return digits.length;
   }
 
-  // Remove leading/trailing zeros (depending on decimal)
+  // Handle decimal numbers
   if (trimmed.includes('.')) {
-    // Decimal number: all digits except leading zeros are significant
-    return trimmed
-      .replace(/^[-+]?0+/, '') // Remove leading zeros
-      .replace('.', '').length; // Remove decimal
-  } else {
-    // Integer: trailing zeros are not significant unless scientific notation
-    return trimmed
-      .replace(/^[-+]?0*/, '') // Remove leading zeros
-      .replace(/0+$/, '').length; // Remove trailing zeros
+    const cleaned = trimmed.replace(/^[-+]/, ''); // remove sign
+    const digits = cleaned.replace('.', '');
+
+    // Remove leading zeros before the first non-zero digit
+    const sigStart = digits.search(/[1-9]/);
+    if (sigStart === -1) return 0; // all zeros
+
+    return digits.slice(sigStart).length;
   }
+
+  // Integer (no decimal)
+  const hasDot = trimmed.endsWith('.');
+  const digits = trimmed.replace(/^[-+]?0+/, ''); // remove leading zeros
+
+  return hasDot
+    ? digits.length // e.g., 100. → all significant
+    : digits.replace(/0+$/, '').length; // e.g., 100 → trailing zeros not significant
 };


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

This PR fixes the follow-up issues mentioned in the ticket. 

I have tested these with the following use cases and they are giving correct Sig figs.
0.003 contains 1 significant figure, the “3”
.003 contains 1 significant figure, the “3”
0.0030 contain 2 significant figures, the “3” and the “0” (after the 3)
3.00 contains 3 significant figures, the “3”, “0” and “0” 
.000310 contains 3 significant figures, the “3”, “1” and “0” (after the 1)
5.00 = 3 sig figs
5.000 = 4 sig figs