### PR TITLE
[CHORE] [MER-0000] disable JIT to restore amazon linux builder

### DIFF
--- a/.github/actions/amazon-linux-builder/Dockerfile
+++ b/.github/actions/amazon-linux-builder/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /tmp
 RUN wget --tries=1 --timeout=30 "http://erlang.org/download/otp_src_${OTP_VERSION}.tar.gz" -O otp_src_${OTP_VERSION}.tar.gz || wget "https://github.com/erlang/otp/releases/download/OTP-${OTP_VERSION}/otp_src_${OTP_VERSION}.tar.gz" -O otp_src_${OTP_VERSION}.tar.gz
 RUN tar xfz otp_src_${OTP_VERSION}.tar.gz
 WORKDIR /tmp/otp_src_${OTP_VERSION}/
-RUN ./configure
+RUN ./configure --disable-jit
 RUN make && make install
 
 WORKDIR /tmp


### PR DESCRIPTION
The JIT compiler in OTP 28.0 has known compatibility issues with certain versions of GCC on Amazon Linux 2. Disabling JIT still gives a fully functional Erlang/OTP installation, just without JIT optimizations.

This fix adds the --disable-jit flag to the OTP configure command in the amazon-linux-builder image. This disables the Just-In-Time compiler that was causing the segmentation fault.

In the future, we will probably want to upgrade to a newer version of Amazon Linux 2023 or alternatively use the docker container for deployments moving forward.