### PR TITLE
[BUG FIX][MER-4822] Opening Project in QA and Tokamak cause a 500 Error

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/add_activities_and_tools_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/add_activities_and_tools_modal.ex
@@ -12,7 +12,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.AddActivitiesAndToolsModal do
       |> assign(
         loading?: true,
         tools: [],
-        activities: []
+        activities: [],
+        test_env?: test_env?()
       )
       |> reset_modal()
 
@@ -152,7 +153,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.AddActivitiesAndToolsModal do
         </div>
       </Modal.modal>
       <button
-        :if={Mix.env() == :test}
+        :if={@test_env?}
         id="test-show-modal-button"
         type="button"
         class="hidden"
@@ -516,4 +517,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.AddActivitiesAndToolsModal do
       search_term: ""
     )
   end
+
+  defp test_env?, do: Application.get_env(:oli, :env) == :test
 end


### PR DESCRIPTION
[MER-4822](https://eliterate.atlassian.net/browse/MER-4822)

Fixes a crash caused by calling Mix.env() at runtime in non-dev environments (like QA or Tokamak), where the Mix module is not available.

This error was preventing access to the Overview of any project.

Now we use Application.get_env(:oli, :env) instead, avoiding the error and ensuring the conditional logic works safely across all environments.