### PR TITLE
[FEATURE] [MER-4665] Browse all table UI - Rework

### DIFF
--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -10,21 +10,19 @@ defmodule OliWeb.Products.ProductsTableModel do
         %ColumnSpec{
           name: :title,
           label: "Product Title",
-          render_fn:
-            &__MODULE__.render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3)
+          render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3)
         },
-        %ColumnSpec{name: :status, label: "Status"},
+        %ColumnSpec{name: :status, label: "Status", render_fn: &render_status_column/3},
         %ColumnSpec{
           name: :requires_payment,
           label: "Requires Payment",
-          render_fn: &__MODULE__.render_payment_column/3,
+          render_fn: &render_payment_column/3,
           sort_fn: &sort_payment_column/2
         },
         %ColumnSpec{
           name: :base_project_id,
           label: "Base Project",
-          render_fn:
-            &__MODULE__.render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3)
+          render_fn: &render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3)
         },
         %ColumnSpec{
           name: :inserted_at,
@@ -54,7 +52,12 @@ defmodule OliWeb.Products.ProductsTableModel do
         project_slug -> ~p"/workspaces/course_author/#{project_slug}/products/#{slug}"
       end
 
-    SortableTableModel.render_link_column(assigns, title, route_path)
+    SortableTableModel.render_link_column(
+      assigns,
+      title,
+      route_path,
+      "text-[#1B67B2] dark:text-[#99CCFF]"
+    )
   end
 
   def render_project_column(assigns, %{base_project: base_project}, _) do
@@ -64,7 +67,28 @@ defmodule OliWeb.Products.ProductsTableModel do
         _project_slug -> ~p"/workspaces/course_author/#{base_project}/overview"
       end
 
-    SortableTableModel.render_link_column(assigns, base_project.title, route_path)
+    SortableTableModel.render_link_column(
+      assigns,
+      base_project.title,
+      route_path,
+      "text-[#1B67B2] dark:text-[#99CCFF]"
+    )
+  end
+
+  def render_status_column(assigns, %{status: :active}, _) do
+    SortableTableModel.render_span_column(
+      assigns,
+      "Active",
+      "text-[#245D45] dark:text-[#39E581]"
+    )
+  end
+
+  def render_status_column(assigns, %{status: :archived}, _) do
+    SortableTableModel.render_span_column(
+      assigns,
+      "Archived",
+      "text-[#A42327] dark:text-[#FF8787]"
+    )
   end
 
   defp sort_payment_column(order, _spec) do

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -3,29 +3,29 @@ defmodule OliWeb.Projects.TableModel do
   use OliWeb, :verified_routes
 
   alias OliWeb.Common.SessionContext
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
 
   def new(%SessionContext{} = ctx, sections) do
     column_specs = [
       %ColumnSpec{
         name: :title,
         label: "Title",
-        render_fn: &__MODULE__.custom_render/3
+        render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :inserted_at,
         label: "Created",
-        render_fn: &OliWeb.Common.Table.Common.render_date/3
+        render_fn: &Common.render_date/3
       },
       %ColumnSpec{
         name: :name,
         label: "Created By",
-        render_fn: &__MODULE__.custom_render/3
+        render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :status,
         label: "Status",
-        render_fn: &__MODULE__.custom_render/3
+        render_fn: &custom_render/3
       }
     ]
 
@@ -46,7 +46,10 @@ defmodule OliWeb.Projects.TableModel do
     case name do
       :title ->
         ~H"""
-        <a href={~p"/workspaces/course_author/#{@project.slug}/overview"}>
+        <a
+          href={~p"/workspaces/course_author/#{@project.slug}/overview"}
+          class="text-[#1B67B2] dark:text-[#99CCFF]"
+        >
           <%= @project.title %>
         </a>
         """
@@ -70,7 +73,8 @@ defmodule OliWeb.Projects.TableModel do
 
       :name ->
         ~H"""
-        <span><%= @project.name %></span> <small class="text-muted"><%= @project.email %></small>
+        <span class="text-[#1B67B2] dark:text-[#99CCFF]"><%= @project.name %></span>
+        <small class="text-[#45464C] dark:text-[#BAB8BF]"><%= @project.email %></small>
         """
     end
   end

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
   use OliWeb, :verified_routes
 
   alias OliWeb.Common.SessionContext
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
   alias OliWeb.Router.Helpers, as: Routes
 
   def new(%SessionContext{} = ctx, sections, render_institution_action \\ false) do
@@ -13,12 +13,12 @@ defmodule OliWeb.Sections.SectionsTableModel do
         %ColumnSpec{
           name: :title,
           label: "Title",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :type,
           label: "Type",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :enrollments_count,
@@ -27,39 +27,39 @@ defmodule OliWeb.Sections.SectionsTableModel do
         %ColumnSpec{
           name: :requires_payment,
           label: "Cost",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :start_date,
           label: "Start",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3,
-          sort_fn: &OliWeb.Common.Table.Common.sort_date/2
+          render_fn: &Common.render_date/3,
+          sort_fn: &Common.sort_date/2
         },
         %ColumnSpec{
           name: :end_date,
           label: "End",
-          render_fn: &OliWeb.Common.Table.Common.render_date/3,
-          sort_fn: &OliWeb.Common.Table.Common.sort_date/2
+          render_fn: &Common.render_date/3,
+          sort_fn: &Common.sort_date/2
         },
         %ColumnSpec{
           name: :status,
           label: "Status",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :base,
           label: "Base Project/Product",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :instructor,
           label: "Instructors",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         },
         %ColumnSpec{
           name: :institution,
           label: "Institution",
-          render_fn: &__MODULE__.custom_render/3
+          render_fn: &custom_render/3
         }
       ],
       event_suffix: "",
@@ -76,7 +76,11 @@ defmodule OliWeb.Sections.SectionsTableModel do
     assigns = Map.merge(assigns, %{section: section})
 
     ~H"""
-    <a href={~p"/sections/#{@section.slug}/manage"} target="_blank">
+    <a
+      href={~p"/sections/#{@section.slug}/manage"}
+      target="_blank"
+      class="text-[#1B67B2] dark:text-[#99CCFF]"
+    >
       <%= @section.title %>
     </a>
     """
@@ -113,19 +117,43 @@ defmodule OliWeb.Sections.SectionsTableModel do
     """
   end
 
-  def custom_render(_assigns, section, %ColumnSpec{name: :status}),
-    do: Phoenix.Naming.humanize(section.status)
+  def custom_render(assigns, section, %ColumnSpec{name: :status}) do
+    class =
+      case section.status do
+        :active -> "text-[#245D45] dark:text-[#39E581]"
+        :deleted -> "text-[#A42327] dark:text-[#FF8787]"
+        _ -> "text-[#1B67B2] dark:text-[#99CCFF]"
+      end
+
+    assigns = Map.merge(assigns, %{section: section, class: class})
+
+    ~H"""
+    <span class={@class}>
+      <%= Phoenix.Naming.humanize(@section.status) %>
+    </span>
+    """
+  end
 
   def custom_render(assigns, section, %ColumnSpec{name: :base}) do
     if section.blueprint_id do
       route_path =
         Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.blueprint.slug)
 
-      SortableTableModel.render_link_column(assigns, section.blueprint.title, route_path)
+      SortableTableModel.render_link_column(
+        assigns,
+        section.blueprint.title,
+        route_path,
+        "text-[#1B67B2] dark:text-[#99CCFF]"
+      )
     else
       route_path = ~p"/workspaces/course_author/#{section.base_project.slug}/overview"
 
-      SortableTableModel.render_link_column(assigns, section.base_project.title, route_path)
+      SortableTableModel.render_link_column(
+        assigns,
+        section.base_project.title,
+        route_path,
+        "text-[#1B67B2] dark:text-[#99CCFF]"
+      )
     end
   end
 

--- a/test/oli_web/live/workspaces/course_author/products_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products_live_test.exs
@@ -115,7 +115,7 @@ defmodule OliWeb.Workspace.CourseAuthor.ProductsLiveTest do
                "/workspaces/course_author/#{project.slug}/products/some_product"
 
       # Table content - Status
-      assert render(element(view, "table tbody tr td:nth-of-type(2) div")) =~ "active"
+      assert render(element(view, "table tbody tr td:nth-of-type(2) div")) =~ "Active"
       assert render(element(view, "table tbody tr td:nth-of-type(3) div")) =~ "None"
 
       # Table content - Base project


### PR DESCRIPTION
[MER-4665](https://eliterate.atlassian.net/browse/MER-4665)

This PR fixes color inconsistencies in table text styles across the Browse All Course Sections, Browse All Projects, and Browse All Products views.

Some text elements (Titles, Status, Email) were being rendered with colors that did not match the Figma designs.

- Projects

<img width="1817" height="823" alt="projects-light" src="https://github.com/user-attachments/assets/225c9252-10d3-43f8-86fb-fd8acf18691d" />

<p>&nbsp;</p>

<img width="1803" height="816" alt="projects-dark" src="https://github.com/user-attachments/assets/c356e7ce-6b77-42af-abef-08fb4d2ed42e" />

<p>&nbsp;</p>

- Sections

<img width="1803" height="725" alt="sections-light" src="https://github.com/user-attachments/assets/68ce78bf-8e64-4558-92f3-f28cdcb4a839" />

<p>&nbsp;</p>

<img width="1796" height="726" alt="sections-dark" src="https://github.com/user-attachments/assets/ed2780c5-a482-460a-b746-eaf9ab039048" />

<p>&nbsp;</p>

- Products

<img width="1779" height="665" alt="products-dark" src="https://github.com/user-attachments/assets/cfac63de-61cd-4afb-b8e6-fb5fcc66b8ce" />

<p>&nbsp;</p>

<img width="1814" height="683" alt="products-light" src="https://github.com/user-attachments/assets/94cdd494-3007-4a86-818c-5656f31a6fdc" />