### PR TITLE
[BUG FIX] [MER-5574] Restore raw My Agenda titles when curriculum numbering is disabled

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -2826,16 +2826,14 @@ defmodule Oli.Delivery.Sections do
   end
 
   defp build_containers_data_map(section) do
+    container_titles = container_titles(section)
+
     short_labels =
       fetch_ordered_container_labels(section.slug, short_label: true)
       |> Map.new()
 
-    full_titles =
-      fetch_ordered_container_labels(section.slug)
-      |> Map.new()
-
-    Map.merge(short_labels, full_titles, fn _container_id, label, title ->
-      %{label: label, title: title}
+    Map.new(short_labels, fn {container_id, label} ->
+      {container_id, %{label: label, title: container_titles[container_id]}}
     end)
   end
 

--- a/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
+++ b/test/oli_web/live/delivery/student/home/components/schedule_component_test.exs
@@ -445,6 +445,9 @@ defmodule OliWeb.Delivery.Student.Home.Components.ScheduleComponentTest do
       refute has_element?(lcd, ~s{#schedule_item_1_2 div[role="container_label"]})
       assert has_element?(lcd, ~s{#schedule_item_1_1 div[role="title"]}, "Graded 1")
       assert has_element?(lcd, ~s{#schedule_item_1_2 div[role="title"]}, "Module 1")
+
+      title_html = element(lcd, ~s{#schedule_item_1_2 div[role="title"]}) |> render()
+      refute title_html =~ "Module 1:"
     end
 
     test "shows attempts info for graded pages", %{

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1333,6 +1333,37 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
 
       refute has_element?(view, first_assignment <> ~s{div[role=title]}, page_3.title)
     end
+
+    test "omits curriculum prefixes in my agenda when numbering is disabled", %{
+      conn: conn,
+      section: section,
+      page_1: page_1,
+      page_2: page_2,
+      page_3: page_3,
+      page_4: page_4
+    } do
+      {:ok, section} =
+        Sections.update_section(section, %{display_curriculum_item_numbering: false})
+
+      stub_current_time(~U[2023-11-03 21:00:00Z])
+
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}")
+
+      first_item = ~s{#home-agenda #schedule_item_1_1 }
+      second_item = ~s{#home-agenda #schedule_item_1_2 }
+      third_item = ~s{#home-agenda #schedule_item_1_3 }
+      fourth_item = ~s{#home-agenda #schedule_item_1_4 }
+
+      refute has_element?(view, first_item <> ~s{div[role=container_label]})
+      refute has_element?(view, second_item <> ~s{div[role=container_label]})
+      refute has_element?(view, third_item <> ~s{div[role=container_label]})
+      refute has_element?(view, fourth_item <> ~s{div[role=container_label]})
+
+      assert has_element?(view, first_item <> ~s{div[role=title]}, page_1.title)
+      assert has_element?(view, second_item <> ~s{div[role=title]}, page_2.title)
+      assert has_element?(view, third_item <> ~s{div[role=title]}, page_3.title)
+      assert has_element?(view, fourth_item <> ~s{div[role=title]}, page_4.title)
+    end
   end
 
   describe "student on a section not yet scheduled" do


### PR DESCRIPTION
This fixes a regression in My Agenda on the student home page where grouped agenda cards could show prefixed container titles like Module 1: ... even when `display_curriculum_item_numbering` was disabled.

  The root cause was a later refactor that started using `fetch_ordered_container_labels/2` as the source for both numbering-aware labels and card titles. That helper returns formatted display labels, so numbering leaked into the always-rendered container_title. This change restores the original separation:

  - numbering-aware short labels still come from `fetch_ordered_container_labels(..., short_label: true)`
  - card titles now come from raw container revision titles again

  Tests were tightened to cover the actual My Agenda path:

  - the schedule component regression test now rejects prefixed grouped-card titles when numbering is disabled
  - a new IndexLive test verifies My Agenda hides container header labels while preserving card titles on the student home page


