### PR TITLE
[FEATURE] [MER-4667] Browse all table logic

### DIFF
--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -176,7 +176,7 @@ defmodule Oli.Authoring.Course do
     query =
       case field do
         :name ->
-          order_by(query, [_, _, _, _, _, _, _, owner], {^direction, owner.name})
+          order_by(query, [_, _, _, _, _, _, owner], {^direction, owner.name})
 
         :collaborators ->
           order_by(
@@ -188,7 +188,7 @@ defmodule Oli.Authoring.Course do
         :published ->
           order_by(
             query,
-            [_, _, _, _, _, pub],
+            [_, _, _, _, pub],
             {^direction, fragment("bool_or(?)", not is_nil(pub.id))}
           )
 

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -37,7 +37,11 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
 
     ~H"""
     <th
-      class={"#{@column_spec.th_class} pl-2.5 border-b border-r p-2 bg-gray-100 font-semibold #{if @column_spec.sortable, do: "cursor-pointer"}"}
+      class={[
+        @column_spec.th_class,
+        "pl-2.5 font-semibold !sticky top-0",
+        if(@column_spec.sortable, do: "cursor-pointer", else: "")
+      ]}
       phx-click={if @column_spec.sortable, do: @sort, else: nil}
       phx-value-sort_by={@column_spec.name}
       data-sortable={if @column_spec.sortable == false, do: "false", else: "true"}
@@ -137,8 +141,8 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
 
   def render(assigns) do
     ~H"""
-    <table class={"min-w-full border " <> @additional_table_class}>
-      <thead class="sticky top-0 bg-white dark:bg-[#000000] z-10">
+    <table class={"min-w-full border table-fixed " <> @additional_table_class}>
+      <thead class="sticky top-0 z-10">
         <tr>
           <%= for column_spec <- @model.column_specs do %>
             {render_th(

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -5,54 +5,64 @@ defmodule OliWeb.Products.ProductsTableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.FormatDateTime
 
-  def new(products, ctx, project_slug \\ "") do
+  def new(products, ctx, opts \\ [], project_slug \\ "") do
     default_td_class = "!border-r border-Table-table-border"
     default_th_class = "!border-r border-Table-table-border"
 
+    column_specs = [
+      %ColumnSpec{
+        name: :title,
+        label: "Title",
+        render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3),
+        td_class: default_td_class,
+        th_class: default_th_class
+      },
+      %ColumnSpec{
+        name: :tags,
+        label: "Tags",
+        render_fn: &render_tags_column/3,
+        sortable: false,
+        td_class: default_td_class,
+        th_class: default_th_class
+      },
+      %ColumnSpec{
+        name: :inserted_at,
+        label: "Created",
+        render_fn: &render_created_column/3,
+        td_class: default_td_class,
+        th_class: default_th_class
+      },
+      %ColumnSpec{
+        name: :requires_payment,
+        label: "Requires Payment",
+        render_fn: &render_payment_column/3,
+        sort_fn: &sort_payment_column/2,
+        td_class: default_td_class,
+        th_class: default_th_class
+      },
+      %ColumnSpec{
+        name: :base_project_id,
+        label: "Base Project",
+        render_fn: &render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3),
+        td_class: default_td_class,
+        th_class: default_th_class
+      },
+      %ColumnSpec{name: :status, label: "Status", render_fn: &render_status_column/3}
+    ]
+
+    sort_by = Keyword.get(opts, :sort_by_spec, :inserted_at)
+    sort_order = Keyword.get(opts, :sort_order, :asc)
+
+    sort_by_spec =
+      Enum.find(column_specs, fn spec -> spec.name == sort_by end)
+
     SortableTableModel.new(
       rows: products,
-      column_specs: [
-        %ColumnSpec{
-          name: :title,
-          label: "Title",
-          render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3),
-          td_class: default_td_class,
-          th_class: default_th_class
-        },
-        %ColumnSpec{
-          name: :tags,
-          label: "Tags",
-          render_fn: &render_tags_column/3,
-          sortable: false,
-          td_class: default_td_class,
-          th_class: default_th_class
-        },
-        %ColumnSpec{
-          name: :inserted_at,
-          label: "Created",
-          render_fn: &render_created_column/3,
-          td_class: default_td_class,
-          th_class: default_th_class
-        },
-        %ColumnSpec{
-          name: :requires_payment,
-          label: "Requires Payment",
-          render_fn: &render_payment_column/3,
-          sort_fn: &sort_payment_column/2,
-          td_class: default_td_class,
-          th_class: default_th_class
-        },
-        %ColumnSpec{
-          name: :base_project_id,
-          label: "Base Project",
-          render_fn: &render_project_column(Map.put(&1, :project_slug, project_slug), &2, &3),
-          td_class: default_td_class,
-          th_class: default_th_class
-        },
-        %ColumnSpec{name: :status, label: "Status", render_fn: &render_status_column/3}
-      ],
+      column_specs: column_specs,
       event_suffix: "",
       id_field: [:id],
+      sort_by_spec: sort_by_spec,
+      sort_order: sort_order,
       data: %{ctx: ctx}
     )
   end

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -14,8 +14,8 @@ defmodule OliWeb.Products.ProductsTableModel do
         name: :title,
         label: "Title",
         render_fn: &render_title_column(Map.put(&1, :project_slug, project_slug), &2, &3),
-        td_class: default_td_class,
-        th_class: default_th_class
+        th_class: "!sticky left-0 z-[60] " <> default_th_class,
+        td_class: "!sticky left-0 z-[1] bg-inherit " <> default_td_class
       },
       %ColumnSpec{
         name: :tags,
@@ -51,7 +51,7 @@ defmodule OliWeb.Products.ProductsTableModel do
     ]
 
     sort_by = Keyword.get(opts, :sort_by_spec, :inserted_at)
-    sort_order = Keyword.get(opts, :sort_order, :asc)
+    sort_order = Keyword.get(opts, :sort_order, :desc)
 
     sort_by_spec =
       Enum.find(column_specs, fn spec -> spec.name == sort_by end)

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.Products.ProductsTableModel do
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.FormatDateTime
 
-  def new(products, ctx, opts \\ [], project_slug \\ "") do
+  def new(products, ctx, project_slug \\ "", opts \\ []) do
     default_td_class = "!border-r border-Table-table-border"
     default_th_class = "!border-r border-Table-table-border"
 

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -70,7 +70,7 @@ defmodule OliWeb.Products.ProductsView do
   end
 
   defp mount_as(params, author, is_admin_view, project, breadcrumbs, title, socket) do
-    project_id = if project === nil, do: nil, else: project.id
+    {project_id, project_slug} = {project && project.id, (project && project.slug) || ""}
 
     products =
       Blueprint.browse(
@@ -86,7 +86,10 @@ defmodule OliWeb.Products.ProductsView do
     ctx = socket.assigns.ctx
 
     {:ok, table_model} =
-      ProductsTableModel.new(products, ctx, sort_by_spec: :inserted_at, sort_order: :asc)
+      ProductsTableModel.new(products, ctx, project_slug,
+        sort_by_spec: :inserted_at,
+        sort_order: :asc
+      )
 
     published? =
       case project do

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -75,7 +75,7 @@ defmodule OliWeb.Products.ProductsView do
     products =
       Blueprint.browse(
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :inserted_at},
+        %Sorting{direction: :desc, field: :inserted_at},
         text_search: Params.get_param(params, "text_search", ""),
         include_archived: Params.get_boolean_param(params, "include_archived", false),
         project_id: project_id
@@ -88,7 +88,7 @@ defmodule OliWeb.Products.ProductsView do
     {:ok, table_model} =
       ProductsTableModel.new(products, ctx, project_slug,
         sort_by_spec: :inserted_at,
-        sort_order: :asc
+        sort_order: :desc
       )
 
     published? =

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -75,7 +75,7 @@ defmodule OliWeb.Products.ProductsView do
     products =
       Blueprint.browse(
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :title},
+        %Sorting{direction: :asc, field: :inserted_at},
         text_search: Params.get_param(params, "text_search", ""),
         include_archived: Params.get_boolean_param(params, "include_archived", false),
         project_id: project_id
@@ -84,7 +84,9 @@ defmodule OliWeb.Products.ProductsView do
     total_count = determine_total(products)
 
     ctx = socket.assigns.ctx
-    {:ok, table_model} = ProductsTableModel.new(products, ctx)
+
+    {:ok, table_model} =
+      ProductsTableModel.new(products, ctx, sort_by_spec: :inserted_at, sort_order: :asc)
 
     published? =
       case project do

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -40,12 +40,16 @@ defmodule OliWeb.Projects.ProjectsLive do
       Course.browse_projects(
         author,
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :title},
+        %Sorting{direction: :asc, field: :inserted_at},
         include_deleted: show_deleted,
         admin_show_all: show_all
       )
 
-    {:ok, table_model} = TableModel.new(ctx, projects)
+    {:ok, table_model} =
+      TableModel.new(ctx, projects,
+        sort_by_spec: :inserted_at,
+        sort_order: :asc
+      )
 
     total_count = determine_total(projects)
 

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -40,7 +40,7 @@ defmodule OliWeb.Projects.ProjectsLive do
       Course.browse_projects(
         author,
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :inserted_at},
+        %Sorting{direction: :desc, field: :inserted_at},
         include_deleted: show_deleted,
         admin_show_all: show_all
       )
@@ -48,7 +48,7 @@ defmodule OliWeb.Projects.ProjectsLive do
     {:ok, table_model} =
       TableModel.new(ctx, projects,
         sort_by_spec: :inserted_at,
-        sort_order: :asc
+        sort_order: :desc
       )
 
     total_count = determine_total(projects)

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -14,8 +14,8 @@ defmodule OliWeb.Projects.TableModel do
         name: :title,
         label: "Title",
         render_fn: &custom_render/3,
-        td_class: default_td_class,
-        th_class: default_th_class
+        td_class: "!sticky left-0 z-[1] bg-inherit " <> default_td_class,
+        th_class: "!sticky left-0 z-[60] " <> default_th_class
       },
       %ColumnSpec{
         name: :tags,
@@ -68,7 +68,7 @@ defmodule OliWeb.Projects.TableModel do
     ]
 
     sort_by = Keyword.get(opts, :sort_by_spec, :inserted_at)
-    sort_order = Keyword.get(opts, :sort_order, :asc)
+    sort_order = Keyword.get(opts, :sort_order, :desc)
 
     sort_by_spec =
       Enum.find(column_specs, fn spec -> spec.name == sort_by end)

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -5,43 +5,60 @@ defmodule OliWeb.Projects.TableModel do
   alias OliWeb.Common.{Chip, FormatDateTime, SessionContext}
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
 
-  def new(%SessionContext{} = ctx, sections) do
+  def new(%SessionContext{} = ctx, sections, opts \\ []) do
+    default_td_class = "!border-r border-Table-table-border"
+    default_th_class = "!border-r border-Table-table-border"
+
     column_specs = [
       %ColumnSpec{
         name: :title,
         label: "Title",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :tags,
         label: "Tags",
         render_fn: &custom_render/3,
-        sortable: false
+        sortable: false,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :inserted_at,
         label: "Created",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :name,
         label: "Created By",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :collaborators,
         label: "Collaborators",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :published,
         label: "Published",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :visibility,
         label: "Visibility",
-        render_fn: &custom_render/3
+        render_fn: &custom_render/3,
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :status,
@@ -50,11 +67,19 @@ defmodule OliWeb.Projects.TableModel do
       }
     ]
 
+    sort_by = Keyword.get(opts, :sort_by_spec, :inserted_at)
+    sort_order = Keyword.get(opts, :sort_order, :asc)
+
+    sort_by_spec =
+      Enum.find(column_specs, fn spec -> spec.name == sort_by end)
+
     SortableTableModel.new(
       rows: sections,
       column_specs: column_specs,
       event_suffix: "",
       id_field: [:id],
+      sort_by_spec: sort_by_spec,
+      sort_order: sort_order,
       data: %{
         ctx: ctx
       }

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -57,7 +57,7 @@ defmodule OliWeb.Sections.SectionsView do
     sections =
       Browse.browse_sections(
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :start_date},
+        %Sorting{direction: :desc, field: :start_date},
         @default_options
       )
 
@@ -67,7 +67,7 @@ defmodule OliWeb.Sections.SectionsView do
       SectionsTableModel.new(ctx, sections,
         render_date: :full,
         sort_by_spec: :start_date,
-        sort_order: :asc
+        sort_order: :desc
       )
 
     {:ok,

--- a/lib/oli_web/live/sections/sections_view.ex
+++ b/lib/oli_web/live/sections/sections_view.ex
@@ -57,12 +57,18 @@ defmodule OliWeb.Sections.SectionsView do
     sections =
       Browse.browse_sections(
         %Paging{offset: 0, limit: @limit},
-        %Sorting{direction: :asc, field: :title},
+        %Sorting{direction: :asc, field: :start_date},
         @default_options
       )
 
     total_count = determine_total(sections)
-    {:ok, table_model} = SectionsTableModel.new(ctx, sections, render_date: :full)
+
+    {:ok, table_model} =
+      SectionsTableModel.new(ctx, sections,
+        render_date: :full,
+        sort_by_spec: :start_date,
+        sort_order: :asc
+      )
 
     {:ok,
      assign(socket,

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
     render_date: :relative,
     exclude_columns: [],
     sort_by_spec: :start_date,
-    sort_order: :asc
+    sort_order: :desc
   ]
 
   def new(%SessionContext{} = ctx, sections, opts \\ []) do
@@ -21,77 +21,80 @@ defmodule OliWeb.Sections.SectionsTableModel do
     date_render =
       if opts[:render_date] == :relative, do: &Common.render_date/3, else: &custom_render/3
 
+    default_td_class = "!border-r border-Table-table-border"
+    default_th_class = "!border-r border-Table-table-border"
+
     column_specs = [
       %ColumnSpec{
         name: :title,
         label: "Title",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        th_class: "!sticky left-0 z-[60] " <> default_th_class,
+        td_class: "!sticky left-0 z-[1] bg-inherit " <> default_td_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :tags,
         label: "Tags",
         sortable: false,
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :enrollments_count,
         label: "# Enrolled",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border"
+        td_class: default_td_class,
+        th_class: default_th_class
       },
       %ColumnSpec{
         name: :requires_payment,
         label: "Cost",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :start_date,
         label: "Start",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: date_render,
         sort_fn: &Common.sort_date/2
       },
       %ColumnSpec{
         name: :end_date,
         label: "End",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: date_render,
         sort_fn: &Common.sort_date/2
       },
       %ColumnSpec{
         name: :base,
         label: "Base Project/Product",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :instructor,
         label: "Instructors",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :institution,
         label: "Institution",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
         name: :type,
         label: "Delivery",
-        td_class: "!border-r border-Table-table-border",
-        th_class: "!border-r border-Table-table-border",
+        td_class: default_td_class,
+        th_class: default_th_class,
         render_fn: &custom_render/3
       },
       %ColumnSpec{
@@ -102,7 +105,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
     ]
 
     sort_by = Keyword.get(opts, :sort_by_spec, :start_date)
-    sort_order = Keyword.get(opts, :sort_order, :asc)
+    sort_order = Keyword.get(opts, :sort_order, :desc)
 
     sort_by_spec =
       Enum.find(column_specs, fn spec -> spec.name == sort_by end)

--- a/lib/oli_web/live/workspaces/course_author/products_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products_live.ex
@@ -35,7 +35,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
     {:ok, table_model} =
       ProductsTableModel.new(products, ctx, project.slug,
         sort_by_spec: :inserted_at,
-        sort_order: :asc
+        sort_order: :desc
       )
 
     published? = Publishing.project_published?(project.slug)
@@ -201,7 +201,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
     limit = assigns[:limit] || @max_items_per_page
 
     table_model = assigns[:table_model]
-    direction = if table_model, do: assigns.table_model.sort_order, else: :asc
+    direction = if table_model, do: assigns.table_model.sort_order, else: :desc
     field = if table_model, do: assigns.table_model.sort_by_spec.name, else: :inserted_at
 
     include_archived = get_in(assigns, [:include_archived]) || false

--- a/lib/oli_web/live/workspaces/course_author/products_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products_live.ex
@@ -31,7 +31,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
     products = get_products(socket.assigns)
 
     ctx = socket.assigns.ctx
-    {:ok, table_model} = ProductsTableModel.new(products, ctx, project.slug)
+
+    {:ok, table_model} =
+      ProductsTableModel.new(products, ctx, project.slug,
+        sort_by_spec: :inserted_at,
+        sort_order: :asc
+      )
+
     published? = Publishing.project_published?(project.slug)
 
     {:ok,
@@ -196,7 +202,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
 
     table_model = assigns[:table_model]
     direction = if table_model, do: assigns.table_model.sort_order, else: :asc
-    field = if table_model, do: assigns.table_model.sort_by_spec.name, else: :title
+    field = if table_model, do: assigns.table_model.sort_by_spec.name, else: :inserted_at
 
     include_archived = get_in(assigns, [:include_archived]) || false
 

--- a/test/oli_web/live/admin/institutions/sections_and_students_view_test.exs
+++ b/test/oli_web/live/admin/institutions/sections_and_students_view_test.exs
@@ -421,7 +421,7 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsViewTest do
       # test order desc
       assert view
              |> element("table > tbody > tr:first-child > td:nth-child(3) > div")
-             |> render() =~ "$10.00"
+             |> render() =~ "$40.00"
 
       view
       |> element("th[phx-value-sort_by=requires_payment]")
@@ -430,7 +430,7 @@ defmodule OliWeb.Admin.Institutions.SectionsAndStudentsViewTest do
       # test order asc
       assert view
              |> element("table > tbody > tr:first-child > td:nth-child(3) > div")
-             |> render() =~ "$40.00"
+             |> render() =~ "$10.00"
     end
   end
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -235,20 +235,22 @@ defmodule OliWeb.ProductsLiveTest do
     end
 
     test "applies paging", %{conn: conn} do
-      [first_p | tail] = insert_list(21, :section) |> Enum.sort_by(& &1.title)
-      last_p = List.last(tail)
+      first_p = insert(:section, title: "First Product", inserted_at: yesterday())
+      last_p = insert(:section, title: "Last Product", inserted_at: tomorrow())
+
+      insert_list(21, :section, inserted_at: DateTime.now!("Etc/UTC"))
 
       {:ok, view, _html} = live(conn, @live_view_all_products)
 
-      assert has_element?(view, "##{first_p.id}")
-      refute has_element?(view, "##{last_p.id}")
+      assert has_element?(view, "##{last_p.id}")
+      refute has_element?(view, "##{first_p.id}")
 
       view
       |> element("#footer_paging button[phx-click='paged_table_page_change']", "2")
       |> render_click()
 
-      refute has_element?(view, "##{first_p.id}")
-      assert has_element?(view, "##{last_p.id}")
+      refute has_element?(view, "##{last_p.id}")
+      assert has_element?(view, "##{first_p.id}")
     end
   end
 

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -176,24 +176,24 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
     end
 
     test "applies paging", %{conn: conn, author: author} do
-      [first_p | tail] =
-        1..26
-        |> Enum.map(fn _ -> create_project_with_owner(author) end)
-        |> Enum.sort_by(& &1.title)
+      first_p =
+        insert(:project, title: "First Project", inserted_at: yesterday(), authors: [author])
 
-      last_p = List.last(tail)
+      last_p = insert(:project, title: "Last Project", inserted_at: tomorrow(), authors: [author])
+
+      insert_list(26, :project, inserted_at: DateTime.now!("Etc/UTC"), authors: [author])
 
       {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
 
-      assert has_element?(view, "##{first_p.id}")
-      refute has_element?(view, "##{last_p.id}")
+      assert has_element?(view, "##{last_p.id}")
+      refute has_element?(view, "##{first_p.id}")
 
       view
       |> element("#footer_paging button[phx-click='paged_table_page_change']", "2")
       |> render_click()
 
-      refute has_element?(view, "##{first_p.id}")
-      assert has_element?(view, "##{last_p.id}")
+      refute has_element?(view, "##{last_p.id}")
+      assert has_element?(view, "##{first_p.id}")
     end
 
     test "applies sorting", %{conn: conn, author: author} do

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -106,14 +106,18 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
 
       {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
 
+      view
+      |> element("th[phx-click='paged_table_sort'][phx-value-sort_by='title']")
+      |> render_click()
+
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
                "Testing A"
 
       view
-      |> element("th[phx-click='paged_table_sort']:first-of-type")
-      |> render_click(%{sort_by: "title"})
+      |> element("th[phx-click='paged_table_sort'][phx-value-sort_by='title']")
+      |> render_click()
 
       assert view
              |> element("tr:first-child > td:first-child")
@@ -198,13 +202,17 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
 
       {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
 
+      view
+      |> element("th[phx-click='paged_table_sort'][phx-value-sort_by='title']")
+      |> render_click(%{sort_by: "title"})
+
       assert view
              |> element("tr:first-child > td:first-child")
              |> render() =~
                "Testing A"
 
       view
-      |> element("th[phx-click='paged_table_sort']:first-of-type")
+      |> element("th[phx-click='paged_table_sort'][phx-value-sort_by='title']")
       |> render_click(%{sort_by: "title"})
 
       assert view

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -220,6 +220,10 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
 
       {:ok, view, _html} = live(conn, @live_view_index_route)
 
+      view
+      |> element("th[phx-click='paged_table_sort']", "Title")
+      |> render_click(%{sort_by: "title"})
+
       # by title
       assert view
              |> element("tr:first-child > td:first-child")

--- a/test/oli_web/live/sections/admin_index_live_test.exs
+++ b/test/oli_web/live/sections/admin_index_live_test.exs
@@ -276,20 +276,25 @@ defmodule OliWeb.Sections.AdminIndexLiveTest do
     end
 
     test "applies paging", %{conn: conn} do
-      [first_s | tail] = insert_list(26, :section, type: :enrollable) |> Enum.sort_by(& &1.title)
-      last_s = List.last(tail)
+      first_section =
+        insert(:section, type: :enrollable, title: "First Section", start_date: yesterday())
+
+      last_section =
+        insert(:section, type: :enrollable, title: "Last Section", start_date: tomorrow())
+
+      insert_list(26, :section, type: :enrollable, start_date: DateTime.now!("Etc/UTC"))
 
       {:ok, view, _html} = live(conn, @live_view_index_route)
 
-      assert has_element?(view, "td", first_s.title)
-      refute has_element?(view, "td", last_s.title)
+      assert has_element?(view, "td", last_section.title)
+      refute has_element?(view, "td", first_section.title)
 
       view
       |> element("#footer_paging button[phx-click='paged_table_page_change']", "2")
       |> render_click()
 
-      refute has_element?(view, "td", first_s.title)
-      assert has_element?(view, "td", last_s.title)
+      refute has_element?(view, "td", last_section.title)
+      assert has_element?(view, "td", first_section.title)
     end
 
     test "section title is a link to the manage tab of the instructor dashboard", %{conn: conn} do

--- a/test/oli_web/live/sections/sections_table_model_test.exs
+++ b/test/oli_web/live/sections/sections_table_model_test.exs
@@ -96,7 +96,7 @@ defmodule OliWeb.Sections.SectionsTableModelTest do
       {:ok, model} = SectionsTableModel.new(ctx, sections)
 
       assert length(model.column_specs) == 11
-      assert model.rows == sections
+      assert model.rows == Enum.sort_by(sections, & &1.start_date, :desc)
       assert model.event_suffix == ""
       assert model.id_field == [:id]
 


### PR DESCRIPTION
[MER-4667](https://eliterate.atlassian.net/browse/MER-4667)

This PR introduces some improvements to the tables in the `Browse All Projects`, `Browse All Products`, and `Browse All Course Sections` views:

- Fixes sorting for the `Published` and `Created By` columns in the Browse All Projects table.

- Implements sticky first column (usually the Title column) when horizontal overflow occurs.

- Sets default table sorting by `creation date`, displaying the most recently created items first.


https://github.com/user-attachments/assets/03434bea-7728-4b0e-8854-3ccaf8810e86


https://github.com/user-attachments/assets/a53721f6-8c7c-4f8b-b9b2-e75b65f56e68


https://github.com/user-attachments/assets/e9b9c858-8d63-4642-a867-8b57522eb542



[MER-4667]: https://eliterate.atlassian.net/browse/MER-4667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ