### PR TITLE
[BUG FIX] [MER-4819] Adaptive assessment manual scoring does not work

### DIFF
--- a/assets/src/apps/authoring/store/parts/actions/updatePart.ts
+++ b/assets/src/apps/authoring/store/parts/actions/updatePart.ts
@@ -152,8 +152,10 @@ export const updatePart = createAsyncThunk(
     }
 
     if (authorPart) {
-      authorPart.gradingApproach = partDef.custom.requiresManualGrading ? 'manual' : 'automatic';
-      authorPart.outOf = partDef.custom.maxScore || 1;
+      authorPart.gradingApproach = payload?.changes?.custom?.requiresManualGrading
+        ? 'manual'
+        : 'automatic';
+      authorPart.outOf = payload?.changes?.custom?.maxScore || 1;
     }
 
     await dispatch(saveActivity({ activity: activityClone, undoable: false }));


### PR DESCRIPTION
Hey @bsparks, could you please take a look at the PR? Thanks!

It’s a bit odd, but I suspect this issue might have been present for the past two years. In [this PR](https://github.com/Simon-Initiative/oli-torus/pull/3393), there were changes made to the update logic.

<img width="1433" height="633" alt="image" src="https://github.com/user-attachments/assets/4b69c8d1-4c24-4a98-9591-f588daf42832" />

Previously, the function `merge(partDef, payload.changes)` was called directly, which meant the latest changes from `payload `were immediately reflected in partDef. So, when the following code was executed:

```
if (authorPart) {
  authorPart.gradingApproach = partDef.custom.requiresManualGrading ? 'manual' : 'automatic';
  authorPart.outOf = partDef.custom.maxScore || 1;
}
```
…it was working as expected because partDef already contained the updated values.

However, the same PR introduced a conditional merge based on the `payload.mergeChanges` flag—which, in the same PR, was set to `false` by default in the property editor. As a result, partDef no longer contains the updated changes at this point.

I've updated the logic to read `requiresManualGrading `and `maxScore` directly from `payload?.changes`, since that holds the latest values.