### PR TITLE
[FEATURE] [MER-4669] Browse All Projects Information - Rework

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -15,7 +15,6 @@ defmodule Oli.Authoring.Course do
 
   alias Oli.Groups.CommunityVisibility
   alias Oli.Inventories
-  alias Oli.Institutions.Institution
   alias Oli.Publishing
   alias Oli.Publishing.Publications.Publication
   alias Oli.Publishing.PublishedResource
@@ -133,8 +132,6 @@ defmodule Oli.Authoring.Course do
         on: ap.author_id == a.id,
         left_join: pv in ProjectVisibility,
         on: pv.project_id == p.id,
-        left_join: i in Institution,
-        on: pv.institution_id == i.id,
         left_join: pub in Publication,
         on: pub.project_id == p.id and not is_nil(pub.published),
         left_join: op in AuthorProject,
@@ -162,6 +159,7 @@ defmodule Oli.Authoring.Course do
           inserted_at: p.inserted_at,
           status: p.status,
           visibility: p.visibility,
+          owner_id: owner.id,
           name: owner.name,
           email: owner.email,
           total_count: fragment("count(*) OVER()"),
@@ -171,13 +169,6 @@ defmodule Oli.Authoring.Course do
               a.id,
               a.name,
               a.id
-            ),
-          institutions:
-            fragment(
-              "json_agg(DISTINCT jsonb_build_object('id', ?, 'name', ?)) FILTER (WHERE ? IS NOT NULL)",
-              i.id,
-              i.name,
-              i.id
             ),
           published: fragment("bool_or(?)", not is_nil(pub.id))
         }
@@ -192,13 +183,6 @@ defmodule Oli.Authoring.Course do
             query,
             [_, _, a],
             {^direction, fragment("string_agg(DISTINCT ?, ', ')", a.name)}
-          )
-
-        :institutions ->
-          order_by(
-            query,
-            [_, _, _, _, i],
-            {^direction, fragment("string_agg(DISTINCT ?, ', ')", i.name)}
           )
 
         :published ->
@@ -255,8 +239,6 @@ defmodule Oli.Authoring.Course do
         on: ap.author_id == a.id,
         left_join: pv in ProjectVisibility,
         on: pv.project_id == p.id,
-        left_join: i in Institution,
-        on: pv.institution_id == i.id,
         left_join: pub in Publication,
         on: pub.project_id == p.id and not is_nil(pub.published),
         left_join: op in AuthorProject,
@@ -284,6 +266,7 @@ defmodule Oli.Authoring.Course do
           inserted_at: p.inserted_at,
           status: p.status,
           visibility: p.visibility,
+          owner_id: owner.id,
           name: owner.name,
           email: owner.email,
           total_count: fragment("count(*) OVER()"),
@@ -293,13 +276,6 @@ defmodule Oli.Authoring.Course do
               a.id,
               a.name,
               a.id
-            ),
-          institutions:
-            fragment(
-              "json_agg(DISTINCT jsonb_build_object('id', ?, 'name', ?)) FILTER (WHERE ? IS NOT NULL)",
-              i.id,
-              i.name,
-              i.id
             ),
           published: fragment("bool_or(?)", not is_nil(pub.id))
         }
@@ -314,13 +290,6 @@ defmodule Oli.Authoring.Course do
             query,
             [_, _, a],
             {^direction, fragment("string_agg(DISTINCT ?, ', ')", a.name)}
-          )
-
-        :institutions ->
-          order_by(
-            query,
-            [_, _, _, _, i],
-            {^direction, fragment("string_agg(DISTINCT ?, ', ')", i.name)}
           )
 
         :published ->

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -34,11 +34,6 @@ defmodule OliWeb.Projects.TableModel do
         render_fn: &custom_render/3
       },
       %ColumnSpec{
-        name: :institutions,
-        label: "Institution",
-        render_fn: &custom_render/3
-      },
-      %ColumnSpec{
         name: :published,
         label: "Published",
         render_fn: &custom_render/3
@@ -118,9 +113,12 @@ defmodule OliWeb.Projects.TableModel do
     assigns = Map.merge(assigns, %{project: project})
 
     ~H"""
-    <span class="text-Text-text-link text-base font-medium leading-normal">
+    <a
+      href={~p"/admin/authors/#{@project.owner_id}"}
+      class="text-Text-text-link text-base font-medium leading-normal"
+    >
       {@project.name}
-    </span>
+    </a>
     <small class="text-Text-text-low text-xs font-semibold leading-3">
       {@project.email}
     </small>
@@ -141,27 +139,6 @@ defmodule OliWeb.Projects.TableModel do
           {collab["name"]}
         </a>
         <%= if index < length(@project.collaborators) - 1 do %>
-          <span class="text-Text-text-high text-base font-medium leading-normal">, </span>
-        <% end %>
-      <% end %>
-    </div>
-    """
-  end
-
-  # Institution
-  def custom_render(assigns, project, %ColumnSpec{name: :institutions}) do
-    assigns = Map.merge(assigns, %{project: project})
-
-    ~H"""
-    <div>
-      <%= for {institution, index} <- Enum.with_index(@project.institutions || []) do %>
-        <a
-          href={~p"/admin/institutions/#{institution["id"]}"}
-          class="text-Text-text-link text-base font-medium leading-normal"
-        >
-          {institution["name"]}
-        </a>
-        <%= if index < length(@project.institutions) - 1 do %>
           <span class="text-Text-text-high text-base font-medium leading-normal">, </span>
         <% end %>
       <% end %>

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -112,17 +112,23 @@ defmodule OliWeb.Projects.TableModel do
   def custom_render(assigns, project, %ColumnSpec{name: :name}) do
     assigns = Map.merge(assigns, %{project: project})
 
-    ~H"""
-    <a
-      href={~p"/admin/authors/#{@project.owner_id}"}
-      class="text-Text-text-link text-base font-medium leading-normal"
-    >
-      {@project.name}
-    </a>
-    <small class="text-Text-text-low text-xs font-semibold leading-3">
-      {@project.email}
-    </small>
-    """
+    case project.owner_id do
+      nil ->
+        ""
+
+      _ ->
+        ~H"""
+        <a
+          href={~p"/admin/authors/#{@project.owner_id}"}
+          class="text-Text-text-link text-base font-medium leading-normal"
+        >
+          {@project.name}
+        </a>
+        <small class="text-Text-text-low text-xs font-semibold leading-3">
+          {@project.email}
+        </small>
+        """
+    end
   end
 
   # Collaborators

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -80,8 +80,11 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
       assert has_element?(view, "##{deleted_project.id}")
     end
 
-    test "applies paging", %{conn: conn} do
-      [first_p | tail] = insert_list(26, :project) |> Enum.sort_by(& &1.title)
+    test "applies paging", %{conn: conn, admin: admin} do
+      [first_p | tail] =
+        insert_list(26, :project, authors: [admin])
+        |> Enum.sort_by(& &1.title)
+
       last_p = List.last(tail)
 
       {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -184,7 +184,7 @@ defmodule Oli.Factory do
       version: "1",
       family: anonymous_build(:family),
       visibility: :global,
-      authors: anonymous_build_list(2, :author),
+      authors: anonymous_build_list(1, :author),
       publisher: anonymous_build(:publisher),
       attributes: anonymous_build(:project_attributes)
     }

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -184,7 +184,7 @@ defmodule Oli.Factory do
       version: "1",
       family: anonymous_build(:family),
       visibility: :global,
-      authors: anonymous_build_list(1, :author),
+      authors: anonymous_build_list(2, :author),
       publisher: anonymous_build(:publisher),
       attributes: anonymous_build(:project_attributes)
     }


### PR DESCRIPTION
[MER-4669](https://eliterate.atlassian.net/browse/MER-4669)

This PR introduces two changes requested during the QA process

- The `Created By` column has been updated so that the project creator’s name is now a clickable link that navigates to the author’s detail view.

- The `Institution` column has been removed from the table, since there is no way to associate an institution with a project, as confirmed in conversation with Jess.

https://github.com/user-attachments/assets/e2d95fef-6942-464f-8f65-2468203a07e7


[MER-4669]: https://eliterate.atlassian.net/browse/MER-4669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ