### PR TITLE
[BUG FIX] [MER-4763] Complexities with two ways to add image links in advanced author

### DIFF
--- a/assets/src/components/parts/janus-image/ImageAuthor.tsx
+++ b/assets/src/components/parts/janus-image/ImageAuthor.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import debounce from 'lodash/debounce';
 import { clone } from 'utils/common';
@@ -6,92 +5,111 @@ import { AuthorPartComponentProps } from '../types/parts';
 import { ImageModel } from './schema';
 
 const ImageAuthor: React.FC<AuthorPartComponentProps<ImageModel>> = (props) => {
-  const { model, onSaveConfigure } = props;
+  const { model, onSaveConfigure, id, onReady } = props;
+  const { width, height, alt, imageSrc, src, defaultSrc, lockAspectRatio } = model;
   const [ready, setReady] = useState<boolean>(false);
   const [imgSrc, setImgSrc] = useState<string>('');
-  const id: string = props.id;
-
-  useEffect(() => {
-    setReady(true);
-  }, []);
-
-  useEffect(() => {
-    if (!ready) {
-      return;
-    }
-    props.onReady({ id, responses: [] });
-  }, [ready]);
-
-  const { width, height, src, imageSrc, alt, defaultSrc } = model;
-  const imageStyles: CSSProperties = {
-    width,
-    height,
-  };
-
-  const debounceWaitTime = 1000;
-  const debounceImage = useCallback(
-    debounce((updatedModel: any) => {
-      manipulateImageSize(updatedModel, true);
-    }, debounceWaitTime),
-    [],
-  );
-
-  useEffect(() => {
-    //Image Source will take precedence ( if there is an image link present in it). If Image Sorce is blank then it will display image link from src.
-    const imageSource = imageSrc?.length && imageSrc != defaultSrc ? imageSrc : src;
-    setImgSrc(imageSource);
-    if (imageSource != defaultSrc && model?.lockAspectRatio) {
-      debounceImage(model);
-    }
-  }, [model]);
   const imageContainerRef = useRef<HTMLImageElement>(null);
-  const manipulateImageSize = (updatedModel: ImageModel, isfromDebaunce: boolean) => {
-    if (!imageContainerRef?.current || !isfromDebaunce) {
-      return;
-    }
-    const naturalWidth = imageContainerRef.current.naturalWidth;
-    const naturalHeight = imageContainerRef.current.naturalHeight;
 
-    const currentWidth = imageContainerRef.current.width;
-    const currentHeight = imageContainerRef.current.height;
+  const debounceImageAdjust = useRef(
+    debounce((modelToUpdate: ImageModel) => {
+      adjustImageSize(modelToUpdate);
+    }, 1000),
+  ).current;
 
-    const updatedWidth = updatedModel?.width || 0;
-    if (
-      naturalWidth <= 0 ||
-      naturalHeight <= 0 ||
-      currentWidth <= 0 ||
-      currentHeight <= 0 ||
-      updatedWidth <= 0
-    ) {
-      return;
-    }
-    const ratioWidth = naturalWidth / currentWidth;
-    const ratioHeight = naturalHeight / currentHeight;
-    if (ratioWidth == ratioHeight) {
-      return;
-    }
-    let newAdjustedHeight = imageContainerRef.current.height;
-    let newAdjustedWidth = imageContainerRef.current.width;
-    if (ratioWidth > ratioHeight) {
-      newAdjustedHeight = parseInt(Number(naturalHeight / ratioWidth).toFixed());
-    } else {
-      newAdjustedWidth = parseInt(Number(naturalWidth / ratioHeight).toFixed());
-    }
-    const modelClone = clone(updatedModel);
-    modelClone.height = newAdjustedHeight;
-    modelClone.width = newAdjustedWidth;
-    if (newAdjustedHeight != updatedModel.height || newAdjustedWidth != updatedModel.width) {
-      //we need to save the new width and height of the image so that the custom property is updated with adjusted values
+  // === useRef guards to prevent duplicate syncs ===
+  const lastSyncedImageSrcRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    onReady?.({ id, responses: [] });
+    setReady(true);
+  }, [id, onReady]);
+
+  const preferredSrc = imageSrc && imageSrc !== defaultSrc ? imageSrc : src;
+
+  useEffect(() => {
+    if (!model) return;
+
+    setImgSrc(preferredSrc);
+
+    const modelClone = clone(model);
+
+    const srcNeedsUpdate =
+      imageSrc && (!src || src !== imageSrc) && imageSrc !== lastSyncedImageSrcRef.current;
+    const imageSrcIsDefault = imageSrc === defaultSrc;
+    const srcChanged = src && src !== defaultSrc && src !== imageSrc;
+
+    // ✅ Case 1 & 2: Sync src from imageSrc (panel wins)
+    if (srcNeedsUpdate) {
+      modelClone.src = imageSrc;
+      console.log('Syncing src from imageSrc');
+      console.log({ imageSrc, modelCloneSrc: modelClone.src });
+      lastSyncedImageSrcRef.current = imageSrc;
       onSaveConfigure({ id, snapshot: modelClone });
     }
-  };
+
+    // ✅ Case 3: Sync imageSrc from src (when imageSrc is default and src changed)
+    else if (imageSrcIsDefault && srcChanged) {
+      console.log('Syncing imageSrc from src');
+      modelClone.imageSrc = src;
+      onSaveConfigure({ id, snapshot: modelClone });
+    }
+
+    // 🔁 Debounced aspect ratio fix
+    if (preferredSrc && preferredSrc !== defaultSrc && lockAspectRatio) {
+      debounceImageAdjust(modelClone);
+    }
+  }, [preferredSrc, imageSrc, src, defaultSrc, lockAspectRatio]);
+
+  const adjustImageSize = useCallback(
+    (updatedModel: ImageModel) => {
+      const imgEl = imageContainerRef.current;
+      if (!imgEl) return;
+
+      const { naturalWidth, naturalHeight, width: currentWidth, height: currentHeight } = imgEl;
+
+      const updatedWidth = updatedModel?.width || 0;
+
+      if (
+        naturalWidth <= 0 ||
+        naturalHeight <= 0 ||
+        currentWidth <= 0 ||
+        currentHeight <= 0 ||
+        updatedWidth <= 0
+      )
+        return;
+
+      const ratioWidth = naturalWidth / currentWidth;
+      const ratioHeight = naturalHeight / currentHeight;
+
+      if (ratioWidth === ratioHeight) return;
+
+      let newWidth = currentWidth;
+      let newHeight = currentHeight;
+
+      if (ratioWidth > ratioHeight) {
+        newHeight = Math.round(naturalHeight / ratioWidth);
+      } else {
+        newWidth = Math.round(naturalWidth / ratioHeight);
+      }
+
+      if (newWidth !== updatedModel.width || newHeight !== updatedModel.height) {
+        onSaveConfigure({
+          id,
+          snapshot: { ...updatedModel, width: newWidth, height: newHeight },
+        });
+      }
+    },
+    [onSaveConfigure, id],
+  );
+
+  const imageStyles: CSSProperties = { width, height };
+
   return ready ? (
     <img
       ref={imageContainerRef}
-      onLoad={() => {
-        manipulateImageSize(model, false);
-      }}
-      draggable="false"
+      onLoad={() => adjustImageSize(model)}
+      draggable={false}
       alt={alt}
       src={imgSrc}
       style={imageStyles}
@@ -100,5 +118,4 @@ const ImageAuthor: React.FC<AuthorPartComponentProps<ImageModel>> = (props) => {
 };
 
 export const tagName = 'janus-image';
-
 export default ImageAuthor;


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks.

This PR aims to do some code refactoring to remove the duplicate code and handle the following use case:

1. Prevents infinite loops using lastSyncedImageSrcRef
2. Triggers aspect ratio adjustment when a valid preferredSrc is set and lockAspectRatio is enabled
3. **Syncs src from imageSrc when:**
   3.1 imageSrc is set and src is missing or different
   3.2 Ensures panel input takes precedence when edited

4. **Syncs imageSrc from src when:**
    4.1 imageSrc is still default and src has been updated via Media Manager
    4.2 Ensures Media Manager updates are reflected in the panel
