### PR TITLE
[BUG FIX] [MER-4597] Rework: fix an issue where admins cant create sections

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -152,10 +152,7 @@ defmodule Oli.Delivery do
            {:ok, section} <- Sections.create_section_resources(section, publication),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
-           {:ok, _enrollment} <-
-             Sections.enroll(user.id, section.id, [
-               ContextRoles.get_role(:context_instructor)
-             ]) do
+           {:ok, _section} <- maybe_enroll_user_as_instructor(user, section) do
         PostProcessing.apply(section, :all)
       else
         {:error, changeset} ->
@@ -169,16 +166,25 @@ defmodule Oli.Delivery do
       with {:ok, section} <- Oli.Delivery.Sections.Blueprint.duplicate(blueprint, section_params),
            {:ok, _} <- Sections.rebuild_contained_pages(section),
            {:ok, _} <- Sections.rebuild_contained_objectives(section),
-           {:ok, _maybe_enrollment} <-
-             Sections.enroll(user.id, section.id, [
-               ContextRoles.get_role(:context_instructor)
-             ]) do
+           {:ok, _section} <- maybe_enroll_user_as_instructor(user, section) do
         PostProcessing.apply(section, :discussions)
       else
         {:error, changeset} -> Repo.rollback(changeset)
       end
     end)
   end
+
+  defp maybe_enroll_user_as_instructor(%User{id: user_id}, section) do
+    # Enroll the user in the section with instructor role
+    case Sections.enroll(user_id, section.id, [ContextRoles.get_role(:context_instructor)]) do
+      {:ok, _enrollment} -> {:ok, section}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  # In cases where the user is nil, this section is being created by
+  # an admin and therefore does not need to enroll a user.
+  defp maybe_enroll_user_as_instructor(_, section), do: {:ok, section}
 
   # Returns a product or project used to create the section based on the source identifier.
   defp from_source_identifier(source_id) do


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-4597

During QA it was identified that admins cannot create course sections. This is due to an assumption in the code that the current_user is not nil.

The fix here is to only attempt to enroll the user in the course (access the user.id) when a user struct is present for current_user.