### PR TITLE
[ENHANCEMENT] [MER-5311] add model details

### DIFF
--- a/lib/oli/conversation/conversation_message.ex
+++ b/lib/oli/conversation/conversation_message.ex
@@ -4,7 +4,17 @@ defmodule Oli.Conversation.ConversationMessage do
   import Ecto.Changeset
   import Oli.GenAI.Completions.Utils
 
-  @derive {Jason.Encoder, only: [:role, :content, :token_length, :user_id, :resource_id]}
+  @derive {Jason.Encoder,
+           only: [
+             :role,
+             :content,
+             :token_length,
+             :user_id,
+             :resource_id,
+             :llm_provider_type,
+             :llm_provider_url,
+             :llm_model
+           ]}
   schema "assistant_conversation_messages" do
     field :role, Ecto.Enum, values: [:system, :user, :assistant, :function]
 
@@ -16,6 +26,9 @@ defmodule Oli.Conversation.ConversationMessage do
 
     # estimated token length of the message
     field :token_length, :integer
+    field :llm_provider_type, Ecto.Enum, values: [:null, :open_ai, :claude]
+    field :llm_provider_url, :string
+    field :llm_model, :string
 
     belongs_to :user, Oli.Accounts.User
     belongs_to :resource, Oli.Resources.Resource
@@ -27,7 +40,17 @@ defmodule Oli.Conversation.ConversationMessage do
   @doc false
   def changeset(message, attrs) do
     message
-    |> cast(attrs, [:role, :content, :name, :user_id, :resource_id, :section_id])
+    |> cast(attrs, [
+      :role,
+      :content,
+      :name,
+      :user_id,
+      :resource_id,
+      :section_id,
+      :llm_provider_type,
+      :llm_provider_url,
+      :llm_model
+    ])
     |> validate_required([:role, :content, :user_id, :section_id])
     |> set_token_length()
   end

--- a/lib/oli/gen_ai/completions/message.ex
+++ b/lib/oli/gen_ai/completions/message.ex
@@ -9,7 +9,10 @@ defmodule Oli.GenAI.Completions.Message do
     # name, id and input are used in function tool calling
     :name,
     :id,
-    :input
+    :input,
+    :llm_provider_type,
+    :llm_provider_url,
+    :llm_model
   ]
 
   def new(role, content) do
@@ -19,7 +22,10 @@ defmodule Oli.GenAI.Completions.Message do
       name: nil,
       token_length: estimate_token_length(content),
       id: nil,
-      input: nil
+      input: nil,
+      llm_provider_type: nil,
+      llm_provider_url: nil,
+      llm_model: nil
     }
   end
 
@@ -30,7 +36,10 @@ defmodule Oli.GenAI.Completions.Message do
       name: name,
       token_length: estimate_token_length(content),
       id: nil,
-      input: nil
+      input: nil,
+      llm_provider_type: nil,
+      llm_provider_url: nil,
+      llm_model: nil
     }
   end
 end

--- a/lib/oli/gen_ai/dialogue/server.ex
+++ b/lib/oli/gen_ai/dialogue/server.ex
@@ -52,6 +52,7 @@ defmodule Oli.GenAI.Dialogue.Server do
   ```
 
   The complete set of `:dialogue_server` messages that can be sent to the client are:
+  - `{:dialogue_server, {:llm_routing, metadata}}`: Sent when routing chooses the model/provider for the current assistant turn.
   - `{:dialogue_server, {:tokens_received, content}}`: Sent when new tokens are received from the LLM.
   - `{:dialogue_server, {:tokens_finished}}`: Sent when the LLM has finished sending tokens (i.e., the assisstant message is complete).
   - `{:dialogue_server, {:function_called, name, arguments}}`: Sent when a function has been requested by the LLM and called by the dialogue server.
@@ -171,7 +172,12 @@ defmodule Oli.GenAI.Dialogue.Server do
            messages_for_execution(state.messages, state.adaptive_runtime_message, message),
            configuration.functions,
            configuration.service_config,
-           response_handler_fn
+           response_handler_fn,
+           on_plan: fn plan ->
+             notify_client_fn.(
+               {:dialogue_server, {:llm_routing, routing_metadata(plan.selected_model)}}
+             )
+           end
          ) do
       :ok ->
         {:noreply, state}
@@ -319,5 +325,15 @@ defmodule Oli.GenAI.Dialogue.Server do
 
   defp remember_message(%State{} = state, message) do
     %State{state | messages: [message | state.messages]}
+  end
+
+  defp routing_metadata(nil), do: %{llm_provider_type: nil, llm_provider_url: nil, llm_model: nil}
+
+  defp routing_metadata(selected_model) do
+    %{
+      llm_provider_type: selected_model.provider,
+      llm_provider_url: selected_model.url_template,
+      llm_model: selected_model.model
+    }
   end
 end

--- a/lib/oli/gen_ai/execution.ex
+++ b/lib/oli/gen_ai/execution.ex
@@ -19,6 +19,7 @@ defmodule Oli.GenAI.Execution do
     with {:ok, plan} <- Router.route(request_ctx, service_config) do
       completer = Keyword.get(opts, :completions_mod, Completions)
       request_type = Map.get(request_ctx, :request_type, :generate)
+      notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
         execute_with_fallback(
@@ -51,6 +52,7 @@ defmodule Oli.GenAI.Execution do
     with {:ok, plan} <- Router.route(request_ctx, service_config) do
       completer = Keyword.get(opts, :completions_mod, Completions)
       request_type = Map.get(request_ctx, :request_type, :stream)
+      notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
         execute_with_fallback(
@@ -261,4 +263,7 @@ defmodule Oli.GenAI.Execution do
       }
     )
   end
+
+  defp notify_plan(nil, _plan), do: :ok
+  defp notify_plan(callback, plan) when is_function(callback, 1), do: callback.(plan)
 end

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -192,6 +192,7 @@ defmodule OliWeb.Dialogue.WindowLive do
                allow_submission?: true,
                trigger_queue: [],
                active_message: nil,
+               current_llm_metadata: nil,
                title: "Dot",
                current_user: Oli.Accounts.get_user!(current_user_id),
                height: 500,
@@ -733,8 +734,13 @@ defmodule OliWeb.Dialogue.WindowLive do
        streaming: false,
        messages: messages,
        allow_submission?: true,
-       active_message: nil
+       active_message: nil,
+       current_llm_metadata: nil
      )}
+  end
+
+  def handle_info({:dialogue_server, {:llm_routing, metadata}}, socket) do
+    {:noreply, assign(socket, current_llm_metadata: metadata)}
   end
 
   def handle_info({:dialogue_server, {:tokens_received, content}}, socket) do
@@ -743,7 +749,9 @@ defmodule OliWeb.Dialogue.WindowLive do
   end
 
   def handle_info({:dialogue_server, {:tokens_finished}}, socket) do
-    message = Message.new(:assistant, Earmark.as_html!(socket.assigns.active_message))
+    message =
+      Message.new(:assistant, Earmark.as_html!(socket.assigns.active_message))
+      |> with_llm_metadata(socket.assigns.current_llm_metadata)
 
     persist_message(message, socket)
 
@@ -757,6 +765,7 @@ defmodule OliWeb.Dialogue.WindowLive do
            streaming: false,
            allow_submission?: true,
            active_message: nil,
+           current_llm_metadata: nil,
            messages: socket.assigns.messages ++ [message]
          )}
 
@@ -769,7 +778,8 @@ defmodule OliWeb.Dialogue.WindowLive do
          assign(socket,
            active_message: socket.assigns.active_message <> "\n\n",
            messages: socket.assigns.messages ++ [message],
-           trigger_queue: rest
+           trigger_queue: rest,
+           current_llm_metadata: nil
          )}
     end
   end
@@ -777,6 +787,7 @@ defmodule OliWeb.Dialogue.WindowLive do
   def handle_info({:dialogue_server, {:function_called, name, arguments}}, socket) do
     # persist the message to the database
     Message.new(:function, Jason.encode!(arguments), name)
+    |> with_llm_metadata(socket.assigns.current_llm_metadata)
     |> persist_message(socket)
 
     {:noreply, socket}
@@ -826,6 +837,17 @@ defmodule OliWeb.Dialogue.WindowLive do
       socket.assigns.resource_id,
       socket.assigns.section.id
     )
+  end
+
+  defp with_llm_metadata(message, nil), do: message
+
+  defp with_llm_metadata(message, metadata) do
+    %{
+      message
+      | llm_provider_type: Map.get(metadata, :llm_provider_type),
+        llm_provider_url: Map.get(metadata, :llm_provider_url),
+        llm_model: Map.get(metadata, :llm_model)
+    }
   end
 
   defp maybe_remember_adaptive_runtime_update(

--- a/priv/repo/migrations/20260421150000_add_llm_metadata_to_assistant_conversation_messages.exs
+++ b/priv/repo/migrations/20260421150000_add_llm_metadata_to_assistant_conversation_messages.exs
@@ -1,0 +1,11 @@
+defmodule Oli.Repo.Migrations.AddLlmMetadataToAssistantConversationMessages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:assistant_conversation_messages) do
+      add :llm_provider_type, :string
+      add :llm_provider_url, :text
+      add :llm_model, :string
+    end
+  end
+end

--- a/test/oli/conversation/conversation_message_test.exs
+++ b/test/oli/conversation/conversation_message_test.exs
@@ -1,0 +1,45 @@
+defmodule Oli.Conversation.ConversationMessageTest do
+  use Oli.DataCase, async: true
+
+  alias Oli.Conversation.ConversationMessage
+
+  describe "changeset/2" do
+    test "casts llm metadata fields" do
+      attrs = %{
+        role: :assistant,
+        content: "hello",
+        user_id: 1,
+        section_id: 2,
+        llm_provider_type: :open_ai,
+        llm_provider_url: "https://api.example.com/v1",
+        llm_model: "gpt-4.1"
+      }
+
+      changeset = ConversationMessage.changeset(%ConversationMessage{}, attrs)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_change(changeset, :llm_provider_type) == :open_ai
+
+      assert Ecto.Changeset.get_change(changeset, :llm_provider_url) ==
+               "https://api.example.com/v1"
+
+      assert Ecto.Changeset.get_change(changeset, :llm_model) == "gpt-4.1"
+    end
+
+    test "allows llm metadata fields to be nil" do
+      attrs = %{
+        role: :user,
+        content: "hello",
+        user_id: 1,
+        section_id: 2
+      }
+
+      changeset = ConversationMessage.changeset(%ConversationMessage{}, attrs)
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :llm_provider_type) == nil
+      assert Ecto.Changeset.get_field(changeset, :llm_provider_url) == nil
+      assert Ecto.Changeset.get_field(changeset, :llm_model) == nil
+    end
+  end
+end

--- a/test/oli/gen_ai/execution_test.exs
+++ b/test/oli/gen_ai/execution_test.exs
@@ -83,6 +83,48 @@ defmodule Oli.GenAI.ExecutionTest do
     assert_received {:generate_called, ^secondary_id}
   end
 
+  test "invokes on_plan callback with the selected model for generate" do
+    parent = self()
+    Process.put(:execution_test_pid, parent)
+    service_config = build_service_config(31, secondary_model: nil, backup_model: nil)
+    request_ctx = %{request_type: :generate}
+
+    assert {:ok, _} =
+             Execution.generate(
+               request_ctx,
+               [],
+               [],
+               service_config,
+               completions_mod: __MODULE__.AlwaysOkCompletions,
+               on_plan: fn plan -> send(parent, {:selected_model, plan.selected_model.id}) end
+             )
+
+    assert_received {:selected_model, selected_model_id}
+    assert selected_model_id == service_config.primary_model.id
+  end
+
+  test "invokes on_plan callback with the selected model for stream" do
+    parent = self()
+    service_config = build_service_config(32)
+    request_ctx = %{request_type: :stream}
+
+    AdmissionControl.put_breaker_snapshot(service_config.primary_model.id, %{state: :open})
+
+    assert :ok =
+             Execution.stream(
+               request_ctx,
+               [],
+               [],
+               service_config,
+               fn _chunk -> :ok end,
+               completions_mod: __MODULE__.AlwaysOkCompletions,
+               on_plan: fn plan -> send(parent, {:selected_model, plan.selected_model.id}) end
+             )
+
+    assert_received {:selected_model, selected_model_id}
+    assert selected_model_id == service_config.secondary_model.id
+  end
+
   test "routes to backup when primary and secondary breakers are open" do
     Process.put(:execution_test_pid, self())
 

--- a/test/oli_web/live/dialogue/window_live_test.exs
+++ b/test/oli_web/live/dialogue/window_live_test.exs
@@ -2,10 +2,13 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
   use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
+  import Ecto.Query
   import Oli.Factory
   import Phoenix.LiveViewTest
 
   alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Conversation.ConversationMessage
+  alias Oli.Repo
   alias Oli.Resources.ResourceType
   alias Oli.Delivery.Sections
   alias Oli.GenAI.Completions.ServiceConfig
@@ -358,6 +361,59 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
 
       assert is_nil(socket_assigns(view).current_activity_attempt_guid)
       assert is_nil(dialogue_state(view).adaptive_runtime_message)
+    end
+
+    test "persists routed llm metadata on assistant and function messages", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Dialogue.WindowLive,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => user.id,
+            "service_config" => stub_service_config()
+          }
+        )
+
+      metadata = %{
+        llm_provider_type: :open_ai,
+        llm_provider_url: "https://router.example.test/v1",
+        llm_model: "gpt-4.1-mini"
+      }
+
+      send(view.pid, {:dialogue_server, {:llm_routing, metadata}})
+      send(view.pid, {:dialogue_server, {:function_called, "lookup", %{"topic" => "atoms"}}})
+      send(view.pid, {:dialogue_server, {:tokens_received, "assistant reply"}})
+      send(view.pid, {:dialogue_server, {:tokens_finished}})
+
+      render(view)
+
+      persisted_messages =
+        from(cm in ConversationMessage,
+          where: cm.user_id == ^user.id and cm.section_id == ^section.id,
+          order_by: [asc: cm.inserted_at]
+        )
+        |> Repo.all()
+
+      assert Enum.map(persisted_messages, & &1.role) == [:function, :assistant]
+
+      function_message = Enum.at(persisted_messages, 0)
+      assistant_message = Enum.at(persisted_messages, 1)
+
+      assert function_message.llm_provider_type == :open_ai
+      assert function_message.llm_provider_url == "https://router.example.test/v1"
+      assert function_message.llm_model == "gpt-4.1-mini"
+
+      assert assistant_message.llm_provider_type == :open_ai
+      assert assistant_message.llm_provider_url == "https://router.example.test/v1"
+      assert assistant_message.llm_model == "gpt-4.1-mini"
+      assert assistant_message.content =~ "assistant reply"
     end
   end
 


### PR DESCRIPTION
This change makes DOT conversation history auditable at the message level by persisting the exact GenAI provider snapshot used for each assistant turn. We added llm_provider_type, llm_provider_url, and llm_model to `assistant_conversation_messages` so we can tell which routed model/provider handled a student exchange, even when dynamic routing changes across conversations or mid-conversation.

To do that, we threaded the selected routed model from `Oli.GenAI.Execution` through the dialogue server back to `WindowLive`, then stamped that metadata onto persisted assistant and function messages. User messages remain
  unchanged. Tests were added tests covering schema casting, execution callback behavior, and LiveView persistence so the new audit trail is verified where routing decisions are made and where conversation rows are written.