### PR TITLE
[ENHANCEMENT] [MER-5509] Superscript and Subscript Support in Component Labels

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/PropertyEditor.tsx
@@ -16,6 +16,7 @@ import { MCQOptionsEditor } from './custom/MCQOptionsEditor';
 import { OptionsCorrectPicker } from './custom/OptionsCorrectPicker';
 import { OptionsCustomErrorFeedbackAuthoring } from './custom/OptionsCustomErrorFeedbackAuthoring';
 import { PopupIconSelector } from './custom/PopupIconSelector';
+import { RichLabelWidget } from './custom/RichLabelWidget';
 import ScreenDropdownTemplate from './custom/ScreenDropdownTemplate';
 import { SliderOptionsTextEditor } from './custom/SliderOptionsTextEditor';
 import { SpokeCompletedOption } from './custom/SpokeCompletedOption';
@@ -58,6 +59,7 @@ const widgets: any = {
   ThemeSelectorWidget: ThemeSelectorWidget,
   PopupIconSelector: PopupIconSelector,
   IframeSourceEditor: IframeSourceEditor,
+  RichLabelWidget: RichLabelWidget,
 };
 
 /**

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
@@ -1,0 +1,126 @@
+import React, { useCallback, useState } from 'react';
+import { WidgetProps } from '@rjsf/core';
+import { JanusRichLabelEditorModal } from 'components/parts/common/JanusRichLabelEditorModal';
+import {
+  isRichLabelHtml,
+  normalizeRichLabelForStorage,
+  sanitizeRichLabelHtml,
+} from 'utils/richOptionLabel';
+
+/**
+ * RJSF custom widget for single-string label/labelText fields on adaptive part components.
+ * Supports plain text entry and rich formatting (sup, sub, bold, italic) via a Quill modal.
+ */
+export const RichLabelWidget: React.FC<WidgetProps> = ({
+  id,
+  value,
+  onChange,
+  onBlur,
+  disabled,
+  readonly,
+}) => {
+  const [showModal, setShowModal] = useState(false);
+  const currentValue: string = typeof value === 'string' ? value : '';
+  const sanitized = sanitizeRichLabelHtml(currentValue);
+  const isRich = isRichLabelHtml(sanitized);
+
+  const commit = useCallback(
+    (normalized: string) => {
+      onChange(normalized);
+      setTimeout(() => onBlur(id, normalized), 0);
+    },
+    [id, onChange, onBlur],
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(e.target.value);
+  };
+
+  const handleInputBlur = () => {
+    onBlur(id, currentValue);
+  };
+
+  const handleModalSave = useCallback(
+    (saved: string) => {
+      commit(normalizeRichLabelForStorage(saved));
+    },
+    [commit],
+  );
+
+  return (
+    <div className="rich-label-widget">
+      <style>{`
+        .rich-label-widget {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+        .rich-label-widget-preview,
+        .rich-label-widget-preview p,
+        .rich-label-widget-preview div {
+          margin: 0;
+          font-size: inherit;
+        }
+        .rich-label-widget-input {
+          flex: 1;
+          min-width: 0;
+        }
+        .rich-label-widget-rich-preview {
+          flex: 1;
+          min-width: 0;
+          padding: 6px 12px;
+          border: 1px solid #ced4da;
+          border-radius: 4px;
+          background: #fff;
+          font-size: 1rem;
+          line-height: 1.5;
+          min-height: 36px;
+        }
+        .rich-label-widget-format-btn {
+          flex-shrink: 0;
+          font-size: 12px;
+          padding: 4px 8px;
+          line-height: 1.2;
+        }
+      `}</style>
+
+      {isRich ? (
+        <div
+          className="rich-label-widget-rich-preview rich-label-widget-preview"
+          dangerouslySetInnerHTML={{ __html: sanitized }}
+        />
+      ) : (
+        <input
+          id={id}
+          type="text"
+          className="form-control rich-label-widget-input"
+          value={currentValue}
+          disabled={disabled || readonly}
+          onChange={handleInputChange}
+          onBlur={handleInputBlur}
+        />
+      )}
+
+      <button
+        type="button"
+        title="Format label (bold, italic, superscript, subscript)"
+        className="btn btn-outline-secondary rich-label-widget-format-btn"
+        disabled={disabled || readonly}
+        onClick={() => setShowModal(true)}
+      >
+        T<sup style={{ fontSize: '0.6em' }}>x</sup>
+      </button>
+
+      <JanusRichLabelEditorModal
+        show={showModal}
+        title="Edit label"
+        value={currentValue}
+        onHide={() => setShowModal(false)}
+        onSave={handleModalSave}
+        aria-label="Edit label with rich formatting"
+      />
+    </div>
+  );
+};
+
+export default RichLabelWidget;

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
@@ -9,7 +9,12 @@ import {
 
 /**
  * RJSF custom widget for single-string label/labelText fields on adaptive part components.
- * Supports plain text entry and rich formatting (sup, sub, bold, italic) via a Quill modal.
+ *
+ * - Plain text label: renders a normal editable text input alongside a format button.
+ * - Rich label (contains sup/sub/bold/italic): renders a read-only bordered preview
+ *   (matching DropdownOptionsEditor style) with an edit-icon button.
+ *
+ * In both cases the format button opens JanusRichLabelEditorModal for rich editing.
  */
 export const RichLabelWidget: React.FC<WidgetProps> = ({
   id,
@@ -24,8 +29,9 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
   const sanitized = sanitizeRichLabelHtml(currentValue);
   const isRich = isRichLabelHtml(sanitized);
 
-  const commit = useCallback(
-    (normalized: string) => {
+  const handleModalSave = useCallback(
+    (saved: string) => {
+      const normalized = normalizeRichLabelForStorage(saved);
       onChange(normalized);
       setTimeout(() => onBlur(id, normalized), 0);
     },
@@ -40,60 +46,39 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
     onBlur(id, currentValue);
   };
 
-  const handleModalSave = useCallback(
-    (saved: string) => {
-      commit(normalizeRichLabelForStorage(saved));
-    },
-    [commit],
-  );
-
   return (
-    <div className="rich-label-widget">
+    <div className="flex align-items-center gap-1">
       <style>{`
-        .rich-label-widget {
-          display: flex;
-          align-items: center;
-          gap: 6px;
-        }
         .rich-label-widget-preview,
         .rich-label-widget-preview p,
         .rich-label-widget-preview div {
           margin: 0;
-          font-size: inherit;
         }
-        .rich-label-widget-input {
-          flex: 1;
-          min-width: 0;
-        }
-        .rich-label-widget-rich-preview {
-          flex: 1;
-          min-width: 0;
-          padding: 6px 12px;
-          border: 1px solid #ced4da;
-          border-radius: 4px;
-          background: #fff;
-          font-size: 1rem;
+        .rich-label-widget-preview p,
+        .rich-label-widget-preview div {
           line-height: 1.5;
-          min-height: 36px;
-        }
-        .rich-label-widget-format-btn {
-          flex-shrink: 0;
-          font-size: 12px;
-          padding: 4px 8px;
-          line-height: 1.2;
         }
       `}</style>
-
       {isRich ? (
+        /* Rich label — read-only preview matching DropdownOptionsEditor */
         <div
-          className="rich-label-widget-rich-preview rich-label-widget-preview"
-          dangerouslySetInnerHTML={{ __html: sanitized }}
-        />
+          id={id}
+          className="flex-1 form-control rich-label-widget-preview"
+          style={{
+            minHeight: 38,
+            cursor: 'default',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <span dangerouslySetInnerHTML={{ __html: sanitized || '&nbsp;' }} />
+        </div>
       ) : (
+        /* Plain text label — normal editable input */
         <input
           id={id}
           type="text"
-          className="form-control rich-label-widget-input"
+          className="flex-1 form-control"
           value={currentValue}
           disabled={disabled || readonly}
           onChange={handleInputChange}
@@ -101,15 +86,18 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
         />
       )}
 
-      <button
-        type="button"
-        title="Format label (bold, italic, superscript, subscript)"
-        className="btn btn-outline-secondary rich-label-widget-format-btn"
-        disabled={disabled || readonly}
-        onClick={() => setShowModal(true)}
-      >
-        T<sup style={{ fontSize: '0.6em' }}>x</sup>
-      </button>
+      <div className="flex-none">
+        <button
+          type="button"
+          className="btn btn-link btn-sm p-1 text-nowrap"
+          disabled={disabled || readonly}
+          onClick={() => setShowModal(true)}
+          aria-label="Edit label formatting"
+          title="Edit label formatting (bold, italic, superscript, subscript)"
+        >
+          <i className="fa-solid fa-pen-to-square" />
+        </button>
+      </div>
 
       <JanusRichLabelEditorModal
         show={showModal}

--- a/assets/src/components/parts/janus-dropdown/Dropdown.tsx
+++ b/assets/src/components/parts/janus-dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ import {
   findOptionIndexForSelectedItem,
   htmlToPlainText,
   optionLabelsNeedRichDropdown,
+  sanitizeRichLabelHtml,
 } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import { DropdownRichSelect } from './DropdownRichSelect';
@@ -442,7 +443,12 @@ const Dropdown: React.FC<PartComponentProps<DropdownModel>> = (props) => {
       <span className="sr-only" style={srOnlyStyle} role="status" aria-live="polite">
         {liveAnnouncement}
       </span>
-      {showLabel && label ? <label htmlFor={`${id}-select`}>{label}</label> : null}
+      {showLabel && label ? (
+        <label
+          htmlFor={`${id}-select`}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }}
+        />
+      ) : null}
       {needRich ? (
         <DropdownRichSelect
           id={id}

--- a/assets/src/components/parts/janus-dropdown/DropdownAuthor.tsx
+++ b/assets/src/components/parts/janus-dropdown/DropdownAuthor.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useEffect } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { DropdownModel } from './schema';
 
 const DropdownAuthor: React.FC<AuthorPartComponentProps<DropdownModel>> = (props) => {
@@ -44,7 +45,10 @@ const DropdownAuthor: React.FC<AuthorPartComponentProps<DropdownModel>> = (props
   };
   return (
     <div data-janus-type={tagName} className="dropdown-input" style={styles}>
-      <label htmlFor={`${id}-select`}>{showLabel && label ? label : ''}</label>
+      <label
+        htmlFor={`${id}-select`}
+        dangerouslySetInnerHTML={{ __html: showLabel && label ? sanitizeRichLabelHtml(label) : '' }}
+      />
       <select
         style={dropDownStyle}
         id={`${id}-select`}

--- a/assets/src/components/parts/janus-dropdown/DropdownAuthor.tsx
+++ b/assets/src/components/parts/janus-dropdown/DropdownAuthor.tsx
@@ -9,6 +9,10 @@ const DropdownAuthor: React.FC<AuthorPartComponentProps<DropdownModel>> = (props
   const { width, showLabel, label, prompt, optionLabels } = model;
   const styles: CSSProperties = {
     width,
+    position: 'relative',
+    display: 'inline-flex',
+    flexDirection: 'column',
+    gap: '4px',
   };
   const dropDownStyle: CSSProperties = {
     width: '100%',

--- a/assets/src/components/parts/janus-dropdown/schema.ts
+++ b/assets/src/components/parts/janus-dropdown/schema.ts
@@ -18,6 +18,9 @@ export interface DropdownModel extends JanusAbsolutePositioned, JanusCustomCss {
 export const simpleUISchema = {
   'ui:classNames': 'dropdown-editor',
   classNames: 'dropdown-editor',
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   correctAnswer: {
     'ui:widget': 'OptionsCorrectPicker',
   },
@@ -141,6 +144,9 @@ export const schema: JSONSchema7Object = {
 };
 
 export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   optionLabels: {
     'ui:widget': 'DropdownOptionsEditor',
     items: {

--- a/assets/src/components/parts/janus-input-number/InputNumber.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumber.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
 import { countSigFigs, parseBool } from '../../../utils/common';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import './InputNumber.scss';
 import { InputNumberModel } from './schema';
@@ -308,9 +309,11 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = ({
     <div data-janus-type={tagName} style={inputNumberDivStyles} className={`number-input`}>
       {showLabel && (
         <React.Fragment>
-          <label htmlFor={`${inputId}`} className="inputNumberLabel">
-            {label?.length > 0 ? label : ''}
-          </label>
+          <label
+            htmlFor={`${inputId}`}
+            className="inputNumberLabel"
+            dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label?.length > 0 ? label : '') }}
+          />
           <br />
         </React.Fragment>
       )}

--- a/assets/src/components/parts/janus-input-number/InputNumber.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumber.tsx
@@ -312,7 +312,9 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = ({
           <label
             htmlFor={`${inputId}`}
             className="inputNumberLabel"
-            dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label?.length > 0 ? label : '') }}
+            dangerouslySetInnerHTML={{
+              __html: sanitizeRichLabelHtml(label?.length > 0 ? label : ''),
+            }}
           />
           <br />
         </React.Fragment>

--- a/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
@@ -33,7 +33,9 @@ const InputNumberAuthor: React.FC<AuthorPartComponentProps<InputNumberModel>> = 
           <label
             htmlFor={`${id}-number-input`}
             className="inputNumberLabel"
-            dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label?.length > 0 ? label : '') }}
+            dangerouslySetInnerHTML={{
+              __html: sanitizeRichLabelHtml(label?.length > 0 ? label : ''),
+            }}
           />
           <br />
         </React.Fragment>

--- a/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useEffect } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { InputNumberModel } from './schema';
 
 const InputNumberAuthor: React.FC<AuthorPartComponentProps<InputNumberModel>> = (props) => {
@@ -29,9 +30,11 @@ const InputNumberAuthor: React.FC<AuthorPartComponentProps<InputNumberModel>> = 
     <div className={`number-input`} style={styles}>
       {showLabel && (
         <React.Fragment>
-          <label htmlFor={`${id}-number-input`} className="inputNumberLabel">
-            {label?.length > 0 ? label : ''}
-          </label>
+          <label
+            htmlFor={`${id}-number-input`}
+            className="inputNumberLabel"
+            dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label?.length > 0 ? label : '') }}
+          />
           <br />
         </React.Fragment>
       )}

--- a/assets/src/components/parts/janus-input-number/schema.ts
+++ b/assets/src/components/parts/janus-input-number/schema.ts
@@ -19,6 +19,9 @@ export interface InputNumberModel extends JanusAbsolutePositioned, JanusCustomCs
 
 export const simpleUiSchema = {
   'ui:ObjectFieldTemplate': CustomFieldTemplate,
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   minValue: {
     classNames: 'col-span-6',
   },
@@ -135,7 +138,11 @@ export const schema: JSONSchema7Object = {
   },
 };
 
-export const uiSchema = {};
+export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
+};
 
 export const adaptivitySchema = {
   value: CapiVariableTypes.NUMBER,

--- a/assets/src/components/parts/janus-input-text/InputText.tsx
+++ b/assets/src/components/parts/janus-input-text/InputText.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
 import { parseBool } from '../../../utils/common';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import { InputTextModel } from './schema';
 
@@ -252,7 +253,11 @@ const InputText: React.FC<PartComponentProps<InputTextModel>> = (props) => {
   return ready ? (
     <div data-janus-type={tagName} className={`short-text-input`} style={{ width: '100%' }}>
       <label htmlFor={`${id}-short-text-input`}>
-        {showLabel && label ? label : <span>&nbsp;</span>}
+        {showLabel && label ? (
+          <span dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }} />
+        ) : (
+          <span>&nbsp;</span>
+        )}
       </label>
       <input
         name="janus-input-text"

--- a/assets/src/components/parts/janus-input-text/InputTextAuthor.tsx
+++ b/assets/src/components/parts/janus-input-text/InputTextAuthor.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useEffect } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { InputTextModel } from './schema';
 
 const InputTextAuthor: React.FC<AuthorPartComponentProps<InputTextModel>> = (props) => {
@@ -20,7 +21,11 @@ const InputTextAuthor: React.FC<AuthorPartComponentProps<InputTextModel>> = (pro
   return (
     <div className={`short-text-input`} style={styles}>
       <label htmlFor={`${id}-short-text-input`}>
-        {showLabel && label ? label : <span>&nbsp;</span>}
+        {showLabel && label ? (
+          <span dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }} />
+        ) : (
+          <span>&nbsp;</span>
+        )}
       </label>
       <input
         name="janus-input-text"

--- a/assets/src/components/parts/janus-input-text/schema.ts
+++ b/assets/src/components/parts/janus-input-text/schema.ts
@@ -104,6 +104,9 @@ export const simpleSchema: JSONSchema7Object = {
   },
 };
 export const simpleUiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   correctFeedback: {
     'ui:widget': 'textarea',
     'ui:options': {
@@ -118,7 +121,11 @@ export const simpleUiSchema = {
   },
 };
 
-export const uiSchema = {};
+export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
+};
 
 export const adaptivitySchema = {
   text: CapiVariableTypes.STRING,

--- a/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
+++ b/assets/src/components/parts/janus-multi-line-text/MultiLineTextInput.tsx
@@ -7,6 +7,7 @@ import {
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import './MultiLineTextInput.scss';
 import { MultiLineTextModel } from './schema';
@@ -328,9 +329,12 @@ const MultiLineTextInput: React.FC<PartComponentProps<MultiLineTextModel>> = (pr
   return ready ? (
     <div data-janus-type={tagName} className={`long-text-input`} style={wrapperStyles}>
       {/* Label - always rendered for accessibility, visually hidden when showLabel is false */}
-      <label id={labelId} htmlFor={id} className={showLabel ? '' : 'sr-only'}>
-        {label || ''}
-      </label>
+      <label
+        id={labelId}
+        htmlFor={id}
+        className={showLabel ? '' : 'sr-only'}
+        dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label || '') }}
+      />
       {/* Screen reader-only character counter announcement */}
       {showCharacterCount && (
         <span

--- a/assets/src/components/parts/janus-multi-line-text/MultiLineTextInputAuthor.tsx
+++ b/assets/src/components/parts/janus-multi-line-text/MultiLineTextInputAuthor.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useEffect } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { MultiLineTextModel } from './schema';
 
 const MultiLineTextInputAuthor: React.FC<AuthorPartComponentProps<MultiLineTextModel>> = (
@@ -32,9 +33,8 @@ const MultiLineTextInputAuthor: React.FC<AuthorPartComponentProps<MultiLineTextM
         style={{
           display: showLabel ? 'inline-block' : 'none',
         }}
-      >
-        {label}
-      </label>
+        dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label || '') }}
+      />
       <textarea
         name={`name-${id}`}
         id={`${id}-input`}

--- a/assets/src/components/parts/janus-multi-line-text/schema.ts
+++ b/assets/src/components/parts/janus-multi-line-text/schema.ts
@@ -84,6 +84,9 @@ export const simpleSchema: JSONSchema7Object = {
 
 export const simpleUiSchema = {
   'ui:ObjectFieldTemplate': CustomFieldTemplate,
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   minimumLength: { classNames: 'col-span-6' },
   fontSize: { classNames: 'col-span-6' },
   correctFeedback: {
@@ -99,7 +102,11 @@ export const simpleUiSchema = {
     },
   },
 };
-export const uiSchema = {};
+export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
+};
 
 export const adaptivitySchema = {
   enabled: CapiVariableTypes.BOOLEAN,

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -2,13 +2,13 @@ import React, { CSSProperties, useCallback, useEffect, useRef, useState } from '
 import ReactDOM from 'react-dom';
 import { Environment } from 'janus-script';
 import { parseBool } from 'utils/common';
-import { htmlToPlainText, sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
   NotificationType,
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
+import { htmlToPlainText, sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import { getIcon, getIconSrc } from './GetIcon';
 import PopupWindow from './PopupWindow';

--- a/assets/src/components/parts/janus-popup/Popup.tsx
+++ b/assets/src/components/parts/janus-popup/Popup.tsx
@@ -2,6 +2,7 @@ import React, { CSSProperties, useCallback, useEffect, useRef, useState } from '
 import ReactDOM from 'react-dom';
 import { Environment } from 'janus-script';
 import { parseBool } from 'utils/common';
+import { htmlToPlainText, sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
   NotificationType,
@@ -458,7 +459,7 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
           aria-haspopup="dialog"
           aria-expanded={showPopup}
           style={containerStyle}
-          aria-label={labelText || description}
+          aria-label={htmlToPlainText(labelText) || description}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
@@ -483,7 +484,7 @@ const Popup: React.FC<PartComponentProps<PopupModel>> = (props) => {
                     onBlur: handleBlur,
                   })}
             >
-              {labelText}
+              <span dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(labelText) }} />
             </span>
           )}
           {/* Icon is decorative when label exists, focusable when no label */}

--- a/assets/src/components/parts/janus-popup/PopupAuthor.tsx
+++ b/assets/src/components/parts/janus-popup/PopupAuthor.tsx
@@ -7,6 +7,7 @@ import {
   subscribeToNotification,
 } from 'apps/delivery/components/NotificationContext';
 import { clone, parseBoolean } from 'utils/common';
+import { htmlToPlainText, sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { getIconSrc } from './GetIcon';
 import PopupWindow from './PopupWindow';
 import { PopupModel } from './schema';
@@ -329,13 +330,13 @@ const PopupAuthor: React.FC<AuthorPartComponentProps<PopupModel>> = (props) => {
             tabIndex={0}
             aria-controls={id}
             aria-haspopup="true"
-            aria-label={shouldShowLabel ? `${labelText}, opens dialog` : undefined}
+            aria-label={shouldShowLabel ? `${htmlToPlainText(labelText)}, opens dialog` : undefined}
             style={labelStyle}
             onDoubleClick={() => {
               setShowWindow(true);
             }}
           >
-            {labelText}
+            <span dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(labelText) }} />
           </span>
         )}
         {/* Icon is decorative when label exists, focusable when no label */}

--- a/assets/src/components/parts/janus-popup/schema.ts
+++ b/assets/src/components/parts/janus-popup/schema.ts
@@ -262,6 +262,7 @@ export const uiSchema = {
   },
   labelText: {
     'ui:title': 'Label Text',
+    'ui:widget': 'RichLabelWidget',
   },
   labelPosition: {
     'ui:title': 'Label Position',

--- a/assets/src/components/parts/janus-slider/Slider.tsx
+++ b/assets/src/components/parts/janus-slider/Slider.tsx
@@ -6,6 +6,7 @@ import {
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import './Slider.scss';
 import { SliderModel } from './schema';
@@ -296,9 +297,12 @@ const Slider: React.FC<PartComponentProps<SliderModel>> = (props) => {
   return ready ? (
     <div data-janus-type={tagName} style={styles} className={`slider`}>
       {showLabel && (
-        <label id={`label-${internalId}`} className="input-label" htmlFor={internalId}>
-          {label}
-        </label>
+        <label
+          id={`label-${internalId}`}
+          className="input-label"
+          htmlFor={internalId}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label ?? '') }}
+        />
       )}
       <div className="sliderInner">
         {showValueLabels && <label htmlFor={internalId}>{invertScale ? maximum : minimum}</label>}

--- a/assets/src/components/parts/janus-slider/SliderAuthor.tsx
+++ b/assets/src/components/parts/janus-slider/SliderAuthor.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useEffect, useRef, useState } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
 import { clone } from 'utils/common';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import './Slider.scss';
 import { SliderModel } from './schema';
 
@@ -97,9 +98,11 @@ const SliderAuthor: React.FC<AuthorPartComponentProps<SliderModel>> = (props) =>
   return (
     <div data-janus-type={tagName} style={styles} className={`slider`}>
       {showLabel && (
-        <label className="input-label" htmlFor={internalId}>
-          {label}
-        </label>
+        <label
+          className="input-label"
+          htmlFor={internalId}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }}
+        />
       )}
       <div className="sliderInner">
         {showValueLabels && <label htmlFor={internalId}>{invertScale ? maximum : minimum}</label>}

--- a/assets/src/components/parts/janus-slider/schema.ts
+++ b/assets/src/components/parts/janus-slider/schema.ts
@@ -64,6 +64,9 @@ export const simpleSchema: JSONSchema7Object = {
 
 export const simpleUISchema = {
   'ui:ObjectFieldTemplate': CustomFieldTemplate,
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   answer: correctOrRange.uiSchema,
   minimum: {
     classNames: 'col-span-6',
@@ -142,7 +145,11 @@ export const schema: JSONSchema7Object = {
   },
 };
 
-export const uiSchema = {};
+export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
+};
 
 export const adaptivitySchema = {
   value: CapiVariableTypes.NUMBER,

--- a/assets/src/components/parts/janus-text-slider/SliderText.tsx
+++ b/assets/src/components/parts/janus-text-slider/SliderText.tsx
@@ -6,6 +6,7 @@ import {
   subscribeToNotification,
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import './Slider-Text.scss';
 import { SliderTextModel } from './schema';
@@ -260,9 +261,12 @@ const SliderText: React.FC<PartComponentProps<SliderTextModel>> = (props) => {
   return ready ? (
     <div data-janus-type={tagName} style={styles} className={`slider`}>
       {showLabel && (
-        <label id={`label-${internalId}`} className="input-label" htmlFor={internalId}>
-          {label}
-        </label>
+        <label
+          id={`label-${internalId}`}
+          className="input-label"
+          htmlFor={internalId}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }}
+        />
       )}
       <div className="sliderInner" style={!showLabel ? { width: '100%' } : {}}>
         <div className="slider-wrapper">

--- a/assets/src/components/parts/janus-text-slider/SliderText.tsx
+++ b/assets/src/components/parts/janus-text-slider/SliderText.tsx
@@ -265,7 +265,7 @@ const SliderText: React.FC<PartComponentProps<SliderTextModel>> = (props) => {
           id={`label-${internalId}`}
           className="input-label"
           htmlFor={internalId}
-          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label ?? '') }}
         />
       )}
       <div className="sliderInner" style={!showLabel ? { width: '100%' } : {}}>

--- a/assets/src/components/parts/janus-text-slider/SliderTextAuthor.tsx
+++ b/assets/src/components/parts/janus-text-slider/SliderTextAuthor.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, useEffect, useRef, useState } from 'react';
 import { AuthorPartComponentProps } from 'components/parts/types/parts';
 import { clone } from 'utils/common';
+import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import './Slider-Text.scss';
 import { SliderTextModel } from './schema';
 
@@ -48,9 +49,11 @@ const SliderTextAuthor: React.FC<AuthorPartComponentProps<SliderTextModel>> = (p
   return (
     <div data-janus-type={tagName} style={styles} className={`slider`}>
       {showLabel && (
-        <label className="input-label" htmlFor={internalId}>
-          {label}
-        </label>
+        <label
+          className="input-label"
+          htmlFor={internalId}
+          dangerouslySetInnerHTML={{ __html: sanitizeRichLabelHtml(label) }}
+        />
       )}
       <div className="sliderInner" style={!showLabel ? { width: '100%' } : {}}>
         <div className="slider-wrapper">

--- a/assets/src/components/parts/janus-text-slider/schema.ts
+++ b/assets/src/components/parts/janus-text-slider/schema.ts
@@ -78,6 +78,9 @@ export const simpleSchema: JSONSchema7Object = {
 
 export const simpleUISchema = {
   'ui:ObjectFieldTemplate': CustomFieldTemplate,
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   answer: correctOrRange.uiSchema,
   sliderOptionLabels: {
     'ui:widget': 'SliderOptionsTextEditor',
@@ -165,6 +168,9 @@ export const schema: JSONSchema7Object = {
 };
 
 export const uiSchema = {
+  label: {
+    'ui:widget': 'RichLabelWidget',
+  },
   minimum: {
     classNames: 'col-span-12 read-only',
   },

--- a/assets/src/utils/richOptionLabel.ts
+++ b/assets/src/utils/richOptionLabel.ts
@@ -20,7 +20,7 @@ export function sanitizeRichLabelHtml(input: string): string {
 }
 
 /**
- * Plain text for aria-live, comparisons, and simple input previews.
+ * Plain text for aria-live, comparison, and simple input previews.
  */
 export function htmlToPlainText(html: string): string {
   const sanitized = sanitizeRichLabelHtml(html);

--- a/assets/styles/common/responsive-layout.scss
+++ b/assets/styles/common/responsive-layout.scss
@@ -133,6 +133,8 @@
     .dropdown-input {
       width: 100% !important;
       display: flex !important;
+      flex-direction: column !important;
+      gap: 4px;
     }
   }
 


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks
This PR inherits some changes from https://github.com/Simon-Initiative/oli-torus/pull/6382 and includes the following updates:

**Rich Label Formatting Support**
Added support for superscript, subscript, bold, and italic in short Janus labels across:
- Dropdowns (main + option labels)
- Text / number inputs
- Multi-line text
- Sliders & text sliders
- Popup trigger labels

**Authoring**
Introduced a lightweight Rich Label Editor (React Quill) with:
- Bold, Italic, Subscript, Superscript

**Integrated into RJSF via RichLabelWidget:**
- Plain text → standard input
- Rich content → preview + edit (modal)

**Rendering / Delivery**
Labels are rendered using dangerouslySetInnerHTML only after sanitization, ensuring safe and consistent output.

**Utilities**:
isRichLabelHtml → detects if rich formatting is present
normalizeRichLabelForStorage → stores HTML only when needed, otherwise plain text (avoids unnecessary wrappers)


https://github.com/user-attachments/assets/70d9d16a-7206-4490-8c83-80ae0fffcb54

