### PR TITLE
[BUG FIX] [MER-4996] Fix auto enroll

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -690,8 +690,7 @@ defmodule Oli.Delivery.Sections do
         e in Enrollment,
         join: s in Section,
         on: e.section_id == s.id,
-        where:
-          e.user_id == ^user_id and s.slug == ^section_slug
+        where: e.user_id == ^user_id and s.slug == ^section_slug
       )
 
     case Repo.one(query) do

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -681,6 +681,26 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Determines if a particular user has an enrollment record in a section.
+
+  """
+  def has_enrollment?(user_id, section_slug) do
+    query =
+      from(
+        e in Enrollment,
+        join: s in Section,
+        on: e.section_id == s.id,
+        where:
+          e.user_id == ^user_id and s.slug == ^section_slug
+      )
+
+    case Repo.one(query) do
+      nil -> false
+      _ -> true
+    end
+  end
+
+  @doc """
   Returns a listing of all enrollments for a given section.
 
   """

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -19,7 +19,13 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
         } = socket
       )
       when not is_nil(user) do
-    if user, do: Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+    if user do
+      if !Sections.is_enrolled?(user.id, section.slug) do
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      end
+    end
+
     {:cont, assign(socket, is_enrolled: true)}
   end
 

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -19,7 +19,6 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
         } = socket
       )
       when not is_nil(user) do
-
     if user do
       if !Sections.has_enrollment?(user.id, section.slug) do
         Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -21,7 +21,7 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
       when not is_nil(user) do
 
     if user do
-      if !Sections.is_enrolled?(user.id, section.slug) do
+      if !Sections.has_enrollment?(user.id, section.slug) do
         Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
       end
     end


### PR DESCRIPTION
This adds a `Sections.has_enrollment?` guard around the (dangerous) upsert of `Sections.enroll`

The existing `Sections.is_enrolled?` is NOT safe to use as it constrains on `s.active = true`.  Which means if an instructor or admin visited an inactive section they would STILL be turned into a student. 