### PR TITLE
[ENHANCEMENT] [MER-4730] Improve modules documentation

### DIFF
--- a/lib/oli/delivery/sections/section_cache.ex
+++ b/lib/oli/delivery/sections/section_cache.ex
@@ -6,7 +6,22 @@ defmodule Oli.Delivery.Sections.SectionCache do
     Keys are set to expire after 1 year as that is the longest a section is expected to be active.
     This is to prevent data from building up in the cache over a long time period. It is more than
     likely that the cache will be restarted/cleared before the 1 year expiration.
+
+    ### DEPRECATION NOTICE
+
+    This module is deprecated and replaced by `Oli.Delivery.Sections.SectionResourceDepot`.
+
+    The current keys still cached here (`:ordered_container_labels`, `:contained_scheduling_types`, and `:page_to_container_map`)
+    are being migrated to `SectionResourceDepot` in upcoming work.
+
+    Once those migrations are completed, this module will be removed entirely.
+
+    ### DO NOT USE THIS MODULE
+
+    Do not introduce new keys or functionality in this module. Use `Oli.Delivery.Sections.SectionResourceDepot` instead.
   """
+
+  @deprecated "Use Oli.Delivery.Sections.SectionResourceDepot instead"
 
   use GenServer
 

--- a/lib/oli/utils/db_seeder.ex
+++ b/lib/oli/utils/db_seeder.ex
@@ -1,4 +1,30 @@
 defmodule Oli.Seeder do
+  @moduledoc """
+    Provides helper functions for seeding test and development data, including sections,
+    projects, users, and other core entities used throughout the platform.
+
+    ### DEPRECATION NOTICE
+
+    This module is deprecated.
+    Please use `Oli.Factory` (based on `ExMachina`) as the only mechanism for generating test data.
+
+    ### What to do instead
+
+    Use the `Oli.Factory` module, located at `test/support/factory.ex`.
+    This module provides a clean, composable, and consistent way to build test data.
+
+    Examples:
+
+        insert(:user)
+        insert(:project, %{title: "My project"})
+        insert(:section_with_associations)
+
+    As part of the deprecation process, all new tests should avoid calling `Oli.Seeder` directly.
+    Legacy tests using it may be refactored over time in follow-up tickets.
+  """
+
+  @deprecated "Use Oli.Factory instead"
+
   import Ecto.Query, warn: false
   import Oli.Delivery.Attempts.Core
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,4 +1,35 @@
 defmodule Oli.Factory do
+  @moduledoc """
+    Provides test data factories for use across the application, based on `ExMachina`.
+
+    This module is the canonical and preferred way to generate test data.
+
+    ### Purpose
+
+    `Oli.Factory` centralizes and standardizes test data generation using clear, composable patterns.
+    It replaces the previously used `Oli.Seeder` module, which is now deprecated.
+
+    ### What this module provides
+
+    - Reusable factory functions for key entities like users, projects, sections, etc.
+    - Clean and minimal setup code for tests.
+    - Integration with `ExMachina` to support `insert/1`, `insert/2`, `build/1`, `build/2`, etc.
+
+    ### Example usage
+
+        insert(:user)
+        insert(:project, title: "Intro to Elixir")
+        insert(:section_with_associations)
+
+    ### Notes
+
+    - Use this module exclusively for generating test data.
+    - Avoid using `Oli.Seeder`, as it is deprecated and will be removed.
+    - Factories live in `test/support/factory.ex` and are available throughout the test suite.
+
+    For more complex setups, consider composing multiple factory calls or defining new factories.
+  """
+
   use ExMachina.Ecto, repo: Oli.Repo
 
   alias Oli.Accounts.VrUserAgent


### PR DESCRIPTION
[MER-4730](https://eliterate.atlassian.net/browse/MER-4730)

This PR adds and updates module documentation related to deprecations and usage guidance.

- **SectionCache**: marked as deprecated and added a clear notice to avoid introducing new keys or logic. It also points developers to use `Oli.Delivery.Sections.SectionResourceDepot` instead.

- **SectionResourceDepot**: left unchanged, as its existing documentation already provides enough clarity.

- **Oli.Seeder**: marked as deprecated in the module documentation and replaced by `Oli.Factory`.
**Note**: @deprecated annotations were intentionally not added to each function, since they produce warnings during test runs and clutter the output unnecessarily.

- **Oli.Factory**: documentation was added to establish it as the canonical way of generating test data, replacing `Oli.Seeder`.

This change aligns with the goal of gradually removing `Oli.Seeder` and migrating data and logic from `SectionCache` to `SectionResourceDepot`.

[MER-4730]: https://eliterate.atlassian.net/browse/MER-4730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ