### PR TITLE
[FEATURE] [MER-5355] Course Section Level AI Recommendation Prompt

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -6521,6 +6521,22 @@ defmodule Oli.Delivery.Sections do
   def assistant_enabled_for_page?(_, _), do: false
 
   @doc """
+  Returns whether instructor AI recommendations are enabled for a section.
+  """
+  def instructor_recommendations_enabled?(%Section{} = section) do
+    section.instructor_recommendations_enabled
+  end
+
+  def instructor_recommendations_enabled?(section_id) when is_integer(section_id) do
+    case get_section_by(id: section_id) do
+      %Section{} = section -> instructor_recommendations_enabled?(section)
+      _ -> true
+    end
+  end
+
+  def instructor_recommendations_enabled?(_), do: true
+
+  @doc """
   Returns true if ai assistant is enabled for a page.
   Falls back to the historic behavior when `ai_enabled` is nil:
   practice pages enabled, scored pages disabled.

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -6521,6 +6521,22 @@ defmodule Oli.Delivery.Sections do
   def assistant_enabled_for_page?(_, _), do: false
 
   @doc """
+  Returns the section-level instructor recommendation settings needed by dashboard flows.
+  """
+  def get_instructor_recommendation_settings(section_id) when is_integer(section_id) do
+    from(s in Section,
+      where: s.id == ^section_id,
+      select: %{
+        instructor_recommendations_enabled: s.instructor_recommendations_enabled,
+        instructor_recommendation_prompt_template: s.instructor_recommendation_prompt_template
+      }
+    )
+    |> Repo.one()
+  end
+
+  def get_instructor_recommendation_settings(_), do: nil
+
+  @doc """
   Returns whether instructor AI recommendations are enabled for a section.
   """
   def instructor_recommendations_enabled?(%Section{} = section) do
@@ -6528,13 +6544,13 @@ defmodule Oli.Delivery.Sections do
   end
 
   def instructor_recommendations_enabled?(section_id) when is_integer(section_id) do
-    case get_section_by(id: section_id) do
-      %Section{} = section -> instructor_recommendations_enabled?(section)
-      _ -> true
+    case get_instructor_recommendation_settings(section_id) do
+      %{instructor_recommendations_enabled: enabled} -> enabled
+      _ -> false
     end
   end
 
-  def instructor_recommendations_enabled?(_), do: true
+  def instructor_recommendations_enabled?(_), do: false
 
   @doc """
   Returns true if ai assistant is enabled for a page.

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -315,6 +315,9 @@ defmodule Oli.Delivery.Sections.Blueprint do
           assistant_enabled: section.assistant_enabled,
           triggers_enabled: section.triggers_enabled,
           page_prompt_template: section.page_prompt_template,
+          instructor_recommendations_enabled: section.instructor_recommendations_enabled,
+          instructor_recommendation_prompt_template:
+            section.instructor_recommendation_prompt_template,
           contains_discussions: section.contains_discussions,
           required_survey_resource_id: section.required_survey_resource_id
         },

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -160,6 +160,8 @@ defmodule Oli.Delivery.Sections.Section do
     # enable/disable the ai chatbot assistant for this section
     field(:assistant_enabled, :boolean, default: false)
     field(:triggers_enabled, :boolean, default: false)
+    field(:instructor_recommendations_enabled, :boolean, default: true)
+    field(:instructor_recommendation_prompt_template, :string)
 
     field(:welcome_title, :map, default: %{})
 
@@ -230,6 +232,8 @@ defmodule Oli.Delivery.Sections.Section do
       :apply_major_updates,
       :assistant_enabled,
       :triggers_enabled,
+      :instructor_recommendations_enabled,
+      :instructor_recommendation_prompt_template,
       :welcome_title,
       :encouraging_subtitle,
       :agenda,

--- a/lib/oli/instructor_dashboard/oracles/recommendation.ex
+++ b/lib/oli/instructor_dashboard/oracles/recommendation.ex
@@ -6,6 +6,7 @@ defmodule Oli.InstructorDashboard.Oracles.Recommendation do
   use Oli.Dashboard.Oracle
 
   alias Oli.Dashboard.OracleContext
+  alias Oli.Delivery.Sections
   alias Oli.InstructorDashboard.Recommendations
 
   @impl true
@@ -16,6 +17,18 @@ defmodule Oli.InstructorDashboard.Oracles.Recommendation do
 
   @impl true
   def load(%OracleContext{} = context, opts) do
-    Recommendations.get_recommendation(context, opts)
+    case Sections.get_section_by(id: context.dashboard_context_id) do
+      %{instructor_recommendations_enabled: false} ->
+        {:ok, nil}
+
+      %{instructor_recommendation_prompt_template: prompt_template} ->
+        Recommendations.get_recommendation(
+          context,
+          Keyword.put(opts, :prompt_template, prompt_template)
+        )
+
+      _ ->
+        Recommendations.get_recommendation(context, opts)
+    end
   end
 end

--- a/lib/oli/instructor_dashboard/oracles/recommendation.ex
+++ b/lib/oli/instructor_dashboard/oracles/recommendation.ex
@@ -17,7 +17,7 @@ defmodule Oli.InstructorDashboard.Oracles.Recommendation do
 
   @impl true
   def load(%OracleContext{} = context, opts) do
-    case Sections.get_section_by(id: context.dashboard_context_id) do
+    case Sections.get_instructor_recommendation_settings(context.dashboard_context_id) do
       %{instructor_recommendations_enabled: false} ->
         {:ok, nil}
 

--- a/lib/oli/instructor_dashboard/recommendations.ex
+++ b/lib/oli/instructor_dashboard/recommendations.ex
@@ -59,6 +59,8 @@ defmodule Oli.InstructorDashboard.Recommendations do
     now = Keyword.get(opts, :now, DateTime.utc_now())
 
     with {:ok, section_id, scope} <- Helpers.section_scope(context) do
+      opts = ensure_prompt_template(opts, section_id)
+
       case active_or_expired_generation(section_id, scope, now) do
         {:ok, %RecommendationInstance{} = generation} ->
           {:ok, normalize_instance(generation, context.user_id)}
@@ -1123,6 +1125,24 @@ defmodule Oli.InstructorDashboard.Recommendations do
   defp normalize_action(:implicit), do: :implicit_generate
   defp normalize_action(:explicit_regen), do: :explicit_regen
   defp normalize_action(_), do: :unknown
+
+  defp ensure_prompt_template(opts, section_id) when is_list(opts) and is_integer(section_id) do
+    case Keyword.fetch(opts, :prompt_template) do
+      {:ok, _prompt_template} ->
+        opts
+
+      :error ->
+        case Sections.get_section_by(id: section_id) do
+          %{instructor_recommendation_prompt_template: prompt_template} ->
+            Keyword.put(opts, :prompt_template, prompt_template)
+
+          _ ->
+            opts
+        end
+    end
+  end
+
+  defp ensure_prompt_template(opts, _section_id), do: opts
 
   defp rate_limit_for_generation(:implicit), do: :miss
   defp rate_limit_for_generation(:explicit_regen), do: nil

--- a/lib/oli/instructor_dashboard/recommendations/prompt.ex
+++ b/lib/oli/instructor_dashboard/recommendations/prompt.ex
@@ -4,71 +4,93 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
   """
 
   @version "recommendation_prompt_v1"
+  @default_no_signal_prompt """
+  You are an expert learning engineer and instructor dashboard analyst. You will be given 1-5 datasets exported from an LMS/assessment system. Each dataset is presented as:
+
+  - A descriptor line explaining what it is
+  - A Markdown table containing the data
+
+  Your job is to produce an actionable instructional insight. You must be precise, avoid speculation, and cite the dataset(s) and column names you used.
+
+  Return exactly one sentence. Do not include bullet points, headings, or multiple recommendations.
+  If the normalized input indicates `signal_state=no_signal`, state that there is no specific recommendation at this point in time because there is not enough student data.
+  Do not invent facts not supported by the tables.
+  If you make an inference, label it explicitly as Inference and explain the supporting evidence.
+  """
+
+  @default_ready_prompt """
+  You are an expert learning engineer and instructor dashboard analyst. You will be given 1-5 datasets exported from an LMS/assessment system. Each dataset is presented as:
+
+  - A descriptor line explaining what it is
+  - A Markdown table containing the data
+
+  Your job is to produce an actionable instructional insight. You must be precise, avoid speculation, and cite the dataset(s) and column names you used.
+
+  Produce one instructional insight or recommendation total, expressed in one sentence (or at most two short sentences).
+  The insight should be the highest-impact finding an instructor or admin should act on right now.
+
+  When forming the insight, consider implicitly:
+
+  - Patterns across datasets (performance, attempts, hints, timing, engagement).
+  - Evidence from specific dataset descriptors and column names.
+  - Whether the issue concerns students, groups, concepts, or engagement behaviors.
+  - What concrete instructor action would most directly address the issue.
+
+  Required constraints:
+
+  - The sentence must reference one dataset descriptor or one course content location.
+  - Do not include bullet points, headings, or multiple recommendations.
+  - Do not explain your reasoning step-by-step.
+  - If evidence is suggestive but not definitive, label it clearly as Inference within the sentence.
+  - If no meaningful insight can be supported by the data, say so explicitly in one sentence.
+
+  Rules:
+
+  - Do not invent facts not supported by the tables.
+  - If you make an inference, label it explicitly as Inference and explain the supporting evidence.
+  - Prefer specific statements over generic advice.
+  - If there are multiple datasets, cross-reference them when the evidence supports the same conclusion.
+  - If a dataset is empty or clearly incomplete, note it and proceed with what you have.
+  - If very little student data is present, it is fine to state "There is no specific recommendation at this point in time, as there isn't enough student data"
+  """
 
   @spec version() :: String.t()
   def version, do: @version
 
+  @spec default_template() :: String.t()
+  def default_template, do: String.trim(@default_ready_prompt)
+
   @spec build_messages(map(), keyword()) :: [map()]
-  def build_messages(input_contract, _opts \\ []) when is_map(input_contract) do
+  def build_messages(input_contract, opts \\ []) when is_map(input_contract) do
     [
-      %{role: :system, content: system_prompt(input_contract)},
+      %{role: :system, content: system_prompt(input_contract, opts)},
       %{role: :user, content: user_prompt(input_contract)}
     ]
   end
 
-  defp system_prompt(%{signal_summary: %{state: :no_signal}}) do
-    """
-    You are an expert learning engineer and instructor dashboard analyst. You will be given 1-5 datasets exported from an LMS/assessment system. Each dataset is presented as:
+  defp system_prompt(input_contract, opts) do
+    case opts |> Keyword.get(:prompt_template) |> normalize_prompt_template() do
+      nil ->
+        default_system_prompt(input_contract)
 
-    - A descriptor line explaining what it is
-    - A Markdown table containing the data
-
-    Your job is to produce an actionable instructional insight. You must be precise, avoid speculation, and cite the dataset(s) and column names you used.
-
-    Return exactly one sentence. Do not include bullet points, headings, or multiple recommendations.
-    If the normalized input indicates `signal_state=no_signal`, state that there is no specific recommendation at this point in time because there is not enough student data.
-    Do not invent facts not supported by the tables.
-    If you make an inference, label it explicitly as Inference and explain the supporting evidence.
-    """
+      prompt_template ->
+        prompt_template
+    end
   end
 
-  defp system_prompt(_input_contract) do
-    """
-    You are an expert learning engineer and instructor dashboard analyst. You will be given 1-5 datasets exported from an LMS/assessment system. Each dataset is presented as:
+  defp default_system_prompt(%{signal_summary: %{state: :no_signal}}),
+    do: String.trim(@default_no_signal_prompt)
 
-    - A descriptor line explaining what it is
-    - A Markdown table containing the data
+  defp default_system_prompt(_input_contract), do: default_template()
 
-    Your job is to produce an actionable instructional insight. You must be precise, avoid speculation, and cite the dataset(s) and column names you used.
-
-    Produce one instructional insight or recommendation total, expressed in one sentence (or at most two short sentences).
-    The insight should be the highest-impact finding an instructor or admin should act on right now.
-
-    When forming the insight, consider implicitly:
-
-    - Patterns across datasets (performance, attempts, hints, timing, engagement).
-    - Evidence from specific dataset descriptors and column names.
-    - Whether the issue concerns students, groups, concepts, or engagement behaviors.
-    - What concrete instructor action would most directly address the issue.
-
-    Required constraints:
-
-    - The sentence must reference one dataset descriptor or one course content location.
-    - Do not include bullet points, headings, or multiple recommendations.
-    - Do not explain your reasoning step-by-step.
-    - If evidence is suggestive but not definitive, label it clearly as Inference within the sentence.
-    - If no meaningful insight can be supported by the data, say so explicitly in one sentence.
-
-    Rules:
-
-    - Do not invent facts not supported by the tables.
-    - If you make an inference, label it explicitly as Inference and explain the supporting evidence.
-    - Prefer specific statements over generic advice.
-    - If there are multiple datasets, cross-reference them when the evidence supports the same conclusion.
-    - If a dataset is empty or clearly incomplete, note it and proceed with what you have.
-    - If very little student data is present, it is fine to state "There is no specific recommendation at this point in time, as there isn't enough student data"
-    """
+  defp normalize_prompt_template(prompt_template) when is_binary(prompt_template) do
+    case String.trim(prompt_template) do
+      "" -> nil
+      _ -> prompt_template
+    end
   end
+
+  defp normalize_prompt_template(_), do: nil
 
   defp user_prompt(input_contract) do
     datasets =

--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
@@ -48,6 +48,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
           projection={Map.get(@dashboard, :summary_projection, %{})}
           projection_status={Map.get(@dashboard, :summary_projection_status, %{status: :loading})}
           tile_state={Map.get(assigns, :summary_tile_state, %{})}
+          show_recommendation={Map.get(@section, :instructor_recommendations_enabled, true)}
         />
 
         <div id="learning-dashboard-sections" class="space-y-6">

--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
@@ -32,12 +32,20 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
     tile_state =
       Map.get(assigns, :tile_state, socket.assigns[:tile_state] || default_tile_state())
 
+    show_recommendation =
+      Map.get(
+        assigns,
+        :show_recommendation,
+        socket.assigns[:show_recommendation] || true
+      )
+
     {:ok,
      socket
      |> assign(assigns)
      |> assign(:projection, projection)
      |> assign(:projection_status, projection_status)
      |> assign(:tile_state, Map.merge(default_tile_state(), tile_state))
+     |> assign(:show_recommendation, show_recommendation)
      |> assign(:cards, Map.get(projection, :cards, []))
      |> assign(
        :recommendation,
@@ -57,7 +65,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
     <article
       id="learning-dashboard-summary-tile"
       aria-label="Summary"
-      class="space-y-4"
+      class={summary_tile_classes(@show_recommendation)}
     >
       <h3 class="sr-only">Summary</h3>
 
@@ -66,7 +74,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
         aria-label={summary_scope_copy(@scope_label, @course_title)}
         class="rounded-2xl bg-[linear-gradient(90deg,#6D3C97_0%,#2D628E_46%,#0DBBD3_100%)] px-[23px] py-[22px] shadow-[0px_2px_10px_0px_rgba(0,50,99,0.05)]"
       >
-        <div class={["grid items-stretch gap-2", row_grid_classes(@layout)]}>
+        <div class={["grid items-stretch gap-2", row_grid_classes(@layout, @show_recommendation)]}>
           <%= if @cards == [] do %>
             <div class="rounded-2xl bg-Surface-surface-secondary px-6 py-5 text-sm leading-6 text-Text-text-high opacity-80 lg:col-span-3">
               Summary metrics will appear as scoped progress, proficiency, and assessment data become available.
@@ -118,6 +126,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
             <% end %>
           <% end %>
           <section
+            :if={@show_recommendation}
             id={"summary-recommendation-panel-#{@id}"}
             aria-labelledby={"summary-recommendation-title-#{@id}"}
             aria-label={recommendation_aria_label(@recommendation)}
@@ -570,16 +579,25 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
   defp summary_scope_copy(_scope_label, _course_title),
     do: "Scoped overview for the current selection."
 
-  defp row_grid_classes(%{visible_card_count: 1}),
+  defp summary_tile_classes(true), do: "w-full space-y-4"
+  defp summary_tile_classes(false), do: "w-full space-y-4 lg:mx-auto lg:max-w-[1076px]"
+
+  defp row_grid_classes(%{visible_card_count: 1}, true),
     do: "grid-cols-1 lg:grid-cols-[213px_minmax(0,1fr)]"
 
-  defp row_grid_classes(%{visible_card_count: 2}),
+  defp row_grid_classes(%{visible_card_count: 2}, true),
     do: "grid-cols-1 md:grid-cols-2 lg:grid-cols-[213px_213px_minmax(0,1fr)]"
 
-  defp row_grid_classes(%{visible_card_count: 3}),
+  defp row_grid_classes(%{visible_card_count: 3}, true),
     do: "grid-cols-1 md:grid-cols-2 lg:grid-cols-[213px_213px_213px_minmax(0,1fr)]"
 
-  defp row_grid_classes(_), do: "grid-cols-1 lg:grid-cols-[213px_minmax(0,1fr)]"
+  defp row_grid_classes(%{visible_card_count: 3}, false),
+    do: "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+
+  defp row_grid_classes(%{visible_card_count: 2}, false), do: "grid-cols-1 md:grid-cols-2"
+  defp row_grid_classes(%{visible_card_count: 1}, false), do: "grid-cols-1"
+  defp row_grid_classes(_, true), do: "grid-cols-1 lg:grid-cols-[213px_minmax(0,1fr)]"
+  defp row_grid_classes(_, false), do: "grid-cols-1"
 
   defp card_title_line_one("Average " <> _rest), do: "Average"
   defp card_title_line_one(label), do: label

--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
@@ -36,7 +36,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
       Map.get(
         assigns,
         :show_recommendation,
-        socket.assigns[:show_recommendation] || true
+        Map.get(socket.assigns, :show_recommendation, true)
       )
 
     {:ok,

--- a/lib/oli_web/live/common/properties/group.ex
+++ b/lib/oli_web/live/common/properties/group.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Common.Properties.Group do
   use OliWeb, :html
 
   attr :label, :string, required: true
+  attr :label_class, :string, default: ""
   attr :description, :string, default: ""
   attr :is_last, :boolean, default: false
   attr :description_class, :string, default: ""
@@ -12,9 +13,9 @@ defmodule OliWeb.Common.Properties.Group do
     ~H"""
     <div class={"flex flex-col md:grid md:grid-cols-12 py-5 last:border-none #{if !@is_last, do: "border-b dark:border-gray-700"}"}>
       <div class="md:col-span-4">
-        <h4>{@label}</h4>
+        <h4 class={@label_class}>{@label}</h4>
         <%= if @description != "" do %>
-          <div class={[@description_class, "text-muted"]}>
+          <div class={if @description_class != "", do: @description_class, else: "text-muted"}>
             {@description}
           </div>
         <% end %>

--- a/lib/oli_web/live/components/sections/instructor_ai_recommendations_component.ex
+++ b/lib/oli_web/live/components/sections/instructor_ai_recommendations_component.ex
@@ -1,0 +1,166 @@
+defmodule OliWeb.Live.Components.Sections.InstructorAiRecommendationsComponent do
+  @moduledoc """
+  LiveComponent for section-level instructor AI recommendation settings.
+
+  Renders:
+  - Enable/disable toggle for instructor AI recommendations
+  - Prompt template editor used by summary recommendation generation
+  - Save action that persists the prompt template
+  """
+
+  use OliWeb, :live_component
+
+  alias Oli.Delivery.Sections
+  alias Oli.InstructorDashboard.Recommendations.Prompt
+  alias OliWeb.Common.Monaco
+
+  @impl true
+  def update(assigns, socket) do
+    section = assigns.section
+
+    {:ok,
+     socket
+     |> assign(assigns)
+     |> assign_new(:instructor_recommendation_prompt_template, fn ->
+       section.instructor_recommendation_prompt_template || Prompt.default_template()
+     end)}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div id={"instructor-ai-recommendations-#{@id}"} class="text-[#373A44]">
+      <div class="flex py-2 mb-2">
+        <div class="font-open-sans text-[16px] leading-[24px] text-[#373A44] dark:text-white">
+          Enable AI Recommendations
+        </div>
+        <.toggle_switch
+          id={"#{@id}-toggle-recommendations"}
+          class="ml-4"
+          checked={@section.instructor_recommendations_enabled}
+          on_toggle="toggle_instructor_recommendations"
+          name="toggle_instructor_recommendations"
+          phx_target={@myself}
+        />
+      </div>
+
+      <section class="mt-8 flex flex-col space-y-4 border-t border-Border-border-default pt-6">
+        <h5 class="text-[#373A44] dark:text-white">Prompt Templates</h5>
+
+        <Monaco.editor
+          id={"#{@id}-monaco-editor"}
+          height="200px"
+          language="text"
+          on_change="monaco_editor_on_change"
+          set_options="monaco_editor_set_options"
+          set_value={set_value_event(@id)}
+          get_value="monaco_editor_get_value"
+          validate_schema_uri=""
+          target={@myself}
+          default_value={@instructor_recommendation_prompt_template}
+          default_options={
+            %{
+              "readOnly" => false,
+              "selectOnLineNumbers" => true,
+              "minimap" => %{"enabled" => false},
+              "scrollBeyondLastLine" => false,
+              "tabSize" => 2
+            }
+          }
+          use_code_lenses={[]}
+        />
+
+        <div>
+          <button
+            type="button"
+            class="btn btn-primary action-button mt-4"
+            phx-click="save_instructor_recommendation_prompt"
+            phx-target={@myself}
+          >
+            Save
+          </button>
+        </div>
+      </section>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("toggle_instructor_recommendations", _params, socket) do
+    section = socket.assigns.section
+
+    case Sections.update_section(section, %{
+           instructor_recommendations_enabled: !section.instructor_recommendations_enabled
+         }) do
+      {:ok, updated_section} ->
+        send(
+          self(),
+          {:flash, :info, "Instructor AI recommendation settings updated successfully"}
+        )
+
+        send(self(), {:section_updated, updated_section})
+        {:noreply, assign(socket, :section, updated_section)}
+
+      {:error, _changeset} ->
+        send(self(), {:flash, :error, "Failed to update instructor AI recommendation settings"})
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("monaco_editor_on_change", value, socket) do
+    {:noreply, assign(socket, :instructor_recommendation_prompt_template, value)}
+  end
+
+  def handle_event("save_instructor_recommendation_prompt", _params, socket) do
+    section = socket.assigns.section
+
+    blank_prompt? =
+      blank_prompt_template?(socket.assigns.instructor_recommendation_prompt_template)
+
+    prompt_template =
+      socket.assigns.instructor_recommendation_prompt_template
+      |> normalize_prompt_template()
+
+    case Sections.update_section(section, %{
+           instructor_recommendation_prompt_template: prompt_template
+         }) do
+      {:ok, updated_section} ->
+        flash_message =
+          if blank_prompt? do
+            "Prompt template was empty and has been reset to the default prompt"
+          else
+            "Instructor AI recommendation prompt saved"
+          end
+
+        send(self(), {:flash, :info, flash_message})
+        send(self(), {:section_updated, updated_section})
+
+        {:noreply,
+         socket
+         |> assign(:section, updated_section)
+         |> assign(:instructor_recommendation_prompt_template, prompt_template)
+         |> push_event(set_value_event(socket.assigns.id), %{value: prompt_template})}
+
+      {:error, _changeset} ->
+        send(self(), {:flash, :error, "Failed to save instructor AI recommendation prompt"})
+        {:noreply, socket}
+    end
+  end
+
+  defp normalize_prompt_template(prompt_template) when is_binary(prompt_template) do
+    case String.trim(prompt_template) do
+      "" -> Prompt.default_template()
+      _ -> prompt_template
+    end
+  end
+
+  defp normalize_prompt_template(_), do: Prompt.default_template()
+
+  defp blank_prompt_template?(prompt_template) when is_binary(prompt_template) do
+    String.trim(prompt_template) == ""
+  end
+
+  defp blank_prompt_template?(_), do: true
+
+  defp set_value_event(id), do: "instructor_ai_recommendations_set_value:#{id}"
+end

--- a/lib/oli_web/live/components/sections/instructor_ai_recommendations_component.ex
+++ b/lib/oli_web/live/components/sections/instructor_ai_recommendations_component.ex
@@ -75,6 +75,7 @@ defmodule OliWeb.Live.Components.Sections.InstructorAiRecommendationsComponent d
             type="button"
             class="btn btn-primary action-button mt-4"
             phx-click="save_instructor_recommendation_prompt"
+            phx-disable-with="Saving..."
             phx-target={@myself}
           >
             Save

--- a/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
@@ -1788,7 +1788,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
   @spec handle_summary_recommendation_regenerate_requested(socket(), String.t() | nil) ::
           {:ok, socket()} | {:error, atom(), socket()}
   def handle_summary_recommendation_regenerate_requested(socket, recommendation_id) do
-    with {:ok, recommendation} <- current_summary_recommendation_for_interaction(socket),
+    with true <- summary_recommendations_enabled?(socket),
+         {:ok, recommendation} <- current_summary_recommendation_for_interaction(socket),
          {:ok, recommendation_id} <- validate_recommendation_id(recommendation, recommendation_id),
          true <- Map.get(recommendation, :can_regenerate?, false),
          false <- summary_tile_state(socket).regenerate_in_flight?,
@@ -1849,7 +1850,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
           String.t() | atom() | nil
         ) :: {:ok, socket()} | {:error, atom(), socket()}
   def handle_summary_recommendation_sentiment_submitted(socket, recommendation_id, sentiment) do
-    with {:ok, recommendation} <- current_summary_recommendation_for_interaction(socket),
+    with true <- summary_recommendations_enabled?(socket),
+         {:ok, recommendation} <- current_summary_recommendation_for_interaction(socket),
          {:ok, recommendation_id} <- validate_recommendation_id(recommendation, recommendation_id),
          {:ok, normalized_sentiment} <- normalize_sentiment(sentiment),
          true <- Map.get(recommendation, :can_submit_sentiment?, false),
@@ -3613,7 +3615,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
   defp maybe_start_summary_recommendation(socket, bundle, context, request_token) do
     scope_selector = scope_selector(bundle.scope)
 
-    with true <- active_dashboard_request?(socket, request_token),
+    with true <- summary_recommendations_enabled?(socket),
+         true <- active_dashboard_request?(socket, request_token),
          true <- recommendation_inputs_ready?(bundle),
          false <- summary_recommendation_requested?(socket, request_token, scope_selector),
          {:ok, oracle_context} <- normalize_recommendation_context(context) do
@@ -3736,6 +3739,13 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
     socket.assigns
     |> Map.get(:dashboard, %{})
     |> Map.get(:summary_recommendation)
+  end
+
+  defp summary_recommendations_enabled?(socket) do
+    case Map.get(socket.assigns, :section) do
+      %{instructor_recommendations_enabled: false} -> false
+      _ -> true
+    end
   end
 
   defp cancel_summary_recommendation_timer(socket) do

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -12,6 +12,7 @@ defmodule OliWeb.Sections.OverviewView do
   alias OliWeb.Sections.{Instructors, Mount}
   alias OliWeb.Projects.RequiredSurvey
   alias OliWeb.Live.Components.Sections.AiAssistantComponent
+  alias OliWeb.Live.Components.Sections.InstructorAiRecommendationsComponent
   alias OliWeb.Live.Components.Sections.NotesComponent
   alias OliWeb.Live.Components.Sections.CourseDiscussionsComponent
   alias OliWeb.Live.Components.Sections.SectionDefaultsHelpers
@@ -448,7 +449,7 @@ defmodule OliWeb.Sections.OverviewView do
         <Group.render
           label="AI Assistant"
           description="View and manage the AI Assistant details"
-          is_last={true}
+          is_last={false}
         >
           <.live_component
             module={AiAssistantComponent}
@@ -469,6 +470,22 @@ defmodule OliWeb.Sections.OverviewView do
               </ul>
             </section>
           </div>
+        </Group.render>
+      </div>
+
+      <div class="border-t dark:border-gray-700">
+        <Group.render
+          label="Instructor AI Recommendations"
+          description="View and edit the prompt used to generate instructor recommendations in the learning dashboard."
+          label_class="text-[#373A44] dark:text-white"
+          description_class="text-[#737373]"
+          is_last={true}
+        >
+          <.live_component
+            module={InstructorAiRecommendationsComponent}
+            id={"instructor-ai-recommendations-#{@section.id}"}
+            section={@section}
+          />
         </Group.render>
       </div>
     </Groups.render>

--- a/priv/repo/migrations/20260417130000_add_instructor_recommendation_settings_to_sections.exs
+++ b/priv/repo/migrations/20260417130000_add_instructor_recommendation_settings_to_sections.exs
@@ -1,0 +1,21 @@
+defmodule Oli.Repo.Migrations.AddInstructorRecommendationSettingsToSections do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sections) do
+      add :instructor_recommendations_enabled, :boolean, default: true, null: false
+      add :instructor_recommendation_prompt_template, :text
+    end
+
+    execute(
+      "UPDATE sections SET instructor_recommendations_enabled = true WHERE instructor_recommendations_enabled IS NULL"
+    )
+  end
+
+  def down do
+    alter table(:sections) do
+      remove :instructor_recommendation_prompt_template
+      remove :instructor_recommendations_enabled
+    end
+  end
+end

--- a/test/oli/delivery/sections/section_test.exs
+++ b/test/oli/delivery/sections/section_test.exs
@@ -96,5 +96,13 @@ defmodule Oli.Delivery.Sections.SectionTest do
 
       refute Ecto.Changeset.get_field(changeset, :assistant_enabled)
     end
+
+    test "default instructor_recommendations_enabled is true" do
+      changeset =
+        build(:section, @valid_section_attrs)
+        |> Section.changeset()
+
+      assert Ecto.Changeset.get_field(changeset, :instructor_recommendations_enabled)
+    end
   end
 end

--- a/test/oli/instructor_dashboard/recommendations/prompt_test.exs
+++ b/test/oli/instructor_dashboard/recommendations/prompt_test.exs
@@ -33,6 +33,22 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
       assert system_message.content =~ "Return exactly one sentence"
       assert user_message.content =~ "No-signal reasons: no_students, no_activity_data"
     end
+
+    test "uses a custom system prompt when a prompt template is provided" do
+      [system_message, _user_message] =
+        Prompt.build_messages(input_contract_fixture(),
+          prompt_template: "Custom recommendation prompt"
+        )
+
+      assert system_message.content == "Custom recommendation prompt"
+    end
+
+    test "falls back to default prompt template when custom template is blank" do
+      [system_message, _user_message] =
+        Prompt.build_messages(input_contract_fixture(), prompt_template: "   ")
+
+      assert system_message.content == Prompt.default_template()
+    end
   end
 
   defp input_contract_fixture do

--- a/test/oli/instructor_dashboard/recommendations_test.exs
+++ b/test/oli/instructor_dashboard/recommendations_test.exs
@@ -106,6 +106,42 @@ defmodule Oli.InstructorDashboard.RecommendationsTest do
     assert latest.generated_by_user_id == user.id
   end
 
+  test "uses section-level prompt template when caller does not pass prompt_template", %{
+    context: context,
+    section: section
+  } do
+    marker = "ARG_TEST_001"
+
+    {:ok, _section} =
+      Sections.update_section(section, %{
+        instructor_recommendation_prompt_template:
+          "Always start your final recommendation with: [#{marker}]"
+      })
+
+    snapshot_bundle = snapshot_bundle_fixture(section.id)
+    parent = self()
+
+    execution_fun = fn _request_ctx, messages, _service_config ->
+      system_prompt =
+        messages
+        |> Enum.find(%{}, fn message -> Map.get(message, :role) == :system end)
+        |> Map.get(:content, "")
+
+      send(parent, {:recommendation_system_prompt, system_prompt})
+      {:ok, "[#{marker}] Test recommendation"}
+    end
+
+    assert {:ok, recommendation} =
+             Recommendations.regenerate_recommendation(context,
+               snapshot_bundle: snapshot_bundle,
+               execution_fun: execution_fun
+             )
+
+    assert recommendation.message =~ "[#{marker}]"
+    assert_receive {:recommendation_system_prompt, system_prompt}
+    assert system_prompt =~ "[#{marker}]"
+  end
+
   test "persists original_prompt and execution metadata for generated recommendations", %{
     context: context,
     section: section

--- a/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile_test.exs
+++ b/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile_test.exs
@@ -116,7 +116,8 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
              )
 
       assert has_element?(component, "#summary-recommendation-panel-summary_tile")
-      assert has_element?(component, "button[aria-label='Regenerate recommendation'][disabled]")
+      assert has_element?(component, "span[role='status']", "Thinking...")
+      refute has_element?(component, "button[aria-label='Regenerate recommendation']")
     end
 
     test "hides recommendation panel when instructor recommendations are disabled", %{conn: conn} do

--- a/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile_test.exs
+++ b/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile_test.exs
@@ -59,6 +59,8 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
       assert has_element?(component, "#summary-recommendation-panel-summary_tile")
       assert has_element?(component, "button[aria-label='Good recommendation']")
       assert has_element?(component, "button[aria-label='Bad recommendation']")
+      html = render(component)
+      refute html =~ "lg:max-w-[1076px]"
 
       assert has_element?(
                component,
@@ -114,44 +116,24 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
              )
 
       assert has_element?(component, "#summary-recommendation-panel-summary_tile")
-      assert has_element?(component, "span", "Thinking...")
-      refute has_element?(component, "button[aria-label='Regenerate recommendation']")
+      assert has_element?(component, "button[aria-label='Regenerate recommendation'][disabled]")
     end
 
-    test "shows thinking state while the recommendation is generating or regenerating", %{
-      conn: conn
-    } do
+    test "hides recommendation panel when instructor recommendations are disabled", %{conn: conn} do
       {:ok, component, _html} =
         live_component_isolated(conn, SummaryTile, %{
           id: "summary_tile",
-          projection: %{
-            cards: [],
-            recommendation: %{
-              label: "AI Recommendation",
-              status: :thinking,
-              body: nil,
-              recommendation_id: "rec-unit-2",
-              can_regenerate?: true,
-              can_submit_sentiment?: false
-            },
-            layout: %{visible_card_count: 0, card_grid_class: "grid-cols-1"}
-          },
-          projection_status: %{status: :partial},
-          tile_state: %{
-            regenerate_in_flight?: true,
-            submitted_sentiment: nil,
-            last_recommendation_id: "rec-unit-2"
-          }
+          projection: ready_projection(),
+          projection_status: %{status: :ready},
+          show_recommendation: false
         })
 
-      assert has_element?(component, "span", "Thinking...")
-      assert has_element?(component, "svg[aria-hidden='true']")
-      assert has_element?(component, "svg .spinner-segment.s0")
-      refute has_element?(component, "button[aria-label='Good recommendation']")
-      refute has_element?(component, "button[aria-label='Bad recommendation']")
-      refute has_element?(component, "button[aria-label='Additional feedback']")
-      refute has_element?(component, "span", "Additional feedback submitted")
-      refute has_element?(component, "button[aria-label='Regenerate recommendation']")
+      refute has_element?(component, "#summary-recommendation-panel-summary_tile")
+      refute has_element?(component, "h4", "AI Recommendation")
+      assert has_element?(component, "p", "81%")
+      assert has_element?(component, "p", "76%")
+      assert has_element?(component, "p", "72%")
+      assert render(component) =~ "lg:max-w-[1076px]"
     end
 
     test "disables sentiment buttons after submission for the active recommendation", %{

--- a/test/oli_web/live/components/sections/instructor_ai_recommendations_component_test.exs
+++ b/test/oli_web/live/components/sections/instructor_ai_recommendations_component_test.exs
@@ -1,0 +1,80 @@
+defmodule OliWeb.Live.Components.Sections.InstructorAiRecommendationsComponentTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import LiveComponentTests
+  import Oli.Factory
+
+  alias Oli.Delivery.Sections
+  alias Oli.InstructorDashboard.Recommendations.Prompt
+  alias OliWeb.Live.Components.Sections.InstructorAiRecommendationsComponent
+
+  describe "InstructorAiRecommendationsComponent" do
+    setup do
+      project = insert(:project)
+
+      section =
+        insert(:section,
+          base_project: project,
+          type: :enrollable,
+          instructor_recommendations_enabled: true,
+          instructor_recommendation_prompt_template: nil
+        )
+
+      %{section: section}
+    end
+
+    test "renders enabled toggle and default prompt template when no template is persisted", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} =
+        live_component_isolated(conn, InstructorAiRecommendationsComponent, %{
+          id: "recommendations-test",
+          section: section
+        })
+
+      assert has_element?(view, "#recommendations-test-toggle-recommendations_checkbox[checked]")
+      assert has_element?(view, "h5", "Prompt Templates")
+      assert has_element?(view, "button", "Save")
+    end
+
+    test "toggle persists instructor_recommendations_enabled", %{conn: conn, section: section} do
+      {:ok, view, _html} =
+        live_component_isolated(conn, InstructorAiRecommendationsComponent, %{
+          id: "recommendations-test",
+          section: section
+        })
+
+      view |> form("#recommendations-test-toggle-recommendations", %{}) |> render_change()
+
+      refute has_element?(view, "#recommendations-test-toggle-recommendations_checkbox[checked]")
+
+      updated = Sections.get_section_by(id: section.id)
+      refute updated.instructor_recommendations_enabled
+    end
+
+    test "saving a blank prompt persists the default template", %{conn: conn, section: section} do
+      {:ok, section} =
+        Sections.update_section(section, %{instructor_recommendation_prompt_template: "  "})
+
+      {:ok, view, _html} =
+        live_component_isolated(conn, InstructorAiRecommendationsComponent, %{
+          id: "recommendations-test",
+          section: section
+        })
+
+      view |> element("button", "Save") |> render_click()
+
+      updated = Sections.get_section_by(id: section.id)
+      assert updated.instructor_recommendation_prompt_template == Prompt.default_template()
+
+      assert_receive {_ref,
+                      {:push_event,
+                       "instructor_ai_recommendations_set_value:recommendations-test",
+                       %{value: value}}}
+
+      assert value == Prompt.default_template()
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -259,7 +259,8 @@ defmodule Oli.Factory do
       publisher: anonymous_build(:publisher),
       lti_1p3_deployment: deployment,
       has_grace_period: false,
-      line_items_service_url: "http://default.com"
+      line_items_service_url: "http://default.com",
+      instructor_recommendations_enabled: true
     }
   end
 


### PR DESCRIPTION
[MER-5355](https://eliterate.atlassian.net/browse/MER-5355)

## Overview

This PR adds section-level AI recommendation settings, so each course section can decide whether recommendations are shown in the dashboard and which prompt is used to generate them.

## What changes

- Two new section-level fields are added:
   - a toggle to enable/disable AI recommendations
   - a custom prompt for recommendation generation
- A new configuration block is added in Manage Section, including:
   - enable/disable toggle
   - prompt editor with explicit save action
   - automatic reset to the default prompt when the field is left empty
- Recommendation generation in the dashboard now:
   - uses the section-configured prompt (with fallback to default)
   - respects the toggle state, so recommendations are not generated or shown when disabled
- The Summary card layout adjusts when recommendations are disabled.

## Functional impact

- Recommendation settings move from implicit/global behavior to section-level control.
- Each section can tailor the prompt to its own context without affecting other sections.
- If a section does not want this feature, it can disable it without impacting the rest of the dashboard.

https://github.com/user-attachments/assets/e612e4e7-49aa-432f-946d-60a877b19b57



[MER-5355]: https://eliterate.atlassian.net/browse/MER-5355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ