### PR TITLE
[BUG FIX] [MER-4683] fix proficiency queries to avoid divide by zero in Logic course

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -441,7 +441,7 @@ defmodule Oli.Delivery.Metrics do
       select: {
         rs.resource_id,
         fragment(
-          "CAST(SUM(?) as float) / CAST(SUM(?) as float)",
+          "CAST(SUM(?) as float) / NULLIF(CAST(SUM(?) as float), 0.0)",
           rs.num_correct,
           rs.num_attempts
         )
@@ -975,10 +975,10 @@ defmodule Oli.Delivery.Metrics do
            fragment(
              """
              (
-               (1 * NULLIF(CAST(SUM(?) as float), 0.0001)) +
-               (0.2 * (NULLIF(CAST(SUM(?) as float), 0.0001) - NULLIF(CAST(SUM(?) as float), 0.0001)))
+               (1 * CAST(SUM(?) as float)) +
+               (0.2 * (CAST(SUM(?) as float) - CAST(SUM(?) as float)))
              ) /
-             NULLIF(CAST(SUM(?) as float), 0.0001)
+             NULLIF(CAST(SUM(?) as float), 0.0)
              """,
              summary.num_first_attempts_correct,
              summary.num_first_attempts,
@@ -1060,10 +1060,10 @@ defmodule Oli.Delivery.Metrics do
           fragment(
             """
             (
-              (1 * NULLIF(CAST(? as float), 0.0001)) +
-              (0.2 * (NULLIF(CAST(? as float), 0.0001) - NULLIF(CAST(? as float), 0.0001)))
+              (1 * CAST(? as float)) +
+              (0.2 * (CAST(? as float) - CAST(? as float)))
             ) /
-            NULLIF(CAST(? as float), 0.0001)
+            NULLIF(CAST(? as float), 0.0)
             """,
             summary.num_first_attempts_correct,
             summary.num_first_attempts,
@@ -1110,10 +1110,10 @@ defmodule Oli.Delivery.Metrics do
            fragment(
              """
              (
-               (1 * NULLIF(CAST(? as float), 0.0001)) +
-               (0.2 * (NULLIF(CAST(? as float), 0.0001) - NULLIF(CAST(? as float), 0.0001)))
+               (1 * CAST(? as float)) +
+               (0.2 * (CAST(? as float) - CAST(? as float)))
              ) /
-             NULLIF(CAST(? as float), 0.0001)
+             NULLIF(CAST(? as float), 0.0)
              """,
              summary.num_first_attempts_correct,
              summary.num_first_attempts,
@@ -1155,10 +1155,10 @@ defmodule Oli.Delivery.Metrics do
            fragment(
              """
              (
-               (1 * NULLIF(CAST(? as float), 0.0001)) +
-               (0.2 * (NULLIF(CAST(? as float), 0.0001) - NULLIF(CAST(? as float), 0.0001)))
+               (1 * CAST(? as float)) +
+               (0.2 * (CAST(? as float) - CAST(? as float)))
              ) /
-             NULLIF(CAST(? as float), 0.0001)
+             NULLIF(CAST(? as float), 0.0)
              """,
              summary.num_first_attempts_correct,
              summary.num_first_attempts,
@@ -1509,10 +1509,10 @@ defmodule Oli.Delivery.Metrics do
            fragment(
              """
              (
-               (1 * NULLIF(CAST(SUM(?) as float), 0.0001)) +
-               (0.2 * (NULLIF(CAST(SUM(?) as float), 0.0001) - NULLIF(CAST(SUM(?) as float), 0.0001)))
+               (1 * CAST(SUM(?) as float)) +
+               (0.2 * (CAST(SUM(?) as float) - CAST(SUM(?) as float)))
              ) /
-             NULLIF(CAST(SUM(?) as float), 0.0001)
+             NULLIF(CAST(SUM(?) as float), 0.0)
              """,
              summary.num_first_attempts_correct,
              summary.num_first_attempts,


### PR DESCRIPTION
[Ticket](https://eliterate.atlassian.net/browse/TRIAGE-1802) Background: At one time we found Logic and Proofs was causing divide-by-zero exceptions in certain proficiency metric calculations done within queries containing divisions. The queries were not protecting against possible divide-by-zero, but this was usually harmless as they normally find nulls rather than explicit zeros for total number of first attempts, and nulls in calculations are OK (turning all results to null). However Logic and Proofs evidently can give rise to zeros, perhaps because of quirks in the LogicLab activity implementation which is an outlier among torus activities in several respects. And no comment in the code gives any argument why zeros couldn't arise. 

That was fixed with https://github.com/Simon-Initiative/oli-torus/pull/4884 which added `NULLIF(..., 0.0)` to denominators to turn zero-valued denominators into nulls. 

This fix got broken by https://github.com/Simon-Initiative/oli-torus/pull/5213 which recoded the relevant proficiency query to use a different algorithm (1 point for first attempt correct, 0.2 points for incorrect first attempt). In the process the recoding changed the protective 
`(NULLIF(CAST(SUM(?) as float), 0.0)`
in various places into
`(NULLIF(CAST(SUM(?) as float), 0.0001)`
for reasons unknown. In addition it added other uses of `(NULLIF(CAST(SUM(?) as float), 0.0001)` throughout the expressions which look to be erroneous.

This restores the `(NULLIF(CAST(SUM(?) as float), 0.0)` to the denominators to protect against divide by zero. It also removes the other apparently spurious NULLIFs, while otherwise retaining the new calculation. 