### PR TITLE
[ENHANCEMENT] [MER-4744] Add adaptive debugger link to review navigation

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -52,6 +52,7 @@ export interface DeliveryProps {
   lateSubmit?: 'allow' | 'disallow';
   isAdmin?: boolean;
   isAuthor?: boolean;
+  debuggerURL?: string;
 }
 
 const Delivery: React.FC<DeliveryProps> = ({
@@ -81,6 +82,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   lateSubmit = 'allow',
   isAdmin,
   isAuthor,
+  debuggerURL,
 }) => {
   const dispatch = useDispatch();
   const currentGroup = useSelector(selectCurrentGroup);
@@ -197,6 +199,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         blobStorageProvider,
         screenIdleTimeOutInSeconds,
         reviewMode,
+        debuggerURL,
       }),
     );
   };

--- a/assets/src/apps/delivery/layouts/deck/components/ReviewModeNavigation.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/ReviewModeNavigation.tsx
@@ -6,7 +6,11 @@ import { selectCurrentActivityId } from '../../../store/features/activities/slic
 import { setHistoryNavigationTriggered } from '../../../store/features/adaptivity/slice';
 import { navigateToActivity } from '../../../store/features/groups/actions/deck';
 import { selectSequence } from '../../../store/features/groups/selectors/deck';
-import { selectShowHistory, setShowHistory } from '../../../store/features/page/slice';
+import {
+  selectDebuggerURL,
+  selectShowHistory,
+  setShowHistory,
+} from '../../../store/features/page/slice';
 import ReviewModeHistoryPanel from './ReviewModeHistoryPanel';
 
 export interface ReviewEntry {
@@ -19,6 +23,7 @@ export interface ReviewEntry {
 
 const ReviewModeNavigation: React.FC = () => {
   const currentActivityId = useSelector(selectCurrentActivityId);
+  const debuggerURL = useSelector(selectDebuggerURL);
   const showHistory = useSelector(selectShowHistory);
   const sequences = useSelector(selectSequence);
   const dispatch = useDispatch();
@@ -104,8 +109,13 @@ const ReviewModeNavigation: React.FC = () => {
               top: 0;
               left: calc(50% - .65rem);
             }
-            .review-button button {
+            .review-button .review-button-control {
               text-decoration: none;
+              display: inline-flex;
+              align-items: center;
+              justify-content: center;
+              width: 44.88px;
+              height: 39.95px;
               padding: 4px 10px;
               font-size: 1.3rem;
               line-height: 1.5;
@@ -114,16 +124,28 @@ const ReviewModeNavigation: React.FC = () => {
               border-top: none;
               transition: color .15s ease-in-out, background-color .15s ease-in-out, box-shadow .15s ease-in-out;
               margin-right:15px;
+              color: inherit;
+              background-color: rgba(255, 255, 255, 0.867);
+              box-sizing: border-box;
             }
-            .review-button button:hover {
+            .review-button .review-button-control:hover {
               color: #fff;
               background-color: #6c757d;
               box-shadow: 0 1px 2px #00000079;
               cursor: pointer;
             }
+            .review-button button.review-button-control:disabled {
+              cursor: default;
+            }
+            .review-button .debugger-icon {
+              width: 1.5rem;
+              height: 1.5rem;
+              fill: currentColor;
+            }
             `}
           </style>
           <button
+            className="review-button-control"
             onClick={() => handleToggleReviewModeScreenList(!showHistory)}
             title="Show lesson history"
             aria-label="Screen List"
@@ -143,6 +165,7 @@ const ReviewModeNavigation: React.FC = () => {
             </div>
           )}
           <button
+            className="review-button-control"
             onClick={prevHandler}
             title="Previous screen"
             aria-label="Previous screen"
@@ -153,6 +176,7 @@ const ReviewModeNavigation: React.FC = () => {
             </span>
           </button>
           <button
+            className="review-button-control"
             onClick={nextHandler}
             title="Next screen"
             aria-label="Next screen"
@@ -162,6 +186,25 @@ const ReviewModeNavigation: React.FC = () => {
               &nbsp;
             </span>
           </button>
+          {debuggerURL && (
+            <a
+              className="review-button-control"
+              href={debuggerURL}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Debugger"
+              aria-label="Debugger"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 576 512"
+                aria-hidden="true"
+                className="debugger-icon"
+              >
+                <path d="M192 96c0-53 43-96 96-96s96 43 96 96l0 3.6c0 15.7-12.7 28.4-28.4 28.4l-135.1 0c-15.7 0-28.4-12.7-28.4-28.4l0-3.6zm345.6 12.8c10.6 14.1 7.7 34.2-6.4 44.8l-97.8 73.3c5.3 8.9 9.3 18.7 11.8 29.1l98.8 0c17.7 0 32 14.3 32 32s-14.3 32-32 32l-96 0 0 32c0 2.6-.1 5.3-.2 7.9l83.4 62.5c14.1 10.6 17 30.7 6.4 44.8s-30.7 17-44.8 6.4l-63.1-47.3c-23.2 44.2-66.5 76.2-117.7 83.9L312 280c0-13.3-10.7-24-24-24s-24 10.7-24 24l0 230.2c-51.2-7.7-94.5-39.7-117.7-83.9L83.2 473.6c-14.1 10.6-34.2 7.7-44.8-6.4s-7.7-34.2 6.4-44.8l83.4-62.5c-.1-2.6-.2-5.2-.2-7.9l0-32-96 0c-17.7 0-32 14.3-32 32s14.3 32 32 32l98.8 0c2.5-10.4 6.5-20.2 11.8-29.1L44.8 153.6c-14.1-10.6-17-30.7-6.4-44.8s30.7-17 44.8-6.4L192 184c12.3-5.1 25.8-8 40-8l112 0c14.2 0 27.7 2.8 40 8l108.8-81.6c14.1-10.6 34.2-7.7 44.8 6.4z" />
+              </svg>
+            </a>
+          )}
         </div>
       }
     </Fragment>

--- a/assets/src/apps/delivery/layouts/deck/components/ReviewModeNavigation.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/ReviewModeNavigation.tsx
@@ -21,9 +21,18 @@ export interface ReviewEntry {
   selected?: boolean;
 }
 
+const getSafeDebuggerURL = (value?: string): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  return /^\/sections\/[^/]+\/debugger\/[^/]+$/.test(value) ? value : undefined;
+};
+
 const ReviewModeNavigation: React.FC = () => {
   const currentActivityId = useSelector(selectCurrentActivityId);
   const debuggerURL = useSelector(selectDebuggerURL);
+  const safeDebuggerURL = getSafeDebuggerURL(debuggerURL);
   const showHistory = useSelector(selectShowHistory);
   const sequences = useSelector(selectSequence);
   const dispatch = useDispatch();
@@ -114,8 +123,8 @@ const ReviewModeNavigation: React.FC = () => {
               display: inline-flex;
               align-items: center;
               justify-content: center;
-              width: 44.88px;
-              height: 39.95px;
+              width: 44px;
+              height: 44px;
               padding: 4px 10px;
               font-size: 1.3rem;
               line-height: 1.5;
@@ -186,10 +195,10 @@ const ReviewModeNavigation: React.FC = () => {
               &nbsp;
             </span>
           </button>
-          {debuggerURL && (
+          {safeDebuggerURL && (
             <a
               className="review-button-control"
-              href={debuggerURL}
+              href={safeDebuggerURL}
               target="_blank"
               rel="noopener noreferrer"
               title="Debugger"

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -29,6 +29,7 @@ export interface PageState {
   screenIdleExpireTime?: number;
   reviewMode?: boolean;
   responsiveLayout?: boolean;
+  debuggerURL?: string;
 }
 
 const initialState: PageState = {
@@ -56,6 +57,7 @@ const initialState: PageState = {
   screenIdleTimeOutInSeconds: 1800,
   reviewMode: false,
   responsiveLayout: false,
+  debuggerURL: undefined,
 };
 
 const pageSlice = createSlice({
@@ -87,6 +89,7 @@ const pageSlice = createSlice({
       state.blobStorageProvider = action.payload.blobStorageProvider || 'deprecated';
       state.screenIdleTimeOutInSeconds = action.payload.screenIdleTimeOutInSeconds;
       state.reviewMode = action.payload.reviewMode;
+      state.debuggerURL = action.payload.debuggerURL;
       if (state.previewMode && !state.resourceAttemptGuid) {
         state.resourceAttemptGuid = `preview_${guid()}`;
       }
@@ -179,6 +182,10 @@ export const selectIsLegacyTheme = createSelector(
 export const selectOverviewURL = createSelector(
   selectState,
   (state: PageState) => state.overviewURL,
+);
+export const selectDebuggerURL = createSelector(
+  selectState,
+  (state: PageState) => state.debuggerURL,
 );
 export const selectFinalizeGradedURL = createSelector(
   selectState,

--- a/assets/test/delivery/review_mode_navigation_test.tsx
+++ b/assets/test/delivery/review_mode_navigation_test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { getEnvState } from 'adaptivity/scripting';
+import ReviewModeNavigation from 'apps/delivery/layouts/deck/components/ReviewModeNavigation';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('adaptivity/scripting', () => ({
+  defaultGlobalEnv: {},
+  getEnvState: jest.fn(() => ({})),
+}));
+
+jest.mock('apps/delivery/layouts/deck/components/ReviewModeHistoryPanel', () => () => null);
+
+describe('ReviewModeNavigation', () => {
+  const configureSelectors = (debuggerURL?: string) => {
+    const selectorValues = ['activity-1', debuggerURL, false, []];
+    let callCount = 0;
+
+    (useSelector as jest.Mock).mockImplementation(() => selectorValues[callCount++]);
+  };
+
+  beforeEach(() => {
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
+    (getEnvState as jest.Mock).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the debugger link as a new-tab link', () => {
+    configureSelectors('/sections/example-section/debugger/attempt-guid');
+    render(<ReviewModeNavigation />);
+
+    const debuggerLink = screen.getByLabelText('Debugger');
+
+    expect(debuggerLink).toHaveAttribute('href', '/sections/example-section/debugger/attempt-guid');
+    expect(debuggerLink).toHaveAttribute('target', '_blank');
+    expect(debuggerLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not render the debugger link when the URL is not allowlisted', () => {
+    configureSelectors('javascript:alert(1)');
+
+    render(<ReviewModeNavigation />);
+
+    expect(screen.queryByLabelText('Debugger')).not.toBeInTheDocument();
+  });
+});

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -816,7 +816,11 @@ defmodule OliWeb.PageDeliveryController do
           ),
         isAuthor: !is_nil(author),
         isAdmin: Accounts.is_admin?(author),
-        isInstructor: context.is_instructor
+        isInstructor: context.is_instructor,
+        debuggerURL:
+          if context.review_mode && Accounts.at_least_content_admin?(author) do
+            ~p"/sections/#{section_slug}/debugger/#{resource_attempt.attempt_guid}"
+          end
       },
       bib_app_params: %{
         bibReferences: context.bib_revisions

--- a/test/oli_web/live/delivery/student/review_live_test.exs
+++ b/test/oli_web/live/delivery/student/review_live_test.exs
@@ -664,6 +664,26 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
         request_path
       )
     end
+
+    test "does not show adaptive debugger link to learners", %{
+      conn: conn,
+      user: user,
+      section: section,
+      graded_adaptive_page_revision: graded_adaptive_page_revision
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+      attempt = create_attempt(user, section, graded_adaptive_page_revision)
+
+      conn =
+        get(
+          conn,
+          "/sections/#{section.slug}/adaptive_lesson/#{graded_adaptive_page_revision.slug}/attempt/#{attempt.attempt_guid}/review"
+        )
+
+      html = html_response(conn, 200)
+      refute html =~ ~s(/sections/#{section.slug}/debugger/#{attempt.attempt_guid})
+    end
   end
 
   describe "instructor" do
@@ -705,6 +725,33 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
         )
 
       assert html_response(conn, 200) =~ "Graded Adaptive Page"
+    end
+
+    test "does not show adaptive debugger link to instructors", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      graded_adaptive_page_revision: graded_adaptive_page_revision
+    } do
+      user = insert(:user)
+
+      Sections.mark_section_visited_for_student(section, user)
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      attempt = create_attempt(user, section, graded_adaptive_page_revision)
+
+      conn =
+        recycle(conn)
+        |> log_in_user(instructor)
+
+      conn =
+        get(
+          conn,
+          "/sections/#{section.slug}/adaptive_lesson/#{graded_adaptive_page_revision.slug}/attempt/#{attempt.attempt_guid}/review"
+        )
+
+      html = html_response(conn, 200)
+      refute html =~ ~s(/sections/#{section.slug}/debugger/#{attempt.attempt_guid})
     end
 
     test "can access student attempt even when review_submission is disallowed", %{
@@ -813,6 +860,31 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
         )
 
       assert html_response(conn, 200) =~ "Graded Adaptive Page"
+    end
+
+    test "shows adaptive debugger link to admins in a new tab", %{
+      conn: conn,
+      section: section,
+      graded_adaptive_page_revision: graded_adaptive_page_revision,
+      admin: admin
+    } do
+      user = insert(:user)
+
+      Sections.mark_section_visited_for_student(section, user)
+      attempt = create_attempt(user, section, graded_adaptive_page_revision)
+
+      conn =
+        recycle(conn)
+        |> log_in_author(admin)
+
+      conn =
+        get(
+          conn,
+          "/sections/#{section.slug}/adaptive_lesson/#{graded_adaptive_page_revision.slug}/attempt/#{attempt.attempt_guid}/review"
+        )
+
+      html = html_response(conn, 200)
+      assert html =~ ~s(/sections/#{section.slug}/debugger/#{attempt.attempt_guid})
     end
   end
 

--- a/test/oli_web/live/delivery/student/review_live_test.exs
+++ b/test/oli_web/live/delivery/student/review_live_test.exs
@@ -884,7 +884,8 @@ defmodule OliWeb.Delivery.Student.ReviewLiveTest do
         )
 
       html = html_response(conn, 200)
-      assert html =~ ~s(/sections/#{section.slug}/debugger/#{attempt.attempt_guid})
+
+      assert html =~ "/sections/#{section.slug}/debugger/#{attempt.attempt_guid}"
     end
   end
 


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-4744

## Summary

- Add a debugger link to adaptive lesson review navigation
- Expose the debugger URL from page delivery into the delivery app state
- Restrict the link to content admins reviewing an attempt

## Improvement

- Adds quick access to the adaptive debugger directly from review navigation without exposing it to learners or instructors
- Opens the debugger in a new tab from the review toolbar
- Covers the permission behavior with review-mode delivery tests

## Validation

- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`

## Demo

- Video/image placeholder to be added
