### PR TITLE
[FEATURE] [MER-4666] Better search for "Browse all" type tables in Admin workspace

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -43,6 +43,19 @@ a.download::after {
   content: '\f019';
 }
 
+.search-highlight {
+  background-color: #fde68a;
+  color: inherit;
+  border-radius: 0.25rem;
+  padding: 0 0.15rem;
+  font-style: normal;
+}
+
+.dark .search-highlight {
+  background-color: #2563eb;
+  color: #0f172a;
+}
+
 .slate-editor p:last-child {
   @apply mb-0;
 }

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -116,9 +116,16 @@ defmodule Oli.Authoring.Course do
       if include_deleted, do: dynamic([p], true), else: dynamic([p], p.status == :active)
 
     filter_by_text =
-      if text_search == "",
-        do: dynamic([p], true),
-        else: dynamic([p], ilike(p.title, ^"%#{text_search}%"))
+      text_search
+      |> project_search_patterns()
+      |> Enum.reduce(dynamic([p], true), fn pattern, acc ->
+        dynamic(
+          [p, ap, a, _, _, _, owner],
+          ^acc and
+            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
+               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
+        )
+      end)
 
     where_clause = dynamic([p], ^filter_by_status and ^filter_by_text)
 
@@ -221,9 +228,16 @@ defmodule Oli.Authoring.Course do
       if include_deleted, do: dynamic([_, p], true), else: dynamic([_, p], p.status == :active)
 
     filter_by_text =
-      if text_search == "",
-        do: dynamic([_, p], true),
-        else: dynamic([_, p], ilike(p.title, ^"%#{text_search}%"))
+      text_search
+      |> project_search_patterns()
+      |> Enum.reduce(dynamic([_, p], true), fn pattern, acc ->
+        dynamic(
+          [_, p, a, _, _, _, owner],
+          ^acc and
+            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
+               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
+        )
+      end)
 
     where_clause =
       dynamic(
@@ -356,7 +370,16 @@ defmodule Oli.Authoring.Course do
     filter_by_status = if include_deleted, do: true, else: dynamic([p], p.status == :active)
 
     filter_by_text =
-      if text_search == "", do: true, else: dynamic([p], ilike(p.title, ^"%#{text_search}%"))
+      text_search
+      |> project_search_patterns()
+      |> Enum.reduce(true, fn pattern, acc ->
+        dynamic(
+          [p, ap, a, _, _, _, owner],
+          ^acc and
+            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
+               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
+        )
+      end)
 
     owner_id = ProjectRole.role_id().owner
 
@@ -458,9 +481,16 @@ defmodule Oli.Authoring.Course do
       if include_deleted, do: true, else: dynamic([p, _, _, _, _, _], p.status == ^:active)
 
     filter_by_text =
-      if text_search == "",
-        do: true,
-        else: dynamic([p, _, _, _, _, _], ilike(p.title, ^"%#{text_search}%"))
+      text_search
+      |> project_search_patterns()
+      |> Enum.reduce(true, fn pattern, acc ->
+        dynamic(
+          [p, ap, a, op, owner],
+          ^acc and
+            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
+               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
+        )
+      end)
 
     query =
       Project
@@ -877,5 +907,19 @@ defmodule Oli.Authoring.Course do
     ap
     |> AuthorProject.changeset(attrs)
     |> Repo.update()
+  end
+
+  defp project_search_patterns(text_search) do
+    text_search
+    |> String.trim()
+    |> case do
+      "" ->
+        []
+
+      trimmed ->
+        trimmed
+        |> String.split(~r/\s+/, trim: true)
+        |> Enum.map(&"%#{&1}%")
+    end
   end
 end

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -909,6 +909,8 @@ defmodule Oli.Authoring.Course do
     |> Repo.update()
   end
 
+  defp project_search_patterns(nil), do: []
+
   defp project_search_patterns(text_search) do
     text_search
     |> String.trim()

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -370,16 +370,7 @@ defmodule Oli.Authoring.Course do
     filter_by_status = if include_deleted, do: true, else: dynamic([p], p.status == :active)
 
     filter_by_text =
-      text_search
-      |> project_search_patterns()
-      |> Enum.reduce(true, fn pattern, acc ->
-        dynamic(
-          [p, ap, a, _, _, _, owner],
-          ^acc and
-            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
-               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
-        )
-      end)
+      if text_search == "", do: true, else: dynamic([p], ilike(p.title, ^"%#{text_search}%"))
 
     owner_id = ProjectRole.role_id().owner
 
@@ -481,16 +472,9 @@ defmodule Oli.Authoring.Course do
       if include_deleted, do: true, else: dynamic([p, _, _, _, _, _], p.status == ^:active)
 
     filter_by_text =
-      text_search
-      |> project_search_patterns()
-      |> Enum.reduce(true, fn pattern, acc ->
-        dynamic(
-          [p, ap, a, op, owner],
-          ^acc and
-            (ilike(p.title, ^pattern) or ilike(p.slug, ^pattern) or ilike(owner.name, ^pattern) or
-               ilike(owner.email, ^pattern) or ilike(a.name, ^pattern))
-        )
-      end)
+      if text_search == "",
+        do: true,
+        else: dynamic([p, _, _, _, _, _], ilike(p.title, ^"%#{text_search}%"))
 
     query =
       Project

--- a/lib/oli/delivery/sections/browse.ex
+++ b/lib/oli/delivery/sections/browse.ex
@@ -9,23 +9,7 @@ defmodule Oli.Delivery.Sections.Browse do
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
 
-  @chars_to_replace_on_search [
-    " ",
-    "&",
-    ":",
-    ";",
-    "(",
-    ")",
-    "|",
-    "!",
-    "'",
-    "<",
-    ">",
-    "-",
-    "_",
-    "@",
-    "."
-  ]
+  @chars_to_replace_on_search [" ", "&", ":", ";", "(", ")", "|", "!", "'", "<", ">"]
 
   @doc """
     Paged, sorted, filterable queries for course sections. Joins the institution,

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -279,7 +279,7 @@ defmodule OliWeb.Common.Utils do
   end
 
   @doc """
-  Helper to highlight search term in text. Returns HTML-safe string with matches wrapped in <em> tags.
+  Helper to highlight search term in text. Returns HTML-safe string with matches wrapped in <em> tags by default.
 
   ## Examples
 
@@ -291,17 +291,21 @@ defmodule OliWeb.Common.Utils do
 
       iex> highlight_search_term("Hello World", "")
       "Hello World"
-  """
-  def highlight_search_term(text, nil), do: escape_html(text)
-  def highlight_search_term(text, ""), do: escape_html(text)
 
-  def highlight_search_term(text, search_term) do
+      iex> highlight_search_term("Hello World", "world", "foo", "bar")
+      "Hello <foo>World</bar>"
+  """
+  def highlight_search_term(text, term, tagstart \\ "em", tagend \\ "em")
+  def highlight_search_term(text, nil, _, _), do: escape_html(text)
+  def highlight_search_term(text, "", _, _), do: escape_html(text)
+
+  def highlight_search_term(text, search_term, tagstart, tagend) do
     pattern = Regex.escape(search_term)
     regex = ~r/#{pattern}/i
 
     text
     |> escape_html()
-    |> String.replace(regex, "<span class=\"search-highlight\">\\0</span>")
+    |> String.replace(regex, "<#{tagstart}>\\0</#{tagend}>")
   end
 
   defp escape_html(text) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -301,7 +301,7 @@ defmodule OliWeb.Common.Utils do
 
     text
     |> escape_html()
-    |> String.replace(regex, "<em>\\0</em>")
+    |> String.replace(regex, "<span class=\"search-highlight\">\\0</span>")
   end
 
   defp escape_html(text) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -297,7 +297,6 @@ defmodule OliWeb.Common.Utils do
 
   def highlight_search_term(text, search_term) do
     pattern = Regex.escape(search_term)
-    # case insensitive match
     regex = ~r/#{pattern}/i
 
     text

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -316,9 +316,15 @@ defmodule OliWeb.Common.Utils do
     |> String.split()
     |> Stream.map(&escape_html/1)
     |> Stream.map(&Regex.escape/1)
-    |> Enum.reduce(text, fn term, acc ->
-      String.replace(acc, ~r/#{term}/i, fn match -> "<#{tagstart}>#{match}</#{tagend}>" end)
-    end)
+    |> Enum.join("|")
+    |> Regex.compile("i")
+    |> case do
+      {:ok, regex} ->
+        String.replace(text, regex, fn match -> "<#{tagstart}>#{match}</#{tagend}>" end)
+
+      _ ->
+        text
+    end
   end
 
   defp escape_html(text) do

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -307,9 +307,8 @@ defmodule OliWeb.Common.Utils do
     search_term
     |> String.split(@chars_to_replace_on_search, trim: true)
     |> Stream.map(&Regex.escape/1)
-    |> Stream.map(fn pattern -> {pattern, "<#{tagstart}>#{pattern}</#{tagend}>"} end)
-    |> Enum.reduce(text, fn {from, to}, acc ->
-      String.replace(acc, ~r/#{from}/i, to)
+    |> Enum.reduce(text, fn term, acc ->
+      String.replace(acc, ~r/#{term}/i, fn match -> "<#{tagstart}>#{match}</#{tagend}>" end)
     end)
   end
 

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -4,10 +4,12 @@ defmodule OliWeb.Products.ProductsTableModel do
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.FormatDateTime
+  alias OliWeb.Common.Utils
 
   def new(products, ctx, project_slug \\ "", opts \\ []) do
     default_td_class = "!border-r border-Table-table-border"
     default_th_class = "!border-r border-Table-table-border"
+    search_term = Keyword.get(opts, :search_term, "")
 
     column_specs = [
       %ColumnSpec{
@@ -63,7 +65,7 @@ defmodule OliWeb.Products.ProductsTableModel do
       id_field: [:id],
       sort_by_spec: sort_by_spec,
       sort_order: sort_order,
-      data: %{ctx: ctx}
+      data: %{ctx: ctx, search_term: search_term}
     )
   end
 
@@ -83,7 +85,15 @@ defmodule OliWeb.Products.ProductsTableModel do
         project_slug -> ~p"/workspaces/course_author/#{project_slug}/products/#{slug}"
       end
 
-    assigns = Map.merge(assigns, %{title: title, slug: slug, route_path: route_path})
+    search_term = Map.get(assigns, :search_term, "")
+
+    assigns =
+      Map.merge(assigns, %{
+        title: title,
+        slug: slug,
+        route_path: route_path,
+        search_term: search_term
+      })
 
     ~H"""
     <div class="flex flex-col">
@@ -91,10 +101,10 @@ defmodule OliWeb.Products.ProductsTableModel do
         href={@route_path}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {@title}
+        {Phoenix.HTML.raw(Utils.highlight_search_term(@title || "", @search_term))}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {@slug}
+        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@slug || "", @search_term))}
       </span>
     </div>
     """
@@ -107,7 +117,14 @@ defmodule OliWeb.Products.ProductsTableModel do
         _project_slug -> ~p"/workspaces/course_author/#{base_project}/overview"
       end
 
-    assigns = Map.merge(assigns, %{base_project: base_project, route_path: route_path})
+    search_term = Map.get(assigns, :search_term, "")
+
+    assigns =
+      Map.merge(assigns, %{
+        base_project: base_project,
+        route_path: route_path,
+        search_term: search_term
+      })
 
     ~H"""
     <div class="flex flex-col">
@@ -115,10 +132,10 @@ defmodule OliWeb.Products.ProductsTableModel do
         href={@route_path}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {@base_project.title}
+        {Phoenix.HTML.raw(Utils.highlight_search_term(@base_project.title || "", @search_term))}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {@base_project.slug}
+        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@base_project.slug || "", @search_term))}
       </span>
     </div>
     """

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -101,10 +101,10 @@ defmodule OliWeb.Products.ProductsTableModel do
         href={@route_path}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {Phoenix.HTML.raw(Utils.highlight_search_term(@title || "", @search_term))}
+        {highlight_search_term(@title, @search_term)}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@slug || "", @search_term))}
+        ID: {highlight_search_term(@slug, @search_term)}
       </span>
     </div>
     """
@@ -132,10 +132,10 @@ defmodule OliWeb.Products.ProductsTableModel do
         href={@route_path}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {Phoenix.HTML.raw(Utils.highlight_search_term(@base_project.title || "", @search_term))}
+        {highlight_search_term(@base_project.title, @search_term)}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@base_project.slug || "", @search_term))}
+        ID: {highlight_search_term(@base_project.slug, @search_term)}
       </span>
     </div>
     """
@@ -198,4 +198,15 @@ defmodule OliWeb.Products.ProductsTableModel do
        _ -> Decimal.new(0)
      end, {order, Decimal}}
   end
+
+  defp highlight_search_term(text, search_term),
+    do:
+      Phoenix.HTML.raw(
+        Utils.highlight_search_term(
+          text || "",
+          search_term,
+          "span class=\"search-highlight\"",
+          "span"
+        )
+      )
 end

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -202,7 +202,7 @@ defmodule OliWeb.Products.ProductsTableModel do
   defp highlight_search_term(text, search_term),
     do:
       Phoenix.HTML.raw(
-        Utils.highlight_search_term(
+        Utils.multi_highlight_search_term(
           text || "",
           search_term,
           "span class=\"search-highlight\"",

--- a/lib/oli_web/live/projects/projects_live.ex
+++ b/lib/oli_web/live/projects/projects_live.ex
@@ -20,6 +20,7 @@ defmodule OliWeb.Projects.ProjectsLive do
   alias OliWeb.Router.Helpers, as: Routes
 
   @limit 20
+  @min_search_length 3
 
   on_mount {OliWeb.AuthorAuth, :ensure_authenticated}
   on_mount OliWeb.LiveSessionPlugs.SetCtx
@@ -36,19 +37,24 @@ defmodule OliWeb.Projects.ProjectsLive do
 
     show_deleted = Accounts.get_author_preference(author, :admin_show_deleted_projects, false)
 
+    initial_search = ""
+    applied_search = sanitize_search_term(initial_search)
+
     projects =
       Course.browse_projects(
         author,
         %Paging{offset: 0, limit: @limit},
         %Sorting{direction: :desc, field: :inserted_at},
         include_deleted: show_deleted,
-        admin_show_all: show_all
+        admin_show_all: show_all,
+        text_search: applied_search
       )
 
     {:ok, table_model} =
       TableModel.new(ctx, projects,
         sort_by_spec: :inserted_at,
-        sort_order: :desc
+        sort_order: :desc,
+        search_term: applied_search
       )
 
     total_count = determine_total(projects)
@@ -67,7 +73,9 @@ defmodule OliWeb.Projects.ProjectsLive do
        show_deleted: show_deleted,
        title: "Projects",
        limit: @limit,
-       export_filename: export_filename
+       export_filename: export_filename,
+       text_search: initial_search,
+       offset: 0
      )}
   end
 
@@ -89,7 +97,8 @@ defmodule OliWeb.Projects.ProjectsLive do
     table_model = SortableTableModel.update_from_params(socket.assigns.table_model, params)
 
     offset = get_int_param(params, "offset", 0)
-    text_search = get_param(params, "text_search", "")
+    text_search = params |> get_param("text_search", "") |> String.trim()
+    applied_search = sanitize_search_term(text_search)
     limit = get_int_param(params, "limit", @limit)
 
     # if author is an admin, get the show_all value and update if its changed
@@ -124,10 +133,14 @@ defmodule OliWeb.Projects.ProjectsLive do
         %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
         include_deleted: show_deleted,
         admin_show_all: show_all,
-        text_search: text_search
+        text_search: applied_search
       )
 
-    table_model = %SortableTableModel{table_model | rows: projects}
+    table_model =
+      table_model
+      |> Map.put(:rows, projects)
+      |> Map.update!(:data, &Map.put(&1, :search_term, applied_search))
+
     total_count = determine_total(projects)
 
     {:noreply,
@@ -272,7 +285,7 @@ defmodule OliWeb.Projects.ProjectsLive do
   end
 
   def handle_event("text_search_change", %{"project_name" => project_name}, socket) do
-    patch_with(socket, %{text_search: project_name})
+    patch_with(socket, %{text_search: String.trim(project_name)})
   end
 
   def handle_event("paged_table_sort", %{"sort_by" => sort_by_str}, socket) do
@@ -340,4 +353,16 @@ defmodule OliWeb.Projects.ProjectsLive do
 
   defp toggle_sort_order(:asc), do: :desc
   defp toggle_sort_order(_), do: :asc
+
+  defp sanitize_search_term(nil), do: ""
+
+  defp sanitize_search_term(search) when is_binary(search) do
+    trimmed = String.trim(search)
+
+    cond do
+      trimmed == "" -> ""
+      String.length(trimmed) < @min_search_length -> ""
+      true -> trimmed
+    end
+  end
 end

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -259,7 +259,7 @@ defmodule OliWeb.Projects.TableModel do
   defp highlight_search_term(text, search_term),
     do:
       Phoenix.HTML.raw(
-        Utils.highlight_search_term(
+        Utils.multi_highlight_search_term(
           text || "",
           search_term,
           "span class=\"search-highlight\"",

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -2,12 +2,13 @@ defmodule OliWeb.Projects.TableModel do
   use Phoenix.Component
   use OliWeb, :verified_routes
 
-  alias OliWeb.Common.{Chip, FormatDateTime, SessionContext}
+  alias OliWeb.Common.{Chip, FormatDateTime, SessionContext, Utils}
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
 
   def new(%SessionContext{} = ctx, sections, opts \\ []) do
     default_td_class = "!border-r border-Table-table-border"
     default_th_class = "!border-r border-Table-table-border"
+    search_term = Keyword.get(opts, :search_term, "")
 
     column_specs = [
       %ColumnSpec{
@@ -81,14 +82,18 @@ defmodule OliWeb.Projects.TableModel do
       sort_by_spec: sort_by_spec,
       sort_order: sort_order,
       data: %{
-        ctx: ctx
+        ctx: ctx,
+        search_term: search_term
       }
     )
   end
 
   # Title
   def custom_render(assigns, project, %ColumnSpec{name: :title}) do
-    assigns = Map.merge(assigns, %{project: project})
+    assigns =
+      assigns
+      |> Map.put_new(:search_term, Map.get(assigns, :search_term, ""))
+      |> Map.merge(%{project: project})
 
     ~H"""
     <div class="flex flex-col">
@@ -96,10 +101,10 @@ defmodule OliWeb.Projects.TableModel do
         href={~p"/workspaces/course_author/#{@project.slug}/overview"}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {@project.title}
+        {Phoenix.HTML.raw(Utils.highlight_search_term(@project.title || "", @search_term))}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {@project.slug}
+        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@project.slug || "", @search_term))}
       </span>
     </div>
     """
@@ -139,7 +144,10 @@ defmodule OliWeb.Projects.TableModel do
 
   # Name
   def custom_render(assigns, project, %ColumnSpec{name: :name}) do
-    assigns = Map.merge(assigns, %{project: project})
+    assigns =
+      assigns
+      |> Map.put_new(:search_term, Map.get(assigns, :search_term, ""))
+      |> Map.merge(%{project: project})
 
     case project.owner_id do
       nil ->
@@ -151,10 +159,10 @@ defmodule OliWeb.Projects.TableModel do
           href={~p"/admin/authors/#{@project.owner_id}"}
           class="text-Text-text-link text-base font-medium leading-normal"
         >
-          {@project.name}
+          {Phoenix.HTML.raw(Utils.highlight_search_term(@project.name || "", @search_term))}
         </a>
         <small class="text-Text-text-low text-xs font-semibold leading-3">
-          {@project.email}
+          {Phoenix.HTML.raw(Utils.highlight_search_term(@project.email || "", @search_term))}
         </small>
         """
     end
@@ -162,7 +170,10 @@ defmodule OliWeb.Projects.TableModel do
 
   # Collaborators
   def custom_render(assigns, project, %ColumnSpec{name: :collaborators}) do
-    assigns = Map.merge(assigns, %{project: project})
+    assigns =
+      assigns
+      |> Map.put_new(:search_term, Map.get(assigns, :search_term, ""))
+      |> Map.merge(%{project: project})
 
     ~H"""
     <div>
@@ -171,7 +182,7 @@ defmodule OliWeb.Projects.TableModel do
           href={~p"/admin/authors/#{collab["id"]}"}
           class="text-Text-text-link text-base font-medium leading-normal"
         >
-          {collab["name"]}
+          {Phoenix.HTML.raw(Utils.highlight_search_term(collab["name"] || "", @search_term))}
         </a>
         <%= if index < length(@project.collaborators) - 1 do %>
           <span class="text-Text-text-high text-base font-medium leading-normal">, </span>

--- a/lib/oli_web/live/projects/table_model.ex
+++ b/lib/oli_web/live/projects/table_model.ex
@@ -101,10 +101,10 @@ defmodule OliWeb.Projects.TableModel do
         href={~p"/workspaces/course_author/#{@project.slug}/overview"}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {Phoenix.HTML.raw(Utils.highlight_search_term(@project.title || "", @search_term))}
+        {highlight_search_term(@project.title, @search_term)}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@project.slug || "", @search_term))}
+        ID: {highlight_search_term(@project.slug, @search_term)}
       </span>
     </div>
     """
@@ -159,10 +159,10 @@ defmodule OliWeb.Projects.TableModel do
           href={~p"/admin/authors/#{@project.owner_id}"}
           class="text-Text-text-link text-base font-medium leading-normal"
         >
-          {Phoenix.HTML.raw(Utils.highlight_search_term(@project.name || "", @search_term))}
+          {highlight_search_term(@project.name, @search_term)}
         </a>
         <small class="text-Text-text-low text-xs font-semibold leading-3">
-          {Phoenix.HTML.raw(Utils.highlight_search_term(@project.email || "", @search_term))}
+          {highlight_search_term(@project.email, @search_term)}
         </small>
         """
     end
@@ -182,7 +182,7 @@ defmodule OliWeb.Projects.TableModel do
           href={~p"/admin/authors/#{collab["id"]}"}
           class="text-Text-text-link text-base font-medium leading-normal"
         >
-          {Phoenix.HTML.raw(Utils.highlight_search_term(collab["name"] || "", @search_term))}
+          {highlight_search_term(collab["name"], @search_term)}
         </a>
         <%= if index < length(@project.collaborators) - 1 do %>
           <span class="text-Text-text-high text-base font-medium leading-normal">, </span>
@@ -255,4 +255,15 @@ defmodule OliWeb.Projects.TableModel do
     <div>nothing</div>
     """
   end
+
+  defp highlight_search_term(text, search_term),
+    do:
+      Phoenix.HTML.raw(
+        Utils.highlight_search_term(
+          text || "",
+          search_term,
+          "span class=\"search-highlight\"",
+          "span"
+        )
+      )
 end

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -13,7 +13,8 @@ defmodule OliWeb.Sections.SectionsTableModel do
     render_date: :relative,
     exclude_columns: [],
     sort_by_spec: :start_date,
-    sort_order: :desc
+    sort_order: :desc,
+    search_term: ""
   ]
 
   def new(%SessionContext{} = ctx, sections, opts \\ []) do

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -356,7 +356,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
   defp highlight_search_term(text, search_term),
     do:
       Phoenix.HTML.raw(
-        Utils.highlight_search_term(
+        Utils.multi_highlight_search_term(
           text || "",
           search_term,
           "span class=\"search-highlight\"",

--- a/lib/oli_web/live/sections/table_model.ex
+++ b/lib/oli_web/live/sections/table_model.ex
@@ -142,10 +142,10 @@ defmodule OliWeb.Sections.SectionsTableModel do
         href={~p"/sections/#{@section.slug}/manage"}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {Phoenix.HTML.raw(Utils.highlight_search_term(@section.title || "", @search_term))}
+        {highlight_search_term(@section.title, @search_term)}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@section.slug || "", @search_term))}
+        ID: {highlight_search_term(@section.slug, @search_term)}
       </span>
     </div>
     """
@@ -208,9 +208,7 @@ defmodule OliWeb.Sections.SectionsTableModel do
             href={~p"/admin/institutions/#{@section.institution.id}"}
             class="text-Text-text-link text-base font-medium leading-normal"
           >
-            {Phoenix.HTML.raw(
-              Utils.highlight_search_term(@section.institution.name || "", @search_term)
-            )}
+            {highlight_search_term(@section.institution.name, @search_term)}
           </a>
         <% end %>
       </span>
@@ -265,10 +263,10 @@ defmodule OliWeb.Sections.SectionsTableModel do
         href={@route_path}
         class="text-Text-text-link text-base font-medium leading-normal"
       >
-        {Phoenix.HTML.raw(Utils.highlight_search_term(@title || "", @search_term))}
+        {highlight_search_term(@title, @search_term)}
       </a>
       <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {Phoenix.HTML.raw(Utils.highlight_search_term(@slug || "", @search_term))}
+        ID: {highlight_search_term(@slug, @search_term)}
       </span>
     </div>
     """
@@ -295,14 +293,14 @@ defmodule OliWeb.Sections.SectionsTableModel do
             href={~p"/admin/authors/#{author_id}"}
             class="text-Text-text-link text-base font-medium leading-normal"
           >
-            {Phoenix.HTML.raw(Utils.highlight_search_term(name || "", @search_term))}
+            {highlight_search_term(name, @search_term)}
           </.link>
         <% else %>
           <.link
             href={~p"/admin/users/#{instructor_id}"}
             class="text-Text-text-link text-base font-medium leading-normal"
           >
-            {Phoenix.HTML.raw(Utils.highlight_search_term(name || "", @search_term))}
+            {highlight_search_term(name, @search_term)}
             <%= if index < length(@instructors) - 1 do %>
               ,
             <% end %>
@@ -353,4 +351,15 @@ defmodule OliWeb.Sections.SectionsTableModel do
     datetime = FormatDateTime.convert_datetime(date, tz)
     Calendar.strftime(datetime, "%B %d, %Y %I:%M %p")
   end
+
+  defp highlight_search_term(text, search_term),
+    do:
+      Phoenix.HTML.raw(
+        Utils.highlight_search_term(
+          text || "",
+          search_term,
+          "span class=\"search-highlight\"",
+          "span"
+        )
+      )
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -173,6 +173,40 @@ defmodule OliWeb.ProductsLiveTest do
       assert has_element?(view, "a", product_2.title)
     end
 
+    test "search enforces minimum characters and highlights matches", %{
+      conn: conn,
+      product: product
+    } do
+      [{_, other_product} | _] = create_product(conn)
+
+      {:ok, view, _html} = live(conn, @live_view_all_products)
+
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{product_name: "pr"})
+
+      assert has_element?(view, "a", product.title)
+      assert has_element?(view, "a", other_product.title)
+      refute has_element?(view, "span.search-highlight")
+
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{product_name: other_product.slug})
+
+      wait_while(fn -> has_element?(view, "a", product.title) end)
+
+      assert has_element?(view, "a", other_product.title)
+      assert has_element?(view, "span.search-highlight")
+
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{product_name: ""})
+
+      assert has_element?(view, "a", product.title)
+      assert has_element?(view, "a", other_product.title)
+      refute has_element?(view, "span.search-highlight")
+    end
+
     @tag :flaky
     @tag :skip
     test "applies sorting by creation date", %{conn: conn, product: product} do

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -148,7 +148,7 @@ defmodule OliWeb.ProductsLiveTest do
 
       {:ok, product_2} =
         Sections.update_section(product_2, %{
-          amount: Money.new(25, "USD")
+          amount: Money.new(250, "USD")
         })
 
       {:ok, view, _html} = live(conn, @live_view_all_products)
@@ -158,7 +158,7 @@ defmodule OliWeb.ProductsLiveTest do
 
       view
       |> element("form[phx-change=\"text_search_change\"]")
-      |> render_change(%{product_name: "25"})
+      |> render_change(%{product_name: "250"})
 
       wait_while(fn -> has_element?(view, "a", product.title) end)
 

--- a/test/oli_web/live/projects_live_test.exs
+++ b/test/oli_web/live/projects_live_test.exs
@@ -124,6 +124,61 @@ defmodule OliWeb.Projects.ProjectsLiveTest do
              |> render() =~
                "Testing B"
     end
+
+    test "search filters across multiple fields with highlighting", %{conn: conn, admin: admin} do
+      project =
+        admin
+        |> create_project_with_owner(%{
+          slug: "search-slug",
+          title: "Searchable Project",
+          authors: []
+        })
+
+      other_project =
+        admin
+        |> create_project_with_owner(%{
+          slug: "other-project",
+          title: "Other Listing",
+          authors: []
+        })
+
+      {:ok, view, _html} = live(conn, Routes.live_path(Endpoint, ProjectsLive))
+
+      # fewer than three characters should not filter or highlight
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{"project_name" => "se"})
+
+      assert has_element?(view, "##{project.id}")
+      assert has_element?(view, "##{other_project.id}")
+      refute has_element?(view, "span.search-highlight")
+
+      # search by slug
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{"project_name" => "search"})
+
+      assert has_element?(view, "##{project.id}")
+      refute has_element?(view, "##{other_project.id}")
+      assert has_element?(view, "span.search-highlight", "search")
+
+      # reset search
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{"project_name" => ""})
+
+      assert has_element?(view, "##{project.id}")
+      assert has_element?(view, "##{other_project.id}")
+      refute has_element?(view, "span.search-highlight")
+
+      # search by owner email
+      view
+      |> element("form[phx-change=\"text_search_change\"]")
+      |> render_change(%{"project_name" => admin.email})
+
+      assert has_element?(view, "##{project.id}")
+      assert has_element?(view, "span.search-highlight", admin.email)
+    end
   end
 
   describe "projects live as author" do


### PR DESCRIPTION
- Expanded admin search to cover IDs, titles, owners, collaborators, institutions, and base products/projects across Projects, Sections, and Products, with 3-char minimum 
- Added themed span-based highlighting for matched terms.


https://github.com/user-attachments/assets/1b07c382-099a-47a3-8745-2d1007029a16




See: https://eliterate.atlassian.net/browse/MER-4666