### PR TITLE
[ENHANCEMENT] [MER-5573] edit template remix containers

### DIFF
--- a/lib/oli/delivery/hierarchy.ex
+++ b/lib/oli/delivery/hierarchy.ex
@@ -460,6 +460,7 @@ defmodule Oli.Delivery.Hierarchy do
         "poster_image" => rev.poster_image,
         "intro_content" => rev.intro_content,
         "duration_minutes" => rev.duration_minutes,
+        "resource_scope" => rev.resource_scope,
         "resource_type_id" => rev.resource_type_id,
         "section_resource" => sr,
         "is_root?" =>
@@ -484,6 +485,7 @@ defmodule Oli.Delivery.Hierarchy do
         "poster_image" => sr.poster_image,
         "intro_content" => sr.intro_content,
         "duration_minutes" => sr.duration_minutes,
+        "resource_scope" => Map.get(sr, :resource_scope),
         "resource_type_id" => sr.resource_type_id,
         "section_resource" => sr,
         "is_root?" => sr.id == root_section_resource_id

--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -341,18 +341,19 @@ defmodule Oli.Delivery.Remix do
          base_project,
          %Author{id: author_id}
        ) do
-    edited_nodes = edited_blueprint_nodes(hierarchy, previous_hierarchy)
+    previous_by_resource_id =
+      previous_hierarchy
+      |> Hierarchy.flatten_hierarchy()
+      |> Map.new(&{&1.resource_id, &1})
+
+    edited_nodes = edited_blueprint_nodes(hierarchy, previous_by_resource_id)
 
     if edited_nodes == [] do
       {:ok, hierarchy}
     else
       Repo.transaction(fn ->
         Enum.reduce_while(edited_nodes, %{}, fn %HierarchyNode{} = node, updated_nodes ->
-          previous_node =
-            Hierarchy.find_in_hierarchy(previous_hierarchy, fn n ->
-              n.resource_id == node.resource_id
-            end)
-
+          previous_node = Map.fetch!(previous_by_resource_id, node.resource_id)
           previous_revision = Repo.get!(Revision, previous_node.revision.id)
 
           attrs = editable_attrs(node.revision)
@@ -395,24 +396,25 @@ defmodule Oli.Delivery.Remix do
 
   defp persist_blueprint_container_edits(
          %HierarchyNode{} = hierarchy,
-         _previous_hierarchy,
+         %HierarchyNode{} = previous_hierarchy,
          _section,
          _base_project,
          nil
        ) do
-    if edited_blueprint_nodes(hierarchy, nil) == [] do
+    previous_by_resource_id =
+      previous_hierarchy
+      |> Hierarchy.flatten_hierarchy()
+      |> Map.new(&{&1.resource_id, &1})
+
+    if edited_blueprint_nodes(hierarchy, previous_by_resource_id) == [] do
       {:ok, hierarchy}
     else
       {:error, :author_required_for_blueprint_container_edit}
     end
   end
 
-  defp edited_blueprint_nodes(%HierarchyNode{} = hierarchy, %HierarchyNode{} = previous_hierarchy) do
-    previous_by_resource_id =
-      previous_hierarchy
-      |> Hierarchy.flatten_hierarchy()
-      |> Map.new(&{&1.resource_id, &1})
-
+  defp edited_blueprint_nodes(%HierarchyNode{} = hierarchy, previous_by_resource_id)
+       when is_map(previous_by_resource_id) do
     hierarchy
     |> Hierarchy.flatten_hierarchy()
     |> Enum.filter(fn

--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -309,20 +309,32 @@ defmodule Oli.Delivery.Remix do
   def save(%State{} = state, author \\ nil) do
     %Section{base_project: base_project} = section = Repo.preload(state.section, :base_project)
 
-    with {:ok, hierarchy} <- ContainerCreation.materialize(state.hierarchy, base_project, author),
-         {:ok, hierarchy} <-
-           persist_blueprint_container_edits(
-             hierarchy,
-             state.previous_hierarchy,
-             section,
-             base_project,
-             author
-           ) do
-      hierarchy = Hierarchy.finalize(hierarchy)
-
-      Sections.rebuild_section_curriculum(section, hierarchy, state.pinned_project_publications)
-
-      {:ok, Sections.get_section!(section.id)}
+    Repo.transaction(fn ->
+      with {:ok, hierarchy} <-
+             ContainerCreation.materialize(state.hierarchy, base_project, author),
+           {:ok, hierarchy} <-
+             persist_blueprint_container_edits(
+               hierarchy,
+               state.previous_hierarchy,
+               section,
+               base_project,
+               author
+             ),
+           {:ok, _} <-
+             rebuild_section_curriculum(
+               section,
+               Hierarchy.finalize(hierarchy),
+               state.pinned_project_publications
+             ) do
+        section.id
+      else
+        {:error, reason} ->
+          Repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, section_id} -> {:ok, Sections.get_section!(section_id)}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -351,45 +363,43 @@ defmodule Oli.Delivery.Remix do
     if edited_nodes == [] do
       {:ok, hierarchy}
     else
-      Repo.transaction(fn ->
-        Enum.reduce_while(edited_nodes, %{}, fn %HierarchyNode{} = node, updated_nodes ->
-          previous_node = Map.fetch!(previous_by_resource_id, node.resource_id)
-          previous_revision = Repo.get!(Revision, previous_node.revision.id)
+      case Enum.reduce_while(edited_nodes, %{}, fn %HierarchyNode{} = node, updated_nodes ->
+             previous_node = Map.fetch!(previous_by_resource_id, node.resource_id)
+             previous_revision = Repo.get!(Revision, previous_node.revision.id)
 
-          attrs = editable_attrs(node.revision)
+             attrs = editable_attrs(node.revision)
 
-          case Resources.create_revision_from_previous(
-                 previous_revision,
-                 Map.put(attrs, :author_id, author_id)
-               ) do
-            {:ok, revision} ->
-              now = DateTime.utc_now(:second)
+             case Resources.create_revision_from_previous(
+                    previous_revision,
+                    Map.put(attrs, :author_id, author_id)
+                  ) do
+               {:ok, revision} ->
+                 now = DateTime.utc_now(:second)
 
-              from(pr in PublishedResource,
-                join: pub in Publication,
-                on: pr.publication_id == pub.id,
-                where:
-                  pub.project_id == ^base_project.id and pr.resource_id == ^revision.resource_id
-              )
-              |> Repo.update_all(set: [revision_id: revision.id, updated_at: now])
+                 from(pr in PublishedResource,
+                   join: pub in Publication,
+                   on: pr.publication_id == pub.id,
+                   where:
+                     pub.project_id == ^base_project.id and
+                       pr.resource_id == ^revision.resource_id
+                 )
+                 |> Repo.update_all(set: [revision_id: revision.id, updated_at: now])
 
-              {:cont,
-               Map.put(updated_nodes, node.uuid, %HierarchyNode{node | revision: revision})}
+                 {:cont,
+                  Map.put(updated_nodes, node.uuid, %HierarchyNode{node | revision: revision})}
 
-            {:error, reason} ->
-              {:halt, Repo.rollback(reason)}
-          end
-        end)
-      end)
-      |> case do
-        {:ok, updated_nodes} ->
+               {:error, reason} ->
+                 {:halt, {:error, reason}}
+             end
+           end) do
+        {:error, reason} ->
+          {:error, reason}
+
+        updated_nodes ->
           updated_hierarchy =
             Hierarchy.find_and_update_nodes(hierarchy, Map.values(updated_nodes))
 
           {:ok, Hierarchy.finalize(updated_hierarchy)}
-
-        {:error, reason} ->
-          {:error, reason}
       end
     end
   end
@@ -480,5 +490,19 @@ defmodule Oli.Delivery.Remix do
         :graded
       ])
     )
+  end
+
+  defp rebuild_section_curriculum(
+         %Section{} = section,
+         %HierarchyNode{} = hierarchy,
+         pinned_project_publications
+       ) do
+    case Sections.rebuild_section_curriculum(section, hierarchy, pinned_project_publications) do
+      {:ok, _} = ok ->
+        ok
+
+      {:error, _operation, reason, _changes} ->
+        {:error, reason}
+    end
   end
 end

--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -11,13 +11,19 @@ defmodule Oli.Delivery.Remix do
   - FDD: docs/features/refactor_remix/fdd.md
   """
 
+  import Ecto.Query, warn: false
+
   alias Oli.Delivery.Remix.ContainerCreation
   alias Oli.Delivery.Remix.State
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Hierarchy
+  alias Oli.Delivery.Hierarchy.HierarchyNode
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Publishing.{PublishedResource, Publications.Publication}
+  alias Oli.Resources
+  alias Oli.Resources.Revision
   alias Oli.Accounts.{User, Author}
   alias Oli.Repo
 
@@ -264,6 +270,36 @@ defmodule Oli.Delivery.Remix do
   end
 
   @doc """
+  Update editable blueprint-container fields in the in-memory hierarchy.
+  Persistence happens during save/2.
+  """
+  @spec update_container_options(State.t(), String.t(), map()) ::
+          {:ok, State.t()} | {:error, term()}
+  def update_container_options(%State{} = state, uuid, attrs) do
+    case Hierarchy.find_in_hierarchy(state.hierarchy, uuid) do
+      %HierarchyNode{} = node ->
+        updated_revision =
+          node.revision
+          |> normalize_revision()
+          |> merge_editable_attrs(attrs)
+
+        updated_node = %HierarchyNode{node | revision: updated_revision}
+
+        hierarchy =
+          state.hierarchy
+          |> Hierarchy.find_and_update_node(updated_node)
+          |> Hierarchy.finalize()
+
+        active = Hierarchy.find_in_hierarchy(hierarchy, state.active.uuid)
+
+        {:ok, %State{state | hierarchy: hierarchy, active: active, has_unsaved_changes: true}}
+
+      _ ->
+        {:error, :not_found}
+    end
+  end
+
+  @doc """
   Persist the current hierarchy and pinned publications for the section.
   Materializes any draft containers (negative resource_id) before rebuilding.
   The author parameter identifies who is performing the save (used for revision authorship).
@@ -273,7 +309,15 @@ defmodule Oli.Delivery.Remix do
   def save(%State{} = state, author \\ nil) do
     %Section{base_project: base_project} = section = Repo.preload(state.section, :base_project)
 
-    with {:ok, hierarchy} <- ContainerCreation.materialize(state.hierarchy, base_project, author) do
+    with {:ok, hierarchy} <- ContainerCreation.materialize(state.hierarchy, base_project, author),
+         {:ok, hierarchy} <-
+           persist_blueprint_container_edits(
+             hierarchy,
+             state.previous_hierarchy,
+             section,
+             base_project,
+             author
+           ) do
       hierarchy = Hierarchy.finalize(hierarchy)
 
       Sections.rebuild_section_curriculum(section, hierarchy, state.pinned_project_publications)
@@ -289,4 +333,150 @@ defmodule Oli.Delivery.Remix do
   end
 
   defp container_revision?(_), do: false
+
+  defp persist_blueprint_container_edits(
+         %HierarchyNode{} = hierarchy,
+         %HierarchyNode{} = previous_hierarchy,
+         %Section{} = _section,
+         base_project,
+         %Author{id: author_id}
+       ) do
+    edited_nodes = edited_blueprint_nodes(hierarchy, previous_hierarchy)
+
+    if edited_nodes == [] do
+      {:ok, hierarchy}
+    else
+      Repo.transaction(fn ->
+        Enum.reduce_while(edited_nodes, %{}, fn %HierarchyNode{} = node, updated_nodes ->
+          previous_node =
+            Hierarchy.find_in_hierarchy(previous_hierarchy, fn n ->
+              n.resource_id == node.resource_id
+            end)
+
+          previous_revision = Repo.get!(Revision, previous_node.revision.id)
+
+          attrs = editable_attrs(node.revision)
+
+          case Resources.create_revision_from_previous(
+                 previous_revision,
+                 Map.put(attrs, :author_id, author_id)
+               ) do
+            {:ok, revision} ->
+              now = DateTime.utc_now(:second)
+
+              from(pr in PublishedResource,
+                join: pub in Publication,
+                on: pr.publication_id == pub.id,
+                where:
+                  pub.project_id == ^base_project.id and pr.resource_id == ^revision.resource_id
+              )
+              |> Repo.update_all(set: [revision_id: revision.id, updated_at: now])
+
+              {:cont,
+               Map.put(updated_nodes, node.uuid, %HierarchyNode{node | revision: revision})}
+
+            {:error, reason} ->
+              {:halt, Repo.rollback(reason)}
+          end
+        end)
+      end)
+      |> case do
+        {:ok, updated_nodes} ->
+          updated_hierarchy =
+            Hierarchy.find_and_update_nodes(hierarchy, Map.values(updated_nodes))
+
+          {:ok, Hierarchy.finalize(updated_hierarchy)}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp persist_blueprint_container_edits(
+         %HierarchyNode{} = hierarchy,
+         _previous_hierarchy,
+         _section,
+         _base_project,
+         nil
+       ) do
+    if edited_blueprint_nodes(hierarchy, nil) == [] do
+      {:ok, hierarchy}
+    else
+      {:error, :author_required_for_blueprint_container_edit}
+    end
+  end
+
+  defp edited_blueprint_nodes(%HierarchyNode{} = hierarchy, %HierarchyNode{} = previous_hierarchy) do
+    previous_by_resource_id =
+      previous_hierarchy
+      |> Hierarchy.flatten_hierarchy()
+      |> Map.new(&{&1.resource_id, &1})
+
+    hierarchy
+    |> Hierarchy.flatten_hierarchy()
+    |> Enum.filter(fn
+      %HierarchyNode{resource_id: resource_id, revision: revision} = node when resource_id > 0 ->
+        blueprint_container?(node) and
+          Map.has_key?(previous_by_resource_id, resource_id) and
+          editable_attrs(revision) !=
+            editable_attrs(previous_by_resource_id[resource_id].revision)
+
+      _ ->
+        false
+    end)
+  end
+
+  defp edited_blueprint_nodes(_hierarchy, _previous_hierarchy), do: []
+
+  defp blueprint_container?(%HierarchyNode{revision: revision}) do
+    revision.resource_type_id == Oli.Resources.ResourceType.id_for_container() and
+      revision.resource_scope == :blueprint
+  end
+
+  defp editable_attrs(revision) do
+    revision = normalize_revision(revision)
+
+    %{
+      title: revision.title,
+      intro_content: revision.intro_content,
+      intro_video: revision.intro_video,
+      poster_image: revision.poster_image
+    }
+  end
+
+  defp merge_editable_attrs(revision, attrs) do
+    %Revision{} = revision = normalize_revision(revision)
+
+    %Revision{
+      revision
+      | title: Map.get(attrs, "title", Map.get(attrs, :title, revision.title)),
+        intro_content:
+          Map.get(attrs, "intro_content", Map.get(attrs, :intro_content, revision.intro_content)),
+        intro_video:
+          Map.get(attrs, "intro_video", Map.get(attrs, :intro_video, revision.intro_video)),
+        poster_image:
+          Map.get(attrs, "poster_image", Map.get(attrs, :poster_image, revision.poster_image))
+    }
+  end
+
+  defp normalize_revision(%Revision{} = revision), do: revision
+
+  defp normalize_revision(revision) when is_map(revision) do
+    struct(
+      Revision,
+      Map.take(revision, [
+        :id,
+        :resource_id,
+        :resource_type_id,
+        :resource_scope,
+        :slug,
+        :title,
+        :intro_content,
+        :intro_video,
+        :poster_image,
+        :graded
+      ])
+    )
+  end
 end

--- a/lib/oli/delivery/remix/container_creation.ex
+++ b/lib/oli/delivery/remix/container_creation.ex
@@ -52,14 +52,17 @@ defmodule Oli.Delivery.Remix.ContainerCreation do
 
   ## Options
     - `:resource_scope` - defaults to `:blueprint`. Use `:section` for instructor remix (future).
+    - `:author_id` - optional author id for draft validation in UI flows.
   """
   def build_draft(hierarchy, project, title, opts \\ []) do
     resource_scope = Keyword.get(opts, :resource_scope, :blueprint)
+    author_id = Keyword.get(opts, :author_id)
     next_id = next_negative_id(hierarchy)
 
     draft_revision = %Revision{
       id: next_id,
       resource_id: next_id,
+      author_id: author_id,
       resource_type_id: ResourceType.id_for_container(),
       resource_scope: resource_scope,
       title: title,

--- a/lib/oli/delivery/remix/container_creation.ex
+++ b/lib/oli/delivery/remix/container_creation.ex
@@ -63,6 +63,9 @@ defmodule Oli.Delivery.Remix.ContainerCreation do
       resource_type_id: ResourceType.id_for_container(),
       resource_scope: resource_scope,
       title: title,
+      intro_content: %{},
+      intro_video: nil,
+      poster_image: nil,
       children: [],
       content: %{"model" => [], "version" => "0.1.0"},
       deleted: false,
@@ -147,6 +150,9 @@ defmodule Oli.Delivery.Remix.ContainerCreation do
       title: draft.revision.title,
       resource_type_id: ResourceType.id_for_container(),
       resource_scope: draft.revision.resource_scope,
+      intro_content: draft.revision.intro_content,
+      intro_video: draft.revision.intro_video,
+      poster_image: draft.revision.poster_image,
       # Intentionally empty — the canonical parent-child structure lives in SectionResource.children,
       # built from the in-memory hierarchy by rebuild_section_curriculum. Revision.children is only
       # used on the authoring side and blueprint containers never appear in authoring views.

--- a/lib/oli/delivery/sections/minimal_hierarchy.ex
+++ b/lib/oli/delivery/sections/minimal_hierarchy.ex
@@ -133,6 +133,7 @@ defmodule Oli.Delivery.Sections.MinimalHierarchy do
            id: rev.id,
            resource_id: rev.resource_id,
            resource_type_id: rev.resource_type_id,
+           resource_scope: rev.resource_scope,
            slug: rev.slug,
            title: rev.title,
            graded: rev.graded

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -70,6 +70,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
 
   attr(:attempt_options, :list, default: @attempt_options)
   attr(:selected_resources, :list, default: [])
+  attr(:submit_label, :string, default: "Save")
 
   def render(%{step: :intro_content} = assigns) do
     ~H"""
@@ -642,7 +643,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
             phx-disable-with="Saving..."
             class="btn btn-primary"
           >
-            Save
+            {@submit_label}
           </button>
         </div>
       </.form>

--- a/lib/oli_web/live/delivery/remix/actions.ex
+++ b/lib/oli_web/live/delivery/remix/actions.ex
@@ -11,6 +11,16 @@ defmodule OliWeb.Delivery.Remix.Actions do
     ~H"""
     <div class="entry-actions flex items-center gap-2">
       <Button.button
+        :if={@show_options}
+        variant={:secondary}
+        size={:sm}
+        class="!px-4"
+        phx-click="show_options_modal"
+        phx-value-uuid={@uuid}
+      >
+        Options
+      </Button.button>
+      <Button.button
         variant={:secondary}
         size={:sm}
         class="!px-4"

--- a/lib/oli_web/live/delivery/remix/actions.ex
+++ b/lib/oli_web/live/delivery/remix/actions.ex
@@ -7,6 +7,12 @@ defmodule OliWeb.Delivery.Remix.Actions do
   alias Oli.Resources.ResourceType
   alias OliWeb.Components.DesignTokens.Primitives.Button
 
+  attr :show_options, :boolean, default: false
+  attr :uuid, :string, required: true
+  attr :hidden, :boolean, required: true
+  attr :resource_type, :integer, required: true
+  attr :is_used_as_source_page, :boolean, required: true
+
   def render(assigns) do
     ~H"""
     <div class="entry-actions flex items-center gap-2">

--- a/lib/oli_web/live/delivery/remix/entry.ex
+++ b/lib/oli_web/live/delivery/remix/entry.ex
@@ -105,7 +105,7 @@ defmodule OliWeb.Delivery.Remix.Entry do
     MapSet.member?(source_page_resource_ids, resource_id)
   end
 
-  defp show_options?(%HierarchyNode{revision: revision, numbering: numbering}) do
-    is_container?(revision) and revision.resource_scope == :blueprint and numbering.level == 1
+  defp show_options?(%HierarchyNode{revision: revision}) do
+    is_container?(revision) and revision.resource_scope == :blueprint
   end
 end

--- a/lib/oli_web/live/delivery/remix/entry.ex
+++ b/lib/oli_web/live/delivery/remix/entry.ex
@@ -69,6 +69,7 @@ defmodule OliWeb.Delivery.Remix.Entry do
         <.live_component
           module={Actions}
           uuid={@node.uuid}
+          show_options={show_options?(@node)}
           hidden={(@node.section_resource && @node.section_resource.hidden) || false}
           resource_type={@node.revision.resource_type_id}
           is_used_as_source_page={
@@ -102,5 +103,9 @@ defmodule OliWeb.Delivery.Remix.Entry do
   def is_used_as_source_page?(resource_id, source_page_resource_ids) do
     # Whether the resource is used as a source page in any gating conditions for the section
     MapSet.member?(source_page_resource_ids, resource_id)
+  end
+
+  defp show_options?(%HierarchyNode{revision: revision, numbering: numbering}) do
+    is_container?(revision) and revision.resource_scope == :blueprint and numbering.level == 1
   end
 end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -451,48 +451,65 @@ defmodule OliWeb.Delivery.RemixSection do
   end
 
   def handle_event("validate-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
+    case socket.assigns[:options_modal_assigns] do
+      %{revision: revision} = modal_assigns ->
+        revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
 
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+        changeset =
+          revision
+          |> Resources.change_revision(revision_params)
+          |> Map.put(:action, :validate)
+          |> Phoenix.Component.to_form()
 
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
-      |> Phoenix.Component.to_form()
+        {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
 
-    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
+      _ ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("save-options", %{"revision" => revision_params}, socket) do
-    %{options_modal_assigns: %{revision: revision, revision_uuid: revision_uuid}} = socket.assigns
-    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+    case socket.assigns[:options_modal_assigns] do
+      %{revision: revision, revision_uuid: revision_uuid} = modal_assigns ->
+        revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
 
-    changeset =
-      revision
-      |> Resources.change_revision(revision_params)
-      |> Map.put(:action, :validate)
+        changeset =
+          revision
+          |> Resources.change_revision(revision_params)
+          |> Map.put(:action, :validate)
 
-    if changeset.valid? do
-      {:ok, state} =
-        Remix.update_container_options(socket.assigns.remix_state, revision_uuid, revision_params)
+        if changeset.valid? do
+          case Remix.update_container_options(
+                 socket.assigns.remix_state,
+                 revision_uuid,
+                 revision_params
+               ) do
+            {:ok, state} ->
+              {:noreply,
+               assign(socket,
+                 options_modal_assigns: nil,
+                 remix_state: state,
+                 hierarchy: state.hierarchy,
+                 active: state.active,
+                 has_unsaved_changes: state.has_unsaved_changes
+               )}
 
-      {:noreply,
-       assign(socket,
-         options_modal_assigns: nil,
-         remix_state: state,
-         hierarchy: state.hierarchy,
-         active: state.active,
-         has_unsaved_changes: state.has_unsaved_changes
-       )}
-    else
-      {:noreply,
-       assign(socket,
-         options_modal_assigns: %{
-           socket.assigns.options_modal_assigns
-           | form: Phoenix.Component.to_form(changeset)
-         }
-       )}
+            {:error, _reason} ->
+              {:noreply,
+               put_flash(socket, :error, "Failed to apply container options. Please try again.")}
+          end
+        else
+          {:noreply,
+           assign(socket,
+             options_modal_assigns: %{
+               modal_assigns
+               | form: Phoenix.Component.to_form(changeset)
+             }
+           )}
+        end
+
+      _ ->
+        {:noreply, socket}
     end
   end
 

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -1220,7 +1220,7 @@ defmodule OliWeb.Delivery.RemixSection do
   defp open_options_modal(socket, uuid, submit_label) do
     node = Hierarchy.find_in_hierarchy(socket.assigns.hierarchy, uuid)
 
-    if editable_blueprint_unit?(node) do
+    if editable_blueprint_container?(node) do
       revision = normalize_options_revision(node)
 
       options_modal_assigns = %{
@@ -1242,11 +1242,11 @@ defmodule OliWeb.Delivery.RemixSection do
     end
   end
 
-  defp editable_blueprint_unit?(%HierarchyNode{revision: revision, numbering: numbering}) do
-    is_container?(revision) and revision.resource_scope == :blueprint and numbering.level == 1
+  defp editable_blueprint_container?(%HierarchyNode{revision: revision}) do
+    is_container?(revision) and revision.resource_scope == :blueprint
   end
 
-  defp editable_blueprint_unit?(_), do: false
+  defp editable_blueprint_container?(_), do: false
 
   defp normalize_options_revision(%HierarchyNode{revision: %Revision{} = revision}), do: revision
 

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -12,6 +12,8 @@ defmodule OliWeb.Delivery.RemixSection do
   alias Oli.Repo
   alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
+  alias Oli.Resources
+  alias Oli.Resources.Revision
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Accounts
 
@@ -39,6 +41,10 @@ defmodule OliWeb.Delivery.RemixSection do
     HideResourceModal,
     UnsavedChangesModal
   }
+
+  alias OliWeb.Curriculum.OptionsModalContent
+  alias OliWeb.Components.Modal
+  alias OliWeb.Curriculum.Container.ContainerLiveHelpers
 
   alias OliWeb.Common.Hierarchy.MoveModal
   alias Oli.Publishing
@@ -203,6 +209,8 @@ defmodule OliWeb.Delivery.RemixSection do
     do: ~p"/authoring/products/#{section.slug}"
 
   defp init_state_from_remix(socket, state, opts) do
+    base_project = Repo.preload(state.section, :base_project).base_project
+
     params = %{
       text_filter: "",
       limit: 5,
@@ -232,6 +240,8 @@ defmodule OliWeb.Delivery.RemixSection do
        title: "Customize Content",
        section: state.section,
        pinned_project_publications: pinned_project_publications,
+       base_project: base_project,
+       project_hierarchy: %{children: []},
        previous_hierarchy: state.hierarchy,
        hierarchy: state.hierarchy,
        pages_table_model_total_count: 0,
@@ -252,6 +262,7 @@ defmodule OliWeb.Delivery.RemixSection do
        source_page_resource_ids: source_page_resource_ids,
        show_add_materials_modal: false,
        show_unsaved_changes_modal: false,
+       options_modal_assigns: nil,
        pending_navigation_target: nil
      )}
   end
@@ -424,6 +435,76 @@ defmodule OliWeb.Delivery.RemixSection do
        )}
     else
       {:noreply, socket}
+    end
+  end
+
+  def handle_event("show_options_modal", %{"uuid" => uuid}, socket) do
+    node = Hierarchy.find_in_hierarchy(socket.assigns.hierarchy, uuid)
+
+    if editable_blueprint_unit?(node) do
+      revision = normalize_options_revision(node)
+
+      options_modal_assigns = %{
+        id: "options_#{uuid}",
+        title: "Container Options",
+        revision_uuid: uuid,
+        revision: revision,
+        form: revision |> Resources.change_revision() |> Phoenix.Component.to_form()
+      }
+
+      {:noreply, assign(socket, options_modal_assigns: options_modal_assigns)}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("restart_options_modal", _, socket) do
+    {:noreply, assign(socket, options_modal_assigns: nil)}
+  end
+
+  def handle_event("validate-options", %{"revision" => revision_params}, socket) do
+    %{options_modal_assigns: %{revision: revision} = modal_assigns} = socket.assigns
+
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
+    changeset =
+      revision
+      |> Resources.change_revision(revision_params)
+      |> Map.put(:action, :validate)
+      |> Phoenix.Component.to_form()
+
+    {:noreply, assign(socket, options_modal_assigns: %{modal_assigns | form: changeset})}
+  end
+
+  def handle_event("save-options", %{"revision" => revision_params}, socket) do
+    %{options_modal_assigns: %{revision: revision, revision_uuid: revision_uuid}} = socket.assigns
+    revision_params = ContainerLiveHelpers.decode_revision_params(revision_params)
+
+    changeset =
+      revision
+      |> Resources.change_revision(revision_params)
+      |> Map.put(:action, :validate)
+
+    if changeset.valid? do
+      {:ok, state} =
+        Remix.update_container_options(socket.assigns.remix_state, revision_uuid, revision_params)
+
+      {:noreply,
+       assign(socket,
+         options_modal_assigns: nil,
+         remix_state: state,
+         hierarchy: state.hierarchy,
+         active: state.active,
+         has_unsaved_changes: state.has_unsaved_changes
+       )}
+    else
+      {:noreply,
+       assign(socket,
+         options_modal_assigns: %{
+           socket.assigns.options_modal_assigns
+           | form: Phoenix.Component.to_form(changeset)
+         }
+       )}
     end
   end
 
@@ -1146,5 +1227,30 @@ defmodule OliWeb.Delivery.RemixSection do
 
   defp reload_remix_state(section, _socket) do
     Remix.init_open_and_free(section)
+  end
+
+  defp editable_blueprint_unit?(%HierarchyNode{revision: revision, numbering: numbering}) do
+    is_container?(revision) and revision.resource_scope == :blueprint and numbering.level == 1
+  end
+
+  defp editable_blueprint_unit?(_), do: false
+
+  defp normalize_options_revision(%HierarchyNode{revision: %Revision{} = revision}), do: revision
+
+  defp normalize_options_revision(%HierarchyNode{revision: revision}) when is_map(revision) do
+    struct(
+      Revision,
+      Map.take(revision, [
+        :id,
+        :resource_id,
+        :resource_type_id,
+        :resource_scope,
+        :slug,
+        :title,
+        :intro_content,
+        :intro_video,
+        :poster_image
+      ])
+    )
   end
 end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -423,39 +423,27 @@ defmodule OliWeb.Delivery.RemixSection do
     if socket.assigns.is_product do
       %{remix_state: state} = socket.assigns
       title = Oli.Delivery.Remix.ContainerCreation.generate_title(state.active)
+      author_id = socket.assigns[:current_author] && socket.assigns.current_author.id
 
-      new_state = Remix.create_container(state, :container, title)
+      new_state = Remix.create_container(state, :container, title, author_id: author_id)
+      new_node = List.last(new_state.active.children)
 
       {:noreply,
-       assign(socket,
+       socket
+       |> assign(
          remix_state: new_state,
          hierarchy: new_state.hierarchy,
          active: new_state.active,
          has_unsaved_changes: new_state.has_unsaved_changes
-       )}
+       )
+       |> open_options_modal(new_node.uuid, "Apply")}
     else
       {:noreply, socket}
     end
   end
 
   def handle_event("show_options_modal", %{"uuid" => uuid}, socket) do
-    node = Hierarchy.find_in_hierarchy(socket.assigns.hierarchy, uuid)
-
-    if editable_blueprint_unit?(node) do
-      revision = normalize_options_revision(node)
-
-      options_modal_assigns = %{
-        id: "options_#{uuid}",
-        title: "Container Options",
-        revision_uuid: uuid,
-        revision: revision,
-        form: revision |> Resources.change_revision() |> Phoenix.Component.to_form()
-      }
-
-      {:noreply, assign(socket, options_modal_assigns: options_modal_assigns)}
-    else
-      {:noreply, socket}
-    end
+    {:noreply, open_options_modal(socket, uuid, "Apply")}
   end
 
   def handle_event("restart_options_modal", _, socket) do
@@ -1229,6 +1217,31 @@ defmodule OliWeb.Delivery.RemixSection do
     Remix.init_open_and_free(section)
   end
 
+  defp open_options_modal(socket, uuid, submit_label) do
+    node = Hierarchy.find_in_hierarchy(socket.assigns.hierarchy, uuid)
+
+    if editable_blueprint_unit?(node) do
+      revision = normalize_options_revision(node)
+
+      options_modal_assigns = %{
+        id: "options_#{uuid}",
+        title: "Container Options",
+        revision_uuid: uuid,
+        revision: revision,
+        submit_label: submit_label,
+        form: revision |> Resources.change_revision() |> Phoenix.Component.to_form()
+      }
+
+      assign(socket, options_modal_assigns: options_modal_assigns)
+      |> push_event("js-exec", %{
+        to: "#options-modal-assigns-trigger",
+        attr: "data-show_modal"
+      })
+    else
+      socket
+    end
+  end
+
   defp editable_blueprint_unit?(%HierarchyNode{revision: revision, numbering: numbering}) do
     is_container?(revision) and revision.resource_scope == :blueprint and numbering.level == 1
   end
@@ -1242,11 +1255,13 @@ defmodule OliWeb.Delivery.RemixSection do
       Revision,
       Map.take(revision, [
         :id,
+        :author_id,
         :resource_id,
         :resource_type_id,
         :resource_scope,
         :slug,
         :title,
+        :deleted,
         :intro_content,
         :intro_video,
         :poster_image

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -9,6 +9,34 @@
 
 <UnsavedChangesModal.render :if={@show_unsaved_changes_modal} show={@show_unsaved_changes_modal} />
 
+<Modal.modal
+  :if={@options_modal_assigns}
+  id="options_modal"
+  class="w-auto min-w-[50%]"
+  body_class="px-6"
+  on_cancel={JS.push("restart_options_modal")}
+>
+  <:title>
+    {@options_modal_assigns[:title]}
+  </:title>
+
+  <.live_component
+    module={OptionsModalContent}
+    ctx={assigns[:ctx]}
+    id="modal_content"
+    redirect_url="#"
+    revision={@options_modal_assigns.revision}
+    project={@base_project}
+    project_hierarchy={@project_hierarchy}
+    validate={JS.push("validate-options")}
+    submit={JS.push("save-options")}
+    cancel={Modal.hide_modal("options_modal") |> JS.push("restart_options_modal")}
+    form={@options_modal_assigns.form}
+  />
+  <div id="options-modal-assigns-trigger" data-show_modal={Modal.show_modal("options_modal")}>
+  </div>
+</Modal.modal>
+
 <div
   data-saved={if @has_unsaved_changes, do: "false", else: "true"}
   phx-hook="NavigationGuard"

--- a/lib/oli_web/live/delivery/remix_section.html.heex
+++ b/lib/oli_web/live/delivery/remix_section.html.heex
@@ -32,6 +32,7 @@
     submit={JS.push("save-options")}
     cancel={Modal.hide_modal("options_modal") |> JS.push("restart_options_modal")}
     form={@options_modal_assigns.form}
+    submit_label={@options_modal_assigns.submit_label}
   />
   <div id="options-modal-assigns-trigger" data-show_modal={Modal.show_modal("options_modal")}>
   </div>

--- a/test/oli/delivery/remix/remix_container_test.exs
+++ b/test/oli/delivery/remix/remix_container_test.exs
@@ -11,6 +11,7 @@ defmodule Oli.Delivery.RemixContainerTest do
   alias Oli.Delivery.Sections.SectionResource
   alias Oli.Delivery.Hierarchy
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Publishing.PublishedResource
 
   import Oli.Test.HierarchyBuilder
 
@@ -61,6 +62,37 @@ defmodule Oli.Delivery.RemixContainerTest do
       base_publication =
         Repo.get!(Oli.Publishing.Publications.Publication, base_publication.id)
 
+      prior_publication =
+        insert(:publication,
+          project: base_project,
+          root_resource_id: base_publication.root_resource_id,
+          published: ~U[2023-01-01 00:00:00Z]
+        )
+
+      latest_publication =
+        insert(:publication,
+          project: base_project,
+          root_resource_id: base_publication.root_resource_id,
+          published: ~U[2024-01-01 00:00:00Z]
+        )
+
+      existing_published_resources =
+        Repo.all(from pr in PublishedResource, where: pr.publication_id == ^base_publication.id)
+
+      Enum.each(existing_published_resources, fn pr ->
+        Repo.insert!(%PublishedResource{
+          publication_id: prior_publication.id,
+          resource_id: pr.resource_id,
+          revision_id: pr.revision_id
+        })
+
+        Repo.insert!(%PublishedResource{
+          publication_id: latest_publication.id,
+          resource_id: pr.resource_id,
+          revision_id: pr.revision_id
+        })
+      end)
+
       section = insert(:section, type: :blueprint, base_project: base_project)
       {:ok, section} = Sections.create_section_resources(section, base_publication)
       {:ok, state} = Remix.init_open_and_free(section)
@@ -69,6 +101,9 @@ defmodule Oli.Delivery.RemixContainerTest do
         state: state,
         section: section,
         base_project: base_project,
+        base_publication: base_publication,
+        prior_publication: prior_publication,
+        latest_publication: latest_publication,
         author: author,
         source_pub: source_publication,
         source_page: source_tree["Extra Page"].resource
@@ -150,6 +185,69 @@ defmodule Oli.Delivery.RemixContainerTest do
         )
 
       assert material_sr.id in container_sr.children
+    end
+
+    test "editing blueprint unit options updates all project publications on save", ctx do
+      created_state = Remix.create_container(ctx.state, :unit, "New Unit")
+      {:ok, saved_section} = Remix.save(created_state, ctx.author)
+      {:ok, reloaded_state} = Remix.init_open_and_free(saved_section)
+
+      new_unit =
+        reloaded_state.hierarchy
+        |> Hierarchy.flatten_hierarchy()
+        |> Enum.find(&(&1.revision.title == "New Unit"))
+
+      original_revision_id = new_unit.revision.id
+
+      {:ok, edited_state} =
+        Remix.update_container_options(reloaded_state, new_unit.uuid, %{
+          "title" => "Renamed Unit",
+          "intro_content" => %{"type" => "p", "children" => [%{"text" => "Intro copy"}]},
+          "poster_image" => "https://cdn.example.com/poster.png",
+          "intro_video" => "https://youtu.be/i8Pq1jpM3PE"
+        })
+
+      assert edited_state.has_unsaved_changes
+
+      {:ok, _section} = Remix.save(edited_state, ctx.author)
+
+      reloaded_hierarchy = DeliveryResolver.full_hierarchy(ctx.section.slug)
+
+      renamed_unit =
+        reloaded_hierarchy
+        |> Hierarchy.flatten_hierarchy()
+        |> Enum.find(&(&1.revision.title == "Renamed Unit"))
+
+      assert renamed_unit.revision.intro_video == "https://youtu.be/i8Pq1jpM3PE"
+      assert renamed_unit.revision.poster_image == "https://cdn.example.com/poster.png"
+
+      assert renamed_unit.revision.intro_content == %{
+               "type" => "p",
+               "children" => [%{"text" => "Intro copy"}]
+             }
+
+      assert renamed_unit.revision.id != original_revision_id
+
+      publication_ids = [
+        ctx.base_publication.id,
+        ctx.prior_publication.id,
+        ctx.latest_publication.id
+      ]
+
+      published_revisions =
+        Repo.all(
+          from pr in PublishedResource,
+            where:
+              pr.publication_id in ^publication_ids and
+                pr.resource_id == ^renamed_unit.resource_id,
+            select: {pr.publication_id, pr.revision_id}
+        )
+
+      assert length(published_revisions) == 3
+
+      assert Enum.uniq_by(published_revisions, &elem(&1, 1)) == [
+               {ctx.base_publication.id, renamed_unit.revision.id}
+             ]
     end
   end
 end

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -936,6 +936,63 @@ defmodule OliWeb.RemixSectionLiveTest do
     end
   end
 
+  describe "template-created unit options in product remix" do
+    setup [:setup_product_manager_session]
+
+    test "options button appears only for created blueprint units and saved title persists", %{
+      conn: conn,
+      prod: prod
+    } do
+      conn = get(conn, Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug))
+      {:ok, view, _html} = live(conn)
+
+      refute render(view) =~ ~s(phx-click="show_options_modal")
+
+      view
+      |> element("#create-container-button")
+      |> render_click()
+
+      options_button =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s(button[phx-click="show_options_modal"]))
+
+      assert length(options_button) == 1
+
+      created_unit_uuid = options_button |> Floki.attribute("phx-value-uuid") |> List.first()
+
+      view
+      |> element(
+        ~s(button[phx-click="show_options_modal"][phx-value-uuid="#{created_unit_uuid}"])
+      )
+      |> render_click()
+
+      render_hook(view, "save-options", %{
+        "revision" => %{
+          "title" => "Custom Unit",
+          "intro_content" => ~s({"type":"p","children":[{"text":"Intro copy"}]}),
+          "poster_image" => "https://cdn.example.com/poster.png",
+          "intro_video" => "https://youtu.be/i8Pq1jpM3PE"
+        }
+      })
+
+      assert render(view) =~ "Custom Unit"
+
+      view
+      |> element(~s(button[phx-click="set_active"][phx-value-uuid="#{created_unit_uuid}"]))
+      |> render_click()
+
+      view
+      |> element("#create-container-button")
+      |> render_click()
+
+      refute render(view) =~ ~s(phx-click="show_options_modal")
+
+      assert view |> element("#save") |> render_click() =~ "Your work has been saved."
+    end
+  end
+
   describe "remix section for open and free" do
     setup [:setup_admin_session]
 

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -1002,6 +1002,17 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert view |> element("#save") |> render_click() =~ "Your work has been saved."
     end
+
+    test "stale options modal events do not crash the liveview", %{conn: conn, prod: prod} do
+      conn = get(conn, Routes.product_remix_path(OliWeb.Endpoint, :product_remix, prod.slug))
+      {:ok, view, _html} = live(conn)
+
+      render_hook(view, "validate-options", %{"revision" => %{"title" => "Ignored"}})
+      render_hook(view, "save-options", %{"revision" => %{"title" => "Ignored"}})
+
+      refute has_element?(view, "#options_modal")
+      assert has_element?(view, "#create-container-button")
+    end
   end
 
   describe "remix section for open and free" do

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -952,6 +952,9 @@ defmodule OliWeb.RemixSectionLiveTest do
       |> element("#create-container-button")
       |> render_click()
 
+      assert has_element?(view, "#options_modal")
+      assert has_element?(view, "#options_modal button[type='submit']", "Apply")
+
       options_button =
         view
         |> render()
@@ -961,12 +964,6 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert length(options_button) == 1
 
       created_unit_uuid = options_button |> Floki.attribute("phx-value-uuid") |> List.first()
-
-      view
-      |> element(
-        ~s(button[phx-click="show_options_modal"][phx-value-uuid="#{created_unit_uuid}"])
-      )
-      |> render_click()
 
       render_hook(view, "save-options", %{
         "revision" => %{

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -936,10 +936,10 @@ defmodule OliWeb.RemixSectionLiveTest do
     end
   end
 
-  describe "template-created unit options in product remix" do
+  describe "template-created container options in product remix" do
     setup [:setup_product_manager_session]
 
-    test "options button appears only for created blueprint units and saved title persists", %{
+    test "options button appears for created blueprint containers at any level", %{
       conn: conn,
       prod: prod
     } do
@@ -984,7 +984,21 @@ defmodule OliWeb.RemixSectionLiveTest do
       |> element("#create-container-button")
       |> render_click()
 
-      refute render(view) =~ ~s(phx-click="show_options_modal")
+      nested_options_buttons =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s(button[phx-click="show_options_modal"]))
+
+      assert length(nested_options_buttons) == 1
+
+      nested_uuid = nested_options_buttons |> Floki.attribute("phx-value-uuid") |> List.first()
+
+      view
+      |> element(~s(button[phx-click="show_options_modal"][phx-value-uuid="#{nested_uuid}"]))
+      |> render_click()
+
+      assert has_element?(view, "#options_modal")
 
       assert view |> element("#save") |> render_click() =~ "Your work has been saved."
     end


### PR DESCRIPTION
• Summary

  Adds a template-remix-only Options flow for blueprint-created units. Authors can now set draft unit metadata from the remix screen, including title, introduction content, poster image, and intro video, without leaving the page.

  This also adjusts the UX so creating a new unit immediately opens the options modal, and the modal submit button reads Apply to reflect that changes are applied to the current remix draft rather than persisted until the page-level Save.

  What Changed

  - Added an Options button for template-created blueprint units in template remix.
  - Reused the existing container options modal UI in the remix context.
  - Kept modal edits draft-only in remix state until the page-wide Save.
  - On remix save, blueprint unit edits create a new revision and update the published-resource mappings across the base project’s publication set.
  - Creating a new unit now auto-opens the options modal.
  - The modal submit button is Apply in template remix.

  Behavior Notes

  - Options is only shown for blueprint-scoped containers created in template remix. Existing project-origin containers do not get the button.
  - Modal Apply updates the current draft on screen and marks remix as dirty.
  - Page-level Save is still required to persist changes.

  Why

  Template authors almost always need to rename a newly created container immediately, so auto-opening the modal reduces friction. Using Apply instead of Save makes the draft-vs-persist distinction clearer in remix.

  Testing

  - Added LiveView coverage for:
      - Options button visibility rules
      - auto-opening the modal on unit creation
      - Apply label in template remix
      - in-session draft updates through the modal
  - Added domain coverage for:
      - blueprint unit edits creating a new revision
      - publication mappings being updated across the base project publication set

  Verification

  - mix test test/oli_web/live/remix_section_test.exs
  - mix test test/oli/delivery/remix/remix_container_test.exs test/oli_web/live/remix_section_test.exs