### PR TITLE
[FEATURE] [MER-5506] Template update badge and banner

### DIFF
--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -55,6 +55,7 @@ import { SaveCookiePreferences } from './save_cookie_preferences';
 import { ScrollToTheTop } from './scroll_to_the_top';
 import { Scroller } from './scroller';
 import { SelectListener } from './select_listener';
+import { SessionBannerDismiss } from './session_banner_dismiss';
 import { ShowTeaser } from './show_teaser';
 import { SliderScroll } from './slider_scroll';
 import { StickyTechSupportButton } from './sticky_tech_support_button';
@@ -121,6 +122,7 @@ export const Hooks = {
   Scroller,
   ResizeListener,
   KeepScrollAtBottom,
+  SessionBannerDismiss,
   SliderScroll,
   VideoPlayer,
   VideoPreview,

--- a/assets/src/hooks/session_banner_dismiss.ts
+++ b/assets/src/hooks/session_banner_dismiss.ts
@@ -1,0 +1,52 @@
+const hideElement = (el: HTMLElement) => {
+  el.classList.add('hidden');
+};
+
+const showElement = (el: HTMLElement) => {
+  el.classList.remove('hidden');
+};
+
+const storageKeyFor = (el: HTMLElement): string | null => el.dataset.storageKey || null;
+
+export const SessionBannerDismiss = {
+  mounted() {
+    this.dismissHandler = (event: Event) => {
+      const target = event.target as HTMLElement | null;
+      const dismissButton = target?.closest?.('[data-banner-dismiss]');
+
+      if (!dismissButton) return;
+
+      const storageKey = storageKeyFor(this.el);
+      if (storageKey) {
+        window.sessionStorage.setItem(storageKey, 'dismissed');
+      }
+
+      hideElement(this.el);
+    };
+
+    this.el.addEventListener('click', this.dismissHandler);
+    this.syncVisibility();
+  },
+
+  updated() {
+    this.syncVisibility();
+  },
+
+  destroyed() {
+    if (this.dismissHandler) {
+      this.el.removeEventListener('click', this.dismissHandler);
+    }
+  },
+
+  syncVisibility() {
+    const storageKey = storageKeyFor(this.el);
+
+    if (!storageKey) return;
+
+    if (window.sessionStorage.getItem(storageKey) === 'dismissed') {
+      hideElement(this.el);
+    } else {
+      showElement(this.el);
+    }
+  },
+};

--- a/assets/src/hooks/session_banner_dismiss.ts
+++ b/assets/src/hooks/session_banner_dismiss.ts
@@ -26,11 +26,15 @@ const isDismissed = (storageKey: string): boolean => {
 
 export const SessionBannerDismiss = {
   mounted() {
+    this.dismissedInView = false;
+
     this.dismissHandler = (event: Event) => {
       const target = event.target as HTMLElement | null;
       const dismissButton = target?.closest?.('[data-banner-dismiss]');
 
       if (!dismissButton) return;
+
+      this.dismissedInView = true;
 
       const storageKey = storageKeyFor(this.el);
       if (storageKey) {
@@ -55,6 +59,11 @@ export const SessionBannerDismiss = {
   },
 
   syncVisibility() {
+    if (this.dismissedInView) {
+      hideElement(this.el);
+      return;
+    }
+
     const storageKey = storageKeyFor(this.el);
 
     if (!storageKey) return;

--- a/assets/src/hooks/session_banner_dismiss.ts
+++ b/assets/src/hooks/session_banner_dismiss.ts
@@ -8,6 +8,22 @@ const showElement = (el: HTMLElement) => {
 
 const storageKeyFor = (el: HTMLElement): string | null => el.dataset.storageKey || null;
 
+const setDismissed = (storageKey: string) => {
+  try {
+    window.sessionStorage.setItem(storageKey, 'dismissed');
+  } catch {
+    // Ignore storage failures and still dismiss the banner for the current page view.
+  }
+};
+
+const isDismissed = (storageKey: string): boolean => {
+  try {
+    return window.sessionStorage.getItem(storageKey) === 'dismissed';
+  } catch {
+    return false;
+  }
+};
+
 export const SessionBannerDismiss = {
   mounted() {
     this.dismissHandler = (event: Event) => {
@@ -18,7 +34,7 @@ export const SessionBannerDismiss = {
 
       const storageKey = storageKeyFor(this.el);
       if (storageKey) {
-        window.sessionStorage.setItem(storageKey, 'dismissed');
+        setDismissed(storageKey);
       }
 
       hideElement(this.el);
@@ -43,7 +59,7 @@ export const SessionBannerDismiss = {
 
     if (!storageKey) return;
 
-    if (window.sessionStorage.getItem(storageKey) === 'dismissed') {
+    if (isDismissed(storageKey)) {
       hideElement(this.el);
     } else {
       showElement(this.el);

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3409,17 +3409,26 @@ defmodule Oli.Delivery.Sections do
   """
   def count_available_blueprint_updates(%Project{id: project_id}) do
     from(s in Section,
+      as: :section,
       where: s.base_project_id == ^project_id and s.type == :blueprint and s.status == :active,
-      select: s
+      join: spp in SectionsProjectsPublications,
+      as: :spp,
+      on: spp.section_id == s.id,
+      join: current_pub in Publication,
+      on: current_pub.id == spp.publication_id,
+      inner_lateral_join:
+        latest_pub in subquery(
+          from(p in Publication,
+            where: p.project_id == parent_as(:spp).project_id and not is_nil(p.published),
+            order_by: [desc: p.published, desc: p.id],
+            limit: 1
+          )
+        ),
+      on: true,
+      where: current_pub.id != latest_pub.id,
+      select: count(s.id, :distinct)
     )
-    |> Repo.all()
-    |> Enum.reduce(0, fn blueprint, total ->
-      if map_size(check_for_available_publication_updates(blueprint)) > 0 do
-        total + 1
-      else
-        total
-      end
-    end)
+    |> Repo.one()
   end
 
   @doc """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3432,6 +3432,40 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Returns a set of blueprint section ids from the given list that have at least
+  one available publication update.
+  """
+  def blueprint_ids_with_available_updates([]), do: MapSet.new()
+
+  def blueprint_ids_with_available_updates(blueprints) when is_list(blueprints) do
+    section_ids = Enum.map(blueprints, & &1.id)
+    project_ids = Enum.map(blueprints, & &1.base_project_id) |> Enum.uniq()
+
+    latest_publications =
+      from(p in Publication,
+        where: p.project_id in ^project_ids and not is_nil(p.published),
+        distinct: p.project_id,
+        order_by: [asc: p.project_id, desc: p.published, desc: p.id],
+        select: %{project_id: p.project_id, id: p.id}
+      )
+
+    from(s in Section,
+      where: s.id in ^section_ids,
+      join: spp in SectionsProjectsPublications,
+      on: spp.section_id == s.id,
+      join: current_pub in Publication,
+      on: current_pub.id == spp.publication_id,
+      join: latest_pub in subquery(latest_publications),
+      on: latest_pub.project_id == spp.project_id,
+      where: current_pub.id != latest_pub.id,
+      select: s.id,
+      distinct: true
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  @doc """
   Returns a map of publication ids as keys for which updates are in progress for the
   given section
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3404,7 +3404,8 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Counts all available publication updates across active blueprint sections for the given project.
+  Counts active blueprint sections for the given project that have at least one
+  available publication update.
   """
   def count_available_blueprint_updates(%Project{id: project_id}) do
     from(s in Section,
@@ -3413,7 +3414,11 @@ defmodule Oli.Delivery.Sections do
     )
     |> Repo.all()
     |> Enum.reduce(0, fn blueprint, total ->
-      total + map_size(check_for_available_publication_updates(blueprint))
+      if map_size(check_for_available_publication_updates(blueprint)) > 0 do
+        total + 1
+      else
+        total
+      end
     end)
   end
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3404,6 +3404,20 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Counts all available publication updates across active blueprint sections for the given project.
+  """
+  def count_available_blueprint_updates(%Project{id: project_id}) do
+    from(s in Section,
+      where: s.base_project_id == ^project_id and s.type == :blueprint and s.status == :active,
+      select: s
+    )
+    |> Repo.all()
+    |> Enum.reduce(0, fn blueprint, total ->
+      total + map_size(check_for_available_publication_updates(blueprint))
+    end)
+  end
+
+  @doc """
   Returns a map of publication ids as keys for which updates are in progress for the
   given section
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3450,7 +3450,7 @@ defmodule Oli.Delivery.Sections do
       )
 
     from(s in Section,
-      where: s.id in ^section_ids,
+      where: s.id in ^section_ids and s.type == :blueprint and s.status == :active,
       join: spp in SectionsProjectsPublications,
       on: spp.section_id == s.id,
       join: current_pub in Publication,

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -9,7 +9,9 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   alias Phoenix.LiveView.JS
   alias OliWeb.Common.SessionContext
+  alias Oli.Authoring.Course
   alias Oli.Authoring.Course.Project
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Accounts.{User, Author}
@@ -421,8 +423,20 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:resource_slug, :string)
   attr(:active_tab, :atom)
   attr(:uri, :string, default: "")
+  attr(:notification_badges, :map, default: %{})
 
   def workspace_sidebar_nav(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :notification_badges,
+        load_workspace_notification_badges(
+          assigns.active_workspace,
+          assigns.resource_slug,
+          assigns.notification_badges
+        )
+      )
+
     ~H"""
     <div class="sticky top-0">
       <nav
@@ -499,6 +513,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
             sidebar_expanded={@sidebar_expanded}
             active_view={@active_view}
             active_workspace={@active_workspace}
+            notification_badges={@notification_badges}
           />
         </div>
         <div class="p-2 flex-col justify-center items-center gap-4 inline-flex h-[var(--footer-buttons-height)]">
@@ -750,6 +765,26 @@ defmodule OliWeb.Components.Delivery.Layouts do
     url_path = uri |> URI.parse() |> Map.get(:path)
     "#{url_path}?#{url_params_updated}"
   end
+
+  defp load_workspace_notification_badges(:course_author, resource_slug, notification_badges)
+       when is_binary(resource_slug) do
+    if Map.has_key?(notification_badges, :template_updates) do
+      notification_badges
+    else
+      case Course.get_project_by_slug(resource_slug) do
+        nil ->
+          notification_badges
+
+        project ->
+          case Sections.count_available_blueprint_updates(project) do
+            count when count > 0 -> Map.put(notification_badges, :template_updates, count)
+            _ -> notification_badges
+          end
+      end
+    end
+  end
+
+  defp load_workspace_notification_badges(_, _, notification_badges), do: notification_badges
 
   defp toggle_sidebar_in_params(uri, sidebar_expanded) do
     uri

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -9,9 +9,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
 
   alias Phoenix.LiveView.JS
   alias OliWeb.Common.SessionContext
-  alias Oli.Authoring.Course
   alias Oli.Authoring.Course.Project
-  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Accounts.{User, Author}
@@ -426,17 +424,6 @@ defmodule OliWeb.Components.Delivery.Layouts do
   attr(:notification_badges, :map, default: %{})
 
   def workspace_sidebar_nav(assigns) do
-    assigns =
-      assign(
-        assigns,
-        :notification_badges,
-        load_workspace_notification_badges(
-          assigns.active_workspace,
-          assigns.resource_slug,
-          assigns.notification_badges
-        )
-      )
-
     ~H"""
     <div class="sticky top-0">
       <nav
@@ -765,26 +752,6 @@ defmodule OliWeb.Components.Delivery.Layouts do
     url_path = uri |> URI.parse() |> Map.get(:path)
     "#{url_path}?#{url_params_updated}"
   end
-
-  defp load_workspace_notification_badges(:course_author, resource_slug, notification_badges)
-       when is_binary(resource_slug) do
-    if Map.has_key?(notification_badges, :template_updates) do
-      notification_badges
-    else
-      case Course.get_project_by_slug(resource_slug) do
-        nil ->
-          notification_badges
-
-        project ->
-          case Sections.count_available_blueprint_updates(project) do
-            count when count > 0 -> Map.put(notification_badges, :template_updates, count)
-            _ -> notification_badges
-          end
-      end
-    end
-  end
-
-  defp load_workspace_notification_badges(_, _, notification_badges), do: notification_badges
 
   defp toggle_sidebar_in_params(uri, sidebar_expanded) do
     uri

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -22,6 +22,7 @@
         resource_title={assigns[:resource_title]}
         resource_slug={assigns[:resource_slug]}
         active_tab={assigns[:active_tab]}
+        notification_badges={assigns[:notification_badges] || %{}}
         uri={assigns[:uri] || ""}
       />
     </div>

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -162,7 +162,12 @@ defmodule OliWeb.Delivery.RemixSection do
       ) do
     if Oli.Delivery.Sections.Blueprint.is_author_of_blueprint?(section.slug, current_author.id) or
          Accounts.at_least_content_admin?(current_author) do
-      {:ok, state} = Remix.init_open_and_free(section)
+      {:ok, state} =
+        if Accounts.at_least_content_admin?(current_author) do
+          Remix.init_open_and_free(section)
+        else
+          Remix.init(section, current_author)
+        end
 
       init_state_from_remix(socket, state,
         redirect_after_save: redirect_after_save(:product_creator, state.section, socket)

--- a/lib/oli_web/live/products/details/template_updates_banner.ex
+++ b/lib/oli_web/live/products/details/template_updates_banner.ex
@@ -1,0 +1,40 @@
+defmodule OliWeb.Products.Details.TemplateUpdatesBanner do
+  use OliWeb, :html
+
+  alias OliWeb.Components.DesignTokens.Primitives.Button
+
+  attr :count, :integer, required: true
+  attr :storage_key, :string, required: true
+
+  def render(%{count: count} = assigns) when count > 0 do
+    ~H"""
+    <div
+      id={"template-updates-banner-#{String.replace(@storage_key, ":", "-")}"}
+      phx-hook="SessionBannerDismiss"
+      data-storage-key={@storage_key}
+      class="mb-5 hidden rounded-[6px] bg-[#CED9F2] px-6 py-4"
+      role="alert"
+    >
+      <div class="flex items-center gap-4">
+        <p class="m-0 flex-1 text-[16px] font-medium leading-6 text-[#45464C]">
+          <%= if @count == 1 do %>
+            There is <span class="font-bold">1 available update</span> for this template.
+          <% else %>
+            There are <span class="font-bold">{@count} available updates</span> for this template.
+          <% end %>
+        </p>
+        <Button.button
+          variant={:close}
+          aria-label="Dismiss template updates banner"
+          data-banner-dismiss
+        />
+      </div>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    """
+  end
+end

--- a/lib/oli_web/live/products/details/template_updates_banner.ex
+++ b/lib/oli_web/live/products/details/template_updates_banner.ex
@@ -13,7 +13,7 @@ defmodule OliWeb.Products.Details.TemplateUpdatesBanner do
       phx-hook="SessionBannerDismiss"
       data-storage-key={@storage_key}
       class="mb-5 hidden rounded-[6px] bg-[#CED9F2] px-6 py-4"
-      role="alert"
+      role="status"
     >
       <div class="flex items-center gap-4">
         <p class="m-0 flex-1 text-[16px] font-medium leading-6 text-[#45464C]">

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -14,6 +14,7 @@ defmodule OliWeb.Products.DetailsView do
   alias OliWeb.Live.Components.Sections.CourseDiscussionsComponent
   alias OliWeb.Live.Components.Sections.NotesComponent
   alias OliWeb.Products.Details.{Actions, Edit, Content, ImageUpload}
+  alias OliWeb.Products.Details.TemplateUpdatesBanner
   alias OliWeb.Products.ImagePreviewState
   alias OliWeb.Products.Payments.Discounts.ProductsIndexView
   alias OliWeb.Products.ProductsToTransferCodes
@@ -66,6 +67,7 @@ defmodule OliWeb.Products.DetailsView do
         publishers = Inventories.list_publishers()
 
         component_data = SectionDefaultsHelpers.load_component_data(product)
+        updates = Sections.check_for_available_publication_updates(product)
 
         {:ok,
          assign(
@@ -73,7 +75,8 @@ defmodule OliWeb.Products.DetailsView do
            Map.merge(component_data, %{
              available_brands: available_brands,
              publishers: publishers,
-             updates: Sections.check_for_available_publication_updates(product),
+             updates: updates,
+             template_update_count: map_size(updates),
              author: author,
              product: product,
              tags: tags,
@@ -109,6 +112,10 @@ defmodule OliWeb.Products.DetailsView do
     ~H"""
     {render_modal(assigns)}
     <div class="overview container">
+      <TemplateUpdatesBanner.render
+        count={@template_update_count}
+        storage_key={"template-updates-banner:#{@product.slug}"}
+      />
       <Overview.section
         title="Details"
         description="The template title and description will be shown to instructors when they create their course section."

--- a/lib/oli_web/live/products/products_table_model.ex
+++ b/lib/oli_web/live/products/products_table_model.ex
@@ -12,6 +12,7 @@ defmodule OliWeb.Products.ProductsTableModel do
     search_term = Keyword.get(opts, :search_term, "")
     is_admin = Keyword.get(opts, :is_admin, false)
     current_author = Keyword.get(opts, :current_author)
+    template_update_ids = Keyword.get(opts, :template_update_ids, MapSet.new())
 
     base_columns = [
       %ColumnSpec{
@@ -78,7 +79,12 @@ defmodule OliWeb.Products.ProductsTableModel do
       id_field: [:id],
       sort_by_spec: sort_by_spec,
       sort_order: sort_order,
-      data: %{ctx: ctx, search_term: search_term, current_author: current_author}
+      data: %{
+        ctx: ctx,
+        search_term: search_term,
+        current_author: current_author,
+        template_update_ids: template_update_ids
+      }
     )
   end
 
@@ -91,7 +97,7 @@ defmodule OliWeb.Products.ProductsTableModel do
     end
   end
 
-  def render_title_column(assigns, %{title: title, slug: slug}, _) do
+  def render_title_column(assigns, %{id: id, title: title, slug: slug}, _) do
     route_path =
       case Map.get(assigns, :project_slug) do
         "" -> ~p"/authoring/products/#{slug}"
@@ -99,26 +105,38 @@ defmodule OliWeb.Products.ProductsTableModel do
       end
 
     search_term = Map.get(assigns, :search_term, "")
+    template_update_ids = Map.get(assigns, :template_update_ids, MapSet.new())
 
     assigns =
       Map.merge(assigns, %{
+        id: id,
         title: title,
         slug: slug,
         route_path: route_path,
-        search_term: search_term
+        search_term: search_term,
+        has_available_updates: MapSet.member?(template_update_ids, id)
       })
 
     ~H"""
-    <div class="flex flex-col">
-      <a
-        href={@route_path}
-        class="text-Text-text-link text-base font-medium leading-normal"
-      >
-        {highlight_search_term(@title, @search_term)}
-      </a>
-      <span class="text-Text-text-low text-sm font-normal leading-tight">
-        ID: {highlight_search_term(@slug, @search_term)}
-      </span>
+    <div class="flex gap-2">
+      <div
+        :if={@has_available_updates}
+        id={"template-update-indicator-#{@id}"}
+        class="mt-[6px] h-[12px] w-[12px] shrink-0 rounded-full bg-[#0073E5] ring-1 ring-white"
+        aria-hidden="true"
+      />
+      <div class="flex flex-col">
+        <span :if={@has_available_updates} class="sr-only">Updates available.</span>
+        <a
+          href={@route_path}
+          class="text-Text-text-link text-base font-medium leading-normal"
+        >
+          {highlight_search_term(@title, @search_term)}
+        </a>
+        <span class="text-Text-text-low text-sm font-normal leading-tight">
+          ID: {highlight_search_term(@slug, @search_term)}
+        </span>
+      </div>
     </div>
     """
   end

--- a/lib/oli_web/live/products/products_view.ex
+++ b/lib/oli_web/live/products/products_view.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Products.ProductsView do
   import OliWeb.DelegatedEvents
 
   alias Oli.Authoring.Course
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Institutions
   alias Oli.Publishing
@@ -127,6 +128,7 @@ defmodule OliWeb.Products.ProductsView do
         sort_by_spec: :inserted_at,
         sort_order: :desc,
         search_term: applied_search,
+        template_update_ids: Sections.blueprint_ids_with_available_updates(products),
         is_admin: is_admin_view,
         current_author: author
       )
@@ -281,7 +283,11 @@ defmodule OliWeb.Products.ProductsView do
     table_model =
       table_model
       |> Map.put(:rows, products)
-      |> Map.update!(:data, &Map.put(&1, :search_term, applied_search))
+      |> Map.update!(:data, fn data ->
+        data
+        |> Map.put(:search_term, applied_search)
+        |> Map.put(:template_update_ids, Sections.blueprint_ids_with_available_updates(products))
+      end)
 
     total_count = determine_total(products)
 

--- a/lib/oli_web/live/workspaces/course_author/products/details_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products/details_live.ex
@@ -20,6 +20,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
   alias OliWeb.Products.Details.Content
   alias OliWeb.Products.Details.Edit
   alias OliWeb.Products.Details.ImageUpload
+  alias OliWeb.Products.Details.TemplateUpdatesBanner
   alias OliWeb.Products.ImagePreviewState
   alias OliWeb.Products.Payments.Discounts.ProductsIndexView
   alias OliWeb.Products.ProductsToTransferCodes
@@ -61,6 +62,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
         latest_publications =
           Sections.check_for_available_publication_updates(product)
 
+        template_update_count = map_size(latest_publications)
+
         component_data = SectionDefaultsHelpers.load_component_data(product)
 
         {:ok,
@@ -69,6 +72,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
            Map.merge(component_data, %{
              publishers: publishers,
              updates: latest_publications,
+             template_update_count: template_update_count,
              author: author,
              product: product,
              is_admin: is_admin,
@@ -102,6 +106,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
     <h2 id="header_id" class="pb-2">Template Overview</h2>
     {render_modal(assigns)}
     <div class="overview container">
+      <TemplateUpdatesBanner.render
+        count={@template_update_count}
+        storage_key={"template-updates-banner:#{@product.slug}"}
+      />
       <div class="grid grid-cols-12 gap-x-[14px] py-5 border-b">
         <div class="col-span-12 md:col-span-4">
           <h4>Details</h4>

--- a/lib/oli_web/live/workspaces/course_author/products_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products_live.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
   import OliWeb.DelegatedEvents
 
   alias __MODULE__
+  alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Publishing
   alias Oli.Repo.Paging
@@ -45,6 +46,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
       ProductsTableModel.new(products, ctx, project.slug,
         sort_by_spec: :inserted_at,
         sort_order: :desc,
+        template_update_ids: Sections.blueprint_ids_with_available_updates(products),
         is_admin: false,
         current_author: socket.assigns.current_author
       )
@@ -86,6 +88,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
       )
 
     table_model = Map.put(table_model, :rows, products)
+
+    table_model =
+      put_in(
+        table_model.data.template_update_ids,
+        Sections.blueprint_ids_with_available_updates(products)
+      )
 
     socket =
       assign(socket,
@@ -218,6 +226,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ProductsLive do
       )
 
     table_model = Map.put(table_model, :rows, products)
+
+    table_model =
+      put_in(
+        table_model.data.template_update_ids,
+        Sections.blueprint_ids_with_available_updates(products)
+      )
 
     socket =
       assign(socket,

--- a/lib/oli_web/live/workspaces/sub_menu_item.ex
+++ b/lib/oli_web/live/workspaces/sub_menu_item.ex
@@ -3,7 +3,7 @@ defmodule OliWeb.Workspaces.SubMenuItem do
     Struct for a sub-menu item.
   """
   @enforce_keys [:text, :view]
-  @optional_keys [parent_view: nil, icon: nil, children: []]
+  @optional_keys [parent_view: nil, icon: nil, children: [], badge_key: nil]
 
   defstruct @enforce_keys ++ @optional_keys
 
@@ -12,6 +12,7 @@ defmodule OliWeb.Workspaces.SubMenuItem do
           view: atom(),
           icon: String.t(),
           parent_view: atom(),
-          children: list(%__MODULE__{})
+          children: list(%__MODULE__{}),
+          badge_key: atom() | nil
         }
 end

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -16,6 +16,7 @@ defmodule OliWeb.Workspaces.Utils do
   attr :active_workspace, :atom, default: nil
   attr :resource_slug, :string
   attr :resource_title, :string
+  attr :notification_badges, :map, default: %{}
 
   def sub_menu(assigns) do
     ~H"""
@@ -36,6 +37,7 @@ defmodule OliWeb.Workspaces.Utils do
           active_view={@active_view}
           active_workspace={@active_workspace}
           resource_slug={@resource_slug}
+          notification_badges={@notification_badges}
         />
       </div>
     </div>
@@ -49,6 +51,7 @@ defmodule OliWeb.Workspaces.Utils do
   attr :active_workspace, :atom, default: nil
   attr :resource_slug, :string
   attr :sub_menu_item, :map
+  attr :notification_badges, :map, default: %{}
 
   def sub_menu_item(%{sub_menu_item: %SubMenuItem{children: []} = item} = assigns) do
     %{
@@ -72,6 +75,7 @@ defmodule OliWeb.Workspaces.Utils do
         sidebar_expanded={@sidebar_expanded}
         sub_menu_item={@item}
         active_view={@active_view}
+        badge={badge_for_item(@item, @notification_badges, @sidebar_expanded)}
       />
     </.link>
     """
@@ -109,6 +113,7 @@ defmodule OliWeb.Workspaces.Utils do
           additional_classes={if(!@sidebar_expanded, do: "pointer-events-none")}
           sub_menu_item={@item}
           active_view={@active_view}
+          badge={badge_for_item(@item, @notification_badges, @sidebar_expanded)}
         />
       </.button>
       <div
@@ -125,6 +130,7 @@ defmodule OliWeb.Workspaces.Utils do
           active_workspace={@active_workspace}
           active_view={@active_view}
           resource_slug={@resource_slug}
+          notification_badges={@notification_badges}
         />
       </div>
     </div>
@@ -166,7 +172,7 @@ defmodule OliWeb.Workspaces.Utils do
           {@sub_menu_item.text}
         </div>
 
-        <%= if @sidebar_expanded and @badge do %>
+        <%= if @badge do %>
           <div>
             <.badge variant={:primary} class="ml-2">{@badge}</.badge>
           </div>
@@ -215,6 +221,31 @@ defmodule OliWeb.Workspaces.Utils do
 
   defp active_view_in_children?(children, active_view) do
     Enum.any?(children, &(&1.view == active_view))
+  end
+
+  defp badge_for_item(%SubMenuItem{badge_key: nil}, _notification_badges, _sidebar_expanded),
+    do: nil
+
+  defp badge_for_item(
+         %SubMenuItem{badge_key: badge_key, children: children},
+         notification_badges,
+         sidebar_expanded
+       ) do
+    badge = Map.get(notification_badges, badge_key)
+
+    cond do
+      is_nil(badge) or badge == 0 ->
+        nil
+
+      sidebar_expanded and children != [] ->
+        nil
+
+      !sidebar_expanded and children == [] ->
+        nil
+
+      true ->
+        badge
+    end
   end
 
   defp build_route(active_workspace, resource_slug, parent_view, view, sidebar_expanded) do
@@ -302,6 +333,7 @@ defmodule OliWeb.Workspaces.Utils do
         text: "Publish",
         icon: "author_publish",
         view: :author_publish,
+        badge_key: :template_updates,
         children: [
           %SubMenuItem{
             text: "Review",
@@ -316,7 +348,8 @@ defmodule OliWeb.Workspaces.Utils do
           %SubMenuItem{
             text: "Templates",
             view: :products,
-            parent_view: :author_publish
+            parent_view: :author_publish,
+            badge_key: :template_updates
           }
         ]
       },

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -63,7 +63,13 @@ defmodule OliWeb.Workspaces.Utils do
     route =
       build_route(active_workspace, resource_slug, item.parent_view, item.view, sidebar_expanded)
 
-    assigns = assign(assigns, item: item, route: route)
+    assigns =
+      assign(assigns,
+        item: item,
+        route: route,
+        badge_id: badge_dom_id(item),
+        badge_hidden: child_badge_hidden?(item, assigns.active_view, assigns.sidebar_expanded)
+      )
 
     ~H"""
     <.link
@@ -75,7 +81,9 @@ defmodule OliWeb.Workspaces.Utils do
         sidebar_expanded={@sidebar_expanded}
         sub_menu_item={@item}
         active_view={@active_view}
-        badge={badge_for_item(@item, @notification_badges, @sidebar_expanded)}
+        badge={badge_for_item(@item, @notification_badges, @sidebar_expanded, @active_view)}
+        badge_id={@badge_id}
+        badge_hidden={@badge_hidden}
       />
     </.link>
     """
@@ -83,9 +91,25 @@ defmodule OliWeb.Workspaces.Utils do
 
   def sub_menu_item(%{sub_menu_item: %SubMenuItem{children: children} = item} = assigns) do
     item_id = item.text |> String.downcase() |> String.replace(" ", "_")
+    submenu_expanded? = active_view_in_children?(children, assigns.active_view)
+
+    js_toggle_badges =
+      children
+      |> Enum.filter(&(&1.badge_key != nil))
+      |> Enum.reduce(
+        JS.toggle_class("hidden", to: "##{badge_dom_id(item)}"),
+        fn child, js -> JS.toggle_class(js, "hidden", to: "##{badge_dom_id(child)}") end
+      )
 
     assigns =
-      assign(assigns, item: item, item_id: item_id, children: children)
+      assign(assigns,
+        item: item,
+        item_id: item_id,
+        children: children,
+        submenu_expanded?: submenu_expanded?,
+        badge_id: badge_dom_id(item),
+        badge_hidden: submenu_expanded?
+      )
 
     ~H"""
     <div class="w-full relative">
@@ -105,6 +129,7 @@ defmodule OliWeb.Workspaces.Utils do
             JS.toggle(to: "##{@item_id}_children")
             |> toggle_class("-rotate-90", to: "##{@item_id}_expand_icon")
             |> JS.remove_class("rotate-0", to: "##{@item_id}_expand_icon")
+            |> then(fn js -> JS.concat(js, js_toggle_badges) end)
         }
       >
         <.nav_link_content
@@ -113,7 +138,9 @@ defmodule OliWeb.Workspaces.Utils do
           additional_classes={if(!@sidebar_expanded, do: "pointer-events-none")}
           sub_menu_item={@item}
           active_view={@active_view}
-          badge={badge_for_item(@item, @notification_badges, @sidebar_expanded)}
+          badge={badge_for_item(@item, @notification_badges, @sidebar_expanded, @active_view)}
+          badge_id={@badge_id}
+          badge_hidden={@badge_hidden}
         />
       </.button>
       <div
@@ -140,6 +167,8 @@ defmodule OliWeb.Workspaces.Utils do
   attr :is_active, :boolean, default: false
   attr :sidebar_expanded, :boolean, default: true
   attr :badge, :integer, default: nil
+  attr :badge_id, :string, default: nil
+  attr :badge_hidden, :boolean, default: false
 
   attr :on_active_bg, :string,
     default: "bg-[#E6E9F2] dark:bg-[#222126] hover:!bg-[#E6E9F2] hover:dark:!bg-[#222126]"
@@ -173,7 +202,7 @@ defmodule OliWeb.Workspaces.Utils do
         </div>
 
         <%= if @badge do %>
-          <div>
+          <div id={@badge_id} class={if(@badge_hidden, do: "hidden")}>
             <.badge variant={:primary} class="ml-2">{@badge}</.badge>
           </div>
         <% end %>
@@ -223,13 +252,23 @@ defmodule OliWeb.Workspaces.Utils do
     Enum.any?(children, &(&1.view == active_view))
   end
 
-  defp badge_for_item(%SubMenuItem{badge_key: nil}, _notification_badges, _sidebar_expanded),
-    do: nil
+  defp badge_for_item(
+         %SubMenuItem{badge_key: nil},
+         _notification_badges,
+         _sidebar_expanded,
+         _active_view
+       ),
+       do: nil
 
   defp badge_for_item(
-         %SubMenuItem{badge_key: badge_key, children: children},
+         %SubMenuItem{
+           badge_key: badge_key,
+           children: children,
+           parent_view: parent_view
+         },
          notification_badges,
-         sidebar_expanded
+         sidebar_expanded,
+         _active_view
        ) do
     badge = Map.get(notification_badges, badge_key)
 
@@ -237,15 +276,41 @@ defmodule OliWeb.Workspaces.Utils do
       is_nil(badge) or badge == 0 ->
         nil
 
-      sidebar_expanded and children != [] ->
-        nil
-
-      !sidebar_expanded and children == [] ->
+      !sidebar_expanded and children == [] and not is_nil(parent_view) ->
         nil
 
       true ->
         badge
     end
+  end
+
+  defp child_badge_hidden?(
+         %SubMenuItem{badge_key: nil},
+         _active_view,
+         _sidebar_expanded
+       ),
+       do: false
+
+  defp child_badge_hidden?(
+         %SubMenuItem{parent_view: nil},
+         _active_view,
+         _sidebar_expanded
+       ),
+       do: false
+
+  defp child_badge_hidden?(
+         %SubMenuItem{} = item,
+         active_view,
+         sidebar_expanded
+       ) do
+    sidebar_expanded and active_view != item.view
+  end
+
+  defp badge_dom_id(%SubMenuItem{text: text}) do
+    text
+    |> String.downcase()
+    |> String.replace(" ", "_")
+    |> Kernel.<>("_badge")
   end
 
   defp build_route(active_workspace, resource_slug, parent_view, view, sidebar_expanded) do

--- a/lib/oli_web/live/workspaces/utils.ex
+++ b/lib/oli_web/live/workspaces/utils.ex
@@ -52,6 +52,7 @@ defmodule OliWeb.Workspaces.Utils do
   attr :resource_slug, :string
   attr :sub_menu_item, :map
   attr :notification_badges, :map, default: %{}
+  attr :parent_expanded?, :boolean, default: false
 
   def sub_menu_item(%{sub_menu_item: %SubMenuItem{children: []} = item} = assigns) do
     %{
@@ -68,7 +69,12 @@ defmodule OliWeb.Workspaces.Utils do
         item: item,
         route: route,
         badge_id: badge_dom_id(item),
-        badge_hidden: child_badge_hidden?(item, assigns.active_view, assigns.sidebar_expanded)
+        badge_hidden:
+          child_badge_hidden?(
+            item,
+            assigns.sidebar_expanded,
+            assigns.parent_expanded?
+          )
       )
 
     ~H"""
@@ -158,6 +164,7 @@ defmodule OliWeb.Workspaces.Utils do
           active_view={@active_view}
           resource_slug={@resource_slug}
           notification_badges={@notification_badges}
+          parent_expanded?={@submenu_expanded?}
         />
       </div>
     </div>
@@ -286,24 +293,24 @@ defmodule OliWeb.Workspaces.Utils do
 
   defp child_badge_hidden?(
          %SubMenuItem{badge_key: nil},
-         _active_view,
-         _sidebar_expanded
+         _sidebar_expanded,
+         _parent_expanded?
        ),
        do: false
 
   defp child_badge_hidden?(
          %SubMenuItem{parent_view: nil},
-         _active_view,
-         _sidebar_expanded
+         _sidebar_expanded,
+         _parent_expanded?
        ),
        do: false
 
   defp child_badge_hidden?(
          %SubMenuItem{} = item,
-         active_view,
-         sidebar_expanded
+         sidebar_expanded,
+         parent_expanded?
        ) do
-    sidebar_expanded and active_view != item.view
+    item.parent_view != nil and (not sidebar_expanded or not parent_expanded?)
   end
 
   defp badge_dom_id(%SubMenuItem{text: text}) do

--- a/lib/oli_web/live_session_plugs/set_project_or_section.ex
+++ b/lib/oli_web/live_session_plugs/set_project_or_section.ex
@@ -1,11 +1,18 @@
 defmodule OliWeb.LiveSessionPlugs.SetProjectOrSection do
   use OliWeb, :verified_routes
 
+  import Phoenix.Component, only: [assign: 2]
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Delivery.Sections
   alias OliWeb.LiveSessionPlugs.SetProject
   alias OliWeb.LiveSessionPlugs.SetSection
 
   def on_mount(:default, %{"project_id" => _project_id} = params, session, socket) do
-    SetProject.on_mount(:default, params, session, socket)
+    case SetProject.on_mount(:default, params, session, socket) do
+      {:cont, socket} -> {:cont, maybe_load_template_updates_badge(socket)}
+      other -> other
+    end
   end
 
   def on_mount(:default, %{"section_slug" => _section_slug} = params, session, socket) do
@@ -15,4 +22,20 @@ defmodule OliWeb.LiveSessionPlugs.SetProjectOrSection do
   def on_mount(:default, _params, _session, socket) do
     {:cont, socket}
   end
+
+  defp maybe_load_template_updates_badge(%{assigns: %{project: %Project{} = project}} = socket) do
+    notification_badges = Map.get(socket.assigns, :notification_badges, %{})
+
+    case Sections.count_available_blueprint_updates(project) do
+      count when count > 0 ->
+        assign(socket,
+          notification_badges: Map.put(notification_badges, :template_updates, count)
+        )
+
+      _ ->
+        assign(socket, notification_badges: notification_badges)
+    end
+  end
+
+  defp maybe_load_template_updates_badge(socket), do: socket
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -987,7 +987,6 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.SetSidebar,
         OliWeb.LiveSessionPlugs.SetPreviewMode,
         OliWeb.LiveSessionPlugs.SetProjectOrSection,
-        OliWeb.LiveSessionPlugs.SetWorkspaceNotificationBadges,
         OliWeb.LiveSessionPlugs.AuthorizeProject
       ] do
       scope "/course_author", CourseAuthor do
@@ -1005,7 +1004,6 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.SetSidebar,
         OliWeb.LiveSessionPlugs.SetPreviewMode,
         OliWeb.LiveSessionPlugs.SetProjectOrSection,
-        OliWeb.LiveSessionPlugs.SetWorkspaceNotificationBadges,
         OliWeb.LiveSessionPlugs.AuthorizeProject
       ] do
       scope "/course_author", CourseAuthor do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -987,6 +987,7 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.SetSidebar,
         OliWeb.LiveSessionPlugs.SetPreviewMode,
         OliWeb.LiveSessionPlugs.SetProjectOrSection,
+        OliWeb.LiveSessionPlugs.SetWorkspaceNotificationBadges,
         OliWeb.LiveSessionPlugs.AuthorizeProject
       ] do
       scope "/course_author", CourseAuthor do
@@ -1004,6 +1005,7 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.SetSidebar,
         OliWeb.LiveSessionPlugs.SetPreviewMode,
         OliWeb.LiveSessionPlugs.SetProjectOrSection,
+        OliWeb.LiveSessionPlugs.SetWorkspaceNotificationBadges,
         OliWeb.LiveSessionPlugs.AuthorizeProject
       ] do
       scope "/course_author", CourseAuthor do

--- a/test/oli_web/components/delivery/layouts_test.exs
+++ b/test/oli_web/components/delivery/layouts_test.exs
@@ -260,7 +260,42 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
       assert html =~ "Exit Course"
     end
 
-    test "renders template update badge on Templates when sidebar is expanded" do
+    test "renders template update badge on Publish when sidebar is expanded but submenu is collapsed" do
+      assigns = %{
+        hierarchy: [
+          %SubMenuItem{
+            text: "Publish",
+            view: :author_publish,
+            badge_key: :template_updates,
+            children: [
+              %SubMenuItem{text: "Review", view: :review, parent_view: :author_publish},
+              %SubMenuItem{text: "Publish", view: :publish, parent_view: :author_publish},
+              %SubMenuItem{
+                text: "Templates",
+                view: :products,
+                parent_view: :author_publish,
+                badge_key: :template_updates
+              }
+            ]
+          }
+        ],
+        resource_slug: "project-slug",
+        resource_title: "Project",
+        active_workspace: :course_author,
+        active_view: :overview,
+        sidebar_expanded: true,
+        notification_badges: %{template_updates: 13}
+      }
+
+      html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
+
+      assert html =~ "button_for_author_publish"
+      assert html =~ ~s(id="publish_badge")
+      assert html =~ ~s(id="templates_badge" class="hidden")
+      assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 2
+    end
+
+    test "renders template update badge on Templates when Publish submenu is expanded" do
       assigns = %{
         hierarchy: [
           %SubMenuItem{
@@ -290,11 +325,13 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
       html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
 
       assert html =~ "Templates"
-      assert Regex.match?(~r/>\s*13\s*<\/span>/, html)
-      assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 1
+      assert html =~ ~s(id="publish_badge" class="hidden")
+      assert html =~ ~s(id="templates_badge")
+      refute html =~ ~s(id="templates_badge" class="hidden")
+      assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 2
     end
 
-    test "renders template update badge on Publish when sidebar is collapsed" do
+    test "renders template update badge on Publish when the whole sidebar is collapsed" do
       assigns = %{
         hierarchy: [
           %SubMenuItem{
@@ -324,6 +361,9 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
       html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
 
       assert html =~ "button_for_author_publish"
+      assert html =~ ~s(id="publish_badge")
+      refute html =~ ~s(id="publish_badge" class="hidden")
+      refute html =~ ~s(id="templates_badge")
       assert Regex.match?(~r/>\s*13\s*<\/span>/, html)
       assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 1
     end

--- a/test/oli_web/components/delivery/layouts_test.exs
+++ b/test/oli_web/components/delivery/layouts_test.exs
@@ -9,6 +9,8 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
   alias Oli.Authoring.Course.Project
   alias Oli.Accounts.User
   alias Oli.Resources.Collaboration.CollabSpaceConfig
+  alias OliWeb.Workspaces.SubMenuItem
+  alias OliWeb.Workspaces.Utils, as: WorkspaceUtils
 
   describe "header/1" do
     test "renders header with logo if include_logo is true" do
@@ -256,6 +258,74 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
       assert html =~ ~s(aria-label="Close menu")
       assert html =~ ~s(aria-label="Settings")
       assert html =~ "Exit Course"
+    end
+
+    test "renders template update badge on Templates when sidebar is expanded" do
+      assigns = %{
+        hierarchy: [
+          %SubMenuItem{
+            text: "Publish",
+            view: :author_publish,
+            badge_key: :template_updates,
+            children: [
+              %SubMenuItem{text: "Review", view: :review, parent_view: :author_publish},
+              %SubMenuItem{text: "Publish", view: :publish, parent_view: :author_publish},
+              %SubMenuItem{
+                text: "Templates",
+                view: :products,
+                parent_view: :author_publish,
+                badge_key: :template_updates
+              }
+            ]
+          }
+        ],
+        resource_slug: "project-slug",
+        resource_title: "Project",
+        active_workspace: :course_author,
+        active_view: :products,
+        sidebar_expanded: true,
+        notification_badges: %{template_updates: 13}
+      }
+
+      html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
+
+      assert html =~ "Templates"
+      assert Regex.match?(~r/>\s*13\s*<\/span>/, html)
+      assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 1
+    end
+
+    test "renders template update badge on Publish when sidebar is collapsed" do
+      assigns = %{
+        hierarchy: [
+          %SubMenuItem{
+            text: "Publish",
+            view: :author_publish,
+            badge_key: :template_updates,
+            children: [
+              %SubMenuItem{text: "Review", view: :review, parent_view: :author_publish},
+              %SubMenuItem{text: "Publish", view: :publish, parent_view: :author_publish},
+              %SubMenuItem{
+                text: "Templates",
+                view: :products,
+                parent_view: :author_publish,
+                badge_key: :template_updates
+              }
+            ]
+          }
+        ],
+        resource_slug: "project-slug",
+        resource_title: "Project",
+        active_workspace: :course_author,
+        active_view: :overview,
+        sidebar_expanded: false,
+        notification_badges: %{template_updates: 13}
+      }
+
+      html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
+
+      assert html =~ "button_for_author_publish"
+      assert Regex.match?(~r/>\s*13\s*<\/span>/, html)
+      assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 1
     end
   end
 end

--- a/test/oli_web/components/delivery/layouts_test.exs
+++ b/test/oli_web/components/delivery/layouts_test.exs
@@ -331,6 +331,74 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
       assert length(Regex.scan(~r/>\s*13\s*<\/span>/, html)) == 2
     end
 
+    test "renders template update badge on Templates when Publish submenu is expanded on Review" do
+      assigns = %{
+        hierarchy: [
+          %SubMenuItem{
+            text: "Publish",
+            view: :author_publish,
+            badge_key: :template_updates,
+            children: [
+              %SubMenuItem{text: "Review", view: :review, parent_view: :author_publish},
+              %SubMenuItem{text: "Publish", view: :publish, parent_view: :author_publish},
+              %SubMenuItem{
+                text: "Templates",
+                view: :products,
+                parent_view: :author_publish,
+                badge_key: :template_updates
+              }
+            ]
+          }
+        ],
+        resource_slug: "project-slug",
+        resource_title: "Project",
+        active_workspace: :course_author,
+        active_view: :review,
+        sidebar_expanded: true,
+        notification_badges: %{template_updates: 13}
+      }
+
+      html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
+
+      assert html =~ ~s(id="publish_badge" class="hidden")
+      assert html =~ ~s(id="templates_badge")
+      refute html =~ ~s(id="templates_badge" class="hidden")
+    end
+
+    test "renders template update badge on Templates when Publish submenu is expanded on Publish" do
+      assigns = %{
+        hierarchy: [
+          %SubMenuItem{
+            text: "Publish",
+            view: :author_publish,
+            badge_key: :template_updates,
+            children: [
+              %SubMenuItem{text: "Review", view: :review, parent_view: :author_publish},
+              %SubMenuItem{text: "Publish", view: :publish, parent_view: :author_publish},
+              %SubMenuItem{
+                text: "Templates",
+                view: :products,
+                parent_view: :author_publish,
+                badge_key: :template_updates
+              }
+            ]
+          }
+        ],
+        resource_slug: "project-slug",
+        resource_title: "Project",
+        active_workspace: :course_author,
+        active_view: :publish,
+        sidebar_expanded: true,
+        notification_badges: %{template_updates: 13}
+      }
+
+      html = render_component(&WorkspaceUtils.sub_menu/1, assigns)
+
+      assert html =~ ~s(id="publish_badge" class="hidden")
+      assert html =~ ~s(id="templates_badge")
+      refute html =~ ~s(id="templates_badge" class="hidden")
+    end
+
     test "renders template update badge on Publish when the whole sidebar is collapsed" do
       assigns = %{
         hierarchy: [

--- a/test/oli_web/live/products/details_view_test.exs
+++ b/test/oli_web/live/products/details_view_test.exs
@@ -6,6 +6,7 @@ defmodule OliWeb.Products.DetailsViewTest do
   import Oli.Factory
   import Oli.TestHelpers
 
+  alias Oli.Delivery.Sections.Blueprint
   alias OliWeb.Products.Details.Content
   alias Oli.Tags
 
@@ -103,6 +104,22 @@ defmodule OliWeb.Products.DetailsViewTest do
 
       assert has_element?(view, "span[role='listitem']", "Chemistry")
       assert has_element?(view, "span[role='listitem']", "Advanced")
+    end
+  end
+
+  describe "product details page - template updates banner" do
+    setup [:setup_admin_conn, :create_product_with_available_updates]
+
+    test "renders the template updates banner when updates are available", %{
+      conn: conn,
+      product: product
+    } do
+      {:ok, view, _html} = live(conn, product_route(product.slug))
+
+      assert has_element?(view, "[phx-hook='SessionBannerDismiss']")
+      assert has_element?(view, "[data-storage-key='template-updates-banner:#{product.slug}']")
+      assert render(view) =~ "available update"
+      assert has_element?(view, "button[data-banner-dismiss]")
     end
   end
 
@@ -683,5 +700,45 @@ defmodule OliWeb.Products.DetailsViewTest do
     {:ok, product} = Oli.Delivery.Sections.create_section_resources(product, publication)
 
     {:ok, project: project, product: product, publication: publication}
+  end
+
+  defp create_product_with_available_updates(%{admin: admin}) do
+    project = insert(:project, authors: [admin])
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        content: %{},
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    publication =
+      insert(:publication, %{
+        project: project,
+        published: nil,
+        root_resource_id: container_resource.id
+      })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: admin
+    })
+
+    {:ok, _initial_publication} =
+      Oli.Publishing.publish_project(project, "initial publication", admin.id)
+
+    {:ok, product} = Blueprint.create_blueprint(project.slug, "Test Product", nil)
+
+    {:ok, _latest_publication} =
+      Oli.Publishing.publish_project(project, "follow-up publication", admin.id)
+
+    {:ok, project: project, product: product}
   end
 end

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.ProductsLiveTest do
   import Mox
 
   alias Oli.Delivery.{Paywall, Sections}
+  alias Oli.Delivery.Sections.Blueprint
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Utils.Seeder
   alias Oli.Authoring.Course
@@ -36,6 +37,53 @@ defmodule OliWeb.ProductsLiveTest do
     Paywall.create_payment_codes(product.slug, 20)
 
     [product: product]
+  end
+
+  defp create_products_with_and_without_updates(admin) do
+    project = insert(:project, authors: [admin])
+    container_resource = insert(:resource)
+
+    container_revision =
+      insert(:revision, %{
+        resource: container_resource,
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        content: %{},
+        slug: "root_container",
+        title: "Root Container"
+      })
+
+    insert(:project_resource, %{project_id: project.id, resource_id: container_resource.id})
+
+    publication =
+      insert(:publication, %{
+        project: project,
+        published: nil,
+        root_resource_id: container_resource.id
+      })
+
+    insert(:published_resource, %{
+      publication: publication,
+      resource: container_resource,
+      revision: container_revision,
+      author: admin
+    })
+
+    {:ok, _initial_publication} =
+      Oli.Publishing.publish_project(project, "initial publication", admin.id)
+
+    {:ok, product_with_updates} =
+      Blueprint.create_blueprint(project.slug, "Updated Template", nil)
+
+    {:ok, _follow_up_publication} =
+      Oli.Publishing.publish_project(project, "follow-up publication", admin.id)
+
+    {:ok, product_without_updates} =
+      Blueprint.create_blueprint(project.slug, "Current Template", nil)
+
+    %{
+      product_with_updates: product_with_updates,
+      product_without_updates: product_without_updates
+    }
   end
 
   describe "product overview content settings" do
@@ -97,6 +145,22 @@ defmodule OliWeb.ProductsLiveTest do
 
       assert has_element?(view, "a", product.title)
       assert has_element?(view, "a", product_2.title)
+    end
+
+    test "shows update indicator only for templates with available updates", %{
+      conn: conn,
+      admin: admin
+    } do
+      %{
+        product_with_updates: product_with_updates,
+        product_without_updates: product_without_updates
+      } =
+        create_products_with_and_without_updates(admin)
+
+      {:ok, view, _html} = live(conn, @live_view_all_products)
+
+      assert has_element?(view, "#template-update-indicator-#{product_with_updates.id}")
+      refute has_element?(view, "#template-update-indicator-#{product_without_updates.id}")
     end
 
     test "search product by title", %{conn: conn, product: product} do

--- a/test/oli_web/live/products_test.exs
+++ b/test/oli_web/live/products_test.exs
@@ -163,6 +163,23 @@ defmodule OliWeb.ProductsLiveTest do
       refute has_element?(view, "#template-update-indicator-#{product_without_updates.id}")
     end
 
+    test "does not show update indicator for archived templates", %{
+      conn: conn,
+      admin: admin
+    } do
+      %{product_with_updates: archived_product} = create_products_with_and_without_updates(admin)
+
+      Oli.Delivery.Sections.update_section!(archived_product, %{status: :archived})
+
+      {:ok, view, _html} = live(conn, @live_view_all_products)
+
+      view
+      |> element("input[phx-click='include_archived']")
+      |> render_click()
+
+      refute has_element?(view, "#template-update-indicator-#{archived_product.id}")
+    end
+
     test "search product by title", %{conn: conn, product: product} do
       [{_, product_2} | _] = create_product(conn)
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -10,6 +10,8 @@ defmodule OliWeb.RemixSectionLiveTest do
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Delivery.Sections
   alias Oli.Accounts
+  alias Oli.Authoring.Course
+  alias Oli.Publishing
 
   describe "remix section as admin" do
     setup [:setup_admin_session]
@@ -962,6 +964,50 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert Floki.text(customize_content_breadcrumb) =~ "Customize Content"
       assert Floki.find(customize_content_breadcrumb, "a") == []
     end
+
+    test "non-admin product manager cannot see unrelated restricted projects in add materials", %{
+      conn: conn,
+      prod: prod,
+      restricted_project_title: restricted_project_title
+    } do
+      conn =
+        get(
+          conn,
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click='show_add_materials_modal']")
+      |> render_click()
+
+      refute render(view) =~ restricted_project_title
+    end
+  end
+
+  describe "remix section as product admin" do
+    setup [:setup_product_admin_session]
+
+    test "admin product manager can see unrelated restricted projects in add materials", %{
+      conn: conn,
+      prod: prod,
+      restricted_project_title: restricted_project_title
+    } do
+      conn =
+        get(
+          conn,
+          Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug)
+        )
+
+      {:ok, view, _html} = live(conn)
+
+      view
+      |> element("button[phx-click='show_add_materials_modal']")
+      |> render_click()
+
+      assert render(view) =~ restricted_project_title
+    end
   end
 
   describe "remix section for open and free" do
@@ -1694,6 +1740,9 @@ defmodule OliWeb.RemixSectionLiveTest do
       |> Seeder.create_product(%{title: "My 1st product", amount: Money.new(100, "USD")}, :prod1)
 
     {:ok, _prod} = Sections.create_section_resources(prod, publication)
+    restricted_project_title = "Restricted Source Project"
+
+    create_restricted_project(product_author, prod.institution, restricted_project_title)
 
     conn =
       Plug.Test.init_test_session(conn, %{})
@@ -1704,6 +1753,33 @@ defmodule OliWeb.RemixSectionLiveTest do
      prod: prod,
      revision1: revision1,
      revision2: revision2,
-     project_slug: project.slug}
+     project_slug: project.slug,
+     restricted_project_title: restricted_project_title}
+  end
+
+  defp setup_product_admin_session(%{conn: conn}) do
+    {:ok, setup} = setup_product_manager_session(%{conn: conn})
+    admin = insert(:author, system_role_id: Oli.Accounts.SystemRole.role_id().content_admin)
+
+    conn =
+      Plug.Test.init_test_session(conn, %{})
+      |> log_in_author(admin)
+
+    {:ok, Keyword.put(setup, :conn, conn)}
+  end
+
+  defp create_restricted_project(_owner, institution, title) do
+    unrelated_author = insert(:author)
+    restricted_project = Seeder.another_project(unrelated_author, institution, title)
+
+    {:ok, _project} =
+      Course.update_project(restricted_project.project, %{visibility: :selected})
+
+    {:ok, _publication} =
+      Publishing.publish_project(
+        restricted_project.project,
+        "publish restricted remix source",
+        unrelated_author.id
+      )
   end
 end

--- a/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
@@ -82,6 +82,19 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
                "Template Overview"
     end
 
+    test "renders the template updates banner when updates are available", ctx do
+      %{conn: conn, project: project, product: product, author: author} = ctx
+
+      Oli.Publishing.publish_project(project, "fresh update", author.id)
+
+      {:ok, live, _html} = live(conn, live_view_route(project.slug, product.slug, %{}))
+
+      assert has_element?(live, "[phx-hook='SessionBannerDismiss']")
+      assert has_element?(live, "[data-storage-key='template-updates-banner:#{product.slug}']")
+      assert render(live) =~ "available update"
+      assert has_element?(live, "button[data-banner-dismiss]")
+    end
+
     test "renders paywall settings after details with support text and controls", ctx do
       %{conn: conn, project: project, product: product} = ctx
 

--- a/test/oli_web/live/workspaces/course_author/products_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products_live_test.exs
@@ -225,6 +225,26 @@ defmodule OliWeb.Workspace.CourseAuthor.ProductsLiveTest do
       assert has_element?(view, "#template-update-indicator-#{product_with_updates.id}")
       refute has_element?(view, "#template-update-indicator-#{product_without_updates.id}")
     end
+
+    test "does not show update indicator for archived templates", %{
+      conn: conn,
+      project: project,
+      author: author
+    } do
+      {:ok, archived_product} =
+        Blueprint.create_blueprint(project.slug, "Archived Template", nil)
+
+      {:ok, _follow_up_publication} =
+        Oli.Publishing.publish_project(project, "fresh update", author.id)
+
+      Oli.Delivery.Sections.update_section!(archived_product, %{status: :archived})
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      view |> element("input[type='checkbox']") |> render_click()
+
+      refute has_element?(view, "#template-update-indicator-#{archived_product.id}")
+    end
   end
 
   ##### HELPER FUNCTIONS #####

--- a/test/oli_web/live/workspaces/course_author/products_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products_live_test.exs
@@ -205,6 +205,26 @@ defmodule OliWeb.Workspace.CourseAuthor.ProductsLiveTest do
       assert Floki.text(rows) =~ "Algebra Template"
       refute Floki.text(rows) =~ "Biology Template"
     end
+
+    test "shows an update indicator only for templates with available updates", %{
+      conn: conn,
+      project: project,
+      author: author
+    } do
+      {:ok, product_with_updates} =
+        Blueprint.create_blueprint(project.slug, "Updated Template", nil)
+
+      {:ok, _follow_up_publication} =
+        Oli.Publishing.publish_project(project, "fresh update", author.id)
+
+      {:ok, product_without_updates} =
+        Blueprint.create_blueprint(project.slug, "Current Template", nil)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(view, "#template-update-indicator-#{product_with_updates.id}")
+      refute has_element?(view, "#template-update-indicator-#{product_without_updates.id}")
+    end
   end
 
   ##### HELPER FUNCTIONS #####


### PR DESCRIPTION
• ## Summary

 Implements [MER-5506](https://eliterate.atlassian.net/browse/MER-5506) adding template update indicators to template overview and workspace navigation.

  This change introduces a dismissible update banner on both template overview pages and adds a workspace sidebar badge when a project has templates with available updates. The sidebar badge reflects the number of templates with updates, while each individual template overview page shows the exact number of updates available for that template.

  ## What Changed

  - Added a dismissible template updates banner to both template overview implementations:
      - workspace route
      - admin/browse-all-templates route
  - Added session-scoped banner dismissal using a LiveView hook backed by sessionStorage
  - Added workspace sidebar badges for template updates:
      - badge appears on Publish when the submenu is closed
      - badge appears on Templates when the submenu is expanded
      - badge is a project-level signal independent of the currently displayed page.
  - Kept page-level and sidebar-level count semantics distinct:
      - overview page banner: exact number of available updates for that template
      - workspace sidebar badge: number of templates in the project that have at least one available update   
  - Added a per-row update indicator on the template list pages so authors can quickly see which templates have
    pending updates without opening each template overview first.
      - shown on both workspace route: Publish -> Templates & Admin -> Browse All Templates
      - the indicator appears next to the title of templates with available updates and is computed in a single
        batch query for the currently visible page of results

  ## Testing
  mix test test/oli_web/components/delivery/layouts_test.exs \
    test/oli_web/live/workspaces/course_author/products/details_live_test.exs \
    test/oli_web/live/products/details_view_test.exs


[MER-5506]: https://eliterate.atlassian.net/browse/MER-5506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ