### PR TITLE
[BUG FIX] [MER-5543] Adaptive Pages: Handle trap-state activation point results in delivery

### DIFF
--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -42,6 +42,7 @@ import {
   selectUserId,
 } from '../store/features/page/slice';
 import { NotificationType } from './NotificationContext';
+import { checkResultsHaveNavigation } from './checkResults';
 
 interface ActivityRendererProps {
   activity: ActivityModelSchema;
@@ -444,38 +445,6 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
     ref?.current?.notify(NotificationType.CHECK_COMPLETE, payload);
   };
 
-  const hasNavigation = (events: any) => {
-    if (!currentActivityTree || !currentActivityTree?.length) {
-      return false;
-    }
-    let eventsToProcess = events.results;
-    const actionsByType: any = {
-      feedback: [],
-      mutateState: [],
-      navigation: [],
-    };
-    const currentActivity = currentActivityTree[currentActivityTree.length - 1];
-    const combineFeedback = !!currentActivity?.content?.custom?.combineFeedback;
-    if (!combineFeedback) {
-      eventsToProcess = [eventsToProcess[0]];
-    }
-    eventsToProcess.forEach((evt: any) => {
-      const { actions } = evt.params;
-      actions.forEach((action: any) => {
-        actionsByType[action.type].push(action);
-      });
-    });
-    if (actionsByType.navigation.length > 0) {
-      const [firstNavAction] = actionsByType.navigation;
-      const navTarget = firstNavAction.params.target;
-      // check current activity id, not *this* one because it could be a layer
-      if (navTarget !== currentActivityId) {
-        return true;
-      }
-    }
-    return false;
-  };
-
   const [lastCheckHandledTimestamp, setLastCheckHandledTimestamp] = useState(0);
 
   useEffect(() => {
@@ -487,7 +456,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
         lastCheckTriggered,
         lastCheckHandledTimestamp,
         lastCheckResults,
-        hasNav: hasNavigation(lastCheckResults),
+        hasNav: checkResultsHaveNavigation(lastCheckResults, currentActivityTree, currentActivityId),
       }); */
       setLastCheckHandledTimestamp(lastCheckTriggered);
       const currentAttempt = sharedAttemptStateMap.get(activity.id);
@@ -500,7 +469,11 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
         });
       }
 
-      const hasNavigationToDifferentActivity = hasNavigation(lastCheckResults);
+      const hasNavigationToDifferentActivity = checkResultsHaveNavigation(
+        lastCheckResults,
+        currentActivityTree,
+        currentActivityId,
+      );
       if (
         (!hasNavigationToDifferentActivity || isEverApp) &&
         !historyModeNavigation &&

--- a/assets/src/apps/delivery/components/checkResults.ts
+++ b/assets/src/apps/delivery/components/checkResults.ts
@@ -50,5 +50,14 @@ export const checkResultsHaveNavigation = (
 
   const [firstNavigationAction] = actionsByType.navigation;
   const target = firstNavigationAction?.params?.target;
-  return typeof target === 'string' && target !== currentActivityId;
+
+  if (typeof target !== 'string' && typeof target !== 'number') {
+    return false;
+  }
+
+  if (currentActivityId == null) {
+    return true;
+  }
+
+  return String(target) !== String(currentActivityId);
 };

--- a/assets/src/apps/delivery/components/checkResults.ts
+++ b/assets/src/apps/delivery/components/checkResults.ts
@@ -38,7 +38,7 @@ export const checkResultsHaveNavigation = (
     const actions = Array.isArray(event?.params?.actions) ? event.params.actions : [];
 
     actions.forEach((action: any) => {
-      if (action?.type in actionsByType) {
+      if (Object.prototype.hasOwnProperty.call(actionsByType, action?.type)) {
         actionsByType[action.type as keyof AdaptiveActionBuckets].push(action);
       }
     });
@@ -49,5 +49,6 @@ export const checkResultsHaveNavigation = (
   }
 
   const [firstNavigationAction] = actionsByType.navigation;
-  return firstNavigationAction?.params?.target !== currentActivityId;
+  const target = firstNavigationAction?.params?.target;
+  return typeof target === 'string' && target !== currentActivityId;
 };

--- a/assets/src/apps/delivery/components/checkResults.ts
+++ b/assets/src/apps/delivery/components/checkResults.ts
@@ -1,0 +1,53 @@
+import { CheckResults } from '../store/features/adaptivity/slice';
+
+type SupportedAdaptiveActionType = 'feedback' | 'mutateState' | 'navigation' | 'activationPoint';
+
+type AdaptiveActionBuckets = Record<SupportedAdaptiveActionType, any[]>;
+
+const createAdaptiveActionBuckets = (): AdaptiveActionBuckets => ({
+  feedback: [],
+  mutateState: [],
+  navigation: [],
+  activationPoint: [],
+});
+
+export const checkResultsHaveNavigation = (
+  checkResults: CheckResults | undefined,
+  currentActivityTree: any[] | undefined,
+  currentActivityId: string | undefined,
+) => {
+  if (!currentActivityTree?.length) {
+    return false;
+  }
+
+  const resultEvents = checkResults?.results;
+  let eventsToProcess = Array.isArray(resultEvents) ? resultEvents : [];
+  if (eventsToProcess.length === 0) {
+    return false;
+  }
+
+  const actionsByType = createAdaptiveActionBuckets();
+  const currentActivity = currentActivityTree[currentActivityTree.length - 1];
+  const combineFeedback = !!currentActivity?.content?.custom?.combineFeedback;
+
+  if (!combineFeedback) {
+    eventsToProcess = [eventsToProcess[0]];
+  }
+
+  eventsToProcess.forEach((event: any) => {
+    const actions = Array.isArray(event?.params?.actions) ? event.params.actions : [];
+
+    actions.forEach((action: any) => {
+      if (action?.type in actionsByType) {
+        actionsByType[action.type as keyof AdaptiveActionBuckets].push(action);
+      }
+    });
+  });
+
+  if (actionsByType.navigation.length === 0) {
+    return false;
+  }
+
+  const [firstNavigationAction] = actionsByType.navigation;
+  return firstNavigationAction?.params?.target !== currentActivityId;
+};

--- a/assets/src/apps/delivery/components/checkResults.ts
+++ b/assets/src/apps/delivery/components/checkResults.ts
@@ -13,8 +13,8 @@ const createAdaptiveActionBuckets = (): AdaptiveActionBuckets => ({
 
 export const checkResultsHaveNavigation = (
   checkResults: CheckResults | undefined,
-  currentActivityTree: any[] | undefined,
-  currentActivityId: string | undefined,
+  currentActivityTree: any[] | null | undefined,
+  currentActivityId: string | number | undefined,
 ) => {
   if (!currentActivityTree?.length) {
     return false;

--- a/assets/test/delivery/activity_renderer_test.ts
+++ b/assets/test/delivery/activity_renderer_test.ts
@@ -1,0 +1,61 @@
+import { checkResultsHaveNavigation } from '../../src/apps/delivery/components/checkResults';
+import { CheckResults } from '../../src/apps/delivery/store/features/adaptivity/slice';
+
+const currentActivityTree = [
+  {
+    content: {
+      custom: {
+        combineFeedback: false,
+      },
+    },
+  },
+];
+
+const buildCheckResults = (actions: any[]): CheckResults => ({
+  timestamp: 1,
+  results: [
+    {
+      params: {
+        actions,
+      },
+    },
+  ],
+  attempt: null,
+  correct: false,
+  score: 0,
+  outOf: 0,
+});
+
+describe('checkResultsHaveNavigation', () => {
+  it('ignores activation point actions while checking for navigation', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'activationPoint',
+        params: {
+          prompt: 'Help the learner recover from this trap state.',
+        },
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(false);
+  });
+
+  it('still detects navigation when an activation point is present in the same result', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'activationPoint',
+        params: {
+          prompt: 'Help the learner recover from this trap state.',
+        },
+      },
+      {
+        type: 'navigation',
+        params: {
+          target: 'screen-2',
+        },
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(true);
+  });
+});

--- a/assets/test/delivery/activity_renderer_test.ts
+++ b/assets/test/delivery/activity_renderer_test.ts
@@ -40,6 +40,17 @@ describe('checkResultsHaveNavigation', () => {
     expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(false);
   });
 
+  it('ignores action types that only exist on the prototype chain', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'toString',
+        params: {},
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(false);
+  });
+
   it('still detects navigation when an activation point is present in the same result', () => {
     const checkResults = buildCheckResults([
       {
@@ -57,5 +68,16 @@ describe('checkResultsHaveNavigation', () => {
     ]);
 
     expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(true);
+  });
+
+  it('ignores malformed navigation actions without a string target', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'navigation',
+        params: {},
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(false);
   });
 });

--- a/assets/test/delivery/activity_renderer_test.ts
+++ b/assets/test/delivery/activity_renderer_test.ts
@@ -80,4 +80,30 @@ describe('checkResultsHaveNavigation', () => {
 
     expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 'screen-1')).toBe(false);
   });
+
+  it('detects navigation when the target is numeric', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'navigation',
+        params: {
+          target: 2,
+        },
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, 1)).toBe(true);
+  });
+
+  it('treats equivalent numeric and string ids as the same activity', () => {
+    const checkResults = buildCheckResults([
+      {
+        type: 'navigation',
+        params: {
+          target: 2,
+        },
+      },
+    ]);
+
+    expect(checkResultsHaveNavigation(checkResults, currentActivityTree, '2')).toBe(false);
+  });
 });


### PR DESCRIPTION
Fixes the error where adding a DOT AI activation point to a trap-state rule could break advanced lesson preview and delivery with a white screen.

The failure came from delivery-side adaptive result handling: trap-state rules can emit an activationPoint action, but one navigation check path only accounted for feedback, mutateState, and navigation. When it encountered activationPoint, it tried to push into an undefined bucket and crashed.

Changes:
- delivery navigation check now ignores supported non-navigation actions like activationPoint

See: https://eliterate.atlassian.net/browse/MER-5543