### PR TITLE
[BUG FIX] [MER-5215] Fix adaptive debugger table sorting

### DIFF
--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -6,6 +6,7 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   alias OliWeb.Common.Breadcrumb
   alias OliWeb.Common.SortableTable.Table
+  alias OliWeb.Common.Table.SortableTableModel
   alias Oli.Delivery.Attempts.Core
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Sections.Mount
@@ -117,6 +118,16 @@ defmodule OliWeb.Attempt.AttemptLive do
      )}
   end
 
+  def handle_event("sort", %{"sort_by" => sort_by}, socket) do
+    table_model =
+      SortableTableModel.update_sort_params_and_sort(
+        socket.assigns.table_model,
+        String.to_existing_atom(sort_by)
+      )
+
+    {:noreply, assign(socket, table_model: table_model)}
+  end
+
   def handle_info({_, guid}, socket) do
     attempts =
       get_attempts(socket.assigns.attempt_guid)
@@ -127,8 +138,10 @@ defmodule OliWeb.Attempt.AttemptLive do
         end
       end)
 
-    {:ok, table_model} = TableModel.new(attempts)
-    table_model = Map.put(table_model, :rows, attempts)
+    table_model =
+      socket.assigns.table_model
+      |> Map.put(:rows, attempts)
+      |> SortableTableModel.sort()
 
     {:noreply,
      assign(socket,

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -119,13 +119,19 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   def handle_event("sort", %{"sort_by" => sort_by}, socket) do
-    table_model =
-      SortableTableModel.update_sort_params_and_sort(
-        socket.assigns.table_model,
-        String.to_existing_atom(sort_by)
-      )
+    case sort_column_name(socket.assigns.table_model.column_specs, sort_by) do
+      nil ->
+        {:noreply, socket}
 
-    {:noreply, assign(socket, table_model: table_model)}
+      column_name ->
+        table_model =
+          SortableTableModel.update_sort_params_and_sort(
+            socket.assigns.table_model,
+            column_name
+          )
+
+        {:noreply, assign(socket, table_model: table_model)}
+    end
   end
 
   def handle_info({_, guid}, socket) do
@@ -165,5 +171,14 @@ defmodule OliWeb.Attempt.AttemptLive do
         order_by: [:resource_id, :attempt_number]
       )
     )
+  end
+
+  defp sort_column_name(column_specs, sort_by) do
+    Enum.find_value(column_specs, fn %{name: name} ->
+      case Atom.to_string(name) do
+        ^sort_by -> name
+        _ -> nil
+      end
+    end)
   end
 end

--- a/lib/oli_web/live/attempt/table_model.ex
+++ b/lib/oli_web/live/attempt/table_model.ex
@@ -1,7 +1,7 @@
 defmodule OliWeb.Attempt.TableModel do
   use Phoenix.Component
 
-  alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
+  alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
 
   def new(members) do
     SortableTableModel.new(
@@ -47,7 +47,8 @@ defmodule OliWeb.Attempt.TableModel do
         },
         %ColumnSpec{
           name: :date_evaluated,
-          label: "Date Evaluated"
+          label: "Date Evaluated",
+          sort_fn: &Common.sort_date/2
         }
       ],
       event_suffix: "",

--- a/test/oli_web/live/attempt/attempt_live_test.exs
+++ b/test/oli_web/live/attempt/attempt_live_test.exs
@@ -8,6 +8,23 @@ defmodule OliWeb.Attempt.AttemptLiveTest do
   setup [:admin_conn]
 
   describe "sorting activity attempts" do
+    test "ignores invalid sort keys" do
+      {:ok, table_model} = OliWeb.Attempt.TableModel.new([])
+      socket = %Phoenix.LiveView.Socket{assigns: %{table_model: table_model}}
+
+      assert {:noreply, updated_socket} =
+               OliWeb.Attempt.AttemptLive.handle_event(
+                 "sort",
+                 %{"sort_by" => "not_a_real_column"},
+                 socket
+               )
+
+      assert updated_socket.assigns.table_model.sort_by_spec.name ==
+               table_model.sort_by_spec.name
+
+      assert updated_socket.assigns.table_model.sort_order == table_model.sort_order
+    end
+
     setup do
       section = insert(:section)
       student = insert(:user)

--- a/test/oli_web/live/attempt/attempt_live_test.exs
+++ b/test/oli_web/live/attempt/attempt_live_test.exs
@@ -1,0 +1,94 @@
+defmodule OliWeb.Attempt.AttemptLiveTest do
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Oli.Factory
+
+  setup [:admin_conn]
+
+  describe "sorting activity attempts" do
+    setup do
+      section = insert(:section)
+      student = insert(:user)
+      page_revision = insert(:revision)
+
+      resource_access =
+        insert(:resource_access,
+          user: student,
+          section: section,
+          resource: page_revision.resource
+        )
+
+      resource_attempt =
+        insert(:resource_attempt,
+          resource_access: resource_access,
+          revision: page_revision,
+          attempt_guid: Ecto.UUID.generate()
+        )
+
+      early_revision = insert(:revision, title: "Early Screen")
+      middle_revision = insert(:revision, title: "Middle Screen")
+      late_revision = insert(:revision, title: "Late Screen")
+
+      insert(:activity_attempt,
+        resource_attempt: resource_attempt,
+        revision: middle_revision,
+        resource: middle_revision.resource,
+        attempt_number: 2,
+        date_evaluated: ~U[2024-01-02 12:00:00Z]
+      )
+
+      insert(:activity_attempt,
+        resource_attempt: resource_attempt,
+        revision: late_revision,
+        resource: late_revision.resource,
+        attempt_number: 3,
+        date_evaluated: ~U[2024-01-03 12:00:00Z]
+      )
+
+      insert(:activity_attempt,
+        resource_attempt: resource_attempt,
+        revision: early_revision,
+        resource: early_revision.resource,
+        attempt_number: 1,
+        date_evaluated: ~U[2024-01-01 12:00:00Z]
+      )
+
+      %{section: section, resource_attempt: resource_attempt}
+    end
+
+    test "sorts by date evaluated", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      view
+      |> element("th[phx-click='sort'][phx-value-sort_by='date_evaluated']")
+      |> render_click(%{sort_by: "date_evaluated"})
+
+      assert view
+             |> element("tbody tr:first-child td:nth-child(5)")
+             |> render() =~ "Early Screen"
+
+      assert view
+             |> element("tbody tr:last-child td:nth-child(5)")
+             |> render() =~ "Late Screen"
+
+      view
+      |> element("th[phx-click='sort'][phx-value-sort_by='date_evaluated']")
+      |> render_click(%{sort_by: "date_evaluated"})
+
+      assert view
+             |> element("tbody tr:first-child td:nth-child(5)")
+             |> render() =~ "Late Screen"
+
+      assert view
+             |> element("tbody tr:last-child td:nth-child(5)")
+             |> render() =~ "Early Screen"
+    end
+  end
+end


### PR DESCRIPTION
## Jira
- Ticket: https://eliterate.atlassian.net/browse/MER-5215

## Summary
- fix sorting in the adaptive debugger table
- enable sorting by Date Evaluated without crashing
- preserve the current sort order when attempts refresh

## Bug Origin
- clicking a sortable debugger column raised an error because the LiveView did not handle sort events
- Date Evaluated sorting also relied on the default comparator, which is not safe for `DateTime` values

## Fix Applied
- added a sort event handler in the debugger LiveView
- reused the existing table sort state when refreshing rows
- added a date-aware sort function for `Date Evaluated`
- covered the regression with a LiveView test for debugger sorting

## Validation
- `mix test test/oli_web/live/attempt/attempt_live_test.exs`
- `mix test test/oli_web/common/table/table_model_test.exs`
- `mix format lib/oli_web/live/attempt/attempt_live.ex lib/oli_web/live/attempt/table_model.ex test/oli_web/live/attempt/attempt_live_test.exs test/oli_web/common/table/table_model_test.exs`

## Demo
### Before

https://github.com/user-attachments/assets/00199920-ca53-4556-bead-e4c5ed47b44a


### After

https://github.com/user-attachments/assets/1f1e0d0c-2dc5-4bfe-9646-54ae755ad6b1


