### PR TITLE
[BUG FIX] [MER-4867] fix divide-by-zero in proficiency bucket calculation

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1445,11 +1445,11 @@ defmodule Oli.Delivery.Metrics do
     end)
     |> Enum.into(%{}, fn {container_id, {first_correct, first_total, _correct, total}} ->
       proficiency =
-        case total do
-          total when total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
+        cond do
+          total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
             nil
 
-          _ ->
+          true ->
             (1 * first_correct + 0.2 * (first_total - first_correct)) / first_total
         end
 

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1446,7 +1446,7 @@ defmodule Oli.Delivery.Metrics do
     |> Enum.into(%{}, fn {container_id, {first_correct, first_total, _correct, total}} ->
       proficiency =
         case total do
-          total when total in [+0.0, -0.0] ->
+          total when total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
             nil
 
           _ ->


### PR DESCRIPTION
https://github.com/Simon-Initiative/oli-torus/pull/5805 fixed divide-by-zero occuring in proficiency queries that include divisions. This addition prevents divide-by-zero at another place in the metric computations missed in that PR, namely the bucketing calculation for container proficiences. 

Again it seems to be only the LogicLab activity used in Logic and Proofs course that gives rise to zero values (as opposed to nulls) that trip divide-by-zero errors here. But code ought to be safe against these. See original PR for detail. 