### PR TITLE
[ENHANCEMENT] [MER-4890] AppSignal: Ignore already-reset failures

### DIFF
--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -787,7 +787,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
-      {:error, e} ->
+      {:error, _e} ->
         error(conn, 500, "Could not reset activity")
     end
   end
@@ -811,7 +811,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
-      {:error, e} ->
+      {:error, _e} ->
         error(conn, 500, "could not reset activity")
     end
   end

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -788,8 +788,7 @@ defmodule OliWeb.Api.AttemptController do
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
       {:error, e} ->
-        {_, msg} = Oli.Utils.log_error("Could not reset activity", e)
-        error(conn, 500, msg)
+        error(conn, 500, "Could not reset activity")
     end
   end
 
@@ -813,8 +812,7 @@ defmodule OliWeb.Api.AttemptController do
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
       {:error, e} ->
-        {_, msg} = Oli.Utils.log_error("Could not reset activity", e)
-        error(conn, 500, msg)
+        error(conn, 500, "could not reset activity")
     end
   end
 


### PR DESCRIPTION
We now handle correctly the `:already_reset` case, but it is now leading to a flood of AppSignal errors.  This disables those for now. 