### PR TITLE
[FEATURE] [MER-4673] Browse All Products Information - Rework

### DIFF
--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -542,7 +542,6 @@ defmodule Oli.Delivery.Sections.Blueprint do
       Section
       |> join(:inner, [s], bp in Project, on: s.base_project_id == bp.id)
       |> preload([s, bp], base_project: bp)
-      |> join(:left, [s, _bp], i in Institution, on: s.institution_id == i.id)
       |> where([s, bp], s.type == :blueprint)
       |> where(^filter_by_text)
       |> where(^filter_by_project)
@@ -551,17 +550,13 @@ defmodule Oli.Delivery.Sections.Blueprint do
       |> offset(^offset)
       |> select([s, bp, i], %{
         s
-        | institution_name: i.name,
-          total_count: fragment("count(*) OVER()")
+        | total_count: fragment("count(*) OVER()")
       })
 
     query =
       case field do
         :base_project_id ->
           order_by(query, [s, bp], [{^direction, bp.title}])
-
-        :institution_name ->
-          order_by(query, [s, _bp, i], {^direction, i.name})
 
         :requires_payment ->
           order_by(

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -6,40 +6,48 @@ defmodule OliWeb.Products.ProductsTableModel do
   alias OliWeb.Common.FormatDateTime
 
   def new(products, ctx, project_slug \\ "") do
+    default_td_class = "!border-r border-Table-table-border"
+    default_th_class = "!border-r border-Table-table-border"
+
     SortableTableModel.new(
       rows: products,
       column_specs: [
         %ColumnSpec{
           name: :title,
           label: "Title",
-          render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3)
+          render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3),
+          td_class: default_td_class,
+          th_class: default_th_class
         },
         %ColumnSpec{
           name: :tags,
           label: "Tags",
           render_fn: &render_tags_column/3,
-          sortable: false
+          sortable: false,
+          td_class: default_td_class,
+          th_class: default_th_class
         },
         %ColumnSpec{
           name: :inserted_at,
           label: "Created",
-          render_fn: &render_created_column/3
+          render_fn: &render_created_column/3,
+          td_class: default_td_class,
+          th_class: default_th_class
         },
         %ColumnSpec{
           name: :requires_payment,
           label: "Requires Payment",
           render_fn: &render_payment_column/3,
-          sort_fn: &sort_payment_column/2
+          sort_fn: &sort_payment_column/2,
+          td_class: default_td_class,
+          th_class: default_th_class
         },
         %ColumnSpec{
           name: :base_project_id,
           label: "Base Project",
-          render_fn: &render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3)
-        },
-        %ColumnSpec{
-          name: :institution_name,
-          label: "Institution",
-          render_fn: &render_institution_column/3
+          render_fn: &render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3),
+          td_class: default_td_class,
+          th_class: default_th_class
         },
         %ColumnSpec{name: :status, label: "Status", render_fn: &render_status_column/3}
       ],
@@ -147,26 +155,6 @@ defmodule OliWeb.Products.ProductsTableModel do
     <span class="text-Text-text-high text-base font-medium">
       {Map.get(@product, :tags, "")}
     </span>
-    """
-  end
-
-  defp render_institution_column(_assigns, %{institution_name: nil}, _), do: ""
-
-  defp render_institution_column(
-         assigns,
-         %{institution_name: institution_name, institution_id: institution_id},
-         _
-       ) do
-    assigns =
-      Map.merge(assigns, %{institution_name: institution_name, institution_id: institution_id})
-
-    ~H"""
-    <a
-      href={~p"/admin/institutions/#{@institution_id}"}
-      class="text-Text-text-link text-base font-medium leading-normal"
-    >
-      {@institution_name}
-    </a>
     """
   end
 


### PR DESCRIPTION
[MER-4673](https://eliterate.atlassian.net/browse/MER-4673)

This PR introduces two changes requested during the QA process

- The necessary table cell styles have been added to match Figma's design.

- The `Institution` column has been removed from the table, as there is no association between institutions and products.

<img width="1834" height="815" alt="Captura de pantalla 2025-08-26 a la(s) 1 13 50 p  m" src="https://github.com/user-attachments/assets/a6220812-5186-4844-9ff9-5386f4c71868" />
<img width="1811" height="809" alt="Captura de pantalla 2025-08-26 a la(s) 1 14 03 p  m" src="https://github.com/user-attachments/assets/8230da40-6c6a-4683-9d94-008aa141ad99" />


[MER-4673]: https://eliterate.atlassian.net/browse/MER-4673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ