### PR TITLE
[FEATURE] [MER-4699] Learning Objectives Table UI

### DIFF
--- a/assets/tailwind.tokens.js
+++ b/assets/tailwind.tokens.js
@@ -56,6 +56,14 @@ module.exports = {
     light: '#0FB863',
     dark: '#0FB863',
   },
+  'Fill-Chip-Green': {
+    light: '#E7FCF3',
+    dark: '#3D4F47',
+  },
+  'Fill-Chip-Gray': {
+    light: '#CED1D9',
+    dark: '#353740',
+  },
   // Fill/Buttons
   'Fill-Buttons-fill-primary': {
     light: '#0080FF',
@@ -227,6 +235,18 @@ module.exports = {
   'Text-text-accent-purple': {
     light: '#9A40A8',
     dark: '#EBAAF2',
+  },
+  'Text-Chip-Orange': {
+    light: '#91450E',
+    dark: '#FFB387',
+  },
+  'Text-Chip-Green': {
+    light: '#175A3D',
+    dark: '#39E581',
+  },
+  'Text-Chip-Gray': {
+    light: '#000000',
+    dark: '#FFFFFF',
   },
   // Table
   'Table-table-row-1': {

--- a/lib/oli_web/components/delivery/content/content_table_model.ex
+++ b/lib/oli_web/components/delivery/content/content_table_model.ex
@@ -112,10 +112,10 @@ defmodule OliWeb.Components.Delivery.ContentTableModel do
   def render_student_proficiency(assigns, container, _) do
     {bg_color, text_color} =
       case container.student_proficiency do
-        "High" -> {"bg-[#e6fcf2] dark:bg-[#3D4F47]", "text-[#175a3d] dark:text-[#39E581]"}
-        "Medium" -> {"bg-[#ffecde] dark:bg-[#4C3F39]", "text-[#91450e] dark:text-[#FFB387]"}
-        "Low" -> {"bg-[#feebed] dark:bg-[#33181A]", "text-[#ce2c31] dark:text-[#FF8787]"}
-        _ -> {"bg-[#ced1d9] dark:bg-[#353740]", "text-[#000000] dark:text-[#FFFFFF]"}
+        "High" -> {"bg-Fill-Chip-Green", "text-Text-Chip-Green"}
+        "Medium" -> {"bg-Fill-Accent-fill-accent-orange", "text-Text-Chip-Orange"}
+        "Low" -> {"bg-Fill-fill-danger", "text-Text-text-danger"}
+        _ -> {"bg-Fill-Chip-Gray", "text-Text-Chip-Gray"}
       end
 
     assigns =

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -1,16 +1,13 @@
 defmodule OliWeb.Components.Delivery.LearningObjectives do
   use OliWeb, :live_component
 
-  import OliWeb.Components.Delivery.Buttons, only: [toggle_chevron: 1]
-
-  alias OliWeb.Common.InstructorDashboardPagedTable
-  alias OliWeb.Common.Params
-  alias OliWeb.Common.SearchInput
+  alias OliWeb.Common.{Params, StripedPagedTable, SearchInput}
   alias OliWeb.Components.Delivery.CardHighlights
+  alias OliWeb.Delivery.Content.MultiSelect
   alias OliWeb.Delivery.LearningObjectives.ObjectivesTableModel
   alias OliWeb.Router.Helpers, as: Routes
-  alias Phoenix.LiveView.JS
   alias OliWeb.Icons
+  alias Phoenix.LiveView.JS
 
   @default_params %{
     offset: 0,
@@ -121,10 +118,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     ~H"""
     <div class="flex flex-col gap-2 mb-10">
       <div class="bg-white shadow-sm dark:bg-gray-800">
-        <div class="flex justify-between items-center px-4 sm:px-9 py-4 instructor_dashboard_table">
-          <div>
-            <h4 class="torus-h4 !py-0 mr-auto mb-2">Learning Objectives</h4>
-          </div>
+        <div class="flex justify-between items-center px-4 pt-8 pb-4 instructor_dashboard_table">
+          <h4 class="justify-center text-Text-text-high text-lg font-bold leading-normal">
+            Learning Objectives
+          </h4>
 
           <div class="flex flex-col-reverse sm:flex-row gap-2 items-end overflow-hidden">
             <.form for={%{}} class="w-full" phx-change="filter_by" phx-target={@myself}>
@@ -154,12 +151,12 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
           </div>
           <a
             href={Routes.delivery_path(OliWeb.Endpoint, :download_learning_objectives, @section_slug)}
-            class="flex items-center justify-center gap-x-2"
+            class="flex items-center justify-center gap-x-2 text-Text-text-button font-bold"
           >
             Download CSV <Icons.download />
           </a>
         </div>
-        <div class="flex flex-row mx-9 gap-x-4">
+        <div class="flex flex-row mx-4 gap-x-4">
           <%= for card <- @card_props do %>
             <CardHighlights.render
               title={card.title}
@@ -171,157 +168,59 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
             />
           <% end %>
         </div>
-        <div class="flex flex-row items-center gap-x-4 mx-9 my-4 dark:bg-gray-800">
-          <.form
-            for={%{}}
-            phx-target={@myself}
-            phx-change="search_objective"
-            class="w-44 border-zinc-400"
-          >
-            <SearchInput.render
-              id="objective_search_input"
-              name="objective_name"
-              text={@params.text_search}
-              class="w-44"
+
+        <div class="flex w-fit gap-2 mx-4 mt-4 mb-4 shadow-[0px_2px_6.099999904632568px_0px_rgba(0,0,0,0.10)] border border-Border-border-default bg-Background-bg-secondary">
+          <div class="flex p-2 gap-2">
+            <.form for={%{}} phx-target={@myself} phx-change="search_objective" class="w-56">
+              <SearchInput.render
+                id="objective_search_input"
+                name="objective_name"
+                text={@params.text_search}
+              />
+            </.form>
+
+            <MultiSelect.render
+              id="proficiency_select"
+              options={@proficiency_options}
+              selected_values={@selected_proficiency_options}
+              selected_proficiency_ids={@selected_proficiency_ids}
+              target={@myself}
+              disabled={@selected_proficiency_ids == %{}}
+              placeholder="Proficiency"
             />
-          </.form>
-          <.multi_select
-            id="proficiency_select"
-            options={@proficiency_options}
-            selected_values={@selected_proficiency_options}
-            selected_proficiency_ids={@selected_proficiency_ids}
-            target={@myself}
-            disabled={@selected_proficiency_ids == %{}}
-            placeholder="Proficiency"
-          />
-          <button
-            class="text-center text-blue-500 text-xs font-semibold underline leading-none"
-            phx-click="clear_all_filters"
-            phx-target={@myself}
-          >
-            Clear All Filters
-          </button>
+
+            <button
+              class="ml-2 mr-4 text-center text-Text-text-high text-sm font-normal leading-none flex items-center gap-x-1 hover:text-Text-text-button"
+              phx-click="clear_all_filters"
+              phx-target={@myself}
+            >
+              <Icons.trash /> Clear All Filters
+            </button>
+          </div>
         </div>
 
         <%= if @total_count > 0 do %>
           <div id="objectives-table">
-            <InstructorDashboardPagedTable.render
+            <StripedPagedTable.render
               table_model={@table_model}
-              page_change={JS.push("paged_table_page_change", target: @myself)}
-              sort={JS.push("paged_table_sort", target: @myself)}
               total_count={@total_count}
               offset={@params.offset}
               limit={@params.limit}
-              additional_table_class="instructor_dashboard_table"
-              show_bottom_paging={false}
               render_top_info={false}
+              additional_table_class="instructor_dashboard_table"
+              sort={JS.push("paged_table_sort", target: @myself)}
+              page_change={JS.push("paged_table_page_change", target: @myself)}
               limit_change={JS.push("paged_table_limit_change", target: @myself)}
+              selection_change={JS.push("paged_table_selection_change", target: @myself)}
               show_limit_change={true}
+              show_bottom_paging={false}
+              allow_selection={true}
+              additional_row_class="!h-20"
             />
           </div>
         <% else %>
           <h6 class="text-center py-4 bg-white dark:bg-gray-800">There are no objectives to show</h6>
         <% end %>
-      </div>
-    </div>
-    """
-  end
-
-  attr :placeholder, :string, default: "Select an option"
-  attr :disabled, :boolean, default: false
-  attr :options, :list, default: []
-  attr :id, :string
-  attr :target, :map, default: %{}
-  attr :selected_values, :map, default: %{}
-  attr :selected_proficiency_ids, :list, default: []
-
-  def multi_select(assigns) do
-    ~H"""
-    <div class={"flex flex-col border relative rounded-md h-9 #{if @selected_values != %{}, do: "border-blue-500", else: "border-zinc-400"}"}>
-      <div
-        phx-click={
-          if(!@disabled,
-            do:
-              JS.toggle(to: "##{@id}-options-container")
-              |> JS.toggle(to: "##{@id}-down-icon")
-              |> JS.toggle(to: "##{@id}-up-icon")
-          )
-        }
-        class={[
-          "flex gap-x-4 px-4 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
-          if(@disabled, do: "bg-gray-300 hover:cursor-not-allowed")
-        ]}
-        id={"#{@id}-selected-options-container"}
-      >
-        <div class="flex gap-1 flex-wrap">
-          <span
-            :if={@selected_values == %{}}
-            class="text-zinc-900 text-xs font-semibold leading-none dark:text-white"
-          >
-            {@placeholder}
-          </span>
-          <span :if={@selected_values != %{}} class="text-blue-500 text-xs font-semibold leading-none">
-            Proficiency is {show_proficiency_selected_values(@selected_values)}
-          </span>
-        </div>
-        <.toggle_chevron id={@id} map_values={@selected_values} />
-      </div>
-      <div class="relative">
-        <div
-          class="py-4 hidden z-50 absolute dark:bg-gray-800 bg-white w-48 border overflow-y-scroll top-1 rounded"
-          id={"#{@id}-options-container"}
-          phx-click-away={
-            JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")
-          }
-        >
-          <div>
-            <.form
-              :let={_f}
-              class="flex flex-column gap-y-3 px-4"
-              for={%{}}
-              as={:options}
-              phx-change="toggle_selected"
-              phx-target={@target}
-            >
-              <.input
-                :for={option <- @options}
-                name={option.id}
-                value={option.selected}
-                label={option.name}
-                checked={option.id in @selected_proficiency_ids}
-                type="checkbox"
-                label_class="text-zinc-900 text-xs font-normal leading-none dark:text-white"
-              />
-            </.form>
-          </div>
-          <div class="w-full border border-gray-200 my-4"></div>
-          <div class="flex flex-row items-center justify-end px-4 gap-x-4">
-            <button
-              class="text-center text-neutral-600 text-xs font-semibold leading-none dark:text-white"
-              phx-click={
-                JS.hide(to: "##{@id}-options-container")
-                |> JS.hide(to: "##{@id}-up-icon")
-                |> JS.show(to: "##{@id}-down-icon")
-              }
-            >
-              Cancel
-            </button>
-            <button
-              class="px-4 py-2 bg-blue-500 rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
-              phx-click={
-                JS.push("apply_proficiency_filter")
-                |> JS.hide(to: "##{@id}-options-container")
-                |> JS.hide(to: "##{@id}-up-icon")
-                |> JS.show(to: "##{@id}-down-icon")
-              }
-              phx-target={@target}
-              phx-value={@selected_proficiency_ids}
-              disabled={@disabled}
-            >
-              Apply
-            </button>
-          </div>
-        </div>
       </div>
     </div>
     """
@@ -466,6 +365,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
      )}
   end
 
+  def handle_event("paged_table_selection_change", %{"id" => _selected_objective_id}, socket) do
+    {:noreply, socket}
+  end
+
   defp do_update_selection(socket, selected_id) do
     %{proficiency_options: proficiency_options} = socket.assigns
 
@@ -487,10 +390,6 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
        proficiency_options: updated_options,
        selected_proficiency_ids: selected_ids
      )}
-  end
-
-  defp show_proficiency_selected_values(values) do
-    Enum.map_join(values, ", ", fn {_id, values} -> values end)
   end
 
   defp update_proficiency_options(selected_proficiency_ids, proficiency_options) do

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -169,10 +169,10 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
               @model.data
             ),
             row
-          ) %>
+          )}
 
           <%= if @model.data[:expandable_rows] do %>
-            <%= render_details_row(
+            {render_details_row(
               with_data(
                 %{
                   model: @model,
@@ -183,7 +183,7 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
                 @model.data
               ),
               row
-            ) %>
+            )}
           <% end %>
         <% end %>
       </tbody>

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -88,7 +88,11 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
     ~H"""
     <tr
       id={id_field(@row, @model)}
-      class={@row_class <> if Map.get(@row, :selected) || id_field(@row, @model) == @model.selected, do: " bg-delivery-primary-100 shadow-inner dark:bg-gray-700 dark:text-black", else: ""}
+      data-row-id={id_field(@row, @model)}
+      class={@row_class <> " hover:bg-Table-table-hover" <>
+    if Map.get(@row, :selected) || id_field(@row, @model) == @model.selected,
+      do: " bg-delivery-primary-100 shadow-inner dark:bg-gray-700 dark:text-black",
+      else: ""}
       aria-selected={if Map.get(@row, :selected), do: "true", else: "false"}
       phx-click={@select}
       phx-value-id={id_field(@row, @model)}
@@ -158,14 +162,29 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
                 additional_table_class: @additional_table_class,
                 additional_row_class:
                   if(Integer.is_even(index),
-                    do: "bg-Table-table-row-1",
-                    else: "bg-Table-table-row-2"
-                  )
+                    do: "bg-Table-table-row-1 ",
+                    else: "bg-Table-table-row-2 "
+                  ) <> @additional_row_class
               },
               @model.data
             ),
             row
-          )}
+          ) %>
+
+          <%= if @model.data[:expandable_rows] do %>
+            <%= render_details_row(
+              with_data(
+                %{
+                  model: @model,
+                  sort: @sort,
+                  select: @select,
+                  additional_table_class: @additional_table_class
+                },
+                @model.data
+              ),
+              row
+            ) %>
+          <% end %>
         <% end %>
       </tbody>
     </table>
@@ -174,5 +193,22 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
 
   defp with_data(assigns, data) do
     Map.merge(assigns, data)
+  end
+
+  defp render_details_row(assigns, row) do
+    row_id = id_field(row, assigns.model)
+    col_span = length(assigns.model.column_specs)
+
+    assigns = Map.merge(assigns, %{row_id: row_id, col_span: col_span})
+
+    ~H"""
+    <tr id={"details-#{@row_id}"} class="hidden">
+      <td colspan={@col_span} class="bg-gray-50 dark:bg-gray-900 p-4">
+        <div class="text-sm text-gray-700 dark:text-gray-200">
+          Information will go here.
+        </div>
+      </td>
+    </tr>
+    """
   end
 end

--- a/lib/oli_web/live/common/table/striped_paged_table.ex
+++ b/lib/oli_web/live/common/table/striped_paged_table.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Common.StripedPagedTable do
   attr :show_bottom_paging, :boolean, default: true
 
   attr :additional_table_class, :string, default: ""
+  attr :additional_row_class, :string, default: ""
   attr :render_top_info, :boolean, default: true
   attr :scrollable, :boolean, default: true
   attr :show_limit_change, :boolean, default: false
@@ -39,8 +40,9 @@ defmodule OliWeb.Common.StripedPagedTable do
             table_model: @table_model,
             sort: @sort,
             selection_change: @selection_change,
-            additional_table_class: @additional_table_class
-          })}
+            additional_table_class: @additional_table_class,
+            additional_row_class: @additional_row_class
+          }) %>
         </div>
         <Paging.render
           id="footer_paging"
@@ -71,6 +73,7 @@ defmodule OliWeb.Common.StripedPagedTable do
         sort={@sort}
         select={@selection_change}
         additional_table_class={@additional_table_class}
+        additional_row_class={@additional_row_class}
       />
       """
     else
@@ -79,6 +82,7 @@ defmodule OliWeb.Common.StripedPagedTable do
         model={@table_model}
         sort={@sort}
         additional_table_class={@additional_table_class}
+        additional_row_class={@additional_row_class}
       />
       """
     end

--- a/lib/oli_web/live/common/table/striped_paged_table.ex
+++ b/lib/oli_web/live/common/table/striped_paged_table.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.Common.StripedPagedTable do
             selection_change: @selection_change,
             additional_table_class: @additional_table_class,
             additional_row_class: @additional_row_class
-          }) %>
+          })}
         </div>
         <Paging.render
           id="footer_paging"

--- a/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
@@ -278,6 +278,17 @@ defmodule OliWeb.Delivery.InstructorDashboard.HTMLComponents do
     """
   end
 
+  attr :title, :string, required: true
+
+  def render_proficiency_label(assigns) do
+    ~H"""
+    <div class="flex items-center gap-x-2">
+      <%= Icons.info(assigns) %>
+      <span><%= @title %></span>
+    </div>
+    """
+  end
+
   attr :entry, :string, required: true
   slot :inner_block, required: true
 

--- a/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/html_components.ex
@@ -283,8 +283,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.HTMLComponents do
   def render_proficiency_label(assigns) do
     ~H"""
     <div class="flex items-center gap-x-2">
-      <%= Icons.info(assigns) %>
-      <span><%= @title %></span>
+      {Icons.info(assigns)}
+      <span>{@title}</span>
     </div>
     """
   end

--- a/lib/oli_web/live/dev/tokens_live.ex
+++ b/lib/oli_web/live/dev/tokens_live.ex
@@ -134,7 +134,7 @@ defmodule OliWeb.Dev.TokensLive do
                           phx-hook="CopyToClipboard"
                           data-copy-text={light}
                         />
-                        <span class="text-xs"><%= light %></span>
+                        <span class="text-xs">{light}</span>
                         <span class="text-xs">Light</span>
                       </div>
 
@@ -146,7 +146,7 @@ defmodule OliWeb.Dev.TokensLive do
                           phx-hook="CopyToClipboard"
                           data-copy-text={dark}
                         />
-                        <span class="text-xs"><%= dark %></span>
+                        <span class="text-xs">{dark}</span>
                         <span class="text-xs">Dark</span>
                       </div>
                     </div>

--- a/lib/oli_web/live/dev/tokens_live.ex
+++ b/lib/oli_web/live/dev/tokens_live.ex
@@ -134,6 +134,7 @@ defmodule OliWeb.Dev.TokensLive do
                           phx-hook="CopyToClipboard"
                           data-copy-text={light}
                         />
+                        <span class="text-xs"><%= light %></span>
                         <span class="text-xs">Light</span>
                       </div>
 
@@ -145,6 +146,7 @@ defmodule OliWeb.Dev.TokensLive do
                           phx-hook="CopyToClipboard"
                           data-copy-text={dark}
                         />
+                        <span class="text-xs"><%= dark %></span>
                         <span class="text-xs">Dark</span>
                       </div>
                     </div>

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -136,26 +136,31 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
 
       assert view
-             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> element(
+               "#objectives-table table.instructor_dashboard_table > tbody > tr[data-row-id='#{obj_revision_1.resource_id}'] > td:nth-child(2)"
+             )
              |> render() =~ obj_revision_1.title
 
       assert view
-             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> element(
+               "#objectives-table table.instructor_dashboard_table > tbody > tr[data-row-id='#{obj_revision_2.resource_id}'] > td:nth-child(2)"
+             )
              |> render() =~ obj_revision_2.title
 
       ## sorting by objective
-      params = %{
-        sort_order: :desc
-      }
-
+      params = %{sort_order: :desc}
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
 
       assert view
-             |> element("table.instructor_dashboard_table > tbody > tr:first-child")
+             |> element(
+               "#objectives-table table.instructor_dashboard_table > tbody > tr[data-row-id='#{obj_revision_2.resource_id}'] > td:nth-child(2)"
+             )
              |> render() =~ obj_revision_2.title
 
       assert view
-             |> element("table.instructor_dashboard_table > tbody > tr:nth-child(2)")
+             |> element(
+               "#objectives-table table.instructor_dashboard_table > tbody > tr[data-row-id='#{obj_revision_1.resource_id}'] > td:nth-child(2)"
+             )
              |> render() =~ obj_revision_1.title
     end
 


### PR DESCRIPTION
[MER-4699](https://eliterate.atlassian.net/browse/MER-4699)

This PR implements visual changes to the instructor’s `Learning Objectives` view, aligning it with the style defined in Figma. 

Enhancements have been introduced to improve readability, such as zebra striping, a sticky header when scrolling, and a redesigned toolbar for filters and search. Row visual states (default, hover, and selected) have been updated for greater clarity, and the proficiency column now uses colored chips to represent each status.


https://github.com/user-attachments/assets/c4dd2db3-fd69-4877-948c-4d14a1a92b08



[MER-4699]: https://eliterate.atlassian.net/browse/MER-4699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ