### PR TITLE
[BUG FIX] [MER-5513] Fix Practice page contrast for hero title

### DIFF
--- a/lib/oli_web/live/delivery/student/practice_live.ex
+++ b/lib/oli_web/live/delivery/student/practice_live.ex
@@ -23,7 +23,7 @@ defmodule OliWeb.Delivery.Student.PracticeLive do
   def render(assigns) do
     ~H"""
     <.hero_banner class="bg-practice">
-      <h1 class="text-4xl md:text-6xl mb-8">Your Practice Pages</h1>
+      <h1 class="text-4xl md:text-6xl mb-8 text-Text-text-white">Your Practice Pages</h1>
     </.hero_banner>
     <div class="overflow-x-scroll md:overflow-x-auto container mx-auto flex flex-col mt-6 px-3 md:px-16">
       <div :if={Enum.count(@practices_by_container) == 0} class="text-center" role="alert">

--- a/test/oli_web/live/delivery/student/practice_live_test.exs
+++ b/test/oli_web/live/delivery/student/practice_live_test.exs
@@ -144,5 +144,19 @@ defmodule OliWeb.Delivery.Student.PracticeLiveTest do
       assert has_element?(view, "h5", practice_1.title)
       assert has_element?(view, "h5", root_practice.title)
     end
+
+    test "renders the practice page title with high-contrast text", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/practice")
+
+      assert has_element?(view, "h1.text-Text-text-white", "Your Practice Pages")
+      assert has_element?(view, "h2.text-Text-text-high", "Unit 1: Introduction")
+    end
   end
 end


### PR DESCRIPTION
Jira: https://eliterate.atlassian.net/browse/MER-5513

## Summary
- Updated the Practice page hero title to use the white text token so it remains readable over the practice background.
- Added a regression test that asserts the hero title uses `text-Text-text-white`.

## Before

https://github.com/user-attachments/assets/85f04c2b-946c-4075-a8cd-7a8a3f2a4d4c



## After

https://github.com/user-attachments/assets/0338376a-8c3f-499e-9036-84ab72478979



## Validation
- mix format lib/oli_web/live/delivery/student/practice_live.ex test/oli_web/live/delivery/student/practice_live_test.exs
- mix test test/oli_web/live/delivery/student/practice_live_test.exs
- mix format
- mix compile
- yarn --cwd assets run format
- yarn --cwd assets run check-types
- yarn --cwd assets run deploy

## Notes
- The unit heading already used `text-Text-text-high`; the test now locks that in as well.
