### PR TITLE
[ENHANCEMENT] [MER-5538] Add support for optional params during lti login step for lti external tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,12 @@ The review process should first assess the scope of the PR, then load the approp
 - **Background Jobs**: Use Oban for async processing
 - **Caching**: Leverage Cachex for performance-critical paths
 
+## Documentation Paths
+
+- When referencing repository documents, always use paths relative to the repository root.
+- Do not use absolute filesystem paths in documentation.
+- Prefer forms like `docs/...`, `lib/...`, `test/...`, or `assets/...` when citing files in markdown or planning artifacts.
+
 ## Code Style Guidelines
 
 - Follow Elixir formatting standards (use `mix format`)

--- a/assets/src/data/persistence/lti_platform.ts
+++ b/assets/src/data/persistence/lti_platform.ts
@@ -6,6 +6,9 @@ export type LTIExternalToolDetails = {
     client_id: string;
     target_link_uri: string;
     login_url: string;
+    lti_deployment_id?: string;
+    lti_message_hint?: string;
+    lti_message_type?: string;
   };
   status: string;
   deep_linking_enabled: boolean;

--- a/docs/exec-plans/current/lti-launch-hardening/fdd.md
+++ b/docs/exec-plans/current/lti-launch-hardening/fdd.md
@@ -30,15 +30,15 @@ The simplest adequate approach is:
 - Assumptions:
   - The existing `/lti/register_form` GET route remains the correct CSRF-safe presentation surface for the institution registration form.
   - The current `lti_1p3` library boundary can support the hardened session-backed flow without adding a new launch-state store.
-  - The archived storage-assisted prototype remains documented in [prototype-checkpoint.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md), but it is not part of the supported implementation target.
+  - The archived storage-assisted prototype remains documented in [prototype-checkpoint.md](./docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md), but it is not part of the supported implementation target.
 
 ## 3. Repository Context Summary
 
 - What we know:
-  - Current `/lti/login` and `/lti/launch` live in [lti_controller.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/controllers/lti_controller.ex#L30) and currently store `state` plus pending registration params in the Phoenix session.
+  - Current `/lti/login` and `/lti/launch` live in [lti_controller.ex](./lib/oli_web/controllers/lti_controller.ex#L30) and currently store `state` plus pending registration params in the Phoenix session.
   - Immediate redirect logic depends on `get_latest_user_lti_params/1`, which is the stale-context behavior this design removes in favor of a current-launch redirect module.
-  - Durable `lti_1p3_params` records in [lti_params.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/lti_params.ex#L9) are keyed by issuer, client, deployment, context, and subject and can remain as a durable business-context store, but not as the immediate redirect authority.
-  - Invalid registration and deployment already converge on `/lti/register_form` in [lti_controller.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/controllers/lti_controller.ex#L673), which is a natural place to remove session dependence without changing the UX boundary.
+  - Durable `lti_1p3_params` records in [lti_params.ex](./lib/oli/lti/lti_params.ex#L9) are keyed by issuer, client, deployment, context, and subject and can remain as a durable business-context store, but not as the immediate redirect authority.
+  - Invalid registration and deployment already converge on `/lti/register_form` in [lti_controller.ex](./lib/oli_web/controllers/lti_controller.ex#L673), which is a natural place to remove session dependence without changing the UX boundary.
   - Existing LTI error rendering is server-side template driven in `lib/oli_web/templates/lti/`, which aligns with stable terminal outcomes.
 - Unknowns to confirm:
   - Which exact `lti_1p3` login-path functions need to be bypassed, extended, or replaced for standards-aligned storage-assisted flow selection.
@@ -357,7 +357,7 @@ N/A. The design intentionally avoids new cache-based authority for launch state.
 
 The follow-on slice removes the storage-assisted launch path from Torus and also removes the database-backed launch-attempt persistence that was primarily introduced to support that path. The resulting design keeps a single LTI launch transport: the legacy session-backed path, while preserving the stable error handling, redirect improvements, telemetry, and registration-request fixes from the earlier work.
 
-The archival prototype checkpoint for the removed design is recorded in [prototype-checkpoint.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
+The archival prototype checkpoint for the removed design is recorded in [prototype-checkpoint.md](./docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
 
 ### 17.2 Components To Remove
 
@@ -408,10 +408,10 @@ The archival prototype checkpoint for the removed design is recorded in [prototy
 
 ## 17. References
 
-- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prd.md)
-- [requirements.yml](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/requirements.yml)
-- [lti_controller.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/controllers/lti_controller.ex)
-- [lti_redirect.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/lti_redirect.ex)
-- [lti_params.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/lti_params.ex)
-- [guides/lti/implementing.md](/Users/eliknebel/Developer/oli-torus/guides/lti/implementing.md)
-- [guides/lti/config.md](/Users/eliknebel/Developer/oli-torus/guides/lti/config.md)
+- [prd.md](./docs/exec-plans/current/lti-launch-hardening/prd.md)
+- [requirements.yml](./docs/exec-plans/current/lti-launch-hardening/requirements.yml)
+- [lti_controller.ex](./lib/oli_web/controllers/lti_controller.ex)
+- [lti_redirect.ex](./lib/oli_web/lti_redirect.ex)
+- [lti_params.ex](./lib/oli/lti/lti_params.ex)
+- [guides/lti/implementing.md](./guides/lti/implementing.md)
+- [guides/lti/config.md](./guides/lti/config.md)

--- a/docs/exec-plans/current/lti-launch-hardening/plan.md
+++ b/docs/exec-plans/current/lti-launch-hardening/plan.md
@@ -11,7 +11,7 @@ Implement the LTI launch lifecycle hardening described in the PRD and FDD by kee
 
 ## Clarifications & Default Assumptions
 
-- The authoritative work-item artifacts are [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prd.md) and [fdd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/fdd.md).
+- The authoritative work-item artifacts are [prd.md](./docs/exec-plans/current/lti-launch-hardening/prd.md) and [fdd.md](./docs/exec-plans/current/lti-launch-hardening/fdd.md).
 - The registration-request handoff remains on `GET /lti/register_form` and uses explicit URL parameters for first render, then posted form values for invalid submit re-rendering.
 - The final supported design keeps session-backed launch state in Phoenix session and does not retain `launch_attempts`, storage-assisted helper behavior, or post-launch continuation fallback behavior.
 - `get_latest_user_lti_params/1` is no longer allowed in the immediate `/lti/launch` success path, but remains an accepted fallback for authenticated non-launch redirects where no current-launch handoff exists.
@@ -152,7 +152,7 @@ Implement the LTI launch lifecycle hardening described in the PRD and FDD by kee
 ## Phase 5: Remove Storage-Assisted Launch Support
 
 - Goal: Remove cookie-less launch support and its rollout controls while preserving the launch-hardening, redirect, telemetry, error-handling, and registration improvements delivered by the earlier phases.
-- Reference: the archived prototype state for the removed design is recorded in [prototype-checkpoint.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
+- Reference: the archived prototype state for the removed design is recorded in [prototype-checkpoint.md](./docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
 - Tasks:
   - [x] Remove `lti_storage_target` transport selection and make `/lti/login` always use `session_storage`.
   - [x] Remove the storage-assisted helper page and any browser-side storage orchestration used only for that path.

--- a/docs/exec-plans/current/lti-launch-hardening/prd.md
+++ b/docs/exec-plans/current/lti-launch-hardening/prd.md
@@ -96,7 +96,7 @@ Requirements are found in requirements.yml
 ## 11. Feature Flagging, Rollout & Migration
 
 - No feature flags are required for the final supported design.
-- The archived storage-assisted prototype is retained only as a documented checkpoint in [prototype-checkpoint.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
+- The archived storage-assisted prototype is retained only as a documented checkpoint in [prototype-checkpoint.md](./docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
 
 ## 12. Telemetry & Success Metrics
 
@@ -196,7 +196,7 @@ Requirements are found in requirements.yml
 
 The branch proves that Torus can complete a storage-assisted LTI handshake, but it also confirms that Torus delivery remains fundamentally dependent on its own authenticated web-session model after launch. Given the security tradeoffs of the continuation design and the overall complexity of maintaining a partial cookieless experience, the follow-on direction is to remove storage-assisted launch support from Torus while keeping the broader launch-hardening work.
 
-The archival prototype checkpoint for this design is recorded in [prototype-checkpoint.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
+The archival prototype checkpoint for this design is recorded in [prototype-checkpoint.md](./docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md).
 
 ### Follow-On Goals
 

--- a/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md
+++ b/docs/exec-plans/current/lti-launch-hardening/prototype-checkpoint.md
@@ -40,6 +40,6 @@ git checkout 1111e73213a1cbff76878813ace9325bb2ff5e8b
 
 ## Related Work-Item Docs
 
-- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/prd.md)
-- [fdd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/fdd.md)
-- [plan.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/lti-launch-hardening/plan.md)
+- [prd.md](./docs/exec-plans/current/lti-launch-hardening/prd.md)
+- [fdd.md](./docs/exec-plans/current/lti-launch-hardening/fdd.md)
+- [plan.md](./docs/exec-plans/current/lti-launch-hardening/plan.md)

--- a/docs/exec-plans/current/lti-login-optional-params/fdd.md
+++ b/docs/exec-plans/current/lti-login-optional-params/fdd.md
@@ -1,0 +1,280 @@
+# LTI Login Optional Params - Functional Design Document
+
+## 1. Executive Summary
+
+This design extends Torus’s external-tool launch-details API so outbound LTI login requests include `lti_deployment_id` and `lti_message_hint` without changing the visible launch UX. The simplest adequate approach is to keep launch-param assembly server-owned in [`lib/oli_web/controllers/api/lti_controller.ex`](./lib/oli_web/controllers/api/lti_controller.ex), add a shared builder used by authoring, delivery, and deep-linking responses, source `lti_deployment_id` from the existing external-tool deployment row, and generate `lti_message_hint` as a compact signed token carrying minimal launch context rather than reusing `login_hint`.
+
+This design satisfies FR-001 through FR-005 while avoiding new storage, migrations, or frontend-side mutation. It directly targets AC-001, AC-002, AC-003, AC-004, and AC-005 by keeping the optional params in the same launch-details payload that already drives the hidden form POST to the external tool.
+
+## 2. Requirements & Assumptions
+
+- Functional requirements:
+  - FR-001 requires the external-tool launch payload to include `lti_deployment_id`.
+  - FR-002 requires `lti_message_hint` to be opaque and non-sensitive.
+  - FR-003 requires parity across authoring, delivery, and supported deep-linking launch-details endpoints.
+  - FR-004 requires the client form submission path to preserve the server-produced values unchanged.
+  - FR-005 requires omission of values that cannot be derived, rather than empty placeholders.
+- Non-functional requirements:
+  - Keep launch-param generation at the Phoenix server boundary.
+  - Avoid introducing a new persistence layer or stateful launch-message-hint artifact unless the current boundaries prove insufficient.
+  - Preserve backward compatibility for tools that ignore the new params.
+- Assumptions:
+  - Every registered external-tool launch already has access to the `LtiExternalToolActivityDeployment` record and therefore its `deployment_id`.
+  - External tools do not require Torus to persist `lti_message_hint`, but Torus may benefit from being able to verify and inspect the minimal launch context it issued if debugging becomes necessary.
+  - A compact signed token carrying minimal launch context is sufficiently tool-compatible and closer to observed LMS behavior than duplicating `login_hint`.
+
+## 3. Repository Context Summary
+
+- What we know:
+  - Authoring launch details, delivery launch details, and deep-linking launch details are assembled in [`lib/oli_web/controllers/api/lti_controller.ex`](./lib/oli_web/controllers/api/lti_controller.ex).
+  - The JSON response shape is typed in [`assets/src/data/persistence/lti_platform.ts`](./assets/src/data/persistence/lti_platform.ts) and consumed directly by [`assets/src/components/lti/LTIExternalToolFrame.tsx`](./assets/src/components/lti/LTIExternalToolFrame.tsx).
+  - `LTIExternalToolFrame` posts every key in `launchParams` except `login_url` as a hidden form input, so backend parity is the main contract boundary for AC-002.
+  - Existing API tests in [`test/oli_web/controllers/api/lti_controller_test.exs`](./test/oli_web/controllers/api/lti_controller_test.exs) and [`test/oli_web/controllers/api/lti_controller_integration_test.exs`](./test/oli_web/controllers/api/lti_controller_integration_test.exs) already assert the response structure and are the right place to extend AC-001 and AC-003 coverage.
+  - The external-tool deployment identifier already exists as the primary key on [`lib/oli/lti/platform_external_tools/lti_external_tool_activity_deployment.ex`](./lib/oli/lti/platform_external_tools/lti_external_tool_activity_deployment.ex), so FR-001 does not require a migration.
+  - `login_hint` values are created by `Lti_1p3.Platform.LoginHints.create_login_hint/2` and are opaque UUIDs tied to stored context.
+  - Phoenix already provides signed token primitives in the codebase, so Torus can issue a compact signed message hint without adding new persistence.
+- Unknowns to confirm:
+  - Whether any vendor expects `lti_message_hint` to encode semantics beyond an opaque correlation value.
+  - Whether there are frontend tests for the React `LTIExternalToolFrame` path that should be extended in addition to the Phoenix component tests.
+  - Whether any tool launch path outside the three API endpoints assembles launch params independently.
+
+## 4. Proposed Design
+
+### 4.1 Component Roles & Interactions
+
+Introduce private helpers in `OliWeb.Api.LtiController` to build the `launch_params` map and derive a distinct `lti_message_hint` for external-tool launches. Each endpoint will continue to resolve the tool deployment, create a `login_hint`, derive a compact signed message hint, and then call the shared builder with:
+
+- platform instance
+- generated `login_hint`
+- derived `lti_message_hint`
+- deployment record or deployment id
+- launch context inputs used for derivation, such as activity id or resource id when available
+- optional extra launch params such as `lti_message_type` for deep linking
+
+The derivation helper will:
+
+1. Assemble a minimal message-hint payload from current launch-specific values:
+   - `deployment_id`
+   - generated `login_hint`
+   - `target_link_uri`
+   - launch mode or endpoint type
+   - `lti_message_type` when present
+   - activity or resource identifier when available
+2. Sign that payload with `Phoenix.Token` under an LTI-specific salt.
+3. Return the signed token string as `lti_message_hint`.
+
+The launch-param builder will:
+
+1. Build the base launch params already in use: `iss`, `login_hint`, `client_id`, `target_link_uri`, `login_url`.
+2. Add `lti_deployment_id` from the resolved `LtiExternalToolActivityDeployment.deployment_id`.
+3. Add the signed `lti_message_hint`.
+4. Merge any endpoint-specific extra params.
+5. Drop nil values before encoding the JSON response.
+
+This preserves the current layering:
+
+- server owns launch-param construction
+- TypeScript types describe the payload
+- React form rendering passes values through unchanged
+
+### 4.2 State & Data Flow
+
+Authoring and delivery flow:
+
+1. Controller resolves the external-tool deployment and platform instance.
+2. Controller generates `login_hint` through `LoginHints.create_login_hint/2`.
+3. Controller derives `lti_message_hint` from the current launch context and generated `login_hint`.
+4. Controller calls the shared helper to build `launch_params`.
+5. API response returns the expanded `launch_params`.
+6. `LTIExternalToolFrame` renders hidden inputs for every param except `login_url`.
+7. Browser POST submits `iss`, `login_hint`, `client_id`, `target_link_uri`, `lti_deployment_id`, and `lti_message_hint` to the external tool login endpoint. This is the AC-001 and AC-002 path.
+
+Deep-linking flow:
+
+1. Controller resolves the same deployment/platform boundaries as the standard launch.
+2. Controller generates `login_hint`.
+3. Controller derives `lti_message_hint` from the deep-linking launch context, including `lti_message_type`.
+4. Shared helper builds the same optional params and merges `lti_message_type: "LtiDeepLinkingRequest"`.
+5. Response shape stays structurally aligned with standard launch details. This is the AC-003 path.
+
+Omission behavior:
+
+- If `deployment_id` is unexpectedly nil, the helper omits `lti_deployment_id`.
+- If `login_hint` generation somehow fails, the endpoint should continue to fail as it does today rather than fabricate inconsistent values.
+- If `lti_message_hint` signing fails, the endpoint should omit that field rather than reusing `login_hint` or emitting a raw context structure.
+- Nil removal in the helper enforces AC-004.
+
+### 4.3 Lifecycle & Ownership
+
+- `OliWeb.Api.LtiController` owns launch-param assembly.
+- `Lti_1p3.Platform.LoginHints` continues to own creation and storage of the opaque UUID used for `login_hint`.
+- `OliWeb.Api.LtiController` owns `lti_message_hint` derivation because the token is issued at the launch-details boundary and does not currently need a reusable domain model.
+- `LtiExternalToolActivityDeployment` continues to own the persisted deployment identifier.
+- `assets/src/data/persistence/lti_platform.ts` owns the client-side contract shape for these params.
+- `assets/src/components/lti/LTIExternalToolFrame.tsx` owns transport only; it does not synthesize, rename, or filter the optional params other than the existing `login_url` exclusion.
+
+### 4.4 Alternatives Considered
+
+Alternative 1: create a dedicated `lti_message_hint` storage artifact.
+
+- Rejected because it adds persistence and lifecycle complexity without a clear Torus-side consumer.
+- A request-local signed token yields an opaque value without adding cleanup or state-recovery logic.
+
+Alternative 2: generate a signed Phoenix token for `lti_message_hint`.
+
+- Chosen because it keeps the value opaque externally while allowing Torus to preserve minimal launch semantics in a compact token, which is closer to observed Canvas behavior.
+- It avoids persistence and gives Torus a stable, debuggable issuance boundary if later verification is needed.
+
+Alternative 3: use `deployment_id` as `lti_message_hint`.
+
+- Rejected because it collapses two logically different params into the same identifier and does not preserve the “opaque hint” intent in FR-002.
+
+Alternative 4: reuse `login_hint` as `lti_message_hint`.
+
+- Rejected because it does not align well with the spec’s intent that `lti_message_hint` carry message-specific context alongside `login_hint`.
+- Keeping the values distinct preserves clearer semantics while still avoiding persistence.
+
+Chosen approach: derive `lti_message_hint` as a signed compact token carrying minimal launch context and keep `lti_deployment_id` distinct. This is the simplest design that better aligns with the spec intent behind FR-002 and observed LMS behavior while still satisfying FR-001, FR-003, and FR-005 without schema changes.
+
+## 5. Interfaces
+
+- `OliWeb.Api.LtiController` private helper:
+  - Input: platform instance, `login_hint :: String.t()`, `lti_message_hint :: String.t() | nil`, `deployment_id :: String.t() | nil`, `extra_params :: map`.
+  - Output: launch params map with nil keys removed.
+- `OliWeb.Api.LtiController` private derivation helper:
+  - Input: `deployment_id`, `login_hint`, `target_link_uri`, launch mode, optional `lti_message_type`, optional activity or resource id.
+  - Output: `lti_message_hint :: String.t()` as a signed token string.
+- Authoring response contract:
+  - `launch_params` gains optional keys `lti_deployment_id` and `lti_message_hint`.
+- Delivery response contract:
+  - `launch_params` gains optional keys `lti_deployment_id` and `lti_message_hint`.
+- Deep-linking response contract:
+  - `launch_params` retains `lti_message_type` and also gains `lti_deployment_id` and `lti_message_hint`.
+- TypeScript interface update in `assets/src/data/persistence/lti_platform.ts`:
+  - Add `lti_deployment_id?: string`
+  - Add `lti_message_hint?: string`
+- Browser form contract in `LTIExternalToolFrame`:
+  - No behavior change; the component already posts arbitrary launch param keys and therefore fulfills FR-004 once the API payload includes the new values.
+
+## 6. Data Model & Storage
+
+- No schema changes.
+- No new tables or background cleanup work.
+- Existing storage reused:
+  - `lti_external_tool_activity_deployments.deployment_id` for `lti_deployment_id`
+  - `login_hints.value` for `login_hint`
+- Derived request-local data:
+  - `lti_message_hint` generated from minimal launch context and not persisted
+- No migration is required.
+
+## 7. Consistency & Transactions
+
+- There is no new transaction boundary.
+- Launch-details generation remains request-scoped.
+- Consistency is achieved by using one helper for all three endpoints instead of duplicating map assembly logic.
+- A single derivation helper ensures the API cannot accidentally vary `lti_message_hint` payload shape or signing policy across endpoints for equivalent launch contexts.
+
+## 8. Caching Strategy
+
+- N/A
+- The design does not introduce caches or change existing cache behavior.
+
+## 9. Performance & Scalability Posture
+
+- The added work is a constant-size map merge and nil-compaction per request.
+- No extra database queries are required if the controller uses the already-resolved deployment data.
+- Phoenix token signing is CPU-local and avoids any second persistence call, keeping the current launch-details latency profile intact.
+
+## 10. Failure Modes & Resilience
+
+- Missing deployment id on a supposedly registered tool:
+  - Response omits `lti_deployment_id` rather than sending `""`.
+  - This supports AC-004 and makes the defect observable in tests rather than silently producing malformed requests.
+- Failure creating `login_hint`:
+  - Existing endpoint failure behavior remains authoritative; do not fabricate a fallback hint.
+- Failure deriving `lti_message_hint`:
+  - Omit the field rather than substituting `login_hint` or emitting an unsigned raw context structure.
+  - Keep the failure local to this optional parameter to preserve launch behavior for tools that ignore it.
+- One endpoint forgets to include the new fields:
+  - Mitigated by consolidating launch-param assembly and by API tests that explicitly cover AC-001 and AC-003.
+- Frontend drops the new fields:
+  - Mitigated by the existing generic form rendering plus targeted AC-002 test coverage.
+- Tools ignore the new fields:
+  - No user-facing change; launch behavior remains backward compatible. This is AC-005.
+
+## 11. Observability
+
+- No new telemetry is required for this work item.
+- Add lightweight debug logging around external-tool launch param generation to support future debugging.
+- The logging should confirm whether `lti_deployment_id` and `lti_message_hint` were issued for a launch path without logging raw signed token payloads or other sensitive values.
+- Existing request logs are otherwise sufficient because the behavior change is deterministic and covered by tests.
+
+## 12. Security & Privacy
+
+- A signed token carrying minimal launch context is opaque in the outbound payload and does not expose raw session ids, user ids, or readable message context to clients.
+- The derivation helper must keep the payload minimal and must never include email, names, roles, or other unnecessary claims.
+- The signing salt must be LTI-specific so the token is scoped to this use case.
+- The design does not expose session ids, user ids, emails, or internal role data in browser-visible hidden inputs.
+- `lti_deployment_id` is an integration identifier, not a secret, and is already intrinsic to the external-tool deployment relationship.
+- No new authorization boundary is introduced because the same users who can request launch details today will continue to do so.
+
+## 13. Testing Strategy
+
+- Extend `test/oli_web/controllers/api/lti_controller_test.exs`:
+  - Authoring `launch_details` asserts `lti_deployment_id` and `lti_message_hint` are present. AC-001.
+  - Delivery `launch_details` asserts the same parity. AC-001.
+  - Add an assertion that `lti_message_hint` is distinct from `login_hint`. AC-001.
+- Extend `test/oli_web/controllers/api/lti_controller_integration_test.exs`:
+  - Authoring response-structure test includes the new keys. AC-001.
+  - Delivery response-structure test includes the new keys. AC-001.
+  - Deep-linking response-structure test includes the new keys alongside `lti_message_type`. AC-003.
+  - Add a parity assertion that `lti_message_hint` is present as a signed token string and that deep-linking changes the token when `lti_message_type` differs. AC-003.
+- Extend launch form tests:
+  - Add unit-level form-rendering assertions for hidden inputs carrying `lti_deployment_id` and `lti_message_hint`. AC-002.
+  - Keep API response-shape assertions and form-rendering assertions separate; do not add backend/frontend integration tests to exercise this behavior end to end.
+  - If React-side unit tests are added for [`LTIExternalToolFrame.tsx`](./assets/src/components/lti/LTIExternalToolFrame.tsx), they are the best place to assert pass-through behavior directly. Otherwise extend [`test/oli_web/components/delivery/lti_external_tools_test.exs`](./test/oli_web/components/delivery/lti_external_tools_test.exs). AC-002.
+- Add a nil-omission unit or controller test:
+  - Construct a launch-details case with a nil optional field and assert the response omits the key instead of returning an empty string. AC-004.
+- Add a derivation helper unit test:
+  - Verify the signed payload includes only the minimal expected launch fields and can be verified with the configured salt. AC-003.
+- Backward-compatibility validation:
+  - Run an existing external-tool launch path and confirm no user-facing behavior change other than the extra hidden inputs. AC-005.
+
+## 14. Backwards Compatibility
+
+- Existing clients that ignore the new keys remain compatible because the response is additive.
+- Existing external tools that ignore optional params continue to receive the same required fields.
+- Existing frontend rendering remains compatible because it already accepts arbitrary launch param keys.
+- No migration or rollout sequencing is needed.
+
+## 15. Risks & Mitigations
+
+- Risk: a vendor expects `lti_message_hint` semantics richer than an opaque correlation string.
+  - Mitigation: choose a message-derived opaque value first; if real integrations prove they need richer semantics, evolve behind the same helper without changing the public endpoint shape.
+- Risk: the signed payload includes too much context and leaks unnecessary metadata if decoded outside Torus.
+  - Mitigation: keep the payload minimal and explicitly exclude user identifiers, roles, and other nonessential fields.
+- Risk: token salt or signing policy changes break stability expectations across endpoints.
+  - Mitigation: isolate issuance in one helper and add unit tests that verify sign/verify behavior with the dedicated salt.
+- Risk: duplicate map assembly persists across endpoints and causes drift.
+  - Mitigation: centralize launch-param construction in one private helper.
+- Risk: tests cover only API payloads and miss actual form pass-through.
+  - Mitigation: add AC-002 form-rendering coverage, not just controller assertions.
+- Risk: a nil deployment id indicates a deeper data issue for a registered tool.
+  - Mitigation: omit the field, keep tests explicit, and treat the nil case as a detectable defect rather than hiding it with an empty string.
+
+## 16. Open Questions & Follow-ups
+
+- No open questions remain for this design.
+- Follow-up: keep `lti_message_hint` token issuance private to `OliWeb.Api.LtiController` unless a new external-tool launch surface is introduced.
+- Follow-up: implement lightweight debug logging around external-tool launch param generation as part of this work item.
+
+## 17. References
+
+- PRD: [prd.md](./docs/exec-plans/current/lti-login-optional-params/prd.md)
+- Requirements: [requirements.yml](./docs/exec-plans/current/lti-login-optional-params/requirements.yml)
+- API controller: [lti_controller.ex](./lib/oli_web/controllers/api/lti_controller.ex)
+- TypeScript contract: [lti_platform.ts](./assets/src/data/persistence/lti_platform.ts)
+- Launch form component: [LTIExternalToolFrame.tsx](./assets/src/components/lti/LTIExternalToolFrame.tsx)
+- Delivery component tests: [lti_external_tools_test.exs](./test/oli_web/components/delivery/lti_external_tools_test.exs)
+- API tests: [lti_controller_test.exs](./test/oli_web/controllers/api/lti_controller_test.exs)
+- API integration tests: [lti_controller_integration_test.exs](./test/oli_web/controllers/api/lti_controller_integration_test.exs)

--- a/docs/exec-plans/current/lti-login-optional-params/informal.md
+++ b/docs/exec-plans/current/lti-login-optional-params/informal.md
@@ -1,0 +1,66 @@
+# Informal Work Summary: External Tool LTI Login Optional Parameter Parity
+
+## Why this work exists
+
+Torus launches third-party LTI 1.3 external tools from authoring and delivery surfaces. Some tools, including VitalSource, expect the platform-initiated login step to include optional parameters that are commonly sent by major LMS platforms such as Canvas.
+
+The ticket specifically calls out these parameters:
+
+- `lti_deployment_id`
+- `lti_message_hint`
+
+These parameters are optional in the standard, but real integrations may still rely on them. When Torus omits them, external tools can reject or mishandle launches even though the core LTI flow is otherwise valid.
+
+## Problem framing
+
+Today, Torus already generates baseline launch parameters for external tool launches, including `iss`, `login_hint`, `client_id`, `target_link_uri`, and `login_url`. The current launch-details payload and UI form-post path do not clearly guarantee parity for the optional login parameters listed above.
+
+That creates an interoperability gap:
+
+- Torus behaves differently from common LMS platforms
+- tool vendors may implicitly treat these fields as required in practice
+- users encounter launch failures against tools that otherwise work in Canvas or similar LMSs
+
+## Desired outcome
+
+Torus should include LMS-parity optional parameters in outbound LTI login requests for external tools wherever Torus has the necessary context to do so, so standards-tolerant but ecosystem-dependent tools continue to work.
+
+At minimum, the resulting behavior should ensure:
+
+- `lti_deployment_id` is supplied for external-tool launches from the deployment record used to register the tool in Torus
+- `lti_message_hint` is supplied for external-tool launches in a stable, tool-consumable, non-sensitive way
+- the launch-details API and HTML form-post path preserve those values without mutating or dropping them
+- missing optional values are handled predictably rather than causing malformed requests
+
+## Scope
+
+In scope:
+
+- outbound LTI login launches from Torus to external tools
+- authoring launch details
+- delivery launch details
+- deep-linking launch details if the same parity expectation applies there
+- regression coverage for API payloads and rendered hidden inputs
+
+Out of scope:
+
+- inbound Torus `/lti/login` launches where Torus acts as the tool for an LMS
+- broader external-tool registration UX changes
+- vendor-specific workarounds beyond sending standards-recognized optional parameters
+- changes to the external tool id-token launch payload unless separately required
+
+## Risks and constraints
+
+- `lti_message_hint` should be useful to the tool without exposing sensitive Torus state in a browser-visible hidden form field.
+- Torus should not send blank or contradictory values for optional params.
+- Authoring, delivery, and deep-linking launch paths should remain internally consistent so one surface does not diverge from another.
+
+## Success signal
+
+An external tool that expects these optional OIDC login parameters should receive them from Torus and launch successfully under the same configuration that works in a mainstream LMS.
+
+## External references
+
+- 1EdTech LTI 1.3 general details: `https://www.imsglobal.org/spec/lti/v1p3#lti-message-general-details`
+- 1EdTech third-party initiated login: `https://www.imsglobal.org/spec/security/v1p0/#step-1-third-party-initiated-login`
+- Chrome LTI Debugger extension: `https://chromewebstore.google.com/detail/lti-debugger/cpjdeioljkbgkldnbojoagdoiggnlhll`

--- a/docs/exec-plans/current/lti-login-optional-params/phase-1-execution.md
+++ b/docs/exec-plans/current/lti-login-optional-params/phase-1-execution.md
@@ -1,0 +1,35 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/lti-login-optional-params`
+Phase: `1`
+
+## Scope from plan.md
+- Establish the shared backend path for optional external-tool login parameter generation.
+- Implement signed `lti_message_hint`, include `lti_deployment_id`, and omit nil optional values.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: Targeted test assertions expected integer `resource_id` values, but the signed token payload carries the request path param as a string.
+- Round 1 fixes: Updated token-verification assertions to use `to_string(activity_id)`.
+- Round 2 findings (optional): None.
+- Round 2 fixes (optional): N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/lti-login-optional-params/phase-2-execution.md
+++ b/docs/exec-plans/current/lti-login-optional-params/phase-2-execution.md
@@ -1,0 +1,35 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/lti-login-optional-params`
+Phase: `2`
+
+## Scope from plan.md
+- Apply the shared builder to project, section, and deep-linking launch-details endpoints.
+- Update the API contract and controller/integration coverage for endpoint parity.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: The second request in the deep-linking parity test lost authenticated user context when recycled.
+- Round 1 fixes: Reused the authenticated connection for both requests and re-ran the targeted suite.
+- Round 2 findings (optional): None.
+- Round 2 fixes (optional): N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/lti-login-optional-params/phase-3-execution.md
+++ b/docs/exec-plans/current/lti-login-optional-params/phase-3-execution.md
@@ -1,0 +1,35 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/lti-login-optional-params`
+Phase: `3`
+
+## Scope from plan.md
+- Prove form pass-through behavior for the new optional params with unit-level rendering tests.
+- Keep omitted optional values from rendering empty hidden inputs.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: The Phoenix launch-form component iterated every launch param entry and would render nil values as empty inputs.
+- Round 1 fixes: Filtered nil values in the component and added rendering assertions for `lti_deployment_id`, `lti_message_hint`, and nil omission.
+- Round 2 findings (optional): None.
+- Round 2 fixes (optional): N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/lti-login-optional-params/phase-4-execution.md
+++ b/docs/exec-plans/current/lti-login-optional-params/phase-4-execution.md
@@ -1,0 +1,35 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/lti-login-optional-params`
+Phase: `4`
+
+## Scope from plan.md
+- Add sanitized debug logging and run final verification for release readiness.
+- Close the work item with compile/test/validation evidence.
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed
+
+## Review Loop
+- Round 1 findings: No additional review-only defects surfaced after targeted tests and compile passed. `harness.yml` was not present, so no repository-mandated harness review round was enabled.
+- Round 1 fixes: N/A.
+- Round 2 findings (optional): None.
+- Round 2 fixes (optional): N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/lti-login-optional-params/plan.md
+++ b/docs/exec-plans/current/lti-login-optional-params/plan.md
@@ -1,0 +1,124 @@
+# LTI Login Optional Params - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/lti-login-optional-params/prd.md`
+- FDD: `docs/exec-plans/current/lti-login-optional-params/fdd.md`
+
+## Scope
+Implement LMS-parity optional LTI login parameters for Torus outbound external-tool launches by adding `lti_deployment_id` and a signed compact `lti_message_hint` to the authoring, delivery, and deep-linking launch-details APIs, preserving pass-through behavior in the launch form, adding lightweight debug logging, and covering the behavior with focused unit and controller tests. The work explicitly excludes inbound Torus-as-tool `/lti/login` behavior and avoids new persistence, feature flags, or backend/frontend integration tests.
+
+## Clarifications & Default Assumptions
+- The authoritative work-item artifacts are [prd.md](./docs/exec-plans/current/lti-login-optional-params/prd.md) and [fdd.md](./docs/exec-plans/current/lti-login-optional-params/fdd.md).
+- `lti_message_hint` is implemented as a compact signed token with minimal launch context and an LTI-specific signing salt.
+- `lti_deployment_id` is sourced from the existing `LtiExternalToolActivityDeployment.deployment_id`.
+- The implementation keeps launch-param assembly server-owned in `OliWeb.Api.LtiController`; no new standalone domain module is required unless a new external-tool launch surface appears later.
+- API response-shape assertions and form-rendering assertions must remain separate unit-level checks; do not add backend/frontend integration tests for this work item.
+- No other external-tool launch surfaces exist today beyond project launch details, section launch details, and section deep-linking launch details.
+- Lightweight debug logging for launch-param issuance is in scope and must not log raw signed token payloads or other sensitive values.
+
+## Phase 1: Backend Launch Param Builder
+- Goal: Establish the shared backend path for optional external-tool login parameter generation.
+- Tasks:
+  - [ ] Add a private launch-param builder in `OliWeb.Api.LtiController` that centralizes authoring, delivery, and deep-linking param assembly.
+  - [ ] Add signed `lti_message_hint` issuance with a dedicated LTI-specific salt and minimal launch-context payload.
+  - [ ] Add `lti_deployment_id` to the shared builder from the resolved external-tool deployment row.
+  - [ ] Ensure the builder omits nil optional values instead of returning empty strings.
+  - [ ] Keep deep-linking-specific extras such as `lti_message_type` composable through the shared builder.
+- Testing Tasks:
+  - [ ] Add unit-level coverage for the token issuance helper, including sign/verify behavior and minimal payload assertions.
+  - [ ] Add focused backend assertions for nil omission behavior in the shared builder or controller boundary.
+  - [ ] Run targeted backend tests for the controller module or helper extraction point.
+  - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs`, `mix format`
+- Definition of Done:
+  - One backend path exists for composing external-tool launch params across all in-scope endpoints.
+  - Signed `lti_message_hint` generation and `lti_deployment_id` inclusion satisfy `FR-001`, `FR-002`, and `FR-005`.
+  - Nil optional fields are omitted rather than serialized as blank values, covering `AC-004`.
+- Gate:
+  - No response-contract or logging work proceeds until the shared builder and signed token issuance are implemented and testable.
+- Dependencies:
+  - None.
+- Parallelizable Work:
+  - `lti_message_hint` signing helper work and `lti_deployment_id` builder wiring can proceed in parallel once the shared builder shape is agreed.
+
+## Phase 2: API Contract And Endpoint Parity
+- Goal: Apply the shared builder to all in-scope launch-details endpoints and lock the API contract with tests.
+- Tasks:
+  - [ ] Refactor project `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
+  - [ ] Refactor section `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
+  - [ ] Refactor `deep_linking_launch_details` to use the shared builder while preserving `lti_message_type: "LtiDeepLinkingRequest"`.
+  - [ ] Update `assets/src/data/persistence/lti_platform.ts` so the launch-details contract includes the optional fields.
+  - [ ] Confirm the signed token differs from `login_hint` and changes appropriately for deep-linking context.
+- Testing Tasks:
+  - [ ] Extend `test/oli_web/controllers/api/lti_controller_test.exs` for authoring and delivery launch details to assert `lti_deployment_id` and `lti_message_hint` presence plus `lti_message_hint != login_hint`.
+  - [ ] Extend `test/oli_web/controllers/api/lti_controller_integration_test.exs` for authoring, delivery, and deep-linking response shape to include the new keys.
+  - [ ] Add deep-linking parity assertions showing the signed token changes when `lti_message_type` differs.
+  - [ ] Run targeted API controller and integration tests.
+  - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs`, `mix format`
+- Definition of Done:
+  - All three in-scope launch-details endpoints return consistent optional login params through one contract.
+  - The TypeScript contract matches the backend response shape.
+  - API coverage satisfies `FR-003`, `AC-001`, and `AC-003`.
+- Gate:
+  - No form-rendering signoff occurs until all three API endpoints are aligned and controller tests are green.
+- Dependencies:
+  - Phase 1.
+- Parallelizable Work:
+  - TypeScript type updates can proceed in parallel with controller test additions after the response shape is fixed.
+
+## Phase 3: Form Pass-Through And Rendering Tests
+- Goal: Prove the client-side launch form preserves the new optional params without adding end-to-end integration coupling.
+- Tasks:
+  - [ ] Add unit-level form-rendering assertions for hidden inputs carrying `lti_deployment_id` and `lti_message_hint`.
+  - [ ] Keep form pass-through testing isolated from API response tests; do not wire backend and frontend together for a single integration assertion.
+  - [ ] If practical, add React-side unit tests for `LTIExternalToolFrame.tsx`; otherwise extend the Phoenix component tests as the repository-native alternative.
+  - [ ] Confirm `login_url` remains excluded from hidden-input rendering while the new optional params are included when present.
+- Testing Tasks:
+  - [ ] Extend [lti_external_tools_test.exs](./test/oli_web/components/delivery/lti_external_tools_test.exs) or add equivalent unit-level component coverage for hidden input rendering.
+  - [ ] Add a negative assertion showing omitted optional params do not render empty hidden inputs.
+  - [ ] Run the chosen unit test module(s) for launch form rendering.
+  - Command(s): `mix test test/oli_web/components/delivery/lti_external_tools_test.exs`, `mix format`
+- Definition of Done:
+  - Form-rendering tests prove pass-through behavior for `lti_deployment_id` and `lti_message_hint`.
+  - The repository has unit-level coverage for AC-002 without introducing backend/frontend integration tests.
+- Gate:
+  - No final observability or manual QA signoff until form pass-through behavior is explicitly covered by unit tests.
+- Dependencies:
+  - Phase 2.
+- Parallelizable Work:
+  - React-side unit-test exploration and Phoenix component-test extension are alternative implementation paths; choose one, do not do both unless needed.
+
+## Phase 4: Observability, Verification, And Release Readiness
+- Goal: Finalize lightweight debug logging, run manual verification, and confirm the change is ready for implementation signoff.
+- Tasks:
+  - [ ] Add lightweight debug logging around external-tool launch param generation for project, section, and deep-linking launch paths.
+  - [ ] Ensure logs confirm whether `lti_deployment_id` and `lti_message_hint` were issued without logging raw signed token payloads or other sensitive values.
+  - [ ] Review the final touched files for consistency with the signed-token design and absence of hidden frontend mutation.
+  - [ ] Reconcile any implementation drift back into the work-item docs if needed.
+- Testing Tasks:
+  - [ ] Add or finalize assertions for the logging behavior where practical without over-coupling tests to log text.
+  - [ ] Run the targeted controller and component test suite for this work item together.
+  - [ ] Run compile and formatting gates for touched backend and frontend files.
+  - [ ] Perform manual verification of an external-tool launch and inspect the outbound login request with browser tools or an LTI debugger.
+  - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs test/oli_web/components/delivery/lti_external_tools_test.exs`, `mix compile`, `mix format`
+- Definition of Done:
+  - Lightweight debug logging exists and is sanitized.
+  - Targeted automated tests are green and manual verification confirms the outbound login request includes `lti_deployment_id` and `lti_message_hint`.
+  - Final verification satisfies `AC-002` and `AC-005` alongside the earlier controller-coverage criteria.
+- Gate:
+  - Final signoff requires green targeted tests, sanitized logging, and successful manual verification of the outbound external-tool login request.
+- Dependencies:
+  - Phases 1 through 3.
+- Parallelizable Work:
+  - Logging work and manual-verification prep can proceed in parallel once endpoint behavior and form rendering are stable.
+
+## Parallelization Notes
+- In Phase 1, shared builder wiring and signed-token helper work are safe to split if both agree on the helper interface and token payload contract.
+- In Phase 2, API test updates and TypeScript response-type updates can proceed in parallel once the response shape is fixed.
+- In Phase 3, choose either React-side unit tests or Phoenix component-test extension for AC-002; both are not required to meet the plan.
+- Phase 4 logging work can overlap with final manual-verification prep, but final signoff must wait for targeted automated tests and sanitized logging review.
+
+## Phase Gate Summary
+- Gate A: shared backend builder, signed `lti_message_hint` issuance, and nil omission must be implemented and unit-tested before endpoint parity work proceeds.
+- Gate B: project, section, and deep-linking launch-details endpoints must all emit the new optional params through a consistent contract.
+- Gate C: unit-level form-rendering coverage must prove pass-through behavior without backend/frontend integration tests.
+- Gate D: sanitized debug logging, green targeted tests, and manual verification of the outbound login request are required for final signoff.

--- a/docs/exec-plans/current/lti-login-optional-params/plan.md
+++ b/docs/exec-plans/current/lti-login-optional-params/plan.md
@@ -19,15 +19,15 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
 ## Phase 1: Backend Launch Param Builder
 - Goal: Establish the shared backend path for optional external-tool login parameter generation.
 - Tasks:
-  - [ ] Add a private launch-param builder in `OliWeb.Api.LtiController` that centralizes authoring, delivery, and deep-linking param assembly.
-  - [ ] Add signed `lti_message_hint` issuance with a dedicated LTI-specific salt and minimal launch-context payload.
-  - [ ] Add `lti_deployment_id` to the shared builder from the resolved external-tool deployment row.
-  - [ ] Ensure the builder omits nil optional values instead of returning empty strings.
-  - [ ] Keep deep-linking-specific extras such as `lti_message_type` composable through the shared builder.
+  - [x] Add a private launch-param builder in `OliWeb.Api.LtiController` that centralizes authoring, delivery, and deep-linking param assembly.
+  - [x] Add signed `lti_message_hint` issuance with a dedicated LTI-specific salt and minimal launch-context payload.
+  - [x] Add `lti_deployment_id` to the shared builder from the resolved external-tool deployment row.
+  - [x] Ensure the builder omits nil optional values instead of returning empty strings.
+  - [x] Keep deep-linking-specific extras such as `lti_message_type` composable through the shared builder.
 - Testing Tasks:
-  - [ ] Add unit-level coverage for the token issuance helper, including sign/verify behavior and minimal payload assertions.
-  - [ ] Add focused backend assertions for nil omission behavior in the shared builder or controller boundary.
-  - [ ] Run targeted backend tests for the controller module or helper extraction point.
+  - [x] Add unit-level coverage for the token issuance helper, including sign/verify behavior and minimal payload assertions.
+  - [x] Add focused backend assertions for nil omission behavior in the shared builder or controller boundary.
+  - [x] Run targeted backend tests for the controller module or helper extraction point.
   - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs`, `mix format`
 - Definition of Done:
   - One backend path exists for composing external-tool launch params across all in-scope endpoints.
@@ -43,16 +43,16 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
 ## Phase 2: API Contract And Endpoint Parity
 - Goal: Apply the shared builder to all in-scope launch-details endpoints and lock the API contract with tests.
 - Tasks:
-  - [ ] Refactor project `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
-  - [ ] Refactor section `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
-  - [ ] Refactor `deep_linking_launch_details` to use the shared builder while preserving `lti_message_type: "LtiDeepLinkingRequest"`.
-  - [ ] Update `assets/src/data/persistence/lti_platform.ts` so the launch-details contract includes the optional fields.
-  - [ ] Confirm the signed token differs from `login_hint` and changes appropriately for deep-linking context.
+  - [x] Refactor project `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
+  - [x] Refactor section `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
+  - [x] Refactor `deep_linking_launch_details` to use the shared builder while preserving `lti_message_type: "LtiDeepLinkingRequest"`.
+  - [x] Update `assets/src/data/persistence/lti_platform.ts` so the launch-details contract includes the optional fields.
+  - [x] Confirm the signed token differs from `login_hint` and changes appropriately for deep-linking context.
 - Testing Tasks:
-  - [ ] Extend `test/oli_web/controllers/api/lti_controller_test.exs` for authoring and delivery launch details to assert `lti_deployment_id` and `lti_message_hint` presence plus `lti_message_hint != login_hint`.
-  - [ ] Extend `test/oli_web/controllers/api/lti_controller_integration_test.exs` for authoring, delivery, and deep-linking response shape to include the new keys.
-  - [ ] Add deep-linking parity assertions showing the signed token changes when `lti_message_type` differs.
-  - [ ] Run targeted API controller and integration tests.
+  - [x] Extend `test/oli_web/controllers/api/lti_controller_test.exs` for authoring and delivery launch details to assert `lti_deployment_id` and `lti_message_hint` presence plus `lti_message_hint != login_hint`.
+  - [x] Extend `test/oli_web/controllers/api/lti_controller_integration_test.exs` for authoring, delivery, and deep-linking response shape to include the new keys.
+  - [x] Add deep-linking parity assertions showing the signed token changes when `lti_message_type` differs.
+  - [x] Run targeted API controller and integration tests.
   - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs`, `mix format`
 - Definition of Done:
   - All three in-scope launch-details endpoints return consistent optional login params through one contract.
@@ -68,14 +68,14 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
 ## Phase 3: Form Pass-Through And Rendering Tests
 - Goal: Prove the client-side launch form preserves the new optional params without adding end-to-end integration coupling.
 - Tasks:
-  - [ ] Add unit-level form-rendering assertions for hidden inputs carrying `lti_deployment_id` and `lti_message_hint`.
-  - [ ] Keep form pass-through testing isolated from API response tests; do not wire backend and frontend together for a single integration assertion.
-  - [ ] If practical, add React-side unit tests for `LTIExternalToolFrame.tsx`; otherwise extend the Phoenix component tests as the repository-native alternative.
-  - [ ] Confirm `login_url` remains excluded from hidden-input rendering while the new optional params are included when present.
+  - [x] Add unit-level form-rendering assertions for hidden inputs carrying `lti_deployment_id` and `lti_message_hint`.
+  - [x] Keep form pass-through testing isolated from API response tests; do not wire backend and frontend together for a single integration assertion.
+  - [x] If practical, add React-side unit tests for `LTIExternalToolFrame.tsx`; otherwise extend the Phoenix component tests as the repository-native alternative.
+  - [x] Confirm `login_url` remains excluded from hidden-input rendering while the new optional params are included when present.
 - Testing Tasks:
-  - [ ] Extend [lti_external_tools_test.exs](./test/oli_web/components/delivery/lti_external_tools_test.exs) or add equivalent unit-level component coverage for hidden input rendering.
-  - [ ] Add a negative assertion showing omitted optional params do not render empty hidden inputs.
-  - [ ] Run the chosen unit test module(s) for launch form rendering.
+  - [x] Extend [lti_external_tools_test.exs](./test/oli_web/components/delivery/lti_external_tools_test.exs) or add equivalent unit-level component coverage for hidden input rendering.
+  - [x] Add a negative assertion showing omitted optional params do not render empty hidden inputs.
+  - [x] Run the chosen unit test module(s) for launch form rendering.
   - Command(s): `mix test test/oli_web/components/delivery/lti_external_tools_test.exs`, `mix format`
 - Definition of Done:
   - Form-rendering tests prove pass-through behavior for `lti_deployment_id` and `lti_message_hint`.
@@ -90,14 +90,14 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
 ## Phase 4: Observability, Verification, And Release Readiness
 - Goal: Finalize lightweight debug logging, run manual verification, and confirm the change is ready for implementation signoff.
 - Tasks:
-  - [ ] Add lightweight debug logging around external-tool launch param generation for project, section, and deep-linking launch paths.
-  - [ ] Ensure logs confirm whether `lti_deployment_id` and `lti_message_hint` were issued without logging raw signed token payloads or other sensitive values.
-  - [ ] Review the final touched files for consistency with the signed-token design and absence of hidden frontend mutation.
-  - [ ] Reconcile any implementation drift back into the work-item docs if needed.
+  - [x] Add lightweight debug logging around external-tool launch param generation for project, section, and deep-linking launch paths.
+  - [x] Ensure logs confirm whether `lti_deployment_id` and `lti_message_hint` were issued without logging raw signed token payloads or other sensitive values.
+  - [x] Review the final touched files for consistency with the signed-token design and absence of hidden frontend mutation.
+  - [x] Reconcile any implementation drift back into the work-item docs if needed.
 - Testing Tasks:
   - [ ] Add or finalize assertions for the logging behavior where practical without over-coupling tests to log text.
-  - [ ] Run the targeted controller and component test suite for this work item together.
-  - [ ] Run compile and formatting gates for touched backend and frontend files.
+  - [x] Run the targeted controller and component test suite for this work item together.
+  - [x] Run compile and formatting gates for touched backend and frontend files.
   - [ ] Perform manual verification of an external-tool launch and inspect the outbound login request with browser tools or an LTI debugger.
   - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs test/oli_web/components/delivery/lti_external_tools_test.exs`, `mix compile`, `mix format`
 - Definition of Done:

--- a/docs/exec-plans/current/lti-login-optional-params/plan.md
+++ b/docs/exec-plans/current/lti-login-optional-params/plan.md
@@ -1,13 +1,16 @@
 # LTI Login Optional Params - Delivery Plan
 
 Scope and reference artifacts:
+
 - PRD: `docs/exec-plans/current/lti-login-optional-params/prd.md`
 - FDD: `docs/exec-plans/current/lti-login-optional-params/fdd.md`
 
 ## Scope
+
 Implement LMS-parity optional LTI login parameters for Torus outbound external-tool launches by adding `lti_deployment_id` and a signed compact `lti_message_hint` to the authoring, delivery, and deep-linking launch-details APIs, preserving pass-through behavior in the launch form, adding lightweight debug logging, and covering the behavior with focused unit and controller tests. The work explicitly excludes inbound Torus-as-tool `/lti/login` behavior and avoids new persistence, feature flags, or backend/frontend integration tests.
 
 ## Clarifications & Default Assumptions
+
 - The authoritative work-item artifacts are [prd.md](./docs/exec-plans/current/lti-login-optional-params/prd.md) and [fdd.md](./docs/exec-plans/current/lti-login-optional-params/fdd.md).
 - `lti_message_hint` is implemented as a compact signed token with minimal launch context and an LTI-specific signing salt.
 - `lti_deployment_id` is sourced from the existing `LtiExternalToolActivityDeployment.deployment_id`.
@@ -17,6 +20,7 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
 - Lightweight debug logging for launch-param issuance is in scope and must not log raw signed token payloads or other sensitive values.
 
 ## Phase 1: Backend Launch Param Builder
+
 - Goal: Establish the shared backend path for optional external-tool login parameter generation.
 - Tasks:
   - [x] Add a private launch-param builder in `OliWeb.Api.LtiController` that centralizes authoring, delivery, and deep-linking param assembly.
@@ -41,6 +45,7 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
   - `lti_message_hint` signing helper work and `lti_deployment_id` builder wiring can proceed in parallel once the shared builder shape is agreed.
 
 ## Phase 2: API Contract And Endpoint Parity
+
 - Goal: Apply the shared builder to all in-scope launch-details endpoints and lock the API contract with tests.
 - Tasks:
   - [x] Refactor project `launch_details` to use the shared builder and include `lti_deployment_id` plus `lti_message_hint`.
@@ -66,6 +71,7 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
   - TypeScript type updates can proceed in parallel with controller test additions after the response shape is fixed.
 
 ## Phase 3: Form Pass-Through And Rendering Tests
+
 - Goal: Prove the client-side launch form preserves the new optional params without adding end-to-end integration coupling.
 - Tasks:
   - [x] Add unit-level form-rendering assertions for hidden inputs carrying `lti_deployment_id` and `lti_message_hint`.
@@ -88,6 +94,7 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
   - React-side unit-test exploration and Phoenix component-test extension are alternative implementation paths; choose one, do not do both unless needed.
 
 ## Phase 4: Observability, Verification, And Release Readiness
+
 - Goal: Finalize lightweight debug logging, run manual verification, and confirm the change is ready for implementation signoff.
 - Tasks:
   - [x] Add lightweight debug logging around external-tool launch param generation for project, section, and deep-linking launch paths.
@@ -95,10 +102,10 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
   - [x] Review the final touched files for consistency with the signed-token design and absence of hidden frontend mutation.
   - [x] Reconcile any implementation drift back into the work-item docs if needed.
 - Testing Tasks:
-  - [ ] Add or finalize assertions for the logging behavior where practical without over-coupling tests to log text.
+  - [x] Add or finalize assertions for the logging behavior where practical without over-coupling tests to log text.
   - [x] Run the targeted controller and component test suite for this work item together.
   - [x] Run compile and formatting gates for touched backend and frontend files.
-  - [ ] Perform manual verification of an external-tool launch and inspect the outbound login request with browser tools or an LTI debugger.
+  - [x] Perform manual verification of an external-tool launch and inspect the outbound login request with browser tools or an LTI debugger.
   - Command(s): `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs test/oli_web/components/delivery/lti_external_tools_test.exs`, `mix compile`, `mix format`
 - Definition of Done:
   - Lightweight debug logging exists and is sanitized.
@@ -112,12 +119,14 @@ Implement LMS-parity optional LTI login parameters for Torus outbound external-t
   - Logging work and manual-verification prep can proceed in parallel once endpoint behavior and form rendering are stable.
 
 ## Parallelization Notes
+
 - In Phase 1, shared builder wiring and signed-token helper work are safe to split if both agree on the helper interface and token payload contract.
 - In Phase 2, API test updates and TypeScript response-type updates can proceed in parallel once the response shape is fixed.
 - In Phase 3, choose either React-side unit tests or Phoenix component-test extension for AC-002; both are not required to meet the plan.
 - Phase 4 logging work can overlap with final manual-verification prep, but final signoff must wait for targeted automated tests and sanitized logging review.
 
 ## Phase Gate Summary
+
 - Gate A: shared backend builder, signed `lti_message_hint` issuance, and nil omission must be implemented and unit-tested before endpoint parity work proceeds.
 - Gate B: project, section, and deep-linking launch-details endpoints must all emit the new optional params through a consistent contract.
 - Gate C: unit-level form-rendering coverage must prove pass-through behavior without backend/frontend integration tests.

--- a/docs/exec-plans/current/lti-login-optional-params/prd.md
+++ b/docs/exec-plans/current/lti-login-optional-params/prd.md
@@ -1,0 +1,105 @@
+# LTI Login Optional Params - Product Requirements Document
+
+## 1. Overview
+
+Add LMS-parity optional parameters to Torus outbound LTI 1.3 external-tool login requests so third-party tools that expect common Canvas-style login inputs can launch successfully from Torus. The scope is limited to Torus acting as the platform for external tools and covers the launch-details API plus the browser form-post path that submits those values to the external tool.
+
+## 2. Background & Problem Statement
+
+Torus currently launches external LTI tools by generating a launch-details payload that includes the core OIDC login fields required to start a tool launch. Some vendors, including VitalSource, also expect optional parameters that many LMS platforms send in practice, specifically `lti_deployment_id` and `lti_message_hint`.
+
+Although these fields are optional in the specification, omitting them creates an interoperability gap between Torus and mainstream LMS behavior. A tool that works when launched from Canvas may fail or degrade when launched from Torus because Torus does not provide the same optional login context. The result is avoidable launch failures for instructors and learners using external tools.
+
+## 3. Goals & Non-Goals
+### Goals
+- Send `lti_deployment_id` in outbound external-tool login requests whenever Torus has a registered deployment for the tool launch.
+- Send `lti_message_hint` in outbound external-tool login requests in a stable, non-sensitive form that tools can consume.
+- Keep authoring, delivery, and deep-linking launch-details responses aligned so the same external tool receives consistent login inputs across Torus surfaces.
+- Preserve pass-through behavior from the server-generated launch-details payload through the rendered HTML form submission.
+- Add regression coverage that proves the optional parameters are present when expected and absent only when context is genuinely unavailable.
+
+### Non-Goals
+- Redesign inbound `/lti/login` behavior where Torus is launched as the tool by another LMS.
+- Add vendor-specific launch branches or per-tool custom behavior beyond standards-recognized optional fields.
+- Change the external tool registration UX or introduce new admin configuration fields unless implementation proves an existing field is missing.
+- Redesign the id-token claims sent later in the external tool launch unless separately required by implementation.
+
+## 4. Users & Use Cases
+- Learners: open a course resource backed by an external tool and complete the launch without vendor-side rejection caused by missing optional login params.
+- Instructors: preview and use external tools in delivery or authoring without seeing behavior differences versus a common LMS such as Canvas.
+- Administrators configuring tools: register a tool once in Torus and expect launches to include the same practical login context that commercial LMS platforms usually provide.
+- Support and engineering staff: diagnose external-tool launch issues without chasing false negatives caused by Torus omitting common optional login fields.
+
+## 5. UX / UI Requirements
+- External tool launch UX must remain unchanged apart from improved launch compatibility.
+- Hidden form fields used to submit launch parameters must reflect the server-generated launch-details payload exactly for the supported optional params.
+- If an optional param is unavailable, the client should omit it rather than rendering an empty or misleading hidden field.
+- No new visible controls, prompts, or user education surfaces are required for this work item.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+- Reliability: authoring, delivery, and deep-linking launch paths must produce consistent optional-param behavior for the same external tool configuration.
+- Security: `lti_message_hint` must not expose sensitive internal Torus state, raw session identifiers, or privileged data through browser-visible form fields.
+- Maintainability: optional-param generation should live at the server boundary where launch params are assembled, not as ad hoc frontend mutation.
+- Compatibility: the additional parameters must remain compatible with existing tools that ignore them.
+- Performance: generating and returning the new optional params must not materially change launch-details latency.
+
+## 9. Data, Interfaces & Dependencies
+- The primary server boundary is [`lib/oli_web/controllers/api/lti_controller.ex`](./lib/oli_web/controllers/api/lti_controller.ex).
+- The main client pass-through boundary is [`assets/src/components/lti/LTIExternalToolFrame.tsx`](./assets/src/components/lti/LTIExternalToolFrame.tsx).
+- Type definitions for launch-details responses live in [`assets/src/data/persistence/lti_platform.ts`](./assets/src/data/persistence/lti_platform.ts).
+- The external tool deployment model already has a deployment identifier through [`lib/oli/lti/platform_external_tools/lti_external_tool_activity_deployment.ex`](./lib/oli/lti/platform_external_tools/lti_external_tool_activity_deployment.ex).
+- Torus depends on `Lti_1p3.Platform.LoginHints` for `login_hint`; this work may reuse that context or introduce a separate opaque hint value for `lti_message_hint`.
+
+## 10. Repository & Platform Considerations
+- Torus is a Phoenix application with React clients, so launch-param assembly should remain server-owned and the frontend should only render and submit what the API returns.
+- Existing API coverage in [`test/oli_web/controllers/api/lti_controller_test.exs`](./test/oli_web/controllers/api/lti_controller_test.exs) should be extended rather than creating only manual verification.
+- Existing component coverage around hidden launch fields should be extended where practical to prove optional-param rendering remains correct.
+- The harness contract files named by the skill were not present in this repository, so this PRD is grounded in the available Torus code, tests, repo instructions, and current work-item patterns.
+
+## 11. Feature Flagging, Rollout & Migration
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+- Primary success signal: affected external tools launch successfully from Torus without requiring vendor-specific exceptions.
+- Manual verification should confirm the outbound login POST includes `lti_deployment_id` and `lti_message_hint` when inspected with an LTI debugging tool or browser tools.
+- No new product telemetry is required unless implementation introduces a new failure mode that needs observability.
+
+## 13. Risks & Mitigations
+- Risk: `lti_message_hint` is populated with sensitive or unstable data. Mitigation: require an opaque, non-sensitive value and keep generation server-owned.
+- Risk: one Torus launch surface includes the optional params while another omits them. Mitigation: define parity requirements across authoring, delivery, and deep-linking responses.
+- Risk: adding fields to the API response breaks strict frontend typing or assumptions. Mitigation: update TypeScript response types and regression tests together.
+- Risk: tools react poorly to empty optional params. Mitigation: omit unavailable values rather than sending blank strings.
+
+## 14. Open Questions & Assumptions
+### Open Questions
+- What exact value should Torus use for `lti_message_hint` so it is both useful to tools and safely opaque from Torus’s perspective?
+- Should deep-linking launches always include the same optional params as regular resource-link launches, or only when the external tool expects them for that message type?
+- Are there existing external tool integrations besides VitalSource that require these params and should be called out in manual QA?
+
+### Assumptions
+- Torus can derive `lti_deployment_id` for external-tool launches from the deployment record associated with the activity registration.
+- Tools that rely on these params will accept Torus-provided values as long as the fields are present and structurally valid.
+- Adding optional params to the launch-details payload is backward compatible for tools that ignore them.
+- The current hidden form-post launch path remains the correct submission mechanism for this work.
+
+## 15. QA Plan
+- Automated validation:
+  - Extend API controller tests to assert `lti_deployment_id` and `lti_message_hint` are present in authoring and delivery launch-details responses when available.
+  - Add or extend deep-linking launch-details tests if that path is expected to include the same optional params.
+  - Extend component tests to confirm the launch form renders hidden inputs for the optional params and omits empty values.
+  - Verify updated TypeScript types compile against the expanded launch-details payload.
+- Manual validation:
+  - Launch an affected external tool such as VitalSource from a Torus section and confirm the login request contains both optional params.
+  - Use an LTI debugging tool or browser network inspection to confirm the submitted POST matches the server-generated launch params.
+  - Verify a tool that ignores the optional params still launches successfully.
+
+## 16. Definition of Done
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/lti-login-optional-params/requirements.yml
+++ b/docs/exec-plans/current/lti-login-optional-params/requirements.yml
@@ -1,0 +1,39 @@
+work_item: lti-login-optional-params
+requirements:
+- title: Torus shall include `lti_deployment_id` in outbound LTI external-tool login
+    parameters for launches backed by a registered tool deployment.
+  id: FR-001
+- title: Torus shall include `lti_message_hint` in outbound LTI external-tool login
+    parameters as an opaque, non-sensitive value that external tools can consume.
+  id: FR-002
+- title: Torus shall expose the optional login parameters consistently through authoring,
+    delivery, and any supported deep-linking launch-details responses for the same
+    external tool launch context.
+  id: FR-003
+- title: Torus shall preserve server-generated optional login parameters unchanged
+    through the client launch form submission path.
+  id: FR-004
+- title: Torus shall omit unsupported optional parameters rather than sending blank
+    or misleading values.
+  id: FR-005
+acceptance_criteria:
+- title: Given a registered external tool deployment is launched from authoring or
+    delivery, when Torus returns launch details, then the payload includes `lti_deployment_id`
+    and `lti_message_hint` alongside the existing login parameters.
+  id: AC-001
+- title: Given an external tool launch form is rendered from launch details that include
+    optional params, when the browser submits the form, then hidden inputs for `lti_deployment_id`
+    and `lti_message_hint` are present with the same values returned by the server.
+  id: AC-002
+- title: Given a supported deep-linking launch uses the same external tool registration,
+    when Torus returns deep-linking launch details, then optional login-param behavior
+    matches the defined parity rules for this work item.
+  id: AC-003
+- title: Given an optional param cannot be derived for a specific launch context,
+    when Torus prepares launch details, then that param is omitted rather than sent
+    as an empty string.
+  id: AC-004
+- title: Given an external tool ignores optional login params, when Torus adds `lti_deployment_id`
+    and `lti_message_hint`, then the launch still succeeds without requiring any user-facing
+    flow changes.
+  id: AC-005

--- a/docs/exec-plans/current/module-level-log-controls/fdd.md
+++ b/docs/exec-plans/current/module-level-log-controls/fdd.md
@@ -23,8 +23,8 @@ Extend the existing admin feature page at `/admin/features` to support a new loc
 ## 3. Repository Context Summary
 
 - What we know:
-  - The current admin page is [lib/oli_web/live/features/features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) and already exposes a global Logger level control through `Logger.configure/1`.
-  - The route already exists at [lib/oli_web/router.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/router.ex) and should not need a new entry point.
+  - The current admin page is [lib/oli_web/live/features/features_live.ex](./lib/oli_web/live/features/features_live.ex) and already exposes a global Logger level control through `Logger.configure/1`.
+  - The route already exists at [lib/oli_web/router.ex](./lib/oli_web/router.ex) and should not need a new entry point.
   - No existing repository abstraction for runtime log overrides was found, so a new small backend module is warranted.
 - Unknowns to confirm:
   - Whether any existing admin audit mechanism should be reused directly or if normal Logger output plus flash feedback is sufficient for first delivery.
@@ -65,7 +65,7 @@ Extend the existing admin feature page at `/admin/features` to support a new loc
 - `Oli.RuntimeLogOverrides` owns validation, Logger API calls, target resolution, and local active override tracking.
 - A small supervised process should own the active override registry.
   - Preferred implementation: a named GenServer backed by a simple map keyed by `{:module, module}`.
-  - This process is local to the node and started under [lib/oli/application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
+  - This process is local to the node and started under [lib/oli/application.ex](./lib/oli/application.ex).
 
 ### 4.4 Alternatives Considered
 
@@ -175,10 +175,10 @@ Extend the existing admin feature page at `/admin/features` to support a new loc
 
 ## 17. References
 
-- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/module-level-log-controls/prd.md)
-- [requirements.yml](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/module-level-log-controls/requirements.yml)
-- [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex)
-- [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex)
+- [prd.md](./docs/exec-plans/current/module-level-log-controls/prd.md)
+- [requirements.yml](./docs/exec-plans/current/module-level-log-controls/requirements.yml)
+- [features_live.ex](./lib/oli_web/live/features/features_live.ex)
+- [application.ex](./lib/oli/application.ex)
 - [Logger.put_module_level/2 docs](https://hexdocs.pm/logger/Logger.html#put_module_level/2)
 
 ### AC Reference Index

--- a/docs/exec-plans/current/module-level-log-controls/plan.md
+++ b/docs/exec-plans/current/module-level-log-controls/plan.md
@@ -29,7 +29,7 @@ Check off the task checkboxes as tasks are completed, and update the status of e
   - [x] Add a new runtime override service module, proposed as `Oli.RuntimeLogOverrides`, under `lib/oli/`.
   - [x] Implement level validation, module-name parsing, and safe existing-module resolution for module-level overrides. [AC-001] [AC-004]
   - [x] Implement `set_module_level/2`, `clear_module_level/1`, and `list_overrides/0` APIs. [AC-001] [AC-005] [AC-006]
-  - [x] Add a supervised local registry process for active overrides and wire it into [application.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/application.ex).
+  - [x] Add a supervised local registry process for active overrides and wire it into [application.ex](./lib/oli/application.ex).
   - [x] Ensure global Logger level remains unchanged when a module override is applied. [AC-002]
   - [x] Add operational Logger entries for successful and failed module override actions.
 - Testing Tasks:
@@ -51,7 +51,7 @@ Check off the task checkboxes as tasks are completed, and update the status of e
 
 - Goal: Add module override controls to `FeaturesLive` without regressing current admin functionality.
 - Tasks:
-  - [x] Extend [features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) with a module-level override form section.
+  - [x] Extend [features_live.ex](./lib/oli_web/live/features/features_live.ex) with a module-level override form section.
   - [x] Add LiveView event handlers that delegate all runtime override mutations to `Oli.RuntimeLogOverrides`.
   - [x] Render current local override state and clear actions. [AC-005]
   - [x] Preserve the existing global log-level control and scoped feature flag sections.

--- a/docs/exec-plans/current/module-level-log-controls/prd.md
+++ b/docs/exec-plans/current/module-level-log-controls/prd.md
@@ -69,7 +69,7 @@ Requirements are found in requirements.yml
 - Tests should cover authorization, validation, success paths, and clearing behavior using ExUnit and relevant Phoenix web tests.
 - The code should preserve the repo's Elixir conventions, including clear control flow and minimal nesting.
 - The work should not require direct shell access for normal use after delivery.
-- The correct home for this control is the existing [lib/oli_web/live/features/features_live.ex](/Users/eliknebel/Developer/oli-torus/lib/oli_web/live/features/features_live.ex) admin page.
+- The correct home for this control is the existing [lib/oli_web/live/features/features_live.ex](./lib/oli_web/live/features/features_live.ex) admin page.
 
 ## 11. Feature Flagging, Rollout & Migration
 

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md
@@ -27,10 +27,10 @@ This design satisfies `FR-002` through `FR-009` and directly implements `AC-001`
 ## 3. Repository Context Summary
 
 - What we know:
-  - [cached_key_provider.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/cached_key_provider.ex) currently schedules Oban refresh and fails immediately on `:keyset_not_cached` and `:key_not_found`.
-  - [keyset_cache.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_cache.ex) stores `%{keys, fetched_at, expires_at}` in ETS and exposes warm-path lookup APIs that are already suitable for the success path.
-  - [keyset_refresh_worker.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_refresh_worker.ex) already encapsulates HTTPS validation, HTTP fetch, JWKS parsing, TTL extraction, and cache population for asynchronous refresh.
-  - Existing tests in [cached_key_provider_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/cached_key_provider_test.exs), [keyset_cache_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_cache_test.exs), and [keyset_refresh_worker_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_refresh_worker_test.exs) already cover most of the current seams.
+  - [cached_key_provider.ex](./lib/oli/lti/cached_key_provider.ex) currently schedules Oban refresh and fails immediately on `:keyset_not_cached` and `:key_not_found`.
+  - [keyset_cache.ex](./lib/oli/lti/keyset_cache.ex) stores `%{keys, fetched_at, expires_at}` in ETS and exposes warm-path lookup APIs that are already suitable for the success path.
+  - [keyset_refresh_worker.ex](./lib/oli/lti/keyset_refresh_worker.ex) already encapsulates HTTPS validation, HTTP fetch, JWKS parsing, TTL extraction, and cache population for asynchronous refresh.
+  - Existing tests in [cached_key_provider_test.exs](./test/oli/lti/cached_key_provider_test.exs), [keyset_cache_test.exs](./test/oli/lti/keyset_cache_test.exs), and [keyset_refresh_worker_test.exs](./test/oli/lti/keyset_refresh_worker_test.exs) already cover most of the current seams.
 - Unknowns to confirm:
   - Whether any `lti_1p3` caller logic assumes the current specific `reason` atoms for cache miss failure.
   - Whether operator tooling or dashboards currently parse the existing log strings and need compatibility-preserving message keys.
@@ -274,10 +274,10 @@ This design satisfies `FR-002` through `FR-009` and directly implements `AC-001`
 
 ## 17. References
 
-- [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md)
-- [requirements.yml](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements.yml)
-- [cached_key_provider.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/cached_key_provider.ex)
-- [keyset_cache.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_cache.ex)
-- [keyset_refresh_worker.ex](/Users/eliknebel/Developer/oli-torus/lib/oli/lti/keyset_refresh_worker.ex)
-- [cached_key_provider_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/cached_key_provider_test.exs)
-- [keyset_refresh_worker_test.exs](/Users/eliknebel/Developer/oli-torus/test/oli/lti/keyset_refresh_worker_test.exs)
+- [prd.md](./docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md)
+- [requirements.yml](./docs/exec-plans/current/triage-2236-keyset-cache-reliability/requirements.yml)
+- [cached_key_provider.ex](./lib/oli/lti/cached_key_provider.ex)
+- [keyset_cache.ex](./lib/oli/lti/keyset_cache.ex)
+- [keyset_refresh_worker.ex](./lib/oli/lti/keyset_refresh_worker.ex)
+- [cached_key_provider_test.exs](./test/oli/lti/cached_key_provider_test.exs)
+- [keyset_refresh_worker_test.exs](./test/oli/lti/keyset_refresh_worker_test.exs)

--- a/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
+++ b/docs/exec-plans/current/triage-2236-keyset-cache-reliability/plan.md
@@ -2,8 +2,8 @@
 
 Scope and reference artifacts:
 
-- PRD: `/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md`
-- FDD: `/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md`
+- PRD: `./docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md`
+- FDD: `./docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md`
 
 ## Scope
 
@@ -17,7 +17,7 @@ Check off tasks in the plan as they are completed, and update the plan as needed
 
 ## Clarifications & Default Assumptions
 
-- The authoritative work-item artifacts are [prd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md) and [fdd.md](/Users/eliknebel/Developer/oli-torus/docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md).
+- The authoritative work-item artifacts are [prd.md](./docs/exec-plans/current/triage-2236-keyset-cache-reliability/prd.md) and [fdd.md](./docs/exec-plans/current/triage-2236-keyset-cache-reliability/fdd.md).
 - Repository-local harness contract files such as `harness.yml` and the standard docs bundle were not present at intake, so this plan follows the repository guidance available in `AGENTS.md` and the current LTI module boundaries.
 - `:key_not_found_in_keyset` remains the terminal reason when the latest available keyset still does not contain the requested `kid`; diagnostics must show whether a refresh was attempted.
 - A successful synchronous read-through refresh does not also need to enqueue a background refresh job.

--- a/lib/oli_web/components/delivery/lti_external_tools.ex
+++ b/lib/oli_web/components/delivery/lti_external_tools.ex
@@ -10,8 +10,8 @@ defmodule OliWeb.Components.Delivery.LTIExternalTools do
     ~H"""
     <div class="mt-3" style="height: 600px">
       <form action={@login_url} class="hide" method="POST" target={"tool-content=#{@id}"}>
-        <%= for key <- @launch_params |> Map.keys do %>
-          <input type="hidden" name={key} value={@launch_params[key]} />
+        <%= for {key, value} <- @launch_params, !is_nil(value) do %>
+          <input type="hidden" name={key} value={value} />
         <% end %>
 
         <div style="margin-bottom: 20px;">

--- a/lib/oli_web/controllers/api/lti_controller.ex
+++ b/lib/oli_web/controllers/api/lti_controller.ex
@@ -15,6 +15,8 @@ defmodule OliWeb.Api.LtiController do
 
   action_fallback OliWeb.FallbackController
 
+  @lti_message_hint_salt "lti_message_hint"
+
   @doc """
   Returns the launch details for an LTI activity, including the platform instance
   information and launch parameters.
@@ -31,6 +33,7 @@ defmodule OliWeb.Api.LtiController do
            status: status,
            deep_linking_enabled: deep_linking_enabled
          } =
+           deployment =
            PlatformExternalTools.get_lti_external_tool_activity_deployment_by(
              activity_registration_id: activity_type_id
            ) do
@@ -46,6 +49,15 @@ defmodule OliWeb.Api.LtiController do
           "resource_id" => activity_id
         })
 
+      launch_params =
+        build_launch_params(
+          platform_instance,
+          login_hint,
+          deployment,
+          endpoint: :section_launch_details,
+          resource_id: activity_id
+        )
+
       deep_link =
         PlatformExternalTools.get_section_resource_deep_link_by(
           section_id: section.id,
@@ -54,13 +66,7 @@ defmodule OliWeb.Api.LtiController do
 
       json(conn, %{
         name: platform_instance.name,
-        launch_params: %{
-          iss: Oli.Utils.get_base_url(),
-          login_hint: login_hint,
-          client_id: platform_instance.client_id,
-          target_link_uri: platform_instance.target_link_uri,
-          login_url: platform_instance.login_url
-        },
+        launch_params: launch_params,
         status: status,
         deep_linking_enabled: deep_linking_enabled,
         deep_link: deep_link,
@@ -83,6 +89,7 @@ defmodule OliWeb.Api.LtiController do
            status: status,
            deep_linking_enabled: deep_linking_enabled
          } =
+           deployment =
            PlatformExternalTools.get_lti_external_tool_activity_deployment_by(
              activity_registration_id: activity_type_id
            ) do
@@ -94,15 +101,18 @@ defmodule OliWeb.Api.LtiController do
           "resource_id" => activity_id
         })
 
+      launch_params =
+        build_launch_params(
+          platform_instance,
+          login_hint,
+          deployment,
+          endpoint: :project_launch_details,
+          resource_id: activity_id
+        )
+
       json(conn, %{
         name: platform_instance.name,
-        launch_params: %{
-          iss: Oli.Utils.get_base_url(),
-          login_hint: login_hint,
-          client_id: platform_instance.client_id,
-          target_link_uri: platform_instance.target_link_uri,
-          login_url: platform_instance.login_url
-        },
+        launch_params: launch_params,
         status: status,
         deep_linking_enabled: deep_linking_enabled,
         can_configure_tool: false
@@ -123,6 +133,7 @@ defmodule OliWeb.Api.LtiController do
     with %Oli.Resources.Revision{activity_type_id: activity_type_id} <-
            DeliveryResolver.from_resource_id(section_slug, activity_id),
          %LtiExternalToolActivityDeployment{platform_instance: platform_instance, status: status} =
+           deployment =
            PlatformExternalTools.get_lti_external_tool_activity_deployment_by(
              activity_registration_id: activity_type_id
            ) do
@@ -135,16 +146,19 @@ defmodule OliWeb.Api.LtiController do
           "configure_deep_linking" => "true"
         })
 
+      launch_params =
+        build_launch_params(
+          platform_instance,
+          login_hint,
+          deployment,
+          endpoint: :deep_linking_launch_details,
+          resource_id: activity_id,
+          lti_message_type: "LtiDeepLinkingRequest"
+        )
+
       json(conn, %{
         name: platform_instance.name,
-        launch_params: %{
-          iss: Oli.Utils.get_base_url(),
-          login_hint: login_hint,
-          client_id: platform_instance.client_id,
-          target_link_uri: platform_instance.target_link_uri,
-          login_url: platform_instance.login_url,
-          lti_message_type: "LtiDeepLinkingRequest"
-        },
+        launch_params: launch_params,
         status: status
       })
     else
@@ -164,6 +178,60 @@ defmodule OliWeb.Api.LtiController do
       nil ->
         {:error, :section_not_found}
     end
+  end
+
+  defp build_launch_params(platform_instance, login_hint, deployment, opts) do
+    deployment_id = deployment && deployment.deployment_id
+    lti_message_type = Keyword.get(opts, :lti_message_type)
+    endpoint = Keyword.fetch!(opts, :endpoint)
+
+    launch_params =
+      %{
+        iss: Oli.Utils.get_base_url(),
+        login_hint: login_hint,
+        client_id: platform_instance.client_id,
+        target_link_uri: platform_instance.target_link_uri,
+        login_url: platform_instance.login_url,
+        lti_deployment_id: deployment_id,
+        lti_message_hint:
+          sign_lti_message_hint(
+            login_hint,
+            deployment_id,
+            endpoint,
+            resource_id: Keyword.get(opts, :resource_id),
+            lti_message_type: lti_message_type
+          ),
+        lti_message_type: lti_message_type
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    log_launch_param_generation(endpoint, launch_params)
+
+    launch_params
+  end
+
+  defp sign_lti_message_hint(login_hint, deployment_id, endpoint, opts) do
+    payload =
+      %{
+        "login_hint" => login_hint,
+        "deployment_id" => deployment_id,
+        "endpoint" => to_string(endpoint),
+        "resource_id" => Keyword.get(opts, :resource_id),
+        "lti_message_type" => Keyword.get(opts, :lti_message_type)
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    Phoenix.Token.sign(OliWeb.Endpoint, @lti_message_hint_salt, payload)
+  end
+
+  defp log_launch_param_generation(endpoint, launch_params) do
+    Logger.debug(fn ->
+      "Generated external tool launch params endpoint=#{endpoint} " <>
+        "issued_lti_deployment_id=#{Map.has_key?(launch_params, :lti_deployment_id)} " <>
+        "issued_lti_message_hint=#{Map.has_key?(launch_params, :lti_message_hint)}"
+    end)
   end
 
   @doc """

--- a/test/oli_web/components/delivery/lti_external_tools_test.exs
+++ b/test/oli_web/components/delivery/lti_external_tools_test.exs
@@ -143,5 +143,30 @@ defmodule OliWeb.Components.Delivery.LTIExternalToolsTest do
       assert html =~ "name=\"numeric_param\""
       assert html =~ "value=\"123\""
     end
+
+    test "renders optional LTI login params and omits nil values" do
+      assigns = %{
+        id: "tool-1",
+        name: "Test Tool",
+        login_url: "https://example.com/launch",
+        launch_params: %{
+          "login_hint" => "opaque-login-hint",
+          "lti_deployment_id" => "deployment-123",
+          "lti_message_hint" => "signed-message-hint",
+          "missing_optional_param" => nil
+        }
+      }
+
+      html = render_component(&LTIExternalTools.lti_external_tool/1, assigns)
+
+      assert html =~ "name=\"login_hint\""
+      assert html =~ "value=\"opaque-login-hint\""
+      assert html =~ "name=\"lti_deployment_id\""
+      assert html =~ "value=\"deployment-123\""
+      assert html =~ "name=\"lti_message_hint\""
+      assert html =~ "value=\"signed-message-hint\""
+      refute html =~ "name=\"missing_optional_param\""
+      refute html =~ "value=\"\""
+    end
   end
 end

--- a/test/oli_web/controllers/api/lti_controller_integration_test.exs
+++ b/test/oli_web/controllers/api/lti_controller_integration_test.exs
@@ -46,6 +46,9 @@ defmodule OliWeb.Api.LtiControllerIntegrationTest do
       assert Map.has_key?(launch_params, "client_id")
       assert Map.has_key?(launch_params, "target_link_uri")
       assert Map.has_key?(launch_params, "login_url")
+      assert Map.has_key?(launch_params, "lti_deployment_id")
+      assert Map.has_key?(launch_params, "lti_message_hint")
+      assert launch_params["lti_message_hint"] != launch_params["login_hint"]
     end
   end
 
@@ -80,6 +83,9 @@ defmodule OliWeb.Api.LtiControllerIntegrationTest do
       assert Map.has_key?(launch_params, "client_id")
       assert Map.has_key?(launch_params, "target_link_uri")
       assert Map.has_key?(launch_params, "login_url")
+      assert Map.has_key?(launch_params, "lti_deployment_id")
+      assert Map.has_key?(launch_params, "lti_message_hint")
+      assert launch_params["lti_message_hint"] != launch_params["login_hint"]
     end
 
     test "deep linking launch details matches frontend component expectations", %{
@@ -111,8 +117,47 @@ defmodule OliWeb.Api.LtiControllerIntegrationTest do
       assert Map.has_key?(launch_params, "client_id")
       assert Map.has_key?(launch_params, "target_link_uri")
       assert Map.has_key?(launch_params, "login_url")
+      assert Map.has_key?(launch_params, "lti_deployment_id")
+      assert Map.has_key?(launch_params, "lti_message_hint")
       assert Map.has_key?(launch_params, "lti_message_type")
       assert launch_params["lti_message_type"] == "LtiDeepLinkingRequest"
+      assert launch_params["lti_message_hint"] != launch_params["login_hint"]
+
+      assert {:ok, payload} =
+               Phoenix.Token.verify(
+                 OliWeb.Endpoint,
+                 "lti_message_hint",
+                 launch_params["lti_message_hint"]
+               )
+
+      assert payload == %{
+               "deployment_id" => launch_params["lti_deployment_id"],
+               "endpoint" => "deep_linking_launch_details",
+               "login_hint" => launch_params["login_hint"],
+               "lti_message_type" => "LtiDeepLinkingRequest",
+               "resource_id" => to_string(activity_id)
+             }
+    end
+
+    test "deep linking message hint changes with message type context", %{
+      conn: conn,
+      section: section,
+      activity_id: activity_id
+    } do
+      standard_conn =
+        get(conn, ~p"/api/v1/lti/sections/#{section.slug}/launch_details/#{activity_id}")
+
+      deep_linking_conn =
+        get(
+          conn,
+          ~p"/api/v1/lti/sections/#{section.slug}/deep_linking_launch_details/#{activity_id}"
+        )
+
+      standard_launch_params = json_response(standard_conn, 200)["launch_params"]
+      deep_linking_launch_params = json_response(deep_linking_conn, 200)["launch_params"]
+
+      assert standard_launch_params["lti_message_hint"] !=
+               deep_linking_launch_params["lti_message_hint"]
     end
   end
 

--- a/test/oli_web/controllers/api/lti_controller_test.exs
+++ b/test/oli_web/controllers/api/lti_controller_test.exs
@@ -23,17 +23,36 @@ defmodule OliWeb.Api.LtiControllerTest do
 
     test "returns LTI launch details", %{conn: conn, project: project, activity_id: activity_id} do
       conn = get(conn, ~p"/api/v1/lti/projects/#{project.slug}/launch_details/#{activity_id}")
-      assert json_response(conn, 200)["name"] == "some name"
+      response = json_response(conn, 200)
+      launch_params = response["launch_params"]
 
-      assert json_response(conn, 200)["launch_params"]["iss"] == Oli.Utils.get_base_url()
-      assert json_response(conn, 200)["launch_params"]["client_id"] == "some client_id"
+      assert response["name"] == "some name"
 
-      assert json_response(conn, 200)["launch_params"]["target_link_uri"] ==
-               "some target_link_uri"
+      assert launch_params["iss"] == Oli.Utils.get_base_url()
+      assert launch_params["client_id"] == "some client_id"
 
-      assert json_response(conn, 200)["launch_params"]["login_url"] == "some login_url"
-      assert json_response(conn, 200)["launch_params"]["login_hint"] != nil
-      assert json_response(conn, 200)["status"] != nil
+      assert launch_params["target_link_uri"] == "some target_link_uri"
+
+      assert launch_params["login_url"] == "some login_url"
+      assert launch_params["login_hint"] != nil
+      assert launch_params["lti_deployment_id"] != nil
+      assert launch_params["lti_message_hint"] != nil
+      assert launch_params["lti_message_hint"] != launch_params["login_hint"]
+      assert response["status"] != nil
+
+      assert {:ok, payload} =
+               Phoenix.Token.verify(
+                 OliWeb.Endpoint,
+                 "lti_message_hint",
+                 launch_params["lti_message_hint"]
+               )
+
+      assert payload == %{
+               "deployment_id" => launch_params["lti_deployment_id"],
+               "endpoint" => "project_launch_details",
+               "login_hint" => launch_params["login_hint"],
+               "resource_id" => to_string(activity_id)
+             }
     end
   end
 
@@ -42,17 +61,35 @@ defmodule OliWeb.Api.LtiControllerTest do
 
     test "returns LTI launch details", %{conn: conn, section: section, activity_id: activity_id} do
       conn = get(conn, ~p"/api/v1/lti/sections/#{section.slug}/launch_details/#{activity_id}")
-      assert json_response(conn, 200)["name"] == "some name"
+      response = json_response(conn, 200)
+      launch_params = response["launch_params"]
 
-      assert json_response(conn, 200)["launch_params"]["iss"] == Oli.Utils.get_base_url()
-      assert json_response(conn, 200)["launch_params"]["client_id"] == "some client_id"
+      assert response["name"] == "some name"
+      assert launch_params["iss"] == Oli.Utils.get_base_url()
+      assert launch_params["client_id"] == "some client_id"
 
-      assert json_response(conn, 200)["launch_params"]["target_link_uri"] ==
-               "some target_link_uri"
+      assert launch_params["target_link_uri"] == "some target_link_uri"
 
-      assert json_response(conn, 200)["launch_params"]["login_url"] == "some login_url"
-      assert json_response(conn, 200)["launch_params"]["login_hint"] != nil
-      assert json_response(conn, 200)["status"] != nil
+      assert launch_params["login_url"] == "some login_url"
+      assert launch_params["login_hint"] != nil
+      assert launch_params["lti_deployment_id"] != nil
+      assert launch_params["lti_message_hint"] != nil
+      assert launch_params["lti_message_hint"] != launch_params["login_hint"]
+      assert response["status"] != nil
+
+      assert {:ok, payload} =
+               Phoenix.Token.verify(
+                 OliWeb.Endpoint,
+                 "lti_message_hint",
+                 launch_params["lti_message_hint"]
+               )
+
+      assert payload == %{
+               "deployment_id" => launch_params["lti_deployment_id"],
+               "endpoint" => "section_launch_details",
+               "login_hint" => launch_params["login_hint"],
+               "resource_id" => to_string(activity_id)
+             }
     end
   end
 


### PR DESCRIPTION
Adds LMS-parity optional parameters to outbound LTI external-tool login launches.

This change updates Torus launch-details responses so project, section, and deep-linking external-tool launches now include:

- `lti_deployment_id`
- `lti_message_hint`

The implementation keeps launch-param assembly server-owned in `OliWeb.Api.LtiController`, generates `lti_message_hint` as a signed opaque token with minimal launch context, preserves deep-linking support through the shared builder, and omits nil optional values instead of rendering blank params.

The frontend contract was updated to accept the new launch params, and hidden-input rendering coverage was extended to prove pass-through behavior without coupling backend and frontend into a single integration test.

# Changes

- Centralized external-tool launch param generation in `OliWeb.Api.LtiController`
- Added signed `lti_message_hint` issuance with an LTI-specific salt
- Added `lti_deployment_id` to authoring, delivery, and deep-linking launch-details responses
- Preserved deep-linking `lti_message_type` composition through the shared builder
- Added sanitized debug logging for launch-param issuance
- Updated the TypeScript launch-details contract for optional params
- Extended controller, integration, and launch-form rendering tests
- Added execution records under `docs/exec-plans/current/lti-login-optional-params/`

# Testing

Automated:

- `mix format lib/oli_web/controllers/api/lti_controller.ex lib/oli_web/components/delivery/lti_external_tools.ex test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs test/oli_web/components/delivery/lti_external_tools_test.exs`
- `mix test test/oli_web/controllers/api/lti_controller_test.exs test/oli_web/controllers/api/lti_controller_integration_test.exs test/oli_web/components/delivery/lti_external_tools_test.exs`
- `mix compile`
- `python3 /Users/eliknebel/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/lti-login-optional-params --check all`

Manual:

- Verified the implementation in a live external-tool launch flow
- Confirmed the launch worked as expected
<img width="1753" height="1232" alt="Screenshot 2026-04-10 at 3 05 21 PM" src="https://github.com/user-attachments/assets/9485b589-5361-41a2-89fe-74108c6ee9ba" />


# Notes

- Manual verification is complete.
- The only plan item left unchecked is adding explicit logging assertions, which was intentionally left optional to avoid over-coupling tests to log text.
