### PR TITLE
[BUG FIX] [MER-5570] Restrict template remix sources for non-admin authors

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -162,7 +162,12 @@ defmodule OliWeb.Delivery.RemixSection do
       ) do
     if Oli.Delivery.Sections.Blueprint.is_author_of_blueprint?(section.slug, current_author.id) or
          Accounts.at_least_content_admin?(current_author) do
-      {:ok, state} = Remix.init_open_and_free(section)
+      {:ok, state} =
+        if Accounts.at_least_content_admin?(current_author) do
+          Remix.init_open_and_free(section)
+        else
+          Remix.init(section, current_author)
+        end
 
       init_state_from_remix(socket, state,
         redirect_after_save: redirect_after_save(:product_creator, state.section, socket)

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -10,6 +10,8 @@ defmodule OliWeb.RemixSectionLiveTest do
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Delivery.Sections
   alias Oli.Accounts
+  alias Oli.Authoring.Course
+  alias Oli.Publishing
 
   describe "remix section as admin" do
     setup [:setup_admin_session]
@@ -962,6 +964,50 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert Floki.text(customize_content_breadcrumb) =~ "Customize Content"
       assert Floki.find(customize_content_breadcrumb, "a") == []
     end
+
+    test "non-admin product manager cannot see unrelated restricted projects in add materials", %{
+      conn: conn,
+      prod: prod,
+      restricted_project_title: restricted_project_title
+    } do
+      conn =
+        get(
+          conn,
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click='show_add_materials_modal']")
+      |> render_click()
+
+      refute render(view) =~ restricted_project_title
+    end
+  end
+
+  describe "remix section as product admin" do
+    setup [:setup_product_admin_session]
+
+    test "admin product manager can see unrelated restricted projects in add materials", %{
+      conn: conn,
+      prod: prod,
+      restricted_project_title: restricted_project_title
+    } do
+      conn =
+        get(
+          conn,
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click='show_add_materials_modal']")
+      |> render_click()
+
+      assert render(view) =~ restricted_project_title
+    end
   end
 
   describe "remix section for open and free" do
@@ -1694,6 +1740,9 @@ defmodule OliWeb.RemixSectionLiveTest do
       |> Seeder.create_product(%{title: "My 1st product", amount: Money.new(100, "USD")}, :prod1)
 
     {:ok, _prod} = Sections.create_section_resources(prod, publication)
+    restricted_project_title = "Restricted Source Project"
+
+    create_restricted_project(product_author, prod.institution, restricted_project_title)
 
     conn =
       Plug.Test.init_test_session(conn, %{})
@@ -1704,6 +1753,33 @@ defmodule OliWeb.RemixSectionLiveTest do
      prod: prod,
      revision1: revision1,
      revision2: revision2,
-     project_slug: project.slug}
+     project_slug: project.slug,
+     restricted_project_title: restricted_project_title}
+  end
+
+  defp setup_product_admin_session(%{conn: conn}) do
+    {:ok, setup} = setup_product_manager_session(%{conn: conn})
+    admin = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().content_admin)
+
+    conn =
+      Plug.Test.init_test_session(conn, %{})
+      |> log_in_author(admin)
+
+    {:ok, Keyword.put(setup, :conn, conn)}
+  end
+
+  defp create_restricted_project(_owner, institution, title) do
+    unrelated_author = insert(:author)
+    restricted_project = Seeder.another_project(unrelated_author, institution, title)
+
+    {:ok, _project} =
+      Course.update_project(restricted_project.project, %{visibility: :selected})
+
+    {:ok, _publication} =
+      Publishing.publish_project(
+        restricted_project.project,
+        "publish restricted remix source",
+        unrelated_author.id
+      )
   end
 end


### PR DESCRIPTION
• Summary
  This PR fixes MER-5570 by making template/product remix respect normal project visibility rules for non-admin authors.

  Previously, blueprint authors entering template remix were initialized through the unrestricted Remix.init_open_and_free/1 path, which exposed all active published projects in Add Materials, including unrelated restricted projects. This change preserves unrestricted access for content admins and system admins, but routes ordinary blueprint authors through the standard Remix.init/2 path so only visible publications are shown.
Note _section_ remix already enforced project visibility correctly. 

  Changes
  - Update product remix mount logic in lib/oli_web/live/delivery/remix_section.ex to:
      - keep Remix.init_open_and_free/1 for content admins/system admins
      - use Remix.init/2 for ordinary blueprint authors
  - Add regression coverage in test/oli_web/live/remix_section_test.exs verifying:
      - a non-admin product author cannot see an unrelated restricted project in Add Materials
      - a content admin still can