### PR TITLE
[BUG FIX] [MER-4834] Adaptive page global variables not recalled - part 2

### DIFF
--- a/assets/src/data/persistence/blob.ts
+++ b/assets/src/data/persistence/blob.ts
@@ -82,13 +82,24 @@ function readGlobal(keys: string[] | null = null) {
   }
 
   return Promise.all(promises).then((results) => {
-    return results.map((result) => {
+    // Map the array results to an object with top-level keys
+    const resultMap: { [key: string]: any } = {};
+
+    keys?.forEach((key, index) => {
+      const result = results[index];
       if (typeof result === 'string') {
-        const json = JSON.parse(result);
-        return json;
+        try {
+          const json = JSON.parse(result);
+          resultMap[key] = json;
+        } catch (e) {
+          resultMap[key] = { type: 'ServerError', message: 'Invalid JSON response' };
+        }
+      } else {
+        resultMap[key] = { type: 'ServerError', message: 'Invalid response from server' };
       }
-      return { type: 'ServerError', message: 'Invalid response from server' };
     });
+
+    return resultMap;
   });
 }
 

--- a/assets/src/data/persistence/extrinsic.ts
+++ b/assets/src/data/persistence/extrinsic.ts
@@ -39,24 +39,7 @@ export const readGlobalUserState = async (
   useLocalStorage = false,
 ) => {
   if (provider === 'new') {
-    const blobResponse = await Blob.readGlobalUserState(keys, useLocalStorage);
-
-    // If the response is an array (from blob storage), map it to the expected format
-    if (Array.isArray(blobResponse) && keys && keys.length > 0) {
-      const mappedResponse = blobResponse.reduce((acc: any, item, index) => {
-        const key = keys[index] || index.toString();
-        if (typeof item === 'object' && item !== null) {
-          Object.keys(item).forEach((subKey) => {
-            acc[key] = acc[key] || {};
-            acc[key][subKey] = item[subKey];
-          });
-        }
-        return acc;
-      }, {});
-      return mappedResponse;
-    }
-
-    return blobResponse;
+    return Blob.readGlobalUserState(keys, useLocalStorage);
   }
   return deprecatedReadGlobalUserState(keys, useLocalStorage);
 };


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4834?focusedCommentId=32567) to the comment in the ticket

This PR moves the response parsing into the `readGlobal` function.
The function used to return an array of maps, and now it returns a map (as adaptive pages expect).

### After
Added observations are kept between different adaptive pages

https://github.com/user-attachments/assets/df7cab87-f3bd-4c0f-b9f3-1e6c1b538c13


