### PR TITLE
[BUG FIX] [MER-5575] Ensure preview banner shows when launched as current user

### DIFF
--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -622,9 +622,8 @@ defmodule OliWeb.Products.DetailsView do
     "Template preview could not be prepared"
   end
 
-  defp preview_launch_url(_socket, section_slug, :current_user), do: ~p"/sections/#{section_slug}"
-
-  defp preview_launch_url(socket, _section_slug, :hidden_instructor) do
+  defp preview_launch_url(socket, _section_slug, launch_identity)
+       when launch_identity in [:current_user, :hidden_instructor] do
     ~p"/authoring/products/#{socket.assigns.product.slug}/preview_launch"
   end
 end

--- a/lib/oli_web/live/workspaces/course_author/products/details_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products/details_live.ex
@@ -629,9 +629,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
     "Template preview could not be prepared"
   end
 
-  defp preview_launch_url(_socket, section_slug, :current_user), do: ~p"/sections/#{section_slug}"
-
-  defp preview_launch_url(socket, _section_slug, :hidden_instructor) do
+  defp preview_launch_url(socket, _section_slug, launch_identity)
+       when launch_identity in [:current_user, :hidden_instructor] do
     ~p"/authoring/products/#{socket.assigns.product.slug}/preview_launch"
   end
 

--- a/test/oli_web/live/products/details_view_test.exs
+++ b/test/oli_web/live/products/details_view_test.exs
@@ -404,7 +404,7 @@ defmodule OliWeb.Products.DetailsViewTest do
                elem(:binary.match(html, "Preview Template"), 0)
     end
 
-    test "prepares preview, creates an enrollment, and pushes a launch event", %{
+    test "prepares preview, creates an enrollment, and pushes controller launch event", %{
       conn: conn,
       admin: admin,
       product: product
@@ -413,7 +413,7 @@ defmodule OliWeb.Products.DetailsViewTest do
       conn = conn |> log_in_user(user) |> log_in_author(admin)
 
       {:ok, view, _html} = live(conn, product_route(product.slug))
-      preview_url = "/sections/#{product.slug}"
+      preview_url = "/authoring/products/#{product.slug}/preview_launch"
 
       render_click(element(view, "button[phx-click='template_preview']"))
 
@@ -430,7 +430,7 @@ defmodule OliWeb.Products.DetailsViewTest do
                &(&1.id == Lti_1p3.Roles.ContextRoles.get_role(:context_learner).id)
              )
 
-      assert has_element?(view, "a[href='/sections/#{product.slug}']", "Open Preview")
+      assert has_element?(view, "a[href='#{preview_url}']", "Open Preview")
     end
 
     test "uses hidden instructor fallback when no current user is present", %{
@@ -455,7 +455,7 @@ defmodule OliWeb.Products.DetailsViewTest do
       conn = conn |> log_in_user(user) |> log_in_author(admin)
 
       {:ok, view, _html} = live(conn, product_route(product.slug))
-      preview_url = "/sections/#{product.slug}"
+      preview_url = "/authoring/products/#{product.slug}/preview_launch"
 
       render_click(element(view, "button[phx-click='template_preview']"))
       assert_push_event(view, "template-preview-open", %{url: ^preview_url})

--- a/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
@@ -278,13 +278,14 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
                elem(:binary.match(html, "Preview Template"), 0)
     end
 
-    test "prepares template preview, creates an enrollment, and pushes a launch event", ctx do
+    test "prepares template preview, creates an enrollment, and pushes controller launch event",
+         ctx do
       %{conn: conn, author: author, project: project, product: product} = ctx
       user = insert(:user, author: author, email: author.email)
       conn = conn |> log_in_user(user) |> log_in_author(author)
 
       {:ok, live, _html} = live(conn, live_view_route(project.slug, product.slug, %{}))
-      preview_url = "/sections/#{product.slug}"
+      preview_url = "/authoring/products/#{product.slug}/preview_launch"
 
       render_click(element(live, "button[phx-click='template_preview']"))
 
@@ -301,7 +302,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
                &(&1.id == Lti_1p3.Roles.ContextRoles.get_role(:context_learner).id)
              )
 
-      assert has_element?(live, "a[href='/sections/#{product.slug}']", "Open Preview")
+      assert has_element?(live, "a[href='#{preview_url}']", "Open Preview")
     end
 
     test "reuses the existing enrollment when preview is launched again", ctx do
@@ -310,7 +311,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
       conn = conn |> log_in_user(user) |> log_in_author(author)
 
       {:ok, live, _html} = live(conn, live_view_route(project.slug, product.slug, %{}))
-      preview_url = "/sections/#{product.slug}"
+      preview_url = "/authoring/products/#{product.slug}/preview_launch"
 
       render_click(element(live, "button[phx-click='template_preview']"))
       assert_push_event(live, "template-preview-open", %{url: ^preview_url})


### PR DESCRIPTION
This fixes inconsistent template preview behavior where the Preview Mode banner and Exit Preview button could be missing depending on how preview was launched.

  Root cause:

  - Template preview had two launch paths in the product details LiveViews.
  - When preview used :hidden_instructor, it opened /authoring/products/:slug/preview_launch, which sets the template-preview session markers used by delivery layouts to render the banner.
  - When preview used :current_user, it opened /sections/:slug directly, bypassing that controller path and therefore skipping the session markers.
  - As a result, preview content loaded normally, but the banner could disappear for users who already had a delivery-side current_user session.

  Fix:

  - Unified both launch identities onto the controller endpoint /authoring/products/:slug/preview_launch
  - This makes the controller the single canonical entry point for template preview, regardless of launch identity
  - The controller continues to handle:
      - preview authorization
      - launch preparation
      - template preview session markers
      - hidden-instructor login when needed
      - redirect into delivery

  Tests:

  - Updated author product-details LiveView preview tests to expect the unified controller launch URL
  - Updated admin product-details LiveView preview tests to expect the unified controller launch URL
  - Re-ran controller preview tests to verify the preview session markers are still set correctly

  Verification:

  - mix test test/oli_web/live/workspaces/course_author/products/details_live_test.exs
  - mix test test/oli_web/live/products/details_view_test.exs
  - mix test test/oli_web/controllers/products_controller_test.exs
