### PR TITLE
[BUG FIX] [MER-3833] Fix batch_timeout variable name bug

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -234,7 +234,7 @@ if config_env() == :prod do
   config :oli, :xapi_upload_pipeline,
     batcher_concurrency: get_env_as_integer.("XAPI_BATCHER_CONCURRENCY", "20"),
     batch_size: get_env_as_integer.("XAPI_BATCH_SIZE", "50"),
-    batch_timeout: get_env_as_integer.("XAPI_BATCHER_CONCURRENCY", "5000"),
+    batch_timeout: get_env_as_integer.("XAPI_BATCH_TIMEOUT", "5000"),
     processor_concurrency: get_env_as_integer.("XAPI_PROCESSOR_CONCURRENCY", "2")
 
   default_description = """

--- a/lib/oli/analytics/xapi/pipeline_config.ex
+++ b/lib/oli/analytics/xapi/pipeline_config.ex
@@ -33,7 +33,7 @@ defmodule Oli.Analytics.XAPI.PipelineConfig do
       uploader_module: Oli.Analytics.XAPI.Uploader,
       batcher_concurrency: get_env_as_integer.("XAPI_BATCHER_CONCURRENCY", "20"),
       batch_size: get_env_as_integer.("XAPI_BATCH_SIZE", "50"),
-      batch_timeout: get_env_as_integer.("XAPI_BATCHER_CONCURRENCY", "5000"),
+      batch_timeout: get_env_as_integer.("XAPI_BATCH_TIMEOUT", "5000"),
       processor_concurrency: get_env_as_integer.("XAPI_PROCESSOR_CONCURRENCY", "2")
     ]
   end


### PR DESCRIPTION
Bug Fixed: MER-3833 - Incorrect environment variable for batch_timeout

Problem: Both lib/oli/analytics/xapi/pipeline_config.ex:36 and config/runtime.exs:237 were incorrectly
  using "XAPI_BATCHER_CONCURRENCY" as the environment variable for batch_timeout.

Solution: Changed the environment variable name to the correct "XAPI_BATCH_TIMEOUT" in both files.