### PR TITLE
[BUG FIX] [MER-4689] Support modal routing by publisher - rework

### DIFF
--- a/lib/oli_web.ex
+++ b/lib/oli_web.ex
@@ -141,11 +141,6 @@ defmodule OliWeb do
       import OliWeb.ViewHelpers
       import OliWeb.Common.FormatDateTime
 
-      import OliWeb.Components.Delivery.Utils,
-        only: [
-          user_is_guest?: 1
-        ]
-
       import Oli.Utils
       import Oli.Branding
 

--- a/lib/oli_web/components/delivery/utils.ex
+++ b/lib/oli_web/components/delivery/utils.ex
@@ -27,19 +27,6 @@ defmodule OliWeb.Components.Delivery.Utils do
   end
 
   @doc """
-  Returns true if a user is signed in as guest
-  """
-  def user_is_guest?(assigns) do
-    case assigns[:current_user] do
-      %User{guest: true} ->
-        true
-
-      _ ->
-        false
-    end
-  end
-
-  @doc """
   Returns true if a user is signed in as an independent learner
   """
   def user_is_independent_learner?(current_user) do

--- a/lib/oli_web/components/utils.ex
+++ b/lib/oli_web/components/utils.ex
@@ -46,6 +46,15 @@ defmodule OliWeb.Components.Utils do
   end
 
   @doc """
+  Returns true if a user is signed in as guest.
+  Can be called with either the assigns (socket.assigns) or the session.
+  """
+  @spec user_is_guest?(map()) :: boolean()
+  def user_is_guest?(%{current_user: %User{guest: true}} = _socket_assigns), do: true
+  def user_is_guest?(%{"user" => %User{guest: true}} = _session), do: true
+  def user_is_guest?(_), do: false
+
+  @doc """
   Returns true if the section is open and free
   """
   def is_open_and_free_section?(section) do

--- a/lib/oli_web/views/delivery_view.ex
+++ b/lib/oli_web/views/delivery_view.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.DeliveryView do
   use Phoenix.Component
 
   import OliWeb.Common.SourceImage
+  import OliWeb.Components.Utils, only: [user_is_guest?: 1]
 
   def source_id(source) do
     case Map.get(source, :type, nil) do

--- a/test/oli_web/components/utils_test.exs
+++ b/test/oli_web/components/utils_test.exs
@@ -1,0 +1,60 @@
+defmodule OliWeb.Components.UtilsTest do
+  use Oli.DataCase
+
+  alias Oli.Accounts.User
+  alias OliWeb.Components.Utils
+
+  describe "user_is_guest?/1" do
+    test "returns true when user is guest in socket assigns" do
+      guest_user = %User{guest: true}
+      assigns = %{current_user: guest_user}
+
+      assert Utils.user_is_guest?(assigns) == true
+    end
+
+    test "returns true when user is guest in session" do
+      guest_user = %User{guest: true}
+      session = %{"user" => guest_user}
+
+      assert Utils.user_is_guest?(session) == true
+    end
+
+    test "returns false when user is not guest in socket assigns" do
+      regular_user = %User{guest: false}
+      assigns = %{current_user: regular_user}
+
+      assert Utils.user_is_guest?(assigns) == false
+    end
+
+    test "returns false when user is not guest in session" do
+      regular_user = %User{guest: false}
+      session = %{"user" => regular_user}
+
+      assert Utils.user_is_guest?(session) == false
+    end
+
+    test "returns false when no user in socket assigns" do
+      assigns = %{current_user: nil}
+
+      assert Utils.user_is_guest?(assigns) == false
+    end
+
+    test "returns false when no user in session" do
+      session = %{}
+
+      assert Utils.user_is_guest?(session) == false
+    end
+
+    test "returns false when current_user key is not present in assigns" do
+      assigns = %{other_field: "value"}
+
+      assert Utils.user_is_guest?(assigns) == false
+    end
+
+    test "returns false when `user` key is not present in session" do
+      session = %{"other_key" => "value"}
+
+      assert Utils.user_is_guest?(session) == false
+    end
+  end
+end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4689?focusedCommentId=30821) to the comment in the ticket

This bug existed before the introduction of MER-4689. The issue occurred when guest users intended to send a support message within a course section; the support form has some hidden fields (name, email) that are populated with the user assigned in the socket. Since guest users have those fields empty, the changeset validation failed on the form submission.

The fix identifies when a guest user is logged in and shows those fields (name, email) in the form for the user to complete.

This PR also refactors the `user_is_guest?` function to support both `assigns` or `session` as an argument, and moves that function from the deprecated `OliWeb.Components.Delivery.Utils` module to the `OliWeb.Components.Utils`. That movement required some updates to the imports made on the OliWeb module.

### Before

https://github.com/user-attachments/assets/8b00de07-f31a-41e1-a8e6-c99cddd952d5



### After

https://github.com/user-attachments/assets/1becb8a8-6cf6-40a4-9761-3ac1155801cc


