### PR TITLE
[BUG FIX] [MER-5099] Preserve tag when removing objective from a bank-activity

### DIFF
--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -494,7 +494,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         scoring_strategy_id: previous.scoring_strategy_id,
         previous_revision_id: previous.id,
         activity_type_id: previous.activity_type_id,
-        scope: previous.scope
+        scope: previous.scope,
+        tags: previous.tags
       })
 
     Publishing.get_published_resource!(publication.id, activity.id)


### PR DESCRIPTION
This fixes the case if a user attached a learning objective and a tag to a question in the activity bank, and then deleted the objective, the question in the activity bank would have it’s tag removed in addition to the objective.


https://github.com/user-attachments/assets/106bb11f-a271-46bc-ab40-583d8a266142



See: https://eliterate.atlassian.net/browse/MER-5099