### PR TITLE
[BUG FIX] [MER-4934] Spinning wheel of death / pages hanging

### DIFF
--- a/assets/src/apps/delivery/store/features/attempt/actions/createActivityAttempt.ts
+++ b/assets/src/apps/delivery/store/features/attempt/actions/createActivityAttempt.ts
@@ -37,6 +37,9 @@ export const createActivityAttempt = createAsyncThunk(
         seedResponses,
       );
       /* console.log({ new_attempt_result }); */
+      if (new_attempt_result === null) {
+        return attempt;
+      }
       attempt = new_attempt_result.attemptState as ActivityState;
       // this should be for the same resource id, which doesn't come back from the server
       // because it's already based on the previous attemptGuid

--- a/assets/src/data/persistence/state/intrinsic.ts
+++ b/assets/src/data/persistence/state/intrinsic.ts
@@ -127,6 +127,8 @@ export const createNewActivityAttempt = async (
     url,
     method,
     body: JSON.stringify({ seedResponsesWithPrevious }),
+  }).catch((e) => {
+    return null;
   });
   return result;
 };


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

### Root Cause:
Max attempt was set to 5. After every incorrect answer we create a new attempt. The server sends a hasMoreAttempts flag to indicate if more attempts are available — we create a new attempt only if this is true, otherwise we continue with the current attempt.

Server does not send hasMoreAttempts in the initial load.

The issue happened because after all attempts were exhausted, a page refresh would set hasMoreAttempts to true by default:

`hasMoreAttempts: result.hasMoreAttempts || true`


Since result.hasMoreAttempts wasn’t returned on initial load, it was always treated as true. As a result, when the user submitted again after a refresh, the system tried to create a new attempt even though none were available, causing server errors.

### Fix:

- If no attempts are available, continue with the current attempt instead of creating a new one.
- Gracefully handle errors from the server when attempts are exhausted.