### PR TITLE
[BUG FIX] [MER-4854] Course with scored pages has no assignments

### DIFF
--- a/lib/oli/delivery/sections/section_resource_migration.ex
+++ b/lib/oli/delivery/sections/section_resource_migration.ex
@@ -2,7 +2,16 @@ defmodule Oli.Delivery.Sections.SectionResourceMigration do
   alias Oli.Repo
   import Ecto.Query
   alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Delivery.Sections.SectionsProjectsPublications
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Resources.Revision
+  alias Oli.Authoring.Course.Project
 
+  @doc """
+  Returns true if at least one SectionResource record requires migration, false otherwise.
+  The check is done on the graded field, since that is one of the fields that get migrated from the pinned revision.
+  """
   def requires_migration?(section_id) do
     query =
       from sr in SectionResource,
@@ -11,58 +20,122 @@ defmodule Oli.Delivery.Sections.SectionResourceMigration do
     Repo.exists?(query)
   end
 
+  @doc """
+  Migrates all section resources for a given section by copying fields from the pinned revision.
+  """
+  @spec migrate(integer()) :: {:ok, integer()} | {:error, any()}
   def migrate(section_id) do
-    # update all SectionResource records to copy over the following fields form
-    # the pinned revision:
-    sql = """
-    UPDATE section_resources
-    SET
-      project_slug = subquery.project_slug,
-      title = subquery.title,
-      graded = subquery.graded,
-      resource_type_id = subquery.resource_type_id,
-      revision_slug = subquery.revision_slug,
-      purpose = subquery.purpose,
-      duration_minutes = subquery.duration_minutes,
-      intro_content = subquery.intro_content,
-      intro_video = subquery.intro_video,
-      poster_image = subquery.poster_image,
-      objectives = subquery.objectives,
-      relates_to = subquery.relates_to,
-      activity_type_id = subquery.activity_type_id,
-      revision_id = subquery.revision_id,
-      updated_at = NOW()
-    FROM (
-        SELECT
-          r.resource_id,
-          proj.slug as project_slug,
-          r.title,
-          r.graded,
-          r.resource_type_id,
-          r.id as revision_id,
-          r.slug as revision_slug,
-          r.purpose,
-          r.duration_minutes,
-          r.intro_content,
-          r.intro_video,
-          r.poster_image,
-          r.objectives,
-          r.relates_to,
-          r.activity_type_id
-        FROM sections_projects_publications spp
-        JOIN publications p ON p.id = spp.publication_id
-        JOIN published_resources pr ON pr.publication_id = p.id
-        JOIN revisions r ON r.id = pr.revision_id
-        JOIN projects proj ON proj.id = spp.project_id
-        WHERE spp.section_id = $1
-    ) AS subquery
-    WHERE section_resources.resource_id = subquery.resource_id
-      AND section_resources.section_id = $2
-    """
+    base_query = build_migration_base_query(section_id)
 
-    case Ecto.Adapters.SQL.query(Repo, sql, [section_id, section_id]) do
-      {:ok, %Postgrex.Result{num_rows: num_rows}} -> {:ok, num_rows}
+    # Build the update query using the base query as a subquery
+    update_query =
+      from sr in SectionResource,
+        join: subquery in subquery(base_query),
+        on: sr.resource_id == subquery.resource_id and sr.section_id == ^section_id,
+        update: [
+          set: [
+            project_slug: subquery.project_slug,
+            title: subquery.title,
+            graded: subquery.graded,
+            resource_type_id: subquery.resource_type_id,
+            revision_slug: subquery.revision_slug,
+            purpose: subquery.purpose,
+            duration_minutes: subquery.duration_minutes,
+            intro_content: subquery.intro_content,
+            intro_video: subquery.intro_video,
+            poster_image: subquery.poster_image,
+            objectives: subquery.objectives,
+            relates_to: subquery.relates_to,
+            activity_type_id: subquery.activity_type_id,
+            revision_id: subquery.revision_id,
+            updated_at: fragment("NOW()")
+          ]
+        ]
+
+    case Repo.update_all(update_query, []) do
+      {num_rows, _} -> {:ok, num_rows}
       e -> e
     end
+  end
+
+  @doc """
+  Migrates only specific section resources by their resource IDs.
+  This is more efficient than migrating the entire section resources.
+  """
+  @spec migrate_specific_resources(integer(), list(integer())) ::
+          {:ok, integer()} | {:error, any()}
+  def migrate_specific_resources(section_id, resource_ids)
+      when is_list(resource_ids) and length(resource_ids) > 0 do
+    base_query = build_migration_base_query(section_id, resource_ids)
+
+    # Build the update query using the base query as a subquery
+    update_query =
+      from sr in SectionResource,
+        join: subquery in subquery(base_query),
+        on: sr.resource_id == subquery.resource_id and sr.section_id == ^section_id,
+        update: [
+          set: [
+            project_slug: subquery.project_slug,
+            title: subquery.title,
+            graded: subquery.graded,
+            resource_type_id: subquery.resource_type_id,
+            revision_slug: subquery.revision_slug,
+            purpose: subquery.purpose,
+            duration_minutes: subquery.duration_minutes,
+            intro_content: subquery.intro_content,
+            intro_video: subquery.intro_video,
+            poster_image: subquery.poster_image,
+            objectives: subquery.objectives,
+            relates_to: subquery.relates_to,
+            activity_type_id: subquery.activity_type_id,
+            revision_id: subquery.revision_id,
+            updated_at: fragment("NOW()")
+          ]
+        ]
+
+    case Repo.update_all(update_query, []) do
+      {num_rows, _} -> {:ok, num_rows}
+      e -> e
+    end
+  end
+
+  def migrate_specific_resources(_section_id, []), do: {:ok, 0}
+
+  defp build_migration_base_query(section_id, resource_ids \\ nil) do
+    filter_by_resource_ids =
+      if resource_ids do
+        dynamic([_, _, _, r, _], r.resource_id in ^resource_ids)
+      else
+        true
+      end
+
+    from spp in SectionsProjectsPublications,
+      join: p in Publication,
+      on: p.id == spp.publication_id,
+      join: pr in PublishedResource,
+      on: pr.publication_id == p.id,
+      join: r in Revision,
+      on: r.id == pr.revision_id,
+      join: proj in Project,
+      on: proj.id == spp.project_id,
+      where: spp.section_id == ^section_id,
+      where: ^filter_by_resource_ids,
+      select: %{
+        resource_id: r.resource_id,
+        project_slug: proj.slug,
+        title: r.title,
+        graded: r.graded,
+        resource_type_id: r.resource_type_id,
+        revision_id: r.id,
+        revision_slug: r.slug,
+        purpose: r.purpose,
+        duration_minutes: r.duration_minutes,
+        intro_content: r.intro_content,
+        intro_video: r.intro_video,
+        poster_image: r.poster_image,
+        objectives: r.objectives,
+        relates_to: r.relates_to,
+        activity_type_id: r.activity_type_id
+      }
   end
 end

--- a/test/oli/delivery/sections/section_resource_migration_test.exs
+++ b/test/oli/delivery/sections/section_resource_migration_test.exs
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.Sections.SectionResourceMigrationTest do
   import Oli.Factory
 
   alias Oli.Delivery.Sections.SectionResourceMigration
+  alias Oli.Delivery.Sections.SectionResource
 
   describe "requires_migration?/1" do
     test "returns true when section has section resources not yet migrated" do
@@ -30,6 +31,292 @@ defmodule Oli.Delivery.Sections.SectionResourceMigrationTest do
       insert(:section_resource, section: section, graded: nil)
 
       assert SectionResourceMigration.requires_migration?(section.id)
+    end
+  end
+
+  describe "migrate/1" do
+    test "migrates all section resources for a given section" do
+      # Create test data
+      section = insert(:section)
+      project = insert(:project)
+      publication = insert(:publication, project: project)
+
+      # Create sections_projects_publications relationship
+      insert(:section_project_publication,
+        section: section,
+        project: project,
+        publication: publication
+      )
+
+      # Create resources and revisions
+      resource1 = insert(:resource)
+      resource2 = insert(:resource)
+
+      revision1 =
+        insert(:revision,
+          resource: resource1,
+          title: "Test Resource 1",
+          graded: true,
+          purpose: :application
+        )
+
+      revision2 =
+        insert(:revision,
+          resource: resource2,
+          title: "Test Resource 2",
+          graded: false,
+          purpose: :foundation
+        )
+
+      # Create published resources
+      insert(:published_resource,
+        resource: resource1,
+        publication: publication,
+        revision: revision1
+      )
+
+      insert(:published_resource,
+        resource: resource2,
+        publication: publication,
+        revision: revision2
+      )
+
+      # Create section resources with old data
+      section_resource1 =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource1.id,
+          title: "Old Title 1",
+          graded: nil,
+          purpose: nil
+        )
+
+      section_resource2 =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource2.id,
+          title: "Old Title 2",
+          graded: nil,
+          purpose: nil
+        )
+
+      # Perform migration
+      assert {:ok, 2} = SectionResourceMigration.migrate(section.id)
+
+      # Verify the section resources were updated
+      updated_sr1 = Repo.get(SectionResource, section_resource1.id)
+      updated_sr2 = Repo.get(SectionResource, section_resource2.id)
+
+      assert updated_sr1.title == "Test Resource 1"
+      assert updated_sr1.graded == true
+      assert updated_sr1.purpose == :application
+      assert updated_sr1.project_slug == project.slug
+      assert updated_sr1.revision_slug == revision1.slug
+      assert updated_sr1.revision_id == revision1.id
+
+      assert updated_sr2.title == "Test Resource 2"
+      assert updated_sr2.graded == false
+      assert updated_sr2.purpose == :foundation
+      assert updated_sr2.project_slug == project.slug
+      assert updated_sr2.revision_slug == revision2.slug
+      assert updated_sr2.revision_id == revision2.id
+    end
+
+    test "handles section with no section resources" do
+      section = insert(:section)
+
+      assert {:ok, 0} = SectionResourceMigration.migrate(section.id)
+    end
+  end
+
+  describe "migrate_specific_resources/2" do
+    test "migrates only specified section resources" do
+      # Create test data
+      section = insert(:section)
+      project = insert(:project)
+      publication = insert(:publication, project: project)
+
+      insert(:section_project_publication,
+        section: section,
+        project: project,
+        publication: publication
+      )
+
+      # Create resources and revisions
+      resource1 = insert(:resource)
+      resource2 = insert(:resource)
+      resource3 = insert(:resource)
+
+      revision1 =
+        insert(:revision,
+          resource: resource1,
+          title: "Test Resource 1",
+          graded: true
+        )
+
+      revision2 =
+        insert(:revision,
+          resource: resource2,
+          title: "Test Resource 2",
+          graded: false
+        )
+
+      revision3 =
+        insert(:revision,
+          resource: resource3,
+          title: "Test Resource 3",
+          graded: true
+        )
+
+      # Create published resources
+      insert(:published_resource,
+        resource: resource1,
+        publication: publication,
+        revision: revision1
+      )
+
+      insert(:published_resource,
+        resource: resource2,
+        publication: publication,
+        revision: revision2
+      )
+
+      insert(:published_resource,
+        resource: resource3,
+        publication: publication,
+        revision: revision3
+      )
+
+      # Create section resources
+      section_resource1 =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource1.id,
+          title: "Old Title 1",
+          graded: nil
+        )
+
+      section_resource2 =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource2.id,
+          title: "Old Title 2",
+          graded: nil
+        )
+
+      section_resource3 =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource3.id,
+          title: "Old Title 3",
+          graded: nil
+        )
+
+      # Migrate only resources 1 and 2
+      resource_ids_to_migrate = [resource1.id, resource2.id]
+
+      assert {:ok, 2} =
+               SectionResourceMigration.migrate_specific_resources(
+                 section.id,
+                 resource_ids_to_migrate
+               )
+
+      # Verify only the specified resources were updated
+      updated_sr1 = Repo.get(SectionResource, section_resource1.id)
+      updated_sr2 = Repo.get(SectionResource, section_resource2.id)
+      updated_sr3 = Repo.get(SectionResource, section_resource3.id)
+
+      assert updated_sr1.title == "Test Resource 1"
+      assert updated_sr1.graded
+      assert updated_sr2.title == "Test Resource 2"
+      refute updated_sr2.graded
+
+      # This one should remain unchanged
+      assert updated_sr3.title == "Old Title 3"
+      refute updated_sr3.graded
+    end
+
+    test "returns {:ok, 0} for empty resource_ids list" do
+      section = insert(:section)
+
+      assert {:ok, 0} = SectionResourceMigration.migrate_specific_resources(section.id, [])
+    end
+
+    test "handles non-existent resource IDs gracefully" do
+      section = insert(:section)
+
+      assert {:ok, 0} =
+               SectionResourceMigration.migrate_specific_resources(section.id, [99999, 88888])
+    end
+  end
+
+  describe "migration data integrity" do
+    test "preserves all required fields during migration" do
+      section = insert(:section)
+      project = insert(:project)
+      publication = insert(:publication, project: project)
+
+      insert(:section_project_publication,
+        section: section,
+        project: project,
+        publication: publication
+      )
+
+      resource = insert(:resource)
+
+      revision =
+        insert(:revision,
+          resource: resource,
+          title: "Complete Test Resource",
+          graded: true,
+          purpose: :foundation,
+          duration_minutes: 30,
+          intro_content: %{"some" => "Introduction content"},
+          intro_video: "video_url",
+          poster_image: "image_url",
+          activity_type_id: 1
+        )
+
+      insert(:published_resource,
+        resource: resource,
+        publication: publication,
+        revision: revision
+      )
+
+      section_resource =
+        insert(:section_resource,
+          section: section,
+          resource_id: resource.id,
+          title: "Old Title",
+          graded: nil,
+          purpose: nil,
+          duration_minutes: nil,
+          intro_content: nil,
+          intro_video: nil,
+          poster_image: nil,
+          objectives: nil,
+          relates_to: nil,
+          activity_type_id: nil
+        )
+
+      # Perform migration
+      assert {:ok, 1} = SectionResourceMigration.migrate(section.id)
+
+      # Verify all fields were properly migrated
+      updated_sr = Repo.get(SectionResource, section_resource.id)
+
+      assert updated_sr.title == "Complete Test Resource"
+      assert updated_sr.graded == true
+      assert updated_sr.purpose == :foundation
+      assert updated_sr.duration_minutes == 30
+      assert updated_sr.intro_content == %{"some" => "Introduction content"}
+      assert updated_sr.intro_video == "video_url"
+      assert updated_sr.poster_image == "image_url"
+      assert updated_sr.activity_type_id == 1
+      assert updated_sr.project_slug == project.slug
+      assert updated_sr.revision_slug == revision.slug
+      assert updated_sr.revision_id == revision.id
+      assert updated_sr.resource_type_id == revision.resource_type_id
     end
   end
 end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-4854) to the ticket

### Before

https://github.com/user-attachments/assets/a28bf790-c65f-404d-9302-d87c3db96330



### After


https://github.com/user-attachments/assets/3e70d2c0-c2d0-453d-a757-fb26587ba447



### Background
When we improved the app's performance by implementing the SectionResourceDepot, we extended the `section_resources` table to include/replicate some fields from the revision (such as the `graded` field). This optimization eliminated the need for four joins to retrieve revision data for a specific section resource, instead providing all necessary data directly in the Depot's section resource record.

### Issue
When an author made minor changes to a page (e.g., changing "PAGE_A" from `graded: false` to `graded: true`) and published those changes, the updates were not reflected in the corresponding `section_resource` record. This caused the SectionResourceDepot —which powers most of our LiveViews, including the Assignments page— to serve stale data. Consequently, when students accessed the assignments page, "PAGE_A" was excluded because it still appeared as `graded: false`.

### Solution
We now trigger section resource migration during the minor-changes publishing flow, ensuring that `section_resources` values remain synchronized with their corresponding revision values.

**Why didn't this issue occur in the major-changes flow?** Because major changes trigger a complete rebuild of section resources from scratch, migrating all current revision data into the section resource records.

### Technical Implementation
- Created a `migrate_specific_resources` function for the minor-changes flow to avoid updating all section resources unnecessarily
- Abstracted the common query logic from the existing `migrate` function into a shared implementation
- Refactored the original raw SQL query into Ecto for improved readability and maintainability

