### PR TITLE
[BUG FIX] [MER-4899] AppSignal: handle nils in LMSGradeUpdate creation

### DIFF
--- a/lib/oli/delivery/attempts/core/lms_grade_update.ex
+++ b/lib/oli/delivery/attempts/core/lms_grade_update.ex
@@ -31,8 +31,6 @@ defmodule Oli.Delivery.Attempts.Core.LMSGradeUpdate do
       :resource_access_id
     ])
     |> validate_required([
-      :score,
-      :out_of,
       :type,
       :result,
       :attempt_number,

--- a/lib/oli_web/live/grades/updates_table_model.ex
+++ b/lib/oli_web/live/grades/updates_table_model.ex
@@ -55,10 +55,14 @@ defmodule OliWeb.Grades.UpdatesTableModel do
     {fn r ->
        case name do
          :score ->
-           if !is_nil(r.score) and r.out_of != 0 do
-             r.score / r.out_of
-           else
-             0.0
+           case {r.score, r.out_of} do
+             # Sort nil scores to the beginning
+             {nil, _} -> -1
+             # Sort nil out_of to the beginning
+             {_, nil} -> -1
+             # Handle division by zero
+             {_, 0} -> 0.0
+             {score, out_of} -> score / out_of
            end
        end
      end, direction}
@@ -67,10 +71,11 @@ defmodule OliWeb.Grades.UpdatesTableModel do
   def custom_render(_, row, %ColumnSpec{name: name}) do
     case name do
       :score ->
-        if !is_nil(row.score) do
-          "#{row.score} / #{row.out_of}"
-        else
-          ""
+        case {row.score, row.out_of} do
+          {nil, nil} -> "No score"
+          {nil, out_of} -> "- / #{out_of}"
+          {score, nil} -> "#{score} / -"
+          {score, out_of} -> "#{score} / #{out_of}"
         end
     end
   end


### PR DESCRIPTION
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/548/samples/618539ab2cf81d7e3cd051ca-1042982761630478536917565206403

```
** (Oban.PerformError) Oli.Delivery.Attempts.PageLifecycle.GradeUpdateWorker failed with {:error, #Ecto.Changeset<action: :insert, changes: %{attempt_number: 4, resource_access_id: 16730535}, errors: [score: {"can't be blank", [validation: :required]}, out_of: {"can't be blank", [validation: :required]}], data: #Oli.Delivery.Attempts.Core.LMSGradeUpdate<>, valid?: false>}
```
