### PR TITLE
[FEATURE] [MER-5053] Aggregate adaptive authoring insights by screen

### DIFF
--- a/lib/oli/analytics/summary/browse_insights.ex
+++ b/lib/oli/analytics/summary/browse_insights.ex
@@ -17,28 +17,23 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     {alpha, beta, gamma}
   end
 
-  defp adaptive_aggregation_max_rows do
-    Application.get_env(:oli, :adaptive_insights_aggregation_max_rows, 5_000)
+  defp adaptive_activity_type_id do
+    case Activities.get_registration_by_slug("oli_adaptive") do
+      %{id: id} -> id
+      nil -> nil
+    end
   end
 
   def browse_insights(
-        %Paging{limit: limit, offset: offset},
+        %Paging{} = paging,
         %Sorting{} = sorting,
         %BrowseInsightsOptions{
           project_id: project_id,
-          resource_type_id: resource_type_id,
-          section_ids: section_ids,
           text_search: text_search
         } = options
       ) do
+    adaptive_activity_type_id = adaptive_activity_type_id()
     where_by = build_where_by(options)
-    aggregate_adaptive_activity_rows? = resource_type_id == ResourceType.id_for_activity()
-
-    total_count =
-      case aggregate_adaptive_activity_rows? do
-        true -> 0
-        false -> get_total_count(project_id, section_ids, where_by)
-      end
 
     text_search_condition =
       if text_search && text_search != "",
@@ -53,22 +48,12 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
       |> where(^where_by)
       |> where(^text_search_condition)
 
-    case aggregate_adaptive_activity_rows? do
+    case activity_resource_type?(options.resource_type_id) do
       true ->
-        query
-        |> add_select(total_count, options)
-        |> add_adaptive_prefetch_order()
-        |> limit(^adaptive_aggregation_max_rows())
-        |> Repo.all()
-        |> aggregate_adaptive_activity_rows(sorting, limit, offset)
+        browse_activity_insights(query, paging, sorting, adaptive_activity_type_id)
 
       false ->
-        query
-        |> add_select(total_count, options)
-        |> add_order_by(sorting, options)
-        |> limit(^limit)
-        |> offset(^offset)
-        |> Repo.all()
+        browse_non_activity_insights(query, paging, sorting, options)
     end
   end
 
@@ -111,7 +96,182 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     end
   end
 
-  defp add_select(query, total_count, %BrowseInsightsOptions{section_ids: section_ids}) do
+  defmacrop adaptive_group_part(activity_type_id, part_id, adaptive_activity_type_id) do
+    quote do
+      fragment(
+        "CASE WHEN ? = ? THEN NULL ELSE ? END",
+        unquote(activity_type_id),
+        unquote(adaptive_activity_type_id),
+        unquote(part_id)
+      )
+    end
+  end
+
+  defp activity_resource_type?(resource_type_id) do
+    resource_type_id == ResourceType.id_for_activity()
+  end
+
+  defp browse_activity_insights(
+         query,
+         %Paging{limit: limit, offset: offset},
+         %Sorting{} = sorting,
+         adaptive_activity_type_id
+       ) do
+    query
+    |> add_activity_row_select(adaptive_activity_type_id)
+    |> aggregate_activity_rows()
+    |> select_aggregated_activity_rows()
+    |> add_aggregated_activity_order_by(sorting)
+    |> limit(^limit)
+    |> offset(^offset)
+    |> Repo.all()
+  end
+
+  defp browse_non_activity_insights(
+         query,
+         %Paging{limit: limit, offset: offset},
+         %Sorting{} = sorting,
+         options
+       ) do
+    total_count = get_total_count(query, options)
+
+    query
+    |> add_non_activity_select(total_count, options)
+    |> add_non_activity_order_by(sorting, options)
+    |> limit(^limit)
+    |> offset(^offset)
+    |> Repo.all()
+  end
+
+  defp add_activity_row_select(query, adaptive_activity_type_id) do
+    select(query, [s, pub, pr, rev], %{
+      title: rev.title,
+      resource_id: s.resource_id,
+      slug: rev.slug,
+      part_id: adaptive_group_part(rev.activity_type_id, s.part_id, ^adaptive_activity_type_id),
+      pub_id: pub.id,
+      activity_type_id: rev.activity_type_id,
+      pr_rev: pr.revision_id,
+      pr_resource: pr.resource_id,
+      num_correct: s.num_correct,
+      num_attempts: s.num_attempts,
+      num_hints: s.num_hints,
+      num_first_attempts: s.num_first_attempts,
+      num_first_attempts_correct: s.num_first_attempts_correct
+    })
+  end
+
+  defp aggregate_activity_rows(query) do
+    {alpha, beta, gamma} = get_relative_difficulty_parameters()
+
+    from(row in subquery(query),
+      group_by: [
+        row.title,
+        row.resource_id,
+        row.slug,
+        row.part_id,
+        row.pub_id,
+        row.activity_type_id,
+        row.pr_rev,
+        row.pr_resource
+      ],
+      select: %{
+        title: row.title,
+        resource_id: row.resource_id,
+        slug: row.slug,
+        part_id: row.part_id,
+        pub_id: row.pub_id,
+        activity_type_id: row.activity_type_id,
+        pr_rev: row.pr_rev,
+        pr_resource: row.pr_resource,
+        num_correct: sum(row.num_correct),
+        num_attempts: sum(row.num_attempts),
+        num_hints: sum(row.num_hints),
+        num_first_attempts: sum(row.num_first_attempts),
+        num_first_attempts_correct: sum(row.num_first_attempts_correct),
+        eventually_correct: safe_div_fragment(sum(row.num_correct), sum(row.num_attempts)),
+        first_attempt_correct:
+          safe_div_fragment(sum(row.num_first_attempts_correct), sum(row.num_first_attempts)),
+        relative_difficulty:
+          fragment(
+            "?::float8 * (1.0 - (?::float8)) + ?::float8 * (1.0 - (?::float8)) + ?::float8 * (?::float8)",
+            ^alpha,
+            safe_div_fragment(sum(row.num_first_attempts_correct), sum(row.num_first_attempts)),
+            ^beta,
+            safe_div_fragment(sum(row.num_correct), sum(row.num_attempts)),
+            ^gamma,
+            sum(row.num_hints)
+          )
+      }
+    )
+  end
+
+  defp select_aggregated_activity_rows(query) do
+    from(row in subquery(query),
+      select: %{
+        id: fragment("gen_random_uuid()::text"),
+        total_count: fragment("count(*) OVER()"),
+        title: row.title,
+        resource_id: row.resource_id,
+        slug: row.slug,
+        part_id: row.part_id,
+        pub_id: row.pub_id,
+        activity_type_id: row.activity_type_id,
+        pr_rev: row.pr_rev,
+        pr_resource: row.pr_resource,
+        num_correct: row.num_correct,
+        num_attempts: row.num_attempts,
+        num_hints: row.num_hints,
+        num_first_attempts: row.num_first_attempts,
+        num_first_attempts_correct: row.num_first_attempts_correct,
+        eventually_correct: row.eventually_correct,
+        first_attempt_correct: row.first_attempt_correct,
+        relative_difficulty: row.relative_difficulty
+      }
+    )
+  end
+
+  defp add_aggregated_activity_order_by(
+         query,
+         %Sorting{direction: direction, field: field}
+       ) do
+    query =
+      case field do
+        :title ->
+          order_by(query, [row], {^direction, row.title})
+
+        :part_id ->
+          order_by(query, [row], {^direction, row.part_id})
+
+        :num_attempts ->
+          order_by(query, [row], {^direction, row.num_attempts})
+
+        :num_first_attempts ->
+          order_by(query, [row], {^direction, row.num_first_attempts})
+
+        :eventually_correct ->
+          order_by(query, [row], {^direction, row.eventually_correct})
+
+        :first_attempt_correct ->
+          order_by(query, [row], {^direction, row.first_attempt_correct})
+
+        :relative_difficulty ->
+          order_by(query, [row], {^direction, row.relative_difficulty})
+
+        _ ->
+          order_by(query, [row], {^direction, field(row, ^field)})
+      end
+
+    query
+    |> order_by([row], asc: row.resource_id)
+    |> order_by([row], asc_nulls_last: row.part_id)
+  end
+
+  defp add_non_activity_select(
+         query,
+         total_count,
+         %BrowseInsightsOptions{section_ids: section_ids}
+       ) do
     {alpha, beta, gamma} = get_relative_difficulty_parameters()
 
     case section_ids do
@@ -158,7 +318,6 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           rev.activity_type_id
         ])
         |> select([s, _, _, rev], %{
-          # select id as a random GUID
           id: fragment("gen_random_uuid()::text"),
           total_count: fragment("?::int", ^total_count),
           resource_id: s.resource_id,
@@ -188,9 +347,11 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     end
   end
 
-  defp add_order_by(query, %Sorting{direction: direction, field: field}, %BrowseInsightsOptions{
-         section_ids: []
-       }) do
+  defp add_non_activity_order_by(
+         query,
+         %Sorting{direction: direction, field: field},
+         %BrowseInsightsOptions{section_ids: []}
+       ) do
     {alpha, beta, gamma} = get_relative_difficulty_parameters()
 
     query =
@@ -245,9 +406,11 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     order_by(query, [s], s.resource_id)
   end
 
-  defp add_order_by(query, %Sorting{direction: direction, field: field}, %BrowseInsightsOptions{
-         section_ids: _
-       }) do
+  defp add_non_activity_order_by(
+         query,
+         %Sorting{direction: direction, field: field},
+         %BrowseInsightsOptions{section_ids: _}
+       ) do
     {alpha, beta, gamma} = get_relative_difficulty_parameters()
 
     query =
@@ -303,22 +466,11 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     order_by(query, [s], s.resource_id)
   end
 
-  defp get_total_count(project_id, section_ids, where_by) do
-    add_group_by = fn query, section_ids ->
-      case section_ids do
-        [] -> query
-        _section_ids -> query |> group_by([s, _, _, _], [s.resource_id, s.part_id])
-      end
-    end
-
-    # First, we compute the total count separately
+  defp get_total_count(query, options) do
     total_count_query =
-      ResourceSummary
-      |> join(:left, [s], pub in Publication, on: pub.project_id == ^project_id)
-      |> join(:left, [s, pub], pr in PublishedResource, on: pr.publication_id == pub.id)
-      |> where(^where_by)
-      |> add_group_by.(section_ids)
-      |> select([s, _], fragment("count(*) OVER() as total_count"))
+      query
+      |> add_non_activity_group_by_for_count(options)
+      |> select(fragment("count(*) OVER() as total_count"))
       |> limit(1)
 
     Repo.one(total_count_query)
@@ -328,117 +480,13 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     end
   end
 
-  defp add_adaptive_prefetch_order(query) do
-    order_by(query, [s], asc: s.resource_id, asc_nulls_last: s.part_id)
-  end
-
-  defp aggregate_adaptive_activity_rows(rows, sorting, limit, offset) do
-    case Activities.get_registration_by_slug("oli_adaptive") do
-      %{id: adaptive_activity_type_id} ->
-        rows
-        |> Enum.group_by(&adaptive_activity_group_key(&1, adaptive_activity_type_id))
-        |> Enum.map(fn
-          {{:adaptive, _resource_id}, grouped_rows} ->
-            aggregate_adaptive_activity_row(grouped_rows)
-
-          {{:standard, _row_id}, [row]} ->
-            row
-        end)
-        |> sort_rows(sorting)
-        |> paginate_rows(limit, offset)
-
-      nil ->
-        rows
-        |> sort_rows(sorting)
-        |> paginate_rows(limit, offset)
+  defp add_non_activity_group_by_for_count(
+         query,
+         %BrowseInsightsOptions{section_ids: section_ids}
+       ) do
+    case section_ids do
+      [] -> query
+      _section_ids -> query |> group_by([s, _, _, _], [s.resource_id, s.part_id])
     end
-  end
-
-  defp adaptive_activity_group_key(row, adaptive_activity_type_id) do
-    case row.activity_type_id do
-      ^adaptive_activity_type_id -> {:adaptive, row.resource_id}
-      _activity_type_id -> {:standard, row.id}
-    end
-  end
-
-  defp aggregate_adaptive_activity_row([first_row | _rest] = rows) do
-    {alpha, beta, gamma} = get_relative_difficulty_parameters()
-
-    num_correct = Enum.sum_by(rows, & &1.num_correct)
-    num_attempts = Enum.sum_by(rows, & &1.num_attempts)
-    num_hints = Enum.sum_by(rows, & &1.num_hints)
-    num_first_attempts = Enum.sum_by(rows, & &1.num_first_attempts)
-    num_first_attempts_correct = Enum.sum_by(rows, & &1.num_first_attempts_correct)
-
-    first_attempt_correct = safe_div(num_first_attempts_correct, num_first_attempts)
-    eventually_correct = safe_div(num_correct, num_attempts)
-
-    Map.merge(first_row, %{
-      id: "adaptive-#{first_row.resource_id}",
-      part_id: nil,
-      num_correct: num_correct,
-      num_attempts: num_attempts,
-      num_hints: num_hints,
-      num_first_attempts: num_first_attempts,
-      num_first_attempts_correct: num_first_attempts_correct,
-      first_attempt_correct: first_attempt_correct,
-      eventually_correct: eventually_correct,
-      relative_difficulty:
-        alpha * (1.0 - first_attempt_correct) + beta * (1.0 - eventually_correct) +
-          gamma * num_hints
-    })
-  end
-
-  defp safe_div(_numerator, 0), do: 0.0
-  defp safe_div(numerator, denominator), do: numerator / denominator
-
-  defp sort_rows(rows, %Sorting{direction: direction, field: field}) do
-    Enum.sort(rows, fn left, right ->
-      case compare_values(Map.get(left, field), Map.get(right, field), direction) do
-        :lt ->
-          true
-
-        :gt ->
-          false
-
-        :eq ->
-          case compare_values(left.resource_id, right.resource_id, :asc) do
-            :lt ->
-              true
-
-            :gt ->
-              false
-
-            :eq ->
-              case compare_values(left.part_id, right.part_id, :asc) do
-                :lt -> true
-                :gt -> false
-                :eq -> compare_values(stable_row_id(left), stable_row_id(right), :asc) != :gt
-              end
-          end
-      end
-    end)
-  end
-
-  defp compare_values(left, right, _direction) when left == right, do: :eq
-  defp compare_values(nil, _right, :asc), do: :gt
-  defp compare_values(_left, nil, :asc), do: :lt
-  defp compare_values(nil, _right, :desc), do: :lt
-  defp compare_values(_left, nil, :desc), do: :gt
-
-  defp compare_values(left, right, :asc) when left < right, do: :lt
-  defp compare_values(left, right, :asc) when left > right, do: :gt
-  defp compare_values(left, right, :desc) when left < right, do: :gt
-  defp compare_values(left, right, :desc) when left > right, do: :lt
-
-  defp stable_row_id(row), do: to_string(row.id)
-
-  defp paginate_rows(rows, limit, offset) do
-    total_count = length(rows)
-
-    rows
-    |> Enum.drop(offset)
-    |> Enum.take(limit)
-    |> Enum.map(&Map.put(&1, :total_count, total_count))
   end
 end

--- a/lib/oli/analytics/summary/browse_insights.ex
+++ b/lib/oli/analytics/summary/browse_insights.ex
@@ -17,6 +17,10 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     {alpha, beta, gamma}
   end
 
+  defp adaptive_aggregation_max_rows do
+    Application.get_env(:oli, :adaptive_insights_aggregation_max_rows, 5_000)
+  end
+
   def browse_insights(
         %Paging{limit: limit, offset: offset},
         %Sorting{} = sorting,
@@ -53,6 +57,8 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
       true ->
         query
         |> add_select(total_count, options)
+        |> add_adaptive_prefetch_order()
+        |> limit(^adaptive_aggregation_max_rows())
         |> Repo.all()
         |> aggregate_adaptive_activity_rows(sorting, limit, offset)
 
@@ -322,17 +328,30 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
     end
   end
 
-  defp aggregate_adaptive_activity_rows(rows, sorting, limit, offset) do
-    adaptive_activity_type_id = Activities.get_registration_by_slug("oli_adaptive").id
+  defp add_adaptive_prefetch_order(query) do
+    order_by(query, [s], asc: s.resource_id, asc_nulls_last: s.part_id)
+  end
 
-    rows
-    |> Enum.group_by(&adaptive_activity_group_key(&1, adaptive_activity_type_id))
-    |> Enum.map(fn
-      {{:adaptive, _resource_id}, grouped_rows} -> aggregate_adaptive_activity_row(grouped_rows)
-      {{:standard, _row_id}, [row]} -> row
-    end)
-    |> sort_rows(sorting)
-    |> paginate_rows(limit, offset)
+  defp aggregate_adaptive_activity_rows(rows, sorting, limit, offset) do
+    case Activities.get_registration_by_slug("oli_adaptive") do
+      %{id: adaptive_activity_type_id} ->
+        rows
+        |> Enum.group_by(&adaptive_activity_group_key(&1, adaptive_activity_type_id))
+        |> Enum.map(fn
+          {{:adaptive, _resource_id}, grouped_rows} ->
+            aggregate_adaptive_activity_row(grouped_rows)
+
+          {{:standard, _row_id}, [row]} ->
+            row
+        end)
+        |> sort_rows(sorting)
+        |> paginate_rows(limit, offset)
+
+      nil ->
+        rows
+        |> sort_rows(sorting)
+        |> paginate_rows(limit, offset)
+    end
   end
 
   defp adaptive_activity_group_key(row, adaptive_activity_type_id) do

--- a/lib/oli/analytics/summary/browse_insights.ex
+++ b/lib/oli/analytics/summary/browse_insights.ex
@@ -1,9 +1,10 @@
 defmodule Oli.Analytics.Summary.BrowseInsights do
+  alias Oli.Activities
   alias Oli.Publishing.Publications.Publication
   alias Oli.Publishing.PublishedResource
   alias Oli.Analytics.Summary.BrowseInsightsOptions
   alias Oli.Analytics.Summary.ResourceSummary
-  alias Oli.Resources.Revision
+  alias Oli.Resources.{ResourceType, Revision}
   alias Oli.Repo.{Paging, Sorting}
   import Ecto.Query, warn: false
   alias Oli.Repo
@@ -21,19 +22,25 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
         %Sorting{} = sorting,
         %BrowseInsightsOptions{
           project_id: project_id,
+          resource_type_id: resource_type_id,
           section_ids: section_ids,
           text_search: text_search
         } = options
       ) do
     where_by = build_where_by(options)
-    total_count = get_total_count(project_id, section_ids, where_by)
+    aggregate_adaptive_activity_rows? = resource_type_id == ResourceType.id_for_activity()
+
+    total_count =
+      case aggregate_adaptive_activity_rows? do
+        true -> 0
+        false -> get_total_count(project_id, section_ids, where_by)
+      end
 
     text_search_condition =
       if text_search && text_search != "",
         do: dynamic([_s, _pub, _pr, rev], ilike(rev.title, ^"%#{text_search}%")),
         else: true
 
-    # Now build the main query with limit, offset, and aggregations
     query =
       ResourceSummary
       |> join(:left, [s], pub in Publication, on: pub.project_id == ^project_id)
@@ -41,12 +48,22 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
       |> join(:left, [s, pub, pr], rev in Revision, on: rev.id == pr.revision_id)
       |> where(^where_by)
       |> where(^text_search_condition)
-      |> add_select(total_count, options)
-      |> add_order_by(sorting, options)
-      |> limit(^limit)
-      |> offset(^offset)
 
-    Repo.all(query)
+    case aggregate_adaptive_activity_rows? do
+      true ->
+        query
+        |> add_select(total_count, options)
+        |> Repo.all()
+        |> aggregate_adaptive_activity_rows(sorting, limit, offset)
+
+      false ->
+        query
+        |> add_select(total_count, options)
+        |> add_order_by(sorting, options)
+        |> limit(^limit)
+        |> offset(^offset)
+        |> Repo.all()
+    end
   end
 
   defp build_where_by(%BrowseInsightsOptions{
@@ -105,8 +122,11 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           activity_type_id: rev.activity_type_id,
           pr_rev: pr.revision_id,
           pr_resource: pr.resource_id,
+          num_correct: s.num_correct,
           num_attempts: s.num_attempts,
+          num_hints: s.num_hints,
           num_first_attempts: s.num_first_attempts,
+          num_first_attempts_correct: s.num_first_attempts_correct,
           eventually_correct: safe_div_fragment(s.num_correct, s.num_attempts),
           first_attempt_correct:
             safe_div_fragment(s.num_first_attempts_correct, s.num_first_attempts),
@@ -140,8 +160,11 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           slug: rev.slug,
           part_id: s.part_id,
           activity_type_id: rev.activity_type_id,
+          num_correct: sum(s.num_correct),
           num_attempts: sum(s.num_attempts),
+          num_hints: sum(s.num_hints),
           num_first_attempts: sum(s.num_first_attempts),
+          num_first_attempts_correct: sum(s.num_first_attempts_correct),
           eventually_correct: safe_div_fragment(sum(s.num_correct), sum(s.num_attempts)),
           first_attempt_correct:
             safe_div_fragment(sum(s.num_first_attempts_correct), sum(s.num_first_attempts)),
@@ -297,5 +320,106 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
       nil -> 0
       count -> count
     end
+  end
+
+  defp aggregate_adaptive_activity_rows(rows, sorting, limit, offset) do
+    adaptive_activity_type_id = Activities.get_registration_by_slug("oli_adaptive").id
+
+    rows
+    |> Enum.group_by(&adaptive_activity_group_key(&1, adaptive_activity_type_id))
+    |> Enum.map(fn
+      {{:adaptive, _resource_id}, grouped_rows} -> aggregate_adaptive_activity_row(grouped_rows)
+      {{:standard, _row_id}, [row]} -> row
+    end)
+    |> sort_rows(sorting)
+    |> paginate_rows(limit, offset)
+  end
+
+  defp adaptive_activity_group_key(row, adaptive_activity_type_id) do
+    case row.activity_type_id do
+      ^adaptive_activity_type_id -> {:adaptive, row.resource_id}
+      _activity_type_id -> {:standard, row.id}
+    end
+  end
+
+  defp aggregate_adaptive_activity_row([first_row | _rest] = rows) do
+    {alpha, beta, gamma} = get_relative_difficulty_parameters()
+
+    num_correct = Enum.sum_by(rows, & &1.num_correct)
+    num_attempts = Enum.sum_by(rows, & &1.num_attempts)
+    num_hints = Enum.sum_by(rows, & &1.num_hints)
+    num_first_attempts = Enum.sum_by(rows, & &1.num_first_attempts)
+    num_first_attempts_correct = Enum.sum_by(rows, & &1.num_first_attempts_correct)
+
+    first_attempt_correct = safe_div(num_first_attempts_correct, num_first_attempts)
+    eventually_correct = safe_div(num_correct, num_attempts)
+
+    Map.merge(first_row, %{
+      id: "adaptive-#{first_row.resource_id}",
+      part_id: nil,
+      num_correct: num_correct,
+      num_attempts: num_attempts,
+      num_hints: num_hints,
+      num_first_attempts: num_first_attempts,
+      num_first_attempts_correct: num_first_attempts_correct,
+      first_attempt_correct: first_attempt_correct,
+      eventually_correct: eventually_correct,
+      relative_difficulty:
+        alpha * (1.0 - first_attempt_correct) + beta * (1.0 - eventually_correct) +
+          gamma * num_hints
+    })
+  end
+
+  defp safe_div(_numerator, 0), do: 0.0
+  defp safe_div(numerator, denominator), do: numerator / denominator
+
+  defp sort_rows(rows, %Sorting{direction: direction, field: field}) do
+    Enum.sort(rows, fn left, right ->
+      case compare_values(Map.get(left, field), Map.get(right, field), direction) do
+        :lt ->
+          true
+
+        :gt ->
+          false
+
+        :eq ->
+          case compare_values(left.resource_id, right.resource_id, :asc) do
+            :lt ->
+              true
+
+            :gt ->
+              false
+
+            :eq ->
+              case compare_values(left.part_id, right.part_id, :asc) do
+                :lt -> true
+                :gt -> false
+                :eq -> compare_values(stable_row_id(left), stable_row_id(right), :asc) != :gt
+              end
+          end
+      end
+    end)
+  end
+
+  defp compare_values(left, right, _direction) when left == right, do: :eq
+  defp compare_values(nil, _right, :asc), do: :gt
+  defp compare_values(_left, nil, :asc), do: :lt
+  defp compare_values(nil, _right, :desc), do: :lt
+  defp compare_values(_left, nil, :desc), do: :gt
+
+  defp compare_values(left, right, :asc) when left < right, do: :lt
+  defp compare_values(left, right, :asc) when left > right, do: :gt
+  defp compare_values(left, right, :desc) when left < right, do: :gt
+  defp compare_values(left, right, :desc) when left > right, do: :lt
+
+  defp stable_row_id(row), do: to_string(row.id)
+
+  defp paginate_rows(rows, limit, offset) do
+    total_count = length(rows)
+
+    rows
+    |> Enum.drop(offset)
+    |> Enum.take(limit)
+    |> Enum.map(&Map.put(&1, :total_count, total_count))
   end
 end

--- a/test/oli/analytics/summary/browse_insights_test.exs
+++ b/test/oli/analytics/summary/browse_insights_test.exs
@@ -438,38 +438,6 @@ defmodule Oli.Analytics.Summary.BrowseInsightsTest do
       assert_in_delta adaptive_row.first_attempt_correct, 1 / 3, 1.0e-6
     end
 
-    test "caps adaptive aggregation fetch size before in-memory processing", %{
-      project: project
-    } do
-      previous_max_rows = Application.get_env(:oli, :adaptive_insights_aggregation_max_rows)
-      Application.put_env(:oli, :adaptive_insights_aggregation_max_rows, 2)
-
-      on_exit(fn ->
-        case previous_max_rows do
-          nil -> Application.delete_env(:oli, :adaptive_insights_aggregation_max_rows)
-          value -> Application.put_env(:oli, :adaptive_insights_aggregation_max_rows, value)
-        end
-      end)
-
-      activity_type_id = Oli.Resources.ResourceType.get_id_by_type("activity")
-
-      results =
-        BrowseInsights.browse_insights(
-          %Oli.Repo.Paging{limit: 10, offset: 0},
-          %Oli.Repo.Sorting{direction: :asc, field: :title},
-          %Oli.Analytics.Summary.BrowseInsightsOptions{
-            project_id: project.id,
-            section_ids: [],
-            resource_type_id: activity_type_id
-          }
-        )
-
-      assert length(results) == 2
-      assert Enum.all?(results, &(&1.total_count == 2))
-      assert Enum.all?(results, &(&1.title == "Regular Activity"))
-      assert Enum.map(results, & &1.part_id) == ["part1", "part2"]
-    end
-
     test "returns unaggregated rows when adaptive registration is unavailable", %{
       project: project,
       adaptive_activity: adaptive_activity

--- a/test/oli/analytics/summary/browse_insights_test.exs
+++ b/test/oli/analytics/summary/browse_insights_test.exs
@@ -1,8 +1,12 @@
 defmodule Oli.Analytics.Summary.BrowseInsightsTest do
   use Oli.DataCase
 
+  import Ecto.Query
+
   alias Oli.Activities
+  alias Oli.Activities.ActivityRegistration
   alias Oli.Analytics.Summary.BrowseInsights
+  alias Oli.Repo
 
   describe "browse insights query, section_id = -1" do
     setup do
@@ -432,6 +436,68 @@ defmodule Oli.Analytics.Summary.BrowseInsightsTest do
       assert adaptive_row.num_first_attempts == 3
       assert_in_delta adaptive_row.eventually_correct, 0.5, 1.0e-6
       assert_in_delta adaptive_row.first_attempt_correct, 1 / 3, 1.0e-6
+    end
+
+    test "caps adaptive aggregation fetch size before in-memory processing", %{
+      project: project
+    } do
+      previous_max_rows = Application.get_env(:oli, :adaptive_insights_aggregation_max_rows)
+      Application.put_env(:oli, :adaptive_insights_aggregation_max_rows, 2)
+
+      on_exit(fn ->
+        case previous_max_rows do
+          nil -> Application.delete_env(:oli, :adaptive_insights_aggregation_max_rows)
+          value -> Application.put_env(:oli, :adaptive_insights_aggregation_max_rows, value)
+        end
+      end)
+
+      activity_type_id = Oli.Resources.ResourceType.get_id_by_type("activity")
+
+      results =
+        BrowseInsights.browse_insights(
+          %Oli.Repo.Paging{limit: 10, offset: 0},
+          %Oli.Repo.Sorting{direction: :asc, field: :title},
+          %Oli.Analytics.Summary.BrowseInsightsOptions{
+            project_id: project.id,
+            section_ids: [],
+            resource_type_id: activity_type_id
+          }
+        )
+
+      assert length(results) == 2
+      assert Enum.all?(results, &(&1.total_count == 2))
+      assert Enum.all?(results, &(&1.title == "Regular Activity"))
+      assert Enum.map(results, & &1.part_id) == ["part1", "part2"]
+    end
+
+    test "returns unaggregated rows when adaptive registration is unavailable", %{
+      project: project,
+      adaptive_activity: adaptive_activity
+    } do
+      from(ar in ActivityRegistration, where: ar.slug == "oli_adaptive")
+      |> Repo.update_all(set: [slug: "oli_adaptive_missing"])
+
+      activity_type_id = Oli.Resources.ResourceType.get_id_by_type("activity")
+
+      results =
+        BrowseInsights.browse_insights(
+          %Oli.Repo.Paging{limit: 10, offset: 0},
+          %Oli.Repo.Sorting{direction: :asc, field: :title},
+          %Oli.Analytics.Summary.BrowseInsightsOptions{
+            project_id: project.id,
+            section_ids: [],
+            resource_type_id: activity_type_id
+          }
+        )
+
+      assert length(results) == 4
+      assert Enum.all?(results, &(&1.total_count == 4))
+
+      adaptive_rows =
+        Enum.filter(results, &(&1.resource_id == adaptive_activity.resource.id))
+        |> Enum.sort_by(& &1.part_id)
+
+      assert Enum.map(adaptive_rows, & &1.part_id) == ["progress", "question"]
     end
   end
 

--- a/test/oli/analytics/summary/browse_insights_test.exs
+++ b/test/oli/analytics/summary/browse_insights_test.exs
@@ -1,6 +1,7 @@
 defmodule Oli.Analytics.Summary.BrowseInsightsTest do
   use Oli.DataCase
 
+  alias Oli.Activities
   alias Oli.Analytics.Summary.BrowseInsights
 
   describe "browse insights query, section_id = -1" do
@@ -261,6 +262,203 @@ defmodule Oli.Analytics.Summary.BrowseInsightsTest do
       # Verify that it has aggregate the results from both sections
       assert Enum.at(results, 0).first_attempt_correct == 0.5
     end
+  end
+
+  describe "adaptive activity aggregation" do
+    setup do
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_activity(%{title: "Regular Activity", content: %{}}, :regular_activity)
+
+      adaptive_activity = create_adaptive_activity(map, "Adaptive Screen")
+
+      %{project: project, regular_activity: regular_activity, section: section} = map
+
+      insert_summaries(project.id, [
+        [
+          adaptive_activity.resource.id,
+          adaptive_activity.revision.resource_type_id,
+          -1,
+          -1,
+          "progress",
+          1,
+          2,
+          1,
+          1,
+          2
+        ],
+        [
+          adaptive_activity.resource.id,
+          adaptive_activity.revision.resource_type_id,
+          -1,
+          -1,
+          "question",
+          2,
+          4,
+          0,
+          1,
+          2
+        ],
+        [
+          regular_activity.resource.id,
+          regular_activity.revision.resource_type_id,
+          -1,
+          -1,
+          "part1",
+          1,
+          2,
+          0,
+          1,
+          1
+        ],
+        [
+          regular_activity.resource.id,
+          regular_activity.revision.resource_type_id,
+          -1,
+          -1,
+          "part2",
+          1,
+          3,
+          0,
+          0,
+          1
+        ],
+        [
+          adaptive_activity.resource.id,
+          adaptive_activity.revision.resource_type_id,
+          -1,
+          section.id,
+          "progress",
+          2,
+          3,
+          0,
+          1,
+          1
+        ],
+        [
+          adaptive_activity.resource.id,
+          adaptive_activity.revision.resource_type_id,
+          -1,
+          section.id,
+          "question",
+          1,
+          3,
+          2,
+          0,
+          2
+        ],
+        [
+          regular_activity.resource.id,
+          regular_activity.revision.resource_type_id,
+          -1,
+          section.id,
+          "part1",
+          1,
+          1,
+          0,
+          1,
+          1
+        ]
+      ])
+
+      Map.put(map, :adaptive_activity, adaptive_activity)
+    end
+
+    test "aggregates adaptive activity rows for authoring insights", %{
+      project: project,
+      regular_activity: regular_activity,
+      adaptive_activity: adaptive_activity
+    } do
+      activity_type_id = Oli.Resources.ResourceType.get_id_by_type("activity")
+
+      results =
+        BrowseInsights.browse_insights(
+          %Oli.Repo.Paging{limit: 10, offset: 0},
+          %Oli.Repo.Sorting{direction: :asc, field: :title},
+          %Oli.Analytics.Summary.BrowseInsightsOptions{
+            project_id: project.id,
+            section_ids: [],
+            resource_type_id: activity_type_id
+          }
+        )
+
+      assert length(results) == 3
+      assert Enum.all?(results, &(&1.total_count == 3))
+
+      assert [adaptive_row] =
+               Enum.filter(results, &(&1.resource_id == adaptive_activity.resource.id))
+
+      assert adaptive_row.title == "Adaptive Screen"
+      assert adaptive_row.part_id == nil
+      assert adaptive_row.num_attempts == 6
+      assert adaptive_row.num_first_attempts == 4
+      assert_in_delta adaptive_row.eventually_correct, 0.5, 1.0e-6
+      assert_in_delta adaptive_row.first_attempt_correct, 0.5, 1.0e-6
+
+      regular_rows =
+        Enum.filter(results, &(&1.resource_id == regular_activity.resource.id))
+        |> Enum.sort_by(& &1.part_id)
+
+      assert Enum.map(regular_rows, & &1.part_id) == ["part1", "part2"]
+    end
+
+    test "aggregates adaptive activity rows across sections before paging", %{
+      project: project,
+      adaptive_activity: adaptive_activity,
+      section: section
+    } do
+      activity_type_id = Oli.Resources.ResourceType.get_id_by_type("activity")
+
+      results =
+        BrowseInsights.browse_insights(
+          %Oli.Repo.Paging{limit: 1, offset: 0},
+          %Oli.Repo.Sorting{direction: :asc, field: :title},
+          %Oli.Analytics.Summary.BrowseInsightsOptions{
+            project_id: project.id,
+            section_ids: [section.id],
+            resource_type_id: activity_type_id
+          }
+        )
+
+      assert length(results) == 1
+      assert hd(results).total_count == 2
+
+      adaptive_row = hd(results)
+
+      assert adaptive_row.resource_id == adaptive_activity.resource.id
+      assert adaptive_row.part_id == nil
+      assert adaptive_row.num_attempts == 6
+      assert adaptive_row.num_first_attempts == 3
+      assert_in_delta adaptive_row.eventually_correct, 0.5, 1.0e-6
+      assert_in_delta adaptive_row.first_attempt_correct, 1 / 3, 1.0e-6
+    end
+  end
+
+  defp create_adaptive_activity(map, title) do
+    adaptive_registration = Activities.get_registration_by_slug("oli_adaptive")
+
+    adaptive_activity =
+      Seeder.create_activity(
+        %{
+          title: title,
+          activity_type_id: adaptive_registration.id,
+          content: %{}
+        },
+        map.publication,
+        map.project,
+        map.author
+      )
+
+    Seeder.create_page(
+      "Adaptive Parent Page",
+      map.publication,
+      map.project,
+      map.author,
+      Seeder.create_sample_adaptive_page_content(adaptive_activity.revision.resource_id)
+    )
+
+    adaptive_activity
   end
 
   defp insert_summaries(project_id, entries) do


### PR DESCRIPTION
In Authoring Insights, adaptive activities are now shown as one row per screen instead of one row per internal part.

The adaptive aggregation now happens in SQL, which keeps sorting, pagination, and total counts correct while preserving the existing behavior for non-adaptive activities.

See: https://eliterate.atlassian.net/browse/MER-5053