### PR TITLE
[BUG FIX] [MER-5567] auto submit job maintenance

### DIFF
--- a/lib/oli/delivery/settings/student_exceptions.ex
+++ b/lib/oli/delivery/settings/student_exceptions.ex
@@ -8,8 +8,11 @@ defmodule Oli.Delivery.Settings.StudentExceptions do
 
   import Ecto.Query, warn: false
 
+  alias Oli.Delivery.Attempts.AutoSubmit.Worker
+  alias Oli.Delivery.Attempts.Core
   alias Oli.Delivery.Settings
   alias Oli.Delivery.Settings.{AutoSubmitCustodian, StudentException}
+  alias Oli.Delivery.Sections
   alias Oli.Repo
 
   @supported_attrs [
@@ -92,7 +95,7 @@ defmodule Oli.Delivery.Settings.StudentExceptions do
 
   defp update_exception(section, %StudentException{} = student_exception, attrs) do
     Repo.transaction(fn ->
-      maybe_adjust_auto_submit(section, student_exception, attrs)
+      maybe_maintain_auto_submit(section, student_exception, attrs)
 
       student_exception
       |> StudentException.changeset(attrs)
@@ -104,22 +107,57 @@ defmodule Oli.Delivery.Settings.StudentExceptions do
     end)
   end
 
-  defp maybe_adjust_auto_submit(_section, _student_exception, attrs)
-       when not is_map_key(attrs, :end_date),
+  defp maybe_maintain_auto_submit(_section, _student_exception, attrs)
+       when not is_map_key(attrs, :end_date) and not is_map_key(attrs, :late_policy) and
+              not is_map_key(attrs, :late_submit) and not is_map_key(attrs, :grace_period) and
+              not is_map_key(attrs, :time_limit),
        do: :ok
 
-  defp maybe_adjust_auto_submit(section, student_exception, %{end_date: new_end_date}) do
-    if student_exception.late_submit == :disallow do
-      case AutoSubmitCustodian.adjust(
-             section.id,
-             student_exception.resource_id,
-             student_exception.end_date,
-             new_end_date,
-             student_exception.user_id
-           ) do
-        {:ok, _count} -> :ok
-        error -> Repo.rollback(error)
-      end
+  defp maybe_maintain_auto_submit(section, student_exception, attrs) do
+    case active_attempt(section, student_exception) do
+      nil ->
+        :ok
+
+      attempt ->
+        old_settings = Settings.get_combined_settings(attempt)
+        new_settings = new_effective_settings(section, student_exception, attempt, attrs)
+
+        old_deadline = Settings.determine_effective_deadline(attempt, old_settings)
+        new_deadline = Settings.determine_effective_deadline(attempt, new_settings)
+
+        old_needs_auto_submit = needs_auto_submit?(old_settings, old_deadline)
+        new_needs_auto_submit = needs_auto_submit?(new_settings, new_deadline)
+
+        cond do
+          new_needs_auto_submit and is_nil(attempt.auto_submit_job_id) ->
+            schedule_auto_submit(section, attempt, new_settings)
+
+          new_needs_auto_submit and
+              (not old_needs_auto_submit or deadline_changed?(old_deadline, new_deadline)) ->
+            case AutoSubmitCustodian.adjust(
+                   section.id,
+                   student_exception.resource_id,
+                   old_deadline || new_deadline,
+                   new_deadline,
+                   student_exception.user_id
+                 ) do
+              {:ok, _count} -> :ok
+              error -> Repo.rollback(error)
+            end
+
+          not new_needs_auto_submit and not is_nil(attempt.auto_submit_job_id) ->
+            case AutoSubmitCustodian.cancel(
+                   section.id,
+                   student_exception.resource_id,
+                   student_exception.user_id
+                 ) do
+              {:ok, _count} -> :ok
+              error -> Repo.rollback(error)
+            end
+
+          true ->
+            :ok
+        end
     end
   end
 
@@ -167,4 +205,51 @@ defmodule Oli.Delivery.Settings.StudentExceptions do
   end
 
   defp normalize_late_policy(attrs), do: attrs
+
+  defp active_attempt(section, student_exception) do
+    case Core.get_latest_resource_attempt(
+           student_exception.resource_id,
+           section.slug,
+           student_exception.user_id
+         ) do
+      %{lifecycle_state: :active} = attempt -> attempt
+      _ -> nil
+    end
+  end
+
+  defp new_effective_settings(section, student_exception, attempt, attrs) do
+    updated_exception =
+      student_exception
+      |> StudentException.changeset(attrs)
+      |> Ecto.Changeset.apply_changes()
+
+    section_resource = Sections.get_section_resource(section.id, student_exception.resource_id)
+
+    Settings.combine(attempt.revision, section_resource, updated_exception)
+  end
+
+  defp needs_auto_submit?(effective_settings, deadline) do
+    effective_settings.late_submit == :disallow and not is_nil(deadline)
+  end
+
+  defp deadline_changed?(nil, nil), do: false
+  defp deadline_changed?(nil, _), do: true
+  defp deadline_changed?(_, nil), do: true
+
+  defp deadline_changed?(old_deadline, new_deadline) do
+    DateTime.compare(old_deadline, new_deadline) != :eq
+  end
+
+  defp schedule_auto_submit(section, attempt, effective_settings) do
+    case Worker.maybe_schedule_auto_submit(effective_settings, section.slug, attempt, nil) do
+      {:ok, :not_scheduled} ->
+        :ok
+
+      {:ok, auto_submit_job_id} ->
+        case Core.update_resource_attempt(attempt, %{auto_submit_job_id: auto_submit_job_id}) do
+          {:ok, _attempt} -> :ok
+          error -> Repo.rollback(error)
+        end
+    end
+  end
 end

--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -9,9 +9,9 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   alias OliWeb.Common.Utils, as: CommonUtils
   alias Phoenix.LiveView.JS
   alias OliWeb.Router.Helpers, as: Routes
-  alias Oli.{Delivery, Repo, Utils}
+  alias Oli.{Repo, Utils}
   alias Oli.Delivery.Settings
-  alias Oli.Delivery.Settings.{AutoSubmitCustodian, StudentException, StudentExceptions}
+  alias Oli.Delivery.Settings.{StudentException, StudentExceptions}
 
   @default_params %{
     offset: 0,
@@ -773,51 +773,18 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   end
 
   defp perform_edits(selected_setting, date_field, new_start_date, new_end_date, socket) do
-    Repo.transaction(fn ->
-      existing_student_exception =
-        Delivery.get_delivery_setting_by(%{
-          resource_id: selected_setting.resource_id,
-          user_id: selected_setting.user_id
-        })
+    attrs =
+      case date_field do
+        :start_date -> %{start_date: new_start_date, end_date: new_end_date}
+        :end_date -> %{start_date: new_start_date, end_date: new_end_date}
+      end
 
-      message =
-        if existing_student_exception.late_submit == :disallow do
-          case AutoSubmitCustodian.adjust(
-                 socket.assigns.section.id,
-                 socket.assigns.selected_assessment.resource_id,
-                 existing_student_exception.end_date,
-                 new_end_date,
-                 existing_student_exception.user_id
-               ) do
-            {:ok, 0} ->
-              ""
-
-            {:ok, count} ->
-              " Adjusted the deadline for #{count} active student #{Gettext.ngettext(OliWeb.Gettext, "attempt", "attempts", count)}."
-
-            e ->
-              Repo.rollback(e)
-          end
-        end
-
-      updated_student_exception =
-        change_student_exception(
-          existing_student_exception,
-          date_field,
-          new_start_date,
-          new_end_date
-        )
-        |> Repo.update()
-        |> case do
-          {:ok, updated_student_exception} ->
-            updated_student_exception
-
-          e ->
-            Repo.rollback(e)
-        end
-
-      {updated_student_exception, message}
-    end)
+    StudentExceptions.set_exception(
+      socket.assigns.section,
+      selected_setting.resource_id,
+      selected_setting.user_id,
+      attrs
+    )
   end
 
   defp on_edit_date(date_field, new_date, socket) do
@@ -827,37 +794,20 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
       maybe_adjust_dates(date_field, new_date, selected_setting, socket.assigns.ctx)
 
     case perform_edits(selected_setting, date_field, new_start_date, new_end_date, socket) do
-      {:ok, {updated_student_exception, additional_message}} ->
+      {:ok, updated_student_exception} ->
         update_liveview_student_exceptions(
           :updated,
           [Repo.preload(updated_student_exception, :user)],
           false
         )
 
-        {:noreply,
-         socket
-         |> flash_to_liveview(:info, "Student Exception updated!.#{message}#{additional_message}")}
+        {:noreply, socket |> flash_to_liveview(:info, "Student Exception updated!.#{message}")}
 
       _ ->
         {:noreply,
          socket
          |> flash_to_liveview(:error, "ERROR: Student Exception could not be updated")}
     end
-  end
-
-  defp change_student_exception(student_exception, :start_date, start_date, end_date) do
-    StudentException.changeset(student_exception, %{
-      start_date: start_date,
-      end_date: end_date
-    })
-  end
-
-  defp change_student_exception(student_exception, :end_date, start_date, end_date) do
-    StudentException.changeset(student_exception, %{
-      start_date: start_date,
-      end_date: end_date,
-      scheduling_type: unless(is_nil(end_date), do: :due_by, else: :read_by)
-    })
   end
 
   defp default_selected_assessment_id(params, assessments) do

--- a/test/oli/delivery/settings/student_exceptions_test.exs
+++ b/test/oli/delivery/settings/student_exceptions_test.exs
@@ -1,0 +1,165 @@
+defmodule Oli.Delivery.Settings.StudentExceptionsTest do
+  use Oli.DataCase
+  use Oban.Testing, repo: Oli.Repo
+
+  alias Oli.Delivery.Attempts.AutoSubmit.Worker
+  alias Oli.Delivery.Attempts.Core
+  alias Oli.Delivery.Settings.StudentExceptions
+  alias Oli.Delivery.Settings
+  alias Oli.Delivery.Sections
+  alias Oli.Repo
+  alias Oli.Seeder
+
+  describe "set_exception/4 auto submit maintenance" do
+    setup do
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_page(%{graded: true}, :graded_page1)
+      |> Seeder.create_section_resources()
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1, lifecycle_state: :active},
+        :user1,
+        :graded_page1,
+        :attempt1
+      )
+      |> configure_section_settings(:graded_page1, %{
+        end_date: DateTime.utc_now() |> DateTime.add(1, :day) |> DateTime.truncate(:second),
+        late_start: :disallow,
+        late_submit: :disallow,
+        scheduling_type: :due_by,
+        time_limit: 0,
+        grace_period: 0
+      })
+      |> schedule_job(:attempt1)
+    end
+
+    test "reschedules an existing auto submit job when a sparse exception due date changes", %{
+      section: section,
+      user1: user,
+      graded_page1: graded_page1,
+      attempt1: attempt
+    } do
+      resource_id = graded_page1.resource.id
+      new_due_date = DateTime.utc_now() |> DateTime.add(2, :day) |> DateTime.truncate(:second)
+
+      assert {:ok, exception} = StudentExceptions.set_exception(section, resource_id, user.id)
+      assert is_nil(exception.late_submit)
+
+      old_job_id = attempt.auto_submit_job_id
+
+      assert {:ok, _updated_exception} =
+               StudentExceptions.set_exception(section, resource_id, user.id, %{
+                 due_date: new_due_date
+               })
+
+      cancelled_job = Repo.get!(Oban.Job, old_job_id)
+      assert cancelled_job.state == "cancelled"
+
+      updated_attempt = Core.get_resource_attempt_by(attempt_guid: attempt.attempt_guid)
+      refute is_nil(updated_attempt.auto_submit_job_id)
+      refute updated_attempt.auto_submit_job_id == old_job_id
+
+      new_job = Repo.get!(Oban.Job, updated_attempt.auto_submit_job_id)
+      assert new_job.state == "scheduled"
+      assert DateTime.compare(new_job.scheduled_at, Worker.add_slack(new_due_date)) == :eq
+    end
+
+    test "cancels an existing auto submit job when an exception changes late policy to allow", %{
+      section: section,
+      user1: user,
+      graded_page1: graded_page1,
+      attempt1: attempt
+    } do
+      resource_id = graded_page1.resource.id
+
+      assert {:ok, exception} = StudentExceptions.set_exception(section, resource_id, user.id)
+      assert is_nil(exception.late_submit)
+
+      old_job_id = attempt.auto_submit_job_id
+
+      assert {:ok, _updated_exception} =
+               StudentExceptions.set_exception(section, resource_id, user.id, %{
+                 late_policy: :allow_late_start_and_late_submit
+               })
+
+      cancelled_job = Repo.get!(Oban.Job, old_job_id)
+      assert cancelled_job.state == "cancelled"
+
+      updated_attempt = Core.get_resource_attempt_by(attempt_guid: attempt.attempt_guid)
+      assert is_nil(updated_attempt.auto_submit_job_id)
+    end
+
+    test "creates an auto submit job when an exception changes late policy to disallow", %{
+      section: section,
+      user1: user,
+      graded_page1: graded_page1,
+      attempt1: attempt
+    } do
+      resource_id = graded_page1.resource.id
+
+      section_resource = Sections.get_section_resource(section.id, resource_id)
+
+      assert {:ok, _section_resource} =
+               Sections.update_section_resource(section_resource, %{
+                 late_start: :allow,
+                 late_submit: :allow
+               })
+
+      assert {:ok, 1} =
+               Oli.Delivery.Settings.AutoSubmitCustodian.cancel(section.id, resource_id, user.id)
+
+      assert {:ok, exception} = StudentExceptions.set_exception(section, resource_id, user.id)
+      assert is_nil(exception.late_submit)
+
+      attempt = Core.get_resource_attempt_by(attempt_guid: attempt.attempt_guid)
+      assert is_nil(attempt.auto_submit_job_id)
+
+      assert {:ok, _updated_exception} =
+               StudentExceptions.set_exception(section, resource_id, user.id, %{
+                 late_policy: :disallow_late_start_and_late_submit
+               })
+
+      updated_attempt = Core.get_resource_attempt_by(attempt_guid: attempt.attempt_guid)
+      refute is_nil(updated_attempt.auto_submit_job_id)
+
+      new_job = Repo.get!(Oban.Job, updated_attempt.auto_submit_job_id)
+      assert new_job.state == "scheduled"
+
+      effective_settings = Settings.get_combined_settings(updated_attempt)
+
+      expected_deadline =
+        Settings.determine_effective_deadline(updated_attempt, effective_settings)
+
+      assert DateTime.compare(new_job.scheduled_at, Worker.add_slack(expected_deadline)) == :eq
+    end
+  end
+
+  defp configure_section_settings(map, page_key, attrs) do
+    resource = map[page_key].resource
+    section_resource = Sections.get_section_resource(map.section.id, resource.id)
+    {:ok, _section_resource} = Sections.update_section_resource(section_resource, attrs)
+    map
+  end
+
+  defp schedule_job(map, attempt_key) do
+    attempt = map[attempt_key]
+    section = map.section
+    effective_settings = Settings.get_combined_settings(attempt)
+    effective_deadline = Settings.determine_effective_deadline(attempt, effective_settings)
+
+    {:ok, job_id} =
+      Worker.maybe_schedule_auto_submit(
+        effective_settings,
+        section.slug,
+        attempt,
+        "this_does_not_matter"
+      )
+
+    assert DateTime.compare(effective_deadline, DateTime.utc_now()) == :gt
+
+    {:ok, attempt} = Core.update_resource_attempt(attempt, %{auto_submit_job_id: job_id})
+
+    Map.put(map, attempt_key, attempt)
+  end
+end


### PR DESCRIPTION
This PR adds proper auto submit job maintenance during student exception updates.  

Tested locally by starting a 1 minute assessment, closing it, then adding an exception to extend it for 5 minutes.  The score in the gradebook didn't show up until after 5 minutes. 
