### PR TITLE
[BUG FIX] [MER-4894] AppSignal: Render malformed content item

### DIFF
--- a/lib/oli/rendering/content.ex
+++ b/lib/oli/rendering/content.ex
@@ -464,6 +464,11 @@ defmodule Oli.Rendering.Content do
     writer.selection(context, fn -> true end, selection)
   end
 
+  # Renders content elements that have a model field containing an array of content elements
+  def render(%Context{} = context, %{"model" => model} = _element, writer) when is_list(model) do
+    render(context, model, writer)
+  end
+
   # Renders an error message if none of the signatures above match. Logging and rendering of errors
   # can be configured using the render_opts in context
   def render(%Context{render_opts: render_opts} = context, element, writer) do

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -787,7 +787,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
-      {:error, e} ->
+      {:error, _e} ->
         error(conn, 500, "Could not reset activity")
     end
   end
@@ -811,7 +811,7 @@ defmodule OliWeb.Api.AttemptController do
       {:ok, {attempt_state, model}} ->
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
-      {:error, e} ->
+      {:error, _e} ->
         error(conn, 500, "could not reset activity")
     end
   end

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -788,8 +788,7 @@ defmodule OliWeb.Api.AttemptController do
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
       {:error, e} ->
-        {_, msg} = Oli.Utils.log_error("Could not reset activity", e)
-        error(conn, 500, msg)
+        error(conn, 500, "Could not reset activity")
     end
   end
 
@@ -813,8 +812,7 @@ defmodule OliWeb.Api.AttemptController do
         json(conn, %{"type" => "success", "attemptState" => attempt_state, "model" => model})
 
       {:error, e} ->
-        {_, msg} = Oli.Utils.log_error("Could not reset activity", e)
-        error(conn, 500, msg)
+        error(conn, 500, "could not reset activity")
     end
   end
 

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -130,5 +130,29 @@ defmodule Oli.Content.Content.HtmlTest do
                         "<div class=\"content unsupported\">Content element type 'i-am-unsupported' is not supported"
              end) =~ "Content element type is not supported"
     end
+
+    test "renders content element with model field", %{author: author} do
+      # This test expects that content with a "model" field should render the model contents
+      content_with_model = %{
+        "model" => [
+          %{
+            "children" => [
+              %{"text" => "Among the following questions, which is a well-designed survey open-ended question?"}
+            ],
+            "id" => "c6929630baf84852849b804665882f90",
+            "type" => "p"
+          }
+        ]
+      }
+
+      context = %Context{user: author}
+
+      rendered_html = Content.render(context, content_with_model, Content.Html)
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      # Should render the paragraph content from the model field
+      assert rendered_html_string =~ 
+               "<p data-point-marker=\"c6929630baf84852849b804665882f90\">Among the following questions, which is a well-designed survey open-ended question?</p>"
+    end
   end
 end

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -137,7 +137,10 @@ defmodule Oli.Content.Content.HtmlTest do
         "model" => [
           %{
             "children" => [
-              %{"text" => "Among the following questions, which is a well-designed survey open-ended question?"}
+              %{
+                "text" =>
+                  "Among the following questions, which is a well-designed survey open-ended question?"
+              }
             ],
             "id" => "c6929630baf84852849b804665882f90",
             "type" => "p"
@@ -151,7 +154,7 @@ defmodule Oli.Content.Content.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       # Should render the paragraph content from the model field
-      assert rendered_html_string =~ 
+      assert rendered_html_string =~
                "<p data-point-marker=\"c6929630baf84852849b804665882f90\">Among the following questions, which is a well-designed survey open-ended question?</p>"
     end
   end


### PR DESCRIPTION
Fixes the longstanding AppSignal error `** (RuntimeError) Content element is invalid`

```
%{"model" => [%{"children" => [%{"text" => "Regardless of the tool you might use to check these columns, first try to briefly explain programmatically how you might examine these fields. Feel free to describe your approach using pseudocode. Feel free to...
```

```
lib/oli/utils/appsignal.ex:21 Oli.Utils.Appsignal.capture_error/2
lib/oli/utils.ex:41 Oli.Utils.log_error/2
lib/oli/rendering/content.ex:470 Oli.Rendering.Content.render/3
lib/oli/rendering/activity/markdown.ex:22 Oli.Rendering.Activity.Markdown.activity/2
lib/oli/rendering/elements.ex:42 anonymous fn/4 in Oli.Rendering.Elements.render/3
lib/enum.ex:2531 Enum."-reduce/3-lists^foldl/2-0-"/3
lib/oli/rendering/elements.ex:31 Oli.Rendering.Elements.render/3
lib/oli/rendering/group/markdown.ex:17 Oli.Rendering.Group.Markdown.group/3
```

Solution was to simply handle this differently formed content element and render it. 