### PR TITLE
[BUG FIX] [MER-4892] AppSignal: Handle already evaluated part attempts

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/utils.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/utils.ex
@@ -61,9 +61,11 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Utils do
             Enum.reduce(part_attempts, %{}, fn p, m -> Map.put(m, p.attempt_guid, p) end)
 
           # flat map the results since the results may contain an additional explanation action
-          for %{attempt_guid: attempt_guid, input: input} <- part_inputs,
-              # Only process inputs that have corresponding attempts
-              Map.has_key?(attempt_map, attempt_guid) do
+          part_inputs
+          |> Enum.filter(fn %{attempt_guid: attempt_guid} ->
+            Map.has_key?(attempt_map, attempt_guid)
+          end)
+          |> Enum.map(fn %{attempt_guid: attempt_guid, input: input} ->
             attempt = Map.get(attempt_map, attempt_guid)
             part = Map.get(part_map, attempt.part_id)
 
@@ -86,7 +88,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Utils do
               resource_revision: resource_attempt.revision,
               effective_settings: effective_settings
             })
-          end
+          end)
 
         _ ->
           []

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -421,7 +421,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save part", e)
         error(conn, 500, msg)
     end
@@ -459,7 +459,7 @@ defmodule OliWeb.Api.AttemptController do
             "These changes could not be saved as this attempt may have already been submitted"
         })
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save part", e)
         error(conn, 500, msg)
     end
@@ -509,7 +509,7 @@ defmodule OliWeb.Api.AttemptController do
 
         json(conn, %{"type" => "success", "actions" => evaluations})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not submit part", e)
         error(conn, 500, msg)
     end
@@ -562,7 +562,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, attempt_state} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not reset part", e)
         error(conn, 500, msg)
     end
@@ -593,7 +593,7 @@ defmodule OliWeb.Api.AttemptController do
       {:error, {:no_more_hints}} ->
         json(conn, %{"type" => "success", "hasMoreHints" => false})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not get hint", e)
         error(conn, 500, msg)
     end
@@ -618,7 +618,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, _} ->
         json(conn, %{"type" => "success"})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save activity", e)
         error(conn, 500, msg)
     end
@@ -655,7 +655,7 @@ defmodule OliWeb.Api.AttemptController do
             "These changes could not be saved as this attempt may have already been submitted"
         })
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not save activity", e)
         error(conn, 500, msg)
     end
@@ -753,7 +753,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, evaluations} ->
         json(conn, %{"type" => "success", "actions" => evaluations})
 
-      {:error, _e} ->
+      {:error, e} ->
         {_, msg} = Oli.Utils.log_error("Could not process activity evaluations", e)
         error(conn, 500, msg)
     end

--- a/test/oli/delivery/submission_test.exs
+++ b/test/oli/delivery/submission_test.exs
@@ -945,6 +945,42 @@ defmodule Oli.Delivery.AttemptsSubmissionTest do
       assert updated_part_attempt.datashop_session_id == datashop_session_id_user1
     end
 
+    test "processing submission with invalid attempt_guids filters correctly", %{
+      ungraded_page_user1_activity_attempt1_part1_attempt1: part_attempt,
+      section: section,
+      ungraded_page_user1_activity_attempt1: activity_attempt
+    } do
+      datashop_session_id_user1 = UUID.uuid4()
+
+      # Create part_inputs with both valid and invalid attempt_guids
+      part_inputs = [
+        %{attempt_guid: part_attempt.attempt_guid, input: %StudentInput{input: "a"}},
+        %{attempt_guid: "invalid-guid-1", input: %StudentInput{input: "b"}},
+        %{attempt_guid: "invalid-guid-2", input: %StudentInput{input: "c"}}
+      ]
+
+      # This should process only the valid attempt_guid and ignore the invalid ones
+      {:ok, [%{attempt_guid: attempt_guid, out_of: out_of, score: score, feedback: %{id: id}}]} =
+        Evaluate.evaluate_from_input(
+          section.slug,
+          activity_attempt.attempt_guid,
+          part_inputs,
+          datashop_session_id_user1
+        )
+
+      # verify only the valid attempt was processed
+      assert attempt_guid == part_attempt.attempt_guid
+      assert score == 10
+      assert out_of == 10
+      assert id == "1"
+
+      # verify the part attempt record was updated correctly
+      updated_attempt = Oli.Repo.get!(PartAttempt, part_attempt.id)
+      assert updated_attempt.score == 10
+      assert updated_attempt.out_of == 10
+      refute updated_attempt.date_evaluated == nil
+    end
+
     test "processing a different submission", %{
       ungraded_page_user1_activity_attempt1_part1_attempt1: part_attempt,
       section: section,


### PR DESCRIPTION
** (KeyError) key :part_id not found in: nil

lib/oli/delivery/attempts/activity_lifecycle/utils.ex:66 anonymous fn/8 in Oli.Delivery.Attempts.ActivityLifecycle.Utils.do_evaluate_submissions/4
lib/enum.ex:1703 Enum."-map/2-lists^map/1-1-"/2
lib/oli/delivery/attempts/activity_lifecycle/utils.ex:64 Oli.Delivery.Attempts.ActivityLifecycle.Utils.do_evaluate_submissions/4
lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex:218 anonymous fn/4 in Oli.Delivery.Attempts.ActivityLifecycle.Evaluate.evaluate_from_input/5
lib/ecto/adapters/sql.ex:1358 anonymous fn/3 in Ecto.Adapters.SQL.checkout_or_transaction/4
lib/db_connection.ex:1753 DBConnection.run_transaction/4
lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex:205 Oli.Delivery.Attempts.ActivityLifecycle.Evaluate.evaluate_from_input/5
lib/oli_web/controllers/api/attempt_controller.ex:489 OliWeb.Api.AttemptController.submit_part/2