### PR TITLE
[BUG FIX] [MER-4814] Cant review attempts in adaptive pages rework 1

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
+++ b/assets/src/apps/delivery/layouts/deck/RestartLessonDialog.tsx
@@ -57,9 +57,12 @@ const RestartLessonDialog: React.FC<RestartLessonDialogProps> = ({ onRestart }) 
   const handleRestart = async () => {
     console.info('Restarting lesson...', onRestart);
     setIsLoading(true);
-    if (onRestart) {
+
+    // We only want to restart if we are in preview mode or the page is not graded
+    if ((isPreviewMode || !graded) && onRestart) {
       onRestart();
     }
+
     let redirectTo = overviewURL;
     if (!isPreviewMode && graded) {
       const finalizeResult = await finalizePageAttempt(


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4814

Fixes an issue where the adaptive player was resetting a user's progress when the student would submit their attempt. This could be related to the changes made with the recent introduction of plain text blob state storage.

After a thorough investigation, it was identified that although the main issue was resolved in the PR, an issue still remained where the client adaptive player was issuing a request to the blob storage service that would reset the entire state.

After working with Devesh, its was determined that the onRestart call here was the culprit and should only be called in non-graded or preview settings.