### PR TITLE
[BUG FIX] [MER-5541] FITB Dropdowns Not Functioning Consistently Across Browsers/Devices

### DIFF
--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
@@ -655,6 +655,200 @@
   min-width: 44px;
 }
 
+/* ── Custom FIB dropdown ── */
+
+.fib-dropdown {
+  display: inline-block; /* override <span> default inline so position:relative works correctly */
+  position: relative;
+  vertical-align: top;
+}
+
+.fib-dropdown.open {
+  z-index: 9999;
+}
+
+/* Trigger button — styled identically to .select2-selection__rendered */
+.fib-select-display {
+  /* Reset button defaults */
+  appearance: none;
+  -webkit-appearance: none;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 1em;
+  text-align: left;
+  outline: none;
+  /* Layout */
+  display: flex;
+  align-items: center;
+  min-height: 44px;
+  min-width: 120px;
+  padding: 8px 28px 8px 8px;
+  /* Visual */
+  background-color: #f8f9fa;
+  border-radius: 3px 3px 0 0;
+  color: #444;
+  cursor: pointer;
+  transition: background-color 0.3s ease-in-out;
+  user-select: none;
+  width: 100%;
+  position: relative;
+}
+
+.fib-select-display:hover:not(:disabled) {
+  background-color: #d9d9de;
+}
+
+.fib-select-text {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+}
+
+/* Chevron arrow — matches .select2-selection__arrow b */
+.fib-select-arrow {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  border-color: #253445 transparent transparent transparent;
+  border-style: solid;
+  border-width: 5px 4px 0 4px;
+  height: 0;
+  width: 0;
+  pointer-events: none;
+}
+
+.fib-select-arrow.open {
+  border-color: transparent transparent #253445 transparent;
+  border-width: 0 4px 5px 4px;
+}
+
+/* Icon base — hidden by default, same SVG as .text-input-container::before */
+.fib-select-display::before {
+  content: '';
+  display: none;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 10px;
+  background-color: #4ad3ad;
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="6" viewBox="0 0 8 6">  <g fill="none" fill-rule="evenodd" transform="translate(-3 -4)">  <rect width="14" height="14" fill="%23D8D8D8" opacity="0"/>  <polygon fill="%23FFF" points="5.857 10 3 7.121 3.806 6.309 5.857 8.37 10.194 4 11 4.818"/>  </g>  </svg>');
+  background-size: 50%;
+  background-position: center;
+  background-repeat: no-repeat;
+  border: none;
+  box-shadow: none;
+  padding: 0;
+  margin-right: 5px;
+}
+
+/* Correct state */
+.fib-select-display.correct {
+  background-color: #daf6ee !important;
+  border-bottom: none;
+}
+
+.fib-select-display.correct::before {
+  display: inline-flex;
+}
+
+.fib-select-display.correct:hover {
+  background-color: #b9eedf !important;
+}
+
+/* Incorrect state */
+.fib-select-display.incorrect {
+  background-color: #fddfdd !important;
+  border-bottom: none;
+}
+
+.fib-select-display.incorrect::before {
+  display: inline-flex;
+  content: '!';
+  background-color: #f96155;
+  background-image: none;
+  color: #fff;
+  padding-left: 6.5px;
+  line-height: 17px;
+  font-size: 11px;
+  box-sizing: border-box;
+  text-align: left;
+}
+
+.fib-select-display.incorrect:hover {
+  background-color: #fbb7b2 !important;
+}
+
+/* Disabled state */
+.fib-select-display:disabled {
+  background-color: rgba(0, 0, 0, 0.07);
+  cursor: not-allowed;
+  color: rgba(0, 0, 0, 0.8);
+  border-bottom: none;
+}
+
+/* Focus ring */
+.fib-select-display:focus-visible,
+.fib-select-display:focus {
+  outline: 2px solid #2196f3;
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(33, 150, 243, 0.3);
+}
+
+/* ── Custom dropdown options panel ── */
+.fib-dropdown-options {
+  display: block; /* <span> needs this to behave as a block container */
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10000;
+  min-width: 130px;
+  width: max-content;
+  max-width: min(420px, calc(100vw - 16px));
+  background-color: #fff;
+  border-radius: 0 0 5px 5px;
+  box-shadow: 0 3px 15px -5px #000;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.fib-dropdown-option {
+  display: block; /* <span> needs this to stack vertically */
+  font-size: 1rem;
+  padding: 12px 10px;
+  min-height: 44px;
+  cursor: pointer;
+  word-wrap: break-word;
+  color: rgba(0, 0, 0, 0.87);
+  box-sizing: border-box;
+  list-style: none;
+}
+
+/* Suppress any Quill/editor bullet styles that target elements inside .ql-editor */
+.ql-editor .fib-dropdown-option,
+.fib-dropdown-option {
+  &::before,
+  &::marker {
+    display: none !important;
+    content: none !important;
+  }
+}
+
+.fib-dropdown-option:hover {
+  background-color: #eee;
+}
+
+.fib-dropdown-option.selected {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+/* ── End native select styled overlay ── */
+
 .dropdown-option-wrapper {
   width: auto;
   padding: 5px;

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
@@ -846,6 +846,10 @@
   background-color: #eee;
 }
 
+.fib-dropdown-option.highlighted {
+  background-color: #eee;
+}
+
 .fib-dropdown-option.selected {
   background-color: rgba(0, 0, 0, 0.12);
 }

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.scss
@@ -668,6 +668,9 @@
 }
 
 /* Trigger button — styled identically to .select2-selection__rendered */
+.fib-container .ql-snow .ql-editor {
+  overflow: visible !important;
+}
 .fib-select-display {
   /* Reset button defaults */
   appearance: none;

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -114,7 +114,7 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
       let responsiveItem = containerRef.current.closest('.responsive-item') as HTMLElement | null;
       if (!responsiveItem) {
         const root = containerRef.current.getRootNode();
-        const host = root && 'host' in root ? (root.host as HTMLElement | null) : null;
+        const host = root instanceof ShadowRoot ? root.host : null;
         if (host) {
           responsiveItem = host.closest('.responsive-item') as HTMLElement | null;
         }

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -46,17 +46,27 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLSpanElement>(null);
+  const selectedIndex = options.findIndex((o) => o.id === value);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(selectedIndex >= 0 ? selectedIndex : 0);
 
   // Stable IDs for ARIA relationships
   const listboxId = `fib-listbox-${name}`;
   const getOptionId = (optId: string) => `${listboxId}-opt-${optId}`;
-  const activeDescendant = value ? getOptionId(value) : undefined;
+  const activeDescendant =
+    isOpen && options[highlightedIndex]
+      ? getOptionId(options[highlightedIndex].id)
+      : value
+      ? getOptionId(value)
+      : undefined;
 
   const selectedOption = options.find((o) => o.id === value);
   const displayText = selectedOption ? selectedOption.text.replace(/<[^>]*>/g, '') : '';
 
   const open = () => {
-    if (!disabled) setIsOpen(true);
+    if (!disabled) {
+      setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
+      setIsOpen(true);
+    }
   };
   const close = () => setIsOpen(false);
   const toggle = () => {
@@ -81,15 +91,67 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
     return () => document.removeEventListener('mousedown', onOutside);
   }, [isOpen]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const activeOpt = options[highlightedIndex];
+    if (!activeOpt) return;
+    const activeEl = document.getElementById(getOptionId(activeOpt.id));
+    activeEl?.scrollIntoView({ block: 'nearest' });
+  }, [isOpen, highlightedIndex, options]);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (!isOpen) {
+        open();
+      } else {
+        setHighlightedIndex((prev) => {
+          if (!options.length) return 0;
+          return prev >= options.length - 1 ? 0 : prev + 1;
+        });
+      }
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (!isOpen) {
+        open();
+      } else {
+        setHighlightedIndex((prev) => {
+          if (!options.length) return 0;
+          return prev <= 0 ? options.length - 1 : prev - 1;
+        });
+      }
+      return;
+    }
+
+    if (e.key === 'Home' && isOpen) {
+      e.preventDefault();
+      setHighlightedIndex(0);
+      return;
+    }
+
+    if (e.key === 'End' && isOpen) {
+      e.preventDefault();
+      setHighlightedIndex(Math.max(options.length - 1, 0));
+      return;
+    }
+
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      toggle();
-    } else if (e.key === 'Escape') {
-      close();
-    } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !isOpen) {
-      e.preventDefault();
-      open();
+      if (isOpen && options[highlightedIndex]) {
+        const selected = options[highlightedIndex];
+        handleOptionSelect(selected.id, selected.text.replace(/<[^>]*>/g, ''));
+      } else {
+        open();
+      }
     }
   };
 
@@ -118,7 +180,7 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
       </button>
       {isOpen && (
         <span id={listboxId} className="fib-dropdown-options" role="listbox" aria-label={ariaLabel}>
-          {options.map((opt) => {
+          {options.map((opt, optIndex) => {
             const label = opt.text.replace(/<[^>]*>/g, '');
             return (
               <span
@@ -126,7 +188,10 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
                 id={getOptionId(opt.id)}
                 role="option"
                 aria-selected={opt.id === value}
-                className={`fib-dropdown-option${opt.id === value ? ' selected' : ''}`}
+                className={`fib-dropdown-option${opt.id === value ? ' selected' : ''}${
+                  optIndex === highlightedIndex ? ' highlighted' : ''
+                }`}
+                onMouseEnter={() => setHighlightedIndex(optIndex)}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   handleOptionSelect(opt.id, label);

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -1,5 +1,4 @@
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
-import Select2 from 'react-select2-wrapper';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
   NotificationType,
@@ -11,10 +10,6 @@ import { PartComponentProps } from '../types/parts';
 import './FillBlanks.scss';
 import { FIBModel } from './schema';
 
-// Module-level variable to track which dropdown should receive focus after selection
-// This persists across component re-renders
-const pendingFocusRestore: Map<string, { elementKey: string; timestamp: number }> = new Map();
-
 export const parseBool = (val: any) => {
   // cast value to number
   const num: number = +val;
@@ -24,6 +19,128 @@ interface SelectOption {
   key: string;
   value: string;
 }
+
+interface FibDropdownOption {
+  id: string;
+  text: string;
+}
+
+interface FibDropdownProps {
+  name: string;
+  value: string;
+  options: FibDropdownOption[];
+  disabled: boolean;
+  ariaLabel: string;
+  displayClass: string;
+  onSelect: (name: string, value: string, displayText: string) => void;
+}
+
+const FibDropdown: React.FC<FibDropdownProps> = ({
+  name,
+  value,
+  options,
+  disabled,
+  ariaLabel,
+  displayClass,
+  onSelect,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLSpanElement>(null);
+
+  // Stable IDs for ARIA relationships
+  const listboxId = `fib-listbox-${name}`;
+  const getOptionId = (optId: string) => `${listboxId}-opt-${optId}`;
+  const activeDescendant = value ? getOptionId(value) : undefined;
+
+  const selectedOption = options.find((o) => o.id === value);
+  const displayText = selectedOption ? selectedOption.text.replace(/<[^>]*>/g, '') : '';
+
+  const open = () => {
+    if (!disabled) setIsOpen(true);
+  };
+  const close = () => setIsOpen(false);
+  const toggle = () => {
+    if (disabled) return;
+    if (isOpen) {
+      close();
+    } else {
+      open();
+    }
+  };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const clickedInsideTrigger = !!containerRef.current && containerRef.current.contains(target);
+      if (!clickedInsideTrigger) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', onOutside);
+    return () => document.removeEventListener('mousedown', onOutside);
+  }, [isOpen]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    } else if (e.key === 'Escape') {
+      close();
+    } else if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && !isOpen) {
+      e.preventDefault();
+      open();
+    }
+  };
+
+  const handleOptionSelect = (optId: string, optText: string) => {
+    onSelect(name, optId, optText);
+    close();
+  };
+
+  return (
+    <span ref={containerRef} className={`fib-dropdown${isOpen ? ' open' : ''}`}>
+      <button
+        type="button"
+        role="combobox"
+        className={`fib-select-display${displayClass ? ` ${displayClass}` : ''}`}
+        onClick={toggle}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={activeDescendant}
+        aria-label={ariaLabel}
+        onKeyDown={handleKeyDown}
+      >
+        <span className="fib-select-text">{displayText}</span>
+        <span className={`fib-select-arrow${isOpen ? ' open' : ''}`} />
+      </button>
+      {isOpen && (
+        <span id={listboxId} className="fib-dropdown-options" role="listbox" aria-label={ariaLabel}>
+          {options.map((opt) => {
+            const label = opt.text.replace(/<[^>]*>/g, '');
+            return (
+              <span
+                key={opt.id}
+                id={getOptionId(opt.id)}
+                role="option"
+                aria-selected={opt.id === value}
+                className={`fib-dropdown-option${opt.id === value ? ' selected' : ''}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  handleOptionSelect(opt.id, label);
+                }}
+              >
+                {label}
+              </span>
+            );
+          })}
+        </span>
+      )}
+    </span>
+  );
+};
 
 const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
   const id: string = props.id;
@@ -322,35 +439,12 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
   const handleInput = (e: any) => {
     if (!e || typeof e === 'undefined') return;
     setAttempted(true);
-    const inputOption: SelectOption = { key: e.name, value: e.value };
-    maybeUpdateElementValues([inputOption]);
+    maybeUpdateElementValues([{ key: e.name, value: e.value }]);
 
-    // Check if this is a dropdown selection
-    if (fibContainer.current) {
-      const container = fibContainer.current as HTMLElement;
-      const selectElement = container.querySelector(
-        `select[name="${e.name}"]`,
-      ) as HTMLSelectElement;
-      if (selectElement) {
-        // This is a dropdown - track it for focus restoration using module-level variable
-        // Use component id + element key as unique identifier
-        const focusKey = `${id}-${e.name}`;
-        pendingFocusRestore.set(focusKey, {
-          elementKey: e.name,
-          timestamp: Date.now(),
-        });
-
-        // Get the selected option text for announcement
-        const selectedOption = selectElement.options[selectElement.selectedIndex];
-        const selectedText = selectedOption ? selectedOption.text : e.value || 'No selection';
-        announceToScreenReader(`Selected: ${selectedText}`);
-      } else {
-        // This is a text input - focus should already be on it
-        const inputRef = inputRefs.current.get(e.name);
-        if (inputRef && document.activeElement !== inputRef) {
-          inputRef.focus();
-        }
-      }
+    // Announce selection to screen reader — prefer explicit displayText, then native option text
+    const displayText = e.displayText || e.options?.[e.selectedIndex]?.text || e.value || '';
+    if (displayText) {
+      announceToScreenReader(`Selected: ${displayText}`);
     }
   };
 
@@ -474,356 +568,6 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
     }
   }, [elementValues, saveElements]);
 
-  useEffect(() => {
-    if (!ready || !fibContainer.current) return;
-
-    const componentFocusKeys = Array.from(pendingFocusRestore.keys()).filter((key) =>
-      key.startsWith(`${id}-`),
-    );
-
-    if (componentFocusKeys.length === 0) return;
-
-    const restoreFocus = () => {
-      if (!fibContainer.current) return;
-
-      const container = fibContainer.current as HTMLElement;
-
-      componentFocusKeys.forEach((focusKey) => {
-        const pendingFocus = pendingFocusRestore.get(focusKey);
-        if (!pendingFocus) return;
-
-        const { elementKey } = pendingFocus;
-
-        const selectElement = container.querySelector(
-          `select[name="${elementKey}"]`,
-        ) as HTMLSelectElement | null;
-
-        if (!selectElement) {
-          // Element gone → clean up
-          pendingFocusRestore.delete(focusKey);
-          return;
-        }
-        let select2Container: HTMLElement | null = null;
-
-        // Sibling container (most common structure)
-        if (selectElement.parentElement) {
-          select2Container = selectElement.parentElement.querySelector('.select2-container');
-        }
-
-        if (!select2Container) return; // retry next render
-
-        const selection = select2Container.querySelector(
-          '.select2-selection--single',
-        ) as HTMLElement | null;
-
-        if (!selection) return; // retry next render
-
-        selection.focus();
-
-        if (document.activeElement === selection) {
-          pendingFocusRestore.delete(focusKey);
-        }
-      });
-    };
-
-    // 🧠 Timing: wait for React + Select2 to settle
-    const timeoutId = setTimeout(() => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(restoreFocus);
-      });
-    }, 100);
-
-    return () => clearTimeout(timeoutId);
-  }, [contentList, ready, id]);
-
-  // Clear pending focus restores when user clicks outside the component
-  useEffect(() => {
-    if (!ready || !fibContainer.current) return;
-
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!fibContainer.current) return;
-      const container = fibContainer.current as HTMLElement;
-
-      const target = event.target as Node;
-      // Check if click is outside the component
-      if (!container.contains(target)) {
-        // Clear all pending focus restores for this component
-        const componentFocusKeys = Array.from(pendingFocusRestore.keys()).filter((key) =>
-          key.startsWith(`${id}-`),
-        );
-        componentFocusKeys.forEach((focusKey) => {
-          pendingFocusRestore.delete(focusKey);
-        });
-      }
-    };
-
-    // Also handle focus changes - if focus moves outside component, clear pending restores
-    const handleFocusChange = () => {
-      if (!fibContainer.current) return;
-      const container = fibContainer.current as HTMLElement;
-
-      const activeElement = document.activeElement;
-      // If focus is outside the component, clear pending restores
-      if (activeElement && !container.contains(activeElement)) {
-        const componentFocusKeys = Array.from(pendingFocusRestore.keys()).filter((key) =>
-          key.startsWith(`${id}-`),
-        );
-        componentFocusKeys.forEach((focusKey) => {
-          pendingFocusRestore.delete(focusKey);
-        });
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('focusin', handleFocusChange);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('focusin', handleFocusChange);
-    };
-  }, [ready, id]);
-
-  // Set up Select2 event listeners for focus management and ARIA updates
-  useEffect(() => {
-    if (!ready || !elements?.length || !fibContainer.current) return;
-
-    const cleanupFunctions: (() => void)[] = [];
-
-    // Find all Select2 dropdowns within the component
-    const container = fibContainer.current as HTMLElement;
-    const select2Containers = container.querySelectorAll('.select2-container');
-
-    select2Containers.forEach((select2Container) => {
-      const $select2 = (window as any).$(select2Container);
-      if (!$select2 || !$select2.data('select2')) return;
-
-      // Find the associated select element to get the name/key
-      const selectElement = select2Container.querySelector('select[name]') as HTMLSelectElement;
-      if (!selectElement) return;
-
-      const elementKey = selectElement.name;
-
-      // Update initial aria-label to avoid redundant reading
-      const selectedOption = selectElement.options[selectElement.selectedIndex];
-      const selectedText = selectedOption ? selectedOption.text : '';
-
-      // Find the index of this dropdown in content array
-      let dropdownIndex = -1;
-      if (content) {
-        for (let i = 0; i < content.length; i++) {
-          if (content[i].dropdown === elementKey) {
-            dropdownIndex = i;
-            break;
-          }
-        }
-      }
-
-      const indexLabel = dropdownIndex >= 0 ? `Dropdown ${dropdownIndex + 1}` : 'Dropdown';
-      if (selectedText) {
-        // Set aria-label to just the value, Select2 will add "combobox" automatically
-        selectElement.setAttribute('aria-label', `${selectedText}, ${indexLabel}`);
-      } else {
-        selectElement.setAttribute('aria-label', `${indexLabel}, Make a selection`);
-      }
-
-      const handleOpen = () => {
-        // Update aria-expanded when dropdown opens
-        const selection = select2Container.querySelector(
-          '.select2-selection--single',
-        ) as HTMLElement;
-        if (selection) {
-          selection.setAttribute('aria-expanded', 'true');
-        }
-      };
-
-      const handleSelect = () => {
-        // Track that this dropdown was selected - use module-level variable
-        const focusKey = `${id}-${elementKey}`;
-        pendingFocusRestore.set(focusKey, {
-          elementKey: elementKey,
-          timestamp: Date.now(),
-        });
-      };
-
-      const handleClose = () => {
-        // Update aria-expanded when dropdown closes
-        const selection = select2Container.querySelector(
-          '.select2-selection--single',
-        ) as HTMLElement;
-        if (selection) {
-          selection.setAttribute('aria-expanded', 'false');
-
-          // Update aria-label to include selected value and avoid redundant reading
-          const selectedOption = selectElement.options[selectElement.selectedIndex];
-          const selectedText = selectedOption ? selectedOption.text : '';
-
-          // Find the index of this dropdown in content array
-          let dropdownIndex = -1;
-          if (content) {
-            for (let i = 0; i < content.length; i++) {
-              if (content[i].dropdown === elementKey) {
-                dropdownIndex = i;
-                break;
-              }
-            }
-          }
-
-          const indexLabel = dropdownIndex >= 0 ? `Dropdown ${dropdownIndex + 1}` : 'Dropdown';
-          if (selectedText) {
-            // Set aria-label to just the value, Select2 will add "combobox" automatically
-            selectElement.setAttribute('aria-label', `${selectedText}, ${indexLabel}`);
-          } else {
-            selectElement.setAttribute('aria-label', `${indexLabel}, Make a selection`);
-          }
-        }
-
-        // Check if this dropdown should have focus restored using module-level variable
-        const focusKey = `${id}-${elementKey}`;
-        const pendingFocus = pendingFocusRestore.get(focusKey);
-
-        if (pendingFocus && pendingFocus.elementKey === elementKey) {
-          // When dropdown closes, restore focus to the trigger
-          // Use multiple delays to ensure component has finished re-rendering
-          setTimeout(() => {
-            requestAnimationFrame(() => {
-              requestAnimationFrame(() => {
-                // Wait a bit more to ensure re-render is complete
-                setTimeout(() => {
-                  // Verify this is still the correct dropdown after re-render
-                  const currentSelectElement = container.querySelector(
-                    `select[name="${elementKey}"]`,
-                  ) as HTMLSelectElement;
-                  if (!currentSelectElement) {
-                    // Element doesn't exist, safe to delete
-                    pendingFocusRestore.delete(focusKey);
-                    return;
-                  }
-
-                  // Try multiple methods to find the Select2 container
-                  // In Select2, the container is often a sibling of the select element
-                  let currentSelect2Container: HTMLElement | null = null;
-
-                  // Method 1: Use jQuery/Select2 API (most reliable)
-                  const $select2 = (window as any).$(currentSelectElement);
-                  if ($select2 && $select2.data('select2')) {
-                    const select2Instance = $select2.data('select2');
-                    if (select2Instance.$container && select2Instance.$container.length > 0) {
-                      currentSelect2Container = select2Instance.$container[0] as HTMLElement;
-                    }
-                  }
-
-                  // Method 2: Find sibling select2-container (they're siblings in the DOM)
-                  if (!currentSelect2Container) {
-                    const parent = currentSelectElement.parentElement;
-                    if (parent) {
-                      // Look for select2-container as a sibling
-                      currentSelect2Container = parent.querySelector(
-                        '.select2-container',
-                      ) as HTMLElement;
-                    }
-                  }
-
-                  // Method 3: closest() - works if select is a descendant
-                  if (!currentSelect2Container) {
-                    currentSelect2Container = currentSelectElement.closest(
-                      '.select2-container',
-                    ) as HTMLElement;
-                  }
-
-                  // Method 4: Find by data-select2-id relationship
-                  if (!currentSelect2Container) {
-                    const select2Id = currentSelectElement.getAttribute('data-select2-id');
-                    if (select2Id) {
-                      // The container's data-select2-id is usually close to the select's id
-                      // Try finding container in the same parent
-                      const parent = currentSelectElement.parentElement;
-                      if (parent) {
-                        currentSelect2Container = parent.querySelector(
-                          '.select2-container',
-                        ) as HTMLElement;
-                      }
-                      // If still not found, search the whole container
-                      if (!currentSelect2Container) {
-                        currentSelect2Container = container.querySelector(
-                          `.select2-container[data-select2-id]`,
-                        ) as HTMLElement;
-                      }
-                    }
-                  }
-
-                  // Method 5: Find container by looking for parent with class
-                  if (!currentSelect2Container) {
-                    let parent = currentSelectElement.parentElement;
-                    while (parent && parent !== container) {
-                      if (parent.classList.contains('select2-container')) {
-                        currentSelect2Container = parent;
-                        break;
-                      }
-                      parent = parent.parentElement;
-                    }
-                  }
-
-                  if (!currentSelect2Container) {
-                    // Select2 container not found yet - might still be initializing after re-render
-                    // Keep pending for retry, don't delete - the post-render effect will retry
-                    return;
-                  }
-
-                  const currentSelection = currentSelect2Container.querySelector(
-                    '.select2-selection--single',
-                  ) as HTMLElement;
-                  if (currentSelection) {
-                    const activeElement = document.activeElement;
-                    const isWithinComponent = container.contains(activeElement);
-
-                    // Only restore focus if focus is still within the component
-                    // This prevents focus jumping when user clicks outside
-                    if (isWithinComponent) {
-                      // Ensure the element is focusable
-                      currentSelection.setAttribute('tabindex', '0');
-                      // Focus the selection element
-                      currentSelection.focus();
-                      // Also ensure the underlying select has focus for Select2 compatibility
-                      currentSelectElement.focus();
-
-                      // Only clear the tracking after focus is successfully restored
-                      if (
-                        document.activeElement === currentSelection ||
-                        document.activeElement === currentSelectElement
-                      ) {
-                        pendingFocusRestore.delete(focusKey);
-                      }
-                    } else {
-                      // User clicked outside, clear the pending restore
-                      pendingFocusRestore.delete(focusKey);
-                    }
-                  } else {
-                    // Selection element not found, but container exists
-                    // Keep pending for retry - might be a timing issue
-                    return;
-                  }
-                }, 100); // Additional delay to ensure re-render is complete
-              });
-            });
-          }, 300); // Initial delay to allow screen reader announcement
-        }
-      };
-
-      $select2.on('select2:open', handleOpen);
-      $select2.on('select2:select', handleSelect);
-      $select2.on('select2:close', handleClose);
-      cleanupFunctions.push(() => {
-        $select2.off('select2:open', handleOpen);
-        $select2.off('select2:select', handleSelect);
-        $select2.off('select2:close', handleClose);
-      });
-    });
-
-    return () => {
-      cleanupFunctions.forEach((cleanup) => cleanup());
-    };
-  }, [ready, elements, contentList]);
-
   const getStateSelections = (snapshot: any) => {
     if (!Object.keys(snapshot)?.length || !elements?.length) return;
 
@@ -891,25 +635,20 @@ const FillBlanks: React.FC<PartComponentProps<FIBModel>> = (props) => {
               insertList.push(
                 <span className="dropdown-blot" tabIndex={-1} key={`dropdown-${insertEl.key}`}>
                   <span className="dropdown-container" tabIndex={-1}>
-                    <Select2
-                      className={`dropdown ${showCorrect || showHints ? answerStatus : ''}`}
+                    <FibDropdown
                       name={insertEl.key}
-                      data={optionsList}
                       value={elVal}
-                      aria-label={
+                      options={optionsList}
+                      disabled={!enabled}
+                      ariaLabel={
                         elVal
                           ? `${elVal}, Dropdown ${index + 1}`
                           : `Dropdown ${index + 1}, Make a selection`
                       }
-                      options={{
-                        dropdownParent: fibContainer.current,
-                        minimumResultsForSearch: 10,
-                        selectOnClose: false,
-                        // 👇 Important to allow HTML rendering in options
-                        escapeMarkup: (markup: string) => markup,
-                      }}
-                      onSelect={(e: any) => handleInput(e.currentTarget)}
-                      disabled={!enabled}
+                      displayClass={showCorrect || showHints ? answerStatus : ''}
+                      onSelect={(fieldName, optionId, displayText) =>
+                        handleInput({ name: fieldName, value: optionId, displayText })
+                      }
                     />
                   </span>
                 </span>,

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -46,6 +46,8 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLSpanElement>(null);
+  const responsiveItemRef = useRef<HTMLElement | null>(null);
+  const previousResponsiveItemZIndexRef = useRef<string>('');
   const selectedIndex = options.findIndex((o) => o.id === value);
   const [highlightedIndex, setHighlightedIndex] = useState<number>(selectedIndex >= 0 ? selectedIndex : 0);
 
@@ -89,6 +91,45 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
     };
     document.addEventListener('mousedown', onOutside);
     return () => document.removeEventListener('mousedown', onOutside);
+  }, [isOpen]);
+
+  useEffect(
+    () => () => {
+      if (responsiveItemRef.current) {
+        responsiveItemRef.current.style.zIndex = previousResponsiveItemZIndexRef.current;
+      }
+    },
+    [],
+  );
+
+  // Raise parent responsive-item z-index while dropdown is open, then restore previous value.
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    if (isOpen) {
+      // In shadow DOM, closest() won't cross the shadow boundary.
+      // Fall back to searching from the shadow host in light DOM.
+      let responsiveItem = containerRef.current.closest('.responsive-item') as HTMLElement | null;
+      if (!responsiveItem) {
+        const root = containerRef.current.getRootNode();
+        const host = root && 'host' in root ? (root.host as HTMLElement | null) : null;
+        if (host) {
+          responsiveItem = host.closest('.responsive-item') as HTMLElement | null;
+        }
+      }
+      if (responsiveItem) {
+        responsiveItemRef.current = responsiveItem;
+        previousResponsiveItemZIndexRef.current = responsiveItem.style.zIndex || '';
+        responsiveItem.style.zIndex = '9999999';
+      }
+      return;
+    }
+
+    if (responsiveItemRef.current) {
+      responsiveItemRef.current.style.zIndex = previousResponsiveItemZIndexRef.current;
+      responsiveItemRef.current = null;
+      previousResponsiveItemZIndexRef.current = '';
+    }
   }, [isOpen]);
 
   useEffect(() => {

--- a/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
+++ b/assets/src/components/parts/janus-fill-blanks/FillBlanks.tsx
@@ -49,7 +49,9 @@ const FibDropdown: React.FC<FibDropdownProps> = ({
   const responsiveItemRef = useRef<HTMLElement | null>(null);
   const previousResponsiveItemZIndexRef = useRef<string>('');
   const selectedIndex = options.findIndex((o) => o.id === value);
-  const [highlightedIndex, setHighlightedIndex] = useState<number>(selectedIndex >= 0 ? selectedIndex : 0);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(
+    selectedIndex >= 0 ? selectedIndex : 0,
+  );
 
   // Stable IDs for ARIA relationships
   const listboxId = `fib-listbox-${name}`;

--- a/assets/styles/common/responsive-layout.scss
+++ b/assets/styles/common/responsive-layout.scss
@@ -277,11 +277,17 @@ janus-input-number .unitsLabel {
   padding-bottom: 25px;
 }
 .responsive-layout-section .stageContainer,
-.responsive-layout-section .content,
-.responsive-layout-section .advance-authoring-responsive-layout {
+.responsive-layout-section .content {
   width: 100vw;
   max-width: 1200px;
   min-width: 350px;
+}
+
+.responsive-layout-section .advance-authoring-responsive-layout {
+  width: 100%;
+  max-width: inherit;
+  min-width: inherit;
+  box-sizing: border-box;
 }
 .checkContainer {
   min-width: 350px;


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

### Replaced Select2 with custom dropdown for FITB

* Replaced `Select2` with a custom dropdown to resolve cross-browser issues observed in Safari, Firefox, and iOS (auto-selection and dropdown closing immediately on open due to conflicting event sequences).

* Preserved existing FITB behavior and styling, including:

  * correct / incorrect / hint states
  * inline layout within content
  * existing visual design expectations

* Implemented accessible combobox pattern:

  * `role="combobox"` trigger with `aria-expanded`, `aria-controls`
  * `role="listbox"` and `role="option"` semantics
  * `aria-activedescendant` for active option tracking

* Added keyboard interaction support:

  * `ArrowUp` / `ArrowDown` to open and navigate
  * `Enter` / `Space` to select
  * `Escape` to close
  * `Home` / `End` for quick navigation

* Improved interaction reliability across input types (mouse, touch, keyboard), avoiding the event timing conflicts seen with Select2.

* Addressed dropdown clipping within responsive containers by managing stacking context (z-index) when open and restoring it on close.


https://github.com/user-attachments/assets/22135207-2da0-405f-8c5a-f5057c5217f0

