### PR TITLE
[BUG FIX] [MER-4893] AppSignal: Avoid nil comparison in query

### DIFF
--- a/lib/oli/conversation/triggers.ex
+++ b/lib/oli/conversation/triggers.ex
@@ -58,19 +58,23 @@ defmodule Oli.Conversation.Triggers do
   with the AI agent and triggers enabled.
   """
   def verify_access(section_slug, user_id) do
-    case Oli.Accounts.User
-         |> join(:left, [u], e in Oli.Delivery.Sections.Enrollment, on: u.id == e.user_id)
-         |> join(:left, [_, e], s in Oli.Delivery.Sections.Section, on: s.id == e.section_id)
-         |> where(
-           [_, e, s],
-           s.slug == ^section_slug and s.triggers_enabled == true and s.assistant_enabled == true and
-             e.user_id == ^user_id
-         )
-         |> select([_, _, s], s)
-         |> limit(1)
-         |> Repo.one() do
-      nil -> {:error, :no_access}
-      section -> {:ok, section}
+    if is_nil(user_id) or is_nil(section_slug) do
+      {:error, :no_access}
+    else
+      case Oli.Accounts.User
+           |> join(:left, [u], e in Oli.Delivery.Sections.Enrollment, on: u.id == e.user_id)
+           |> join(:left, [_, e], s in Oli.Delivery.Sections.Section, on: s.id == e.section_id)
+           |> where(
+             [_, e, s],
+             s.slug == ^section_slug and s.triggers_enabled == true and s.assistant_enabled == true and
+               e.user_id == ^user_id
+           )
+           |> select([_, _, s], s)
+           |> limit(1)
+           |> Repo.one() do
+        nil -> {:error, :no_access}
+        section -> {:ok, section}
+      end
     end
   end
 

--- a/test/oli/conversation/triggers_test.exs
+++ b/test/oli/conversation/triggers_test.exs
@@ -241,4 +241,19 @@ defmodule Oli.Conversation.TriggersTest do
     trigger = Triggers.check_for_hint_trigger(activity_attempt, part_attempt, model, hint, false)
     assert is_nil(trigger)
   end
+
+  test "verify_access returns error when user_id is nil" do
+    result = Triggers.verify_access("some-section-slug", nil)
+    assert result == {:error, :no_access}
+  end
+
+  test "verify_access returns error when section_slug is nil" do
+    result = Triggers.verify_access(nil, 123)
+    assert result == {:error, :no_access}
+  end
+
+  test "verify_access returns error when both user_id and section_slug are nil" do
+    result = Triggers.verify_access(nil, nil)
+    assert result == {:error, :no_access}
+  end
 end


### PR DESCRIPTION
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/67/samples/618539ab2cf81d7e3cd051ca-733585056698300711117565334801

```
** (ArgumentError) comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use is_nil/1 instead
```

```
lib/ecto/query/builder.ex:1069 Ecto.Query.Builder.not_nil!/1
lib/oli/conversation/triggers.ex:70 Oli.Conversation.Triggers.verify_access/2
lib/oli/conversation/triggers.ex:99 Oli.Conversation.Triggers.possibly_invoke_trigger/3
lib/task/supervised.ex:101 Task.Supervised.invoke_mfa/2
```