### PR TITLE
[BUG FIX] [MER-4889] Submitted (not evaluted) part attempts trigger failure in snapshot worker

### DIFF
--- a/lib/oli/delivery/snapshots/worker.ex
+++ b/lib/oli/delivery/snapshots/worker.ex
@@ -68,6 +68,10 @@ defmodule Oli.Delivery.Snapshots.Worker do
       end
 
     case Oli.Analytics.Summary.execute_analytics_pipeline(results, project_id, host_name()) do
+      {:ok, %Pipeline{data: nil}} ->
+        # No evaluated part attempts found - job completes successfully without sending bundle
+        :ok
+
       {:ok, %Pipeline{data: attempt_group}} ->
         body =
           StatementFactory.to_statements(attempt_group)

--- a/test/oli/delivery/snapshots/worker_test.exs
+++ b/test/oli/delivery/snapshots/worker_test.exs
@@ -1,0 +1,68 @@
+defmodule Oli.Delivery.Snapshots.WorkerTest do
+  use Oli.DataCase
+
+  import Oli.Factory
+
+  alias Oli.Delivery.Snapshots.Worker
+
+  describe "perform_now/3" do
+    test "returns :ok when part attempts are in :submitted state (not :evaluated)" do
+      # Create the full hierarchy needed for the join query
+      section = insert(:section)
+      user = insert(:user)
+      resource = insert(:resource)
+      revision = insert(:revision, resource: resource)
+      
+      # Create resource access
+      resource_access = insert(:resource_access, %{
+        section: section,
+        user: user,
+        resource: resource
+      })
+
+      # Create resource attempt
+      resource_attempt = insert(:resource_attempt, %{
+        resource_access: resource_access,
+        lifecycle_state: :evaluated
+      })
+
+      # Create activity attempt  
+      activity_attempt = insert(:activity_attempt, %{
+        resource_attempt: resource_attempt,
+        revision: revision,
+        lifecycle_state: :evaluated
+      })
+
+      # Create part attempt in :submitted state (not :evaluated)
+      part_attempt = insert(:part_attempt, %{
+        activity_attempt: activity_attempt,
+        attempt_guid: "test-guid-123",
+        lifecycle_state: :submitted  # This is the key - not :evaluated
+      })
+
+      # Call perform_now with the part attempt GUID and section slug
+      result = Worker.perform_now([part_attempt.attempt_guid], section.slug)
+
+      # Should return :ok because no evaluated part attempts were found
+      assert result == :ok
+    end
+
+    test "returns :ok when part attempt guids list is empty" do
+      section = insert(:section)
+      
+      result = Worker.perform_now([], section.slug)
+      
+      assert result == :ok
+    end
+
+    test "returns :ok when no part attempts match the guids" do
+      section = insert(:section)
+      
+      # Call with non-existent GUIDs
+      result = Worker.perform_now(["non-existent-guid"], section.slug)
+      
+      # Should return :ok because no evaluated part attempts were found
+      assert result == :ok
+    end
+  end
+end


### PR DESCRIPTION
Snapshot worker for XAPI upload didn't handle case that part attempt is submitted, not evaluated.  The failure here triggers a retry, which fails again, another retry, which also fails. 

So explicitly handling this saves us 3 failed oban jobs. 

https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/825/samples/618539ab2cf81d7e3cd051ca-1426492702470160536017565166202

** (FunctionClauseError) no function clause matching in Oli.Analytics.XAPI.StatementFactory.to_statements/1**

lib/oli/analytics/xapi/statement_factory.ex:10 Oli.Analytics.XAPI.StatementFactory.to_statements(nil)
lib/oli/delivery/snapshots/worker.ex:73 Oli.Delivery.Snapshots.Worker.perform_now/3
lib/oban/queue/executor.ex:129 Oban.Queue.Executor.perform/1
lib/oban/queue/executor.ex:74 Oban.Queue.Executor.call/1
lib/task/supervised.ex:101 Task.Supervised.invoke_mfa/2
lib/task/supervised.ex:36 Task.Supervised.reply/4

