### PR TITLE
[FIX] Removes prefetching logiclab in delivery.

### DIFF
--- a/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
@@ -157,6 +157,7 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
   const [baseUrl, setBaseUrl] = useState<string>('');
   useEffect(() => {
     if (!labServer) {
+      setBaseUrl('');
       return;
     }
     if (!activity) {
@@ -190,9 +191,10 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
       />
       <iframe
         title={`LogicLab Activity ${model.context?.title}`}
+        // Note: the minimum width and height here are based on the minimum size of the LogicLab UI.
+        // If LogicLab ever supports a responsive UI, these could be changed to better fit the
+        // containing element.
         className="mb-3 rounded inset-shadow-sm min-w-[1024px] min-h-[756px] w-full"
-        width={1024}
-        height={756}
         src={baseUrl}
         allow="fullscreen"
         // data attributes only work if same-site, so using message passing instead.

--- a/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabDelivery.tsx
@@ -9,7 +9,6 @@ import ReactDOM from 'react-dom';
 import { Provider, useDispatch } from 'react-redux';
 import { ScoreAsYouGoHeaderBase } from 'components/activities/common/ScoreAsYouGoHeader';
 import { ErrorBoundary } from 'components/common/ErrorBoundary';
-import { LoadingSpinner } from 'components/common/LoadingSpinner';
 import {
   activityDeliverySlice,
   listenForParentSurveyReset,
@@ -161,9 +160,7 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
       return;
     }
     if (!activity) {
-      throw new Error(
-        'LogicLab activity is not configured.  Please contact the course author for assistance.',
-      );
+      throw new Error('LogicLab activity is not configured.  Please contact the course author.');
     }
     // If the activity is a LabActivity, then use message passing to get the activity configuration.
     // Otherwise, use the activity ID to get the configuration from the logiclab server.
@@ -179,7 +176,9 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
   }, [activity, mode, activityState, labServer]);
 
   return !baseUrl ? (
-    <LoadingSpinner />
+    <div className="alert alert-warning" role="alert">
+      Configuring LogicLab... If this message persists, please contact the system administrator.
+    </div>
   ) : (
     <div>
       <ScoreAsYouGoHeaderBase
@@ -191,10 +190,11 @@ const LogicLab: React.FC<LogicLabDeliveryProps> = () => {
       />
       <iframe
         title={`LogicLab Activity ${model.context?.title}`}
+        className="mb-3 rounded inset-shadow-sm min-w-[1024px] min-h-[756px] w-full"
+        width={1024}
+        height={756}
         src={baseUrl}
         allow="fullscreen"
-        height="800"
-        width="100%"
         // data attributes only work if same-site, so using message passing instead.
         data-oli-activity-mode={mode}
         // data-logiclab-activity={JSON.stringify(activity)} // use message passing instead of data attribute.

--- a/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
@@ -1,7 +1,6 @@
 /*
   Models for Torus LogicLab activity data and data exchange.
 */
-import { useEffect, useState } from 'react';
 import { ActivityModelSchema, Feedback, Part, Transformation } from '../types';
 
 // Typing and type checking for existence of variables in a context.
@@ -10,40 +9,22 @@ function contextHasVariables(ctx: ContextVariables | unknown): ctx is ContextVar
   return !!ctx && ctx instanceof Object && 'variables' in ctx;
 }
 /**
- * Extract the LogicLab url from a context with null safety.
+ * Extract the LogicLab server URL from a context with null safety.
  * @param context deploy context or activity edit context
- * @returns url to use as a base for logiclab service calls
+ * @returns the LogicLab server URL or undefined if not reachable
  */
-function getLabServer(context: ContextVariables | unknown): string {
+export function useLabServer(context: ContextVariables | unknown): string | undefined {
   if (contextHasVariables(context)) {
     const variables = context.variables;
     if ('ACTIVITY_LOGICLAB_URL' in variables && variables.ACTIVITY_LOGICLAB_URL) {
       return variables.ACTIVITY_LOGICLAB_URL;
     }
   }
-  throw new ReferenceError('ACTIVITY_LOGICLAB_URL is not set.');
-}
-/**
- * Extract the LogicLab server URL from a context with null safety.
- * @param context deploy context or activity edit context
- * @returns the LogicLab server URL or undefined if not reachable
- */
-export function useLabServer(context: ContextVariables | unknown): string | undefined {
-  const [server, setServer] = useState<string | undefined>();
-  useEffect(() => {
-    try {
-      const url = getLabServer(context);
-      setServer(url);
-    } catch (e) {
-      if (e instanceof ReferenceError) {
-        console.warn('LogicLab server URL not set in context, using default.');
-        // Default LogicLab server URL.
-        // This should be removed once the environment variable is consistently set in deployment environments.
-        setServer('https://logiclab.oli.cmu.edu');
-      }
-    }
-  }, [context]);
-  return server;
+  console.warn('LogicLab server URL not set in context, using default.');
+  // Default LogicLab server URL.
+  // This default should be removed once the environment variable is consistently set in deployment environments.
+  return 'https://logiclab.oli.cmu.edu';
+  // throw new ReferenceError('Server configuration error: LogicLab url environment variable is not set.');
 }
 
 export interface LogicLabModelSchema extends ActivityModelSchema {

--- a/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
+++ b/assets/src/components/activities/logic_lab/LogicLabModelSchema.tsx
@@ -1,6 +1,7 @@
 /*
   Models for Torus LogicLab activity data and data exchange.
 */
+import { useEffect, useState } from 'react';
 import { ActivityModelSchema, Feedback, Part, Transformation } from '../types';
 
 // Typing and type checking for existence of variables in a context.
@@ -14,17 +15,22 @@ function contextHasVariables(ctx: ContextVariables | unknown): ctx is ContextVar
  * @returns the LogicLab server URL or undefined if not reachable
  */
 export function useLabServer(context: ContextVariables | unknown): string | undefined {
-  if (contextHasVariables(context)) {
-    const variables = context.variables;
-    if ('ACTIVITY_LOGICLAB_URL' in variables && variables.ACTIVITY_LOGICLAB_URL) {
-      return variables.ACTIVITY_LOGICLAB_URL;
+  const [labServer, setLabServer] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (contextHasVariables(context)) {
+      const variables = context.variables;
+      if ('ACTIVITY_LOGICLAB_URL' in variables && variables.ACTIVITY_LOGICLAB_URL) {
+        setLabServer(variables.ACTIVITY_LOGICLAB_URL);
+        return;
+      }
     }
-  }
-  console.warn('LogicLab server URL not set in context, using default.');
-  // Default LogicLab server URL.
-  // This default should be removed once the environment variable is consistently set in deployment environments.
-  return 'https://logiclab.oli.cmu.edu';
-  // throw new ReferenceError('Server configuration error: LogicLab url environment variable is not set.');
+    console.warn('LogicLab server URL not set in context, using default.');
+    // Default LogicLab server URL.
+    // This default should be removed once the environment variable is consistently set in deployment environments.
+    setLabServer('https://logiclab.oli.cmu.edu');
+    // throw new ReferenceError('Server configuration error: LogicLab url environment variable is not set.');
+  }, [context]);
+  return labServer;
 }
 
 export interface LogicLabModelSchema extends ActivityModelSchema {


### PR DESCRIPTION
In the delivery component, the probing of the logiclab url is probably unnecessary and thus removed.  This also greatly simplifies the code and is an extension of the work for #5891.  Most of the probing checks were to verify that ACTIVITY_LOGICLAB_URL was properly set but adding a hard-coded default value mitigates the need for these checks.  Eventually, the hard coded default should be removed, but that requires changes in deployment to guarantee that this environment variable is set.  If it is not set, the logiclab activity should probably not be made available as an activity option or some other indication that it is not set in the activity configuration page.