### PR TITLE
[ENHANCEMENT] [MER-4731] Upgrade Elixir to 1.18.4 and Erlang to OTP 28.0.2

### DIFF
--- a/.github/actions/amazon-linux-builder/Dockerfile
+++ b/.github/actions/amazon-linux-builder/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux:2
 
 ARG ELIXIR_VERSION=1.18.4
-ARG OTP_VERSION=28.0.2
+ARG OTP_VERSION=28.0
 
 RUN yum update -y
 RUN yum install -y tar wget git


### PR DESCRIPTION
This PR fixes the version of OTP that was failing to be downloaded because that specific version does not exist in the available downloads:


<img width="1064" height="319" alt="Screenshot 2025-07-31 at 5 22 00 PM" src="https://github.com/user-attachments/assets/051b0a18-bf71-42f4-b53f-f7d1d4dc5fb1" />

## Error
<img width="1421" height="482" alt="Screenshot 2025-07-31 at 5 28 14 PM" src="https://github.com/user-attachments/assets/06768690-a967-425b-8a7e-1b19372185b3" />


