### PR TITLE
[FEATURE] [MER-4677] Browse All Projects - Fix CSV download button style

### DIFF
--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -210,10 +210,11 @@ defmodule OliWeb.Projects.ProjectsLive do
           </button>
         </div>
         <button
-          class="mr-4 inline-flex items-center gap-1 text-sm font-medium text-[#0080FF] hover:underline"
+          class="group mr-4 inline-flex items-center gap-1 text-sm text-Text-text-button font-bold leading-none hover:text-Text-text-button-hover"
           phx-click="export_csv"
         >
-          Download CSV <Icons.download stroke_class="stroke-[#0080FF]" />
+          Download CSV
+          <Icons.download stroke_class="group-hover:stroke-Text-text-button-hover stroke-Text-text-button" />
         </button>
       </div>
 


### PR DESCRIPTION
[MER-4677](https://eliterate.atlassian.net/browse/MER-4677)

This PR fixes the button color styling for downloading the CSV file on the `Browse All Projects` view.


https://github.com/user-attachments/assets/718f16a6-e73f-4d11-9c54-cf19d81a3929



[MER-4677]: https://eliterate.atlassian.net/browse/MER-4677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ