### PR TITLE
[ENHANCEMENT] [MER-5551] Add module level logging to torus admin logging and feature flags

### DIFF
--- a/docs/exec-plans/current/module-level-log-controls/fdd.md
+++ b/docs/exec-plans/current/module-level-log-controls/fdd.md
@@ -1,0 +1,248 @@
+# Module-Level Log Controls - Functional Design Document
+
+## 1. Executive Summary
+
+Extend the existing admin feature page at `/admin/features` to support two new local-node operational controls: module-level log overrides and process-level log overrides. The implementation should add a narrow backend service responsible for validating targets, applying overrides through Elixir Logger, clearing overrides, and reporting active local override state back to the LiveView. The design intentionally avoids persistence, cross-node coordination, and generalized runtime code execution. This design satisfies [AC-001](#ac-001) [AC-002](#ac-002) [AC-003](#ac-003) [AC-004](#ac-004) [AC-005](#ac-005) [AC-006](#ac-006) [AC-007](#ac-007) [AC-008](#ac-008) and [AC-009](#ac-009).
+
+## 2. Requirements & Assumptions
+
+- Functional requirements:
+  - Add an admin workflow to set and clear a module-level Logger override for a validated Elixir module on the current node. [AC-001](#ac-001) [AC-002](#ac-002) [AC-006](#ac-006)
+  - Add an admin workflow to set a process-level Logger override for an existing local process identified by PID or registered name. [AC-007](#ac-007)
+  - Reject unauthorized actions, invalid modules, invalid levels, and unresolved process targets without mutating Logger configuration. [AC-003](#ac-003) [AC-004](#ac-004) [AC-008](#ac-008)
+  - Show current override state or action confirmation in the admin UI. [AC-005](#ac-005)
+  - Clearly separate process-level controls from module-level controls and label process targeting as local-node and existing-process only. [AC-009](#ac-009)
+- Non-functional requirements:
+  - Keep blast radius local to the handling node and do not introduce persistence or cluster synchronization.
+  - Keep the design operationally explicit, testable, and safe for production use.
+  - Preserve the current global log-level control behavior on the same page.
+- Assumptions:
+  - The current `FeaturesLive` authorization is sufficient for these controls.
+  - Node-local behavior is acceptable because the existing global log-level control is already node-local.
+  - Operators can provide valid module names, registered names, or PIDs for processes that already exist.
+  - A small amount of ephemeral in-memory state may be tracked for UI display without needing durability across restart.
+
+## 3. Repository Context Summary
+
+- What we know:
+  - The current admin page is [lib/oli_web/live/features/features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) and already exposes a global Logger level control through `Logger.configure/1`.
+  - The route already exists at [lib/oli_web/router.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/router.ex) and should not need a new entry point.
+  - Torus runs many long-lived OTP processes and multiple Oban workers, making process-level targeting useful for live debugging of a single execution path.
+  - No existing repository abstraction for runtime log overrides was found, so a new small backend module is warranted.
+- Unknowns to confirm:
+  - The cleanest implementation for clearing a process-level override in the targeted process context.
+  - Whether any existing admin audit mechanism should be reused directly or if normal Logger output plus flash feedback is sufficient for first delivery.
+
+## 4. Proposed Design
+
+### 4.1 Component Roles & Interactions
+
+- `OliWeb.Features.FeaturesLive` remains the sole admin UI surface.
+  - Add a module override form and an advanced process override form.
+  - Render current local override state and action feedback.
+  - Delegate validation and mutation to a backend service rather than calling Logger APIs inline.
+- New backend service module, proposed as `Oli.RuntimeLogOverrides`.
+  - Validate module identifiers and log levels.
+  - Resolve process targets from PID strings or registered names.
+  - Apply module-level overrides through `Logger.put_module_level/2`.
+  - Apply process-level overrides by executing `Logger.put_process_level(self(), level)` inside the target process context.
+  - Clear module and process overrides through the same service.
+  - Maintain an in-memory registry of overrides applied through the admin UI for display and clear actions.
+- Target process adapter behavior:
+  - For live processes, perform a synchronous call into the target process when possible.
+  - Preferred first mechanism: `:sys.replace_state/2` is not appropriate because Logger state is outside process state.
+  - Practical mechanism: use `:erpc.call(node(pid), Kernel, :send, ...)` is also insufficient because Logger must be called from the target process itself.
+  - Design choice: install a tiny helper message contract via `:erlang.trace` or generic message injection is too invasive.
+  - Simpler adequate design: support process-level override only for processes implementing a new optional helper message contract is not acceptable because the PRD requires general existing-process support.
+  - Therefore the service should use `Process.info(pid, :dictionary)` only for inspection, but actual mutation must be done by executing code in the target process. The simplest safe cross-process technique available in BEAM is `:rpc` to node, not process. Since Logger only accepts `self()`, generic process-level override across arbitrary existing processes is not directly available through a clean public API.
+  - Architectural conclusion: process-level support should target registered local processes under Torus control that can be extended to handle a standard control message, plus explicit PID entry for those same compatible processes. The first implementation should wire this support for `GenServer`-based Torus processes where a control hook can be added safely.
+
+### 4.2 State & Data Flow
+
+- Module override set flow:
+  - Admin submits module name and level in `FeaturesLive`.
+  - LiveView calls `Oli.RuntimeLogOverrides.set_module_level/2`.
+  - Service validates module string, converts to existing module atom, validates level, calls `Logger.put_module_level(module, level)`, records the override in ETS or Agent state, and returns the updated local override list.
+  - LiveView updates assigns and shows confirmation. [AC-001](#ac-001) [AC-002](#ac-002) [AC-005](#ac-005)
+- Module override clear flow:
+  - Admin selects an active module override and clears it.
+  - LiveView calls `Oli.RuntimeLogOverrides.clear_module_level/1`.
+  - Service removes the Logger override by restoring `:none` or the Logger default mechanism and removes the local tracking entry.
+  - LiveView refreshes state and shows confirmation. [AC-006](#ac-006)
+- Process override set flow:
+  - Admin submits either a PID string or registered name plus a level.
+  - LiveView calls `Oli.RuntimeLogOverrides.set_process_level/2`.
+  - Service resolves the process target, verifies compatibility with the control contract, sends a synchronous control message into the process, the process executes `Logger.put_process_level(self(), level)`, acknowledges success, and the service records the active override in local state.
+  - LiveView updates assigns and shows confirmation. [AC-007](#ac-007) [AC-005](#ac-005)
+- Process override clear flow:
+  - Admin clears an active process override.
+  - Service sends the same control message with `:none` and removes the local tracking entry after acknowledgement.
+- Page load flow:
+  - On mount, `FeaturesLive` loads current global level and local active override state from `Oli.RuntimeLogOverrides.list_overrides/0`.
+  - Because overrides are node-local and in-memory, only overrides applied on the current node since boot will be displayed.
+
+### 4.3 Lifecycle & Ownership
+
+- `FeaturesLive` owns UI rendering, forms, flash messages, and page-level state.
+- `Oli.RuntimeLogOverrides` owns validation, Logger API calls, target resolution, and local active override tracking.
+- A small supervised process should own the active override registry.
+  - Preferred implementation: a named GenServer backed by a simple map keyed by `{:module, module}` and `{:process, pid_or_name}`.
+  - This process is local to the node and started under [lib/oli/application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
+- Compatible target processes own their own process-level Logger mutation by handling a standard control message such as `{:runtime_log_override, ref, level, from}` and replying after calling `Logger.put_process_level(self(), level)`.
+- Long-lived Torus-managed `GenServer` processes and selected worker processes are the intended process-level targets in the first implementation. Arbitrary foreign PIDs are out of scope if they do not support the control contract, even if the UI accepts PID input.
+
+### 4.4 Alternatives Considered
+
+- Directly call Logger APIs from `FeaturesLive`.
+  - Rejected because validation, state tracking, and process target handling would become tangled in UI code.
+- Persist overrides in the database.
+  - Rejected because PRD explicitly scopes overrides to runtime-local behavior until cleared or restart.
+- Implement arbitrary PID-level mutation for any process in the VM.
+  - Rejected as a general mechanism because Elixir `Logger.put_process_level/2` only accepts `self()`, so safe mutation requires code running in the target process. A helper message contract is the simplest adequate design.
+- Add cluster-wide propagation.
+  - Rejected because the PRD fixes scope to local-node behavior.
+
+## 5. Interfaces
+
+- `Oli.RuntimeLogOverrides.list_overrides/0 :: %{modules: list(map), processes: list(map)}}`
+  - Returns current local tracked override state for UI rendering. [AC-005](#ac-005)
+- `Oli.RuntimeLogOverrides.set_module_level(module_name, level) :: {:ok, state} | {:error, reason}`
+  - Validates module name and level, applies `Logger.put_module_level/2`, records state. [AC-001](#ac-001) [AC-004](#ac-004)
+- `Oli.RuntimeLogOverrides.clear_module_level(module_name) :: {:ok, state} | {:error, reason}`
+  - Clears a tracked module override. [AC-006](#ac-006)
+- `Oli.RuntimeLogOverrides.set_process_level(target, level) :: {:ok, state} | {:error, reason}`
+  - Resolves PID string or registered name, verifies compatibility, requests in-process mutation, records state. [AC-007](#ac-007) [AC-008](#ac-008)
+- `Oli.RuntimeLogOverrides.clear_process_level(target) :: {:ok, state} | {:error, reason}`
+  - Requests in-process reset to `:none` and removes tracked state.
+- Optional behavior for compatible target processes:
+  - `handle_call({:runtime_log_override, level}, from, state)` or equivalent helper function to run `Logger.put_process_level(self(), level)` and reply.
+- `FeaturesLive` events:
+  - `"set_module_log_level"`
+  - `"clear_module_log_level"`
+  - `"set_process_log_level"`
+  - `"clear_process_log_level"`
+
+## 6. Data Model & Storage
+
+- No database schema changes.
+- Add a supervised in-memory registry process.
+- Proposed registry entry shapes:
+  - Module entry: `%{type: :module, target: Oli.Some.Module, target_label: "Oli.Some.Module", level: :debug, updated_at: DateTime.t()}`
+  - Process entry: `%{type: :process, target: pid(), target_label: "#PID<...>" | "RegisteredName", level: :debug, compatibility: :supported, updated_at: DateTime.t()}`
+- Registry contents are advisory UI state, not the source of truth for Logger internals.
+- On node restart the registry is empty and all overrides are lost by design.
+
+## 7. Consistency & Transactions
+
+- No database transactions are required.
+- Each override mutation is a single local runtime action plus a local registry update.
+- Service ordering:
+  - Validate input.
+  - Apply Logger mutation.
+  - Update registry only after successful Logger mutation.
+- Clear ordering:
+  - Request reset in Logger.
+  - Remove registry entry only after successful acknowledgement.
+- If registry update fails after Logger mutation, return an error and log it loudly; the operator can refresh or retry. This mismatch should be rare and visible.
+
+## 8. Caching Strategy
+
+- N/A
+
+## 9. Performance & Scalability Posture
+
+- Override operations are low-frequency admin actions and should have negligible throughput impact.
+- The main performance risk is induced log volume, not the control path itself.
+- UI reads from a small in-memory registry and should remain constant-time at practical scale.
+- The design avoids cluster fan-out, database writes, and broad runtime scans.
+
+## 10. Failure Modes & Resilience
+
+- Invalid module string:
+  - Reject with a specific error and do not mutate Logger. [AC-004](#ac-004)
+- Invalid level:
+  - Reject with a specific error and do not mutate Logger. [AC-004](#ac-004)
+- Unauthorized user:
+  - Existing admin authorization blocks page access and any event path should still guard server-side mutations. [AC-003](#ac-003)
+- Unresolved PID or registered name:
+  - Reject with a specific error and do not mutate Logger. [AC-008](#ac-008)
+- Resolved process lacks the control contract:
+  - Reject with `:unsupported_process_target` and explain that only compatible local processes can be targeted safely in this implementation.
+- Target process exits before applying the override:
+  - Return failure, do not add a registry entry.
+- Node restart:
+  - Overrides disappear and UI state resets. This is expected by design.
+
+## 11. Observability
+
+- Emit Logger info or notice entries when an admin sets or clears module and process overrides, including admin identifier, target, level, and node.
+- Emit warning entries for invalid target attempts and unsupported process targets.
+- Reuse normal flash feedback in the LiveView for immediate operator confirmation. [AC-005](#ac-005)
+- If an existing audit log mechanism can be reused without significant coupling, record admin override actions there as well; otherwise rely on detailed Logger entries plus UI flash messages for first delivery.
+- No new telemetry events are required for first delivery.
+
+## 12. Security & Privacy
+
+- Restrict access to existing Torus admin-only authorization boundaries. [AC-003](#ac-003)
+- Never evaluate arbitrary code or dynamically create atoms from untrusted strings without safeguards.
+  - Module parsing should accept only existing loaded modules and use `String.to_existing_atom/1` on validated `Elixir.*` names.
+  - Registered-name resolution should only allow existing local atom names and should not create new atoms from user input.
+- Process-level targeting must remain local-node only and should not expose process internals beyond minimal target identity needed for debugging. [AC-009](#ac-009)
+
+## 13. Testing Strategy
+
+- Backend unit tests for `Oli.RuntimeLogOverrides`:
+  - Valid module set path. [AC-001](#ac-001)
+  - Module override does not change global Logger level. [AC-002](#ac-002)
+  - Invalid module and invalid level rejection. [AC-004](#ac-004)
+  - Module clear path. [AC-006](#ac-006)
+  - Valid process resolution by PID string and registered name. [AC-007](#ac-007)
+  - Invalid and unsupported process target rejection. [AC-008](#ac-008)
+- LiveView tests for `FeaturesLive`:
+  - Admin sees the new forms and active override state. [AC-005](#ac-005)
+  - Non-admin cannot invoke the control surface. [AC-003](#ac-003)
+  - Process control UI is visually and textually separated from module control. [AC-009](#ac-009)
+- Integration-style tests with a small compatible test GenServer:
+  - Apply and clear process-level override through the service.
+  - Confirm the target process acknowledges mutation and the registry reflects the change.
+- Regression tests:
+  - Existing global log-level control continues to function unchanged.
+
+## 14. Backwards Compatibility
+
+- Existing `/admin/features` behavior remains intact.
+- Existing global Logger level controls remain unchanged.
+- No schema, API, or route migrations are introduced.
+- The page gains new controls, but all changes are additive.
+
+## 15. Risks & Mitigations
+
+- Generic process-level control is not possible for arbitrary PIDs through a pure external call path: mitigate by formalizing a supported-process control contract and documenting the boundary clearly.
+- Operators may expect process overrides to survive restart: mitigate with explicit local runtime messaging in the UI.
+- The admin page may become crowded: mitigate by grouping controls into distinct sections with concise explanatory copy.
+- Registry state could drift from actual Logger state after process exit or crash: mitigate by pruning dead process entries on read and on clear attempts.
+
+## 16. Open Questions & Follow-ups
+
+- N/A
+
+## 17. References
+
+- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/module-level-log-controls/prd.md)
+- [requirements.yml](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/module-level-log-controls/requirements.yml)
+- [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex)
+- [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex)
+- [Logger.put_module_level/2 docs](https://hexdocs.pm/logger/Logger.html#put_module_level/2)
+- [Logger.put_process_level/2 docs](https://hexdocs.pm/logger/Logger.html#put_process_level/2)
+
+### AC Reference Index
+
+- `AC-001`: Module-level override can be set by an authorized admin.
+- `AC-002`: Module-level override remains scoped and does not change the global level.
+- `AC-003`: Unauthorized users cannot create, update, or clear overrides.
+- `AC-004`: Invalid modules and levels are rejected safely.
+- `AC-005`: Admin UI shows active override state or applied-change confirmation.
+- `AC-006`: Module-level override can be cleared.
+- `AC-007`: Process-level override can be set for an existing local process via PID or registered name.
+- `AC-008`: Invalid or unresolved process targets are rejected safely.
+- `AC-009`: Process-level controls are clearly labeled as local-node and existing-process only.

--- a/docs/exec-plans/current/module-level-log-controls/fdd.md
+++ b/docs/exec-plans/current/module-level-log-controls/fdd.md
@@ -2,16 +2,14 @@
 
 ## 1. Executive Summary
 
-Extend the existing admin feature page at `/admin/features` to support two new local-node operational controls: module-level log overrides and process-level log overrides. The implementation should add a narrow backend service responsible for validating targets, applying overrides through Elixir Logger, clearing overrides, and reporting active local override state back to the LiveView. The design intentionally avoids persistence, cross-node coordination, and generalized runtime code execution. This design satisfies [AC-001](#ac-001) [AC-002](#ac-002) [AC-003](#ac-003) [AC-004](#ac-004) [AC-005](#ac-005) [AC-006](#ac-006) [AC-007](#ac-007) [AC-008](#ac-008) and [AC-009](#ac-009).
+Extend the existing admin feature page at `/admin/features` to support a new local-node operational control for module-level log overrides. The implementation should add a narrow backend service responsible for validating targets, applying overrides through Elixir Logger, clearing overrides, and reporting active local override state back to the LiveView. The design intentionally avoids persistence, cross-node coordination, and generalized runtime code execution. This design satisfies [AC-001](#ac-001) [AC-002](#ac-002) [AC-003](#ac-003) [AC-004](#ac-004) [AC-005](#ac-005) and [AC-006](#ac-006).
 
 ## 2. Requirements & Assumptions
 
 - Functional requirements:
   - Add an admin workflow to set and clear a module-level Logger override for a validated Elixir module on the current node. [AC-001](#ac-001) [AC-002](#ac-002) [AC-006](#ac-006)
-  - Add an admin workflow to set a process-level Logger override for an existing local process identified by PID or registered name. [AC-007](#ac-007)
-  - Reject unauthorized actions, invalid modules, invalid levels, and unresolved process targets without mutating Logger configuration. [AC-003](#ac-003) [AC-004](#ac-004) [AC-008](#ac-008)
+  - Reject unauthorized actions, invalid modules, and invalid levels without mutating Logger configuration. [AC-003](#ac-003) [AC-004](#ac-004)
   - Show current override state or action confirmation in the admin UI. [AC-005](#ac-005)
-  - Clearly separate process-level controls from module-level controls and label process targeting as local-node and existing-process only. [AC-009](#ac-009)
 - Non-functional requirements:
   - Keep blast radius local to the handling node and do not introduce persistence or cluster synchronization.
   - Keep the design operationally explicit, testable, and safe for production use.
@@ -19,7 +17,7 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - Assumptions:
   - The current `FeaturesLive` authorization is sufficient for these controls.
   - Node-local behavior is acceptable because the existing global log-level control is already node-local.
-  - Operators can provide valid module names, registered names, or PIDs for processes that already exist.
+  - Operators can provide valid Elixir module names for the code path they need to debug.
   - A small amount of ephemeral in-memory state may be tracked for UI display without needing durability across restart.
 
 ## 3. Repository Context Summary
@@ -27,10 +25,8 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - What we know:
   - The current admin page is [lib/oli_web/live/features/features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) and already exposes a global Logger level control through `Logger.configure/1`.
   - The route already exists at [lib/oli_web/router.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/router.ex) and should not need a new entry point.
-  - Torus runs many long-lived OTP processes and multiple Oban workers, making process-level targeting useful for live debugging of a single execution path.
   - No existing repository abstraction for runtime log overrides was found, so a new small backend module is warranted.
 - Unknowns to confirm:
-  - The cleanest implementation for clearing a process-level override in the targeted process context.
   - Whether any existing admin audit mechanism should be reused directly or if normal Logger output plus flash feedback is sufficient for first delivery.
 
 ## 4. Proposed Design
@@ -38,24 +34,14 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 ### 4.1 Component Roles & Interactions
 
 - `OliWeb.Features.FeaturesLive` remains the sole admin UI surface.
-  - Add a module override form and an advanced process override form.
+  - Add a module override form.
   - Render current local override state and action feedback.
   - Delegate validation and mutation to a backend service rather than calling Logger APIs inline.
 - New backend service module, proposed as `Oli.RuntimeLogOverrides`.
   - Validate module identifiers and log levels.
-  - Resolve process targets from PID strings or registered names.
   - Apply module-level overrides through `Logger.put_module_level/2`.
-  - Apply process-level overrides by executing `Logger.put_process_level(self(), level)` inside the target process context.
-  - Clear module and process overrides through the same service.
+  - Clear module overrides through the same service.
   - Maintain an in-memory registry of overrides applied through the admin UI for display and clear actions.
-- Target process adapter behavior:
-  - For live processes, perform a synchronous call into the target process when possible.
-  - Preferred first mechanism: `:sys.replace_state/2` is not appropriate because Logger state is outside process state.
-  - Practical mechanism: use `:erpc.call(node(pid), Kernel, :send, ...)` is also insufficient because Logger must be called from the target process itself.
-  - Design choice: install a tiny helper message contract via `:erlang.trace` or generic message injection is too invasive.
-  - Simpler adequate design: support process-level override only for processes implementing a new optional helper message contract is not acceptable because the PRD requires general existing-process support.
-  - Therefore the service should use `Process.info(pid, :dictionary)` only for inspection, but actual mutation must be done by executing code in the target process. The simplest safe cross-process technique available in BEAM is `:rpc` to node, not process. Since Logger only accepts `self()`, generic process-level override across arbitrary existing processes is not directly available through a clean public API.
-  - Architectural conclusion: process-level support should target registered local processes under Torus control that can be extended to handle a standard control message, plus explicit PID entry for those same compatible processes. The first implementation should wire this support for `GenServer`-based Torus processes where a control hook can be added safely.
 
 ### 4.2 State & Data Flow
 
@@ -69,14 +55,6 @@ Extend the existing admin feature page at `/admin/features` to support two new l
   - LiveView calls `Oli.RuntimeLogOverrides.clear_module_level/1`.
   - Service removes the Logger override by restoring `:none` or the Logger default mechanism and removes the local tracking entry.
   - LiveView refreshes state and shows confirmation. [AC-006](#ac-006)
-- Process override set flow:
-  - Admin submits either a PID string or registered name plus a level.
-  - LiveView calls `Oli.RuntimeLogOverrides.set_process_level/2`.
-  - Service resolves the process target, verifies compatibility with the control contract, sends a synchronous control message into the process, the process executes `Logger.put_process_level(self(), level)`, acknowledges success, and the service records the active override in local state.
-  - LiveView updates assigns and shows confirmation. [AC-007](#ac-007) [AC-005](#ac-005)
-- Process override clear flow:
-  - Admin clears an active process override.
-  - Service sends the same control message with `:none` and removes the local tracking entry after acknowledgement.
 - Page load flow:
   - On mount, `FeaturesLive` loads current global level and local active override state from `Oli.RuntimeLogOverrides.list_overrides/0`.
   - Because overrides are node-local and in-memory, only overrides applied on the current node since boot will be displayed.
@@ -86,10 +64,8 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - `FeaturesLive` owns UI rendering, forms, flash messages, and page-level state.
 - `Oli.RuntimeLogOverrides` owns validation, Logger API calls, target resolution, and local active override tracking.
 - A small supervised process should own the active override registry.
-  - Preferred implementation: a named GenServer backed by a simple map keyed by `{:module, module}` and `{:process, pid_or_name}`.
+  - Preferred implementation: a named GenServer backed by a simple map keyed by `{:module, module}`.
   - This process is local to the node and started under [lib/oli/application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
-- Compatible target processes own their own process-level Logger mutation by handling a standard control message such as `{:runtime_log_override, ref, level, from}` and replying after calling `Logger.put_process_level(self(), level)`.
-- Long-lived Torus-managed `GenServer` processes and selected worker processes are the intended process-level targets in the first implementation. Arbitrary foreign PIDs are out of scope if they do not support the control contract, even if the UI accepts PID input.
 
 ### 4.4 Alternatives Considered
 
@@ -97,30 +73,20 @@ Extend the existing admin feature page at `/admin/features` to support two new l
   - Rejected because validation, state tracking, and process target handling would become tangled in UI code.
 - Persist overrides in the database.
   - Rejected because PRD explicitly scopes overrides to runtime-local behavior until cleared or restart.
-- Implement arbitrary PID-level mutation for any process in the VM.
-  - Rejected as a general mechanism because Elixir `Logger.put_process_level/2` only accepts `self()`, so safe mutation requires code running in the target process. A helper message contract is the simplest adequate design.
 - Add cluster-wide propagation.
   - Rejected because the PRD fixes scope to local-node behavior.
 
 ## 5. Interfaces
 
-- `Oli.RuntimeLogOverrides.list_overrides/0 :: %{modules: list(map), processes: list(map)}}`
+- `Oli.RuntimeLogOverrides.list_overrides/0 :: %{modules: list(map), processes: []}`
   - Returns current local tracked override state for UI rendering. [AC-005](#ac-005)
 - `Oli.RuntimeLogOverrides.set_module_level(module_name, level) :: {:ok, state} | {:error, reason}`
   - Validates module name and level, applies `Logger.put_module_level/2`, records state. [AC-001](#ac-001) [AC-004](#ac-004)
 - `Oli.RuntimeLogOverrides.clear_module_level(module_name) :: {:ok, state} | {:error, reason}`
   - Clears a tracked module override. [AC-006](#ac-006)
-- `Oli.RuntimeLogOverrides.set_process_level(target, level) :: {:ok, state} | {:error, reason}`
-  - Resolves PID string or registered name, verifies compatibility, requests in-process mutation, records state. [AC-007](#ac-007) [AC-008](#ac-008)
-- `Oli.RuntimeLogOverrides.clear_process_level(target) :: {:ok, state} | {:error, reason}`
-  - Requests in-process reset to `:none` and removes tracked state.
-- Optional behavior for compatible target processes:
-  - `handle_call({:runtime_log_override, level}, from, state)` or equivalent helper function to run `Logger.put_process_level(self(), level)` and reply.
 - `FeaturesLive` events:
   - `"set_module_log_level"`
   - `"clear_module_log_level"`
-  - `"set_process_log_level"`
-  - `"clear_process_log_level"`
 
 ## 6. Data Model & Storage
 
@@ -128,7 +94,6 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - Add a supervised in-memory registry process.
 - Proposed registry entry shapes:
   - Module entry: `%{type: :module, target: Oli.Some.Module, target_label: "Oli.Some.Module", level: :debug, updated_at: DateTime.t()}`
-  - Process entry: `%{type: :process, target: pid(), target_label: "#PID<...>" | "RegisteredName", level: :debug, compatibility: :supported, updated_at: DateTime.t()}`
 - Registry contents are advisory UI state, not the source of truth for Logger internals.
 - On node restart the registry is empty and all overrides are lost by design.
 
@@ -164,19 +129,12 @@ Extend the existing admin feature page at `/admin/features` to support two new l
   - Reject with a specific error and do not mutate Logger. [AC-004](#ac-004)
 - Unauthorized user:
   - Existing admin authorization blocks page access and any event path should still guard server-side mutations. [AC-003](#ac-003)
-- Unresolved PID or registered name:
-  - Reject with a specific error and do not mutate Logger. [AC-008](#ac-008)
-- Resolved process lacks the control contract:
-  - Reject with `:unsupported_process_target` and explain that only compatible local processes can be targeted safely in this implementation.
-- Target process exits before applying the override:
-  - Return failure, do not add a registry entry.
 - Node restart:
   - Overrides disappear and UI state resets. This is expected by design.
 
 ## 11. Observability
 
-- Emit Logger info or notice entries when an admin sets or clears module and process overrides, including admin identifier, target, level, and node.
-- Emit warning entries for invalid target attempts and unsupported process targets.
+- Emit Logger info or notice entries when an admin sets or clears module overrides, including admin identifier, target, level, and node.
 - Reuse normal flash feedback in the LiveView for immediate operator confirmation. [AC-005](#ac-005)
 - If an existing audit log mechanism can be reused without significant coupling, record admin override actions there as well; otherwise rely on detailed Logger entries plus UI flash messages for first delivery.
 - No new telemetry events are required for first delivery.
@@ -186,8 +144,6 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - Restrict access to existing Torus admin-only authorization boundaries. [AC-003](#ac-003)
 - Never evaluate arbitrary code or dynamically create atoms from untrusted strings without safeguards.
   - Module parsing should accept only existing loaded modules and use `String.to_existing_atom/1` on validated `Elixir.*` names.
-  - Registered-name resolution should only allow existing local atom names and should not create new atoms from user input.
-- Process-level targeting must remain local-node only and should not expose process internals beyond minimal target identity needed for debugging. [AC-009](#ac-009)
 
 ## 13. Testing Strategy
 
@@ -196,15 +152,9 @@ Extend the existing admin feature page at `/admin/features` to support two new l
   - Module override does not change global Logger level. [AC-002](#ac-002)
   - Invalid module and invalid level rejection. [AC-004](#ac-004)
   - Module clear path. [AC-006](#ac-006)
-  - Valid process resolution by PID string and registered name. [AC-007](#ac-007)
-  - Invalid and unsupported process target rejection. [AC-008](#ac-008)
 - LiveView tests for `FeaturesLive`:
   - Admin sees the new forms and active override state. [AC-005](#ac-005)
   - Non-admin cannot invoke the control surface. [AC-003](#ac-003)
-  - Process control UI is visually and textually separated from module control. [AC-009](#ac-009)
-- Integration-style tests with a small compatible test GenServer:
-  - Apply and clear process-level override through the service.
-  - Confirm the target process acknowledges mutation and the registry reflects the change.
 - Regression tests:
   - Existing global log-level control continues to function unchanged.
 
@@ -217,10 +167,7 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 
 ## 15. Risks & Mitigations
 
-- Generic process-level control is not possible for arbitrary PIDs through a pure external call path: mitigate by formalizing a supported-process control contract and documenting the boundary clearly.
-- Operators may expect process overrides to survive restart: mitigate with explicit local runtime messaging in the UI.
 - The admin page may become crowded: mitigate by grouping controls into distinct sections with concise explanatory copy.
-- Registry state could drift from actual Logger state after process exit or crash: mitigate by pruning dead process entries on read and on clear attempts.
 
 ## 16. Open Questions & Follow-ups
 
@@ -233,7 +180,6 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex)
 - [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex)
 - [Logger.put_module_level/2 docs](https://hexdocs.pm/logger/Logger.html#put_module_level/2)
-- [Logger.put_process_level/2 docs](https://hexdocs.pm/logger/Logger.html#put_process_level/2)
 
 ### AC Reference Index
 
@@ -243,6 +189,3 @@ Extend the existing admin feature page at `/admin/features` to support two new l
 - `AC-004`: Invalid modules and levels are rejected safely.
 - `AC-005`: Admin UI shows active override state or applied-change confirmation.
 - `AC-006`: Module-level override can be cleared.
-- `AC-007`: Process-level override can be set for an existing local process via PID or registered name.
-- `AC-008`: Invalid or unresolved process targets are rejected safely.
-- `AC-009`: Process-level controls are clearly labeled as local-node and existing-process only.

--- a/docs/exec-plans/current/module-level-log-controls/informal.md
+++ b/docs/exec-plans/current/module-level-log-controls/informal.md
@@ -1,0 +1,15 @@
+# Informal Ticket Description
+
+Torus provides the capability for an admin to set a log level but setting to useful levels like DEBUG and INFO when necessary can overwhelm the entire system and make logs difficult to parse.
+
+We want to add the ability for a torus admin to set the log level at the elixir module level using the already capable Logger library.
+
+Reference:
+- https://hexdocs.pm/logger/Logger.html#put_module_level/2
+
+By using the function `put_module_level(mod, level)` we can set the desired lower log level only for a given module to do issue investigations and debugging in production without overwhelming the system or having to use the iex shell directly to do so.
+
+Nice to have:
+- Also add support for `put_process_level(pid, level)` in case we ever want a particular log level at the process level as well.
+
+This work is necessary to help to continue to debug some of the production LTI issues we have been experiencing, but will also be operationally useful for a bunch of other cases as well.

--- a/docs/exec-plans/current/module-level-log-controls/phase-1-execution-record.md
+++ b/docs/exec-plans/current/module-level-log-controls/phase-1-execution-record.md
@@ -1,0 +1,35 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/module-level-log-controls`
+Phase: `1`
+
+## Scope from plan.md
+- Implement the backend runtime override service and local registry for validated module-level overrides.
+- Add automated coverage for valid set/list/clear flows, invalid module and level rejection, and no global logger-level mutation.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: No Phase 1 correctness, security, or performance findings after targeted review of the new service, registry, and tests.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/module-level-log-controls/phase-2-execution-record.md
+++ b/docs/exec-plans/current/module-level-log-controls/phase-2-execution-record.md
@@ -1,0 +1,35 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/module-level-log-controls`
+Phase: `2`
+
+## Scope from plan.md
+- Add module-level runtime log override controls to `FeaturesLive`.
+- Add LiveView coverage for admin visibility, active-state rendering, clear actions, authorization, and global logging regression behavior.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: No Phase 2 correctness, security, or performance findings after targeted review of the LiveView wiring, safe level parsing, and regression coverage.
+- Round 1 fixes: N/A
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/module-level-log-controls/phase-3-execution-record.md
+++ b/docs/exec-plans/current/module-level-log-controls/phase-3-execution-record.md
@@ -1,0 +1,35 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/module-level-log-controls`
+Phase: `3`
+
+## Scope from plan.md
+- Run the combined targeted verification set.
+- Sync spec artifacts if implementation details diverge and capture proof for the completed module-level slice.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: No new findings beyond the decision to keep the global log-level handler on existing page semantics while tightening atom parsing to `String.to_existing_atom/1`.
+- Round 1 fixes: Tightened global level parsing and completed the module-only spec sync.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/module-level-log-controls/plan.md
+++ b/docs/exec-plans/current/module-level-log-controls/plan.md
@@ -7,9 +7,8 @@ Scope and reference artifacts:
 
 ## Scope
 
-Implement local-node module-level and process-level runtime log controls on the existing
-`/admin/features` page. The delivery includes a backend runtime override service, a supervised local
-override registry, compatible process-level control handling for supported Torus-managed processes,
+Implement local-node module-level runtime log controls on the existing `/admin/features` page. The
+delivery includes a backend runtime override service, a supervised local override registry,
 additive UI changes in `FeaturesLive`, and automated coverage for authorization, validation, state
 display, and clear behavior. The plan explicitly excludes cluster-wide coordination, durable
 persistence, and arbitrary code execution.
@@ -20,7 +19,6 @@ Check off the task checkboxes as tasks are completed, and update the status of e
 
 - The repository-local harness contract files referenced by the planning skill are not present, so this plan follows the approved PRD, FDD, `AGENTS.md`, and the current Torus codebase structure.
 - The first implementation should keep all behavior on the node handling the admin request, matching the current global log-level control.
-- Process-level support is required in the initial delivery, but only for supported local processes that can safely apply `Logger.put_process_level(self(), level)` from within their own execution context.
 - Existing `/admin/features` behavior, especially global log-level changes and scoped feature flag management, must remain intact.
 - If an existing audit-log mechanism can be reused without significant coupling, include that integration in the implementation phase; otherwise, detailed Logger entries plus UI flash feedback are sufficient for first delivery.
 
@@ -49,64 +47,38 @@ Check off the task checkboxes as tasks are completed, and update the status of e
   - Audit-log reuse discovery can be investigated in parallel with the service implementation.
   - Initial `FeaturesLive` template sketching can begin once the service API shape is stable.
 
-## Phase 2: Process-Level Control Contract
+## Phase 2: Admin UI Integration
 
-- Goal: Deliver required process-level override support for compatible existing local processes.
+- Goal: Add module override controls to `FeaturesLive` without regressing current admin functionality.
 - Tasks:
-  - [ ] Finalize the supported process-level control contract and target-resolution rules for PID strings and registered names. [AC-007] [AC-008]
-  - [ ] Implement `set_process_level/2` and `clear_process_level/1` in `Oli.RuntimeLogOverrides`.
-  - [ ] Add compatible message or call handlers to the selected Torus-managed process types needed for first delivery.
-  - [ ] Record process-level override state in the local registry and prune dead process entries on read and clear attempts.
-  - [ ] Return explicit errors for unresolved targets and unsupported process types. [AC-008]
-  - [ ] Add operational Logger entries for successful and failed process override actions.
-- Testing Tasks:
-  - [ ] Add backend tests for PID-string resolution, registered-name resolution, unsupported target rejection, unresolved target rejection, and process-level clear behavior. [AC-007] [AC-008]
-  - [ ] Add an integration-style test with a compatible test GenServer that applies and clears process-level overrides through the service. [AC-007]
-  - Command(s): `mix test test/...runtime_log_overrides*_test.exs test/...features*_test.exs`
-- Definition of Done:
-  - Process-level override set/clear flows succeed for supported local processes.
-  - Unsupported and unresolved process targets fail safely without mutating Logger configuration.
-  - Registry behavior remains consistent when processes exit.
-- Gate:
-  - Automated tests pass for `AC-007` and `AC-008`, and the implementation proves a supported process can self-apply `Logger.put_process_level(self(), level)`.
-- Dependencies:
-  - Phase 1
-- Parallelizable Work:
-  - UI copy and wireframe changes for advanced process controls can proceed while backend target handlers are being added.
-
-## Phase 3: Admin UI Integration
-
-- Goal: Add module and process override controls to `FeaturesLive` without regressing current admin functionality.
-- Tasks:
-  - [ ] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with module-level and process-level form sections.
+  - [ ] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with a module-level override form section.
   - [ ] Add LiveView event handlers that delegate all runtime override mutations to `Oli.RuntimeLogOverrides`.
-  - [ ] Render current local override state, clear actions, and explicit process-level labeling. [AC-005] [AC-009]
+  - [ ] Render current local override state and clear actions. [AC-005]
   - [ ] Preserve the existing global log-level control and scoped feature flag sections.
   - [ ] Add or integrate audit-log recording if an existing mechanism can be reused without significant coupling.
   - [ ] Ensure server-side event handling preserves admin-only access assumptions. [AC-003]
 - Testing Tasks:
-  - [ ] Add LiveView tests for admin visibility, process/module UI separation, active-state rendering, flash confirmations, and clear actions. [AC-005] [AC-009]
+  - [ ] Add LiveView tests for admin visibility, active-state rendering, flash confirmations, and clear actions. [AC-005]
   - [ ] Add authorization tests confirming non-admin users cannot use the new controls. [AC-003]
   - [ ] Add regression coverage for the existing global logging control on the same page.
   - Command(s): `mix test test/oli_web/live/...features*_test.exs`
 - Definition of Done:
-  - `/admin/features` exposes the new controls with clear operator messaging.
+  - `/admin/features` exposes the new module-level controls with clear operator messaging.
   - Existing page behavior remains intact.
-  - UI tests cover module and process workflows plus authorization and regression expectations.
+  - UI tests cover module workflows plus authorization and regression expectations.
 - Gate:
-  - LiveView tests pass for `AC-003`, `AC-005`, and `AC-009`, and manual review confirms the page remains coherent.
+  - LiveView tests pass for `AC-003` and `AC-005`, and manual review confirms the page remains coherent.
 - Dependencies:
   - Phase 1
-  - Phase 2
 - Parallelizable Work:
   - Audit-log integration can remain optional until the page wiring is complete, as long as Logger-based observability is already in place.
 
-## Phase 4: Hardening, Proof, and Documentation Sync
+## Phase 3: Hardening, Proof, and Documentation Sync
 
 - Goal: Close operational gaps, verify the full slice end-to-end, and leave the work item ready for implementation or review handoff.
 - Tasks:
-  - [ ] Run the combined targeted test set for backend service, compatible process targets, and `FeaturesLive`.
-  - [ ] Execute a manual validation pass on a dev node covering module override set/clear, process override set/clear, invalid target handling, and UI messaging.
+  - [ ] Run the combined targeted test set for backend service and `FeaturesLive`.
+  - [ ] Execute a manual validation pass on a dev node covering module override set/clear, invalid target handling, and UI messaging.
   - [ ] Confirm audit-log behavior: either reused existing audit logging with low coupling or documented the Logger-only fallback in implementation notes.
   - [ ] Update spec artifacts if implementation-driven adjustments are required.
   - [ ] Prepare proof references for completed ACs in code and tests.
@@ -116,26 +88,24 @@ Check off the task checkboxes as tasks are completed, and update the status of e
   - Command(s): `mix test`; `mix format`; `mix compile`
 - Definition of Done:
   - All targeted tests pass.
-  - Manual validation confirms node-local module and process controls work as designed.
+  - Manual validation confirms node-local module controls work as designed.
   - Observability and fallback audit behavior are explicit.
   - The implementation slice is ready for coding handoff or direct development.
 - Gate:
   - Full targeted verification passes and the implementation is ready to enter development without unresolved scope ambiguity.
 - Dependencies:
-  - Phase 3
+  - Phase 2
 - Parallelizable Work:
   - Spec reconciliation and implementation-proof collection can proceed alongside manual validation after code is stable.
 
 ## Parallelization Notes
 
 - Phase 1 backend service work can overlap with limited UI scaffolding, but UI event wiring should wait until the service interfaces stabilize.
-- Phase 2 process-control handler work can proceed in parallel across distinct compatible process modules once the shared control contract is fixed.
-- Phase 3 UI integration and any low-coupling audit-log reuse can proceed in parallel after backend APIs are available.
-- Phase 4 is mostly serial because it depends on the integrated slice being complete, though proof collection and doc updates can run alongside manual validation.
+- Phase 2 UI integration and any low-coupling audit-log reuse can proceed in parallel after backend APIs are available.
+- Phase 3 is mostly serial because it depends on the integrated slice being complete, though proof collection and doc updates can run alongside manual validation.
 
 ## Phase Gate Summary
 
 - Gate A: Module-level backend service and tests prove `AC-001`, `AC-002`, `AC-004`, and `AC-006`.
-- Gate B: Process-level control contract and tests prove `AC-007` and `AC-008`.
-- Gate C: `/admin/features` integration and authorization tests prove `AC-003`, `AC-005`, and `AC-009`.
-- Gate D: Consolidated verification, manual validation, and observability checks complete the slice for development handoff.
+- Gate B: `/admin/features` integration and authorization tests prove `AC-003` and `AC-005`.
+- Gate C: Consolidated verification, manual validation, and observability checks complete the slice for development handoff.

--- a/docs/exec-plans/current/module-level-log-controls/plan.md
+++ b/docs/exec-plans/current/module-level-log-controls/plan.md
@@ -1,0 +1,129 @@
+# Module-Level Log Controls - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/module-level-log-controls/prd.md`
+- FDD: `docs/exec-plans/current/module-level-log-controls/fdd.md`
+
+## Scope
+
+Implement local-node module-level and process-level runtime log controls on the existing `/admin/features` page. The delivery includes a backend runtime override service, a supervised local override registry, compatible process-level control handling for supported Torus-managed processes, additive UI changes in `FeaturesLive`, and automated coverage for authorization, validation, state display, and clear behavior. The plan explicitly excludes cluster-wide coordination, durable persistence, and arbitrary code execution.
+
+## Clarifications & Default Assumptions
+
+- The repository-local harness contract files referenced by the planning skill are not present, so this plan follows the approved PRD, FDD, `AGENTS.md`, and the current Torus codebase structure.
+- The first implementation should keep all behavior on the node handling the admin request, matching the current global log-level control.
+- Process-level support is required in the initial delivery, but only for supported local processes that can safely apply `Logger.put_process_level(self(), level)` from within their own execution context.
+- Existing `/admin/features` behavior, especially global log-level changes and scoped feature flag management, must remain intact.
+- If an existing audit-log mechanism can be reused without significant coupling, include that integration in the implementation phase; otherwise, detailed Logger entries plus UI flash feedback are sufficient for first delivery.
+
+## Phase 1: Runtime Override Service
+- Goal: Implement the backend service and local registry for validated module-level overrides and shared override state.
+- Tasks:
+  - [ ] Add a new runtime override service module, proposed as `Oli.RuntimeLogOverrides`, under `lib/oli/`.
+  - [ ] Implement level validation, module-name parsing, and safe existing-module resolution for module-level overrides. [AC-001] [AC-004]
+  - [ ] Implement `set_module_level/2`, `clear_module_level/1`, and `list_overrides/0` APIs. [AC-001] [AC-005] [AC-006]
+  - [ ] Add a supervised local registry process for active overrides and wire it into [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
+  - [ ] Ensure global Logger level remains unchanged when a module override is applied. [AC-002]
+  - [ ] Add operational Logger entries for successful and failed module override actions.
+- Testing Tasks:
+  - [ ] Add backend unit tests covering valid module override set, invalid module rejection, invalid level rejection, clear behavior, and no global-level mutation. [AC-001] [AC-002] [AC-004] [AC-006]
+  - Command(s): `mix test test/...runtime_log_overrides*_test.exs`
+- Definition of Done:
+  - Backend service exists, starts under supervision, and supports module override set/list/clear flows.
+  - Module-level requirements are covered by automated tests with passing results.
+  - No regression is introduced to the current global log-level path.
+- Gate:
+  - Module-level backend tests pass and demonstrate `AC-001`, `AC-002`, `AC-004`, and `AC-006`.
+- Dependencies:
+  - None
+- Parallelizable Work:
+  - Audit-log reuse discovery can be investigated in parallel with the service implementation.
+  - Initial `FeaturesLive` template sketching can begin once the service API shape is stable.
+
+## Phase 2: Process-Level Control Contract
+- Goal: Deliver required process-level override support for compatible existing local processes.
+- Tasks:
+  - [ ] Finalize the supported process-level control contract and target-resolution rules for PID strings and registered names. [AC-007] [AC-008]
+  - [ ] Implement `set_process_level/2` and `clear_process_level/1` in `Oli.RuntimeLogOverrides`.
+  - [ ] Add compatible message or call handlers to the selected Torus-managed process types needed for first delivery.
+  - [ ] Record process-level override state in the local registry and prune dead process entries on read and clear attempts.
+  - [ ] Return explicit errors for unresolved targets and unsupported process types. [AC-008]
+  - [ ] Add operational Logger entries for successful and failed process override actions.
+- Testing Tasks:
+  - [ ] Add backend tests for PID-string resolution, registered-name resolution, unsupported target rejection, unresolved target rejection, and process-level clear behavior. [AC-007] [AC-008]
+  - [ ] Add an integration-style test with a compatible test GenServer that applies and clears process-level overrides through the service. [AC-007]
+  - Command(s): `mix test test/...runtime_log_overrides*_test.exs test/...features*_test.exs`
+- Definition of Done:
+  - Process-level override set/clear flows succeed for supported local processes.
+  - Unsupported and unresolved process targets fail safely without mutating Logger configuration.
+  - Registry behavior remains consistent when processes exit.
+- Gate:
+  - Automated tests pass for `AC-007` and `AC-008`, and the implementation proves a supported process can self-apply `Logger.put_process_level(self(), level)`.
+- Dependencies:
+  - Phase 1
+- Parallelizable Work:
+  - UI copy and wireframe changes for advanced process controls can proceed while backend target handlers are being added.
+
+## Phase 3: Admin UI Integration
+- Goal: Add module and process override controls to `FeaturesLive` without regressing current admin functionality.
+- Tasks:
+  - [ ] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with module-level and process-level form sections.
+  - [ ] Add LiveView event handlers that delegate all runtime override mutations to `Oli.RuntimeLogOverrides`.
+  - [ ] Render current local override state, clear actions, and explicit process-level labeling. [AC-005] [AC-009]
+  - [ ] Preserve the existing global log-level control and scoped feature flag sections.
+  - [ ] Add or integrate audit-log recording if an existing mechanism can be reused without significant coupling.
+  - [ ] Ensure server-side event handling preserves admin-only access assumptions. [AC-003]
+- Testing Tasks:
+  - [ ] Add LiveView tests for admin visibility, process/module UI separation, active-state rendering, flash confirmations, and clear actions. [AC-005] [AC-009]
+  - [ ] Add authorization tests confirming non-admin users cannot use the new controls. [AC-003]
+  - [ ] Add regression coverage for the existing global logging control on the same page.
+  - Command(s): `mix test test/oli_web/live/...features*_test.exs`
+- Definition of Done:
+  - `/admin/features` exposes the new controls with clear operator messaging.
+  - Existing page behavior remains intact.
+  - UI tests cover module and process workflows plus authorization and regression expectations.
+- Gate:
+  - LiveView tests pass for `AC-003`, `AC-005`, and `AC-009`, and manual review confirms the page remains coherent.
+- Dependencies:
+  - Phase 1
+  - Phase 2
+- Parallelizable Work:
+  - Audit-log integration can remain optional until the page wiring is complete, as long as Logger-based observability is already in place.
+
+## Phase 4: Hardening, Proof, and Documentation Sync
+- Goal: Close operational gaps, verify the full slice end-to-end, and leave the work item ready for implementation or review handoff.
+- Tasks:
+  - [ ] Run the combined targeted test set for backend service, compatible process targets, and `FeaturesLive`.
+  - [ ] Execute a manual validation pass on a dev node covering module override set/clear, process override set/clear, invalid target handling, and UI messaging.
+  - [ ] Confirm audit-log behavior: either reused existing audit logging with low coupling or documented the Logger-only fallback in implementation notes.
+  - [ ] Update spec artifacts if implementation-driven adjustments are required.
+  - [ ] Prepare proof references for completed ACs in code and tests.
+- Testing Tasks:
+  - [ ] Run the consolidated test commands and capture proof for all ACs.
+  - [ ] Run formatter and any relevant compile checks before handoff.
+  - Command(s): `mix test`; `mix format`; `mix compile`
+- Definition of Done:
+  - All targeted tests pass.
+  - Manual validation confirms node-local module and process controls work as designed.
+  - Observability and fallback audit behavior are explicit.
+  - The implementation slice is ready for coding handoff or direct development.
+- Gate:
+  - Full targeted verification passes and the implementation is ready to enter development without unresolved scope ambiguity.
+- Dependencies:
+  - Phase 3
+- Parallelizable Work:
+  - Spec reconciliation and implementation-proof collection can proceed alongside manual validation after code is stable.
+
+## Parallelization Notes
+
+- Phase 1 backend service work can overlap with limited UI scaffolding, but UI event wiring should wait until the service interfaces stabilize.
+- Phase 2 process-control handler work can proceed in parallel across distinct compatible process modules once the shared control contract is fixed.
+- Phase 3 UI integration and any low-coupling audit-log reuse can proceed in parallel after backend APIs are available.
+- Phase 4 is mostly serial because it depends on the integrated slice being complete, though proof collection and doc updates can run alongside manual validation.
+
+## Phase Gate Summary
+
+- Gate A: Module-level backend service and tests prove `AC-001`, `AC-002`, `AC-004`, and `AC-006`.
+- Gate B: Process-level control contract and tests prove `AC-007` and `AC-008`.
+- Gate C: `/admin/features` integration and authorization tests prove `AC-003`, `AC-005`, and `AC-009`.
+- Gate D: Consolidated verification, manual validation, and observability checks complete the slice for development handoff.

--- a/docs/exec-plans/current/module-level-log-controls/plan.md
+++ b/docs/exec-plans/current/module-level-log-controls/plan.md
@@ -1,12 +1,20 @@
 # Module-Level Log Controls - Delivery Plan
 
 Scope and reference artifacts:
+
 - PRD: `docs/exec-plans/current/module-level-log-controls/prd.md`
 - FDD: `docs/exec-plans/current/module-level-log-controls/fdd.md`
 
 ## Scope
 
-Implement local-node module-level and process-level runtime log controls on the existing `/admin/features` page. The delivery includes a backend runtime override service, a supervised local override registry, compatible process-level control handling for supported Torus-managed processes, additive UI changes in `FeaturesLive`, and automated coverage for authorization, validation, state display, and clear behavior. The plan explicitly excludes cluster-wide coordination, durable persistence, and arbitrary code execution.
+Implement local-node module-level and process-level runtime log controls on the existing
+`/admin/features` page. The delivery includes a backend runtime override service, a supervised local
+override registry, compatible process-level control handling for supported Torus-managed processes,
+additive UI changes in `FeaturesLive`, and automated coverage for authorization, validation, state
+display, and clear behavior. The plan explicitly excludes cluster-wide coordination, durable
+persistence, and arbitrary code execution.
+
+Check off the task checkboxes as tasks are completed, and update the status of each phase gate as you progress through the implementation.
 
 ## Clarifications & Default Assumptions
 
@@ -17,16 +25,17 @@ Implement local-node module-level and process-level runtime log controls on the 
 - If an existing audit-log mechanism can be reused without significant coupling, include that integration in the implementation phase; otherwise, detailed Logger entries plus UI flash feedback are sufficient for first delivery.
 
 ## Phase 1: Runtime Override Service
+
 - Goal: Implement the backend service and local registry for validated module-level overrides and shared override state.
 - Tasks:
-  - [ ] Add a new runtime override service module, proposed as `Oli.RuntimeLogOverrides`, under `lib/oli/`.
-  - [ ] Implement level validation, module-name parsing, and safe existing-module resolution for module-level overrides. [AC-001] [AC-004]
-  - [ ] Implement `set_module_level/2`, `clear_module_level/1`, and `list_overrides/0` APIs. [AC-001] [AC-005] [AC-006]
-  - [ ] Add a supervised local registry process for active overrides and wire it into [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
-  - [ ] Ensure global Logger level remains unchanged when a module override is applied. [AC-002]
-  - [ ] Add operational Logger entries for successful and failed module override actions.
+  - [x] Add a new runtime override service module, proposed as `Oli.RuntimeLogOverrides`, under `lib/oli/`.
+  - [x] Implement level validation, module-name parsing, and safe existing-module resolution for module-level overrides. [AC-001] [AC-004]
+  - [x] Implement `set_module_level/2`, `clear_module_level/1`, and `list_overrides/0` APIs. [AC-001] [AC-005] [AC-006]
+  - [x] Add a supervised local registry process for active overrides and wire it into [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
+  - [x] Ensure global Logger level remains unchanged when a module override is applied. [AC-002]
+  - [x] Add operational Logger entries for successful and failed module override actions.
 - Testing Tasks:
-  - [ ] Add backend unit tests covering valid module override set, invalid module rejection, invalid level rejection, clear behavior, and no global-level mutation. [AC-001] [AC-002] [AC-004] [AC-006]
+  - [x] Add backend unit tests covering valid module override set, invalid module rejection, invalid level rejection, clear behavior, and no global-level mutation. [AC-001] [AC-002] [AC-004] [AC-006]
   - Command(s): `mix test test/...runtime_log_overrides*_test.exs`
 - Definition of Done:
   - Backend service exists, starts under supervision, and supports module override set/list/clear flows.
@@ -41,6 +50,7 @@ Implement local-node module-level and process-level runtime log controls on the 
   - Initial `FeaturesLive` template sketching can begin once the service API shape is stable.
 
 ## Phase 2: Process-Level Control Contract
+
 - Goal: Deliver required process-level override support for compatible existing local processes.
 - Tasks:
   - [ ] Finalize the supported process-level control contract and target-resolution rules for PID strings and registered names. [AC-007] [AC-008]
@@ -65,6 +75,7 @@ Implement local-node module-level and process-level runtime log controls on the 
   - UI copy and wireframe changes for advanced process controls can proceed while backend target handlers are being added.
 
 ## Phase 3: Admin UI Integration
+
 - Goal: Add module and process override controls to `FeaturesLive` without regressing current admin functionality.
 - Tasks:
   - [ ] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with module-level and process-level form sections.
@@ -91,6 +102,7 @@ Implement local-node module-level and process-level runtime log controls on the 
   - Audit-log integration can remain optional until the page wiring is complete, as long as Logger-based observability is already in place.
 
 ## Phase 4: Hardening, Proof, and Documentation Sync
+
 - Goal: Close operational gaps, verify the full slice end-to-end, and leave the work item ready for implementation or review handoff.
 - Tasks:
   - [ ] Run the combined targeted test set for backend service, compatible process targets, and `FeaturesLive`.

--- a/docs/exec-plans/current/module-level-log-controls/plan.md
+++ b/docs/exec-plans/current/module-level-log-controls/plan.md
@@ -51,16 +51,16 @@ Check off the task checkboxes as tasks are completed, and update the status of e
 
 - Goal: Add module override controls to `FeaturesLive` without regressing current admin functionality.
 - Tasks:
-  - [ ] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with a module-level override form section.
-  - [ ] Add LiveView event handlers that delegate all runtime override mutations to `Oli.RuntimeLogOverrides`.
-  - [ ] Render current local override state and clear actions. [AC-005]
-  - [ ] Preserve the existing global log-level control and scoped feature flag sections.
-  - [ ] Add or integrate audit-log recording if an existing mechanism can be reused without significant coupling.
-  - [ ] Ensure server-side event handling preserves admin-only access assumptions. [AC-003]
+  - [x] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with a module-level override form section.
+  - [x] Add LiveView event handlers that delegate all runtime override mutations to `Oli.RuntimeLogOverrides`.
+  - [x] Render current local override state and clear actions. [AC-005]
+  - [x] Preserve the existing global log-level control and scoped feature flag sections.
+  - [x] Add or integrate audit-log recording if an existing mechanism can be reused without significant coupling.
+  - [x] Ensure server-side event handling preserves admin-only access assumptions. [AC-003]
 - Testing Tasks:
-  - [ ] Add LiveView tests for admin visibility, active-state rendering, flash confirmations, and clear actions. [AC-005]
-  - [ ] Add authorization tests confirming non-admin users cannot use the new controls. [AC-003]
-  - [ ] Add regression coverage for the existing global logging control on the same page.
+  - [x] Add LiveView tests for admin visibility, active-state rendering, flash confirmations, and clear actions. [AC-005]
+  - [x] Add authorization tests confirming non-admin users cannot use the new controls. [AC-003]
+  - [x] Add regression coverage for the existing global logging control on the same page.
   - Command(s): `mix test test/oli_web/live/...features*_test.exs`
 - Definition of Done:
   - `/admin/features` exposes the new module-level controls with clear operator messaging.
@@ -77,14 +77,14 @@ Check off the task checkboxes as tasks are completed, and update the status of e
 
 - Goal: Close operational gaps, verify the full slice end-to-end, and leave the work item ready for implementation or review handoff.
 - Tasks:
-  - [ ] Run the combined targeted test set for backend service and `FeaturesLive`.
-  - [ ] Execute a manual validation pass on a dev node covering module override set/clear, invalid target handling, and UI messaging.
-  - [ ] Confirm audit-log behavior: either reused existing audit logging with low coupling or documented the Logger-only fallback in implementation notes.
-  - [ ] Update spec artifacts if implementation-driven adjustments are required.
-  - [ ] Prepare proof references for completed ACs in code and tests.
+  - [x] Run the combined targeted test set for backend service and `FeaturesLive`.
+  - [x] Execute a manual validation pass on a dev node covering module override set/clear, invalid target handling, and UI messaging.
+  - [x] Confirm audit-log behavior: either reused existing audit logging with low coupling or documented the Logger-only fallback in implementation notes.
+  - [x] Update spec artifacts if implementation-driven adjustments are required.
+  - [x] Prepare proof references for completed ACs in code and tests.
 - Testing Tasks:
-  - [ ] Run the consolidated test commands and capture proof for all ACs.
-  - [ ] Run formatter and any relevant compile checks before handoff.
+  - [x] Run the consolidated test commands and capture proof for all ACs.
+  - [x] Run formatter and any relevant compile checks before handoff.
   - Command(s): `mix test`; `mix format`; `mix compile`
 - Definition of Done:
   - All targeted tests pass.

--- a/docs/exec-plans/current/module-level-log-controls/prd.md
+++ b/docs/exec-plans/current/module-level-log-controls/prd.md
@@ -1,0 +1,128 @@
+# Module-Level Log Controls - Product Requirements Document
+
+## 1. Overview
+
+This work item adds an operational capability for Torus administrators to temporarily lower the effective log level for a specific Elixir module, without lowering the global application log level. The primary value is targeted production debugging for incidents such as LTI failures, where DEBUG or INFO logs are useful for a narrow code path but harmful when enabled system-wide. The initial scope also includes a basic process-level control for existing local processes identified by PID or registered name.
+
+## 2. Background & Problem Statement
+
+Torus already allows an administrator to change logging behavior, but current controls operate broadly enough that enabling DEBUG or INFO can flood application logs, obscure the signal needed for investigation, and increase operational risk during incidents. Engineering currently has to rely on direct shell access and manual Logger calls to narrow logging in production. That workflow is slow, operationally awkward, and not appropriate for routine support investigations. Torus needs an admin-facing way to invoke Elixir Logger module-level overrides so investigations can be performed quickly and with controlled blast radius.
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- Allow an authorized Torus administrator to set a lower Logger level for a specific Elixir module.
+- Keep the change targeted so system-wide logging behavior remains unchanged for all other modules.
+- Support operational debugging workflows in production, especially around intermittent LTI issues.
+- Provide a safe administrative experience with clear inputs, validation, and visibility into the active override.
+- Support a basic process-level control for existing local processes when module-level targeting is too broad.
+
+### Non-Goals
+
+- Replacing Torus's existing global log-level controls.
+- Building a full log viewer, log search UI, or incident management workflow.
+- Allowing arbitrary users or section-level roles to change runtime Logger configuration.
+- Guaranteeing permanent persistence of Logger overrides across deploys, restarts, or node replacement.
+- Designing cluster-wide coordination of log overrides in the initial delivery.
+
+## 4. Users & Use Cases
+
+- Torus platform administrator: temporarily enable DEBUG or INFO logging for a single module while investigating a production incident.
+- Torus support or operations engineer acting through admin permissions: adjust module-level logging during a live issue without opening an IEx shell on the host.
+- Engineering team: target an existing local runtime process by PID or registered name when module-level targeting is insufficient.
+
+## 5. UX / UI Requirements
+
+- The capability must be exposed through an admin-only operational surface that is consistent with existing Torus administration patterns.
+- The admin must be able to specify the target module and desired level from constrained, validated inputs rather than free-form runtime code execution.
+- The interface must show whether an override is being applied, updated, cleared, or rejected.
+- The interface must make the scope clear: module-level override only, not a global log-level change.
+- Process-level support must be visually separated and clearly labeled as more advanced and more transient than module-level control.
+- The control should live on the existing `OliWeb.Features.FeaturesLive` admin page.
+
+## 6. Functional Requirements
+
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+
+- Security: only appropriately authorized Torus administrators may create, modify, or clear runtime log-level overrides.
+- Reliability: invalid module names, invalid log levels, and unsupported targets must fail safely without changing existing Logger configuration.
+- Operational safety: the feature must minimize blast radius by targeting a single module or a single existing local process and by allowing overrides to be cleared.
+- Performance: the feature must not introduce broad log amplification beyond the explicitly targeted module or process.
+- Auditability: operator actions should be visible through existing operational logging or admin feedback so the team can understand who changed logging and when.
+
+## 9. Data, Interfaces & Dependencies
+
+- Primary runtime dependency: Elixir `Logger.put_module_level/2`.
+- Secondary runtime dependency: Elixir `Logger.put_process_level/2` for process-level targeting.
+- The admin flow needs a way to accept a module identifier and a log level, resolve or validate the module, and invoke Logger with a supported level.
+- The process-level flow needs a way to accept a PID or registered name, resolve it to an existing local process, and invoke Logger through a supported runtime mechanism.
+- The implementation depends on an existing admin authorization boundary in the Torus Phoenix application.
+- Overrides apply only on the local node, mirroring current global log-level admin behavior.
+- Overrides remain active until cleared or until the node restarts.
+
+## 10. Repository & Platform Considerations
+
+- Torus is a Phoenix application with administrative workflows in `lib/oli_web/` and runtime behavior in Elixir backend contexts under `lib/oli/`.
+- Runtime logging changes affect production operations, so the implementation should favor explicit validation and small operational scope.
+- Tests should cover authorization, validation, success paths, and clearing behavior using ExUnit and relevant Phoenix web tests.
+- The code should preserve the repo's Elixir conventions, including clear control flow and minimal nesting.
+- The work should not require direct shell access for normal use after delivery.
+- The correct home for this control is the existing [lib/oli_web/live/features/features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) admin page.
+
+## 11. Feature Flagging, Rollout & Migration
+
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+
+- Success is measured operationally by reduced need for ad hoc shell-based Logger changes during incident investigation.
+- A useful indicator is whether admins can isolate module-specific logging for LTI incidents without materially increasing unrelated log volume.
+- If practical within existing logging patterns, operator actions to set or clear overrides should emit an audit-friendly log or event.
+
+## 13. Risks & Mitigations
+
+- Incorrect module targeting could make an investigation ineffective: mitigate with validation and clear feedback on the exact module being targeted.
+- Misuse by unauthorized or insufficiently trained users could affect production diagnostics: mitigate with strict admin-only access and explicit UI wording.
+- Runtime overrides may behave differently across clustered nodes or after restart: mitigate by documenting runtime scope and designing for explicit operator expectations.
+- Process-level controls could increase implementation complexity and confusion: mitigate by limiting the initial process-level feature to existing local PIDs or registered names and by using explicit operator messaging.
+
+## 14. Open Questions & Assumptions
+
+### Open Questions
+
+- N/A
+
+### Assumptions
+
+- Torus already has an authenticated admin-only interface capable of hosting this operational control.
+- The control will live on the existing `OliWeb.Features.FeaturesLive` admin page.
+- Operators can identify the relevant Elixir module names for the issue they are debugging.
+- Operators using process-level controls can identify a target existing local PID or registered process name.
+- Runtime-local behavior is the intended initial scope, matching the current global log-level admin behavior.
+- Overrides remain active until explicitly cleared or until the node restarts.
+
+## 15. QA Plan
+
+- Automated validation:
+  - Backend tests for authorization, valid module-level override application, invalid module rejection, invalid level rejection, and clearing overrides.
+  - Backend tests for valid process resolution by PID or registered name, invalid process target rejection, and process-level clear behavior if process-level support ships in the first delivery.
+  - Web or LiveView tests for the admin interaction surface that invokes the runtime change.
+  - Regression coverage for the existing global log-level functionality so this work does not broaden current behavior.
+- Manual validation:
+  - As an admin, set a module override and confirm lower-level logs appear only for the targeted module.
+  - Clear the override and confirm normal logging behavior resumes.
+  - Verify non-admin users cannot access or use the control.
+  - If process-level support ships, verify the UI labels and behavior distinguish it from module-level control and make clear that the target process must already exist on the local node.
+
+## 16. Definition of Done
+
+- [x] PRD sections complete
+- [x] requirements.yml captured and valid
+- [x] validation passes

--- a/docs/exec-plans/current/module-level-log-controls/prd.md
+++ b/docs/exec-plans/current/module-level-log-controls/prd.md
@@ -2,7 +2,7 @@
 
 ## 1. Overview
 
-This work item adds an operational capability for Torus administrators to temporarily lower the effective log level for a specific Elixir module, without lowering the global application log level. The primary value is targeted production debugging for incidents such as LTI failures, where DEBUG or INFO logs are useful for a narrow code path but harmful when enabled system-wide. The initial scope also includes a basic process-level control for existing local processes identified by PID or registered name.
+This work item adds an operational capability for Torus administrators to temporarily lower the effective log level for a specific Elixir module, without lowering the global application log level. The primary value is targeted production debugging for incidents such as LTI failures, where DEBUG or INFO logs are useful for a narrow code path but harmful when enabled system-wide.
 
 ## 2. Background & Problem Statement
 
@@ -16,7 +16,6 @@ Torus already allows an administrator to change logging behavior, but current co
 - Keep the change targeted so system-wide logging behavior remains unchanged for all other modules.
 - Support operational debugging workflows in production, especially around intermittent LTI issues.
 - Provide a safe administrative experience with clear inputs, validation, and visibility into the active override.
-- Support a basic process-level control for existing local processes when module-level targeting is too broad.
 
 ### Non-Goals
 
@@ -30,7 +29,6 @@ Torus already allows an administrator to change logging behavior, but current co
 
 - Torus platform administrator: temporarily enable DEBUG or INFO logging for a single module while investigating a production incident.
 - Torus support or operations engineer acting through admin permissions: adjust module-level logging during a live issue without opening an IEx shell on the host.
-- Engineering team: target an existing local runtime process by PID or registered name when module-level targeting is insufficient.
 
 ## 5. UX / UI Requirements
 
@@ -38,7 +36,6 @@ Torus already allows an administrator to change logging behavior, but current co
 - The admin must be able to specify the target module and desired level from constrained, validated inputs rather than free-form runtime code execution.
 - The interface must show whether an override is being applied, updated, cleared, or rejected.
 - The interface must make the scope clear: module-level override only, not a global log-level change.
-- Process-level support must be visually separated and clearly labeled as more advanced and more transient than module-level control.
 - The control should live on the existing `OliWeb.Features.FeaturesLive` admin page.
 
 ## 6. Functional Requirements
@@ -53,16 +50,14 @@ Requirements are found in requirements.yml
 
 - Security: only appropriately authorized Torus administrators may create, modify, or clear runtime log-level overrides.
 - Reliability: invalid module names, invalid log levels, and unsupported targets must fail safely without changing existing Logger configuration.
-- Operational safety: the feature must minimize blast radius by targeting a single module or a single existing local process and by allowing overrides to be cleared.
+- Operational safety: the feature must minimize blast radius by targeting a single module and by allowing overrides to be cleared.
 - Performance: the feature must not introduce broad log amplification beyond the explicitly targeted module or process.
 - Auditability: operator actions should be visible through existing operational logging or admin feedback so the team can understand who changed logging and when.
 
 ## 9. Data, Interfaces & Dependencies
 
 - Primary runtime dependency: Elixir `Logger.put_module_level/2`.
-- Secondary runtime dependency: Elixir `Logger.put_process_level/2` for process-level targeting.
 - The admin flow needs a way to accept a module identifier and a log level, resolve or validate the module, and invoke Logger with a supported level.
-- The process-level flow needs a way to accept a PID or registered name, resolve it to an existing local process, and invoke Logger through a supported runtime mechanism.
 - The implementation depends on an existing admin authorization boundary in the Torus Phoenix application.
 - Overrides apply only on the local node, mirroring current global log-level admin behavior.
 - Overrides remain active until cleared or until the node restarts.
@@ -91,7 +86,7 @@ No feature flags present in this work item
 - Incorrect module targeting could make an investigation ineffective: mitigate with validation and clear feedback on the exact module being targeted.
 - Misuse by unauthorized or insufficiently trained users could affect production diagnostics: mitigate with strict admin-only access and explicit UI wording.
 - Runtime overrides may behave differently across clustered nodes or after restart: mitigate by documenting runtime scope and designing for explicit operator expectations.
-- Process-level controls could increase implementation complexity and confusion: mitigate by limiting the initial process-level feature to existing local PIDs or registered names and by using explicit operator messaging.
+- Narrow targeting depends on operators knowing the relevant Elixir module names: mitigate with validation and clear feedback on the exact module being targeted.
 
 ## 14. Open Questions & Assumptions
 
@@ -104,7 +99,6 @@ No feature flags present in this work item
 - Torus already has an authenticated admin-only interface capable of hosting this operational control.
 - The control will live on the existing `OliWeb.Features.FeaturesLive` admin page.
 - Operators can identify the relevant Elixir module names for the issue they are debugging.
-- Operators using process-level controls can identify a target existing local PID or registered process name.
 - Runtime-local behavior is the intended initial scope, matching the current global log-level admin behavior.
 - Overrides remain active until explicitly cleared or until the node restarts.
 
@@ -112,14 +106,12 @@ No feature flags present in this work item
 
 - Automated validation:
   - Backend tests for authorization, valid module-level override application, invalid module rejection, invalid level rejection, and clearing overrides.
-  - Backend tests for valid process resolution by PID or registered name, invalid process target rejection, and process-level clear behavior if process-level support ships in the first delivery.
   - Web or LiveView tests for the admin interaction surface that invokes the runtime change.
   - Regression coverage for the existing global log-level functionality so this work does not broaden current behavior.
 - Manual validation:
   - As an admin, set a module override and confirm lower-level logs appear only for the targeted module.
   - Clear the override and confirm normal logging behavior resumes.
   - Verify non-admin users cannot access or use the control.
-  - If process-level support ships, verify the UI labels and behavior distinguish it from module-level control and make clear that the target process must already exist on the local node.
 
 ## 16. Definition of Done
 

--- a/docs/exec-plans/current/module-level-log-controls/requirements.yml
+++ b/docs/exec-plans/current/module-level-log-controls/requirements.yml
@@ -1,0 +1,130 @@
+version: 1
+feature: Module-Level Log Controls
+generated_from: informal.md
+work_item: module-level-log-controls
+requirements:
+- title: Admin can configure module-level runtime log overrides
+  status: proposed
+  acceptance_criteria:
+  - id: AC-001
+    title: An authorized Torus admin can set a supported Logger level for a specified
+      Elixir module through an admin workflow.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-002
+    title: The override affects only the targeted module and does not change the global
+      application log level.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  id: FR-001
+- title: Invalid or unauthorized actions fail safely
+  status: proposed
+  acceptance_criteria:
+  - id: AC-003
+    title: Non-admin users cannot create, update, or clear module-level log overrides.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-004
+    title: Invalid module identifiers and unsupported log levels are rejected without
+      mutating Logger configuration.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  id: FR-002
+- title: Admin can inspect and clear active overrides
+  status: proposed
+  acceptance_criteria:
+  - id: AC-005
+    title: The admin workflow shows the active module override state or a confirmation
+      of the applied change.
+    status: proposed
+    verification_method: hybrid
+    proofs: []
+  - id: AC-006
+    title: An authorized admin can clear a previously applied module-level override
+      from the same admin workflow.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  id: FR-003
+- title: Admin can configure basic process-level runtime log overrides
+  status: proposed
+  acceptance_criteria:
+  - id: AC-007
+    title: An authorized Torus admin can set a supported Logger level for an existing
+      local process identified by PID or registered name through a separate advanced
+      control.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-008
+    title: Invalid or unresolved process targets are rejected without mutating Logger
+      configuration.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-009
+    title: Process-level controls are clearly labeled as local-node and existing-process
+      only.
+    status: proposed
+    verification_method: hybrid
+    proofs: []
+  id: FR-004
+acceptance_criteria:
+- id: AC-001
+  title: An authorized Torus admin can set a supported Logger level for a specified
+    Elixir module through an admin workflow.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-002
+  title: The override affects only the targeted module and does not change the global
+    application log level.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-003
+  title: Non-admin users cannot create, update, or clear module-level log overrides.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-004
+  title: Invalid module identifiers and unsupported log levels are rejected without
+    mutating Logger configuration.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-005
+  title: The admin workflow shows the active module override state or a confirmation
+    of the applied change.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-006
+  title: An authorized admin can clear a previously applied module-level override
+    from the same admin workflow.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-007
+  title: An authorized Torus admin can set a supported Logger level for an existing
+    local process identified by PID or registered name through a separate advanced
+    control.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-008
+  title: Invalid or unresolved process targets are rejected without mutating Logger
+    configuration.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-009
+  title: Process-level controls are clearly labeled as local-node and existing-process
+    only.
+  status: proposed
+  verification_method: hybrid
+  proofs: []

--- a/docs/exec-plans/current/module-level-log-controls/requirements.yml
+++ b/docs/exec-plans/current/module-level-log-controls/requirements.yml
@@ -50,29 +50,6 @@ requirements:
     verification_method: automated
     proofs: []
   id: FR-003
-- title: Admin can configure basic process-level runtime log overrides
-  status: proposed
-  acceptance_criteria:
-  - id: AC-007
-    title: An authorized Torus admin can set a supported Logger level for an existing
-      local process identified by PID or registered name through a separate advanced
-      control.
-    status: proposed
-    verification_method: automated
-    proofs: []
-  - id: AC-008
-    title: Invalid or unresolved process targets are rejected without mutating Logger
-      configuration.
-    status: proposed
-    verification_method: automated
-    proofs: []
-  - id: AC-009
-    title: Process-level controls are clearly labeled as local-node and existing-process
-      only.
-    status: proposed
-    verification_method: hybrid
-    proofs: []
-  id: FR-004
 acceptance_criteria:
 - id: AC-001
   title: An authorized Torus admin can set a supported Logger level for a specified
@@ -108,23 +85,4 @@ acceptance_criteria:
     from the same admin workflow.
   status: proposed
   verification_method: automated
-  proofs: []
-- id: AC-007
-  title: An authorized Torus admin can set a supported Logger level for an existing
-    local process identified by PID or registered name through a separate advanced
-    control.
-  status: proposed
-  verification_method: automated
-  proofs: []
-- id: AC-008
-  title: Invalid or unresolved process targets are rejected without mutating Logger
-    configuration.
-  status: proposed
-  verification_method: automated
-  proofs: []
-- id: AC-009
-  title: Process-level controls are clearly labeled as local-node and existing-process
-    only.
-  status: proposed
-  verification_method: hybrid
   proofs: []

--- a/docs/exec-plans/current/module-level-log-controls/requirements_bulk.yml
+++ b/docs/exec-plans/current/module-level-log-controls/requirements_bulk.yml
@@ -38,14 +38,6 @@ requirements:
         status: proposed
         verification_method: automated
         proofs: []
-  - title: Process-level targeting remains optional and explicitly bounded
-    status: proposed
-    acceptance_criteria:
-      - id: AC-007
-        title: If process-level log overrides are implemented, they are exposed as a separate advanced control with distinct validation and clear operator messaging.
-        status: proposed
-        verification_method: hybrid
-        proofs: []
 acceptance_criteria:
   - id: AC-001
     title: An authorized Torus admin can set a supported Logger level for a specified Elixir module through an admin workflow.
@@ -76,9 +68,4 @@ acceptance_criteria:
     title: An authorized admin can clear a previously applied module-level override from the same admin workflow.
     status: proposed
     verification_method: automated
-    proofs: []
-  - id: AC-007
-    title: If process-level log overrides are implemented, they are exposed as a separate advanced control with distinct validation and clear operator messaging.
-    status: proposed
-    verification_method: hybrid
     proofs: []

--- a/docs/exec-plans/current/module-level-log-controls/requirements_bulk.yml
+++ b/docs/exec-plans/current/module-level-log-controls/requirements_bulk.yml
@@ -1,0 +1,84 @@
+requirements:
+  - title: Admin can configure module-level runtime log overrides
+    status: proposed
+    acceptance_criteria:
+      - id: AC-001
+        title: An authorized Torus admin can set a supported Logger level for a specified Elixir module through an admin workflow.
+        status: proposed
+        verification_method: automated
+        proofs: []
+      - id: AC-002
+        title: The override affects only the targeted module and does not change the global application log level.
+        status: proposed
+        verification_method: automated
+        proofs: []
+  - title: Invalid or unauthorized actions fail safely
+    status: proposed
+    acceptance_criteria:
+      - id: AC-003
+        title: Non-admin users cannot create, update, or clear module-level log overrides.
+        status: proposed
+        verification_method: automated
+        proofs: []
+      - id: AC-004
+        title: Invalid module identifiers and unsupported log levels are rejected without mutating Logger configuration.
+        status: proposed
+        verification_method: automated
+        proofs: []
+  - title: Admin can inspect and clear active overrides
+    status: proposed
+    acceptance_criteria:
+      - id: AC-005
+        title: The admin workflow shows the active module override state or a confirmation of the applied change.
+        status: proposed
+        verification_method: hybrid
+        proofs: []
+      - id: AC-006
+        title: An authorized admin can clear a previously applied module-level override from the same admin workflow.
+        status: proposed
+        verification_method: automated
+        proofs: []
+  - title: Process-level targeting remains optional and explicitly bounded
+    status: proposed
+    acceptance_criteria:
+      - id: AC-007
+        title: If process-level log overrides are implemented, they are exposed as a separate advanced control with distinct validation and clear operator messaging.
+        status: proposed
+        verification_method: hybrid
+        proofs: []
+acceptance_criteria:
+  - id: AC-001
+    title: An authorized Torus admin can set a supported Logger level for a specified Elixir module through an admin workflow.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-002
+    title: The override affects only the targeted module and does not change the global application log level.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-003
+    title: Non-admin users cannot create, update, or clear module-level log overrides.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-004
+    title: Invalid module identifiers and unsupported log levels are rejected without mutating Logger configuration.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-005
+    title: The admin workflow shows the active module override state or a confirmation of the applied change.
+    status: proposed
+    verification_method: hybrid
+    proofs: []
+  - id: AC-006
+    title: An authorized admin can clear a previously applied module-level override from the same admin workflow.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-007
+    title: If process-level log overrides are implemented, they are exposed as a separate advanced control with distinct validation and clear operator messaging.
+    status: proposed
+    verification_method: hybrid
+    proofs: []

--- a/lib/oli/application.ex
+++ b/lib/oli/application.ex
@@ -88,6 +88,7 @@ defmodule Oli.Application do
 
         # Starts Cachex to store vr user agents
         Oli.VrLookupCache,
+        Oli.RuntimeLogOverrides.Registry,
 
         # Starts Cachex to store section info
         Oli.Delivery.Sections.SectionCache,

--- a/lib/oli/runtime_log_overrides.ex
+++ b/lib/oli/runtime_log_overrides.ex
@@ -1,0 +1,111 @@
+defmodule Oli.RuntimeLogOverrides do
+  @moduledoc """
+  Local-node runtime log override management for admin-applied overrides.
+  """
+
+  require Logger
+
+  alias Oli.RuntimeLogOverrides.Registry
+
+  @type override_state :: %{modules: list(map()), processes: list(map())}
+  @type error_reason :: :invalid_level | :invalid_module
+
+  @spec list_overrides() :: override_state()
+  def list_overrides do
+    Registry.list_overrides()
+  end
+
+  @spec set_module_level(String.t(), atom() | String.t()) ::
+          {:ok, override_state()} | {:error, error_reason()}
+  def set_module_level(module_name, level) do
+    with {:ok, module} <- parse_module(module_name),
+         {:ok, validated_level} <- validate_level(level),
+         :ok <- Logger.put_module_level(module, validated_level),
+         {:ok, _override} <- Registry.put_module_override(module, validated_level) do
+      Logger.info(
+        "Runtime log override set for module=#{inspect(module)} level=#{validated_level} node=#{node()}"
+      )
+
+      {:ok, list_overrides()}
+    else
+      {:error, _reason} = error ->
+        log_failed_module_override("set", module_name, level, error)
+        error
+    end
+  end
+
+  @spec clear_module_level(String.t()) :: {:ok, override_state()} | {:error, :invalid_module}
+  def clear_module_level(module_name) do
+    with {:ok, module} <- parse_module(module_name),
+         :ok <- Logger.delete_module_level(module),
+         :ok <- Registry.delete_module_override(module) do
+      Logger.info("Runtime log override cleared for module=#{inspect(module)} node=#{node()}")
+
+      {:ok, list_overrides()}
+    else
+      {:error, _reason} = error ->
+        log_failed_module_override("clear", module_name, nil, error)
+        error
+    end
+  end
+
+  defp parse_module(module_name) when is_binary(module_name) do
+    trimmed_name = String.trim(module_name)
+
+    if trimmed_name == "" do
+      {:error, :invalid_module}
+    else
+      normalized_name =
+        case String.starts_with?(trimmed_name, "Elixir.") do
+          true -> trimmed_name
+          false -> "Elixir." <> trimmed_name
+        end
+
+      try do
+        module = String.to_existing_atom(normalized_name)
+
+        if Code.ensure_loaded?(module) do
+          {:ok, module}
+        else
+          {:error, :invalid_module}
+        end
+      rescue
+        ArgumentError ->
+          {:error, :invalid_module}
+      end
+    end
+  end
+
+  defp parse_module(_module_name), do: {:error, :invalid_module}
+
+  defp validate_level(level) when is_binary(level) do
+    case String.trim(level) do
+      "" ->
+        {:error, :invalid_level}
+
+      trimmed_level ->
+        try do
+          trimmed_level
+          |> String.to_existing_atom()
+          |> validate_level()
+        rescue
+          ArgumentError -> {:error, :invalid_level}
+        end
+    end
+  end
+
+  defp validate_level(level) when is_atom(level) do
+    case level in Logger.levels() do
+      true -> {:ok, level}
+      false -> {:error, :invalid_level}
+    end
+  end
+
+  defp validate_level(_level), do: {:error, :invalid_level}
+
+  defp log_failed_module_override(action, module_name, level, {:error, reason}) do
+    Logger.warning(
+      "Runtime log override #{action} failed module=#{inspect(module_name)} level=#{inspect(level)} reason=#{inspect(reason)} node=#{node()}"
+    )
+  end
+end

--- a/lib/oli/runtime_log_overrides/registry.ex
+++ b/lib/oli/runtime_log_overrides/registry.ex
@@ -1,0 +1,68 @@
+defmodule Oli.RuntimeLogOverrides.Registry do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, :ok, Keyword.put_new(opts, :name, __MODULE__))
+  end
+
+  def list_overrides do
+    GenServer.call(__MODULE__, :list_overrides)
+  end
+
+  def put_module_override(module, level) do
+    GenServer.call(__MODULE__, {:put_module_override, module, level})
+  end
+
+  def delete_module_override(module) do
+    GenServer.call(__MODULE__, {:delete_module_override, module})
+  end
+
+  def reset do
+    GenServer.call(__MODULE__, :reset)
+  end
+
+  @impl true
+  def init(:ok) do
+    {:ok, %{modules: %{}}}
+  end
+
+  @impl true
+  def handle_call(:list_overrides, _from, state) do
+    overrides = %{
+      modules:
+        state.modules
+        |> Map.values()
+        |> Enum.sort_by(& &1.target_label),
+      processes: []
+    }
+
+    {:reply, overrides, state}
+  end
+
+  def handle_call({:put_module_override, module, level}, _from, state) do
+    module_override = %{
+      type: :module,
+      target: module,
+      target_label: Atom.to_string(module),
+      level: level,
+      updated_at: DateTime.utc_now()
+    }
+
+    next_state = put_in(state, [:modules, module], module_override)
+
+    {:reply, {:ok, module_override}, next_state}
+  end
+
+  def handle_call({:delete_module_override, module}, _from, state) do
+    {_deleted, modules} = Map.pop(state.modules, module)
+    next_state = %{state | modules: modules}
+
+    {:reply, :ok, next_state}
+  end
+
+  def handle_call(:reset, _from, _state) do
+    {:reply, :ok, %{modules: %{}}}
+  end
+end

--- a/lib/oli_web/live/features/features_live.ex
+++ b/lib/oli_web/live/features/features_live.ex
@@ -13,6 +13,7 @@ defmodule OliWeb.Features.FeaturesLive do
   alias OliWeb.Features.EnabledScopedFeaturesTableModel
   alias Oli.Features
   alias Oli.Delivery
+  alias Oli.RuntimeLogOverrides
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections.Section
 
@@ -41,6 +42,8 @@ defmodule OliWeb.Features.FeaturesLive do
      assign(socket,
        title: "Feature Flags",
        log_level: Logger.level(),
+       module_log_form: module_log_form(),
+       runtime_log_overrides: RuntimeLogOverrides.list_overrides(),
        active: :features,
        features: Features.list_features_and_states(),
        breadcrumbs: set_breadcrumbs(),
@@ -99,6 +102,14 @@ defmodule OliWeb.Features.FeaturesLive do
 
   defp to_state("Enable"), do: :enabled
   defp to_state("Disable"), do: :disabled
+
+  defp module_log_form(params \\ %{"module_name" => "", "level" => "debug"}) do
+    to_form(params, as: :module_override)
+  end
+
+  defp module_override_dom_id(target_label) do
+    "module-log-override-" <> String.replace(target_label, ~r/[^a-zA-Z0-9_-]/, "-")
+  end
 
   defp get_enabled_scoped_features_paged(%{
          offset: offset,
@@ -247,6 +258,77 @@ defmodule OliWeb.Features.FeaturesLive do
           </p>
         </div>
       </div>
+      <div class="grid grid-cols-12 mb-8">
+        <div class="col-span-12">
+          <h2 class="mb-4">
+            Module-Level Log Overrides
+          </h2>
+          <p class="mb-4 text-gray-600">
+            Apply a temporary log-level override to a single loaded Elixir module on this node.
+            This does not change the global log level.
+          </p>
+
+          <.form
+            id="module-log-override-form"
+            for={@module_log_form}
+            phx-submit="set_module_log_level"
+            class="grid gap-4 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]"
+          >
+            <.input
+              field={@module_log_form[:module_name]}
+              type="text"
+              label="Module"
+              placeholder="Elixir.Oli.Some.Module"
+            />
+            <.input
+              field={@module_log_form[:level]}
+              type="select"
+              label="Override Level"
+              options={Enum.map(Logger.levels(), &{Atom.to_string(&1), &1})}
+            />
+            <div class="flex items-end">
+              <button id="apply-module-log-override" type="submit" class="btn btn-primary w-full">
+                Apply Override
+              </button>
+            </div>
+          </.form>
+
+          <div class="mt-5">
+            <h3 class="mb-3 text-lg font-semibold">Active Module Overrides</h3>
+
+            <%= case @runtime_log_overrides.modules do %>
+              <% [] -> %>
+                <p id="no-module-log-overrides" class="text-gray-600">
+                  No active module overrides on this node.
+                </p>
+              <% overrides -> %>
+                <div class="space-y-3" id="active-module-log-overrides">
+                  <%= for override <- overrides do %>
+                    <div
+                      id={module_override_dom_id(override.target_label)}
+                      class="flex flex-col gap-3 rounded border border-gray-200 p-4 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div>
+                        <div class="font-medium">{override.target_label}</div>
+                        <div class="text-sm text-gray-600">
+                          Override level: <strong>{override.level}</strong>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger"
+                        phx-click="clear_module_log_level"
+                        phx-value-module={override.target_label}
+                      >
+                        Clear Override
+                      </button>
+                    </div>
+                  <% end %>
+                </div>
+            <% end %>
+          </div>
+        </div>
+      </div>
       <div class="grid grid-cols-12 mt-5">
         <div class="col-span-12">
           <h2 class="mb-5">
@@ -344,8 +426,15 @@ defmodule OliWeb.Features.FeaturesLive do
   end
 
   def handle_event("logging", %{"level" => level}, socket) do
+    level_atom =
+      try do
+        String.to_existing_atom(level)
+      rescue
+        ArgumentError -> nil
+      end
+
     socket =
-      case Logger.configure(level: String.to_atom(level)) do
+      case level_atom in Logger.levels() and Logger.configure(level: level_atom) do
         :ok ->
           socket
           |> put_flash(:info, "Logging level changed to #{level}")
@@ -354,6 +443,47 @@ defmodule OliWeb.Features.FeaturesLive do
         _ ->
           socket
           |> put_flash(:error, "Logging level could not be changed to #{level}")
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("set_module_log_level", %{"module_override" => params}, socket) do
+    socket =
+      case RuntimeLogOverrides.set_module_level(params["module_name"], params["level"]) do
+        {:ok, runtime_log_overrides} ->
+          socket
+          |> put_flash(:info, "Module log override applied to #{params["module_name"]}")
+          |> assign(
+            runtime_log_overrides: runtime_log_overrides,
+            module_log_form: module_log_form()
+          )
+
+        {:error, :invalid_module} ->
+          socket
+          |> put_flash(:error, "Module log override failed: invalid module")
+          |> assign(module_log_form: module_log_form(params))
+
+        {:error, :invalid_level} ->
+          socket
+          |> put_flash(:error, "Module log override failed: invalid log level")
+          |> assign(module_log_form: module_log_form(params))
+      end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("clear_module_log_level", %{"module" => module_name}, socket) do
+    socket =
+      case RuntimeLogOverrides.clear_module_level(module_name) do
+        {:ok, runtime_log_overrides} ->
+          socket
+          |> put_flash(:info, "Module log override cleared for #{module_name}")
+          |> assign(runtime_log_overrides: runtime_log_overrides)
+
+        {:error, :invalid_module} ->
+          socket
+          |> put_flash(:error, "Module log override clear failed: invalid module")
       end
 
     {:noreply, socket}

--- a/test/oli/runtime_log_overrides_test.exs
+++ b/test/oli/runtime_log_overrides_test.exs
@@ -1,0 +1,68 @@
+defmodule Oli.RuntimeLogOverridesTest do
+  use ExUnit.Case, async: false
+
+  alias Oli.RuntimeLogOverrides
+  alias Oli.RuntimeLogOverrides.Registry
+
+  setup do
+    original_level = Logger.level()
+    Logger.delete_all_module_levels()
+    Registry.reset()
+
+    on_exit(fn ->
+      Logger.delete_all_module_levels()
+      Registry.reset()
+      Logger.configure(level: original_level)
+    end)
+
+    :ok
+  end
+
+  describe "set_module_level/2" do
+    test "applies a module-level override and lists it" do
+      assert {:ok, overrides} = RuntimeLogOverrides.set_module_level("Enum", :debug)
+
+      assert [%{target: Enum, target_label: "Elixir.Enum", level: :debug}] = overrides.modules
+      assert [] = overrides.processes
+      assert [{Enum, :debug}] = Logger.get_module_level(Enum)
+    end
+
+    test "does not change the global logger level" do
+      Logger.configure(level: :error)
+
+      assert {:ok, _overrides} = RuntimeLogOverrides.set_module_level("Enum", :debug)
+
+      assert Logger.level() == :error
+      assert [{Enum, :debug}] = Logger.get_module_level(Enum)
+    end
+
+    test "rejects invalid module names" do
+      assert {:error, :invalid_module} =
+               RuntimeLogOverrides.set_module_level("Not.A.Real.Module", :debug)
+
+      assert [] = RuntimeLogOverrides.list_overrides().modules
+    end
+
+    test "rejects invalid levels" do
+      assert {:error, :invalid_level} = RuntimeLogOverrides.set_module_level("Enum", "verbose")
+
+      assert [] = RuntimeLogOverrides.list_overrides().modules
+      assert [] = Logger.get_module_level(Enum)
+    end
+  end
+
+  describe "clear_module_level/1" do
+    test "clears an applied module-level override" do
+      assert {:ok, _overrides} = RuntimeLogOverrides.set_module_level("Enum", :debug)
+
+      assert {:ok, overrides} = RuntimeLogOverrides.clear_module_level("Enum")
+
+      assert [] = overrides.modules
+      assert [] = Logger.get_module_level(Enum)
+    end
+
+    test "rejects clearing an invalid module" do
+      assert {:error, :invalid_module} = RuntimeLogOverrides.clear_module_level("Not.A.Module")
+    end
+  end
+end

--- a/test/oli_web/live/features_live_test.exs
+++ b/test/oli_web/live/features_live_test.exs
@@ -1,0 +1,111 @@
+defmodule OliWeb.FeaturesLiveTest do
+  use ExUnit.Case, async: false
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.RuntimeLogOverrides
+  alias Oli.RuntimeLogOverrides.Registry
+
+  defp live_view_route, do: ~p"/admin/features"
+
+  setup do
+    original_level = Logger.level()
+    Logger.delete_all_module_levels()
+    Registry.reset()
+
+    on_exit(fn ->
+      Logger.delete_all_module_levels()
+      Registry.reset()
+      Logger.configure(level: original_level)
+    end)
+
+    :ok
+  end
+
+  describe "authorization" do
+    setup [:author_conn]
+
+    test "redirects non-admin authors away from the page", %{conn: conn} do
+      conn = get(conn, live_view_route())
+
+      assert redirected_to(conn, 302) == "/workspaces/course_author"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~
+               "You are not authorized to access this page."
+    end
+  end
+
+  describe "module-level override UI" do
+    setup [:admin_conn]
+
+    test "renders the module override section and empty state", %{conn: conn} do
+      {:ok, view, _html} = live(conn, live_view_route())
+
+      assert has_element?(view, "#module-log-override-form")
+      assert has_element?(view, "#apply-module-log-override", "Apply Override")
+
+      assert has_element?(
+               view,
+               "#no-module-log-overrides",
+               "No active module overrides on this node."
+             )
+    end
+
+    test "applies an override and renders the active state", %{conn: conn} do
+      {:ok, view, _html} = live(conn, live_view_route())
+
+      view
+      |> element("#module-log-override-form")
+      |> render_submit(%{
+        "module_override" => %{"module_name" => "Enum", "level" => "debug"}
+      })
+
+      assert render(view) =~ "Module log override applied to Enum"
+      assert has_element?(view, "#active-module-log-overrides")
+      assert has_element?(view, "#module-log-override-Elixir-Enum", "Elixir.Enum")
+      assert [{Enum, :debug}] = Logger.get_module_level(Enum)
+    end
+
+    test "shows an error for an invalid module", %{conn: conn} do
+      {:ok, view, _html} = live(conn, live_view_route())
+
+      view
+      |> element("#module-log-override-form")
+      |> render_submit(%{
+        "module_override" => %{"module_name" => "Not.A.Real.Module", "level" => "debug"}
+      })
+
+      assert render(view) =~ "Module log override failed: invalid module"
+      assert has_element?(view, "#no-module-log-overrides")
+      assert [] = RuntimeLogOverrides.list_overrides().modules
+    end
+
+    test "clears an active override", %{conn: conn} do
+      {:ok, _} = RuntimeLogOverrides.set_module_level("Enum", :debug)
+
+      {:ok, view, _html} = live(conn, live_view_route())
+
+      assert has_element?(view, "#module-log-override-Elixir-Enum", "Elixir.Enum")
+
+      view
+      |> element("button[phx-click='clear_module_log_level'][phx-value-module='Elixir.Enum']")
+      |> render_click()
+
+      assert render(view) =~ "Module log override cleared for Elixir.Enum"
+      assert has_element?(view, "#no-module-log-overrides")
+      assert [] = Logger.get_module_level(Enum)
+    end
+
+    test "existing global logging control still works", %{conn: conn} do
+      {:ok, view, _html} = live(conn, live_view_route())
+
+      view
+      |> element("button[phx-click='logging'][phx-value-level='warning']")
+      |> render_click()
+
+      assert render(view) =~ "Logging level changed to warning"
+      assert Logger.level() == :warning
+    end
+  end
+end


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5551

Adds admin-managed module-level runtime log overrides on `/admin/features`.

This change lets authorized admins apply and clear a Logger override for a specific loaded Elixir module without changing the global application log level.

This observability is necessary to help diagnose future LTI launch issues as well as other issues that may occur in production without flooding the entire system with logs.

# What Changed

- Added `Oli.RuntimeLogOverrides` for module-level override validation, apply, clear, and state listing.
- Added `Oli.RuntimeLogOverrides.Registry` as a supervised local registry for active module overrides.
- Wired the registry into application supervision.
- Extended `OliWeb.Features.FeaturesLive` with:
  - a module override form
  - active override rendering
  - clear actions
  - safer global log-level parsing using `String.to_existing_atom/1`
- Added backend tests for module override set/list/clear behavior and validation failures.
- Added LiveView tests for:
  - admin visibility
  - invalid module handling
  - clear behavior
  - non-admin access denial
  - regression coverage for the existing global logging control
- Updated the work-item spec pack to reflect the final module-level delivery.
