### PR TITLE
[BUG FIX] [MER-4880] Fix for the activity reset race condition

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/roll_up.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/roll_up.ex
@@ -342,7 +342,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
   Account for bad records by filtering out multiple records for the same attempt number.
   """
   def fix_bad_records(attempts) do
-
     # Group the records by activity id
     by_activity_id = Enum.group_by(attempts, & &1.resource_id)
 
@@ -350,11 +349,9 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
     Enum.reduce(by_activity_id, [], fn {_activity_id, records}, acc ->
       acc ++ fix_bad_records_for_activity_id(records)
     end)
-
   end
 
   defp fix_bad_records_for_activity_id(attempts) do
-
     grouped = Enum.group_by(attempts, & &1.attempt_number)
 
     # For all groups where there is more than one entry, that
@@ -362,15 +359,12 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
     # the same attempt number
     Enum.reduce(grouped, [], fn {_attempt_number, records}, acc ->
       if length(records) > 1 do
-
         # Filter down to only those that are evaluated
-        evaluated = Enum.filter(records, & &1.lifecycle_state == :evaluated)
+        evaluated = Enum.filter(records, &(&1.lifecycle_state == :evaluated))
 
         case Enum.count(evaluated) do
-
           # None were evaluated, so it is safe to use any one of them
-          0 -> acc ++ [(records |> hd())]
-
+          0 -> acc ++ [records |> hd()]
           # Sort by date evaluated descending, return the most recently evaluated
           _n -> acc ++ [Enum.sort_by(evaluated, & &1.date_evaluated, :desc) |> List.first()]
         end

--- a/lib/oli/delivery/attempts/activity_lifecycle/roll_up.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/roll_up.ex
@@ -148,6 +148,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
             a.resource_id == activity_id and a.attempt_guid != activity_attempt_guid
           end)
 
+        other_attempts_for_this_activity = fix_bad_records(other_attempts_for_this_activity)
+
         all_attempts = [
           %{score: score, out_of: out_of, date_evaluated: now} | other_attempts_for_this_activity
         ]
@@ -164,6 +166,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
           end)
           |> Enum.group_by(fn a -> a.resource_id end)
           |> Enum.map(fn {_, attempts} ->
+            attempts = fix_bad_records(attempts)
             Enum.max_by(attempts, fn a -> a.attempt_number end)
           end)
           |> List.flatten()
@@ -333,6 +336,48 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUp do
         end
       end
     )
+  end
+
+  @doc """
+  Account for bad records by filtering out multiple records for the same attempt number.
+  """
+  def fix_bad_records(attempts) do
+
+    # Group the records by activity id
+    by_activity_id = Enum.group_by(attempts, & &1.resource_id)
+
+    # Then disambiguate the records for each activity id
+    Enum.reduce(by_activity_id, [], fn {_activity_id, records}, acc ->
+      acc ++ fix_bad_records_for_activity_id(records)
+    end)
+
+  end
+
+  defp fix_bad_records_for_activity_id(attempts) do
+
+    grouped = Enum.group_by(attempts, & &1.attempt_number)
+
+    # For all groups where there is more than one entry, that
+    # means that we somehow ended up with multiple records for
+    # the same attempt number
+    Enum.reduce(grouped, [], fn {_attempt_number, records}, acc ->
+      if length(records) > 1 do
+
+        # Filter down to only those that are evaluated
+        evaluated = Enum.filter(records, & &1.lifecycle_state == :evaluated)
+
+        case Enum.count(evaluated) do
+
+          # None were evaluated, so it is safe to use any one of them
+          0 -> acc ++ [(records |> hd())]
+
+          # Sort by date evaluated descending, return the most recently evaluated
+          _n -> acc ++ [Enum.sort_by(evaluated, & &1.date_evaluated, :desc) |> List.first()]
+        end
+      else
+        acc ++ records
+      end
+    end)
   end
 
   defp initiate_grade_passback(section_id, resource_access_id) do

--- a/test/oli/delivery/attempts/activity_lifecycle/roll_up_fix_bad_records_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/roll_up_fix_bad_records_test.exs
@@ -1,0 +1,341 @@
+defmodule Oli.Delivery.Attempts.ActivityLifecycle.RollUpFixBadRecordsTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Delivery.Attempts.ActivityLifecycle.RollUp
+
+  describe "fix_bad_records/1" do
+    test "returns empty list when given empty list" do
+      assert RollUp.fix_bad_records([]) == []
+    end
+
+    test "returns single record unchanged when only one record exists" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert result == records
+    end
+
+    test "returns records unchanged when no duplicates exist across different resources" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        %{
+          resource_id: 2,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert result == records
+    end
+
+    test "returns records unchanged when no duplicates exist for same resource" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 2,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-02 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert result == records
+    end
+
+    test "handles duplicate attempt numbers with one evaluated record" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :active,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      assert hd(result).lifecycle_state == :evaluated
+    end
+
+    test "handles duplicate attempt numbers with multiple evaluated records, returns most recent" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-02 12:00:00Z]
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 10:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      assert hd(result).date_evaluated == ~U[2024-01-02 12:00:00Z]
+    end
+
+    test "handles duplicate attempt numbers with no evaluated records, returns any one" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :active,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :submitted,
+          date_evaluated: nil
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      assert hd(result).attempt_number == 1
+      assert hd(result).resource_id == 1
+    end
+
+    test "handles multiple resources with duplicate attempt numbers" do
+      records = [
+        # Resource 1 duplicates
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :active,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        # Resource 2 duplicates
+        %{
+          resource_id: 2,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 10:00:00Z]
+        },
+        %{
+          resource_id: 2,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-02 10:00:00Z]
+        },
+        # Resource 3 no duplicates
+        %{
+          resource_id: 3,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 3
+
+      # Group results by resource_id for verification
+      by_resource = Enum.group_by(result, & &1.resource_id)
+
+      # Resource 1 should have the evaluated record
+      resource_1_result = by_resource[1] |> hd()
+      assert resource_1_result.lifecycle_state == :evaluated
+
+      # Resource 2 should have the most recent evaluated record
+      resource_2_result = by_resource[2] |> hd()
+      assert resource_2_result.date_evaluated == ~U[2024-01-02 10:00:00Z]
+
+      # Resource 3 should remain unchanged
+      resource_3_result = by_resource[3] |> hd()
+      assert resource_3_result.date_evaluated == ~U[2024-01-01 12:00:00Z]
+    end
+
+    test "handles complex scenario with multiple duplicates per resource" do
+      records = [
+        # Resource 1 - attempt 1 duplicates (2 evaluated)
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-02 12:00:00Z]
+        },
+        # Resource 1 - attempt 2 duplicates (no evaluated)
+        %{
+          resource_id: 1,
+          attempt_number: 2,
+          lifecycle_state: :active,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 2,
+          lifecycle_state: :submitted,
+          date_evaluated: nil
+        },
+        # Resource 1 - attempt 3 no duplicates
+        %{
+          resource_id: 1,
+          attempt_number: 3,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-03 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 3
+
+      sorted_result = Enum.sort_by(result, & &1.attempt_number)
+
+      # Attempt 1 should have most recent evaluated
+      attempt_1 = Enum.at(sorted_result, 0)
+      assert attempt_1.attempt_number == 1
+      assert attempt_1.date_evaluated == ~U[2024-01-02 12:00:00Z]
+
+      # Attempt 2 should have any one of the non-evaluated
+      attempt_2 = Enum.at(sorted_result, 1)
+      assert attempt_2.attempt_number == 2
+      assert attempt_2.lifecycle_state in [:active, :submitted]
+
+      # Attempt 3 should remain unchanged
+      attempt_3 = Enum.at(sorted_result, 2)
+      assert attempt_3.attempt_number == 3
+      assert attempt_3.lifecycle_state == :evaluated
+    end
+
+    test "preserves order of non-duplicate records" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        },
+        %{
+          resource_id: 2,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-02 12:00:00Z]
+        },
+        %{
+          resource_id: 3,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-03 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert result == records
+    end
+
+    test "handles records with nil date_evaluated correctly" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2024-01-01 12:00:00Z]
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      # Should return the one with a date_evaluated
+      assert hd(result).date_evaluated == ~U[2024-01-01 12:00:00Z]
+    end
+
+    test "handles all records with nil date_evaluated" do
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          date_evaluated: nil
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      assert hd(result).date_evaluated == nil
+    end
+
+    test "handles edge case with single record in list format" do
+      # This tests the head function behavior
+      records = [
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :active,
+          date_evaluated: nil
+        },
+        %{
+          resource_id: 1,
+          attempt_number: 1,
+          lifecycle_state: :submitted,
+          date_evaluated: nil
+        }
+      ]
+
+      result = RollUp.fix_bad_records(records)
+      assert length(result) == 1
+      # Should return the first one (head of the list)
+      assert hd(result).lifecycle_state == :active
+    end
+  end
+end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -808,8 +808,9 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert attempt_state.hasMoreAttempts == false
 
       # now try to reset the guid from the first attempt, simulating the
-      # student clicking 'Reset' in tab A.
-      assert {:error, {:no_more_attempts}} ==
+      # student clicking 'Reset' in tab A. This should fail because attempt 1
+      # is no longer the latest attempt (attempt 2 was created above).
+      assert {:error, {:already_reset}} ==
                ActivityLifecycle.reset_activity(
                  section.slug,
                  activity_attempt.attempt_guid,


### PR DESCRIPTION
Here's a detailed description of the three-pronged approach to address the race condition issues which are affecting (but not caused by) Score as you Go.  I believe this issue has been in the codebase for quite some time, but we never saw reports about it because up until this point in time, there had never been a way to "reset" an activity in a high stakes context.  

## 1. Core Serialization and Locking in reset_activity and reset_part

### The Problem

  The original implementation had a critical race condition where multiple concurrent reset requests could:
  - Read the same activity attempt simultaneously
  - Both calculate the same "next attempt number"
  - Create duplicate attempts with identical attempt numbers
  - Corrupt the scoring calculations that depend on sequential attempt numbering 

### The Solution: Database-Level Concurrency Control

  Serializable Isolation Level: The transaction runs with isolation: :serializable, the highest isolation level
  that prevents:
  - Dirty reads
  - Non-repeatable reads
  - Phantom reads
  - Serialization anomalies

  Row-Level Locking: Uses FOR UPDATE to lock the parent resource_attempt row.

  Concurrent and Serial Reset Detection: After acquiring the lock, validates that the activity attempt being reset is still the latest:
```
  {max_attempt_number} =
    Repo.one(
      from(a in ActivityAttempt,
        where: a.resource_attempt_id == ^resource_attempt.id and
               a.resource_id == ^activity_attempt.resource_id,
        select: {max(a.attempt_number)}
      )
    )
  if activity_attempt.attempt_number != max_attempt_number do
    Repo.rollback({:already_reset})
  end
```

### Why This Approach Works

  1. Mutual Exclusion: Only one transaction can hold the FOR UPDATE lock at a time
  2. Atomic Validation: The "latest attempt" check happens within the same transaction as the creation
  3. Clean Failure Mode: Subsequent requests fail fast with {:error, {:already_reset}} rather than creating
  corrupt data
  4. Performance: Minimal overhead - just one additional query and lock per reset operation

## 2. Debounced UI Controls and Client-Side Request Management

### Frontend Safeguards

Button Debouncing: Implement client-side debouncing to prevent rapid-fire clicks from sending multiple network requests to reset. 

Visual Feedback: Provide immediate UI feedback to discourage multiple submissions:
  - Disable the reset button during processing
  - Show loading spinners or progress indicators
  - Display "Processing..." messages

## 3. Inline Record Cleanup with fix_bad_records Function

While the locking prevents new race conditions, existing corrupted data needed immediate remediation for score-as-you-go assessments.

Cleanup Strategy

  1. Prefer Evaluated Records: If duplicates exist, choose evaluated over non-evaluated
  2. Recency Priority: Among evaluated records, pick the most recently evaluated
  3. Deterministic Fallback: If no evaluated records exist, consistently pick the first record
  4. Preserve Good Data: Non-duplicate records pass through unchanged
  5. Maintain Order: Original ordering is preserved where possible
