### PR TITLE
[BUG FIX] [MER-4897] AppSignal: Handle nils in History view

### DIFF
--- a/lib/oli_web/live/history/table.ex
+++ b/lib/oli_web/live/history/table.ex
@@ -39,7 +39,8 @@ defmodule OliWeb.RevisionHistory.Table do
     to_display = Enum.slice(assigns.revisions, range)
 
     tr_props = fn rev_id ->
-      if rev_id == assigns.selected.id do
+      selected_id = if assigns.selected, do: assigns.selected.id, else: nil
+      if rev_id == selected_id do
         [class: "table-active"]
       else
         [style: "cursor: pointer;", "phx-click": "select", "phx-value-rev": rev_id]
@@ -65,10 +66,15 @@ defmodule OliWeb.RevisionHistory.Table do
         <%= for rev <- @to_display do %>
           <tr id={"revision-#{rev.id}"} {@tr_props.(rev.id)}>
             <td>{rev.id}</td>
-            <td>{Map.get(@tree, rev.id).project_id}</td>
+            <td>{
+              case Map.get(@tree, rev.id) do
+                %{project_id: project_id} -> project_id
+                _ -> "Unknown"
+              end
+            }</td>
             <td>{Utils.render_date(rev, :inserted_at, @ctx)}</td>
             <td>{Utils.render_date(rev, :updated_at, @ctx)}</td>
-            <td>{rev.author.email}</td>
+            <td>{if rev.author, do: rev.author.email, else: "Unknown"}</td>
             <td>{rev.slug}</td>
             <td>{publication_state(assigns, rev.id)}</td>
           </tr>


### PR DESCRIPTION
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/302/samples/618539ab2cf81d7e3cd051ca-688004869511640336417564130001

```
** (KeyError) key :project_id not found in: nil

If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map
```

```
lib/oli_web/live/history/table.ex:68 anonymous fn/2 in OliWeb.RevisionHistory.Table."render (overridable 1)"/1
lib/enum.ex:1703 Enum."-map/2-lists^map/1-1-"/2
lib/oli_web/live/history/table.ex:65 anonymous fn/2 in OliWeb.RevisionHistory.Table."render (overridable 1)"/1
/github/workspace/lib/oli_web/live/history/revision_history.html.heex:38 OliWeb.RevisionHistory.render/1
lib/enum.ex:2531 Enum."-reduce/3-lists^foldl/2-0-"/3
lib/phoenix_live_view/diff.ex:389 Phoenix.LiveView.Diff.traverse/7
```