### PR TITLE
[BUG FIX] [MER-4836] Fix 500 error when accessing sections with AI Assistant enabled

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -344,6 +344,19 @@ config :oli, :datashop,
 config :oli, :student_sign_in,
   background_color: System.get_env("STUDENT_SIGNIN_BACKGROUND_COLOR", "#FF82E4")
 
+case System.get_env("CLOAK_VAULT_KEY") do
+  nil ->
+    # When CI or when no variable, don't configure
+    :ok
+
+  key ->
+    config :oli, Oli.Vault,
+      json_library: Jason,
+      ciphers: [
+        default: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V1", key: Base.decode64!(key)}
+      ]
+end
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/lib/oli/gen_ai_feature_config.ex
+++ b/lib/oli/gen_ai_feature_config.ex
@@ -6,9 +6,10 @@ defmodule Oli.GenAIFeatureConfig do
   import Ecto.Changeset
 
   schema "gen_ai_feature_configs" do
-    field(:feature, Ecto.Enum, values: [:student_dialogue, :instructor_dashboard])
+    field :feature, Ecto.Enum, values: [:student_dialogue, :instructor_dashboard]
+
     belongs_to :service_config, Oli.GenAI.Completions.ServiceConfig
-    belongs_to(:section, Oli.Delivery.Sections.Section)
+    belongs_to :section, Oli.Delivery.Sections.Section
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/oli/vault.ex
+++ b/lib/oli/vault.ex
@@ -1,8 +1,12 @@
 defmodule Oli.Vault do
   use Cloak.Vault, otp_app: :oli
 
+  require Logger
+
   @impl GenServer
   def init(config) do
+    Logger.info("Initializing Oli.Vault")
+
     config =
       Keyword.put(config, :ciphers,
         default: {Cloak.Ciphers.AES.GCM, tag: "AES.GCM.V1", key: decode_env!("CLOAK_VAULT_KEY")}

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -21,6 +21,8 @@ alias Oli.Utils.DataGenerators.NameGenerator
 alias Oli.GenAI.Completions.{ServiceConfig, RegisteredModel}
 alias Oli.GenAIFeatureConfig
 
+import Ecto.Query, only: [from: 2]
+
 # create system roles
 if !Oli.Repo.get_by(Oli.Accounts.SystemRole, id: 1) do
   Oli.Repo.insert!(%Oli.Accounts.SystemRole{
@@ -188,7 +190,8 @@ case Oli.Repo.all(RegisteredModel) do
     })
 
     primary_model =
-      Oli.Repo.get!(RegisteredModel, 1)
+      from(r in RegisteredModel, order_by: [asc: :id], limit: 1)
+      |> Oli.Repo.one!()
 
     # Insert the completions_service_config
     Oli.Repo.insert!(%ServiceConfig{


### PR DESCRIPTION
### Problem 
Students got 500 errors when accessing sections with AI Assistant enabled because the required GenAI infrastructure data (registered models, service configs, feature configs) wasn't seeded in the database.

### Root Cause
After checking Tokamak deployment logs, we found that seeds are failing with the error:
```
** (Ecto.ChangeError) value `"model-key"` for `Oli.GenAI.Completions.RegisteredModel.api_key` in `insert` does not match type Oli.Encrypted.Binary
```
This error is caused by missing `Cloak.Vault` configuration, as documented in this [GitHub issue](https://github.com/danielberkompas/cloak/issues/117).

### Solution
Added proper `Cloak.Vault` configuration in `config/config.exs` to ensure the vault is properly initialized before seeds run, allowing automatic encryption of API keys during database seeding.