### PR TITLE
[BUG FIX] [MER-000] devmode.sh quote claude alias body with argument

### DIFF
--- a/devmode.sh
+++ b/devmode.sh
@@ -61,7 +61,7 @@ echo "## "
 echo "## Use the command 'exit' to leave anytime."
 echo "## To get started, run 'mix phx.server'"
 
-ALIASES="alias c=claude --dangerously-skip-permissions; alias dc=docker-compose; alias reload-env='set -a;source oli.env;';"
+ALIASES="alias c='claude --dangerously-skip-permissions'; alias dc=docker-compose; alias reload-env='set -a;source oli.env;';"
 FUNCTIONS="cd() { builtin cd \"\$@\" && ls; };"
 PROMPT="PS1='\n\[\e[0m\]🚧 oli-dev \[\e[0;34m\][\[\e[0;34m\]\w\[\e[0;34m\]]\[\e[0m\] $ \[\e[0m\]';"
 


### PR DESCRIPTION
The c alias definition was giving error message because it needed quotes to include the argument. 