### PR TITLE
[BUG FIX] [MER-5540] Fix LTI keyset cache refresh not reliably working

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ Example activity types: Multiple Choice, Short Answer, File Upload, Multi-Input,
 - **Frontend**: Jest tests alongside source files
 - Use factories for test data generation
 - Integration tests for critical workflows
+- For ExUnit cases that intentionally trigger application logs as part of the expected behavior, do not leave those logs visible in normal test output: use `@tag capture_log: true` when the test only needs to silence them, or use `capture_log([level: ...], fn -> ... end)` when the test needs to assert on the emitted logs
 - Always run tests before committing
 
 ## Code Reviews

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ yarn format
 The backend follows Phoenix context pattern with clear separation of concerns:
 
 #### Core Contexts (`lib/oli/`)
+
 - **Authoring**: Project management, collaboration, content creation
 - **Delivery**: Section management, student progress, grading
 - **Activities**: Extensible activity framework with registration system
@@ -65,6 +66,7 @@ The backend follows Phoenix context pattern with clear separation of concerns:
 - **Accounts**: User and author management
 
 #### Web Layer (`lib/oli_web/`)
+
 - **Controllers**: Traditional HTTP endpoints
 - **LiveViews**: Real-time interactive UI components
 - **API**: REST endpoints for frontend integration
@@ -92,6 +94,7 @@ Located in `assets/src/`:
 ## Database Schema
 
 PostgreSQL with Ecto ORM. Key tables:
+
 - `projects`: Course authoring projects
 - `sections`: Course delivery instances
 - `resources` & `revisions`: Versioned content
@@ -103,6 +106,7 @@ PostgreSQL with Ecto ORM. Key tables:
 ## Activity Development
 
 Activities are self-contained components with:
+
 - Manifest file defining metadata
 - Authoring component (React)
 - Delivery component (React)
@@ -117,7 +121,10 @@ Example activity types: Multiple Choice, Short Answer, File Upload, Multi-Input,
 - **Frontend**: Jest tests alongside source files
 - Use factories for test data generation
 - Integration tests for critical workflows
-- For ExUnit cases that intentionally trigger application logs as part of the expected behavior, do not leave those logs visible in normal test output: use `@tag capture_log: true` when the test only needs to silence them, or use `capture_log([level: ...], fn -> ... end)` when the test needs to assert on the emitted logs
+- For ExUnit cases that intentionally trigger application logs:
+  - If a test intentionally triggers application logs and does not assert on them, use `@tag capture_log: true`.
+  - If a test needs to verify emitted logs, wrap the relevant code in `capture_log(...)`.
+  - Do not leave intentional logs visible in normal test output.
 - Always run tests before committing
 
 ## Code Reviews
@@ -148,18 +155,21 @@ The review process should first assess the scope of the PR, then load the approp
 ## Common Development Tasks
 
 ### Adding a New Page/LiveView
+
 1. Create LiveView module in `lib/oli_web/live/`
 2. Add route in `lib/oli_web/router.ex`
 3. Create corresponding templates if needed
 4. Add tests in `test/oli_web/live/`
 
 ### Modifying Activities
+
 1. Update activity manifest in `assets/src/components/activities/[activity_type]/`
 2. Modify authoring/delivery components
 3. Update model schema if needed
 4. Test both authoring and delivery modes
 
 ### Working with Resources/Content
+
 1. Use `Oli.Resources` context for content operations
 2. Always work with revisions, not resources directly
 3. Respect the publication model - don't modify published content

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md
@@ -1,0 +1,283 @@
+# TRIAGE-2236 LTI Keyset Cache Reliability - Functional Design Document
+
+## 1. Executive Summary
+
+This design changes Torus keyset resolution from fail-fast-plus-background-refresh to read-through-on-miss while preserving the current ETS cache and Oban refresh worker. The simplest adequate approach is to keep `Oli.Lti.KeysetCache` as the warm-path authority, keep `Oli.Lti.KeysetRefreshWorker` for periodic and operator-triggered background warming, and extend `Oli.Lti.CachedKeyProvider` so launch-time cold-cache and cached-`kid`-miss paths synchronously fetch the latest JWKS before returning an error.
+
+This design satisfies `FR-002` through `FR-009` and directly implements `AC-001`, `AC-002`, `AC-003`, `AC-004`, `AC-005`, `AC-006`, and `AC-007` without introducing a new persistence layer or broad LTI launch redesign.
+
+## 2. Requirements & Assumptions
+
+- Functional requirements:
+  - `FR-001`: capture enough diagnostics and operational context to explain plausible stale-cache and failed-recovery causes after implementation.
+  - `FR-002`, `FR-005`, `FR-006`: cold-cache launch paths must read through instead of failing immediately, so first launch from a valid registration can succeed. This maps to `AC-001`.
+  - `FR-003`, `FR-004`, `FR-005`: cached `kid` misses must synchronously refresh and repopulate ETS before returning a terminal key lookup failure. This maps to `AC-002` and `AC-005`.
+  - `FR-007`: warm-cache hits must stay cache-only. This maps to `AC-003`.
+  - `FR-008`: logs and telemetry must explain cache source, refresh path, key ids, and terminal classification. This maps to `AC-004` and `AC-006`.
+  - `FR-009`: user-facing messages must describe actual recovery behavior, not just queued work. This maps to `AC-007`.
+- Non-functional requirements:
+  - Launch validation remains HTTPS-only and must not weaken signature verification.
+  - Warm-cache performance remains the primary path; synchronous network fetch is reserved for exceptional miss paths.
+  - The design must remain operable in the existing Phoenix, ETS, and Oban runtime without new infrastructure.
+- Assumptions:
+  - `Lti_1p3.KeyProvider.get_public_key/2` may perform synchronous work as long as it returns the same success and error shapes expected by launch validation.
+  - Existing HTTP client behavior in `Lti_1p3.Config.http_client!/0` is acceptable for launch-path read-through requests.
+  - The repository-local harness contract files were not present at intake, so this FDD relies on `AGENTS.md`, the PRD, and current LTI module boundaries.
+
+## 3. Repository Context Summary
+
+- What we know:
+  - [cached_key_provider.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/cached_key_provider.ex) currently schedules Oban refresh and fails immediately on `:keyset_not_cached` and `:key_not_found`.
+  - [keyset_cache.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_cache.ex) stores `%{keys, fetched_at, expires_at}` in ETS and exposes warm-path lookup APIs that are already suitable for the success path.
+  - [keyset_refresh_worker.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_refresh_worker.ex) already encapsulates HTTPS validation, HTTP fetch, JWKS parsing, TTL extraction, and cache population for asynchronous refresh.
+  - Existing tests in [cached_key_provider_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/cached_key_provider_test.exs), [keyset_cache_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_cache_test.exs), and [keyset_refresh_worker_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_refresh_worker_test.exs) already cover most of the current seams.
+- Unknowns to confirm:
+  - Whether any `lti_1p3` caller logic assumes the current specific `reason` atoms for cache miss failure.
+  - Whether operator tooling or dashboards currently parse the existing log strings and need compatibility-preserving message keys.
+  - Which OTP coordination primitive is the best fit for per-URL single-flight fetch ownership in this codebase.
+
+## 4. Proposed Design
+
+### 4.1 Component Roles & Interactions
+
+- `Oli.Lti.CachedKeyProvider` becomes the read-through coordinator.
+  - Warm hit: return cached JWK immediately.
+  - Cold cache: synchronously fetch, populate cache, retry lookup, then return success or classified error. Covers `AC-001`, `AC-004`, and `AC-006`.
+  - Cached `kid` miss: synchronously refresh, overwrite cache, retry lookup, then return success or classified error. Covers `AC-002`, `AC-005`, and `AC-006`.
+  - Per-URL single-flight request coalescing is part of the initial implementation. If one request is already fetching a JWKS for a given `key_set_url`, later requests for that same URL wait for the first fetch attempt to finish and then re-read ETS instead of triggering duplicate HTTP fetches.
+  - Continue to expose `preload_keys/1` and `refresh_all_keys/0` for manual and background operations.
+- `Oli.Lti.KeysetCache` remains the in-memory storage boundary.
+  - No new storage backend.
+  - Keep `fetched_at` and `expires_at`.
+  - Optionally extend cached metadata with lightweight source context only if needed for diagnostics.
+- `Oli.Lti.KeysetRefreshWorker` remains the asynchronous maintainer.
+  - Background refresh still warms cache and supports periodic reliability posture.
+  - Shared fetch/parse/cache code should be extracted so both synchronous and asynchronous paths use the same JWKS parsing and TTL logic.
+- Shared fetch module:
+  - Introduce a narrow internal helper such as `Oli.Lti.KeysetFetcher` or a private extracted function module.
+  - Responsibilities: HTTPS validation, HTTP GET, JWKS JSON validation, TTL extraction, and normalized result tuples.
+  - This avoids duplicating fetch logic between launch path and worker path.
+- Single-flight coordinator:
+  - Introduce a small coordination boundary such as `Oli.Lti.KeysetFetchCoordinator` keyed by `key_set_url`.
+  - Responsibilities: grant a single active fetch owner per URL, let same-URL waiters block with a bounded timeout, and signal completion so waiters re-read ETS after the shared fetch finishes.
+  - This coordinator is not a cache and does not own JWKS data. It only suppresses duplicate in-flight fetches.
+
+### 4.2 State & Data Flow
+
+1. Launch validation calls `CachedKeyProvider.get_public_key(key_set_url, kid)`.
+2. Provider checks `KeysetCache.get_public_key/2`.
+3. If warm hit:
+   - return cached `JOSE.JWK`
+   - emit warm-cache diagnostics
+   - satisfies `AC-003`
+4. If cache is missing:
+   - if another request is already fetching the same `key_set_url`, wait for that attempt to complete and then retry ETS lookup
+   - otherwise perform synchronous fetch using shared fetch helper
+   - on successful JWKS load, write to ETS and retry key lookup
+   - if the requested `kid` is found, return success and record `cache_source=sync_cold_fill`
+   - if fetch fails or loaded keyset still cannot satisfy lookup, return classified error
+   - satisfies `AC-001`, `AC-004`, and `AC-006`
+5. If cache exists but `kid` is absent:
+   - acquire the same per-URL single-flight ownership used by cold-cache fill
+   - if another request is already refreshing that `key_set_url`, wait for completion and then retry ETS lookup
+   - otherwise perform synchronous refresh using shared fetch helper
+   - overwrite ETS entry with fresh JWKS and updated TTL
+   - retry key lookup
+   - if the requested `kid` is found, return success and record `cache_source=sync_refresh_after_kid_miss`
+   - if not found or refresh fails, return classified error
+   - satisfies `AC-002`, `AC-005`, and `AC-006`
+6. Background refresh remains available:
+   - keep `schedule_refresh/1` and `schedule_refresh_all/0`
+   - do not depend on queued work for correctness of the current launch
+
+### 4.3 Lifecycle & Ownership
+
+- Cache ownership:
+  - ETS remains the only keyset cache store in scope.
+  - `KeysetCache` owns insertion, expiration, and deletion semantics.
+- Fetch ownership:
+  - Synchronous fetch is owned by `CachedKeyProvider` because launch correctness depends on it.
+  - Asynchronous fetch is owned by `KeysetRefreshWorker` because background warming is an operational concern.
+  - Shared parsing and normalization belongs in a helper module, not split across both callers.
+- Error ownership:
+  - `CachedKeyProvider` owns translation from low-level fetch/lookup outcomes into user-facing `reason`/`msg` maps expected by the LTI validation boundary.
+  - Worker logs operational failures but does not define launch-path messaging.
+
+### 4.4 Alternatives Considered
+
+- Keep the current async-only refresh design:
+  - rejected because it directly violates `FR-005` and fails `AC-001` and `AC-002`.
+- Bypass cache entirely and always fetch JWKS synchronously:
+  - rejected because it would regress warm-path performance, increase external dependency on every launch, and violate `FR-007`.
+- Persist keysets in the database:
+  - rejected because the PRD does not require durable storage and ETS already satisfies the intended steady-state behavior.
+- Skip single-flight coordination and accept duplicate miss-path fetches:
+  - rejected because the first implementation should already prevent thundering herd behavior during cold-cache and rotation incidents.
+  - repeated same-URL fetches would add avoidable load to the LMS JWKS endpoint at exactly the moment Torus is recovering from a miss.
+
+## 5. Interfaces
+
+- Existing public interface stays stable:
+  - `CachedKeyProvider.get_public_key(key_set_url, kid) -> {:ok, JOSE.JWK.t()} | {:error, %{reason: atom(), msg: String.t()}}`
+- New internal interface:
+  - `KeysetFetcher.fetch_and_cache(key_set_url) -> {:ok, %{keys: list(), fetched_at: DateTime.t(), expires_at: DateTime.t(), ttl_seconds: integer()}} | {:error, fetch_reason}`
+- New coordination interface:
+  - `KeysetFetchCoordinator.run(key_set_url, fun) -> {:ok, result} | {:error, reason}`
+  - semantics:
+    - first caller for a URL executes `fun`
+    - concurrent callers for the same URL wait for completion up to a bounded timeout
+    - waiters re-read ETS after owner completion rather than trusting an in-memory return value alone
+- Existing cache interface remains:
+  - `KeysetCache.get_public_key/2`
+  - `KeysetCache.put_keyset/3`
+  - `KeysetCache.get_keyset/1`
+  - `KeysetCache.delete_keyset/1`
+- Existing worker interface remains:
+  - `KeysetRefreshWorker.schedule_refresh/1`
+  - `KeysetRefreshWorker.schedule_refresh_all/0`
+- Log and telemetry payload interface:
+  - required fields: `key_set_url`, `requested_kid`, `lookup_source`, `cached_key_ids`, `refreshed_key_ids`, `cache_fetched_at`, `cache_expires_at`, `outcome`
+  - values must remain non-sensitive and should omit raw token or full JWKS payload content
+
+## 6. Data Model & Storage
+
+- No new database tables or migrations are required.
+- ETS cached value may remain `%{keys, fetched_at, expires_at}`.
+- If diagnostic needs justify it, cached entry may add:
+  - `last_refresh_source` with values like `background`, `preload`, `sync_cold_fill`, `sync_refresh_after_kid_miss`
+  - this is optional and should stay in-memory only
+- The design intentionally does not persist negative cache results.
+
+## 7. Consistency & Transactions
+
+- There is no cross-process transaction boundary because ETS writes and HTTP fetches are not transactional.
+- Consistency model:
+  - warm reads are eventually refreshed based on TTL or explicit refresh
+  - sync miss paths update ETS before retrying lookup in the same request
+  - the current request must only succeed after the refreshed cache has been written and re-read
+- Concurrent read-through misses on the same URL are coalesced through the single-flight coordinator.
+  - one fetch owner performs the network call
+  - same-URL waiters re-read ETS after completion
+  - if the owner fails, waiters surface the same terminal condition after the shared attempt completes or times out
+
+## 8. Caching Strategy
+
+- Primary cache remains ETS in `KeysetCache`.
+- TTL continues to come from `Cache-Control: max-age` when present, else default TTL.
+- Expired entries are treated as uncached and trigger the same synchronous read-through behavior as first use. This supports `AC-001`.
+- Cached `kid` miss is treated as a refresh trigger, not an immediate terminal failure. This supports `AC-002`.
+- Read-through fetches are coalesced per `key_set_url` so only one in-flight HTTP fetch for a URL happens at a time.
+- Background Oban refresh remains useful for proactive warming and administrative recovery, but not correctness of the current launch.
+
+## 9. Performance & Scalability Posture
+
+- Warm path remains unchanged and in-memory, satisfying `FR-007` and `AC-003`.
+- Exceptional miss paths add one synchronous network call and one ETS write before retry.
+- Read-through launch latency is acceptable because it trades one-time delay for correctness and removal of manual intervention.
+- Per-URL single-flight coordination prevents thundering herd amplification on miss paths and reduces redundant load on the JWKS endpoint.
+
+## 10. Failure Modes & Resilience
+
+- JWKS URL invalid or insecure:
+  - return classified error immediately after validation failure
+  - worker continues to discard these as permanent configuration problems
+- HTTP/network failure during read-through:
+  - return classified fetch failure for the current launch
+  - diagnostics must show that sync recovery was attempted
+  - covers `AC-004`
+- Single-flight owner crashes or waiters time out:
+  - waiting callers fail in a bounded way rather than blocking indefinitely
+  - diagnostics must show whether the request was fetch owner or waiter and whether the shared wait timed out
+- JWKS JSON invalid or missing `"keys"`:
+  - return classified parse failure for the current launch
+  - covers `AC-004`
+- Refreshed JWKS still missing requested `kid`:
+  - return classified key-not-found-after-refresh failure
+  - covers `AC-005`
+- Background refresh enqueue or execution failure:
+  - no longer blocks correctness of the current launch if sync refresh succeeded
+  - remains visible as an operational issue
+- Misleading user-facing copy:
+  - replace “background job has been scheduled” launch-path copy with text that reflects whether Torus attempted synchronous recovery and why it still failed
+  - covers `AC-007`
+
+## 11. Observability
+
+- Add structured logging around every `get_public_key/2` outcome:
+  - warm hit
+  - sync cold fill attempted/succeeded/failed
+  - sync refresh after cached `kid` miss attempted/succeeded/failed
+  - single-flight waiter resumed after shared fetch
+  - single-flight wait timeout or owner failure
+- Include explicit AC traceability in implementation comments or test names for:
+  - `AC-001`, `AC-002`, `AC-003`, `AC-004`, `AC-005`, `AC-006`, `AC-007`
+- Diagnostic fields:
+  - `lookup_source`
+  - `requested_kid`
+  - `cached_key_ids_before_refresh`
+  - `refreshed_key_ids`
+  - `cache_fetched_at`
+  - `cache_expires_at`
+  - `error_reason`
+- If telemetry hooks already exist in the LTI boundary, emit corresponding structured events; otherwise structured logs are the minimum acceptable outcome for this slice.
+
+## 12. Security & Privacy
+
+- Keep HTTPS validation for all JWKS fetches.
+- Do not log raw JWTs, full JWKS payloads, private keys, cookies, or session data.
+- Logging key ids is acceptable because they are public signing-key identifiers and necessary for diagnosis.
+- Maintain existing JOSE and `lti_1p3` signature verification behavior; this design changes cache population timing, not trust rules.
+
+## 13. Testing Strategy
+
+- Unit and integration coverage in `CachedKeyProvider` tests:
+  - cold-cache success path for `AC-001`
+  - cached `kid` miss followed by successful sync refresh for `AC-002`
+  - warm-cache hit without HTTP fetch for `AC-003`
+  - unreachable endpoint, invalid JSON, and invalid JWKS for `AC-004`
+  - refreshed JWKS still missing `kid` for `AC-005`
+  - log or telemetry assertions for lookup source and refresh-path classification for `AC-006`
+  - user-facing error copy assertions showing truthful messaging for `AC-007`
+- Single-flight coverage:
+  - concurrent cold-cache requests for the same `key_set_url` perform one HTTP fetch and all callers resolve from the shared result
+  - concurrent cached-`kid`-miss requests for the same `key_set_url` perform one refresh and then re-read ETS
+  - waiter timeout or owner failure returns a bounded classified failure rather than hanging
+- Shared fetch helper tests:
+  - HTTPS URL validation
+  - cache-control TTL extraction
+  - normalized fetch result shape
+- Worker regression tests:
+  - confirm asynchronous refresh still uses shared fetch logic and still populates ETS correctly
+
+## 14. Backwards Compatibility
+
+- Public key provider behavior remains compatible at the interface level.
+- Warm-cache launches remain unchanged.
+- Error `reason` atoms should be preserved. `:key_not_found_in_keyset` continues to cover the case where the cache was refreshed but still does not contain the requested `kid`, with diagnostics showing that refresh was attempted.
+- Background refresh APIs remain in place, so operational playbooks using `preload_keys/1` or worker refresh remain valid.
+
+## 15. Risks & Mitigations
+
+- Launch latency spikes on miss paths: keep sync fetch only on miss paths and monitor frequency.
+- Single-flight coordination complexity: keep the coordinator narrow, keyed only by `key_set_url`, with bounded waits and explicit cleanup on both success and failure.
+- Divergence between sync and async parsing logic: centralize fetch/parse/cache behavior in a shared helper module.
+- Operators may lose previous log cues: preserve comparable log coverage while adding structured fields rather than replacing observability wholesale.
+
+## 16. Open Questions & Follow-ups
+
+- Choose the concrete coordinator primitive for single-flight ownership:
+  - dedicated GenServer
+  - `Registry` plus monitored task ownership
+  - another minimal OTP primitive already used in the repo
+- Decide the waiter timeout budget relative to the existing 10-second HTTP timeout so shared fetch waiting fails predictably.
+- Confirm whether structured telemetry events should be added alongside logs in this same slice or in the next implementation phase.
+
+## 17. References
+
+- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md)
+- [requirements.yml](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements.yml)
+- [cached_key_provider.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/cached_key_provider.ex)
+- [keyset_cache.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_cache.ex)
+- [keyset_refresh_worker.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_refresh_worker.ex)
+- [cached_key_provider_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/cached_key_provider_test.exs)
+- [keyset_refresh_worker_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_refresh_worker_test.exs)

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/informal.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/informal.md
@@ -1,0 +1,54 @@
+# Informal Work Summary: TRIAGE-2236 LTI Keyset Cache Reliability
+
+## Incident
+
+This work item captures a production incident where a small subset of instructors and students could not access Torus from Brightspace.
+
+- Ticket: `TRIAGE-2236`
+- Title: `Torus link fails to connect users`
+- Status at intake: `IN PROGRESS`
+- Affected platform keyset URL:
+  `[redacted Brightspace JWKS URL]`
+
+Observed behavior:
+
+- Torus rejected some launches because the JWT `kid` was not present in the cached keyset.
+- The runtime error indicated that Torus would trigger a keyset refresh, but the issue persisted for multiple days.
+- The incident was only resolved after manually connecting to the production IEx shell and forcing a refresh:
+
+```elixir
+Oli.Lti.CachedKeyProvider.preload_keys("[redacted Brightspace JWKS URL]")
+```
+
+## Current implementation behavior
+
+The current LTI key provider uses an ETS-backed cache and treats launch-time cache misses as fail-fast conditions:
+
+- if the keyset is not cached, launch validation fails and an Oban refresh job is scheduled
+- if the keyset is cached but the requested `kid` is missing, launch validation fails and an Oban refresh job is scheduled
+- synchronous fetching is only used by `preload_keys/1`, which is currently an operational/manual recovery path
+
+This means the user-facing error text promises an immediate recovery path, but the launch itself does not wait for that refresh to complete. If the refresh job is delayed, not executed, fails repeatedly, or refreshes to the same stale data, affected launches continue to fail.
+
+## Problem to solve
+
+We need to determine why the `kid` was missing from the cached keyset and why the refresh path did not recover automatically in production. If the root cause cannot be pinned down with confidence, we still need a reliable product behavior that prevents the same class of outage.
+
+The preferred safety behavior is to treat the JWKS cache as a read-through cache:
+
+- on cold cache, synchronously fetch the keyset before failing due to keyset retrieval
+- on `kid` miss in cached data, synchronously refresh the keyset from the keyset URL before failing due to key lookup
+- if that read-through attempt still fails, surface the actual error that occurred, such as:
+  - the JWKS URL could not be reached
+  - the keyset could not be loaded or parsed
+  - the requested `kid` is still absent from the freshly fetched keyset
+
+## Why this matters
+
+This incident affects both reliability and first-use experience:
+
+- it can block valid instructors and students from entering Torus
+- it makes launch recovery depend on delayed background execution or manual operator intervention
+- it causes the first launch from a newly registered LMS to fail when the keyset has not been pre-cached yet
+
+The desired end state is that LTI key validation behaves predictably for both warm-cache and cold-cache cases, with clear diagnostics when the platform keyset itself is unavailable or invalid.

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-1-execution.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-1-execution.md
@@ -1,0 +1,38 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/triage-2236-keyset-cache-reliability`
+Phase: `1`
+
+## Scope from plan.md
+- Extract a shared JWKS fetch-and-cache boundary so synchronous and asynchronous refresh paths use the same HTTPS validation, parsing, TTL, and cache update logic.
+- Implement the shared helper, refactor the worker and manual preload path onto it, and add targeted Phase 1 regression coverage.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [ ] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+  - `mix format`
+  - `mix test test/oli/lti/keyset_fetcher_test.exs test/oli/lti/keyset_refresh_worker_test.exs test/oli/lti/keyset_cache_test.exs test/oli/lti/cached_key_provider_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+  - No PRD or FDD content changes were required for Phase 1. `plan.md` was updated to record Phase 1 completion and the added helper test command.
+
+## Review Loop
+- Round 1 findings: No separate harness review run. Repository-local `harness.yml` is not present in the current workspace, so the skill's review gate could not be applied.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-2-execution.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-2-execution.md
@@ -1,0 +1,38 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/triage-2236-keyset-cache-reliability`
+Phase: `2`
+
+## Scope from plan.md
+- Make `CachedKeyProvider.get_public_key/2` recover synchronously from cold-cache and cached-`kid`-miss conditions before surfacing a terminal error.
+- Keep warm-cache lookups cache-only and replace fail-fast background-refresh messaging with truthful read-through behavior for the current request.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [ ] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+  - `mix format`
+  - `mix test test/oli/lti/cached_key_provider_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+  - No PRD or FDD content changes were required for Phase 2. `plan.md` was updated to record Phase 2 completion.
+
+## Review Loop
+- Round 1 findings: No separate harness review run. Repository-local `harness.yml` is not present in the current workspace, so the skill's review gate could not be applied.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-3-execution.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-3-execution.md
@@ -1,0 +1,38 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/triage-2236-keyset-cache-reliability`
+Phase: `3`
+
+## Scope from plan.md
+- Prevent thundering herd behavior by ensuring only one in-flight read-through fetch runs per `key_set_url` at a time.
+- Add bounded waiter behavior so same-URL callers share the fetch result or fail predictably when the owner times out or exits.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [ ] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+  - `mix format`
+  - `mix test test/oli/lti/keyset_fetch_coordinator_test.exs test/oli/lti/cached_key_provider_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+  - No PRD or FDD content changes were required for Phase 3. `plan.md` was updated to record Phase 3 completion.
+
+## Review Loop
+- Round 1 findings: No separate harness review run. Repository-local `harness.yml` is not present in the current workspace, so the skill's review gate could not be applied.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-4-execution.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/phase-4-execution.md
@@ -1,0 +1,44 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/triage-2236-keyset-cache-reliability`
+Phase: `4`
+
+## Scope from plan.md
+- Add operator-usable diagnostics for warm-cache hits, synchronous read-through success and failure, and single-flight coordination outcomes.
+- Finalize truthful launch-path error copy, run the backend verification gates, and verify requirements traceability through implementation.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+  - `mix format`
+  - `mix test test/oli/lti/keyset_fetch_coordinator_test.exs test/oli/lti/cached_key_provider_test.exs`
+  - `mix test test/oli/lti`
+  - `mix compile`
+  - `python3 /Users/eliknebel/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/triage-2236-keyset-cache-reliability --action verify_fdd`
+  - `python3 /Users/eliknebel/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/triage-2236-keyset-cache-reliability --action verify_plan`
+  - `python3 /Users/eliknebel/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/triage-2236-keyset-cache-reliability --action verify_implementation`
+  - `python3 /Users/eliknebel/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/triage-2236-keyset-cache-reliability --action master_validate --stage implementation_complete`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+  - `plan.md` was updated to record Phases 3 and 4 completion. No PRD or FDD wording changes were required.
+
+## Review Loop
+- Round 1 findings: No separate harness review run. Repository-local `harness.yml` is not present in the current workspace, so the skill's review gate could not be applied.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
@@ -52,16 +52,16 @@ Check off tasks in the plan as they are completed, and update the plan as needed
 
 - Goal: Make `CachedKeyProvider.get_public_key/2` recover synchronously from cold-cache and cached-`kid`-miss conditions before surfacing a terminal error.
 - Tasks:
-  - [ ] Refactor `CachedKeyProvider.get_public_key/2` so warm hits remain cache-only and uncached keysets trigger synchronous read-through fetch before failure. Supports `FR-002`, `FR-005`, `FR-006`. Covers `AC-001`.
-  - [ ] Refactor cached `kid` miss handling so it performs synchronous refresh, updates ETS, retries lookup, and only then returns `:key_not_found_in_keyset` if the fresh keyset still lacks the key. Supports `FR-003`, `FR-004`, `FR-005`. Covers `AC-002`, `AC-005`.
-  - [ ] Keep warm-cache hits free of unnecessary HTTP fetches. Supports `FR-007`. Covers `AC-003`.
-  - [ ] Remove launch-path dependence on “background job has been scheduled” semantics for correctness of the current request. Supports `FR-005`, `FR-009`.
+  - [x] Refactor `CachedKeyProvider.get_public_key/2` so warm hits remain cache-only and uncached keysets trigger synchronous read-through fetch before failure. Supports `FR-002`, `FR-005`, `FR-006`. Covers `AC-001`.
+  - [x] Refactor cached `kid` miss handling so it performs synchronous refresh, updates ETS, retries lookup, and only then returns `:key_not_found_in_keyset` if the fresh keyset still lacks the key. Supports `FR-003`, `FR-004`, `FR-005`. Covers `AC-002`, `AC-005`.
+  - [x] Keep warm-cache hits free of unnecessary HTTP fetches. Supports `FR-007`. Covers `AC-003`.
+  - [x] Remove launch-path dependence on “background job has been scheduled” semantics for correctness of the current request. Supports `FR-005`, `FR-009`.
 - Testing Tasks:
-  - [ ] Add `CachedKeyProvider` tests for cold-cache launch success after synchronous fetch. Covers `AC-001`.
-  - [ ] Add `CachedKeyProvider` tests for cached `kid` miss recovery after synchronous refresh. Covers `AC-002`.
-  - [ ] Add regression tests proving warm-cache hits do not perform extra HTTP fetches. Covers `AC-003`.
-  - [ ] Add terminal failure tests for unreachable JWKS URL, invalid JSON, invalid JWKS payload, and post-refresh missing-`kid` behavior. Covers `AC-004`, `AC-005`.
-  - [ ] Run targeted provider tests after the refactor.
+  - [x] Add `CachedKeyProvider` tests for cold-cache launch success after synchronous fetch. Covers `AC-001`.
+  - [x] Add `CachedKeyProvider` tests for cached `kid` miss recovery after synchronous refresh. Covers `AC-002`.
+  - [x] Add regression tests proving warm-cache hits do not perform extra HTTP fetches. Covers `AC-003`.
+  - [x] Add terminal failure tests for unreachable JWKS URL, invalid JSON, invalid JWKS payload, and post-refresh missing-`kid` behavior. Covers `AC-004`, `AC-005`.
+  - [x] Run targeted provider tests after the refactor.
   - Command(s): `mix test test/oli/lti/cached_key_provider_test.exs`, `mix format`
 - Definition of Done:
   - Launch-path key lookup reads through on cold cache and cached `kid` miss.
@@ -78,15 +78,15 @@ Check off tasks in the plan as they are completed, and update the plan as needed
 
 - Goal: Prevent thundering herd behavior by ensuring only one in-flight read-through fetch runs per `key_set_url` at a time.
 - Tasks:
-  - [ ] Introduce a narrow coordination boundary such as `Oli.Lti.KeysetFetchCoordinator` keyed by `key_set_url`. Supports `FR-002`, `FR-003`, `FR-007`, `FR-008`.
-  - [ ] Make cold-cache misses wait on an existing same-URL fetch owner and re-read ETS after completion instead of starting duplicate HTTP fetches. Supports `FR-002`, `FR-005`, `FR-007`. Covers `AC-001`, `AC-006`.
-  - [ ] Make cached-`kid`-miss refreshes use the same single-flight ownership and waiter behavior. Supports `FR-003`, `FR-005`, `FR-007`, `FR-008`. Covers `AC-002`, `AC-006`.
-  - [ ] Add bounded timeout and owner-cleanup behavior so waiters fail predictably if the owner crashes or hangs. Supports `FR-008`.
+  - [x] Introduce a narrow coordination boundary such as `Oli.Lti.KeysetFetchCoordinator` keyed by `key_set_url`. Supports `FR-002`, `FR-003`, `FR-007`, `FR-008`.
+  - [x] Make cold-cache misses wait on an existing same-URL fetch owner and re-read ETS after completion instead of starting duplicate HTTP fetches. Supports `FR-002`, `FR-005`, `FR-007`. Covers `AC-001`, `AC-006`.
+  - [x] Make cached-`kid`-miss refreshes use the same single-flight ownership and waiter behavior. Supports `FR-003`, `FR-005`, `FR-007`, `FR-008`. Covers `AC-002`, `AC-006`.
+  - [x] Add bounded timeout and owner-cleanup behavior so waiters fail predictably if the owner crashes or hangs. Supports `FR-008`.
 - Testing Tasks:
-  - [ ] Add concurrency tests proving multiple cold-cache requests for the same URL produce one HTTP fetch and shared success resolution. Covers `AC-001`, `AC-006`.
-  - [ ] Add concurrency tests proving multiple cached-`kid`-miss requests for the same URL produce one refresh and shared ETS re-read behavior. Covers `AC-002`, `AC-006`.
-  - [ ] Add bounded-failure tests for waiter timeout or owner failure. Supports `FR-008`.
-  - [ ] Run targeted provider and coordinator tests.
+  - [x] Add concurrency tests proving multiple cold-cache requests for the same URL produce one HTTP fetch and shared success resolution. Covers `AC-001`, `AC-006`.
+  - [x] Add concurrency tests proving multiple cached-`kid`-miss requests for the same URL produce one refresh and shared ETS re-read behavior. Covers `AC-002`, `AC-006`.
+  - [x] Add bounded-failure tests for waiter timeout or owner failure. Supports `FR-008`.
+  - [x] Run targeted provider and coordinator tests.
   - Command(s): `mix test test/oli/lti/cached_key_provider_test.exs`, `mix format`
 - Definition of Done:
   - Duplicate same-URL read-through fetches are coalesced.
@@ -103,14 +103,14 @@ Check off tasks in the plan as they are completed, and update the plan as needed
 
 - Goal: Make launch failures diagnosable and user-visible copy truthful, then verify the full slice against the work item requirements.
 - Tasks:
-  - [ ] Add structured logs and any in-scope telemetry for warm hits, sync cold fill, sync refresh after cached `kid` miss, shared-fetch waiter success, and shared-fetch timeout or owner failure. Supports `FR-001`, `FR-008`. Covers `AC-006`.
-  - [ ] Include non-sensitive diagnostics such as `requested_kid`, cached key ids before refresh, refreshed key ids, lookup source, and cache freshness context when available. Supports `FR-001`, `FR-008`. Covers `AC-004`, `AC-005`, `AC-006`.
-  - [ ] Update user-facing error messages so they describe actual current-request recovery behavior and do not claim that queued background work already resolved the problem. Supports `FR-009`. Covers `AC-007`.
-  - [ ] Reconcile any test fixtures, docs, and operational comments to describe the new read-through and single-flight behavior accurately. Supports `FR-001`, `FR-009`.
+  - [x] Add structured logs and any in-scope telemetry for warm hits, sync cold fill, sync refresh after cached `kid` miss, shared-fetch waiter success, and shared-fetch timeout or owner failure. Supports `FR-001`, `FR-008`. Covers `AC-006`.
+  - [x] Include non-sensitive diagnostics such as `requested_kid`, cached key ids before refresh, refreshed key ids, lookup source, and cache freshness context when available. Supports `FR-001`, `FR-008`. Covers `AC-004`, `AC-005`, `AC-006`.
+  - [x] Update user-facing error messages so they describe actual current-request recovery behavior and do not claim that queued background work already resolved the problem. Supports `FR-009`. Covers `AC-007`.
+  - [x] Reconcile any test fixtures, docs, and operational comments to describe the new read-through and single-flight behavior accurately. Supports `FR-001`, `FR-009`.
 - Testing Tasks:
-  - [ ] Add log or telemetry assertions for lookup source, refresh-attempt visibility, and terminal classification. Covers `AC-004`, `AC-005`, `AC-006`.
-  - [ ] Add assertions for truthful user-facing error copy after failed synchronous recovery. Covers `AC-007`.
-  - [ ] Run targeted LTI tests, compile, and formatting gates for the touched backend surfaces.
+  - [x] Add log or telemetry assertions for lookup source, refresh-attempt visibility, and terminal classification. Covers `AC-004`, `AC-005`, `AC-006`.
+  - [x] Add assertions for truthful user-facing error copy after failed synchronous recovery. Covers `AC-007`.
+  - [x] Run targeted LTI tests, compile, and formatting gates for the touched backend surfaces.
   - Command(s): `mix test test/oli/lti`, `mix compile`, `mix format`
 - Definition of Done:
   - Operators can distinguish warm-cache success, synchronous recovery success, and terminal failure from logs and in-scope telemetry.

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
@@ -1,0 +1,138 @@
+# TRIAGE-2236 LTI Keyset Cache Reliability - Delivery Plan
+
+Scope and reference artifacts:
+
+- PRD: `/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md`
+- FDD: `/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md`
+
+## Scope
+
+Implement the keyset-cache reliability work described in the PRD and FDD by converting launch-path
+key lookup from fail-fast-plus-background-refresh to read-through-on-miss, adding per-URL
+single-flight request coalescing, preserving ETS as the warm-path cache, keeping Oban background
+refresh for proactive maintenance, and improving diagnostics and user-facing messaging so launch
+failures reflect the actual recovery behavior that occurred.
+
+Check off tasks in the plan as they are completed, and update the plan as needed if implementation details or requirements clarifications arise.
+
+## Clarifications & Default Assumptions
+
+- The authoritative work-item artifacts are [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md) and [fdd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md).
+- Repository-local harness contract files such as `harness.yml` and the standard docs bundle were not present at intake, so this plan follows the repository guidance available in `AGENTS.md` and the current LTI module boundaries.
+- `:key_not_found_in_keyset` remains the terminal reason when the latest available keyset still does not contain the requested `kid`; diagnostics must show whether a refresh was attempted.
+- A successful synchronous read-through refresh does not also need to enqueue a background refresh job.
+- Per-URL single-flight request coalescing is in scope for the initial implementation, not deferred follow-up work.
+- During implementation, task checkboxes in this plan should be updated as work is completed so phase status remains accurate.
+
+## Phase 1: Shared Fetch And Cache Boundaries
+
+- Goal: Extract a shared JWKS fetch-and-cache boundary so synchronous and asynchronous refresh paths use the same HTTPS validation, parsing, TTL, and cache update logic.
+- Tasks:
+  - [x] Add a narrow shared helper such as `Oli.Lti.KeysetFetcher` to own HTTPS validation, HTTP fetch, JWKS parsing, TTL extraction, and normalized result tuples. Supports `FR-002`, `FR-003`, `FR-004`, `FR-005`.
+  - [x] Refactor `Oli.Lti.KeysetRefreshWorker` to use the shared helper without changing its external scheduling interface. Supports `FR-004`, `FR-008`.
+  - [x] Keep `Oli.Lti.KeysetCache` as the ETS authority and preserve the current stored shape unless minimal in-memory metadata is needed for diagnostics. Supports `FR-004`, `FR-007`, `FR-008`.
+  - [x] Confirm `preload_keys/1` uses the same shared fetch path so manual operational recovery matches launch-path parsing behavior. Supports `FR-001`, `FR-004`.
+- Testing Tasks:
+  - [x] Add unit tests for shared fetch helper success, HTTPS validation failures, invalid JSON, invalid JWKS shape, and TTL extraction.
+  - [x] Update worker tests to prove asynchronous refresh still populates ETS correctly through the shared helper.
+  - [x] Run targeted LTI unit tests for fetch helper, cache, and worker boundaries.
+  - Command(s): `mix test test/oli/lti/keyset_fetcher_test.exs test/oli/lti/keyset_refresh_worker_test.exs test/oli/lti/keyset_cache_test.exs test/oli/lti/cached_key_provider_test.exs`, `mix format`
+- Definition of Done:
+  - One shared implementation path exists for JWKS fetch, parse, TTL selection, and cache population.
+  - Background refresh and manual preload continue to work through that shared path.
+  - This phase provides the reusable foundation for `AC-001`, `AC-002`, `AC-004`, and `AC-005`.
+- Gate:
+  - Do not change launch-path provider behavior until the shared fetch boundary is tested and stable.
+- Dependencies:
+  - None.
+- Parallelizable Work:
+  - Helper extraction and worker refactor can proceed in parallel once the normalized fetch result contract is fixed.
+
+## Phase 2: Launch-Path Read-Through Resolution
+
+- Goal: Make `CachedKeyProvider.get_public_key/2` recover synchronously from cold-cache and cached-`kid`-miss conditions before surfacing a terminal error.
+- Tasks:
+  - [ ] Refactor `CachedKeyProvider.get_public_key/2` so warm hits remain cache-only and uncached keysets trigger synchronous read-through fetch before failure. Supports `FR-002`, `FR-005`, `FR-006`. Covers `AC-001`.
+  - [ ] Refactor cached `kid` miss handling so it performs synchronous refresh, updates ETS, retries lookup, and only then returns `:key_not_found_in_keyset` if the fresh keyset still lacks the key. Supports `FR-003`, `FR-004`, `FR-005`. Covers `AC-002`, `AC-005`.
+  - [ ] Keep warm-cache hits free of unnecessary HTTP fetches. Supports `FR-007`. Covers `AC-003`.
+  - [ ] Remove launch-path dependence on “background job has been scheduled” semantics for correctness of the current request. Supports `FR-005`, `FR-009`.
+- Testing Tasks:
+  - [ ] Add `CachedKeyProvider` tests for cold-cache launch success after synchronous fetch. Covers `AC-001`.
+  - [ ] Add `CachedKeyProvider` tests for cached `kid` miss recovery after synchronous refresh. Covers `AC-002`.
+  - [ ] Add regression tests proving warm-cache hits do not perform extra HTTP fetches. Covers `AC-003`.
+  - [ ] Add terminal failure tests for unreachable JWKS URL, invalid JSON, invalid JWKS payload, and post-refresh missing-`kid` behavior. Covers `AC-004`, `AC-005`.
+  - [ ] Run targeted provider tests after the refactor.
+  - Command(s): `mix test test/oli/lti/cached_key_provider_test.exs`, `mix format`
+- Definition of Done:
+  - Launch-path key lookup reads through on cold cache and cached `kid` miss.
+  - Warm-cache behavior remains cache-only.
+  - Terminal fetch and lookup failures occur only after the read-through attempt has been exhausted.
+- Gate:
+  - Do not add coordination or observability signoff until read-through behavior is correct for single-request success and failure paths.
+- Dependencies:
+  - Phase 1.
+- Parallelizable Work:
+  - Cold-cache and cached-`kid`-miss test additions can proceed in parallel once the provider control flow is agreed.
+
+## Phase 3: Per-URL Single-Flight Coordination
+
+- Goal: Prevent thundering herd behavior by ensuring only one in-flight read-through fetch runs per `key_set_url` at a time.
+- Tasks:
+  - [ ] Introduce a narrow coordination boundary such as `Oli.Lti.KeysetFetchCoordinator` keyed by `key_set_url`. Supports `FR-002`, `FR-003`, `FR-007`, `FR-008`.
+  - [ ] Make cold-cache misses wait on an existing same-URL fetch owner and re-read ETS after completion instead of starting duplicate HTTP fetches. Supports `FR-002`, `FR-005`, `FR-007`. Covers `AC-001`, `AC-006`.
+  - [ ] Make cached-`kid`-miss refreshes use the same single-flight ownership and waiter behavior. Supports `FR-003`, `FR-005`, `FR-007`, `FR-008`. Covers `AC-002`, `AC-006`.
+  - [ ] Add bounded timeout and owner-cleanup behavior so waiters fail predictably if the owner crashes or hangs. Supports `FR-008`.
+- Testing Tasks:
+  - [ ] Add concurrency tests proving multiple cold-cache requests for the same URL produce one HTTP fetch and shared success resolution. Covers `AC-001`, `AC-006`.
+  - [ ] Add concurrency tests proving multiple cached-`kid`-miss requests for the same URL produce one refresh and shared ETS re-read behavior. Covers `AC-002`, `AC-006`.
+  - [ ] Add bounded-failure tests for waiter timeout or owner failure. Supports `FR-008`.
+  - [ ] Run targeted provider and coordinator tests.
+  - Command(s): `mix test test/oli/lti/cached_key_provider_test.exs`, `mix format`
+- Definition of Done:
+  - Duplicate same-URL read-through fetches are coalesced.
+  - Waiters resolve from the shared fetch result or fail in a bounded, diagnosable way.
+  - Single-flight behavior is covered by concurrency-focused regression tests.
+- Gate:
+  - Do not finalize observability and user-facing error text until single-flight owner and waiter outcomes are stable.
+- Dependencies:
+  - Phase 2.
+- Parallelizable Work:
+  - Coordinator implementation and concurrency test scaffolding can proceed in parallel once the coordinator API is fixed.
+
+## Phase 4: Diagnostics, Messaging, And Final Verification
+
+- Goal: Make launch failures diagnosable and user-visible copy truthful, then verify the full slice against the work item requirements.
+- Tasks:
+  - [ ] Add structured logs and any in-scope telemetry for warm hits, sync cold fill, sync refresh after cached `kid` miss, shared-fetch waiter success, and shared-fetch timeout or owner failure. Supports `FR-001`, `FR-008`. Covers `AC-006`.
+  - [ ] Include non-sensitive diagnostics such as `requested_kid`, cached key ids before refresh, refreshed key ids, lookup source, and cache freshness context when available. Supports `FR-001`, `FR-008`. Covers `AC-004`, `AC-005`, `AC-006`.
+  - [ ] Update user-facing error messages so they describe actual current-request recovery behavior and do not claim that queued background work already resolved the problem. Supports `FR-009`. Covers `AC-007`.
+  - [ ] Reconcile any test fixtures, docs, and operational comments to describe the new read-through and single-flight behavior accurately. Supports `FR-001`, `FR-009`.
+- Testing Tasks:
+  - [ ] Add log or telemetry assertions for lookup source, refresh-attempt visibility, and terminal classification. Covers `AC-004`, `AC-005`, `AC-006`.
+  - [ ] Add assertions for truthful user-facing error copy after failed synchronous recovery. Covers `AC-007`.
+  - [ ] Run targeted LTI tests, compile, and formatting gates for the touched backend surfaces.
+  - Command(s): `mix test test/oli/lti`, `mix compile`, `mix format`
+- Definition of Done:
+  - Operators can distinguish warm-cache success, synchronous recovery success, and terminal failure from logs and in-scope telemetry.
+  - User-facing copy reflects actual read-through behavior.
+  - The implementation satisfies `FR-001` through `FR-009` and `AC-001` through `AC-007`.
+- Gate:
+  - Final signoff requires green targeted tests, clear diagnostics, truthful copy, and intact requirements traceability.
+- Dependencies:
+  - Phases 1 through 3.
+- Parallelizable Work:
+  - Diagnostic assertions and user-facing copy refinement can proceed in parallel once failure classifications are stable.
+
+## Parallelization Notes
+
+- Phase 1 helper extraction and worker refactor are parallel-safe once the fetch helper return contract is fixed.
+- In Phase 2, cold-cache and cached-`kid`-miss test additions can be developed in parallel against the agreed provider behavior.
+- In Phase 3, coordinator implementation and concurrency test scaffolding are parallel-safe once the coordinator API and timeout budget are fixed.
+- Phase 4 logging assertions and error-copy refinement can overlap after provider outcomes and single-flight states stop changing.
+
+## Phase Gate Summary
+
+- Gate A: shared JWKS fetch/parse/cache behavior must be centralized and tested before launch-path provider refactor begins.
+- Gate B: launch-path read-through must work correctly for cold-cache, cached-`kid`-miss, warm-hit, and terminal failure cases before concurrency coordination is added.
+- Gate C: per-URL single-flight coordination must be stable under concurrency before observability and copy are finalized.
+- Gate D: final signoff requires targeted tests, compile/format gates, truthful user-facing messaging, and complete requirements traceability.

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md
@@ -1,0 +1,132 @@
+# TRIAGE-2236 LTI Keyset Cache Reliability - Product Requirements Document
+
+## 1. Overview
+
+Improve Torus LTI launch reliability by making platform JWKS retrieval dependable at the moment it is needed for token validation. The system should investigate and explain why cached keysets can become stale or incomplete, and it should provide a safe fallback where launch-time cache misses behave like a read-through cache instead of requiring manual intervention or a later background retry.
+
+## 2. Background & Problem Statement
+
+Torus currently validates inbound LTI launches using `Oli.Lti.CachedKeyProvider`, which reads platform public keys from an ETS-backed cache populated by `Oli.Lti.KeysetRefreshWorker`. When a keyset is missing from cache or when the requested `kid` is not found in the cached keyset, the provider fails the launch immediately and only schedules an asynchronous Oban refresh for a future attempt.
+
+That behavior created a production incident affecting Brightspace launches. Some valid launches failed because the requested `kid` was not present in the cached keyset. The system message claimed that an immediate refresh had been triggered, but the issue persisted for days until an operator manually forced a synchronous refresh through `preload_keys/1` in a production IEx session.
+
+This exposes two product problems:
+
+- Torus cannot currently guarantee recovery when cached JWKS content is missing, stale, or incomplete.
+- The very first launch from a newly registered LMS can fail simply because the keyset was not already cached.
+
+The work must first try to identify the actual failure mode behind the stale or incomplete cache. If the exact cause remains uncertain, the shipped behavior should still eliminate dependence on delayed background refresh for launch correctness.
+
+## 3. Goals & Non-Goals
+### Goals
+
+- Determine the most plausible causes for a missing `kid` in a cached keyset and for failed automatic recovery after a launch-time cache miss.
+- Make keyset retrieval reliable enough that valid launches do not require manual cache warming or production shell intervention.
+- Treat the platform JWKS cache as a read-through cache for launch validation when cached data is absent or does not contain the requested `kid`.
+- Ensure first launch from a registered LMS can succeed without requiring prior asynchronous cache population.
+- Preserve clear, operator-usable diagnostics for cache state, refresh attempts, fetched key identifiers, and terminal failure reason.
+- Avoid failing immediately on uncached keysets or cached `kid` misses by attempting a read-through fetch first, then surfacing the actual retrieval or lookup error if that fetch does not resolve the problem.
+
+### Non-Goals
+
+- Redesign the entire Torus LTI launch lifecycle beyond the keyset caching and validation boundary.
+- Replace the existing LTI validation stack or `Lti_1p3` integration.
+- Introduce long-lived persistence of platform keysets outside the scope required to make cache behavior reliable.
+- Solve unrelated LMS configuration problems that are not caused by keyset retrieval or `kid` resolution.
+
+## 4. Users & Use Cases
+
+- Students: launch Torus from the LMS and enter successfully even when the platform keyset has not been cached yet.
+- Instructors: launch Torus reliably after an LMS rotates signing keys without waiting for a later retry window or operator intervention.
+- Support and operations staff: determine whether launch failure was caused by stale cache contents, failed refresh execution, unreachable JWKS URL, invalid JWKS payload, or a genuine missing `kid`.
+- Engineers maintaining LTI integrations: reason about cache state and refresh behavior using deterministic logs, telemetry, and tests.
+
+## 5. UX / UI Requirements
+
+- User-facing launch errors must avoid claiming that recovery has already happened when the system only scheduled asynchronous work.
+- Launch failures caused by JWKS retrieval should explain the actionable failure class in plain language without exposing tokens, claims, secrets, or raw key material.
+- The first launch from a newly registered LMS should not fail solely because the keyset is uncached before Torus has attempted a read-through fetch.
+- If a fresh JWKS fetch still cannot resolve the requested key, the error state should clearly indicate that the platform signing key could not be verified from the latest available keyset.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+
+- Reliability: launch validation must not depend solely on a previously warmed ETS entry when the platform JWKS endpoint is reachable.
+- Security: Torus must continue validating signatures only against trusted HTTPS JWKS endpoints and must not relax signature verification rules to compensate for cache failures.
+- Privacy: logs and telemetry must exclude raw JWTs, private key material, cookies, session contents, and other sensitive launch data.
+- Performance: synchronous read-through refresh should only occur on cold cache or `kid` miss paths and should not materially slow healthy warm-cache launches.
+- Maintainability: the cache contract should make it explicit when data came from warm cache versus a synchronous read-through refresh.
+- Operability: support staff must be able to distinguish background refresh behavior from launch-path synchronous recovery behavior.
+
+## 9. Data, Interfaces & Dependencies
+
+- The work centers on `Oli.Lti.CachedKeyProvider`, `Oli.Lti.KeysetCache`, and `Oli.Lti.KeysetRefreshWorker`.
+- The key input is the registration `key_set_url` and the JWT header `kid` supplied during LTI launch validation.
+- Read-through behavior may require a synchronous fetch path that can populate `KeysetCache` and immediately retry key lookup during the same request.
+- Existing asynchronous refresh remains a candidate for background warming and periodic maintenance, but it should no longer be the only recovery path for launch-time cache miss conditions.
+- Any instrumentation should capture the requested `kid`, fetched key ids, cache age or freshness context when available, refresh path used, and terminal outcome using non-sensitive metadata only.
+
+## 10. Repository & Platform Considerations
+
+- Torus is a Phoenix application with LTI validation logic in Elixir, so reliability changes should stay at the server boundary rather than moving key resolution into frontend code.
+- The current implementation uses ETS for fast in-memory reads and Oban for asynchronous refresh jobs; the PRD should preserve that context while correcting launch-time correctness behavior.
+- Verification should focus on targeted ExUnit coverage for cold-cache launch success, `kid` rotation recovery, refresh failure handling, and truthful user-facing error behavior.
+- Repository-local harness contract files such as `harness.yml` and the standard docs bundle were not present at intake, so this PRD relies on the repository guidance available in `AGENTS.md` and the existing LTI code structure.
+
+## 11. Feature Flagging, Rollout & Migration
+
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+
+- Emit structured diagnostics for launch-time key lookup showing whether resolution came from warm cache, synchronous read-through refresh, or asynchronous background refresh state.
+- Emit structured diagnostics when a requested `kid` is absent, including requested `kid`, cached key ids before refresh, fetched key ids after refresh when available, and final classification.
+- Success signal: first launch from a valid registered LMS succeeds without requiring prior manual or scheduled cache warming.
+- Success signal: a platform key rotation that introduces a new `kid` can recover during the same launch attempt when the fresh JWKS endpoint contains that key.
+- Success signal: support can identify why a key lookup failed without remote shell access.
+
+## 13. Risks & Mitigations
+
+- Synchronous fetch on launch-path failures could add latency: restrict synchronous refresh to cold-cache and `kid`-miss paths, and keep warm-cache hits unchanged.
+- JWKS endpoints can be temporarily unavailable: surface clear failure classifications and keep background refresh available for later warming.
+- A fresh fetch may still return stale or incomplete platform data: log fetched key ids and freshness context so Torus can distinguish local cache issues from upstream LMS issues.
+- User-facing messaging can drift from real behavior: align copy with the actual refresh path taken and whether recovery happened within the current request.
+
+## 14. Open Questions & Assumptions
+### Open Questions
+
+- What exact production condition caused the stale or incomplete cached keyset for the affected Brightspace registration?
+- Did the asynchronous refresh job fail to enqueue, fail to execute, retry unsuccessfully, or refresh to the same stale platform data?
+- Should successful synchronous read-through refresh also enqueue or update a background refresh cadence, or is updating the current cache entry sufficient?
+- Do we need explicit cache freshness metadata beyond `fetched_at` and `expires_at` to diagnose repeated `kid` misses over time?
+
+### Assumptions
+
+- The Brightspace JWKS endpoint is expected to be reachable over HTTPS during normal launch conditions.
+- Manual `preload_keys/1` success is evidence that synchronous fetching can resolve at least some incidents that asynchronous scheduling does not recover quickly enough.
+- Treating the keyset cache as read-through on miss is an acceptable tradeoff because those paths are exceptional and correctness is more important than avoiding a one-time network request.
+- Existing ETS caching remains appropriate for warm-path performance as long as miss recovery is made reliable.
+
+## 15. QA Plan
+
+- Automated validation:
+  - ExUnit coverage for launch-time cold-cache lookup that performs synchronous fetch and succeeds when the JWKS endpoint returns the requested key.
+  - ExUnit coverage for cached keyset `kid` miss that performs synchronous refresh, updates cache contents, and succeeds when the refreshed JWKS contains the new key.
+  - Regression coverage proving warm-cache hits do not perform unnecessary HTTP fetches.
+  - Tests for unreachable JWKS URL, invalid JSON, invalid JWKS shape, and persistent post-refresh missing-`kid` failures.
+  - Tests for truthful error messaging and diagnostics on each terminal failure class.
+- Manual validation:
+  - Verify first launch from a valid registration succeeds without preloading keys.
+  - Simulate platform key rotation and verify a single affected launch can recover after a synchronous refresh.
+  - Verify support-oriented logs and telemetry clearly show cache source, refresh action, and final outcome.
+
+## 16. Definition of Done
+
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements.yml
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements.yml
@@ -1,0 +1,69 @@
+work_item: triage-2236-keyset-cache-reliability
+requirements:
+- id: FR-001
+  title: Torus shall investigate and document the plausible causes of cached JWKS
+    entries missing the requested `kid` and of failed automatic recovery after a launch-time
+    key lookup failure.
+- id: FR-002
+  title: Torus shall treat the LTI platform keyset cache as a read-through cache when
+    a launch requests a keyset URL that is not currently cached.
+- id: FR-003
+  title: Torus shall synchronously refresh the keyset from the platform keyset URL
+    when the cached keyset does not contain the requested `kid` before concluding
+    that the key is unavailable.
+- id: FR-004
+  title: Torus shall update the in-memory cache with successfully fetched JWKS contents
+    so the current launch and subsequent launches can use the refreshed keyset.
+- id: FR-005
+  title: Torus shall not fail immediately when the keyset is uncached or when the
+    requested `kid` is absent from cached data, and shall first attempt a read-through
+    fetch or refresh before surfacing the actual keyset retrieval or key lookup
+    error.
+- id: FR-006
+  title: Torus shall make first launch from a valid registered LMS succeed without
+    requiring prior manual cache warming or a previously completed background refresh.
+- id: FR-007
+  title: Torus shall preserve warm-cache launch performance by avoiding synchronous
+    JWKS fetches when the requested key is already present in a non-expired cached
+    keyset.
+- id: FR-008
+  title: Torus shall emit structured non-sensitive diagnostics for key lookup source,
+    requested `kid`, cached and refreshed key identifiers, refresh attempt outcome,
+    and terminal failure classification.
+- id: FR-009
+  title: Torus shall align launch error messaging with the actual recovery behavior
+    taken during the request and shall not claim that recovery has already occurred
+    when only delayed work was scheduled.
+acceptance_criteria:
+- id: AC-001
+  title: Given a valid registration whose keyset URL is not yet cached, when the first
+    launch requires a public key and the JWKS endpoint returns a keyset containing
+    the requested `kid`, then Torus fetches the keyset during that request, caches
+    it, and completes validation without requiring a retry.
+- id: AC-002
+  title: Given a non-expired cached keyset that does not contain the requested `kid`,
+    when the platform JWKS endpoint returns a newer keyset containing that `kid`,
+    then Torus refreshes synchronously, updates the cache, and completes the launch
+    in the same request.
+- id: AC-003
+  title: Given a warm cached keyset already contains the requested `kid`, when a launch
+    is validated, then Torus returns the key from cache without performing an extra
+    HTTP fetch.
+- id: AC-004
+  title: Given the platform JWKS endpoint is unreachable or returns an invalid response,
+    when Torus cannot load a usable fresh keyset, then launch validation fails with
+    a stable error classification and diagnostics that explain the fetch failure without
+    exposing sensitive data.
+- id: AC-005
+  title: Given Torus performs a fresh JWKS fetch and the requested `kid` is still
+    not present, when launch validation fails, then the error and diagnostics identify
+    that the latest fetched keyset still did not contain the requested key.
+- id: AC-006
+  title: Given a launch experiences a cold-cache miss or cached `kid` miss, when logs
+    or telemetry are inspected, then they show whether resolution came from warm cache,
+    synchronous read-through refresh, or a terminal refresh failure.
+- id: AC-007
+  title: Given user-facing launch failure copy is rendered for a keyset retrieval
+    problem, when the current request did not complete a successful recovery, then
+    the message does not inaccurately state that an immediate refresh already resolved
+    the issue.

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements_bulk.yml
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements_bulk.yml
@@ -1,0 +1,34 @@
+requirements:
+  - id: FR-001
+    title: Torus shall investigate and document the plausible causes of cached JWKS entries missing the requested `kid` and of failed automatic recovery after a launch-time key lookup failure.
+  - id: FR-002
+    title: Torus shall treat the LTI platform keyset cache as a read-through cache when a launch requests a keyset URL that is not currently cached.
+  - id: FR-003
+    title: Torus shall synchronously refresh the keyset from the platform keyset URL when the cached keyset does not contain the requested `kid` before concluding that the key is unavailable.
+  - id: FR-004
+    title: Torus shall update the in-memory cache with successfully fetched JWKS contents so the current launch and subsequent launches can use the refreshed keyset.
+  - id: FR-005
+    title: Torus shall not fail immediately when the keyset is uncached or when the requested `kid` is absent from cached data, and shall first attempt a read-through fetch or refresh before surfacing the actual keyset retrieval or key lookup error.
+  - id: FR-006
+    title: Torus shall make first launch from a valid registered LMS succeed without requiring prior manual cache warming or a previously completed background refresh.
+  - id: FR-007
+    title: Torus shall preserve warm-cache launch performance by avoiding synchronous JWKS fetches when the requested key is already present in a non-expired cached keyset.
+  - id: FR-008
+    title: Torus shall emit structured non-sensitive diagnostics for key lookup source, requested `kid`, cached and refreshed key identifiers, refresh attempt outcome, and terminal failure classification.
+  - id: FR-009
+    title: Torus shall align launch error messaging with the actual recovery behavior taken during the request and shall not claim that recovery has already occurred when only delayed work was scheduled.
+acceptance_criteria:
+  - id: AC-001
+    title: Given a valid registration whose keyset URL is not yet cached, when the first launch requires a public key and the JWKS endpoint returns a keyset containing the requested `kid`, then Torus fetches the keyset during that request, caches it, and completes validation without requiring a retry.
+  - id: AC-002
+    title: Given a non-expired cached keyset that does not contain the requested `kid`, when the platform JWKS endpoint returns a newer keyset containing that `kid`, then Torus refreshes synchronously, updates the cache, and completes the launch in the same request.
+  - id: AC-003
+    title: Given a warm cached keyset already contains the requested `kid`, when a launch is validated, then Torus returns the key from cache without performing an extra HTTP fetch.
+  - id: AC-004
+    title: Given the platform JWKS endpoint is unreachable or returns an invalid response, when Torus cannot load a usable fresh keyset, then launch validation fails with a stable error classification and diagnostics that explain the fetch failure without exposing sensitive data.
+  - id: AC-005
+    title: Given Torus performs a fresh JWKS fetch and the requested `kid` is still not present, when launch validation fails, then the error and diagnostics identify that the latest fetched keyset still did not contain the requested key.
+  - id: AC-006
+    title: Given a launch experiences a cold-cache miss or cached `kid` miss, when logs or telemetry are inspected, then they show whether resolution came from warm cache, synchronous read-through refresh, or a terminal refresh failure.
+  - id: AC-007
+    title: Given user-facing launch failure copy is rendered for a keyset retrieval problem, when the current request did not complete a successful recovery, then the message does not inaccurately state that an immediate refresh already resolved the issue.

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -95,6 +95,7 @@ defmodule Oli.Application do
 
         # Starts the LTI 1.3 keyset cache for caching platform public keys
         Oli.Lti.KeysetCache,
+        Oli.Lti.KeysetFetchCoordinator,
 
         # a supervisor which can be used to dynamically supervise tasks
         {Task.Supervisor, name: Oli.TaskSupervisor},

--- a/lib/oli/lti/cached_key_provider.ex
+++ b/lib/oli/lti/cached_key_provider.ex
@@ -20,6 +20,7 @@ defmodule Oli.Lti.CachedKeyProvider do
 
   require Logger
   alias Oli.Lti.KeysetCache
+  alias Oli.Lti.KeysetFetchCoordinator
   alias Oli.Lti.KeysetFetcher
   alias Oli.Lti.KeysetRefreshWorker
 
@@ -27,46 +28,26 @@ defmodule Oli.Lti.CachedKeyProvider do
   def get_public_key(key_set_url, kid) do
     case KeysetCache.get_public_key(key_set_url, kid) do
       {:ok, public_key} ->
-        Logger.debug("Cache hit: Found key #{kid} for #{key_set_url} in ETS cache")
+        log_lookup("warm_cache_hit", %{
+          key_set_url: key_set_url,
+          requested_kid: kid,
+          lookup_source: :warm_cache,
+          outcome: :success
+        })
+
         {:ok, public_key}
 
       {:error, :keyset_not_cached} ->
-        Logger.error(
-          "Cache miss: Keyset for #{key_set_url} not cached. " <>
-            "The background worker has not yet fetched keys for this platform. " <>
-            "Scheduling immediate refresh."
-        )
-
-        # Schedule a refresh for next time, but fail this request fast
-        schedule_refresh_for_url(key_set_url)
-
-        {:error,
-         %{
-           reason: :keyset_not_cached,
-           msg:
-             "Public keys for #{key_set_url} are not yet cached. " <>
-               "A background job has been scheduled to fetch them. " <>
-               "Please try the launch again in a few moments, or contact your administrator."
-         }}
+        Logger.info("Cache miss for #{key_set_url}; attempting synchronous keyset fetch")
+        refresh_and_retry_lookup(key_set_url, kid, :cold_cache)
 
       {:error, :key_not_found} ->
         Logger.error(
           "Key #{kid} not found in cached keyset for #{key_set_url}. " <>
-            "This may indicate the platform rotated keys. Scheduling immediate refresh."
+            "Attempting synchronous keyset refresh."
         )
 
-        # Schedule a refresh for next time, but fail this request fast
-        schedule_refresh_for_url(key_set_url)
-
-        {:error,
-         %{
-           reason: :key_not_found_in_keyset,
-           msg:
-             "Key with kid '#{kid}' not found in the cached keyset from #{key_set_url}. " <>
-               "This may indicate the platform rotated its keys. " <>
-               "A background job has been scheduled to fetch the updated keys. " <>
-               "Please try the launch again in a few moments."
-         }}
+        refresh_and_retry_lookup(key_set_url, kid, :cached_key_miss)
     end
   end
 
@@ -134,33 +115,176 @@ defmodule Oli.Lti.CachedKeyProvider do
 
   # Private Functions
 
-  defp schedule_refresh_for_url(key_set_url) do
-    # Find registration(s) with this key_set_url and schedule refresh
-    # Note: Multiple registrations might share the same key_set_url
-    case find_registration_by_key_set_url(key_set_url) do
-      nil ->
-        Logger.warning(
-          "No registration found for key_set_url #{key_set_url}, cannot schedule refresh"
+  defp refresh_and_retry_lookup(key_set_url, kid, refresh_context) do
+    cached_keyset_before_refresh =
+      case KeysetCache.get_keyset(key_set_url) do
+        {:ok, keyset} -> keyset
+        _ -> nil
+      end
+
+    fetch =
+      KeysetFetchCoordinator.run_with_metadata(key_set_url, fn ->
+        KeysetFetcher.fetch_and_cache(key_set_url)
+      end)
+
+    case fetch.result do
+      {:ok, fetched_keyset} ->
+        handle_post_refresh_lookup(
+          key_set_url,
+          kid,
+          refresh_context,
+          fetch.role,
+          cached_keyset_before_refresh,
+          fetched_keyset
         )
 
-        :ok
+      {:error, reason} ->
+        log_lookup("sync_lookup_failed", %{
+          key_set_url: key_set_url,
+          requested_kid: kid,
+          lookup_source: lookup_source(refresh_context),
+          single_flight_role: fetch.role,
+          cached_key_ids_before_refresh: key_ids(cached_keyset_before_refresh),
+          refreshed_key_ids: [],
+          outcome: reason
+        })
 
-      registration ->
-        Logger.info("Scheduling immediate refresh for registration #{registration.id}")
-
-        case KeysetRefreshWorker.schedule_refresh(registration.id) do
-          {:ok, _job} -> :ok
-          {:error, reason} -> Logger.error("Failed to schedule refresh: #{inspect(reason)}")
-        end
+        {:error, fetch_error(reason, key_set_url, kid, refresh_context)}
     end
   end
 
-  defp find_registration_by_key_set_url(key_set_url) do
-    import Ecto.Query
+  defp handle_post_refresh_lookup(
+         key_set_url,
+         kid,
+         refresh_context,
+         role,
+         cached_keyset_before_refresh,
+         fetched_keyset
+       ) do
+    case KeysetCache.get_public_key(key_set_url, kid) do
+      {:ok, public_key} ->
+        log_lookup("sync_lookup_success", %{
+          key_set_url: key_set_url,
+          requested_kid: kid,
+          lookup_source: lookup_source(refresh_context),
+          single_flight_role: role,
+          cached_key_ids_before_refresh: key_ids(cached_keyset_before_refresh),
+          refreshed_key_ids: key_ids(fetched_keyset),
+          cache_fetched_at: fetched_keyset.fetched_at,
+          cache_expires_at: fetched_keyset.expires_at,
+          outcome: :success
+        })
 
-    Oli.Lti.Tool.Registration
-    |> where([r], r.key_set_url == ^key_set_url)
-    |> limit(1)
-    |> Oli.Repo.one()
+        {:ok, public_key}
+
+      {:error, :key_not_found} ->
+        log_lookup("sync_lookup_failed", %{
+          key_set_url: key_set_url,
+          requested_kid: kid,
+          lookup_source: lookup_source(refresh_context),
+          single_flight_role: role,
+          cached_key_ids_before_refresh: key_ids(cached_keyset_before_refresh),
+          refreshed_key_ids: key_ids(fetched_keyset),
+          outcome: :key_not_found_in_keyset
+        })
+
+        {:error, key_not_found_error(key_set_url, kid, refresh_context)}
+
+      {:error, :keyset_not_cached} ->
+        log_lookup("sync_lookup_failed", %{
+          key_set_url: key_set_url,
+          requested_kid: kid,
+          lookup_source: lookup_source(refresh_context),
+          single_flight_role: role,
+          cached_key_ids_before_refresh: key_ids(cached_keyset_before_refresh),
+          refreshed_key_ids: key_ids(fetched_keyset),
+          outcome: :keyset_not_cached
+        })
+
+        {:error, fetch_error(:keyset_not_cached, key_set_url, kid, refresh_context)}
+    end
   end
+
+  defp key_ids(nil), do: []
+
+  defp key_ids(%{keys: keys}) do
+    Enum.map(keys, &Map.get(&1, "kid"))
+  end
+
+  defp lookup_source(:cold_cache), do: :sync_cold_fill
+  defp lookup_source(:cached_key_miss), do: :sync_refresh_after_kid_miss
+
+  defp log_lookup(event, metadata) do
+    Logger.info("lti_keyset_lookup #{event} #{inspect(metadata)}")
+  end
+
+  defp key_not_found_error(key_set_url, kid, :cold_cache) do
+    %{
+      reason: :key_not_found_in_keyset,
+      msg:
+        "Key with kid '#{kid}' was not found in the keyset fetched from #{key_set_url}. " <>
+          "Torus fetched the latest available keys for this launch, but the requested signing key was still unavailable."
+    }
+  end
+
+  defp key_not_found_error(key_set_url, kid, :cached_key_miss) do
+    %{
+      reason: :key_not_found_in_keyset,
+      msg:
+        "Key with kid '#{kid}' was not found after refreshing the keyset from #{key_set_url}. " <>
+          "Torus retried with the latest available keys for this launch, but the requested signing key was still unavailable."
+    }
+  end
+
+  defp fetch_error(reason, key_set_url, kid, refresh_context) do
+    %{
+      reason: reason,
+      msg: fetch_error_message(reason, key_set_url, kid, refresh_context)
+    }
+  end
+
+  defp fetch_error_message({:http_error, status_code}, key_set_url, _kid, refresh_context) do
+    "Torus could not fetch a usable keyset from #{key_set_url} during #{describe_refresh_context(refresh_context)} " <>
+      "because the JWKS endpoint returned HTTP #{status_code}."
+  end
+
+  defp fetch_error_message(:json_decode_failed, key_set_url, _kid, refresh_context) do
+    "Torus could not decode the JWKS response from #{key_set_url} during #{describe_refresh_context(refresh_context)}."
+  end
+
+  defp fetch_error_message(:invalid_jwks_format, key_set_url, _kid, refresh_context) do
+    "Torus fetched #{key_set_url} during #{describe_refresh_context(refresh_context)}, but the response was not a valid JWKS payload."
+  end
+
+  defp fetch_error_message(:invalid_url_no_scheme, key_set_url, _kid, _refresh_context) do
+    "The configured JWKS URL '#{key_set_url}' is invalid because it has no URL scheme."
+  end
+
+  defp fetch_error_message(:insecure_url_scheme, key_set_url, _kid, _refresh_context) do
+    "The configured JWKS URL '#{key_set_url}' is invalid because Torus only allows HTTPS keyset URLs."
+  end
+
+  defp fetch_error_message(:invalid_url_no_host, key_set_url, _kid, _refresh_context) do
+    "The configured JWKS URL '#{key_set_url}' is invalid because it has no host."
+  end
+
+  defp fetch_error_message(:keyset_not_cached, key_set_url, kid, refresh_context) do
+    "Torus refreshed #{key_set_url} during #{describe_refresh_context(refresh_context)}, " <>
+      "but the requested key '#{kid}' was still unavailable from cache."
+  end
+
+  defp fetch_error_message(:single_flight_timeout, key_set_url, _kid, refresh_context) do
+    "Torus timed out while waiting for a shared keyset fetch from #{key_set_url} during #{describe_refresh_context(refresh_context)}."
+  end
+
+  defp fetch_error_message(:single_flight_owner_down, key_set_url, _kid, refresh_context) do
+    "Torus could not complete the shared keyset fetch from #{key_set_url} during #{describe_refresh_context(refresh_context)} because the fetch owner exited before finishing."
+  end
+
+  defp fetch_error_message(reason, key_set_url, _kid, refresh_context) do
+    "Torus could not refresh the keyset from #{key_set_url} during #{describe_refresh_context(refresh_context)}: #{inspect(reason)}"
+  end
+
+  defp describe_refresh_context(:cold_cache), do: "launch-time cache fill"
+  defp describe_refresh_context(:cached_key_miss), do: "launch-time key refresh"
 end

--- a/lib/oli/lti/cached_key_provider.ex
+++ b/lib/oli/lti/cached_key_provider.ex
@@ -20,10 +20,8 @@ defmodule Oli.Lti.CachedKeyProvider do
 
   require Logger
   alias Oli.Lti.KeysetCache
+  alias Oli.Lti.KeysetFetcher
   alias Oli.Lti.KeysetRefreshWorker
-
-  @http_timeout_ms 10_000
-  @default_ttl_seconds 3600
 
   @impl Lti_1p3.KeyProvider
   def get_public_key(key_set_url, kid) do
@@ -77,8 +75,8 @@ defmodule Oli.Lti.CachedKeyProvider do
     Logger.info("Preloading keys for #{key_set_url}")
 
     # preload_keys is explicitly called (not during launches), so synchronous fetch is acceptable
-    case refresh_keyset_sync(key_set_url) do
-      :ok -> :ok
+    case KeysetFetcher.fetch_and_cache(key_set_url) do
+      {:ok, _result} -> :ok
       {:error, reason} -> {:error, %{reason: reason, msg: "Failed to preload keys"}}
     end
   end
@@ -164,80 +162,5 @@ defmodule Oli.Lti.CachedKeyProvider do
     |> where([r], r.key_set_url == ^key_set_url)
     |> limit(1)
     |> Oli.Repo.one()
-  end
-
-  # Synchronous refresh functions - ONLY used by preload_keys (not in launch path)
-
-  defp refresh_keyset_sync(key_set_url) do
-    with :ok <- validate_https_url(key_set_url),
-         {:ok, response} <- http_get(key_set_url) do
-      handle_http_response(response, key_set_url)
-    else
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp handle_http_response(%{status_code: 200, body: body, headers: headers}, key_set_url) do
-    case Jason.decode(body) do
-      {:ok, %{"keys" => keys}} when is_list(keys) ->
-        ttl = parse_cache_control_max_age(headers)
-        KeysetCache.put_keyset(key_set_url, keys, ttl)
-        :ok
-
-      {:ok, _invalid_json} ->
-        {:error, :invalid_jwks_format}
-
-      {:error, _decode_error} ->
-        {:error, :json_decode_failed}
-    end
-  end
-
-  defp handle_http_response(%{status_code: status_code}, _key_set_url) do
-    {:error, {:http_error, status_code}}
-  end
-
-  defp http_get(url) do
-    http_client = Lti_1p3.Config.http_client!()
-    http_client.get(url, [], timeout: @http_timeout_ms, recv_timeout: @http_timeout_ms)
-  end
-
-  defp validate_https_url(url) do
-    uri = URI.parse(url)
-
-    cond do
-      is_nil(uri.scheme) ->
-        Logger.error("Invalid URL: No scheme provided for #{url}")
-        {:error, :invalid_url_no_scheme}
-
-      uri.scheme != "https" ->
-        Logger.error("Insecure URL: Only HTTPS URLs are allowed, got #{uri.scheme}://")
-        {:error, :insecure_url_scheme}
-
-      is_nil(uri.host) or uri.host == "" ->
-        Logger.error("Invalid URL: No host provided for #{url}")
-        {:error, :invalid_url_no_host}
-
-      true ->
-        :ok
-    end
-  end
-
-  defp parse_cache_control_max_age(headers) do
-    headers
-    |> Enum.find_value(fn
-      {"cache-control", value} -> value
-      {"Cache-Control", value} -> value
-      _ -> nil
-    end)
-    |> case do
-      nil ->
-        @default_ttl_seconds
-
-      cache_control ->
-        case Regex.run(~r/max-age=(\d+)/, cache_control) do
-          [_, max_age_str] -> String.to_integer(max_age_str)
-          _ -> @default_ttl_seconds
-        end
-    end
   end
 end

--- a/lib/oli/lti/keyset_fetch_coordinator.ex
+++ b/lib/oli/lti/keyset_fetch_coordinator.ex
@@ -1,0 +1,102 @@
+defmodule Oli.Lti.KeysetFetchCoordinator do
+  @moduledoc """
+  Coalesces concurrent keyset fetches per keyset URL.
+  """
+
+  use GenServer
+
+  @default_timeout 12_000
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  def run(key_set_url, fun, timeout \\ @default_timeout) when is_function(fun, 0) do
+    case run_with_metadata(key_set_url, fun, timeout) do
+      %{result: result} -> result
+    end
+  end
+
+  def run_with_metadata(key_set_url, fun, timeout \\ @default_timeout) when is_function(fun, 0) do
+    case GenServer.call(__MODULE__, {:acquire, key_set_url}, timeout + 1_000) do
+      {:owner, token} ->
+        result = execute_fetch(fun, timeout)
+        GenServer.cast(__MODULE__, {:complete, key_set_url, token, result})
+        %{role: :owner, result: result}
+
+      {:waiter, result} ->
+        %{role: :waiter, result: result}
+    end
+  catch
+    :exit, {:timeout, _} ->
+      %{role: :waiter, result: {:error, :single_flight_timeout}}
+  end
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{entries: %{}}}
+  end
+
+  @impl true
+  def handle_call({:acquire, key_set_url}, from, %{entries: entries} = state) do
+    case Map.get(entries, key_set_url) do
+      nil ->
+        token = make_ref()
+        owner_pid = elem(from, 0)
+        monitor_ref = Process.monitor(owner_pid)
+
+        entry = %{
+          owner_pid: owner_pid,
+          owner_monitor_ref: monitor_ref,
+          token: token,
+          waiters: []
+        }
+
+        {:reply, {:owner, token}, put_in(state, [:entries, key_set_url], entry)}
+
+      entry ->
+        updated_entry = %{entry | waiters: [from | entry.waiters]}
+        {:noreply, put_in(state, [:entries, key_set_url], updated_entry)}
+    end
+  end
+
+  @impl true
+  def handle_cast({:complete, key_set_url, token, result}, %{entries: entries} = state) do
+    case Map.get(entries, key_set_url) do
+      %{token: ^token, owner_monitor_ref: monitor_ref, waiters: waiters} ->
+        Process.demonitor(monitor_ref, [:flush])
+        Enum.each(waiters, &GenServer.reply(&1, {:waiter, result}))
+        {:noreply, %{state | entries: Map.delete(entries, key_set_url)}}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:DOWN, monitor_ref, :process, _pid, _reason}, %{entries: entries} = state) do
+    case Enum.find(entries, fn {_key, entry} -> entry.owner_monitor_ref == monitor_ref end) do
+      {key_set_url, %{waiters: waiters}} ->
+        Enum.each(waiters, &GenServer.reply(&1, {:waiter, {:error, :single_flight_owner_down}}))
+        {:noreply, %{state | entries: Map.delete(entries, key_set_url)}}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  defp execute_fetch(fun, timeout) do
+    task = Task.async(fun)
+
+    try do
+      Task.await(task, timeout)
+    catch
+      :exit, {:timeout, _} ->
+        Task.shutdown(task, :brutal_kill)
+        {:error, :single_flight_timeout}
+
+      :exit, reason ->
+        {:error, {:single_flight_fetch_failed, reason}}
+    end
+  end
+end

--- a/lib/oli/lti/keyset_fetcher.ex
+++ b/lib/oli/lti/keyset_fetcher.ex
@@ -1,0 +1,107 @@
+defmodule Oli.Lti.KeysetFetcher do
+  @moduledoc """
+  Shared JWKS fetch-and-cache boundary for LTI platform public keys.
+  """
+
+  require Logger
+
+  alias Oli.Lti.KeysetCache
+
+  @default_ttl_seconds 3600
+  @http_timeout_ms 10_000
+
+  @spec fetch_and_cache(String.t()) ::
+          {:ok,
+           %{
+             keys: list(),
+             fetched_at: DateTime.t(),
+             expires_at: DateTime.t(),
+             ttl_seconds: non_neg_integer()
+           }}
+          | {:error, term()}
+  def fetch_and_cache(key_set_url) do
+    with :ok <- validate_https_url(key_set_url),
+         {:ok, response} <- http_get(key_set_url),
+         {:ok, %{keys: keys, ttl_seconds: ttl_seconds}} <- parse_response(response, key_set_url),
+         :ok <- KeysetCache.put_keyset(key_set_url, keys, ttl_seconds),
+         {:ok, %{fetched_at: fetched_at, expires_at: expires_at}} <-
+           KeysetCache.get_keyset(key_set_url) do
+      {:ok,
+       %{
+         keys: keys,
+         fetched_at: fetched_at,
+         expires_at: expires_at,
+         ttl_seconds: ttl_seconds
+       }}
+    end
+  end
+
+  @spec validate_https_url(String.t()) :: :ok | {:error, atom()}
+  def validate_https_url(url) do
+    uri = URI.parse(url)
+
+    cond do
+      is_nil(uri.scheme) ->
+        Logger.error("Invalid URL: No scheme provided for #{url}")
+        {:error, :invalid_url_no_scheme}
+
+      uri.scheme != "https" ->
+        Logger.error("Insecure URL: Only HTTPS URLs are allowed, got #{uri.scheme}://")
+        {:error, :insecure_url_scheme}
+
+      is_nil(uri.host) or uri.host == "" ->
+        Logger.error("Invalid URL: No host provided for #{url}")
+        {:error, :invalid_url_no_host}
+
+      true ->
+        :ok
+    end
+  end
+
+  @spec parse_cache_control_max_age(list()) :: non_neg_integer()
+  def parse_cache_control_max_age(headers) do
+    headers
+    |> Enum.find_value(fn
+      {"cache-control", value} -> value
+      {"Cache-Control", value} -> value
+      _ -> nil
+    end)
+    |> case do
+      nil ->
+        @default_ttl_seconds
+
+      cache_control ->
+        case Regex.run(~r/max-age=(\d+)/, cache_control) do
+          [_, max_age_str] -> String.to_integer(max_age_str)
+          _ -> @default_ttl_seconds
+        end
+    end
+  end
+
+  defp parse_response(%{status_code: 200, body: body, headers: headers}, key_set_url) do
+    case Jason.decode(body) do
+      {:ok, %{"keys" => keys}} when is_list(keys) ->
+        {:ok, %{keys: keys, ttl_seconds: parse_cache_control_max_age(headers)}}
+
+      {:ok, invalid_json} ->
+        Logger.error(
+          "Invalid JWKS format from #{key_set_url}: missing 'keys' array. Body: #{inspect(invalid_json)}"
+        )
+
+        {:error, :invalid_jwks_format}
+
+      {:error, decode_error} ->
+        Logger.error("Failed to decode JSON from #{key_set_url}: #{inspect(decode_error)}")
+        {:error, :json_decode_failed}
+    end
+  end
+
+  defp parse_response(%{status_code: status_code}, _key_set_url) do
+    {:error, {:http_error, status_code}}
+  end
+
+  defp http_get(url) do
+    http_client = Lti_1p3.Config.http_client!()
+    http_client.get(url, [], timeout: @http_timeout_ms, recv_timeout: @http_timeout_ms)
+  end
+end

--- a/lib/oli/lti/keyset_refresh_worker.ex
+++ b/lib/oli/lti/keyset_refresh_worker.ex
@@ -19,11 +19,8 @@ defmodule Oli.Lti.KeysetRefreshWorker do
     max_attempts: 5
 
   require Logger
-  alias Oli.Lti.KeysetCache
+  alias Oli.Lti.KeysetFetcher
   alias Oli.Repo
-
-  @default_ttl_seconds 3600
-  @http_timeout_ms 10_000
 
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"registration_id" => registration_id}}) do
@@ -111,108 +108,39 @@ defmodule Oli.Lti.KeysetRefreshWorker do
   defp fetch_and_cache_keyset(%{key_set_url: key_set_url, id: registration_id} = _registration) do
     Logger.debug("Fetching keyset from #{key_set_url} for registration #{registration_id}")
 
-    with :ok <- validate_https_url(key_set_url),
-         {:ok, response} <- http_get(key_set_url) do
-      handle_http_response(response, key_set_url)
-    else
-      # URL validation failures are permanent configuration errors - discard immediately
-      {:error, :invalid_url_no_scheme} -> :discard
-      {:error, :insecure_url_scheme} -> :discard
-      {:error, :invalid_url_no_host} -> :discard
-      # HTTP/network errors may be transient - allow retry
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp handle_http_response(%{status_code: 200, body: body, headers: headers}, key_set_url) do
-    case Jason.decode(body) do
-      {:ok, %{"keys" => keys}} when is_list(keys) ->
-        ttl = parse_cache_control_max_age(headers)
-
+    case KeysetFetcher.fetch_and_cache(key_set_url) do
+      {:ok, %{keys: keys, ttl_seconds: ttl_seconds}} ->
         Logger.info(
-          "Successfully fetched #{length(keys)} keys from #{key_set_url}, caching with TTL #{ttl}s"
+          "Successfully fetched #{length(keys)} keys from #{key_set_url}, caching with TTL #{ttl_seconds}s"
         )
 
-        KeysetCache.put_keyset(key_set_url, keys, ttl)
         :ok
 
-      {:ok, invalid_json} ->
+      {:error, :invalid_url_no_scheme} ->
+        :discard
+
+      {:error, :insecure_url_scheme} ->
+        :discard
+
+      {:error, :invalid_url_no_host} ->
+        :discard
+
+      {:error, {:http_error, status_code}} when status_code in 400..499 ->
         Logger.error(
-          "Invalid JWKS format from #{key_set_url}: missing 'keys' array. Body: #{inspect(invalid_json)}"
+          "HTTP #{status_code} client error fetching keyset from #{key_set_url} - permanent failure"
         )
 
-        # Platform is returning invalid JWKS - permanent config issue, discard
         :discard
 
-      {:error, decode_error} ->
-        Logger.error("Failed to decode JSON from #{key_set_url}: #{inspect(decode_error)}")
-        # Platform is returning invalid JSON - permanent config issue, discard
+      {:error, :invalid_jwks_format} ->
         :discard
-    end
-  end
 
-  defp handle_http_response(%{status_code: status_code}, key_set_url)
-       when status_code in 400..499 do
-    Logger.error(
-      "HTTP #{status_code} client error fetching keyset from #{key_set_url} - permanent failure"
-    )
+      {:error, :json_decode_failed} ->
+        :discard
 
-    # 4xx errors are permanent (wrong URL, unauthorized, not found) - discard
-    :discard
-  end
-
-  defp handle_http_response(%{status_code: status_code}, key_set_url) do
-    Logger.error("HTTP #{status_code} error fetching keyset from #{key_set_url}")
-    # 5xx errors and other codes may be transient - allow retry
-    {:error, {:http_error, status_code}}
-  end
-
-  defp http_get(url) do
-    http_client = Lti_1p3.Config.http_client!()
-    http_client.get(url, [], timeout: @http_timeout_ms, recv_timeout: @http_timeout_ms)
-  end
-
-  defp validate_https_url(url) do
-    uri = URI.parse(url)
-
-    cond do
-      is_nil(uri.scheme) ->
-        Logger.error("Invalid URL: No scheme provided for #{url}")
-        {:error, :invalid_url_no_scheme}
-
-      uri.scheme != "https" ->
-        Logger.error("Insecure URL: Only HTTPS URLs are allowed, got #{uri.scheme}://")
-        {:error, :insecure_url_scheme}
-
-      is_nil(uri.host) or uri.host == "" ->
-        Logger.error("Invalid URL: No host provided for #{url}")
-        {:error, :invalid_url_no_host}
-
-      true ->
-        :ok
-    end
-  end
-
-  defp parse_cache_control_max_age(headers) do
-    headers
-    |> Enum.find_value(fn
-      {"cache-control", value} -> value
-      {"Cache-Control", value} -> value
-      _ -> nil
-    end)
-    |> case do
-      nil ->
-        @default_ttl_seconds
-
-      cache_control ->
-        # Parse "max-age=3600" from cache-control header
-        case Regex.run(~r/max-age=(\d+)/, cache_control) do
-          [_, max_age_str] ->
-            String.to_integer(max_age_str)
-
-          _ ->
-            @default_ttl_seconds
-        end
+      {:error, reason} ->
+        Logger.error("Failed to fetch keyset from #{key_set_url}: #{inspect(reason)}")
+        {:error, reason}
     end
   end
 end

--- a/test/oli/lti/cached_key_provider_test.exs
+++ b/test/oli/lti/cached_key_provider_test.exs
@@ -135,6 +135,16 @@ defmodule Oli.Lti.CachedKeyProviderTest do
       # Verify keys were cached
       assert {:ok, _} = KeysetCache.get_keyset(@test_url)
     end
+
+    test "returns the shared fetch error when preload fails" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok, %HTTPoison.Response{status_code: 503, body: "", headers: []}}
+      end)
+
+      assert {:error, %{reason: {:http_error, 503}, msg: "Failed to preload keys"}} =
+               CachedKeyProvider.preload_keys(@test_url)
+    end
   end
 
   describe "refresh_all_keys/0" do

--- a/test/oli/lti/cached_key_provider_test.exs
+++ b/test/oli/lti/cached_key_provider_test.exs
@@ -1,9 +1,8 @@
 defmodule Oli.Lti.CachedKeyProviderTest do
   use Oli.DataCase, async: false
 
+  import ExUnit.CaptureLog
   import Mox
-  import Oli.Factory
-
   alias Oli.Lti.CachedKeyProvider
   alias Oli.Lti.KeysetCache
 
@@ -25,7 +24,7 @@ defmodule Oli.Lti.CachedKeyProviderTest do
     "kid" => "test-key-2",
     "use" => "sig",
     "n" =>
-      "xjlA_0kzqN-nfN9-pzYaQ8TqG4h6c-2YZ-3KKQi6vYp6AQAB1t7yjQsY2fEaGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pGFp3Xr3pQ",
+      "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
     "e" => "AQAB"
   }
 
@@ -46,22 +45,6 @@ defmodule Oli.Lti.CachedKeyProviderTest do
       assert is_struct(public_key, JOSE.JWK)
     end
 
-    test "returns descriptive error when key not found in cached keyset" do
-      # Pre-populate cache with keys
-      KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
-
-      # Insert a registration for this URL so the refresh can be scheduled
-      insert(:lti_registration, %{key_set_url: @test_url})
-
-      # When a key is not found, the provider will schedule a refresh but fail fast
-      assert {:error, error} =
-               CachedKeyProvider.get_public_key(@test_url, "nonexistent-kid")
-
-      # The error should indicate key not found and mention scheduling a refresh
-      assert error.reason == :key_not_found_in_keyset
-      assert error.msg =~ "background job has been scheduled"
-    end
-
     test "retrieves same key consistently from same keyset" do
       KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
 
@@ -74,45 +57,190 @@ defmodule Oli.Lti.CachedKeyProviderTest do
       # Same key should be returned
       assert key1 == key2
     end
-  end
 
-  describe "get_public_key/2 with cache miss" do
-    test "fails fast when keyset not cached and schedules refresh" do
-      # Insert a registration for this URL so the refresh can be scheduled
-      insert(:lti_registration, %{key_set_url: @test_url})
+    test "AC-003 does not perform an http fetch for warm cache hits" do
+      KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
 
-      result = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+      assert {:ok, _public_key} = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+    end
 
-      # Should fail fast with descriptive error
-      assert {:error, error} = result
-      assert error.reason == :keyset_not_cached
-      assert error.msg =~ "not yet cached"
-      assert error.msg =~ "background job has been scheduled"
+    test "AC-006 emits warm-cache diagnostics" do
+      KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
+      previous_level = Logger.level()
+      Logger.configure(level: :info)
+
+      log =
+        capture_log([level: :info], fn ->
+          assert {:ok, _public_key} =
+                   CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+        end)
+
+      Logger.configure(level: previous_level)
+
+      assert log =~ "lti_keyset_lookup warm_cache_hit"
+      assert log =~ "lookup_source: :warm_cache"
+      assert log =~ "requested_kid: \"test-key-1\""
     end
   end
 
-  describe "get_public_key/2 error messages" do
-    test "distinguishes between different error scenarios" do
-      # Insert a registration for this URL so the refresh can be scheduled
-      insert(:lti_registration, %{key_set_url: @test_url})
+  describe "get_public_key/2 read-through behavior" do
+    test "AC-001 loads and returns the key on a cold-cache miss" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1, @test_key_2]}),
+           headers: [{"cache-control", "max-age=300"}]
+         }}
+      end)
 
-      # Scenario 1: Keyset not cached
-      KeysetCache.clear_cache()
+      assert {:ok, public_key} = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+      assert is_struct(public_key, JOSE.JWK)
+      assert {:ok, %{keys: [@test_key_1, @test_key_2]}} = KeysetCache.get_keyset(@test_url)
+    end
 
-      assert {:error, error} = CachedKeyProvider.get_public_key(@test_url, "any-key")
+    test "AC-001 AC-006 coalesces concurrent cold-cache requests for the same url into one fetch" do
+      parent = self()
 
-      # Should indicate cache miss
-      assert error.reason == :keyset_not_cached
-      assert error.msg =~ "not yet cached"
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        send(parent, :http_fetch)
 
-      # Scenario 2: Keyset cached but key not found
+        Process.sleep(50)
+
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1, @test_key_2]}),
+           headers: []
+         }}
+      end)
+
+      tasks =
+        Enum.map(1..2, fn _ ->
+          Task.async(fn ->
+            Mox.allow(Oli.Test.MockHTTP, parent, self())
+            CachedKeyProvider.get_public_key(@test_url, "test-key-2")
+          end)
+        end)
+
+      assert_receive :http_fetch
+      refute_receive :http_fetch, 100
+      assert Enum.all?(Enum.map(tasks, &Task.await(&1, 1_000)), &match?({:ok, _}, &1))
+    end
+
+    @tag capture_log: true
+    test "AC-002 refreshes synchronously when the cached keyset misses the requested kid" do
       KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
 
-      assert {:error, error2} = CachedKeyProvider.get_public_key(@test_url, "missing-key")
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1, @test_key_2]}),
+           headers: []
+         }}
+      end)
 
-      # Should indicate key not found in keyset
-      assert error2.reason == :key_not_found_in_keyset
-      assert error2.msg =~ "not found in the cached keyset"
+      assert {:ok, public_key} = CachedKeyProvider.get_public_key(@test_url, "test-key-2")
+      assert is_struct(public_key, JOSE.JWK)
+      assert {:ok, %{keys: [@test_key_1, @test_key_2]}} = KeysetCache.get_keyset(@test_url)
+    end
+
+    @tag capture_log: true
+    test "AC-004 returns an http fetch failure on cold-cache miss after read-through attempt" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok, %HTTPoison.Response{status_code: 503, body: "", headers: []}}
+      end)
+
+      assert {:error, error} = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+      assert error.reason == {:http_error, 503}
+      assert error.msg =~ "HTTP 503"
+      assert error.msg =~ "launch-time cache fill"
+      refute error.msg =~ "background job has been scheduled"
+    end
+
+    @tag capture_log: true
+    test "AC-004 returns an invalid json failure on cold-cache miss after read-through attempt" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok, %HTTPoison.Response{status_code: 200, body: "{invalid", headers: []}}
+      end)
+
+      assert {:error, error} = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+      assert error.reason == :json_decode_failed
+      assert error.msg =~ "could not decode"
+    end
+
+    @tag capture_log: true
+    test "AC-004 returns an invalid jwks failure on cold-cache miss after read-through attempt" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"unexpected" => []}),
+           headers: []
+         }}
+      end)
+
+      assert {:error, error} = CachedKeyProvider.get_public_key(@test_url, "test-key-1")
+      assert error.reason == :invalid_jwks_format
+      assert error.msg =~ "not a valid JWKS payload"
+    end
+
+    @tag capture_log: true
+    test "AC-005 AC-007 returns key_not_found_in_keyset after refresh when the requested kid is still missing" do
+      KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
+
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1]}),
+           headers: []
+         }}
+      end)
+
+      assert {:error, error} = CachedKeyProvider.get_public_key(@test_url, "missing-key")
+      assert error.reason == :key_not_found_in_keyset
+      assert error.msg =~ "not found after refreshing the keyset"
+      assert error.msg =~ "latest available keys for this launch"
+      refute error.msg =~ "background job has been scheduled"
+    end
+
+    test "AC-005 AC-006 emits sync refresh diagnostics for terminal failures" do
+      KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
+      previous_level = Logger.level()
+      Logger.configure(level: :info)
+
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1]}),
+           headers: []
+         }}
+      end)
+
+      log =
+        capture_log([level: :info], fn ->
+          assert {:error, %{reason: :key_not_found_in_keyset}} =
+                   CachedKeyProvider.get_public_key(@test_url, "missing-key")
+        end)
+
+      Logger.configure(level: previous_level)
+
+      assert log =~ "lti_keyset_lookup sync_lookup_failed"
+      assert log =~ "lookup_source: :sync_refresh_after_kid_miss"
+      assert log =~ "cached_key_ids_before_refresh: [\"test-key-1\"]"
+      assert log =~ "refreshed_key_ids: [\"test-key-1\"]"
+      assert log =~ "outcome: :key_not_found_in_keyset"
     end
   end
 
@@ -260,21 +388,26 @@ defmodule Oli.Lti.CachedKeyProviderTest do
   end
 
   describe "key rotation scenario" do
-    test "schedules refresh when kid not found to handle key rotation" do
+    @tag capture_log: true
+    test "AC-002 recovers synchronously when a rotated kid appears in the refreshed keyset" do
       # Initial cache with one key
       KeysetCache.put_keyset(@test_url, [@test_key_1], 3600)
 
-      # Insert a registration for this URL so the refresh can be scheduled
-      insert(:lti_registration, %{key_set_url: @test_url})
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key_1, @test_key_2]}),
+           headers: []
+         }}
+      end)
 
       # Try to get a key that doesn't exist in cache (simulating key rotation)
-      result = CachedKeyProvider.get_public_key(@test_url, "missing-rotated-key")
+      result = CachedKeyProvider.get_public_key(@test_url, "test-key-2")
 
-      # Should fail fast and schedule a refresh
-      assert {:error, error} = result
-      assert error.reason == :key_not_found_in_keyset
-      assert error.msg =~ "platform rotated its keys"
-      assert error.msg =~ "background job has been scheduled"
+      assert {:ok, public_key} = result
+      assert is_struct(public_key, JOSE.JWK)
     end
   end
 end

--- a/test/oli/lti/keyset_fetch_coordinator_test.exs
+++ b/test/oli/lti/keyset_fetch_coordinator_test.exs
@@ -1,0 +1,67 @@
+defmodule Oli.Lti.KeysetFetchCoordinatorTest do
+  use ExUnit.Case, async: false
+
+  alias Oli.Lti.KeysetFetchCoordinator
+
+  @test_url "https://example.com/jwks"
+
+  describe "run/3" do
+    test "AC-001 AC-002 AC-006 coalesces concurrent callers for the same url" do
+      parent = self()
+
+      tasks =
+        Enum.map(1..2, fn _ ->
+          Task.async(fn ->
+            KeysetFetchCoordinator.run(@test_url, fn ->
+              send(parent, :fetch_executed)
+              Process.sleep(50)
+              {:ok, :fetched}
+            end)
+          end)
+        end)
+
+      assert_receive :fetch_executed
+      refute_receive :fetch_executed, 100
+      assert Enum.map(tasks, &Task.await(&1, 1_000)) == [{:ok, :fetched}, {:ok, :fetched}]
+    end
+
+    test "returns a bounded timeout error when the owner fetch exceeds the timeout" do
+      assert {:error, :single_flight_timeout} =
+               KeysetFetchCoordinator.run(
+                 @test_url,
+                 fn ->
+                   Process.sleep(50)
+                   {:ok, :fetched}
+                 end,
+                 10
+               )
+    end
+
+    test "returns owner down for waiters when the fetch owner exits" do
+      parent = self()
+
+      owner =
+        spawn(fn ->
+          KeysetFetchCoordinator.run(@test_url, fn ->
+            send(parent, :owner_started)
+            Process.sleep(5_000)
+            {:ok, :fetched}
+          end)
+        end)
+
+      assert_receive :owner_started
+
+      waiter =
+        Task.async(fn ->
+          KeysetFetchCoordinator.run(@test_url, fn ->
+            {:ok, :unexpected_second_fetch}
+          end)
+        end)
+
+      Process.sleep(50)
+      Process.exit(owner, :kill)
+
+      assert {:error, :single_flight_owner_down} = Task.await(waiter, 1_000)
+    end
+  end
+end

--- a/test/oli/lti/keyset_fetcher_test.exs
+++ b/test/oli/lti/keyset_fetcher_test.exs
@@ -1,0 +1,100 @@
+defmodule Oli.Lti.KeysetFetcherTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Oli.Lti.KeysetCache
+  alias Oli.Lti.KeysetFetcher
+
+  setup :verify_on_exit!
+
+  @test_url "https://example.com/jwks"
+  @test_key %{
+    "kty" => "RSA",
+    "kid" => "test-key-1",
+    "use" => "sig",
+    "n" =>
+      "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+    "e" => "AQAB"
+  }
+
+  setup do
+    KeysetCache.clear_cache()
+    :ok
+  end
+
+  describe "fetch_and_cache/1" do
+    test "fetches JWKS, caches it, and returns normalized metadata" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [@test_key]}),
+           headers: [{"cache-control", "public, max-age=123"}]
+         }}
+      end)
+
+      assert {:ok, result} = KeysetFetcher.fetch_and_cache(@test_url)
+      assert result.keys == [@test_key]
+      assert result.ttl_seconds == 123
+      assert is_struct(result.fetched_at, DateTime)
+      assert is_struct(result.expires_at, DateTime)
+
+      assert DateTime.diff(result.expires_at, result.fetched_at, :second) in 123..124
+      assert {:ok, %{keys: [@test_key]}} = KeysetCache.get_keyset(@test_url)
+    end
+
+    test "rejects non-https urls before issuing a request" do
+      assert {:error, :insecure_url_scheme} =
+               KeysetFetcher.fetch_and_cache("http://example.com/jwks")
+    end
+
+    test "returns an error for invalid JSON payloads" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: "{invalid json",
+           headers: []
+         }}
+      end)
+
+      assert {:error, :json_decode_failed} = KeysetFetcher.fetch_and_cache(@test_url)
+      assert {:error, :not_found} = KeysetCache.get_keyset(@test_url)
+    end
+
+    test "returns an error for invalid JWKS payloads" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"unexpected" => []}),
+           headers: []
+         }}
+      end)
+
+      assert {:error, :invalid_jwks_format} = KeysetFetcher.fetch_and_cache(@test_url)
+      assert {:error, :not_found} = KeysetCache.get_keyset(@test_url)
+    end
+
+    test "returns http errors without caching partial results" do
+      Oli.Test.MockHTTP
+      |> expect(:get, fn @test_url, _headers, _opts ->
+        {:ok, %HTTPoison.Response{status_code: 503, body: "", headers: []}}
+      end)
+
+      assert {:error, {:http_error, 503}} = KeysetFetcher.fetch_and_cache(@test_url)
+      assert {:error, :not_found} = KeysetCache.get_keyset(@test_url)
+    end
+  end
+
+  describe "parse_cache_control_max_age/1" do
+    test "uses the default ttl when max-age is missing" do
+      assert KeysetFetcher.parse_cache_control_max_age([{"cache-control", "public"}]) == 3600
+      assert KeysetFetcher.parse_cache_control_max_age([]) == 3600
+    end
+  end
+end

--- a/test/oli/lti/keyset_fetcher_test.exs
+++ b/test/oli/lti/keyset_fetcher_test.exs
@@ -45,11 +45,13 @@ defmodule Oli.Lti.KeysetFetcherTest do
       assert {:ok, %{keys: [@test_key]}} = KeysetCache.get_keyset(@test_url)
     end
 
+    @tag capture_log: true
     test "rejects non-https urls before issuing a request" do
       assert {:error, :insecure_url_scheme} =
                KeysetFetcher.fetch_and_cache("http://example.com/jwks")
     end
 
+    @tag capture_log: true
     test "returns an error for invalid JSON payloads" do
       Oli.Test.MockHTTP
       |> expect(:get, fn @test_url, _headers, _opts ->
@@ -65,6 +67,7 @@ defmodule Oli.Lti.KeysetFetcherTest do
       assert {:error, :not_found} = KeysetCache.get_keyset(@test_url)
     end
 
+    @tag capture_log: true
     test "returns an error for invalid JWKS payloads" do
       Oli.Test.MockHTTP
       |> expect(:get, fn @test_url, _headers, _opts ->

--- a/test/oli/lti/keyset_refresh_worker_test.exs
+++ b/test/oli/lti/keyset_refresh_worker_test.exs
@@ -96,9 +96,6 @@ defmodule Oli.Lti.KeysetRefreshWorkerTest do
   end
 
   describe "cache-control header parsing" do
-    # This tests the private parse_cache_control_max_age function indirectly
-    # by checking the TTL used when caching
-
     test "uses default TTL when no cache-control header present" do
       registration = insert(:lti_registration, %{key_set_url: "https://platform.com/jwks"})
       job = %Oban.Job{args: %{"registration_id" => registration.id}}
@@ -123,6 +120,41 @@ defmodule Oli.Lti.KeysetRefreshWorkerTest do
       end)
 
       assert :ok = KeysetRefreshWorker.perform(job)
+
+      assert {:ok, %{fetched_at: fetched_at, expires_at: expires_at}} =
+               KeysetCache.get_keyset("https://platform.com/jwks")
+
+      assert DateTime.diff(expires_at, fetched_at, :second) in 3600..3601
+    end
+
+    test "caches using the shared fetcher ttl parsing" do
+      registration = insert(:lti_registration, %{key_set_url: "https://platform.com/jwks"})
+      job = %Oban.Job{args: %{"registration_id" => registration.id}}
+
+      test_key = %{
+        "kty" => "RSA",
+        "kid" => "test-key",
+        "use" => "sig",
+        "n" => "test-n",
+        "e" => "AQAB"
+      }
+
+      Oli.Test.MockHTTP
+      |> expect(:get, fn "https://platform.com/jwks", _headers, _opts ->
+        {:ok,
+         %HTTPoison.Response{
+           status_code: 200,
+           body: Jason.encode!(%{"keys" => [test_key]}),
+           headers: [{"cache-control", "max-age=90"}]
+         }}
+      end)
+
+      assert :ok = KeysetRefreshWorker.perform(job)
+
+      assert {:ok, %{fetched_at: fetched_at, expires_at: expires_at}} =
+               KeysetCache.get_keyset("https://platform.com/jwks")
+
+      assert DateTime.diff(expires_at, fetched_at, :second) in 90..91
     end
   end
 

--- a/test/oli/lti/keyset_refresh_worker_test.exs
+++ b/test/oli/lti/keyset_refresh_worker_test.exs
@@ -47,6 +47,7 @@ defmodule Oli.Lti.KeysetRefreshWorkerTest do
       assert :discard = KeysetRefreshWorker.perform(job)
     end
 
+    @tag capture_log: true
     test "discards job when registration has no key_set_url" do
       registration = insert(:lti_registration, %{key_set_url: nil})
       job = %Oban.Job{args: %{"registration_id" => registration.id}}


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5540

This PR fixes LTI keyset cache refresh by making LTI platform JWKS lookup reliable at launch time instead of depending on a previously warmed ETS cache entry or a later background refresh.

The main behavior change is that `Oli.Lti.CachedKeyProvider` now treats the keyset cache as read-through on cold-cache and cached-`kid`-miss paths:

- Warm-cache hits stay cache-only.
- Cold-cache misses synchronously fetch and cache the latest JWKS before retrying lookup.
- Cached `kid` misses synchronously refresh the JWKS, update ETS, and retry lookup before returning a terminal failure.
- Same-URL concurrent miss-path fetches are coalesced through a single-flight coordinator so Torus does not stampede the LMS JWKS endpoint.

## Why

The previous behavior could fail valid launches when:

- the LMS keyset had not been cached yet
- the cached JWKS no longer contained the requested `kid`
- the system only scheduled an asynchronous refresh and required a later retry or manual operator intervention

This change removes that correctness gap from the launch path while preserving ETS as the warm-path cache and Oban refresh as a background maintenance mechanism.

## Backend

- Added `Oli.Lti.KeysetFetcher` as the shared HTTPS fetch/parse/TTL/cache boundary used by both manual/synchronous and background refresh paths.
- Refactored `Oli.Lti.KeysetRefreshWorker` to use the shared fetcher without changing its scheduling interface.
- Added `Oli.Lti.KeysetFetchCoordinator` and supervised it in `Oli.Application` to coalesce in-flight fetches per `key_set_url`.
- Refactored `Oli.Lti.CachedKeyProvider.get_public_key/2` to:
  - read through on uncached keysets
  - refresh synchronously on cached `kid` miss
  - keep `:key_not_found_in_keyset` as the terminal result when the latest fetched keyset still does not contain the requested `kid`
  - return truthful launch-path failure messages that reflect the current request behavior instead of claiming a background job has already resolved the issue
- Added structured, non-sensitive lookup diagnostics covering lookup source, requested `kid`, cached and refreshed key ids, single-flight role, and terminal outcome.

## Tests

- Added focused coverage for:
  - shared fetch helper success and failure handling
  - cold-cache launch recovery
  - cached `kid` miss recovery
  - warm-cache no-fetch regression
  - single-flight coalescing
  - bounded timeout / owner-down coordination failures
  - truthful failure messaging and lookup diagnostics
- Updated intentional log-producing tests to use `@tag capture_log: true` or `capture_log(...)` so normal test output stays clean.
