### PR TITLE
[BUG FIX] [MER-4848] Prevent unintended AI settings changes on LiveView reconnection

### DIFF
--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -1141,7 +1141,7 @@ defmodule OliWeb.Components.Common do
   def toggle_switch(assigns) do
     ~H"""
     <div {@rest}>
-      <form id={@id} phx-change={@on_toggle} phx-target={@phx_target}>
+      <form id={@id} phx-change={@on_toggle} phx-target={@phx_target} phx-auto-recover="ignore">
         <label class="inline-flex items-center cursor-pointer">
           <input
             id={"#{@id}_checkbox"}


### PR DESCRIPTION
[MER-4848](https://eliterate.atlassian.net/browse/MER-4848)

### Problem
When users leave the section manage page and return after a server restart, AI-related settings (like enable/disable DOT and trigger points) were being inadvertently changed. This happened because Phoenix LiveView's automatic form recovery process was re-sending form change events during reconnection, causing `handle_event` callbacks to execute without user interaction.

### Root Cause
The `toggle_switch` component was incorrectly implemented as a form with `phx-change` events, when it should have been a simple click-based component. When LiveView reconnects after a crash or disconnect, it automatically re-sends form data to maintain state consistency, which triggered the toggle handlers and caused unwanted side effects.

### Solution
Added `phx-auto-recover="ignore"` to the toggle switch form to prevent automatic form recovery during reconnection. This prevents the form from re-sending change events when the LiveView reconnects.

### References
- [Elixir Forum Discussion](https://elixirforum.com/t/livecomponents-handle_event-gets_called-on-server-restart-seemingly-for-no-reason-how-to-debug-event-triggers/52057)
- [Phoenix LiveView Form Recovery Documentation](https://hexdocs.pm/phoenix_live_view/form-bindings.html#recovery-following-crashes-or-disconnects)

### Long-term Improvement
This is a partial fix. For a complete solution, we should refactor toggle switches and similar interactive components to use `phx-click` events instead of forms with `phx-change`. Forms should only be used for actual form data collection, not for toggle actions or other interactive behaviors.

[MER-4848]: https://eliterate.atlassian.net/browse/MER-4848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ