### PR TITLE
[DEVOPS] [MER-0000] Fix Github Actions Package Workflow (hotfix branch)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,10 +49,8 @@ jobs:
           load: true
           push: false
           tags: amazon-linux-builder:local
-          cache-from: |
-            type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-${{ github.ref_name }}
-            type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-main
-          cache-to: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-${{ github.ref_name }},mode=max
+          cache-from: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache
+          cache-to: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache,mode=max
 
       - name: 📦 Package for Amazon Linux
         uses: ./.github/actions/amazon-linux-builder

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   amazon-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
 
     outputs:
       app_version: ${{ steps.info.outputs.app_version }}
@@ -31,6 +34,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: 🔑 Log in to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
         # build (or retrieve from cache) the amazon-linux-builder image, used by the next step to build the release for Amazon Linux 2
       - name: 🐳 Build amazon-linux-builder image
         uses: docker/build-push-action@v5
@@ -39,8 +49,8 @@ jobs:
           load: true
           push: false
           tags: amazon-linux-builder:local
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache
+          cache-to: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache,mode=max
 
       - name: 📦 Package for Amazon Linux
         uses: ./.github/actions/amazon-linux-builder

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,8 +49,10 @@ jobs:
           load: true
           push: false
           tags: amazon-linux-builder:local
-          cache-from: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache
-          cache-to: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache,mode=max
+          cache-from: |
+            type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-${{ github.ref_name }}
+            type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-main
+          cache-to: type=registry,ref=ghcr.io/simon-initiative/amazon-linux-builder:buildcache-${{ github.ref_name }},mode=max
 
       - name: 📦 Package for Amazon Linux
         uses: ./.github/actions/amazon-linux-builder


### PR DESCRIPTION
Fixes the Github Actions Package workflow for amazon linux builder.

The issue seems to be that caching the amazon linux builder image using the old strategy seems to have broke, so this changes the caching strategy to a better more reliable approach.