### PR TITLE
[BUG FIX] [MER-4900] AppSignal: handle nil module in LearnLive

### DIFF
--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -2803,9 +2803,15 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         unit["resource_id"] == unit_resource_id
       end)
 
-    Enum.find(unit["children"], fn module ->
-      module["resource_id"] == module_resource_id
-    end)
+    case unit do
+      nil ->
+        nil
+
+      unit ->
+        Enum.find(unit["children"], fn module ->
+          module["resource_id"] == module_resource_id
+        end)
+    end
   end
 
   defp resource_url(resource_slug, section_slug, resource_id, selected_view) do
@@ -2904,6 +2910,15 @@ defmodule OliWeb.Delivery.Student.LearnLive do
         )
       end)
     )
+  end
+
+  defp mark_visited_and_completed_pages(
+         nil,
+         _visited_pages,
+         _student_raw_avg_score_per_page_id,
+         _student_progress_per_resource_id
+       ) do
+    nil
   end
 
   defp completed_page?(true = _graded, visited?, raw_avg_score, progress),

--- a/lib/oli_web/live/delivery/student/learn_live.ex
+++ b/lib/oli_web/live/delivery/student/learn_live.ex
@@ -688,24 +688,31 @@ defmodule OliWeb.Delivery.Student.LearnLive do
               module_resource_id
             )
 
-          if clicked_module["resource_id"] == current_module["resource_id"] do
-            # if the user clicked in an already expanded module, then we should collapse it
-            {Map.drop(
-               socket.assigns.selected_module_per_unit_resource_id,
-               [unit_resource_id]
-             ), false}
-          else
-            {Map.merge(socket.assigns.selected_module_per_unit_resource_id, %{
-               unit_resource_id =>
-                 mark_visited_and_completed_pages(
-                   clicked_module,
-                   socket.assigns.student_visited_pages,
-                   socket.assigns.student_raw_avg_score_per_page_id,
-                   socket.assigns.student_progress_per_resource_id
-                 )
-               # The learning objectives tooltip was disabled in ticket NG-201 but will be reactivated with NG23-199
-               #  |> fetch_learning_objectives(socket.assigns.section.id)
-             }), true}
+          case clicked_module do
+            nil ->
+              # If clicked module not found, keep current state unchanged
+              {socket.assigns.selected_module_per_unit_resource_id, false}
+
+            clicked_module ->
+              if clicked_module["resource_id"] == current_module["resource_id"] do
+                # if the user clicked in an already expanded module, then we should collapse it
+                {Map.drop(
+                   socket.assigns.selected_module_per_unit_resource_id,
+                   [unit_resource_id]
+                 ), false}
+              else
+                {Map.merge(socket.assigns.selected_module_per_unit_resource_id, %{
+                   unit_resource_id =>
+                     mark_visited_and_completed_pages(
+                       clicked_module,
+                       socket.assigns.student_visited_pages,
+                       socket.assigns.student_raw_avg_score_per_page_id,
+                       socket.assigns.student_progress_per_resource_id
+                     )
+                   # The learning objectives tooltip was disabled in ticket NG-201 but will be reactivated with NG23-199
+                   #  |> fetch_learning_objectives(socket.assigns.section.id)
+                 }), true}
+              end
           end
       end
 


### PR DESCRIPTION
```
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): DBConnection.PrepareStream, DBConnection.Stream, Date.Range, Ecto.Adapters.SQL.Stream, File.Stream, Floki.HTMLTree, Function, GenEvent.Stream, HashDict, HashSet, IO.Stream, Jason.OrderedObject, List, Map, MapSet, Phoenix.LiveView.LiveStream, Postgrex.Stream, Range, Stream, Table.Mapper, Table.Zipper, Timex.Interval
```

```
lib/enum.ex:1 Enumerable.impl_for!/1
lib/enum.ex:166 Enumerable.reduce/3
lib/enum.ex:1166 Enum.find/3
lib/oli_web/live/delivery/student/learn_live.ex:3211 OliWeb.Delivery.Student.LearnLive.merge_target_module_as_selected/8
lib/oli_web/live/delivery/student/learn_live.ex:344 OliWeb.Delivery.Student.LearnLive.scroll_to_target_resource/4
lib/oli_web/live/delivery/student/learn_live.ex:135 OliWeb.Delivery.Student.LearnLive.handle_params/3
lib/phoenix_live_view/utils.ex:451 anonymous fn/5 in Phoenix.LiveView.Utils.call_handle_params!/5
/github/workspace/deps/telemetry/src/telemetry.erl:272 :telemetry.span/3
```