### PR TITLE
[BUG FIX] [MER-4896] AppSignal: (KeyError) key :state not found in: nil

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -3260,11 +3260,14 @@ defmodule OliWeb.Delivery.Student.LearnLive do
     FormatDateTime.to_formatted_datetime(due_date, context, format)
   end
 
-  defp get_viewed_intro_video_resource_ids(section_slug, current_user_id) do
-    Sections.get_enrollment(section_slug, current_user_id).state[
-      "viewed_intro_video_resource_ids"
-    ] ||
-      []
+  @doc false
+  def get_viewed_intro_video_resource_ids(section_slug, current_user_id) do
+    case Sections.get_enrollment(section_slug, current_user_id) do
+      %{state: state} when is_map(state) ->
+        state["viewed_intro_video_resource_ids"] || []
+      _ ->
+        []
+    end
   end
 
   defp async_mark_video_as_viewed_in_student_enrollment_state(

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -3242,4 +3242,55 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       end)
     end
   end
+
+  describe "get_viewed_intro_video_resource_ids/2" do
+    alias OliWeb.Delivery.Student.LearnLive
+
+    test "returns empty list when enrollment is nil" do
+      # This simulates the bug scenario where get_enrollment returns nil
+      section_slug = "non_existent_section"
+      user_id = 99999
+
+      result = LearnLive.get_viewed_intro_video_resource_ids(section_slug, user_id)
+      assert result == []
+    end
+
+    test "returns empty list when enrollment exists but state is nil" do
+      user = insert(:user)
+      section = insert(:section)
+      
+      # Create enrollment with nil state
+      insert(:enrollment, user: user, section: section, state: nil)
+
+      result = LearnLive.get_viewed_intro_video_resource_ids(section.slug, user.id)
+      assert result == []
+    end
+
+    test "returns empty list when enrollment exists but state doesn't have viewed_intro_video_resource_ids" do
+      user = insert(:user)
+      section = insert(:section)
+      
+      # Create enrollment with state but without the specific key
+      insert(:enrollment, user: user, section: section, state: %{"other_key" => "value"})
+
+      result = LearnLive.get_viewed_intro_video_resource_ids(section.slug, user.id)
+      assert result == []
+    end
+
+    test "returns the viewed resource ids when they exist in the state" do
+      user = insert(:user)
+      section = insert(:section)
+      viewed_ids = [1, 2, 3]
+      
+      # Create enrollment with viewed intro video resource ids
+      insert(:enrollment, 
+        user: user, 
+        section: section, 
+        state: %{"viewed_intro_video_resource_ids" => viewed_ids}
+      )
+
+      result = LearnLive.get_viewed_intro_video_resource_ids(section.slug, user.id)
+      assert result == viewed_ids
+    end
+  end
 end


### PR DESCRIPTION
```
(KeyError) key :state not found in: nil
```

```
Backtrace: lib/oli_web/live/delivery/student/learn_live.ex:3151 in OliWeb.Delivery.Student.LearnLive.get_viewed_intro_video_resource_ids/2
```