### PR TITLE
[BUG FIX] [MER-5542] Fix screen panel bug

### DIFF
--- a/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/AddComponentToolbar.tsx
@@ -22,7 +22,7 @@ import {
 import { selectResponsiveLayout } from 'apps/delivery/store/features/page/slice';
 import { useKeyDown } from 'hooks/useKeyDown';
 import guid from 'utils/guid';
-import { RightPanelTabs } from '../RightMenu/RightMenu';
+import { RightPanelTabs } from '../RightMenu/RightPanelTabs';
 
 const defaultFrequentlyUsed = [
   'janus_text_flow',

--- a/assets/src/apps/authoring/components/ComponentToolbar/ComponentSearchContextMenu.tsx
+++ b/assets/src/apps/authoring/components/ComponentToolbar/ComponentSearchContextMenu.tsx
@@ -14,7 +14,7 @@ import { selectCurrentSelection, setCurrentSelection } from 'apps/authoring/stor
 import { selectCurrentActivityTree } from 'apps/delivery/store/features/groups/selectors/deck';
 import { IPartLayout } from '../../../delivery/store/features/activities/slice';
 import { ReorderingIcon } from '../Flowchart/toolbar/ReorderingIcon';
-import { RightPanelTabs } from '../RightMenu/RightMenu';
+import { RightPanelTabs } from '../RightMenu/RightPanelTabs';
 
 const ComponentSearchContextMenu: React.FC<{
   authoringContainer: React.RefObject<HTMLElement>;

--- a/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
+++ b/assets/src/apps/authoring/components/EditingCanvas/EditingCanvas.tsx
@@ -19,7 +19,7 @@ import {
   setCurrentPartPropertyFocus,
   setCurrentSelection,
 } from '../../store/parts/slice';
-import { RightPanelTabs } from '../RightMenu/RightMenu';
+import { RightPanelTabs } from '../RightMenu/RightPanelTabs';
 import AuthoringActivityRenderer from './AuthoringActivityRenderer';
 import ConfigurationModal from './ConfigurationModal';
 import StagePan from './StagePan';

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -26,7 +26,7 @@ import { selectHasRedo, selectHasUndo } from '../../../store/history/slice';
 import { addPart } from '../../../store/parts/actions/addPart';
 import ComponentSearchContextMenu from '../../ComponentToolbar/ComponentSearchContextMenu';
 import ShowInformationModal from '../../Modal/ShowInformationModal';
-import { RightPanelTabs } from '../../RightMenu/RightMenu';
+import { RightPanelTabs } from '../../RightMenu/RightPanelTabs';
 import { isStaticQuestionType } from '../paths/path-options';
 import { isEndScreen } from '../screens/screen-utils';
 import PasteIcon from './PasteIcon';

--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -39,7 +39,7 @@ import partSchema, {
   transformModelToSchema as transformPartModelToSchema,
   transformSchemaToModel as transformPartSchemaToModel,
 } from '../PropertyEditor/schemas/part';
-import { RightPanelTabs } from './RightMenu';
+import { RightPanelTabs } from './RightPanelTabs';
 
 interface Props {
   currentActivity: IActivity;

--- a/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
@@ -55,8 +55,8 @@ import {
   transformScreenModeltoSchema,
   transformScreenSchematoModel,
 } from '../PropertyEditor/schemas/screen';
-import { RightPanelTabs } from './RightPanelTabs';
 import { PartPropertyEditor } from './PartPropertyEditor';
+import { RightPanelTabs } from './RightPanelTabs';
 
 const RightMenu: React.FC<any> = () => {
   const editorInstanceId = useRef(`aa_${Math.random().toString(36).slice(2, 10)}`);

--- a/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/RightMenu.tsx
@@ -55,13 +55,8 @@ import {
   transformScreenModeltoSchema,
   transformScreenSchematoModel,
 } from '../PropertyEditor/schemas/screen';
+import { RightPanelTabs } from './RightPanelTabs';
 import { PartPropertyEditor } from './PartPropertyEditor';
-
-export enum RightPanelTabs {
-  LESSON = 'lesson',
-  SCREEN = 'screen',
-  COMPONENT = 'component',
-}
 
 const RightMenu: React.FC<any> = () => {
   const editorInstanceId = useRef(`aa_${Math.random().toString(36).slice(2, 10)}`);

--- a/assets/src/apps/authoring/components/RightMenu/RightPanelTabs.ts
+++ b/assets/src/apps/authoring/components/RightMenu/RightPanelTabs.ts
@@ -1,0 +1,5 @@
+export enum RightPanelTabs {
+  LESSON = 'lesson',
+  SCREEN = 'screen',
+  COMPONENT = 'component',
+}

--- a/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
+++ b/assets/src/apps/authoring/components/SequenceEditor/SequenceEditor.tsx
@@ -42,7 +42,7 @@ import { setCurrentActivityFromSequence } from '../../store/groups/layouts/deck/
 import { savePage } from '../../store/page/actions/savePage';
 import ContextAwareToggle from '../Accordion/ContextAwareToggle';
 import ConfirmDelete from '../Modal/DeleteConfirmationModal';
-import { RightPanelTabs } from '../RightMenu/RightMenu';
+import { RightPanelTabs } from '../RightMenu/RightPanelTabs';
 
 const SequenceEditor: React.FC<any> = (props: any) => {
   const dispatch = useDispatch();

--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -9,7 +9,7 @@ import {
 } from 'apps/delivery/store/features/attempt/actions/savePart';
 import { aiTriggerPartSlug } from '../../../../components/parts/janus-ai-trigger/constants';
 import { Objective } from '../../../../data/content/objective';
-import { RightPanelTabs } from '../../components/RightMenu/RightMenu';
+import { RightPanelTabs } from '../../components/RightMenu/RightPanelTabs';
 import { savePage } from '../page/actions/savePage';
 import { AuthoringRootState } from '../rootReducer';
 import { acquireEditingLock, releaseEditingLock } from './actions/locking';

--- a/assets/test/advanced_authoring/right_menu_render_test.tsx
+++ b/assets/test/advanced_authoring/right_menu_render_test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import RightMenu from '../../src/apps/authoring/components/RightMenu/RightMenu';
+
+const renderWithState = (state: any) => {
+  const store = configureStore({
+    reducer: () => state,
+  });
+
+  return render(
+    <Provider store={store}>
+      <RightMenu />
+    </Provider>,
+  );
+};
+
+describe('RightMenu', () => {
+  it('renders the simple author screen tab', () => {
+    const activity = {
+      id: 1,
+      resourceId: 1,
+      title: 'Welcome Screen',
+      content: {
+        custom: {
+          width: 1000,
+          height: 500,
+          palette: {
+            backgroundColor: '#ffffff',
+          },
+          mainBtnLabel: 'Next',
+          applyBtnLabel: 'Try again',
+          applyBtnFlag: false,
+        },
+        partsLayout: [],
+      },
+      authoring: {
+        parts: [],
+        flowchart: {
+          screenType: 'welcome_screen',
+          templateApplied: true,
+          paths: [],
+        },
+      },
+      objectives: {},
+    };
+
+    expect(() =>
+      renderWithState({
+        mainApp: {
+          applicationMode: 'flowchart',
+          editingMode: 'page',
+          paths: { images: '/images' },
+          isAdmin: false,
+          projectSlug: 'demo',
+          revisionSlug: 'rev',
+          leftPanel: true,
+          rightPanel: true,
+          topPanel: true,
+          bottomPanel: true,
+          visible: true,
+          hasEditingLock: true,
+          rightPanelActiveTab: 'screen',
+          currentRule: undefined,
+          partComponentTypes: [],
+          activityTypes: [],
+          allObjectives: [],
+          copiedPart: null,
+          copiedPartActivityId: null,
+          allowTriggers: true,
+          readonly: false,
+          showDiagnosticsWindow: false,
+          showScoringOverview: false,
+          sequenceEditorHeight: '100vh',
+          topLeftPanel: true,
+          bottomLeftPanel: true,
+          sequenceEditorExpanded: false,
+        },
+        page: {
+          title: 'Lesson',
+          custom: {
+            responsiveLayout: false,
+          },
+          additionalStylesheets: [],
+        },
+        parts: {
+          currentSelection: '',
+          currentPartPropertyFocus: true,
+        },
+        groups: {
+          ids: [1],
+          entities: {
+            1: {
+              id: 1,
+              type: 'group',
+              layout: 'deck',
+              children: [
+                {
+                  type: 'activity-reference',
+                  resourceId: 1,
+                  custom: { sequenceId: 'seq-1' },
+                },
+              ],
+            },
+          },
+          currentGroupId: 1,
+        },
+        activities: {
+          ids: [1],
+          entities: { 1: activity },
+          currentActivityId: 1,
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/assets/test/advanced_authoring/right_menu_render_test.tsx
+++ b/assets/test/advanced_authoring/right_menu_render_test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react';
 import RightMenu from '../../src/apps/authoring/components/RightMenu/RightMenu';
 
 const renderWithState = (state: any) => {


### PR DESCRIPTION
I found and fixed an initialization bug on the Simple Author page-edit path: a circular import between
  `assets/src/apps/authoring/store/app/slice.ts` and `assets/src/apps/authoring/components/RightMenu/RightMenu.tsx`.

  `app/slice.ts` was importing `RightPanelTabs` from `RightMenu.tsx`, while `RightMenu.tsx` imports selectors from `app/
  slice.ts`. In a focused render test this was enough to make `RightPanelTabs` come through as undefined during
  module init. That kind of cycle is exactly the sort of thing that can degrade into a production-only `undefined` render path and show up as a React minified error.

  I extracted `RightPanelTabs` into `assets/src/apps/authoring/components/RightMenu/RightPanelTabs.ts` and updated
  the dependent imports so the cycle is gone. I also added a regression test in `assets/test/advanced_authoring/
  right_menu_render_test.tsx`.