### PR TITLE
[BUG FIX] [MER-5549] redo truncation fix for section delivery

### DIFF
--- a/assets/styles/common/previous_next_nav.scss
+++ b/assets/styles/common/previous_next_nav.scss
@@ -56,6 +56,7 @@
   .page-nav-link-placeholder {
     margin-top: 20px;
     width: 30%;
+    min-width: 0;
   }
 
   .nav-label {
@@ -84,6 +85,7 @@
     .page-nav-link-placeholder {
       padding: 16px;
       width: 40%;
+      min-width: 0;
     }
 
     .nav-label {

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -1052,7 +1052,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
           <div
             :if={!is_nil(@previous_page)}
-            class="hidden lg:flex grow shrink basis-0 h-10 justify-start items-center z-10"
+            class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-start items-center z-10"
             role="prev_page"
           >
             <div
@@ -1074,9 +1074,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
                 <.left_arrow />
               </.link>
             </div>
-            <div class="hidden sm:flex flex-row gap-x-1 justify-start items-center grow shrink basis-0 dark:text-white text-xs font-normal overflow-hidden text-ellipsis whitespace-nowrap">
+            <div class="hidden sm:flex flex-row gap-x-1 justify-start items-center grow shrink basis-0 w-0 flex-1 min-w-0 dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap">
               {maybe_add_icon(@previous_page, @pages_progress)}
-              <span class="overflow-hidden text-ellipsis" title={@previous_page["title"]}>
+              <span
+                class="block w-0 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
+                title={@previous_page["title"]}
+              >
                 {@previous_page["title"]}
               </span>
             </div>
@@ -1084,12 +1087,15 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
           <div
             :if={!is_nil(@next_page)}
-            class="hidden lg:flex grow shrink basis-0 h-10 justify-end items-center z-10"
+            class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-end items-center z-10"
             role="next_page"
           >
-            <div class="hidden sm:flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 text-right dark:text-white text-xs font-normal overflow-hidden text-ellipsis whitespace-nowrap">
+            <div class="hidden sm:flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 w-0 flex-1 min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap">
               {maybe_add_icon(@next_page, @pages_progress)}
-              <span class="overflow-hidden text-ellipsis" title={@next_page["title"]}>
+              <span
+                class="block w-0 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
+                title={@next_page["title"]}
+              >
                 {@next_page["title"]}
               </span>
             </div>

--- a/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
+++ b/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
@@ -1,0 +1,46 @@
+defmodule OliWeb.Components.Delivery.LayoutsPreviousNextNavTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias OliWeb.Components.Delivery.Layouts
+
+  describe "previous_next_nav/1" do
+    test "renders desktop title rows with shrinkable truncating spans" do
+      page = %{
+        "id" => "1",
+        "slug" => "long-title-page",
+        "type" => "page",
+        "level" => "3",
+        "title" => "A very long page title that should truncate in the section delivery bottom bar",
+        "graded" => "false"
+      }
+
+      html =
+        render_component(&Layouts.previous_next_nav/1, %{
+          current_page: %{"id" => "99"},
+          previous_page: page,
+          next_page: page,
+          section_slug: "section-slug",
+          pages_progress: %{},
+          request_path: "/sections/section-slug/page/long-title-page",
+          selected_view: "gallery"
+        })
+
+      assert html =~
+               ~s(class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-start items-center z-10")
+
+      assert html =~
+               ~s(class="hidden sm:flex flex-row gap-x-1 justify-start items-center grow shrink basis-0 w-0 flex-1 min-w-0 dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap")
+
+      assert html =~
+               ~s(class="block w-0 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap")
+
+      assert html =~
+               ~s(class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-end items-center z-10")
+
+      assert html =~
+               ~s(class="hidden sm:flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 w-0 flex-1 min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap")
+    end
+  end
+end

--- a/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
+++ b/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
@@ -12,7 +12,8 @@ defmodule OliWeb.Components.Delivery.LayoutsPreviousNextNavTest do
         "slug" => "long-title-page",
         "type" => "page",
         "level" => "3",
-        "title" => "A very long page title that should truncate in the section delivery bottom bar",
+        "title" =>
+          "A very long page title that should truncate in the section delivery bottom bar",
         "graded" => "false"
       }
 


### PR DESCRIPTION
This PR corrects the earlier attempted fix for MER-5549 by targeting the actual section-delivery navigation component used in production lesson pages.

  The previous fix updated older previous/next navigation markup and improved truncation behavior in preview-style surfaces, but section delivery uses a different bottom bar implementation lib/oli_web/components/delivery/layouts.ex.    That component had its own desktop previous/next title layout, and the title region was missing the full flexbox shrink constraints required for ellipsis truncation to apply. 

  This PR fixes the production path directly by updating the desktop previous/next title containers in the section-delivery bottom bar to use truncation-safe flex sizing (min-w-0, w-0, and flex-1) so long titles reliably truncate within the available space. It also adds focused regression coverage for this actual section-delivery component in test/oli_web/components/delivery/layouts_previous_next_nav_test.exs, addressing the test gap that allowed the earlier fix to miss the live section-delivery case.

  Verification:

  - mix test test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
  - mix test test/oli_web/views/page_delivery_view_test.exs test/oli_web/controllers/resource_controller_test.exs