### PR TITLE
[FEATURE] [MER-4684] Add available dates to student assignment UI- Rework 2

### DIFF
--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -286,7 +286,6 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
           <%= @assignment.title %>
         </.link>
         <span
-          :if={@has_scheduled_resources?}
           role="assignment schedule details"
           class="text-[#757682] dark:text-[#eeebf5]/75 text-xs font-semibold leading-3 whitespace-nowrap truncate"
         >
@@ -304,11 +303,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
           </span>
           <span class="ml-6">
             <%= Utils.label_for_scheduling_type(@assignment.scheduling_type) %>
-            <%= FormatDateTime.to_formatted_datetime(
-              @assignment.end_date,
-              @ctx,
-              "{WDshort} {Mshort} {D}, {YYYY}"
-            ) %>
+            <%= format_date(@assignment.end_date, @ctx, "{WDshort} {Mshort} {D}, {YYYY}") %>
           </span>
         </span>
       </div>
@@ -515,4 +510,9 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
     do:
       certificate.assessments_apply_to == :all or
         assignment.id in certificate.custom_assessments
+
+  defp format_date(nil, _ctx, _format), do: "None"
+
+  defp format_date(date, ctx, _format),
+    do: FormatDateTime.to_formatted_datetime(date, ctx, "{WDshort} {Mshort} {D}, {YYYY}")
 end

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -188,7 +188,10 @@ defmodule OliWeb.Delivery.Student.Utils do
         TERMS
       </span>
       <ul class="list-disc ml-6">
-        <li :if={@has_scheduled_resources?} id="page_due_terms">
+        <li
+          :if={@has_scheduled_resources? or not is_nil(@effective_settings.end_date)}
+          id="page_due_terms"
+        >
           <.page_due_term effective_settings={@effective_settings} ctx={@ctx} />
         </li>
         <li :if={!@effective_settings.batch_scoring} id="score_as_you_go_term">

--- a/test/oli_web/live/delivery/student/assignments_live_test.exs
+++ b/test/oli_web/live/delivery/student/assignments_live_test.exs
@@ -584,10 +584,10 @@ defmodule OliWeb.Delivery.Student.AssignmentsLiveTest do
              |> Floki.text()
              |> String.replace(~r/\s+/, " ")
              |> String.trim() =~
-               "Available: Now Read by: Not yet scheduled"
+               "Available: Now Read by: None"
     end
 
-    test "can not see schedule details when course has no scheduled resources", %{
+    test "can see schedule details when course has no scheduled resources", %{
       conn: conn,
       user: user
     } do
@@ -605,7 +605,7 @@ defmodule OliWeb.Delivery.Student.AssignmentsLiveTest do
         live(conn, live_view_assignments_live_route(section_without_schedule.slug))
 
       Enum.each([page_1, page_2, page_3, page_4], fn page ->
-        refute has_element?(
+        assert has_element?(
                  view,
                  ~s{div[role="assignment detail"][id="assignment_#{page.resource_id}"] span[role="assignment schedule details"]}
                )


### PR DESCRIPTION
[MER-4684](https://eliterate.atlassian.net/browse/MER-4684)

This PR is a rework to address the issues found during QA based on the expectations defined in the related ticket.

It specifically aims to fix the behavior mentioned in [these comments](https://eliterate.atlassian.net/browse/MER-4684?focusedCommentId=31148).

I added a private `format_date/3` function in `AssignmentsLive` module to handle cases where the end date is nil, displaying the text "None".

I chose not to modify the public `FormatDateTime.to_formatted_datetime/3` function to return "None" when the end date is nil, as I’m unsure whether such a change would conflict with expected behavior elsewhere in the application.

[MER-4684]: https://eliterate.atlassian.net/browse/MER-4684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ