### PR TITLE
[BUGFIX] [MER-4867] fix bucketing divide by zero, location 2

### DIFF
--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1399,7 +1399,7 @@ defmodule Oli.Delivery.Metrics do
                                  num_attempts}},
                                acc ->
           proficiency =
-            if num_attempts in [+0.0, -0.0] or num_first_attempts in [+0.0, 0.0] do
+            if num_attempts in [+0.0, -0.0] or num_first_attempts in [+0.0, -0.0] do
               nil
             else
               (1 * num_first_attempts_correct +

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1445,11 +1445,11 @@ defmodule Oli.Delivery.Metrics do
     end)
     |> Enum.into(%{}, fn {container_id, {first_correct, first_total, _correct, total}} ->
       proficiency =
-        case total do
-          total when total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
+        cond do
+          total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
             nil
 
-          _ ->
+          true ->
             (1 * first_correct + 0.2 * (first_total - first_correct)) / first_total
         end
 

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1446,7 +1446,7 @@ defmodule Oli.Delivery.Metrics do
     |> Enum.into(%{}, fn {container_id, {first_correct, first_total, _correct, total}} ->
       proficiency =
         case total do
-          total when total in [+0.0, -0.0] ->
+          total when total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
             nil
 
           _ ->

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1399,14 +1399,12 @@ defmodule Oli.Delivery.Metrics do
                                  num_attempts}},
                                acc ->
           proficiency =
-            case num_attempts do
-              num_attempts when num_attempts in [+0.0, -0.0] ->
-                nil
-
-              _ ->
-                (1 * num_first_attempts_correct +
-                   0.2 * (num_first_attempts - num_first_attempts_correct)) /
-                  num_first_attempts
+            if num_attempts in [+0.0, -0.0] or num_first_attempts in [+0.0, 0.0] do
+              nil
+            else
+              (1 * num_first_attempts_correct +
+                 0.2 * (num_first_attempts - num_first_attempts_correct)) /
+                num_first_attempts
             end
 
           Map.put(acc, user_id, proficiency_range(proficiency, num_attempts))
@@ -1445,12 +1443,10 @@ defmodule Oli.Delivery.Metrics do
     end)
     |> Enum.into(%{}, fn {container_id, {first_correct, first_total, _correct, total}} ->
       proficiency =
-        cond do
-          total in [+0.0, -0.0] or first_total in [+0.0, -0.0] ->
-            nil
-
-          true ->
-            (1 * first_correct + 0.2 * (first_total - first_correct)) / first_total
+        if total in [+0.0, -0.0] or first_total in [+0.0, -0.0] do
+          nil
+        else
+          (1 * first_correct + 0.2 * (first_total - first_correct)) / first_total
         end
 
       {container_id, proficiency_range(proficiency, total)}


### PR DESCRIPTION
https://github.com/Simon-Initiative/oli-torus/pull/5813 prevented divide-by-zero in routine `bucket_into_container_totals`. This extends that to prevent it in a second location missed by that PR, routine `bucket_into_container_mode ` Have examined all occurrences of / in metrics.ex to check for others.

Also minor recoding to use if/else rather than cond.