### PR TITLE
[BUG FIX] [MER-4882] Fix major updates causing remix content removal

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3891,7 +3891,6 @@ defmodule Oli.Delivery.Sections do
       |> Enum.filter(fn child_id -> !is_nil(child_id) end)
       |> Enum.filter(fn child_id ->
         case Map.get(new_published_resources_map, sr_id_to_resource_id[child_id]) do
-          nil -> false
           %{deleted: true} -> false
           _ -> true
         end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3883,14 +3883,14 @@ defmodule Oli.Delivery.Sections do
   end
 
   # For a given section resource, clean the children attribute to ensure that:
-  # 1. Any nil records are removed
-  # 2. All non-nil sr id references map to a non-deleted revision in the new pub
+  # 1. All non-nil sr id references map to a non-deleted revision in the new pub get removed
   def clean_children(section_resource, sr_id_to_resource_id, new_published_resources_map) do
     updated_children =
       section_resource.children
       |> Enum.filter(fn child_id -> !is_nil(child_id) end)
       |> Enum.filter(fn child_id ->
         case Map.get(new_published_resources_map, sr_id_to_resource_id[child_id]) do
+          nil -> false
           %{deleted: true} -> false
           _ -> true
         end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -808,8 +808,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert attempt_state.hasMoreAttempts == false
 
       # now try to reset the guid from the first attempt, simulating the
-      # student clicking 'Reset' in tab A. This should fail because attempt 1
-      # is no longer the latest attempt (attempt 2 was created above).
+      # student clicking 'Reset' in tab A.
       assert {:error, {:no_more_attempts}} ==
                ActivityLifecycle.reset_activity(
                  section.slug,

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -810,7 +810,7 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       # now try to reset the guid from the first attempt, simulating the
       # student clicking 'Reset' in tab A. This should fail because attempt 1
       # is no longer the latest attempt (attempt 2 was created above).
-      assert {:error, {:already_reset}} ==
+      assert {:error, {:no_more_attempts}} ==
                ActivityLifecycle.reset_activity(
                  section.slug,
                  activity_attempt.attempt_guid,

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -808,8 +808,9 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert attempt_state.hasMoreAttempts == false
 
       # now try to reset the guid from the first attempt, simulating the
-      # student clicking 'Reset' in tab A.
-      assert {:error, {:no_more_attempts}} ==
+      # student clicking 'Reset' in tab A. This should fail because attempt 1
+      # is no longer the latest attempt (attempt 2 was created above).
+      assert {:error, {:already_reset}} ==
                ActivityLifecycle.reset_activity(
                  section.slug,
                  activity_attempt.attempt_guid,

--- a/test/oli/major_updates_test.exs
+++ b/test/oli/major_updates_test.exs
@@ -1,0 +1,183 @@
+defmodule Oli.MajorUpdatesTest do
+  use Oli.DataCase
+  use Oban.Testing, repo: Oli.Repo
+
+  alias Oli.Delivery.Sections
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Publishing
+  alias Oli.Delivery.Hierarchy
+  alias Oli.Seeder
+
+  describe "remix major updates" do
+    setup do
+      # Create source project using existing seeder helper
+      source_map = Seeder.base_project_with_resource2()
+
+      # Create destination project using existing seeder helper
+      dest_map = Seeder.base_project_with_resource2()
+
+      # Publish the destination project to get an initial publication for the section
+      {:ok, dest_initial_pub} =
+        Publishing.publish_project(dest_map.project, "initial destination", dest_map.author.id)
+
+      # Create a course section using the destination project's initial publication
+      {:ok, section} =
+        Sections.create_section(%{
+          title: "Test Course Section",
+          registration_open: true,
+          context_id: UUID.uuid4(),
+          institution_id: dest_map.institution.id,
+          base_project_id: dest_map.project.id
+        })
+        |> then(fn {:ok, section} -> section end)
+        |> Sections.create_section_resources(dest_initial_pub)
+
+      {:ok,
+       %{
+         source_map: source_map,
+         dest_map: dest_map,
+         dest_initial_pub: dest_initial_pub,
+         section: section
+       }}
+    end
+
+    @tag capture_log: true
+    test "major update incorrectly removes remixed container from another project", %{
+      source_map: source_map,
+      dest_map: dest_map,
+      section: section
+    } do
+      # Verify the initial curriculum structure - should have 2 pages in the root container
+      hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+      assert hierarchy.children |> Enum.count() == 2
+      assert hierarchy.children |> Enum.at(0) |> Map.get(:resource_id) == dest_map.page1.id
+      assert hierarchy.children |> Enum.at(1) |> Map.get(:resource_id) == dest_map.page2.id
+
+      # TODO: Add remix functionality here - this is where we will remix content from source_project into the section
+      # source_map has: project, publication, container, page1, page2, author, institution etc.
+      # dest_map has: project, publication, container, page1, page2, author, institution etc.
+
+      # REMIX: Add the entire source container into the section
+      # Step 1: Get current hierarchy
+      current_hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      # Step 2: Prepare selection (we want to remix the source container)
+      source_container_resource_id = source_map.container.resource.id
+      source_publication_id = source_map.publication.id
+      selection = [{source_publication_id, source_container_resource_id}]
+
+      # Step 3: Get published resources for the source publication
+      published_resources_by_resource_id_by_pub =
+        Publishing.get_published_resources_for_publications([source_publication_id])
+
+      # Step 4: Add the source container to the current section's hierarchy
+      updated_hierarchy =
+        Hierarchy.add_materials_to_hierarchy(
+          current_hierarchy,
+          # add to root level
+          current_hierarchy,
+          selection,
+          published_resources_by_resource_id_by_pub
+        )
+        |> Hierarchy.finalize()
+
+      # Step 5: Get current pinned publications and add the source publication
+      current_pinned_publications = Sections.get_pinned_project_publications(section.id)
+
+      updated_pinned_publications =
+        Map.put(current_pinned_publications, source_map.project.id, source_map.publication)
+
+      # Step 6: Apply the remix by rebuilding the section curriculum
+      Sections.rebuild_section_curriculum(section, updated_hierarchy, updated_pinned_publications)
+
+      # Verify the remix worked - should now have dest pages + source container with source pages
+      updated_hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+      # 2 dest pages + 1 source container
+      assert updated_hierarchy.children |> Enum.count() == 3
+
+      # Find the remixed container
+      source_container_in_section =
+        Enum.find(updated_hierarchy.children, fn child ->
+          child.resource_id == source_container_resource_id
+        end)
+
+      assert source_container_in_section != nil
+      # source container has 2 pages
+      assert source_container_in_section.children |> Enum.count() == 2
+
+      # MAJOR UPDATE: Now make major changes to the destination project
+      # This will trigger the bug where the remixed source container gets incorrectly removed
+
+      # Get the working publication for the destination project to make changes
+      dest_working_pub = Publishing.project_working_publication(dest_map.project.slug)
+
+      # Make major structural changes - add a new container with pages to the destination project
+      %{resource: new_dest_container_resource, revision: new_dest_container_revision} =
+        Seeder.create_container(
+          "New Dest Container",
+          dest_working_pub,
+          dest_map.project,
+          dest_map.author
+        )
+
+      %{resource: new_dest_page_resource, revision: _new_dest_page_revision} =
+        Seeder.create_page("New Dest Page", dest_working_pub, dest_map.project, dest_map.author)
+
+      # Attach the new page to the new container
+      _new_dest_container_revision =
+        Seeder.attach_pages_to(
+          [new_dest_page_resource],
+          new_dest_container_resource,
+          new_dest_container_revision,
+          dest_working_pub
+        )
+
+      # Attach the new container to the root container of dest project
+      dest_container = dest_map.container
+
+      _updated_dest_container_revision =
+        Seeder.attach_pages_to(
+          [new_dest_container_resource],
+          dest_container.resource,
+          dest_container.revision,
+          dest_working_pub
+        )
+
+      # Publish the major changes (this creates a MAJOR publication)
+      {:ok, major_publication} =
+        Publishing.publish_project(
+          dest_map.project,
+          "major structural changes",
+          dest_map.author.id
+        )
+
+      # APPLY THE MAJOR UPDATE: This is where the bug should manifest
+      # The apply_publication_update should preserve the remixed source container, but the bug causes it to be removed
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, major_publication.id)
+
+      # VERIFY THE BUG: Check if the remixed container was incorrectly removed
+      final_hierarchy = DeliveryResolver.full_hierarchy(section.slug)
+
+      _final_resource_ids = Enum.map(final_hierarchy.children, & &1.resource_id)
+
+      # Check if section resources still exist
+      final_section_resources = Sections.get_section_resources(section.id)
+
+      _source_srs =
+        Enum.filter(final_section_resources, fn sr ->
+          sr.resource_id == source_container_resource_id
+        end)
+
+      # The section should still have the remixed source container, but the bug removes it
+      remaining_source_container =
+        Enum.find(final_hierarchy.children, fn child ->
+          child.resource_id == source_container_resource_id
+        end)
+
+      # This assertion FAILS due to the bug - when a major publication update is applied to a project,
+      # it incorrectly removes remixed containers from OTHER projects that were added to the section
+      assert remaining_source_container != nil,
+             "BUG: Major publication update incorrectly removed remixed container from source project"
+    end
+  end
+end


### PR DESCRIPTION

The new unit tests demonstrates the bug and was written (and failed) prior to changing any production code. That unit test shows a remixed course section getting a major publication pushed to it.  During application of that update, the course section has a container that was added from the "remix" project completely dropped from the hieararchy. 

The root cause of the error is in a (somewhat recently added) step that "cleans" each container after the updates are applied.  This cleaning step is given a map of "all known resource ids in the course section" and was instructed to remove any from the current section resource `:children` list that either do not exist (`nil`) or are deleted.  

The issue here was the the clean function was given ONLY a mapping of the resources in the project being updated - and NOT the complete mapping of all remixed projects.  These changes now pass the unit test. 
