### PR TITLE
[BUG FIX] [MER-5579] Fix markdown issues

### DIFF
--- a/assets/src/components/editing/SlateOrMarkdownEditor.tsx
+++ b/assets/src/components/editing/SlateOrMarkdownEditor.tsx
@@ -68,9 +68,24 @@ export class SlateOrMarkdownEditor extends React.Component<
         newHistory.shift();
       }
 
-      return { contentHistory: newHistory, hadEdit: true };
+      return { content, contentHistory: newHistory, hadEdit: true };
     });
   };
+
+  componentDidUpdate(prevProps: Readonly<SlateOrMarkdownEditorProps>) {
+    if (prevProps.content !== this.props.content) {
+      this.setState((state) => {
+        if (state.content === this.props.content) {
+          return null;
+        }
+
+        return {
+          content: this.props.content,
+          contentHistory: [...state.contentHistory, this.props.content].slice(-25),
+        };
+      });
+    }
+  }
 
   revert = () => {
     this.setState((state) => {

--- a/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
+++ b/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
@@ -32,6 +32,24 @@ const defaultContext: SerializationContext = {
   },
 };
 
+const decodeHtmlEntities = (text: string): string => {
+  if (typeof document !== 'undefined') {
+    const textarea = document.createElement('textarea');
+    textarea.innerHTML = text;
+    return textarea.value;
+  }
+
+  return text
+    .replace(/&#(\d+);/g, (_match, code) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code) => String.fromCodePoint(parseInt(code, 16)))
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&');
+};
+
 export const createLexer = (): _Lexer => {
   const lexer = new marked.Lexer({
     gfm: true,
@@ -56,7 +74,7 @@ const serializeTokenToText = (
     {},
   );
 
-  return [{ text: token.text, ...marks }];
+  return [{ text: decodeHtmlEntities(token.text), ...marks }];
 };
 
 const serializeToken =
@@ -89,7 +107,7 @@ const serializeToken =
           marks: { ...context.marks, underline: true },
         });
       case 'codespan':
-        return [{ code: true, text: token.text }];
+        return [{ code: true, text: decodeHtmlEntities(token.text) }];
       case 'code':
         return serializeCode(token as Tokens.Code, context);
       case 'del':

--- a/assets/test/components/editing/slate_or_markdown_editor_test.tsx
+++ b/assets/test/components/editing/slate_or_markdown_editor_test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import { SlateOrMarkdownEditor } from 'components/editing/SlateOrMarkdownEditor';
+import { Model } from 'data/content/model/elements/factories';
+
+let markdownEditorProps: any;
+let slateEditorProps: any;
+
+jest.mock('components/editing/markdown_editor/MarkdownEditor', () => ({
+  MarkdownEditor: (props: any) => {
+    markdownEditorProps = props;
+    return <div data-testid="markdown-editor" />;
+  },
+}));
+
+jest.mock('components/editing/editor/Editor', () => ({
+  Editor: (props: any) => {
+    slateEditorProps = props;
+    return <div data-testid="slate-editor" />;
+  },
+}));
+
+jest.mock('components/editing/editor/SwitchToMarkdownModal', () => ({
+  SwitchToMarkdownModal: () => null,
+}));
+
+jest.mock('components/editing/markdown_editor/SwitchToSlateModal', () => ({
+  SwitchToSlateModal: () => null,
+}));
+
+describe('SlateOrMarkdownEditor', () => {
+  beforeEach(() => {
+    markdownEditorProps = undefined;
+    slateEditorProps = undefined;
+  });
+
+  it('preserves markdown edits when switching back to the slate editor', () => {
+    const initialContent = [Model.p('Initial paragraph')];
+    const editedContent = [Model.p('Edited in markdown')];
+    const onEdit = jest.fn();
+
+    const { rerender } = render(
+      <SlateOrMarkdownEditor
+        allowBlockElements={true}
+        className=""
+        content={initialContent}
+        editMode={true}
+        editorType="markdown"
+        onEdit={onEdit}
+        projectSlug="project"
+        toolbarInsertDescs={[]}
+      />,
+    );
+
+    act(() => {
+      markdownEditorProps.onEdit(editedContent, null, []);
+    });
+
+    rerender(
+      <SlateOrMarkdownEditor
+        allowBlockElements={true}
+        className=""
+        content={initialContent}
+        editMode={true}
+        editorType="slate"
+        onEdit={onEdit}
+        projectSlug="project"
+        toolbarInsertDescs={[]}
+      />,
+    );
+
+    expect(slateEditorProps.value).toBe(editedContent);
+  });
+});

--- a/assets/test/editor/markdown/markdown_round_trip_test.ts
+++ b/assets/test/editor/markdown/markdown_round_trip_test.ts
@@ -53,6 +53,16 @@ describe('Markdown round trip', () => {
     ]);
   });
 
+  it('should preserve apostrophes and ampersands across markdown round trips', () => {
+    testRoundTrip([
+      {
+        type: 'p',
+        id: '1',
+        children: [{ text: "Test's are great & nice" }],
+      },
+    ]);
+  });
+
   it('should serialize and deserialize a paragraph with formatted text', () => {
     testRoundTrip([
       {

--- a/assets/test/editor/markdown/markdown_serializer_test.ts
+++ b/assets/test/editor/markdown/markdown_serializer_test.ts
@@ -93,6 +93,19 @@ describe('Markdown serializer', () => {
     );
   });
 
+  it('should decode html entities in plain text tokens', () => {
+    const content = `Test's are great & nice\n\n`;
+    expect(serializeMarkdown(content)).toEqual(
+      expectAnyId([
+        {
+          type: 'p',
+          id: '1',
+          children: [{ text: "Test's are great & nice" }],
+        },
+      ]),
+    );
+  });
+
   it('should serialize multiple paragraphs', () => {
     const content = `This is a paragraph.\n\nThis is also a paragraph.\n\n`;
     expect(serializeMarkdown(content)).toEqual(


### PR DESCRIPTION
Fixes two issues in the markdown editor:

1. Fixed paragraph content loss when switching between Markdown and rich text editors by keeping the editor wrapper’s internal content state in sync with edits, so mode changes no longer reinitialize from stale content.
2. Fixed Markdown character/entity corruption on reload by decoding HTML entities from parsed Markdown text before storing it in the content model, so characters like apostrophes render normally instead of coming back as `&#39;`.