### PR TITLE
[BUG FIX] [MER-4958] Skip enrollment check in LiveSession plug if section does not require enrollment.

### DIFF
--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -14,12 +14,11 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
         %{
           assigns: %{
             current_user: user,
-            current_author: author,
             section: %Sections.Section{requires_enrollment: false} = section
           }
         } = socket
       )
-      when not is_nil(user) or not is_nil(author) do
+      when not is_nil(user) do
     if user, do: Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
     {:cont, assign(socket, is_enrolled: true)}
   end

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -6,6 +6,14 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
 
   alias Oli.Delivery.Sections
 
+  def on_mount(
+        :default,
+        _params,
+        _session,
+        %{assigns: %{section: %Sections.Section{requires_enrollment: false}}} = socket
+      ),
+      do: {:cont, socket}
+
   def on_mount(:default, %{"section_slug" => section_slug}, _session, socket) do
     is_admin? = Oli.Accounts.is_admin?(socket.assigns[:current_author])
 

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -5,14 +5,24 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
   import Phoenix.LiveView, only: [redirect: 2, put_flash: 3]
 
   alias Oli.Delivery.Sections
+  alias Lti_1p3.Roles.ContextRoles
 
   def on_mount(
         :default,
         _params,
         _session,
-        %{assigns: %{section: %Sections.Section{requires_enrollment: false}}} = socket
-      ),
-      do: {:cont, socket}
+        %{
+          assigns: %{
+            current_user: user,
+            current_author: author,
+            section: %Sections.Section{requires_enrollment: false} = section
+          }
+        } = socket
+      )
+      when not is_nil(user) or not is_nil(author) do
+    if user, do: Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+    {:cont, assign(socket, is_enrolled: true)}
+  end
 
   def on_mount(:default, %{"section_slug" => section_slug}, _session, socket) do
     is_admin? = Oli.Accounts.is_admin?(socket.assigns[:current_author])

--- a/test/oli_web/live_session_plugs/require_enrollment_test.exs
+++ b/test/oli_web/live_session_plugs/require_enrollment_test.exs
@@ -1,0 +1,120 @@
+defmodule OliWeb.LiveSessionPlugs.RequireEnrollmentTest do
+  use OliWeb.ConnCase, async: true
+
+  import Oli.Factory
+
+  alias Phoenix.LiveView
+  alias OliWeb.LiveSessionPlugs.RequireEnrollment
+  alias Oli.Delivery.Sections
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> Map.replace!(:secret_key_base, OliWeb.Endpoint.config(:secret_key_base))
+      |> init_test_session(%{})
+
+    user = insert(:user)
+    author = insert(:author)
+
+    %{user: user, author: author, conn: conn}
+  end
+
+  describe "on_mount: :default with section that doesn't require enrollment" do
+    test "allows access when section requires_enrollment is false" do
+      section = %Sections.Section{requires_enrollment: false}
+
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}, section: section}
+      }
+
+      assert {:cont, ^socket} = RequireEnrollment.on_mount(:default, %{}, %{}, socket)
+    end
+  end
+
+  describe "on_mount: :default with section_slug" do
+    test "allows access for admin author", %{author: author} do
+      author = %{author | system_role_id: 2}
+
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}, current_author: author}
+      }
+
+      assert {:cont, updated_socket} =
+               RequireEnrollment.on_mount(
+                 :default,
+                 %{"section_slug" => "test_section"},
+                 %{},
+                 socket
+               )
+
+      assert updated_socket.assigns.is_enrolled == true
+    end
+
+    test "redirects to login when no user is present" do
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}, current_author: nil, flash: %{}}
+      }
+
+      assert {:halt, redirected_socket} =
+               RequireEnrollment.on_mount(
+                 :default,
+                 %{"section_slug" => "test_section"},
+                 %{},
+                 socket
+               )
+
+      assert redirected_socket.redirected
+    end
+
+    test "redirects to student workspace when user is not enrolled", %{user: user} do
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}, current_user: user, current_author: nil, flash: %{}}
+      }
+
+      assert {:halt, redirected_socket} =
+               RequireEnrollment.on_mount(
+                 :default,
+                 %{"section_slug" => "nonexistent_section"},
+                 %{},
+                 socket
+               )
+
+      assert redirected_socket.redirected
+    end
+
+    test "allows access when user is enrolled", %{user: user} do
+      section = insert(:section)
+      insert(:enrollment, user: user, section: section)
+
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}, current_user: user, current_author: nil}
+      }
+
+      assert {:cont, updated_socket} =
+               RequireEnrollment.on_mount(
+                 :default,
+                 %{"section_slug" => section.slug},
+                 %{},
+                 socket
+               )
+
+      assert updated_socket.assigns.is_enrolled == true
+    end
+  end
+
+  describe "on_mount: :default without section_slug" do
+    test "continues without checking enrollment" do
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{__changed__: %{}}
+      }
+
+      assert {:cont, ^socket} = RequireEnrollment.on_mount(:default, %{}, %{}, socket)
+    end
+  end
+end

--- a/test/oli_web/live_session_plugs/require_enrollment_test.exs
+++ b/test/oli_web/live_session_plugs/require_enrollment_test.exs
@@ -36,26 +36,12 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollmentTest do
       assert Sections.is_enrolled?(user.id, section.slug)
     end
 
-    test "sets is_enrolled for author when section requires_enrollment is false", %{
-      author: author
-    } do
-      section = insert(:section, requires_enrollment: false)
-
-      socket = %LiveView.Socket{
-        endpoint: OliWeb.Endpoint,
-        assigns: %{__changed__: %{}, current_user: nil, current_author: author, section: section}
-      }
-
-      assert {:cont, updated_socket} = RequireEnrollment.on_mount(:default, %{}, %{}, socket)
-      assert updated_socket.assigns.is_enrolled == true
-    end
-
-    test "falls through to default clause when both current_user and current_author are nil" do
+    test "falls through to default clause when current_user is nil" do
       section = %Sections.Section{requires_enrollment: false}
 
       socket = %LiveView.Socket{
         endpoint: OliWeb.Endpoint,
-        assigns: %{__changed__: %{}, current_user: nil, current_author: nil, section: section}
+        assigns: %{__changed__: %{}, current_user: nil, section: section}
       }
 
       assert {:cont, ^socket} = RequireEnrollment.on_mount(:default, %{}, %{}, socket)


### PR DESCRIPTION
If section doesn't require enrollment and the user or author is logged in:
1) [If user is logged in] enrolls it to the section (this is needed for future steps like checking if the user has visited that section)
2) Assigns `is_enrolled: true` and continues




See: https://eliterate.atlassian.net/browse/TRIAGE-1882