### PR TITLE
[FEATURE] [MER-4706] Scored Pages Filters

### DIFF
--- a/lib/oli_web/components/delivery/content/card_highlights.ex
+++ b/lib/oli_web/components/delivery/content/card_highlights.ex
@@ -44,6 +44,7 @@ defmodule OliWeb.Components.Delivery.CardHighlights do
         :modules -> "Module"
         :students -> "Student"
         :pages -> "Page"
+        :questions -> "Question"
         _ -> to_string(type || "")
       end
 

--- a/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
+++ b/lib/oli_web/components/delivery/practice_activities/practice_activities.ex
@@ -482,7 +482,7 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
         do: nil,
         else: String.to_existing_atom(value)
 
-    send(self(), {:selected_card_assessments, value})
+    send(self(), {:selected_card_assessments, value, :practice_activities})
 
     {:noreply, socket}
   end
@@ -516,7 +516,10 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
     do: Enum.filter(assessments, fn assessment -> assessment.students_completion < 0.40 end)
 
   defp maybe_filter_by_card(assessments, :low_or_no_attempts),
-    do: Enum.filter(assessments, fn assessment -> assessment.total_attempts <= 5 end)
+    do:
+      Enum.filter(assessments, fn assessment ->
+        assessment.total_attempts <= 5 || assessment.total_attempts == nil
+      end)
 
   defp maybe_filter_by_card(assessments, _), do: assessments
 
@@ -571,9 +574,9 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
 
     Enum.filter(assessments, fn assessment ->
       Enum.any?(selected_attempts_ids, fn
-        1 -> assessment.total_attempts == 0
-        2 -> assessment.total_attempts < 5
-        3 -> assessment.total_attempts > 5
+        1 -> assessment.total_attempts in [nil, 0]
+        2 -> not is_nil(assessment.total_attempts) and assessment.total_attempts <= 5
+        3 -> not is_nil(assessment.total_attempts) and assessment.total_attempts > 5
         _ -> false
       end)
     end)
@@ -600,7 +603,7 @@ defmodule OliWeb.Components.Delivery.PracticeActivities do
         end),
       low_or_no_attempts:
         Enum.count(assessments, fn assessment ->
-          assessment.total_attempts <= 5
+          assessment.total_attempts <= 5 || assessment.total_attempts == nil
         end)
     }
   end

--- a/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
+++ b/lib/oli_web/components/delivery/scored_activities/scored_activities.ex
@@ -151,13 +151,15 @@ defmodule OliWeb.Components.Delivery.ScoredActivities do
                 if s.id in students_with_attempts, do: acc, else: [s.email | acc]
               end)
 
-
             percentage_score =
-              Metrics.avg_score_across_for_pages(assigns.section, [current_assessment.resource_id], student_ids)
+              Metrics.avg_score_across_for_pages(
+                assigns.section,
+                [current_assessment.resource_id],
+                student_ids
+              )
               |> Map.get(current_assessment.resource_id, 0)
               |> Kernel.*(100)
               |> round()
-
 
             selected_activity_card_value =
               Map.get(assigns.params, "selected_activity_card_value", nil)

--- a/lib/oli_web/live/common/table/striped_paged_table.ex
+++ b/lib/oli_web/live/common/table/striped_paged_table.ex
@@ -57,7 +57,7 @@ defmodule OliWeb.Common.StripedPagedTable do
           is_page_size_right={true}
         />
       <% else %>
-        <div class="bg-white dark:bg-gray-800 dark:text-white px-10 my-5">
+        <div class="bg-white dark:bg-gray-800 dark:text-white px-10 py-5">
           <p>{@no_records_message}</p>
         </div>
       <% end %>

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -797,7 +797,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   end
 
   def handle_info(
-        {:selected_card_assessments, value},
+        {:selected_card_assessments, value, view},
         socket
       ) do
     params = Map.merge(socket.assigns.params, %{"selected_card_value" => value})
@@ -805,7 +805,20 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
     {:noreply,
      push_patch(socket,
        to:
-         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/practice_activities?#{params}"
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/#{Atom.to_string(view)}?#{params}"
+     )}
+  end
+
+  def handle_info(
+        {:selected_activity_card, value, view},
+        socket
+      ) do
+    params = Map.merge(socket.assigns.params, %{"selected_activity_card_value" => value})
+
+    {:noreply,
+     push_patch(socket,
+       to:
+         ~p"/sections/#{socket.assigns.section.slug}/instructor_dashboard/insights/#{Atom.to_string(view)}?#{params}"
      )}
   end
 

--- a/test/oli_web/components/delivery/scored_activities/scored_activities_test.exs
+++ b/test/oli_web/components/delivery/scored_activities/scored_activities_test.exs
@@ -6,6 +6,29 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
   alias OliWeb.Components.Delivery.ScoredActivities
   alias Oli.Delivery.Sections.Section
 
+  @attempts_options [
+    %{id: 1, name: "None", selected: false},
+    %{id: 2, name: "Less than 5", selected: false},
+    %{id: 3, name: "More than 5", selected: false}
+  ]
+
+  @default_params %{
+    offset: 0,
+    limit: 20,
+    sort_order: :asc,
+    sort_by: :order,
+    text_search: nil,
+    selected_card_value: nil,
+    selected_activity_card_value: nil,
+    progress_percentage: 100,
+    progress_selector: nil,
+    avg_score_percentage: 100,
+    avg_score_selector: nil,
+    selected_attempts_ids: Jason.encode!([]),
+    card_props: [],
+    card_activity_props: []
+  }
+
   describe "mount/1" do
     test "mounts with default assigns" do
       {:ok, socket} = ScoredActivities.mount(%Phoenix.LiveView.Socket{})
@@ -22,10 +45,10 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
         section: %Section{id: 1, slug: "section"},
         view: :scored_activities,
         ctx: %{user: %{id: 1}},
-        assessments: [%{id: 1, title: "A1", order: 1}],
+        assessments: [%{id: 1, title: "A1", order: 1, resource_id: 1, avg_score: 0.67, students_completion: 0.75, total_attempts: 10}],
         students: [%{id: 1, email: "student@example.com"}],
         scripts: [],
-        activity_types_map: %{}
+        activity_types_map: %{},
       }
 
       socket = %Phoenix.LiveView.Socket{assigns: %{myself: :self, __changed__: %{}}}
@@ -103,7 +126,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
           }
         },
         current_assessment: nil,
-        params: %{text_search: nil, offset: 0, limit: 20},
+        params: @default_params,
         total_count: 1,
         view: :scored_activities,
         section: %{slug: "section"},
@@ -111,7 +134,12 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
         activity_types_map: %{},
         scripts: [],
         assessments: [%{id: 1, title: "A1"}],
-        myself: :self
+        myself: :self,
+        attempts_options: @attempts_options,
+        selected_attempts_options: %{},
+        selected_attempts_ids: [],
+        avg_score_percentage: 67,
+        card_props: []
       }
 
       html = render_component(&ScoredActivities.render/1, assigns)
@@ -156,7 +184,7 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
           batch_scoring: false
         },
         activities: [%{id: 1, title: "Q1"}],
-        params: %{text_search: nil, offset: 0, limit: 20},
+        params: @default_params,
         total_count: 1,
         view: :scored_activities,
         section: %{slug: "section"},
@@ -168,7 +196,12 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
         students_with_attempts_count: 1,
         total_attempts_count: 5,
         student_emails_without_attempts: [],
-        selected_activity: %{id: 1, title: "Q1", first_attempt_pct: 75.0, all_attempt_pct: 85.0}
+        selected_activity: %{id: 1, title: "Q1", first_attempt_pct: 75.0, all_attempt_pct: 85.0},
+        attempts_options: @attempts_options,
+        selected_attempts_options: %{},
+        selected_attempts_ids: [],
+        avg_score_percentage: 67,
+        card_activity_props: []
       }
 
       html = render_component(&ScoredActivities.render/1, assigns)

--- a/test/oli_web/components/delivery/scored_activities/scored_activities_test.exs
+++ b/test/oli_web/components/delivery/scored_activities/scored_activities_test.exs
@@ -45,10 +45,20 @@ defmodule OliWeb.Components.Delivery.ScoredActivitiesTest do
         section: %Section{id: 1, slug: "section"},
         view: :scored_activities,
         ctx: %{user: %{id: 1}},
-        assessments: [%{id: 1, title: "A1", order: 1, resource_id: 1, avg_score: 0.67, students_completion: 0.75, total_attempts: 10}],
+        assessments: [
+          %{
+            id: 1,
+            title: "A1",
+            order: 1,
+            resource_id: 1,
+            avg_score: 0.67,
+            students_completion: 0.75,
+            total_attempts: 10
+          }
+        ],
         students: [%{id: 1, email: "student@example.com"}],
         scripts: [],
-        activity_types_map: %{},
+        activity_types_map: %{}
       }
 
       socket = %Phoenix.LiveView.Socket{assigns: %{myself: :self, __changed__: %{}}}

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1268,7 +1268,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       assert page2.title == "Module 1: IntroductionPage 2"
     end
 
-    test "Attempts filter works correctly", %{
+    test "Attemps filter works correctly", %{
       conn: conn,
       section: section,
       page_1: page_1,
@@ -1545,7 +1545,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       assert page2.title == "Module 1: IntroductionPage 2"
       assert page3.title == "Module 2: BasicsPage 3"
       assert page4.title == "Module 2: BasicsPage 4"
-      assert orphaned_page.title == "Curriculum 1: Root Container Orphaned Page"
+      assert orphaned_page.title == "Curriculum 1: Root ContainerOrphaned Page"
     end
   end
 

--- a/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/overview/practice_activities_tab_test.exs
@@ -1268,7 +1268,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       assert page2.title == "Module 1: IntroductionPage 2"
     end
 
-    test "Attemps filter works correctly", %{
+    test "Attempts filter works correctly", %{
       conn: conn,
       section: section,
       page_1: page_1,
@@ -1329,9 +1329,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       |> render_click()
 
       # After filter: only Page 2 is shown
-      pages = [page1] = table_as_list_of_maps(view)
-      assert Enum.count(pages) == 1
-      assert page1.title == "Module 1: IntroductionPage 2"
+      pages = [page1, page2] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 2
+      assert page1.title == "Module 1: IntroductionPage 1"
+      assert page2.title == "Module 1: IntroductionPage 2"
     end
 
     test "Clear all filters works correctly", %{
@@ -1497,7 +1498,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       project: project,
       publication: publication
     } do
-      Enum.each(1..3, fn _ ->
+      Enum.each(1..6, fn _ ->
         set_activity_attempt(
           page_1,
           mcq_activity_1,
@@ -1539,10 +1540,12 @@ defmodule OliWeb.Delivery.InstructorDashboard.PracticeActivitiesTabTest do
       |> render_click()
 
       # After filter: Page 1 and Page 2 are shown
-      pages = [page1, page2] = table_as_list_of_maps(view)
-      assert Enum.count(pages) == 2
-      assert page1.title == "Module 1: IntroductionPage 1"
+      pages = [page2, page3, page4, orphaned_page] = table_as_list_of_maps(view)
+      assert Enum.count(pages) == 4
       assert page2.title == "Module 1: IntroductionPage 2"
+      assert page3.title == "Module 2: BasicsPage 3"
+      assert page4.title == "Module 2: BasicsPage 4"
+      assert orphaned_page.title == "Curriculum 1: Root Container Orphaned Page"
     end
   end
 


### PR DESCRIPTION
[MER-4706](https://eliterate.atlassian.net/browse/MER-4706)

This PR implements filtering functionality in the `Scored Pages` section under `Insights > Practice Pages`, both at the page level and the question level, following Figma designs and reusing shared components where appropriate.

✅ Page-Level Filters

- Added three main filters to help instructors quickly identify problematic content:
    
    - **Low Scores**: filters pages with average scores flagged in red.  
    - **Low Progress**: filters pages with low completion percentage.  
    - **Low or No Attempts**: filters pages with either 0 attempts or fewer than 5 attempts.  

- Added toolbar filters:

    - **Progress**: allows filtering by completion percentage range.  
    - **Attempts**: dropdown with `None`, `< 5`, `> 5` options.  
    - **Score**: allows filtering by average score percentage range.  

- A **“Clear All Filters”** button was added to reset all filters at once.  
- The **search bar** was integrated into the table toolbar to ensure consistency with other Insights views.

✅ Question-Level Filters
- The **average score** of the page is displayed at the top of the view as a percentage.

- Added two main filters:

    - **Low Accuracy**: filters questions with low percent correct (flagged in red).  
    - **Low or No Attempts**: filters questions with no attempts or fewer than 5 attempts.  

- Added toolbar filters:

    - **Attempts**: dropdown with `None`, `< 5`, `> 5`.  
    - **Score**: percentage range input.  

- The **Clear All Filters** button and **search bar** are styled and positioned according to Figma.




https://github.com/user-attachments/assets/607dd9f8-439b-47ff-9350-af7b45667724



[MER-4706]: https://eliterate.atlassian.net/browse/MER-4706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ