### PR TITLE
[FEATURE] [MER-4710] Practice Pages Formatting Table UI

### DIFF
--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -43,6 +43,7 @@ defmodule OliWeb.Components.Delivery.CardHighlights do
         :units -> "Unit"
         :modules -> "Module"
         :students -> "Student"
+        :pages -> "Page"
         _ -> to_string(type || "")
       end
 

--- a/lib/oli_web/components/delivery/content/content.ex
+++ b/lib/oli_web/components/delivery/content/content.ex
@@ -213,14 +213,14 @@ defmodule OliWeb.Components.Delivery.Content do
               id="proficiency_select"
               options={@proficiency_options}
               selected_values={@selected_proficiency_options}
-              selected_proficiency_ids={@selected_proficiency_ids}
+              selected_ids={@selected_proficiency_ids}
               target={@myself}
               disabled={@selected_proficiency_ids == %{}}
               placeholder="Proficiency"
             />
 
             <button
-              class="ml-2 mr-6 text-center text-Text-text-high text-sm font-normal leading-none flex items-center gap-x-2"
+              class="ml-2 mr-6 text-center text-Text-text-high text-sm font-normal leading-none flex items-center gap-x-2 hover:text-Text-text-button"
               phx-click="clear_all_filters"
               phx-target={@myself}
             >
@@ -253,7 +253,7 @@ defmodule OliWeb.Components.Delivery.Content do
 
   def handle_event("apply_proficiency_filter", _params, socket) do
     %{
-      selected_proficiency_ids: selected_proficiency_ids,
+      selected_proficiency_ids: selected_ids,
       patch_url_type: patch_url_type
     } = socket.assigns
 
@@ -262,7 +262,7 @@ defmodule OliWeb.Components.Delivery.Content do
        to:
          route_for(
            socket,
-           %{selected_proficiency_ids: Jason.encode!(selected_proficiency_ids)},
+           %{selected_proficiency_ids: Jason.encode!(selected_ids)},
            patch_url_type
          )
      )}

--- a/lib/oli_web/components/delivery/content/multi_select.ex
+++ b/lib/oli_web/components/delivery/content/multi_select.ex
@@ -10,7 +10,9 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
   attr :id, :string
   attr :target, :map, default: %{}
   attr :selected_values, :map, default: %{}
-  attr :selected_proficiency_ids, :list, default: []
+  attr :selected_ids, :list, default: []
+  attr :submit_event, :string, default: "apply_proficiency_filter"
+  attr :label, :string, default: "Proficiency"
 
   def render(assigns) do
     ~H"""
@@ -41,7 +43,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
             :if={@selected_values != %{}}
             class="text-[#006CD9] dark:text-[#4CA6FF] text-base font-semibold leading-none"
           >
-            Proficiency is {show_proficiency_selected_values(@selected_values)}
+            {@label} is {show_selected_values(@selected_values)}
           </span>
         </div>
         <.toggle_chevron id={@id} map_values={@selected_values} />
@@ -68,7 +70,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
                 name={option.id}
                 value={option.selected}
                 label={option.name}
-                checked={option.id in @selected_proficiency_ids}
+                checked={option.id in @selected_ids}
                 type="checkbox"
                 label_class="text-zinc-900 text-xs font-normal leading-none dark:text-white"
               />
@@ -89,13 +91,13 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
             <button
               class="px-4 py-2 bg-[#0080FF] rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
               phx-click={
-                JS.push("apply_proficiency_filter")
+                JS.push(@submit_event)
                 |> JS.hide(to: "##{@id}-options-container")
                 |> JS.hide(to: "##{@id}-up-icon")
                 |> JS.show(to: "##{@id}-down-icon")
               }
               phx-target={@target}
-              phx-value={@selected_proficiency_ids}
+              phx-value={@selected_ids}
               disabled={@disabled}
             >
               Apply
@@ -107,7 +109,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
     """
   end
 
-  defp show_proficiency_selected_values(values) do
+  defp show_selected_values(values) do
     Enum.map_join(values, ", ", fn {_id, values} -> values end)
   end
 end

--- a/lib/oli_web/components/delivery/content/multi_select.ex
+++ b/lib/oli_web/components/delivery/content/multi_select.ex
@@ -99,6 +99,7 @@ defmodule OliWeb.Delivery.Content.MultiSelect do
               phx-target={@target}
               phx-value={@selected_ids}
               disabled={@disabled}
+              data-event={@submit_event}
             >
               Apply
             </button>

--- a/lib/oli_web/components/delivery/content/progress.ex
+++ b/lib/oli_web/components/delivery/content/progress.ex
@@ -3,9 +3,13 @@ defmodule OliWeb.Delivery.Content.Progress do
 
   import OliWeb.Components.Delivery.Buttons, only: [toggle_chevron: 1]
 
-  attr(:progress_percentage, :string, default: "100")
+  attr(:id, :string, default: "progress")
+  attr(:progress_percentage, :string)
   attr(:params_from_url, :map, default: %{})
   attr(:target, :any)
+  attr(:label, :string, default: "Progress")
+  attr(:submit_event, :string, default: "apply_progress_filter")
+  attr(:input_name, :string, default: "progress_percentage")
 
   attr(:progress_selector, :atom,
     values: [:is_equal_to, :is_less_than_or_equal, :is_greather_than_or_equal]
@@ -18,14 +22,13 @@ defmodule OliWeb.Delivery.Content.Progress do
     <div class="relative !z-50">
       <div
         phx-click={
-          JS.toggle(to: "#progress_form", display: "flex")
-          |> JS.toggle(to: "#progress-down-icon")
-          |> JS.toggle(to: "#progress-up-icon")
+          JS.toggle(to: "##{@id}_form", display: "flex")
+          |> JS.toggle(to: "##{@id}-down-icon")
+          |> JS.toggle(to: "##{@id}-up-icon")
         }
         class="w-full h-9"
       >
         <button
-          data-dropdown-toggle="dropdown"
           class={[
             "h-full flex-shrink-0 rounded z-10 inline-flex items-center py-2.5 px-2 text-[#353740] text-base font-semibold leading-none",
             "outline outline-1",
@@ -37,57 +40,57 @@ defmodule OliWeb.Delivery.Content.Progress do
           ]}
           type="button"
         >
-          Progress {progress_filter_text(
-            @params_from_url,
-            @progress_selector,
-            @progress_percentage
-          )}
+          {@label}
+          {progress_filter_text(@params_from_url, @progress_selector, @progress_percentage)}
           <div class="ml-2">
-            <.toggle_chevron id="progress" map_values={@progress_selector} />
+            <.toggle_chevron id={@id} map_values={@progress_selector} />
           </div>
         </button>
       </div>
       <.form
         for={%{}}
         phx-click-away={
-          JS.hide(to: "#progress_form")
-          |> JS.hide(to: "#progress-up-icon")
-          |> JS.show(to: "#progress-down-icon")
+          JS.hide(to: "##{@id}_form")
+          |> JS.hide(to: "##{@id}-up-icon")
+          |> JS.show(to: "##{@id}-down-icon")
         }
         class="hidden bg-white dark:bg-gray-800 mt-1 rounded border flex flex-col p-2 px-4 absolute w-auto"
-        phx-submit="apply_progress_filter"
-        id="progress_form"
+        phx-submit={@submit_event}
+        id={"#{@id}_form"}
         phx-target={@target}
       >
         <div class="progress-options mt-2">
           {radio_button(:progress, :option, "is_equal_to",
             field: "is_equal_to",
             checked: @progress_selector == :is_equal_to,
-            id: "is_equal_to"
+            id: "#{@id}_is_equal_to"
           )}
-          <label for="is_equal_to">{"is ="}</label>
+          <label for={"#{@id}_is_equal_to"}>is =</label>
+
           {radio_button(:progress, :option, "is_less_than_or_equal",
             field: "is_less_than_or_equal",
             checked: @progress_selector == :is_less_than_or_equal,
-            id: "is_less_than_or_equal"
+            id: "#{@id}_is_less_than_or_equal"
           )}
-          <label for="is_less_than_or_equal">{"< ="}</label>
+          <label for={"#{@id}_is_less_than_or_equal"}>&le;</label>
+
           {radio_button(:progress, :option, "is_greather_than_or_equal",
             field: "is_greather_than_or_equal",
             checked: @progress_selector == :is_greather_than_or_equal,
-            id: "is_greather_than_or_equal"
+            id: "#{@id}_is_greather_than_or_equal"
           )}
-          <label for="is_greather_than_or_equal">{"> ="}</label>
+          <label for={"#{@id}_is_greather_than_or_equal"}>&ge;</label>
         </div>
         <div class="flex items-center gap-2 mt-4">
           <.input
             type="number"
             min="0"
             max="100"
-            name="progress_percentage"
+            name={@input_name}
             value={@progress_percentage}
             class="w-[75px] h-[27px] border border-slate-300 text-xs"
-          /> <span class="text-xs">&percnt;</span>
+          />
+          <span class="text-xs">&percnt;</span>
         </div>
         <div>
           <div class="w-full border border-gray-200 my-4"></div>
@@ -95,9 +98,9 @@ defmodule OliWeb.Delivery.Content.Progress do
             <button
               type="button"
               phx-click={
-                JS.hide(to: "#progress_form")
-                |> JS.hide(to: "#progress-up-icon")
-                |> JS.show(to: "#progress-down-icon")
+                JS.hide(to: "##{@id}_form")
+                |> JS.hide(to: "##{@id}-up-icon")
+                |> JS.show(to: "##{@id}-down-icon")
               }
               class="text-center text-[#006CD9] text-xs font-semibold leading-none dark:text-white"
             >
@@ -105,9 +108,9 @@ defmodule OliWeb.Delivery.Content.Progress do
             </button>
             <button
               phx-click={
-                JS.hide(to: "#progress_form")
-                |> JS.hide(to: "#progress-up-icon")
-                |> JS.show(to: "#progress-down-icon")
+                JS.hide(to: "##{@id}_form")
+                |> JS.hide(to: "##{@id}-up-icon")
+                |> JS.show(to: "##{@id}-down-icon")
               }
               class="px-4 py-2 bg-[#0080FF] rounded justify-center items-center gap-2 inline-flex opacity-90 text-right text-white text-xs font-semibold leading-none"
             >
@@ -119,6 +122,8 @@ defmodule OliWeb.Delivery.Content.Progress do
     </div>
     """
   end
+
+  defp progress_filter_text(_params, nil, _progress_percentage), do: nil
 
   defp progress_filter_text(%{"progress_percentage" => _}, progress_selector, progress_percentage) do
     progress_selector_text =

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -190,7 +190,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
               id="proficiency_select"
               options={@proficiency_options}
               selected_values={@selected_proficiency_options}
-              selected_proficiency_ids={@selected_proficiency_ids}
+              selected_ids={@selected_proficiency_ids}
               target={@myself}
               disabled={@selected_proficiency_ids == %{}}
               placeholder="Proficiency"

--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -1,12 +1,13 @@
 defmodule OliWeb.Components.Delivery.PracticeActivities do
   use OliWeb, :live_component
 
-  alias OliWeb.Common.InstructorDashboardPagedTable
-
-  alias OliWeb.Common.{Params, SearchInput}
+  alias OliWeb.Common.{Params, SearchInput, StripedPagedTable}
   alias OliWeb.Common.Table.SortableTableModel
+  alias OliWeb.Components.Delivery.CardHighlights
   alias OliWeb.Delivery.ActivityHelpers
+  alias OliWeb.Delivery.Content.{MultiSelect, Progress}
   alias OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel
+  alias OliWeb.Icons
   alias OliWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
 
@@ -16,8 +17,19 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
     sort_order: :asc,
     sort_by: :order,
     text_search: nil,
-    container_id: nil
+    selected_card_value: nil,
+    progress_percentage: 100,
+    progress_selector: nil,
+    avg_score_percentage: 100,
+    avg_score_selector: nil,
+    selected_attempts_ids: Jason.encode!([])
   }
+
+  @attempts_options [
+    %{id: 1, name: "None", selected: false},
+    %{id: 2, name: "Less than 5", selected: false},
+    %{id: 3, name: "More than 5", selected: false}
+  ]
 
   def mount(socket) do
     {:ok,
@@ -44,10 +56,45 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
       })
       |> SortableTableModel.update_sort_params(params.sort_by)
 
+    selected_card_value = Map.get(assigns.params, "selected_card_value", nil)
+    assessments_count = assessments_count(assigns.assessments)
+
+    card_props = [
+      %{
+        title: "Low Scores",
+        count: Map.get(assessments_count, :low_scores),
+        is_selected: selected_card_value == "low_scores",
+        value: :low_scores
+      },
+      %{
+        title: "Low Progress",
+        count: Map.get(assessments_count, :low_progress),
+        is_selected: selected_card_value == "low_progress",
+        value: :low_progress
+      },
+      %{
+        title: "Low or No Attempts",
+        count: Map.get(assessments_count, :low_or_no_attempts),
+        is_selected: selected_card_value == "low_or_no_attempts",
+        value: :low_or_no_attempts
+      }
+    ]
+
+    selected_attempts_ids = Jason.decode!(params.selected_attempts_ids)
+    attempts_options = update_attempts_options(selected_attempts_ids, @attempts_options)
+
+    selected_attempts_options =
+      Enum.reduce(attempts_options, %{}, fn option, acc ->
+        if option.selected,
+          do: Map.put(acc, option.id, option.name),
+          else: acc
+      end)
+
     {:ok,
      assign(socket,
        params: params,
        section: assigns.section,
+       section_slug: assigns.section.slug,
        view: assigns.view,
        ctx: assigns.ctx,
        assessments: assigns.assessments,
@@ -58,72 +105,114 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
        preview_rendered: nil,
        units_and_modules_options: assigns.units_and_modules_options,
        table_model: table_model,
-       total_count: total_count
+       total_count: total_count,
+       card_props: card_props,
+       params_from_url: assigns.params,
+       attempts_options: attempts_options,
+       selected_attempts_ids: selected_attempts_ids,
+       selected_attempts_options: selected_attempts_options
      )}
   end
+
+  attr(:params, :map, required: true)
+  attr(:section_slug, :string, required: true)
+  attr(:card_props, :list)
 
   def render(assigns) do
     ~H"""
     <div>
       <.loader :if={!@table_model} />
       <div :if={@table_model} class="bg-white shadow-sm dark:bg-gray-800 dark:text-white">
-        <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:justify-between px-9 lg:items-center">
-          <h4 class="torus-h4 whitespace-nowrap">Practice Activities</h4>
-          <div class="flex flex-col">
-            <div class="flex sm:flex-row gap-y-4 flex-col gap-x-2 items-center sm:justify-between">
-              <form
-                for="search"
-                phx-target={@myself}
-                phx-change="search_assessment"
-                class="pb-6 lg:ml-auto lg:pt-7 order-last"
-              >
-                <SearchInput.render
-                  id="assessments_search_input"
-                  name="assessment_name"
-                  text={@params.text_search}
-                />
-              </form>
-              <.form
-                id="select_container_form"
-                for={%{}}
-                phx-change="change_container"
-                phx-target={@myself}
-              >
-                <div
-                  :if={length(@units_and_modules_options) > 0}
-                  class="inline-flex flex-col gap-1 mr-2"
-                >
-                  <small class="torus-small uppercase">
-                    Container
-                  </small>
-                  <select class="torus-select" name="container_id">
-                    <option value={nil}>All</option>
-                    <option
-                      :for={container <- @units_and_modules_options}
-                      selected={assigns.params.container_id == container.resource_id}
-                      value={container.resource_id}
-                    >
-                      {if(container.numbering_level == 1, do: "Unit", else: "Module")} {container.numbering_index}: {container.title}
-                    </option>
-                  </select>
-                </div>
-              </.form>
-            </div>
+        <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:justify-between px-4 pt-8 pb-4 lg:items-center instructor_dashboard_table dark:bg-[#262626]">
+          <div class="self-stretch justify-center text-zinc-700 text-lg font-bold leading-normal dark:text-white">
+            Practice Pages
+          </div>
+          <div>
+            <a
+              href=""
+              class="flex items-center justify-center gap-x-2 text-Text-text-button font-bold leading-none"
+            >
+              Download CSV <Icons.download />
+            </a>
           </div>
         </div>
 
-        <InstructorDashboardPagedTable.render
+        <div class="flex flex-row mx-4 gap-x-4">
+          <%= for card <- @card_props do %>
+            <CardHighlights.render
+              title={card.title}
+              count={card.count}
+              is_selected={card.is_selected}
+              value={card.value}
+              on_click={JS.push("select_card", target: @myself)}
+              container_filter_by={:pages}
+            />
+          <% end %>
+        </div>
+
+        <div class="flex w-fit gap-2 mx-4 mt-4 mb-4 shadow-[0px_2px_6.099999904632568px_0px_rgba(0,0,0,0.10)] border border-Border-border-default bg-Background-bg-secondary">
+          <div class="flex p-2 gap-2">
+            <.form for={%{}} phx-target={@myself} phx-change="search_page" class="w-56">
+              <SearchInput.render
+                id="practice_activities_search_input"
+                name="page_name"
+                text={@params.text_search}
+              />
+            </.form>
+
+            <Progress.render
+              target={@myself}
+              progress_percentage={@params.progress_percentage}
+              progress_selector={@params.progress_selector}
+              params_from_url={@params_from_url}
+            />
+
+            <MultiSelect.render
+              id="attempts_select"
+              label="Attempts"
+              options={@attempts_options}
+              selected_values={@selected_attempts_options}
+              selected_ids={@selected_attempts_ids}
+              target={@myself}
+              disabled={@selected_attempts_ids == %{}}
+              placeholder="Attempts"
+              submit_event="apply_attempts_filter"
+            />
+
+            <Progress.render
+              id="score"
+              label="Score"
+              target={@myself}
+              progress_percentage={@params.avg_score_percentage}
+              progress_selector={@params.avg_score_selector}
+              params_from_url={@params_from_url}
+              submit_event="apply_avg_score_filter"
+              input_name="avg_score_percentage"
+            />
+
+            <button
+              class="ml-2 mr-6 text-center text-Text-text-high text-sm font-normal leading-none flex items-center gap-x-2 hover:text-Text-text-button"
+              phx-click="clear_all_filters"
+              phx-target={@myself}
+            >
+              <Icons.trash /> Clear All Filters
+            </button>
+          </div>
+        </div>
+
+        <StripedPagedTable.render
           table_model={@table_model}
           total_count={@total_count}
           offset={@params.offset}
           limit={@params.limit}
-          page_change={JS.push("paged_table_page_change", target: @myself)}
-          selection_change={JS.push("paged_table_selection_change", target: @myself)}
-          sort={JS.push("paged_table_sort", target: @myself)}
+          render_top_info={false}
           additional_table_class="instructor_dashboard_table"
+          sort={JS.push("paged_table_sort", target: @myself)}
+          page_change={JS.push("paged_table_page_change", target: @myself)}
+          limit_change={JS.push("paged_table_limit_change", target: @myself)}
+          selection_change={JS.push("paged_table_selection_change", target: @myself)}
           allow_selection={true}
           show_bottom_paging={false}
-          limit_change={JS.push("paged_table_limit_change", target: @myself)}
           show_limit_change={true}
         />
       </div>
@@ -243,8 +332,8 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
   end
 
   def handle_event(
-        "search_assessment",
-        %{"assessment_name" => assessment_name},
+        "search_page",
+        %{"page_name" => page_name},
         socket
       ) do
     {:noreply,
@@ -255,7 +344,7 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
          route_to(
            socket,
            update_params(socket.assigns.params, %{
-             text_search: assessment_name,
+             text_search: page_name,
              offset: 0
            })
          )
@@ -326,30 +415,194 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
      )}
   end
 
-  def handle_event("change_container", %{"container_id" => container_id} = _params, socket) do
+  def handle_event("toggle_selected", %{"_target" => [id]}, socket) do
+    selected_id = String.to_integer(id)
+    do_update_selection(socket, selected_id)
+  end
+
+  def handle_event("apply_attempts_filter", _params, socket) do
+    %{
+      selected_attempts_ids: selected_ids,
+      params: params
+    } = socket.assigns
+
     {:noreply,
-     socket
-     |> assign(activities: nil, current_assessment: nil)
-     |> push_patch(
+     push_patch(socket,
        to:
          route_to(
            socket,
-           update_params(socket.assigns.params, %{
-             container_id: container_id,
-             offset: 0
-           })
+           update_params(params, %{selected_attempts_ids: Jason.encode!(selected_ids)})
          )
      )}
+  end
+
+  def handle_event(
+        "apply_progress_filter",
+        %{
+          "progress_percentage" => progress_percentage,
+          "progress" => %{"option" => progress_selector}
+        },
+        socket
+      ) do
+    new_params =
+      %{
+        progress_percentage: progress_percentage,
+        progress_selector: progress_selector
+      }
+
+    {:noreply,
+     push_patch(socket,
+       to: route_to(socket, update_params(socket.assigns.params, new_params))
+     )}
+  end
+
+  def handle_event(
+        "apply_avg_score_filter",
+        %{
+          "avg_score_percentage" => avg_score_percentage,
+          "progress" => %{"option" => avg_score_selector}
+        },
+        socket
+      ) do
+    new_params =
+      %{
+        avg_score_percentage: avg_score_percentage,
+        avg_score_selector: avg_score_selector
+      }
+
+    {:noreply,
+     push_patch(socket,
+       to: route_to(socket, update_params(socket.assigns.params, new_params))
+     )}
+  end
+
+  def handle_event("select_card", %{"selected" => value}, socket) do
+    value =
+      if String.to_existing_atom(value) == Map.get(socket.assigns.params, :selected_card_value),
+        do: nil,
+        else: String.to_existing_atom(value)
+
+    send(self(), {:selected_card_assessments, value})
+
+    {:noreply, socket}
+  end
+
+  def handle_event("clear_all_filters", _params, socket) do
+    section_slug = socket.assigns.section.slug
+    path = ~p"/sections/#{section_slug}/instructor_dashboard/insights/practice_activities"
+    {:noreply, push_patch(socket, to: path)}
   end
 
   defp apply_filters(assessments, params) do
     assessments =
       assessments
-      |> maybe_filter_by_container_resource_id(params.container_id)
       |> maybe_filter_by_text(params.text_search)
+      |> maybe_filter_by_card(params.selected_card_value)
+      |> maybe_filter_by_progress(params.progress_selector, params.progress_percentage)
+      |> maybe_filter_by_avg_score(params.avg_score_selector, params.avg_score_percentage)
+      |> maybe_filter_by_attempts(params.selected_attempts_ids)
       |> sort_by(params.sort_by, params.sort_order)
 
     {length(assessments), assessments |> Enum.drop(params.offset) |> Enum.take(params.limit)}
+  end
+
+  defp maybe_filter_by_card(assessments, :low_scores),
+    do:
+      Enum.filter(assessments, fn assessment ->
+        assessment.avg_score < 0.40
+      end)
+
+  defp maybe_filter_by_card(assessments, :low_progress),
+    do: Enum.filter(assessments, fn assessment -> assessment.students_completion < 0.40 end)
+
+  defp maybe_filter_by_card(assessments, :low_or_no_attempts),
+    do: Enum.filter(assessments, fn assessment -> assessment.total_attempts <= 5 end)
+
+  defp maybe_filter_by_card(assessments, _), do: assessments
+
+  defp maybe_filter_by_progress(assessments, progress_selector, percentage) do
+    case progress_selector do
+      :is_equal_to ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.students_completion || 0.0) == percentage
+        end)
+
+      :is_less_than_or_equal ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.students_completion || 0.0) <= percentage
+        end)
+
+      :is_greather_than_or_equal ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.students_completion || 0.0) >= percentage
+        end)
+
+      nil ->
+        assessments
+    end
+  end
+
+  defp maybe_filter_by_avg_score(assessments, avg_score_selector, avg_score_percentage) do
+    case avg_score_selector do
+      :is_equal_to ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.avg_score || 0.0) == avg_score_percentage
+        end)
+
+      :is_less_than_or_equal ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.avg_score || 0.0) <= avg_score_percentage
+        end)
+
+      :is_greather_than_or_equal ->
+        Enum.filter(assessments, fn assessment ->
+          parse_progress(assessment.avg_score || 0.0) >= avg_score_percentage
+        end)
+
+      nil ->
+        assessments
+    end
+  end
+
+  defp maybe_filter_by_attempts(assessments, "[]"), do: assessments
+
+  defp maybe_filter_by_attempts(assessments, selected_attempts_ids) do
+    selected_attempts_ids = Jason.decode!(selected_attempts_ids)
+
+    Enum.filter(assessments, fn assessment ->
+      Enum.any?(selected_attempts_ids, fn
+        1 -> assessment.total_attempts == 0
+        2 -> assessment.total_attempts < 5
+        3 -> assessment.total_attempts > 5
+        _ -> false
+      end)
+    end)
+  end
+
+  defp parse_progress(progress) do
+    {progress, _} =
+      Float.round(progress * 100)
+      |> Float.to_string()
+      |> Integer.parse()
+
+    progress
+  end
+
+  defp assessments_count(assessments) do
+    %{
+      low_scores:
+        Enum.count(assessments, fn assessment ->
+          assessment.avg_score < 0.40
+        end),
+      low_progress:
+        Enum.count(assessments, fn assessment ->
+          assessment.students_completion < 0.40
+        end),
+      low_or_no_attempts:
+        Enum.count(assessments, fn assessment ->
+          assessment.total_attempts <= 5
+        end)
+    }
   end
 
   defp maybe_filter_by_text(assessments, nil), do: assessments
@@ -361,15 +614,6 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
         String.downcase(assessment.title),
         String.downcase(text_search)
       )
-    end)
-  end
-
-  defp maybe_filter_by_container_resource_id(assessments, nil), do: assessments
-  defp maybe_filter_by_container_resource_id(assessments, ""), do: assessments
-
-  defp maybe_filter_by_container_resource_id(assessments, container_id) do
-    Enum.filter(assessments, fn assessment ->
-      assessment.container_id == container_id
     end)
   end
 
@@ -427,7 +671,33 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
       text_search: Params.get_param(params, "text_search", @default_params.text_search),
       assessment_id: Params.get_int_param(params, "assessment_id", nil),
       selected_activity: Params.get_param(params, "selected_activity", nil),
-      container_id: Params.get_int_param(params, "container_id", nil)
+      selected_card_value:
+        Params.get_atom_param(
+          params,
+          "selected_card_value",
+          [:low_scores, :low_progress, :low_or_no_attempts],
+          @default_params.selected_card_value
+        ),
+      progress_percentage:
+        Params.get_int_param(params, "progress_percentage", @default_params.progress_percentage),
+      progress_selector:
+        Params.get_atom_param(
+          params,
+          "progress_selector",
+          [:is_equal_to, :is_less_than_or_equal, :is_greather_than_or_equal],
+          @default_params.progress_selector
+        ),
+      avg_score_percentage:
+        Params.get_int_param(params, "avg_score_percentage", @default_params.avg_score_percentage),
+      avg_score_selector:
+        Params.get_atom_param(
+          params,
+          "avg_score_selector",
+          [:is_equal_to, :is_less_than_or_equal, :is_greather_than_or_equal],
+          @default_params.avg_score_selector
+        ),
+      selected_attempts_ids:
+        Params.get_param(params, "selected_attempts_ids", @default_params.selected_attempts_ids)
     }
   end
 
@@ -470,6 +740,12 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
     )
   end
 
+  defp update_attempts_options(selected_attempts_ids, attempts_options) do
+    Enum.map(attempts_options, fn option ->
+      if option.id in selected_attempts_ids, do: %{option | selected: true}, else: option
+    end)
+  end
+
   defp assign_selected_assessment(socket, selected_assessment_resource_id)
        when selected_assessment_resource_id in ["", nil] do
     case socket.assigns.table_model.rows do
@@ -488,5 +764,28 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
       })
 
     assign(socket, table_model: table_model)
+  end
+
+  defp do_update_selection(socket, selected_id) do
+    %{attempts_options: attempts_options} = socket.assigns
+
+    updated_options =
+      Enum.map(attempts_options, fn option ->
+        if option.id == selected_id, do: %{option | selected: !option.selected}, else: option
+      end)
+
+    {selected_attempts_options, selected_ids} =
+      Enum.reduce(updated_options, {%{}, []}, fn option, {values, acc_ids} ->
+        if option.selected,
+          do: {Map.put(values, option.id, option.name), [option.id | acc_ids]},
+          else: {values, acc_ids}
+      end)
+
+    {:noreply,
+     assign(socket,
+       selected_attempts_options: selected_attempts_options,
+       attempts_options: updated_options,
+       selected_attempts_ids: selected_ids
+     )}
   end
 end

--- a/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_assessments_table_model.ex
@@ -1,39 +1,45 @@
 defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
   use Phoenix.Component
+  use OliWeb, :verified_routes
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Icons
+  alias OliWeb.Delivery.InstructorDashboard.HTMLComponents
 
   def new(assessments, ctx, target) do
     column_specs = [
       %ColumnSpec{
         name: :order,
-        label: "ORDER",
-        render_fn: &__MODULE__.render_order_column/3,
-        th_class: "pl-10"
+        label: "#",
+        th_class: "w-2"
       },
       %ColumnSpec{
         name: :title,
-        label: "ASSESSMENT",
-        render_fn: &__MODULE__.render_assessment_column/3,
+        label: "Page Title",
+        render_fn: &render_assessment_column/3,
         th_class: "pl-2"
       },
       %ColumnSpec{
         name: :avg_score,
-        label: "AVG SCORE",
-        render_fn: &__MODULE__.render_avg_score_column/3
+        label: HTMLComponents.render_proficiency_label(%{title: "Avg Score"}),
+        render_fn: &render_avg_score_column/3,
+        td_class: "!pl-10",
+        tooltip: "Average score across all student attempts on this page."
       },
       %ColumnSpec{
         name: :total_attempts,
-        label: "TOTAL ATTEMPTS",
-        render_fn: &__MODULE__.render_attempts_column/3
+        label: HTMLComponents.render_proficiency_label(%{title: "Total Attempts"}),
+        render_fn: &render_attempts_column/3,
+        td_class: "!pl-10",
+        tooltip:
+          "Total number of attempts made by all students. Some students may have multiple attempts based on your course settings."
       },
       %ColumnSpec{
         name: :students_completion,
-        label: "STUDENTS PROGRESS",
-        tooltip:
-          "Progress is percent attempted of activities present on the page from the most recent page attempt. If there are no activities within the page, and if the student has visited that page, we count that as an attempt.",
-        render_fn: &__MODULE__.render_students_completion_column/3
+        label: HTMLComponents.render_proficiency_label(%{title: "Students Progress"}),
+        render_fn: &render_students_completion_column/3,
+        td_class: "!pl-10",
+        tooltip: "Average progress on this page across all students."
       }
     ]
 
@@ -49,23 +55,15 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
     )
   end
 
-  def render_order_column(assigns, assessment, _) do
-    assigns = Map.merge(assigns, %{order: assessment.order})
-
-    ~H"""
-    <div class="pl-9 pr-4 flex flex-col">
-      {@order}
-    </div>
-    """
-  end
-
   def render_assessment_column(assigns, assessment, _) do
     assigns =
       Map.merge(assigns, %{
         title: assessment.title,
+        slug: assessment.slug,
         container_label: assessment.container_label,
         resource_id: assessment.resource_id,
-        has_lti_activity: assessment.has_lti_activity
+        has_lti_activity: assessment.has_lti_activity,
+        section_slug: assigns.ctx.section.slug
       })
 
     ~H"""
@@ -78,22 +76,37 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
         class="flex items-center gap-2"
       >
         <Icons.plug />
-        <.question_text container_label={@container_label} title={@title} />
+        <.question_text
+          container_label={@container_label}
+          title={@title}
+          slug={@slug}
+          section_slug={@section_slug}
+        />
       </div>
     <% else %>
-      <.question_text container_label={@container_label} title={@title} />
+      <.question_text
+        container_label={@container_label}
+        title={@title}
+        slug={@slug}
+        section_slug={@section_slug}
+      />
     <% end %>
     """
   end
 
   defp question_text(assigns) do
     ~H"""
-    <div class="pl-0 pr-4 flex flex-col">
+    <div class="pl-0 pr-4 flex flex-col gap-y-1 py-2">
       <%= if @container_label do %>
-        <span class="text-gray-600 font-bold text-sm">{@container_label}</span>
+        <span class="text-Text-text-high text-sm font-bold leading-none">{@container_label}</span>
       <% end %>
       <span>
-        {@title}
+        <a
+          href={~p"/sections/#{@section_slug}/preview/page/#{@slug}"}
+          class="text-Text-text-link text-base font-medium leading-normal"
+        >
+          {@title}
+        </a>
       </span>
     </div>
     """
@@ -103,7 +116,7 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
     assigns = Map.merge(assigns, %{avg_score: assessment.avg_score})
 
     ~H"""
-    <div class={if @avg_score < 0.40, do: "text-red-600 font-bold"}>
+    <div class={"text-Text-text-high text-sm font-bold leading-none #{if @avg_score < 0.40, do: "text-Text-text-danger"}"}>
       {format_value(@avg_score)}
     </div>
     """
@@ -113,7 +126,9 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
     assigns = Map.merge(assigns, %{total_attempts: assessment.total_attempts})
 
     ~H"""
-    {@total_attempts || "-"}
+    <div class="text-Text-text-high text-sm font-bold leading-none">
+      {@total_attempts || "-"}
+    </div>
     """
   end
 
@@ -125,7 +140,7 @@ defmodule OliWeb.Delivery.PracticeActivities.PracticeAssessmentsTableModel do
       })
 
     ~H"""
-    <div class={if @students_completion < 0.40, do: "text-red-600 font-bold"}>
+    <div class={"text-Text-text-high text-sm font-bold leading-none #{if @students_completion < 0.40, do: "text-Text-text-danger"}"}>
       {format_value(@students_completion)}
     </div>
     """

--- a/lib/oli_web/components/delivery/students/students.ex
+++ b/lib/oli_web/components/delivery/students/students.ex
@@ -587,7 +587,7 @@ defmodule OliWeb.Components.Delivery.Students do
               id="proficiency_select"
               options={@proficiency_options}
               selected_values={@selected_proficiency_options}
-              selected_proficiency_ids={@selected_proficiency_ids}
+              selected_ids={@selected_proficiency_ids}
               target={@myself}
               disabled={@selected_proficiency_ids == %{}}
               placeholder="Proficiency"

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -451,7 +451,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
         active: is_active_tab?(:scored_activities, active_tab)
       },
       %TabLink{
-        label: "Practice Activities",
+        label: "Practice Pages",
         path: path_for(:insights, :practice_activities, section_slug, preview_mode),
         badge: nil,
         active: is_active_tab?(:practice_activities, active_tab)

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -631,7 +631,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
     ~H"""
     <InstructorDashboard.tabs tabs={insights_tabs(@section_slug, @preview_mode, @active_tab)} />
 
-    <div class="mx-10 mb-10">
+    <div class="container mx-auto mb-10">
       <.live_component
         id="practice_activities_tab"
         module={OliWeb.Components.Delivery.PracticeActivities}
@@ -653,7 +653,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
     ~H"""
     <InstructorDashboard.tabs tabs={insights_tabs(@section_slug, @preview_mode, @active_tab)} />
 
-    <div class="mx-10 mb-10">
+    <div class="container mx-auto mb-10">
       <.live_component
         id="surveys_tab"
         module={OliWeb.Components.Delivery.Surveys}
@@ -793,6 +793,19 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
        socket |> put_flash(:info, message),
        to:
          ~p"/sections/#{socket.assigns.section_slug}/instructor_dashboard/#{socket.assigns.view}/#{socket.assigns.active_tab}"
+     )}
+  end
+
+  def handle_info(
+        {:selected_card_assessments, value},
+        socket
+      ) do
+    params = Map.merge(socket.assigns.params, %{"selected_card_value" => value})
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/practice_activities?#{params}"
      )}
   end
 

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -134,8 +134,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
       refute has_element?(view, "a.active", "Learning Objectives")
       assert has_element?(view, "a", "Scored Pages")
       refute has_element?(view, "a.active", "Scored Pages")
-      assert has_element?(view, "a", "Practice Activities")
-      refute has_element?(view, "a.active", "Practice Activities")
+      assert has_element?(view, "a", "Practice Pages")
+      refute has_element?(view, "a.active", "Practice Pages")
       assert has_element?(view, "a", "Surveys")
       refute has_element?(view, "a.active", "Surveys")
     end

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1142,6 +1142,408 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       # Checks for displaying student progress with a value different from null
       assert a0.total_attempts == "25%"
     end
+
+    test "Progress filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      Enum.each(1..5, fn _ ->
+        set_activity_attempt(
+          page_1,
+          mcq_activity_1,
+          student_1,
+          section,
+          project.id,
+          publication.id,
+          "id_for_option_a",
+          true
+        )
+      end)
+
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
+
+      # All pages are shown before applying any filters
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title =~ "Orphaned Page"
+
+      # Apply progress filter: show pages with progress exactly 25%
+      view
+      |> element("form[phx-submit=\"apply_progress_filter\"]")
+      |> render_submit(%{
+        "progress_percentage" => "25",
+        "progress" => %{"option" => "is_equal_to"}
+      })
+
+      assert has_element?(view, "button", "Progress is = 25")
+
+      # After filter: only Page 1 matches the 25% progress
+      pages = [page1] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 1
+      assert page1.title == "Module 1: IntroductionPage 1"
+    end
+
+    test "Score filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      Enum.each(1..5, fn _ ->
+        set_activity_attempt(
+          page_1,
+          mcq_activity_1,
+          student_1,
+          section,
+          project.id,
+          publication.id,
+          "id_for_option_a",
+          true
+        )
+      end)
+
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
+
+      # All pages are shown before applying any filters
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title =~ "Orphaned Page"
+
+      # Apply score filter: show pages with score exactly 100%
+      view
+      |> element("form[phx-submit=\"apply_avg_score_filter\"]")
+      |> render_submit(%{
+        "avg_score_percentage" => "100",
+        "progress" => %{"option" => "is_equal_to"}
+      })
+
+      assert has_element?(view, "button", "Score is = 100")
+
+      # After filter: only Page 1 and Page 2 match the 100% score
+      pages = [page1, page2] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 2
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+    end
+
+    test "Attemps filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      Enum.each(1..5, fn _ ->
+        set_activity_attempt(
+          page_1,
+          mcq_activity_1,
+          student_1,
+          section,
+          project.id,
+          publication.id,
+          "id_for_option_a",
+          true
+        )
+      end)
+
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
+
+      # All pages are shown before applying any filters
+      assert a0.title == "Module 1: IntroductionPage 1"
+      assert a1.title == "Module 1: IntroductionPage 2"
+      assert a2.title == "Module 2: BasicsPage 3"
+      assert a3.title == "Module 2: BasicsPage 4"
+      assert a4.title =~ "Orphaned Page"
+
+      # Simulate toggle of option "2"
+      view
+      |> element("form[phx-change=\"toggle_selected\"]")
+      |> render_change(%{
+        "_target" => ["2"]
+      })
+
+      assert has_element?(view, "span", "Attempts is Less than 5")
+
+      # Trigger attempts filter via 'Apply' button
+      view
+      |> element("button[data-event='apply_attempts_filter']")
+      |> render_click()
+
+      # After filter: only Page 2 is shown
+      pages = [page1] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 1
+      assert page1.title == "Module 1: IntroductionPage 2"
+    end
+
+    test "Clear all filters works correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      Enum.each(1..5, fn _ ->
+        set_activity_attempt(
+          page_1,
+          mcq_activity_1,
+          student_1,
+          section,
+          project.id,
+          publication.id,
+          "id_for_option_a",
+          true
+        )
+      end)
+
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        true
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      # Filter by progress
+      view
+      |> element("form[phx-submit=\"apply_progress_filter\"]")
+      |> render_submit(%{
+        "progress_percentage" => "25",
+        "progress" => %{"option" => "is_equal_to"}
+      })
+
+      # Filter by progress was applied
+      pages = [page1] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 1
+      assert page1.title == "Module 1: IntroductionPage 1"
+
+      # Clear all filters and check that all pages are shown
+      view
+      |> element("button[phx-click='clear_all_filters']")
+      |> render_click()
+
+      # After filter: all pages are shown
+      pages = [page1, page2, page3, page4, page5] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 5
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+      assert page3.title == "Module 2: BasicsPage 3"
+      assert page4.title == "Module 2: BasicsPage 4"
+      assert page5.title =~ "Orphaned Page"
+    end
+
+    test "Low Scores filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        false
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      pages = [page1, page2, page3, page4, page5] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 5
+
+      # All pages are shown before applying any filters
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+      assert page3.title == "Module 2: BasicsPage 3"
+      assert page4.title == "Module 2: BasicsPage 4"
+      assert page5.title =~ "Orphaned Page"
+
+      # Filter by low scores clicking on the card
+      view
+      |> element("div[phx-value-selected=\"low_scores\"]")
+      |> render_click()
+
+      # After filter: only Page 2 is shown
+      pages = [page2] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 1
+      assert page2.title == "Module 1: IntroductionPage 2"
+    end
+
+    test "Low Progress filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        false
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      pages = [page1, page2, page3, page4, page5] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 5
+
+      # All pages are shown before applying any filters
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+      assert page3.title == "Module 2: BasicsPage 3"
+      assert page4.title == "Module 2: BasicsPage 4"
+      assert page5.title =~ "Orphaned Page"
+
+      # Filter by low progress clicking on the card
+      view
+      |> element("div[phx-value-selected=\"low_progress\"]")
+      |> render_click()
+
+      # After filter: Page 1 and Page 2 are shown
+      pages = [page1, page2] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 2
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+    end
+
+    test "Low or No Attempts filter works correctly", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      student_1: student_1,
+      mcq_activity_1: mcq_activity_1,
+      mcq_activity_2: mcq_activity_2,
+      project: project,
+      publication: publication
+    } do
+      Enum.each(1..3, fn _ ->
+        set_activity_attempt(
+          page_1,
+          mcq_activity_1,
+          student_1,
+          section,
+          project.id,
+          publication.id,
+          "id_for_option_a",
+          true
+        )
+      end)
+
+      set_activity_attempt(
+        page_2,
+        mcq_activity_2,
+        student_1,
+        section,
+        project.id,
+        publication.id,
+        "id_for_option_a",
+        false
+      )
+
+      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
+
+      pages = [page1, page2, page3, page4, page5] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 5
+
+      # All pages are shown before applying any filters
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+      assert page3.title == "Module 2: BasicsPage 3"
+      assert page4.title == "Module 2: BasicsPage 4"
+      assert page5.title =~ "Orphaned Page"
+
+      # Filter by low or no attempts clicking on the card
+      view
+      |> element("div[phx-value-selected=\"low_or_no_attempts\"]")
+      |> render_click()
+
+      # After filter: Page 1 and Page 2 are shown
+      pages = [page1, page2] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 2
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
+    end
   end
 
   describe "details of assessment activities" do

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1116,7 +1116,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
     } do
       {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
 
-      assert has_element?(view, "h4", "Practice Activities")
+      assert has_element?(view, "div", "Practice Pages")
       assert has_element?(view, "p", "None exist")
     end
   end
@@ -1132,7 +1132,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
 
       [a0, a1, a2, a3, a4] = table_as_list_of_maps(view)
 
-      assert has_element?(view, "h4", "Practice Activities")
+      assert has_element?(view, "div", "Practice Pages")
       assert a0.title == "Module 1: IntroductionPage 1"
       assert a1.title == "Module 1: IntroductionPage 2"
       assert a2.title == "Module 2: BasicsPage 3"
@@ -1141,55 +1141,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
 
       # Checks for displaying student progress with a value different from null
       assert a0.total_attempts == "25%"
-    end
-
-    test "gets results correctly when changing the container selection", %{
-      conn: conn,
-      section: section,
-      page_1: page_1,
-      page_2: page_2,
-      unit_1: unit_1,
-      module_1: module_1
-    } do
-      {:ok, view, _html} = live(conn, live_view_practice_activities_route(section.slug))
-
-      view
-      |> element("form[phx-change='change_container']")
-      |> render_change(%{container_id: module_1.resource_id})
-
-      [page0, page1] = table_as_list_of_maps(view)
-
-      assert element(
-               view,
-               "table tbody tr[id='#{page_1.resource_id}']",
-               page0.title
-             )
-
-      assert element(
-               view,
-               "table tbody tr td div[phx-value-id='#{page_2.id}']",
-               page1.title
-             )
-
-      assert has_element?(
-               view,
-               "table tbody tr td div span",
-               module_1.title
-             )
-
-      # unit 1 does not have any direct practice page attached
-      # (the filter only shows direct children pages of the selected container)
-      view
-      |> element("form[phx-change='change_container']")
-      |> render_change(%{container_id: unit_1.resource_id})
-
-      refute has_element?(
-               view,
-               "table tbody tr td div span",
-               unit_1.title
-             )
-
-      assert view |> element("p", "None exist")
     end
   end
 


### PR DESCRIPTION
[MER-4710](https://eliterate.atlassian.net/browse/MER-4710)

This PR implements visual improvements to the `Insights > Practice Pages` view to help instructors scan information more quickly and effectively, following the design specifications provided in Figma.

Key changes include:

- Applied zebra striping to table rows for better readability.
- Grouped the `Progress`, `Attempts`, and `Score` filters together with the search field into a unified toolbar.
- Added a visually updated `Clear All Filters` button matching the Figma design.
- Made the table header row sticky, keeping it visible while scrolling vertically.
- Pagination behavior remains unchanged.
- The `Download CSV` button has been added to match the Figma design, but its functionality is not implemented in this ticket.

In addition, the changes requested in [MER-4705](https://eliterate.atlassian.net/browse/MER-4705) are addressed:

- The tab label is updated to `Practice Pages`
- All filters reference `pages` instead of `activities`
- The page title/header displays as `Practice Pages`
- In the table, the `Title` column is renamed to `Page Title`



https://github.com/user-attachments/assets/7b0b29e1-d514-45f9-b7f3-6513cc9aa556



[MER-4710]: https://eliterate.atlassian.net/browse/MER-4710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MER-4705]: https://eliterate.atlassian.net/browse/MER-4705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ