### PR TITLE
 [BUG FIX] [MER-4956] Captcha Loop if student is invited via email, but signs-in with invitation link

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -506,7 +506,7 @@ defmodule Oli.Delivery.Sections do
       # Enrollment exists, we are potentially just updating it
       e -> e
     end
-    |> Enrollment.changeset(%{section_id: section_id})
+    |> Enrollment.changeset(%{section_id: section_id, status: status})
     |> Ecto.Changeset.put_assoc(:context_roles, context_roles)
     |> Repo.insert_or_update()
   end


### PR DESCRIPTION
In `Sections.enroll/3` when the enrollment already exists update the status (Default status: enrolled).
This fixes the case when an existing pending enrollment exists, and we call Sections.enroll for that user, the status should be updated to `:enrolled`

See: https://eliterate.atlassian.net/browse/MER-4956