### PR TITLE
[ENHANCEMENT] [MER-4078] Designer or TA Role in Canvas Does Not Work

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -14,7 +14,6 @@ defmodule Oli.Delivery.Paywall do
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Institutions.Institution
   alias Oli.Delivery.Paywall.AccessSummary
-  alias Lti_1p3.Roles.ContextRoles
 
   @maximum_batch_size 500
 
@@ -74,9 +73,7 @@ defmodule Oli.Delivery.Paywall do
         enrollment,
         payment
       ) do
-    instructor_context_role_id = ContextRoles.get_role(:context_instructor).id
-
-    if user_role_id == instructor_context_role_id or Sections.is_admin?(user, slug) do
+    if user_role_id in Sections.get_instructor_role_ids() or Sections.is_admin?(user, slug) do
       AccessSummary.instructor()
     else
       if is_nil(enrollment) and section.requires_enrollment do

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -5,6 +5,7 @@ defmodule Oli.Delivery.Sections.Browse do
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Accounts.User
   alias Oli.Delivery.Sections.{Section, Enrollment, BrowseOptions}
+  alias Oli.Delivery.Sections
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
 
@@ -83,15 +84,13 @@ defmodule Oli.Delivery.Sections.Browse do
         do: true,
         else: dynamic([s, _], s.base_project_id == ^options.project_id)
 
-    instructor_role_id = ContextRoles.get_role(:context_instructor).id
-
     instructor =
       from u in User,
         join: e in Enrollment,
         on: e.user_id == u.id,
         join: ecr in "enrollments_context_roles",
         on:
-          ecr.enrollment_id == e.id and ecr.context_role_id == ^instructor_role_id and
+          ecr.enrollment_id == e.id and ecr.context_role_id in ^Sections.get_instructor_role_ids() and
             e.status == :enrolled,
         select: %{
           name: fragment("array_to_string((array_agg(?)), ', ')", u.name),

--- a/lib/oli/interop/custom_activities/authorizations.ex
+++ b/lib/oli/interop/custom_activities/authorizations.ex
@@ -1,5 +1,5 @@
 defmodule Oli.Interop.CustomActivities.Authorizations do
-  alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Delivery.Sections
 
   import XmlBuilder
 
@@ -9,16 +9,8 @@ defmodule Oli.Interop.CustomActivities.Authorizations do
     element(
       :authorizations,
       %{
-        grade_responses:
-          ContextRoles.contains_role?(
-            context.enrollment.context_roles,
-            ContextRoles.get_role(:context_instructor)
-          ),
-        instruct_material:
-          ContextRoles.contains_role?(
-            context.enrollment.context_roles,
-            ContextRoles.get_role(:context_instructor)
-          ),
+        grade_responses: Sections.contains_instructor_role?(context.enrollment.context_roles),
+        instruct_material: Sections.contains_instructor_role?(context.enrollment.context_roles),
         view_material: "true",
         view_responses: "true"
       }

--- a/lib/oli/interop/custom_activities/registration.ex
+++ b/lib/oli/interop/custom_activities/registration.ex
@@ -1,6 +1,4 @@
 defmodule Oli.Interop.CustomActivities.Registration do
-  alias Lti_1p3.Roles.ContextRoles
-
   import XmlBuilder
 
   def setup(%{
@@ -11,11 +9,7 @@ defmodule Oli.Interop.CustomActivities.Registration do
       %{
         date_created: DateTime.to_unix(context.enrollment.inserted_at),
         guid: context.enrollment.id,
-        role:
-          ContextRoles.contains_role?(
-            context.enrollment.context_roles,
-            ContextRoles.get_role(:context_instructor)
-          ),
+        role: Oli.Delivery.Sections.contains_instructor_role?(context.enrollment.context_roles),
         section_guid: context.section.slug,
         status: "valid",
         user_guid: context.user.email

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -248,7 +248,8 @@ defmodule OliWeb.Components.Delivery.Utils do
 
   @instructor_roles [
     PlatformRoles.get_role(:institution_instructor),
-    ContextRoles.get_role(:context_instructor)
+    ContextRoles.get_role(:context_instructor),
+    ContextRoles.get_role(:context_content_developer)
   ]
 
   @student_roles [

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.DeliveryController do
     PlatformRoles.get_role(:system_administrator),
     PlatformRoles.get_role(:institution_administrator),
     ContextRoles.get_role(:context_administrator),
-    ContextRoles.get_role(:context_instructor)
+    ContextRoles.get_role(:context_instructor),
+    ContextRoles.get_role(:context_content_developer)
   ]
 
   @doc """

--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -11,10 +11,6 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
 
   @default_params %{text_search: "", sidebar_expanded: true}
 
-  @context_instructor_roles [
-    Lti_1p3.Roles.ContextRoles.get_role(:context_instructor)
-  ]
-
   @impl Phoenix.LiveView
   def mount(_params, _session, %{assigns: %{current_user: current_user, ctx: ctx}} = socket)
       when not is_nil(current_user) do
@@ -417,6 +413,7 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
   end
 
   defp sections_where_user_is_instructor(user_id) do
-    Sections.get_open_and_free_active_sections_by_roles(user_id, @context_instructor_roles)
+    context_instructor_roles = Sections.get_instructor_roles()
+    Sections.get_open_and_free_active_sections_by_roles(user_id, context_instructor_roles)
   end
 end

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -2185,8 +2185,6 @@ defmodule Oli.SectionsTest do
   end
 
   describe "contains_instructor_role?/1" do
-    alias Lti_1p3.Roles.ContextRoles
-
     test "returns true if roles include context_instructor" do
       roles = [ContextRoles.get_role(:context_instructor)]
       assert Oli.Delivery.Sections.contains_instructor_role?(roles)


### PR DESCRIPTION
[MER-4078](https://eliterate.atlassian.net/browse/MER-4078)

### Summary:

This PR updates Torus to treat users with the Canvas "Designer" role (represented as ContentDeveloper in LTI) as instructors throughout the platform. Previously, Designers were incorrectly mapped to students, preventing them from configuring or managing course sections. With this change, both Instructors and Designers are recognized as instructors in the system.

- The LTI role ContentDeveloper is now included wherever instructor roles are checked (e.g., enrollments, permissions, filters, and UI helpers).
- All queries and helper functions that previously only considered context_instructor now also include context_content_developer.

💡 **Note:** The TA role was already mapped to instructor in Torus, so no changes were required for TAs.



https://github.com/user-attachments/assets/e10ca7f1-caf5-4ca1-8c78-34357c021a60



[MER-4078]: https://eliterate.atlassian.net/browse/MER-4078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ