### PR TITLE
[BUG FIX] [MER-4814] cant review attempts in adaptive pages

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -518,29 +518,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     end)
   end
 
-  # Retrieving the extrinsic state of the resource attempt must take
-  # into account if the blob storage API is in use for extrinsic state.
-  defp fetch_extrinsic_state(resource_attempt) do
-    if Application.get_env(:oli, :blob_storage)[:use_deprecated_api] do
-      resource_attempt.state
-    else
-      Oli.Delivery.TextBlob.read(
-        resource_attempt.attempt_guid,
-        "{}"
-      )
-      |> case do
-        {:ok, state} ->
-          case Jason.decode(state) do
-            {:ok, decoded_state} -> decoded_state
-            _ -> %{}
-          end
-
-        _ ->
-          %{}
-      end
-    end
-  end
-
   defp assemble_full_adaptive_state(
          resource_attempt,
          activities_required_for_evaluation,

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -739,7 +739,7 @@ defmodule OliWeb.PageDeliveryController do
         graded: context.page.graded,
         content:
           build_page_content(context.page.content, Plug.Conn.get_session(conn, :request_path)),
-        resourceAttemptState: resource_attempt.state,
+        resourceAttemptState: Core.fetch_extrinsic_state(resource_attempt),
         resourceAttemptGuid: resource_attempt.attempt_guid,
         currentServerTime: DateTime.utc_now() |> to_epoch,
         effectiveEndTime:

--- a/lib/oli_web/live_session_plugs/init_page.ex
+++ b/lib/oli_web/live_session_plugs/init_page.ex
@@ -175,7 +175,7 @@ defmodule OliWeb.LiveSessionPlugs.InitPage do
       pageSlug: page_context.page.slug,
       graded: page_context.page.graded,
       content: build_page_content(page_context.page.content, params["request_path"]),
-      resourceAttemptState: resource_attempt && resource_attempt.state,
+      resourceAttemptState: Core.fetch_extrinsic_state(resource_attempt),
       resourceAttemptGuid: resource_attempt && resource_attempt.attempt_guid,
       currentServerTime: DateTime.utc_now() |> to_epoch,
       effectiveEndTime:


### PR DESCRIPTION
Fixes an issue where the adaptive player was not working properly in review mode.

The issue was caused from the migration from resource.state storage to text blob storage, where the necessary state for review mode was trying to be loaded via the old resource.state method even when the system is configured to use the new blob storage.

The fix here is to use the new blob storage mechanism to load state when the system is configured to use this storage.