### PR TITLE
[ENHANCEMENT] [MER-4960] Cache activation points

### DIFF
--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -62,7 +62,17 @@ defmodule Oli.Application do
         # Starts Cachex to store page content info
         Oli.Delivery.DistributedDepotCoordinator,
         Oli.Delivery.DepotWarmer,
-        {Cachex, name: :page_content_cache},
+        Supervisor.child_spec({Cachex, name: :page_content_cache}, id: :page_content_cache),
+
+        # Cache assistant replies for AI page triggers (per-node, capped)
+        Supervisor.child_spec(
+          {Cachex,
+           name: :ai_page_trigger_reply_cache,
+           # Keep at most 10k entries, evict oldest first
+           limit: 10_000,
+           policy: Cachex.Policy.LRW},
+          id: :ai_page_trigger_reply_cache
+        ),
 
         # Starts Cachex to store vr user agents
         Oli.VrLookupCache,

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -66,11 +66,11 @@ defmodule Oli.Application do
 
         # Cache assistant replies for AI page triggers (per-node, capped)
         Supervisor.child_spec(
-          {Cachex,
-           name: :ai_page_trigger_reply_cache,
-           # Keep at most 10k entries, evict oldest first
-           limit: 10_000,
-           policy: Cachex.Policy.LRW},
+          {
+            Cachex,
+            # Keep at most 10k entries, evict oldest first
+            name: :ai_page_trigger_reply_cache, limit: 10_000, policy: Cachex.Policy.LRW
+          },
           id: :ai_page_trigger_reply_cache
         ),
 

--- a/lib/oli/conversation/dialogue_handler.ex
+++ b/lib/oli/conversation/dialogue_handler.ex
@@ -85,6 +85,7 @@ defmodule Oli.Conversation.DialogueHandler do
               case socket.assigns[:last_trigger_meta] do
                 %{type: :page, revision_id: rid} when is_binary(socket.assigns.active_message) ->
                   PageTriggerReplyCache.put(rid, socket.assigns.active_message)
+
                 _ ->
                   :ok
               end
@@ -101,7 +102,7 @@ defmodule Oli.Conversation.DialogueHandler do
                    active_message: nil,
                    allow_submission?: allow_submission?,
                    last_trigger_meta: nil
-                  )}
+                 )}
 
               [trigger | rest] ->
                 prompt = Oli.Conversation.Triggers.assemble_trigger_prompt(trigger)

--- a/lib/oli/conversation/page_trigger_reply_cache.ex
+++ b/lib/oli/conversation/page_trigger_reply_cache.ex
@@ -1,0 +1,31 @@
+defmodule Oli.Conversation.PageTriggerReplyCache do
+  @moduledoc """
+  Per-node cache for assistant replies to page visit triggers, keyed by
+  page `revision_id`. Used to avoid unnecessary LLM calls for repeated
+  visits to the same page revision.
+
+  This cache is intentionally non-distributed. Each node maintains its
+  own entries. Eviction is handled by Cachex according to the limit
+  configured in the application supervisor.
+  """
+
+  @cache_name :ai_page_trigger_reply_cache
+
+  @spec get(any()) :: {:hit, String.t()} | :miss | {:error, term()}
+  def get(revision_id) do
+    case Cachex.get(@cache_name, revision_id) do
+      {:ok, nil} -> :miss
+      {:ok, value} -> {:hit, value}
+      other -> {:error, other}
+    end
+  end
+
+  @spec put(any(), String.t()) :: :ok | {:error, term()}
+  def put(revision_id, reply_text) when is_binary(reply_text) do
+    case Cachex.put(@cache_name, revision_id, reply_text) do
+      {:ok, _} -> :ok
+      other -> {:error, other}
+    end
+  end
+end
+

--- a/lib/oli/conversation/page_trigger_reply_cache.ex
+++ b/lib/oli/conversation/page_trigger_reply_cache.ex
@@ -28,4 +28,3 @@ defmodule Oli.Conversation.PageTriggerReplyCache do
     end
   end
 end
-

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -96,19 +96,19 @@ defmodule OliWeb.Dialogue.WindowLive do
            build_dialogue(section, project, session["revision_id"], current_user_id, self()),
          form: to_form(UserInput.changeset(%UserInput{}, %{content: ""})),
          streaming: false,
-          allow_submission?: true,
-          trigger_queue: [],
+         allow_submission?: true,
+         trigger_queue: [],
          last_trigger_meta: nil,
          active_message: nil,
-          function_call: nil,
-          title: "Dot",
-          current_user: Oli.Accounts.get_user!(current_user_id),
-          height: 500,
-          width: 400,
-          section: section,
-          resource_id: session["resource_id"],
+         function_call: nil,
+         title: "Dot",
+         current_user: Oli.Accounts.get_user!(current_user_id),
+         height: 500,
+         width: 400,
+         section: section,
+         resource_id: session["resource_id"],
          revision_id: session["revision_id"],
-          is_page: session["is_page"] == true || false
+         is_page: session["is_page"] == true || false
        )}
     else
       {:ok, assign(socket, enabled: false)}


### PR DESCRIPTION
This PR adds a per node cache for the page view activation points.  This should significantly cut down on OpenAI API endpoint usage and thus lower costs.  