### PR TITLE
[BUG FIX] [MER-4992] fix right-to-left text in mcq/CATA/ordering choice delivery

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.modules.scss
@@ -23,7 +23,7 @@
 }
 
 .choicesChoiceContent {
-  margin-left: 0.6rem;
+  margin-inline-start: 0.6rem;
   flex-grow: 1;
 
   /* When inside a MCQ/CATA, we want the images near the checkbox, not centered on the page */

--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -47,7 +47,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
           onClick={onClicked(choice.id)}
           className={classNames(styles.choicesChoiceRow, isSelected(choice.id) ? 'selected' : '')}
         >
-          <div className={styles.choicesChoiceWrapper}>
+          <div className={styles.choicesChoiceWrapper} dir={choice.textDirection}>
             <label className={styles.choicesChoiceLabel} htmlFor={`choice-${index}`}>
               <div className="d-flex align-items-center col">
                 {isSelected(choice.id) ? selectedIcon : unselectedIcon}

--- a/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
+++ b/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
@@ -33,7 +33,7 @@ export const ResponseChoices: React.FC<Props> = ({
           {(choice, index) => (
             <>
               <Draggable.DragIndicator isDragDisabled={disabled ?? false} />
-              <div style={{ marginRight: '0.5rem' }}>{index + 1}.</div>
+              <div style={{ marginInlineEnd: '0.5rem' }}>{index + 1}.</div>
               <HtmlContentModelRenderer
                 direction={choice.textDirection}
                 content={choice.content}

--- a/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
+++ b/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
@@ -28,6 +28,7 @@ export const ResponseChoices: React.FC<Props> = ({
           id={choice.id}
           item={choice}
           color={colorMap?.get(choice.id)}
+          direction={choice.textDirection}
         >
           {(choice, index) => (
             <>

--- a/assets/src/components/common/DraggableColumn.tsx
+++ b/assets/src/components/common/DraggableColumn.tsx
@@ -8,6 +8,7 @@ import {
   Droppable,
   NotDraggingStyle,
 } from 'react-beautiful-dnd';
+import { TextDirection } from 'data/content/model/elements/types';
 import { ClassName, classNames } from 'utils/classNames';
 import guid from 'utils/guid';
 import styles from './DraggableColumn.modules.scss';
@@ -36,6 +37,7 @@ interface ItemProps {
   displayOutline?: boolean;
   color?: string;
   isDragDisabled?: boolean;
+  direction?: TextDirection | 'auto';
 }
 const Item: React.FC<ItemProps> = ({
   id,
@@ -49,11 +51,13 @@ const Item: React.FC<ItemProps> = ({
   displayOutline,
   color,
   isDragDisabled,
+  direction,
 }) => {
   return (
     <DraggableDND draggableId={id} key={id} index={index} isDragDisabled={isDragDisabled ?? false}>
       {(provided, snapshot) => (
         <div
+          dir={direction}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}


### PR DESCRIPTION
Choices in multiple choice, CATA and ordering questions were appearing not to respect the right-to-left text direction setting in preview and delivery. This has a severe impact on Arabic courses that rely on right-to-left text.

This happened because the dir="rtl" attribute was being set at the wrong level, at the choice content itself (leading to it being set on, say, a `<p>` within which the choice content is rendered), but NOT the containing div that groups the relevant icon (e.g. radio button for mcq) and choice content as a unit. The choice content box winds up laid out within a flex box container that lays out left to right and sizes its children to fit their content. Because choice content is rendered within such a left-aligned, sized-to-fit layout box, it makes no difference that it is rendered as rtl within this box.

This occurred in the ChoicesDelivery component; the ChoicesAuthoring component uses an editor so is different. Ordering choices go through a different component supporting draggable items, but the issue is similar.

Fix is to set the attribute at the containing div level for each choice. This has the effect that the icon (radio button or check box or drag handle) associated with the choice now appears on the right, rather than the left, when rtl order is used, which seems appropriate. Note this allows a mix of right-to-left and left-to-right choices within the same choice list, which may be odd, but is allowed in the model, which has the text direction as an attribute of the individual choice.

Also adjusted style so text margin from mcq icon (radio button) is specified in a text-direction-neutral way.

Old (these have right-to-left setting on choices):
<img width="526" height="206" alt="Screenshot 2025-09-25 at 4 59 12 PM" src="https://github.com/user-attachments/assets/3cd9b11e-b4fa-4fb0-a5c3-40b0e50fa8d1" />


New:
<img width="390" height="215" alt="Screenshot 2025-09-25 at 5 02 33 PM" src="https://github.com/user-attachments/assets/3acb9fd1-9898-4d2a-b87d-08b510ba4e1b" />
