### PR TITLE
[BUG FIX] [MER-4871] [MER-4754] fix code syntax highlighting & add line numbering

### DIFF
--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,7 +3,6 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
-    console.log('EvaluateMathJax');
     const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
 
     const getGlobalLastPromise = () => {

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -3,6 +3,7 @@
 
 export const EvaluateMathJaxExpressions = {
   mounted() {
+    console.log('EvaluateMathJax');
     const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
 
     const getGlobalLastPromise = () => {

--- a/assets/src/hooks/highlight_code.ts
+++ b/assets/src/hooks/highlight_code.ts
@@ -1,0 +1,12 @@
+export const HighlightCode = {
+  mounted() {
+    const hljs = (window as any).hljs;
+
+    hljs.configure({
+      cssSelector: 'pre code.torus-code',
+    });
+
+    hljs.highlightAll();
+    hljs.initLineNumbersOnLoad();
+  },
+};

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -22,6 +22,7 @@ import { ExpandContainers } from './expand_containers';
 import { FixedNavigationBar } from './fixed_navigation_bar';
 import { GraphNavigation } from './graph';
 import { HierarchySelector } from './hierarchy_selector';
+import { HighlightCode } from './highlight_code';
 import { InputAutoSelect } from './input_auto_select';
 import { KeepScrollAtBottom } from './keep_scroll_at_bottom';
 import { LiveModal } from './live_modal';
@@ -30,6 +31,7 @@ import { LtiConnectInstructions } from './lti_connect_instructions';
 import { ModalLaunch } from './modal';
 import { MonacoEditor } from './monaco_editor';
 import { OnMountAndUpdate } from './on_mount_and_update';
+import { PageContentHooks } from './page_content_hooks';
 import { FirePageTrigger } from './page_trigger';
 import { PointMarkers } from './point_markers';
 import { ProjectsTypeahead } from './projects_typeahead';
@@ -105,6 +107,8 @@ export const Hooks = {
   CountdownTimer,
   EndDateTimer,
   EvaluateMathJaxExpressions,
+  HighlightCode,
+  PageContentHooks,
   ReactToLiveView,
   DisableSubmitted,
   Recaptcha,

--- a/assets/src/hooks/page_content_hooks.ts
+++ b/assets/src/hooks/page_content_hooks.ts
@@ -1,0 +1,10 @@
+import { EvaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
+import { HighlightCode } from './highlight_code';
+
+// single delegating hook to apply all hooks adjusting special page content elements
+export const PageContentHooks = {
+  mounted() {
+    EvaluateMathJaxExpressions.mounted.call(this);
+    HighlightCode.mounted.call(this);
+  },
+};

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -178,6 +178,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   hljs.highlightAll();
+  hljs.initLineNumbersOnLoad();
 });
 
 let currentlyPlaying: HTMLAudioElement | null = null;

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -129,12 +129,6 @@ $element-margin-bottom: 1.5em;
     }
   }
 
-  html.delivery.dark {
-    pre code {
-      background: green;
-    }
-  }
-
   ul {
     padding-left: 1.5em;
     margin-bottom: $element-margin-bottom;

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -97,7 +97,7 @@ $element-margin-bottom: 1.5em;
     padding: 1em;
     margin-bottom: $element-margin-bottom;
 
-    code.hljs {
+    code {
       color: inherit;
       background: inherit;
 
@@ -627,7 +627,7 @@ html.dark {
       background: var(--color-gray-900);
     }
 
-    pre:has(code.hljs) {
+    pre:has(code) {
       background: inherit;
 
       table.hljs-ln {

--- a/assets/styles/common/elements.scss
+++ b/assets/styles/common/elements.scss
@@ -97,12 +97,41 @@ $element-margin-bottom: 1.5em;
     padding: 1em;
     margin-bottom: $element-margin-bottom;
 
-    code {
-      color: inherit;
-    }
-
     code.hljs {
+      color: inherit;
       background: inherit;
+
+      // table for code line numbering by hljs-line-number add-on to highlightjs
+      table.hljs-ln {
+        width: 100%;
+        background: white;
+        border: 1px solid #ced1d9;
+        border-radius: 5px;
+        border-collapse: separate;
+        border-spacing: 0;
+
+        td.hljs-ln-numbers {
+          min-width: 25px;
+          width: 3em;
+          padding-right: 0.3em;
+          text-align: right;
+        }
+
+        td.hljs-ln-code {
+          border-left: 1px solid #ced1d9;
+          padding-left: 0.5em;
+        }
+
+        tr:nth-child(even) td.hljs-ln-code {
+          background: #f3f4f8;
+        }
+      }
+    }
+  }
+
+  html.delivery.dark {
+    pre code {
+      background: green;
     }
   }
 
@@ -602,6 +631,22 @@ html.dark {
     pre {
       color: var(--color-body-color-dark);
       background: var(--color-gray-900);
+    }
+
+    pre:has(code.hljs) {
+      background: inherit;
+
+      table.hljs-ln {
+        background: #2b282e;
+        border: 1px solid #3b3740;
+
+        td.hljs-ln-code {
+          border-left: 1px solid #3b3740;
+        }
+        tr:nth-child(even) td.hljs-ln-code {
+          background: #0d0c0f;
+        }
+      }
     }
 
     .highlighted-annotation-point-block {

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -69,7 +69,7 @@
         <div
           :if={@section}
           id="page-content"
-          phx-hook="EvaluateMathJaxExpressions"
+          phx-hook="PageContentHooks"
           class="flex flex-col justify-center items-start relative"
         >
           <div
@@ -78,7 +78,6 @@
           >
             {react_component("Components.OfflineDetector")}
           </div>
-
           {@inner_content}
         </div>
       </div>
@@ -134,13 +133,13 @@
 
         <%= if @section && !@page_context.page.graded do %>
           {live_render(@socket, OliWeb.Dialogue.WindowLive,
-            session: %{
-              "section_slug" => @section.slug,
-              "resource_id" => @page_context.page.resource_id,
-              "revision_id" => @page_context.page.id,
-              "is_page" => true
-            },
-            id: "dialogue-window"
+          session: %{
+          "section_slug" => @section.slug,
+          "resource_id" => @page_context.page.resource_id,
+          "revision_id" => @page_context.page.id,
+          "is_page" => true
+          },
+          id: "dialogue-window"
           )}
         <% end %>
       </div>

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -133,13 +133,13 @@
 
         <%= if @section && !@page_context.page.graded do %>
           {live_render(@socket, OliWeb.Dialogue.WindowLive,
-          session: %{
-          "section_slug" => @section.slug,
-          "resource_id" => @page_context.page.resource_id,
-          "revision_id" => @page_context.page.id,
-          "is_page" => true
-          },
-          id: "dialogue-window"
+            session: %{
+              "section_slug" => @section.slug,
+              "resource_id" => @page_context.page.resource_id,
+              "revision_id" => @page_context.page.id,
+              "is_page" => true
+            },
+            id: "dialogue-window"
           )}
         <% end %>
       </div>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -49,9 +49,7 @@
     >
     </script>
     <!-- Typeahead -->
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"
-    >
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js">
     </script>
     <!-- Moment.js https://momentjs.com -->
     <script
@@ -113,9 +111,7 @@
       referrerpolicy="no-referrer"
     >
     </script>
-    <script
-      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
-    >
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js">
     </script>
     <!-- ReCAPTCHA -->
     <script src="https://www.google.com/recaptcha/api.js">
@@ -151,7 +147,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -49,9 +49,7 @@
     >
     </script>
     <!-- Typeahead -->
-    <script
-      src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"
-    >
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js">
     </script>
     <!-- Moment.js https://momentjs.com -->
     <script
@@ -147,7 +145,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -49,7 +49,9 @@
     >
     </script>
     <!-- Typeahead -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js">
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"
+    >
     </script>
     <!-- Moment.js https://momentjs.com -->
     <script
@@ -104,14 +106,6 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/atom-one-dark.min.css"
-      integrity="sha512-Jk4AqjWsdSzSWCSuQTfYRIF84Rq/eV0G2+tu07byYwHcbTGfdmLrHjUSwvzp5HvbiqK4ibmNwdcG49Y5RGYPTg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      media="screen and (prefers-color-scheme: dark)"
-    />
     <script
       src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"
       integrity="sha512-IaaKO80nPNs5j+VLxd42eK/7sYuXQmr+fyywCNA0e+C6gtQnuCXNtORe9xR4LqGPz5U9VpH+ff41wKs/ZmC3iA=="
@@ -128,7 +122,6 @@
     <script>
       window.cite = require('citation-js')
     </script>
-
     {OliWeb.Common.MathJaxScript.render(@conn)}
 
     {csrf_meta_tag()}
@@ -147,7 +140,6 @@
   </head>
   <body class="dark:bg-body-dark dark:text-white">
     <input type="hidden" id="layout-id" data-layout-id="authoring" />
-
     {live_render(@conn, OliWeb.SystemMessageLive.ShowView)}
 
     {Map.get(assigns, :inner_layout) || @inner_content}
@@ -155,7 +147,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/authoring.html.heex
+++ b/lib/oli_web/templates/layout/authoring.html.heex
@@ -49,7 +49,9 @@
     >
     </script>
     <!-- Typeahead -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js">
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-3-typeahead/4.0.2/bootstrap3-typeahead.min.js"
+    >
     </script>
     <!-- Moment.js https://momentjs.com -->
     <script
@@ -111,6 +113,10 @@
       referrerpolicy="no-referrer"
     >
     </script>
+    <script
+      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
+    >
+    </script>
     <!-- ReCAPTCHA -->
     <script src="https://www.google.com/recaptcha/api.js">
     </script>
@@ -145,7 +151,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/chromeless.html.heex
+++ b/lib/oli_web/templates/layout/chromeless.html.heex
@@ -7,9 +7,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    {csrf_meta_tag()}
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" /> {csrf_meta_tag()}
     <Phoenix.Component.live_title>
       {assigns[:page_title] || assigns[:title] || Oli.VendorProperties.product_short_name()}
     </Phoenix.Component.live_title>
@@ -89,6 +87,10 @@
     />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js">
     </script>
+    <script
+      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
+    >
+    </script>
 
     <link id="preview-theme-light" rel="stylesheet" href="/css/preview.css" />
 
@@ -102,14 +104,11 @@
     <script>
       window.cite = require('citation-js')
     </script>
-
     {OliWeb.Common.MathJaxScript.render(@conn)}
-
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/vendor.js")}>
     </script>
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/app.js")}>
     </script>
-
     {additional_stylesheets(assigns)}
   </head>
   <body>

--- a/lib/oli_web/templates/layout/chromeless.html.heex
+++ b/lib/oli_web/templates/layout/chromeless.html.heex
@@ -87,9 +87,7 @@
     />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.0/highlight.min.js">
     </script>
-    <script
-      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
-    >
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js">
     </script>
 
     <link id="preview-theme-light" rel="stylesheet" href="/css/preview.css" />

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -107,19 +107,15 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/atom-one-dark.min.css"
-      integrity="sha512-Jk4AqjWsdSzSWCSuQTfYRIF84Rq/eV0G2+tu07byYwHcbTGfdmLrHjUSwvzp5HvbiqK4ibmNwdcG49Y5RGYPTg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      media="screen and (prefers-color-scheme: dark)"
-    />
     <script
       src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"
       integrity="sha512-IaaKO80nPNs5j+VLxd42eK/7sYuXQmr+fyywCNA0e+C6gtQnuCXNtORe9xR4LqGPz5U9VpH+ff41wKs/ZmC3iA=="
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
+    >
+    </script>
+    <script
+      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
     >
     </script>
 
@@ -136,7 +132,6 @@
     <script>
       window.cite = require('citation-js')
     </script>
-
     {OliWeb.Common.MathJaxScript.render(@conn)}
 
     {csrf_meta_tag()}
@@ -155,7 +150,6 @@
   </head>
   <body class="min-h-screen flex flex-col bg-delivery-body text-delivery-body-color dark:bg-delivery-body-dark dark:text-delivery-body-color-dark">
     <input type="hidden" id="layout-id" data-layout-id="delivery" />
-
     {live_render(@conn, OliWeb.SystemMessageLive.ShowView)}
 
     {Map.get(assigns, :inner_layout) || @inner_content}
@@ -163,7 +157,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery.html.heex
+++ b/lib/oli_web/templates/layout/delivery.html.heex
@@ -114,9 +114,7 @@
       referrerpolicy="no-referrer"
     >
     </script>
-    <script
-      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
-    >
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js">
     </script>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
@@ -157,7 +155,7 @@
     {react_component("Components.ModalDisplay")}
 
     {live_render(@conn, OliWeb.TechSupportLive,
-    session: OliWeb.CollectHelpRequestInfo.collect(@conn)
+      session: OliWeb.CollectHelpRequestInfo.collect(@conn)
     )}
   </body>
 </html>

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -84,9 +84,7 @@
       referrerpolicy="no-referrer"
     >
     </script>
-    <script
-      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
-    >
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js">
     </script>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -84,6 +84,10 @@
       referrerpolicy="no-referrer"
     >
     </script>
+    <script
+      src="//cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.9.0/highlightjs-line-numbers.min.js"
+    >
+    </script>
 
     <%= unless Map.get(assigns, :vr_agent_active, false) do %>
       <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6">

--- a/lib/oli_web/templates/layout/delivery_from_payment.html.heex
+++ b/lib/oli_web/templates/layout/delivery_from_payment.html.heex
@@ -77,14 +77,6 @@
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/atom-one-dark.min.css"
-      integrity="sha512-Jk4AqjWsdSzSWCSuQTfYRIF84Rq/eV0G2+tu07byYwHcbTGfdmLrHjUSwvzp5HvbiqK4ibmNwdcG49Y5RGYPTg=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-      media="screen and (prefers-color-scheme: dark)"
-    />
     <script
       src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"
       integrity="sha512-IaaKO80nPNs5j+VLxd42eK/7sYuXQmr+fyywCNA0e+C6gtQnuCXNtORe9xR4LqGPz5U9VpH+ff41wKs/ZmC3iA=="
@@ -106,7 +98,6 @@
     <script>
       window.cite = require('citation-js')
     </script>
-
     {csrf_meta_tag()}
     <script type="text/javascript" src={Routes.static_path(@conn, "/js/vendor.js")}>
     </script>


### PR DESCRIPTION
This addresses two issues with code block styling in delivery:

[MER-4871 ](https://eliterate.atlassian.net/browse/MER-4871) Even though the `highlightjs` syntax highlighting script was being loaded by the page, syntax highlighting was not getting applied in delivery. This happened because the highlightjs processing of code elements on the page was not getting kicked off at the right time for a LiveView page. Added `HighlightCode` hook for this purpose. Wrapped together with `EvaluateMathJaxExpressions` in new `PageContentHooks` composite hook to execute both over the same element scope to find and adjust content elements on page. 

[MER-4754](https://eliterate.atlassian.net/browse/MER-4754) Code line numbering as in legacy was not being done. This implements via the `highlightjs-line-numbers` add-on to highlightjs, defining custom styles for light and dark mode. 

Note: discovered pages were loading BOTH light and dark mode stylesheets for a certain theme from highlightjs, with the latter link controlled by a media query for user's preferred colored scheme. The media query apparently did not work to prevent loading the darkmode stylesheet (possibly a webpack artifact), but in any case is not sensitive torus dark mode, which is implemented as an app-specific mode not related to user's browser-wide or OS-wide preference. With our style customizations adjusting background colors for dark mode, it appears the highlightjs dark mode stylesheet is unnecessary, so just removed it.


Current:  

<img width="842" height="331" alt="Screenshot 2025-08-28 at 6 46 27 AM" src="https://github.com/user-attachments/assets/94c63639-05f9-43ff-abf6-779e82644a2e" />


New:  

<img width="1015" height="346" alt="Screenshot 2025-08-28 at 6 26 32 AM" src="https://github.com/user-attachments/assets/0725ae43-95f9-44cc-8abd-b6d47f323855" />

<img width="1032" height="352" alt="Screenshot 2025-08-28 at 6 26 57 AM" src="https://github.com/user-attachments/assets/89a73116-00fc-4daa-a571-40f972c457d6" />



<br><br>Note 2: now that we are seeing the highlightjs syntax coloring for the first time, we should examine it carefully to see if we like the theme it is using or need to customize some of the colors. For example, this theme ('atom-one") colors types, variables and numeric constants the same, which is different than the highlighting done by other highlighters including the component used in our authoring editor. But this can be a separate issue.

Java in highlightjs with atom-one theme:  

<img width="583" height="302" alt="Screenshot 2025-08-28 at 7 02 58 AM" src="https://github.com/user-attachments/assets/b8d5bdae-140a-4bc1-a4fc-b99e47b994c0" />

[MER-4754]: https://eliterate.atlassian.net/browse/MER-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Same in authoring editor component:  

<img width="461" height="265" alt="Screenshot 2025-08-28 at 10 23 33 AM" src="https://github.com/user-attachments/assets/a14406ac-dc7e-40a3-9cfd-48069897c15c" />

The CS111 course content includes screenshots from a third-party web-based Java IDE used in the course. This also uses different highlighting conventions; they look more similar to those of preview component:

<img width="490" height="157" alt="java-ide" src="https://github.com/user-attachments/assets/b9bf70f1-28d6-4c52-a210-48f705785bfc" />

