### PR TITLE
[BUG FIX] [MER-4836] Add Vault Init on Release Seed Function

### DIFF
--- a/lib/oli/release.ex
+++ b/lib/oli/release.ex
@@ -100,6 +100,8 @@ defmodule Oli.Release do
   end
 
   def seed do
+    # Initialize Vault before seeds to ensure Cloak.Ecto can encrypt fields
+    Oli.Vault.start_link()
     load_app()
 
     for repo <- repos() do


### PR DESCRIPTION
[MER-4836](https://eliterate.atlassian.net/browse/MER-4836)

### Problem 
Students got 500 errors when accessing sections with AI Assistant enabled because the required GenAI infrastructure data (registered models, service configs, feature configs) wasn't seeded in the database.

### Root Cause
During deployment, seeds were failing with `Ecto.ChangeError` for encrypted fields because `Oli.Vault` wasn't initialized when running seeds in release context ([example failing job](https://github.com/Simon-Initiative/oli-torus/actions/runs/17045887187/job/48321457692)):
```
** (Ecto.ChangeError) value `"model-key"` for `Oli.GenAI.Completions.RegisteredModel.api_key` in `insert` does not match type Oli.Encrypted.Binary
```

### Solution
Added `Oli.Vault.start_link()` to `Oli.Release.seed()` to ensure Vault is initialized before executing seeds, as required by `Cloak.Ecto` for field encryption.

### References: 
- [Phoenix Releases Custom Commands](https://hexdocs.pm/phoenix/releases.html#custom-commands)
- [Cloak Issue #125](https://github.com/danielberkompas/cloak/issues/125)
- [Cloak.Ecto Issue #47](https://github.com/danielberkompas/cloak_ecto/issues/47)

[MER-4836]: https://eliterate.atlassian.net/browse/MER-4836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ