### PR TITLE
[ENHANCEMENT] [MER-4903] Test updates to product based sections

### DIFF
--- a/test/oli/delivery/major_updates/apply_major_updates_from_product.scenario.yaml
+++ b/test/oli/delivery/major_updates/apply_major_updates_from_product.scenario.yaml
@@ -1,0 +1,89 @@
+# Test scenario: Verify that when apply_major_updates is true on a product-based section,
+# new content published to the project appears in the section
+
+# Step 1: Create a project with initial content
+- project:
+    name: "base_project"
+    title: "Base Project"
+    root:
+      children:
+        - page: "Introduction"
+        - container: "Module 1"
+          children:
+            - page: "Lesson 1"
+            - page: "Lesson 2"
+
+# Step 2: Create a product from the project
+- product:
+    name: "course_template"
+    title: "Course Template Product"
+    from: "base_project"
+
+# Step 3: Change the product to enable apply_major_updates
+- manipulate:
+    to: "course_template"
+    ops:
+      - change:
+          apply_major_updates: true
+
+# Step 4: Customize the product structure by removing Lesson 2
+- customize:
+    to: "course_template"
+    ops:
+      - remove:
+          from: "Lesson 2"
+
+# Step 5: Create a section from the customized product (will inherit apply_major_updates and customizations)
+- section:
+    name: "course_section"
+    from: "course_template"
+    title: "Spring 2025 Course"
+
+# Step 6: Verify initial section structure (should NOT have Lesson 2)
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1"
+            children:
+              - page: "Lesson 1"
+              # Lesson 2 should NOT be here due to product customization
+
+# Step 7: Add new content to the project
+- manipulate:
+    to: "base_project"
+    ops:
+      - add_page:
+          title: "New Lesson 3"
+          to: "Module 1"
+      - add_page:
+          title: "Conclusion"
+          to: "root"
+
+# Step 8: Publish the changes
+- publish:
+    to: "base_project"
+    description: "Added new lesson and conclusion page"
+
+# Step 9: Apply the publication to the section
+# This should work because apply_major_updates is true
+- update:
+    from: "base_project"
+    to: "course_section"
+
+# Step 10: Verify the new pages appear BUT Lesson 2 remains removed
+# The product customization should persist even after major updates
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1"
+            children:
+              - page: "Lesson 1"
+              # Lesson 2 should STILL not be here (removed by product customization)
+              - page: "New Lesson 3"  # This should now exist from major update
+          - page: "Conclusion"  # This should now exist from major update

--- a/test/oli/delivery/major_updates/product_publishing_with_remix.scenario.yaml
+++ b/test/oli/delivery/major_updates/product_publishing_with_remix.scenario.yaml
@@ -1,0 +1,185 @@
+# Test scenario: Product publishing with remixed content from another project
+# Verifies that products can be remixed with content from other projects
+# and still receive updates from their base project
+
+# Step 1: Create the first project (base for the product)
+- project:
+    name: "base_project"
+    title: "Base Course Project"
+    root:
+      children:
+        - page: "Introduction"
+        - container: "Module 1: Fundamentals"
+          children:
+            - page: "Lesson 1.1"
+            - page: "Lesson 1.2"
+        - page: "Midterm Exam"
+
+# Step 2: Create a second project (source for remix content)
+- project:
+    name: "supplemental_project"
+    title: "Supplemental Materials Project"
+    root:
+      children:
+        - container: "Advanced Topics"
+          children:
+            - page: "Advanced Lesson 1"
+            - page: "Advanced Lesson 2"
+            - page: "Advanced Quiz"
+        - container: "Extra Resources"
+          children:
+            - page: "Resource A"
+            - page: "Resource B"
+
+# Step 3: Create a product from the base project
+- product:
+    name: "course_product"
+    title: "Course Product Template"
+    from: "base_project"
+
+# Step 3b: Enable major updates on the product so sections can receive updates
+- manipulate:
+    to: "course_product"
+    ops:
+      - change:
+          apply_major_updates: true
+
+# Step 5: Verify initial product structure (matches base project)
+- verify:
+    to: "course_product"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1: Fundamentals"
+            children:
+              - page: "Lesson 1.1"
+              - page: "Lesson 1.2"
+          - page: "Midterm Exam"
+
+# Step 6: Remix the product to add content from the supplemental project
+# Add the "Advanced Topics" module to the product's root
+- remix:
+    section: "course_product"
+    from: "supplemental_project"
+    resource: "Advanced Topics"
+    to: "root"
+
+# Step 7: Verify the product now has remixed content
+- verify:
+    to: "course_product"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1: Fundamentals"
+            children:
+              - page: "Lesson 1.1"
+              - page: "Lesson 1.2"
+          - page: "Midterm Exam"
+          - container: "Advanced Topics"
+            children:
+              - page: "Advanced Lesson 1"
+              - page: "Advanced Lesson 2"
+              - page: "Advanced Quiz"
+
+# Step 8: Create a section from the remixed product to verify inheritance
+- section:
+    name: "course_section"
+    from: "course_product"
+    title: "Spring 2025 Course"
+
+# Step 9: Verify the section has the remixed content from the product
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1: Fundamentals"
+            children:
+              - page: "Lesson 1.1"
+              - page: "Lesson 1.2"
+          - page: "Midterm Exam"
+          - container: "Advanced Topics"  # Remixed content from product
+            children:
+              - page: "Advanced Lesson 1"
+              - page: "Advanced Lesson 2"
+              - page: "Advanced Quiz"
+
+# Step 10: Add new content to the base project
+- manipulate:
+    to: "base_project"
+    ops:
+      - add_container:
+          title: "Module 2: Applications"
+      - add_page:
+          title: "Lesson 2.1"
+          to: "Module 2: Applications"
+      - add_page:
+          title: "Lesson 2.2"
+          to: "Module 2: Applications"
+      - add_page:
+          title: "Final Exam"
+          to: "root"
+
+# Step 11: Publish the changes in the base project
+- publish:
+    to: "base_project"
+    description: "Added Module 2 and Final Exam"
+
+# Step 12: Update the product from the base project
+# This tests whether products themselves can receive updates
+- update:
+    from: "base_project"
+    to: "course_product"
+
+# Step 13: Verify the product structure after update
+# Products may not receive structural updates the same way sections do
+# The remixed content should still be present, but new content may not appear
+- verify:
+    to: "course_product"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1: Fundamentals"
+            children:
+              - page: "Lesson 1.1"
+              - page: "Lesson 1.2"
+          - page: "Midterm Exam"
+          - container: "Advanced Topics"  # Remixed content should still be present
+            children:
+              - page: "Advanced Lesson 1"
+              - page: "Advanced Lesson 2"
+              - page: "Advanced Quiz"
+
+# Step 14: Update the section from the base project
+# This should work because apply_major_updates is enabled on the product
+- update:
+    from: "base_project"
+    to: "course_section"
+
+# Step 15: Verify final section structure
+# Should have BOTH the remixed content (Advanced Topics) AND the new content (Module 2, Final Exam)
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Introduction"
+          - container: "Module 1: Fundamentals"
+            children:
+              - page: "Lesson 1.1"
+              - page: "Lesson 1.2"
+          - page: "Midterm Exam"
+          - container: "Module 2: Applications"  # New from base project update
+            children:
+              - page: "Lesson 2.1"
+              - page: "Lesson 2.2"
+          - page: "Final Exam"  # New from base project update
+          - container: "Advanced Topics"  # Remixed content stays at the end
+            children:
+              - page: "Advanced Lesson 1"
+              - page: "Advanced Lesson 2"
+              - page: "Advanced Quiz"

--- a/test/oli/delivery/major_updates/remix_selective_updates.scenario.yaml
+++ b/test/oli/delivery/major_updates/remix_selective_updates.scenario.yaml
@@ -1,0 +1,149 @@
+# Test scenario: Selective updates from remixed content
+# Verifies that when a section has remixed content from a secondary project,
+# updates to the remixed content show selective update behavior
+
+# Step 1: Create the primary project with basic content
+- project:
+    name: "primary"
+    title: "Primary Course Project"
+    root:
+      children:
+        - page: "Welcome to Primary"
+        - container: "Module 1: Primary Content"
+          children:
+            - page: "Primary Lesson 1"
+            - page: "Primary Lesson 2"
+        - page: "Primary Assessment"
+
+# Step 2: Create the secondary project with content to be remixed
+- project:
+    name: "secondary"
+    title: "Secondary Resource Project"
+    root:
+      children:
+        - container: "Supplemental Materials"
+          children:
+            - page: "Supplemental Topic A"
+            - page: "Supplemental Topic B"
+            - page: "Supplemental Quiz"
+
+# Step 3: Publish both projects initially
+- publish:
+    to: "primary"
+    description: "Initial primary publication"
+
+- publish:
+    to: "secondary"
+    description: "Initial secondary publication"
+
+# Step 4: Create a section from the primary project
+- section:
+    name: "course_section"
+    title: "Spring 2025 Course"
+    from: "primary"
+    type: enrollable
+
+# Step 5: Remix content from secondary project into the section
+# Add the "Supplemental Materials" container to the section's root
+- remix:
+    section: "course_section"
+    from: "secondary"
+    resource: "Supplemental Materials"
+    to: "root"
+
+# Step 6: Verify the section has both primary and remixed content
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Welcome to Primary"
+          - container: "Module 1: Primary Content"
+            children:
+              - page: "Primary Lesson 1"
+              - page: "Primary Lesson 2"
+          - page: "Primary Assessment"
+          - container: "Supplemental Materials"  # Remixed from secondary
+            children:
+              - page: "Supplemental Topic A"
+              - page: "Supplemental Topic B"
+              - page: "Supplemental Quiz"
+
+# Step 7: Make changes to the secondary project
+- manipulate:
+    to: "secondary"
+    ops:
+      # Add a new page to the Supplemental Materials container
+      - add_page:
+          title: "NEW Supplemental Topic C"
+          to: "Supplemental Materials"
+
+      # Change the title of an existing page
+      - revise:
+          target: "Supplemental Topic A"
+          set:
+            title: "RENAMED Topic A"
+
+# Step 8: Publish the changes in the secondary project
+- publish:
+    to: "secondary"
+    description: "Added new topic and renamed existing topic"
+
+# Step 9: Now we need to verify what happens to remixed content
+# The expectation is that remixed content is a snapshot and doesn't auto-update
+# So the section should still have the original content
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Welcome to Primary"
+          - container: "Module 1: Primary Content"
+            children:
+              - page: "Primary Lesson 1"
+              - page: "Primary Lesson 2"
+          - page: "Primary Assessment"
+          - container: "Supplemental Materials"
+            children:
+              - page: "Supplemental Topic A"  # Original title, not renamed
+              - page: "Supplemental Topic B"
+              - page: "Supplemental Quiz"
+              # NOTE: "NEW Supplemental Topic C" is NOT here
+              # Remixed content is a snapshot and doesn't auto-update
+
+# Step 10: Test updates from the primary project still work
+- manipulate:
+    to: "primary"
+    ops:
+      - add_page:
+          title: "New Primary Page"
+          to: "root"
+
+# Step 11: Publish the primary project
+- publish:
+    to: "primary"
+    description: "Added new page to primary"
+
+# Step 12: Apply updates from the primary project to the section
+- update:
+    from: "primary"
+    to: "course_section"
+
+# Step 13: Verify primary updates apply but remixed content remains unchanged
+- verify:
+    to: "course_section"
+    structure:
+      root:
+        children:
+          - page: "Welcome to Primary"
+          - container: "Module 1: Primary Content"
+            children:
+              - page: "Primary Lesson 1"
+              - page: "Primary Lesson 2"
+          - page: "Primary Assessment"
+          - page: "New Primary Page"  # New page from primary update appears
+          - container: "Supplemental Materials"  # Remixed content unchanged
+            children:
+              - page: "Supplemental Topic A"  # Still original title
+              - page: "Supplemental Topic B"
+              - page: "Supplemental Quiz"

--- a/test/oli/scenarios/change_operation_test.exs
+++ b/test/oli/scenarios/change_operation_test.exs
@@ -1,0 +1,204 @@
+defmodule Oli.Scenarios.ChangeOperationTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios.TestHelpers
+  alias Oli.Scenarios.DirectiveTypes.ExecutionResult
+
+  describe "change operation" do
+    test "can change project settings" do
+      yaml = """
+      - project:
+          name: "test_project"
+          title: "Test Project"
+          root:
+            children:
+              - page: "Page 1"
+
+      # Change project settings
+      - manipulate:
+          to: "test_project"
+          ops:
+            - change:
+                title: "Updated Project Title"
+                description: "This is an updated description"
+                allow_triggers: true
+
+      # Create a section to verify the project changes
+      - section:
+          name: "test_section"
+          from: "test_project"
+      """
+
+      result = TestHelpers.execute_yaml(yaml)
+
+      assert %ExecutionResult{errors: []} = result
+      
+      # Verify the project was updated
+      project = result.state.projects["test_project"].project
+      assert project.title == "Updated Project Title"
+      assert project.description == "This is an updated description"
+      assert project.allow_triggers == true
+    end
+
+    test "can change section settings" do
+      yaml = """
+      - project:
+          name: "test_project"
+          title: "Test Project"
+          root:
+            children:
+              - page: "Page 1"
+
+      - section:
+          name: "test_section"
+          from: "test_project"
+
+      # Change section settings
+      - manipulate:
+          to: "test_section"
+          ops:
+            - change:
+                title: "Updated Section Title"
+                apply_major_updates: true
+                grace_period_strategy: "@atom(relative_to_student)"
+                has_grace_period: true
+                grace_period_days: 7
+
+      """
+
+      result = TestHelpers.execute_yaml(yaml)
+
+      assert %ExecutionResult{errors: []} = result
+      
+      # Verify the section was updated
+      section = result.state.sections["test_section"]
+      assert section.title == "Updated Section Title"
+      assert section.apply_major_updates == true
+      assert section.grace_period_strategy == :relative_to_student
+      assert section.has_grace_period == true
+      assert section.grace_period_days == 7
+    end
+
+    test "can change product settings" do
+      yaml = """
+      - project:
+          name: "test_project"
+          title: "Test Project"
+          root:
+            children:
+              - page: "Page 1"
+
+      - product:
+          name: "test_product"
+          from: "test_project"
+          title: "Test Product"
+
+      # Change product settings
+      - manipulate:
+          to: "test_product"
+          ops:
+            - change:
+                title: "Updated Product Title"
+                apply_major_updates: false
+                description: "Updated product description"
+
+      """
+
+      result = TestHelpers.execute_yaml(yaml)
+
+      assert %ExecutionResult{errors: []} = result
+      
+      # Verify the product was updated
+      product = result.state.products["test_product"]
+      assert product.title == "Updated Product Title"
+      assert product.apply_major_updates == false
+      assert product.description == "Updated product description"
+    end
+
+    test "supports multiple data types in change operation" do
+      yaml = """
+      - project:
+          name: "test_project"
+          title: "Test Project"
+          root:
+            children:
+              - page: "Page 1"
+
+      - section:
+          name: "test_section"
+          from: "test_project"
+
+      # Change with various data types
+      - manipulate:
+          to: "test_section"
+          ops:
+            - change:
+                title: "String Value"
+                apply_major_updates: true
+                grace_period_days: 5
+                grade_passback_enabled: false
+                context_id: "context-123"
+
+      """
+
+      result = TestHelpers.execute_yaml(yaml)
+
+      assert %ExecutionResult{errors: []} = result
+      
+      section = result.state.sections["test_section"]
+      assert section.title == "String Value"
+      assert section.apply_major_updates == true
+      assert section.grace_period_days == 5
+      assert section.grade_passback_enabled == false
+      assert section.context_id == "context-123"
+    end
+
+    test "can combine change with other operations" do
+      yaml = """
+      - project:
+          name: "test_project"
+          title: "Test Project"
+          root:
+            children:
+              - page: "Page 1"
+
+      # Multiple operations including change
+      - manipulate:
+          to: "test_project"
+          ops:
+            - change:
+                title: "Updated Title"
+                description: "Updated Description"
+            - add_page:
+                title: "New Page"
+                to: "root"
+            - revise:
+                target: "Page 1"
+                set:
+                  graded: true
+                  max_attempts: 2
+
+      - section:
+          name: "test_section"
+          from: "test_project"
+      """
+
+      result = TestHelpers.execute_yaml(yaml)
+
+      assert %ExecutionResult{errors: []} = result
+      
+      # Verify all operations were applied
+      project = result.state.projects["test_project"]
+      assert project.project.title == "Updated Title"
+      assert project.project.description == "Updated Description"
+      
+      # Verify the new page was added
+      assert Map.has_key?(project.id_by_title, "New Page")
+      
+      # Verify Page 1 was revised
+      page1_rev = project.rev_by_title["Page 1"]
+      assert page1_rev.graded == true
+      assert page1_rev.max_attempts == 2
+    end
+  end
+end

--- a/test/support/scenarios/directives/update_handler.ex
+++ b/test/support/scenarios/directives/update_handler.ex
@@ -6,57 +6,113 @@ defmodule Oli.Scenarios.Directives.UpdateHandler do
   alias Oli.Scenarios.DirectiveTypes.UpdateDirective
   alias Oli.Scenarios.Engine
 
-  def handle(%UpdateDirective{from: project_name, to: section_name}, state) do
+  def handle(%UpdateDirective{from: project_name, to: target_name}, state) do
     try do
-      # Get the section
-      section =
-        Engine.get_section(state, section_name) ||
-          raise "Section '#{section_name}' not found"
-
-      # Get the project
-      built_project =
-        Engine.get_project(state, project_name) ||
-          raise "Project '#{project_name}' not found"
-
-      # Get the latest published publication for this project
-      latest_publication =
-        Oli.Publishing.get_latest_published_publication_by_slug(built_project.project.slug)
-
-      if is_nil(latest_publication) do
-        raise "No published publications found for project '#{project_name}'"
-      end
-
-      # Verify the section is from this project
-      if section.base_project_id != built_project.project.id do
-        raise "Section '#{section_name}' is not based on project '#{project_name}'"
-      end
-
-      # Apply the publication update to the section
-      result =
-        Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
-
-      # Check if result looks like an error
-      case result do
-        {:error, reason} ->
-          raise "Failed to apply update: #{inspect(reason)}"
-
-        {:ok, updated_section} ->
-          refreshed_section = Oli.Delivery.Sections.get_section!(updated_section.id)
-
-          # Update the section in state with the refreshed section
-          updated_state = Engine.put_section(state, section_name, refreshed_section)
-          {:ok, updated_state}
-
-        _ ->
-          updated_section = Oli.Delivery.Sections.get_section!(section.id)
-
-          updated_state = Engine.put_section(state, section_name, updated_section)
-          {:ok, updated_state}
+      # First check if target is a product
+      product = Engine.get_product(state, target_name)
+      
+      if product != nil do
+        # Handle product update
+        handle_product_update(project_name, target_name, product, state)
+      else
+        # Handle section update (existing logic)
+        handle_section_update(project_name, target_name, state)
       end
     rescue
       e ->
         {:error,
-         "Failed to apply update from '#{project_name}' to '#{section_name}': #{Exception.message(e)}"}
+         "Failed to apply update from '#{project_name}' to '#{target_name}': #{Exception.message(e)}"}
+    end
+  end
+
+  defp handle_product_update(project_name, product_name, product, state) do
+    # Get the project
+    built_project =
+      Engine.get_project(state, project_name) ||
+        raise "Project '#{project_name}' not found"
+
+    # Get the latest published publication for this project
+    latest_publication =
+      Oli.Publishing.get_latest_published_publication_by_slug(built_project.project.slug)
+
+    if is_nil(latest_publication) do
+      raise "No published publications found for project '#{project_name}'"
+    end
+
+    # Verify the product is from this project
+    if product.base_project_id != built_project.project.id do
+      raise "Product '#{product_name}' is not based on project '#{project_name}'"
+    end
+
+    # Apply the publication update to the product (which is actually a Section with type :blueprint)
+    result =
+      Oli.Delivery.Sections.Updates.apply_publication_update(product, latest_publication.id)
+
+    # Check if result looks like an error
+    case result do
+      {:error, reason} ->
+        raise "Failed to apply update: #{inspect(reason)}"
+
+      {:ok, updated_product} ->
+        refreshed_product = Oli.Delivery.Sections.get_section!(updated_product.id)
+
+        # Update the product in state with the refreshed product
+        updated_state = Engine.put_product(state, product_name, refreshed_product)
+        {:ok, updated_state}
+
+      _ ->
+        updated_product = Oli.Delivery.Sections.get_section!(product.id)
+
+        updated_state = Engine.put_product(state, product_name, updated_product)
+        {:ok, updated_state}
+    end
+  end
+
+  defp handle_section_update(project_name, section_name, state) do
+    # Get the section
+    section =
+      Engine.get_section(state, section_name) ||
+        raise "Section '#{section_name}' not found"
+
+    # Get the project
+    built_project =
+      Engine.get_project(state, project_name) ||
+        raise "Project '#{project_name}' not found"
+
+    # Get the latest published publication for this project
+    latest_publication =
+      Oli.Publishing.get_latest_published_publication_by_slug(built_project.project.slug)
+
+    if is_nil(latest_publication) do
+      raise "No published publications found for project '#{project_name}'"
+    end
+
+    # Verify the section is from this project
+    if section.base_project_id != built_project.project.id do
+      raise "Section '#{section_name}' is not based on project '#{project_name}'"
+    end
+
+    # Apply the publication update to the section
+    result =
+      Oli.Delivery.Sections.Updates.apply_publication_update(section, latest_publication.id)
+
+    # Check if result looks like an error
+    case result do
+      {:error, reason} ->
+        raise "Failed to apply update: #{inspect(reason)}"
+
+      {:ok, updated_section} ->
+        refreshed_section = Oli.Delivery.Sections.get_section!(updated_section.id)
+
+        # Update the section in state with the refreshed section
+        updated_state = Engine.put_section(state, section_name, refreshed_section)
+        {:ok, updated_state}
+
+      _ ->
+        updated_section = Oli.Delivery.Sections.get_section!(section.id)
+
+        updated_state = Engine.put_section(state, section_name, updated_section)
+        {:ok, updated_state}
     end
   end
 end


### PR DESCRIPTION
Adds a few more scenario integration tests for product based sections. 

Adds 1 new piece of `Oli.Scenarios` infrastructure, the `change:` operation for the `manipulate:` directive.  This allows a scenario to change a project, section or product setting like title, description, grace period.  This was needed so that we can toggle the `apply_major_updates` attribute of a product. 