### PR TITLE
[BUG FIX] [MER-5548] REWORK - Fix author account linking redirect 500

### DIFF
--- a/lib/oli_web/author_auth.ex
+++ b/lib/oli_web/author_auth.ex
@@ -30,7 +30,7 @@ defmodule OliWeb.AuthorAuth do
     # Get the return path AFTER account linking to respect any changes made
     author_return_to =
       build_redirect_path(params["request_path"]) ||
-        get_session(conn, :author_return_to) ||
+        build_redirect_path(get_session(conn, :author_return_to)) ||
         signed_in_path(conn)
 
     conn

--- a/lib/oli_web/author_auth.ex
+++ b/lib/oli_web/author_auth.ex
@@ -29,7 +29,9 @@ defmodule OliWeb.AuthorAuth do
 
     # Get the return path AFTER account linking to respect any changes made
     author_return_to =
-      params["request_path"] || get_session(conn, :author_return_to) || signed_in_path(conn)
+      build_redirect_path(params["request_path"]) ||
+        get_session(conn, :author_return_to) ||
+        signed_in_path(conn)
 
     conn
     |> put_token_in_session(token)
@@ -37,6 +39,13 @@ defmodule OliWeb.AuthorAuth do
     |> maybe_write_remember_me_cookie(token, params)
     |> redirect(to: author_return_to)
   end
+
+  defp build_redirect_path(path) do
+    if valid_local_path?(path), do: path, else: nil
+  end
+
+  defp valid_local_path?("/" <> rest), do: rest != "" and not String.starts_with?(rest, "/")
+  defp valid_local_path?(_), do: false
 
   defp maybe_write_remember_me_cookie(conn, token, %{"remember_me" => "true"}) do
     put_resp_cookie(conn, @remember_me_cookie, token, @remember_me_options)

--- a/lib/oli_web/live/link_account_live.ex
+++ b/lib/oli_web/live/link_account_live.ex
@@ -12,10 +12,10 @@ defmodule OliWeb.LinkAccountLive do
   on_mount {OliWeb.UserAuth, :ensure_authenticated}
   on_mount {OliWeb.AuthorAuth, :mount_current_author}
 
-  def mount(params, _session, socket) do
+  def mount(params, session, socket) do
     email = Phoenix.Flash.get(socket.assigns.flash, :email)
     form = to_form(%{"email" => email}, as: "author")
-    request_path = validate_request_path(params["request_path"])
+    request_path = validate_request_path(params["request_path"] || session["author_return_to"])
 
     authentication_providers =
       Oli.AssentAuth.AuthorAssentAuth.authentication_providers() |> Keyword.keys()
@@ -112,7 +112,7 @@ defmodule OliWeb.LinkAccountLive do
               }
               class="w-full inline-block text-center mt-2"
             >
-              Back to Account Settings
+              Cancel
             </.button>
           </div>
         </div>

--- a/lib/oli_web/plugs/store_author_return_to.ex
+++ b/lib/oli_web/plugs/store_author_return_to.ex
@@ -1,0 +1,46 @@
+defmodule OliWeb.Plugs.StoreAuthorReturnTo do
+  @moduledoc """
+  Stores a same-origin referer path when navigating to the author-linking flow so
+  the user can be returned to the page they came from after linking accounts.
+  """
+
+  import Plug.Conn
+
+  @excluded_paths ["/users/link_account", "/authors/log_in"]
+
+  def init(opts), do: opts
+
+  def call(%Plug.Conn{request_path: "/users/link_account", method: "GET"} = conn, _opts) do
+    referer = get_req_header(conn, "referer") |> List.first()
+
+    case parse_referer_path(referer, conn.host) do
+      nil -> conn
+      path -> maybe_store_path(conn, path)
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  defp parse_referer_path(nil, _host), do: nil
+
+  defp parse_referer_path(referer, host) do
+    case URI.parse(referer) do
+      %URI{host: ^host, path: path, query: query} when is_binary(path) ->
+        build_path(path, query)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_path(path, nil), do: path
+  defp build_path(path, ""), do: path
+  defp build_path(path, query), do: path <> "?" <> query
+
+  defp maybe_store_path(conn, path) do
+    if should_store_path?(path), do: put_session(conn, "author_return_to", path), else: conn
+  end
+
+  defp should_store_path?(path),
+    do: not Enum.any?(@excluded_paths, &String.starts_with?(path, &1))
+end

--- a/lib/oli_web/plugs/store_author_return_to.ex
+++ b/lib/oli_web/plugs/store_author_return_to.ex
@@ -42,5 +42,8 @@ defmodule OliWeb.Plugs.StoreAuthorReturnTo do
   end
 
   defp should_store_path?(path),
-    do: not Enum.any?(@excluded_paths, &String.starts_with?(path, &1))
+    do: valid_local_path?(path) and not Enum.any?(@excluded_paths, &String.starts_with?(path, &1))
+
+  defp valid_local_path?("/" <> rest), do: rest != "" and not String.starts_with?(rest, "/")
+  defp valid_local_path?(_), do: false
 end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -208,6 +208,10 @@ defmodule OliWeb.Router do
     plug OliWeb.Plugs.StoreSettingsReturnTo
   end
 
+  pipeline :store_author_return_to do
+    plug OliWeb.Plugs.StoreAuthorReturnTo
+  end
+
   pipeline :community_admin do
     plug(Oli.Plugs.CommunityAdmin)
   end
@@ -336,6 +340,7 @@ defmodule OliWeb.Router do
     pipe_through [
       :browser,
       :delivery,
+      :store_author_return_to,
       :require_authenticated_user,
       :fetch_current_author
     ]

--- a/test/oli_web/author_auth_test.exs
+++ b/test/oli_web/author_auth_test.exs
@@ -37,6 +37,15 @@ defmodule OliWeb.AuthorAuthTest do
       conn = conn |> put_session(:author_return_to, "/hello") |> AuthorAuth.log_in_author(author)
       assert redirected_to(conn) == "/hello"
     end
+
+    test "ignores an unsafe configured session path", %{conn: conn, author: author} do
+      conn =
+        conn
+        |> put_session(:author_return_to, "//evil.example")
+        |> AuthorAuth.log_in_author(author)
+
+      assert redirected_to(conn) == ~p"/workspaces/course_author"
+    end
   end
 
   describe "logout_author/1" do

--- a/test/oli_web/live/link_account_live_test.exs
+++ b/test/oli_web/live/link_account_live_test.exs
@@ -105,6 +105,34 @@ defmodule OliWeb.LinkAccountLiveTest do
       assert redirected_to(conn) == ~p"/sections/new/some-context-id"
     end
 
+    test "falls back to account settings when request path is empty after linking", %{conn: conn} do
+      user = insert(:user, author: nil)
+
+      conn = log_in_user(conn, user)
+
+      password = "123456789abcd"
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(%{password: password})
+
+      {:ok, lv, _html} = live(conn, ~p"/users/link_account")
+
+      form =
+        form(lv, "#link_account_form",
+          author: %{
+            email: author.email,
+            password: password,
+            link_account_user_id: "#{user.id}",
+            request_path: ""
+          }
+        )
+
+      conn = submit_form(form, conn)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
+               "Your authoring account has been linked to your user account."
+
+      assert redirected_to(conn) == ~p"/users/settings"
+    end
+
     test "redirects back to link account page with a flash error if there are no valid credentials",
          %{
            conn: conn

--- a/test/oli_web/live/link_account_live_test.exs
+++ b/test/oli_web/live/link_account_live_test.exs
@@ -134,9 +134,10 @@ defmodule OliWeb.LinkAccountLiveTest do
       assert redirected_to(conn) == ~p"/workspaces/instructor"
     end
 
-    test "ignores an unsafe referer return path after linking when request_path is not provided", %{
-      conn: conn
-    } do
+    test "ignores an unsafe referer return path after linking when request_path is not provided",
+         %{
+           conn: conn
+         } do
       user = insert(:user, author: nil)
 
       conn =

--- a/test/oli_web/live/link_account_live_test.exs
+++ b/test/oli_web/live/link_account_live_test.exs
@@ -105,6 +105,35 @@ defmodule OliWeb.LinkAccountLiveTest do
       assert redirected_to(conn) == ~p"/sections/new/some-context-id"
     end
 
+    test "redirects back to the referer after linking when request_path is not provided", %{
+      conn: conn
+    } do
+      user = insert(:user, author: nil)
+
+      conn =
+        conn
+        |> log_in_user(user)
+        |> Plug.Conn.put_req_header("referer", "http://www.example.com/workspaces/instructor")
+        |> get(~p"/users/link_account")
+
+      password = "123456789abcd"
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(%{password: password})
+
+      {:ok, lv, _html} = live(recycle(conn), ~p"/users/link_account")
+
+      form =
+        form(lv, "#link_account_form",
+          author: %{email: author.email, password: password, link_account_user_id: "#{user.id}"}
+        )
+
+      conn = submit_form(form, recycle(conn))
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
+               "Your authoring account has been linked to your user account."
+
+      assert redirected_to(conn) == ~p"/workspaces/instructor"
+    end
+
     test "falls back to account settings when request path is empty after linking", %{conn: conn} do
       user = insert(:user, author: nil)
 

--- a/test/oli_web/live/link_account_live_test.exs
+++ b/test/oli_web/live/link_account_live_test.exs
@@ -134,6 +134,35 @@ defmodule OliWeb.LinkAccountLiveTest do
       assert redirected_to(conn) == ~p"/workspaces/instructor"
     end
 
+    test "ignores an unsafe referer return path after linking when request_path is not provided", %{
+      conn: conn
+    } do
+      user = insert(:user, author: nil)
+
+      conn =
+        conn
+        |> log_in_user(user)
+        |> Plug.Conn.put_req_header("referer", "http://www.example.com//evil.example")
+        |> get(~p"/users/link_account")
+
+      password = "123456789abcd"
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(%{password: password})
+
+      {:ok, lv, _html} = live(recycle(conn), ~p"/users/link_account")
+
+      form =
+        form(lv, "#link_account_form",
+          author: %{email: author.email, password: password, link_account_user_id: "#{user.id}"}
+        )
+
+      conn = submit_form(form, recycle(conn))
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
+               "Your authoring account has been linked to your user account."
+
+      assert redirected_to(conn) == ~p"/users/settings"
+    end
+
     test "falls back to account settings when request path is empty after linking", %{conn: conn} do
       user = insert(:user, author: nil)
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5548

Fix an issue identified in QA where redirecting a user after linking an authoring account resulted in a 500 error. This fix is 2-fold:
1. If no return to path is specified, the redirect will default to the account settings page to prevent 500.
2. The link authoring account feature now tracks the local route where a user came from and redirected them back to that page instead of always landing them back on the account settings page, which really no longer makes sense.