### PR TITLE
[FEATURE] [MER-5214] Show student responses in adaptive debugger detail pane

### DIFF
--- a/lib/oli_web/components/delivery/content/select_dropdown.ex
+++ b/lib/oli_web/components/delivery/content/select_dropdown.ex
@@ -17,22 +17,37 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
   # @phx_change to the server. Useful for read-only displays (e.g. debug panes)
   # where the dropdown exists to show the selected value + the allowed set.
   attr :push_on_select, :boolean, default: true
-  # When true, the dropdown renders with aria-disabled + dimmed styling so
-  # assistive tech and sighted users both perceive it as non-editable.
-  # Dropdown still opens on click so users can see the allowed values.
-  # Typically paired with push_on_select: false.
+  # When true, the dropdown renders with `aria-readonly="true"` (per WAI-ARIA
+  # 1.2: "not editable, but otherwise operable") plus dimmed styling so both
+  # assistive tech and sighted users perceive it as non-editable. Dropdown
+  # still opens on click so users can see the allowed values. Typically
+  # paired with push_on_select: false.
   attr :readonly, :boolean, default: false
+  # When true, the trigger renders at a reduced height (h-7) to fit alongside
+  # plain text rows in dense displays (e.g. debug panes). Default keeps h-9.
+  attr :compact, :boolean, default: false
 
   def render(assigns) do
+    effective_value =
+      assigns.selected_value ||
+        (List.first(assigns.options) && List.first(assigns.options).value)
+
     assigns =
       assign(assigns,
-        effective_value:
-          assigns.selected_value ||
-            (List.first(assigns.options) && List.first(assigns.options).value)
+        effective_value: effective_value,
+        height_class: if(assigns.compact, do: "h-6", else: "h-9"),
+        label_size_class: if(assigns.compact, do: "text-sm", else: "text-base"),
+        # Compact uses `border` (inside box-sizing) instead of `outline` so the
+        # outer chrome doesn't extend visual height beyond the box.
+        border_class:
+          if(assigns.compact,
+            do: "border border-Border-border-subtle",
+            else: "outline outline-1 #{outline_class(effective_value, assigns.readonly)}"
+          )
       )
 
     ~H"""
-    <div class={"flex flex-col relative rounded outline outline-1 h-9 #{outline_class(@effective_value, @readonly)}"}>
+    <div class={"flex flex-col relative rounded #{@border_class} #{@height_class}"}>
       <div
         phx-click={
           if(!@disabled,
@@ -43,7 +58,8 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
           )
         }
         class={[
-          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto rounded",
+          "flex gap-x-2 px-2 justify-between items-center w-auto rounded",
+          @height_class,
           cond do
             @disabled -> "bg-gray-300 hover:cursor-not-allowed"
             @readonly -> "cursor-default"
@@ -55,7 +71,7 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
         id={"#{@id}-selected-options-container"}
       >
         <div class="flex gap-1 flex-wrap">
-          <span class={"text-base font-semibold leading-none #{label_color(@readonly)}"}>
+          <span class={"#{@label_size_class} font-semibold leading-none #{label_color(@readonly)}"}>
             {selected_option_label(@effective_value, @options)}
           </span>
         </div>

--- a/lib/oli_web/components/delivery/content/select_dropdown.ex
+++ b/lib/oli_web/components/delivery/content/select_dropdown.ex
@@ -13,6 +13,15 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
   attr :target, :any, default: nil
   attr :selected_value, :string, default: nil
   attr :options, :list, required: true
+  # When false, clicking an option closes the dropdown but does NOT push
+  # @phx_change to the server. Useful for read-only displays (e.g. debug panes)
+  # where the dropdown exists to show the selected value + the allowed set.
+  attr :push_on_select, :boolean, default: true
+  # When true, the dropdown renders with aria-disabled + dimmed styling so
+  # assistive tech and sighted users both perceive it as non-editable.
+  # Dropdown still opens on click so users can see the allowed values.
+  # Typically paired with push_on_select: false.
+  attr :readonly, :boolean, default: false
 
   def render(assigns) do
     assigns =
@@ -23,7 +32,7 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
       )
 
     ~H"""
-    <div class={"flex flex-col relative rounded outline outline-1 h-9 #{outline_class(@effective_value)}"}>
+    <div class={"flex flex-col relative rounded outline outline-1 h-9 #{outline_class(@effective_value, @readonly)}"}>
       <div
         phx-click={
           if(!@disabled,
@@ -34,13 +43,18 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
           )
         }
         class={[
-          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto hover:cursor-pointer rounded",
-          if(@disabled, do: "bg-gray-300 hover:cursor-not-allowed")
+          "flex gap-x-2 px-2 h-9 justify-between items-center w-auto rounded",
+          cond do
+            @disabled -> "bg-gray-300 hover:cursor-not-allowed"
+            @readonly -> "cursor-default"
+            true -> "hover:cursor-pointer"
+          end
         ]}
+        aria-disabled={if @readonly or @disabled, do: "true"}
         id={"#{@id}-selected-options-container"}
       >
         <div class="flex gap-1 flex-wrap">
-          <span class="text-Text-text-button text-base font-semibold leading-none">
+          <span class={"text-base font-semibold leading-none #{label_color(@readonly)}"}>
             {selected_option_label(@effective_value, @options)}
           </span>
         </div>
@@ -55,11 +69,7 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
             JS.hide() |> JS.hide(to: "##{@id}-up-icon") |> JS.show(to: "##{@id}-down-icon")
           }
         >
-          <.form
-            for={%{}}
-            phx-change={@phx_change}
-            phx-target={@target}
-          >
+          <.form for={%{}} phx-change={@phx_change} phx-target={@target}>
             <div class="flex flex-col gap-2">
               <select name={@name} class="hidden" />
               <button
@@ -68,12 +78,7 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
                 name={@name}
                 value={opt.value}
                 class="flex flex-row justify-between text-left text-sm text-Text-text-high bg-Specially-Tokens-Fill-fill-input hover:bg-Fill-fill-hover px-2 py-1 rounded"
-                phx-click={
-                  JS.push(@phx_change)
-                  |> JS.hide(to: "##{@id}-options-container")
-                  |> JS.hide(to: "##{@id}-up-icon")
-                  |> JS.show(to: "##{@id}-down-icon")
-                }
+                phx-click={option_click_js(@id, @phx_change, @push_on_select)}
                 phx-target={@target}
                 phx-value-filter={opt.value}
               >
@@ -92,8 +97,21 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
     """
   end
 
-  defp outline_class(nil), do: "outline-Border-border-default"
-  defp outline_class(_selected), do: "outline-Text-text-button"
+  defp option_click_js(id, phx_change, push_on_select) do
+    close_js =
+      JS.hide(to: "##{id}-options-container")
+      |> JS.hide(to: "##{id}-up-icon")
+      |> JS.show(to: "##{id}-down-icon")
+
+    if push_on_select, do: JS.push(close_js, phx_change), else: close_js
+  end
+
+  defp outline_class(_selected, true), do: "outline-Border-border-subtle"
+  defp outline_class(nil, _), do: "outline-Border-border-default"
+  defp outline_class(_selected, _), do: "outline-Text-text-button"
+
+  defp label_color(true), do: "text-Text-text-low"
+  defp label_color(_), do: "text-Text-text-button"
 
   defp selected_option_label(selected, options) do
     selected_str = to_string(selected)

--- a/lib/oli_web/components/delivery/content/select_dropdown.ex
+++ b/lib/oli_web/components/delivery/content/select_dropdown.ex
@@ -50,7 +50,8 @@ defmodule OliWeb.Delivery.Content.SelectDropdown do
             true -> "hover:cursor-pointer"
           end
         ]}
-        aria-disabled={if @readonly or @disabled, do: "true"}
+        aria-readonly={if @readonly, do: "true"}
+        aria-disabled={if @disabled, do: "true"}
         id={"#{@id}-selected-options-container"}
       >
         <div class="flex gap-1 flex-wrap">

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -283,11 +283,10 @@ defmodule OliWeb.Attempt.AttemptLive do
     """
   end
 
-  # Recursive renderer on already-grouped data — no per-render regrouping.
   defp render_grouped_map(assigns) do
     ~H"""
     <ul class="m-0 list-none p-0">
-      <%= for {key, value} <- sorted_entries(@data) do %>
+      <%= for {key, value} <- @data do %>
         <li class="border-b border-Border-border-subtle py-1">
           <%= cond do %>
             <% capi_variable?(value) -> %>
@@ -302,7 +301,7 @@ defmodule OliWeb.Attempt.AttemptLive do
                   />
                 </div>
               </div>
-            <% is_map(value) and map_size(value) > 0 -> %>
+            <% is_list(value) and value != [] -> %>
               <details class="group/keygroup">
                 <summary class="flex cursor-pointer list-none items-center gap-2 [&::-webkit-details-marker]:hidden">
                   <Icons.chevron_down
@@ -511,12 +510,14 @@ defmodule OliWeb.Attempt.AttemptLive do
 
     %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids} = build_part_indexes(attempts)
 
+    expanded_parts = MapSet.intersection(socket.assigns.expanded_parts, valid_part_ids)
+
     table_model =
       socket.assigns.table_model
       |> build_expandable_table_model(
         attempts,
         socket.assigns.expanded_rows,
-        socket.assigns.expanded_parts
+        expanded_parts
       )
       |> SortableTableModel.sort()
 
@@ -525,6 +526,7 @@ defmodule OliWeb.Attempt.AttemptLive do
        table_model: table_model,
        valid_part_ids: valid_part_ids,
        row_part_ids: row_part_ids,
+       expanded_parts: expanded_parts,
        total_count: Enum.count(attempts),
        attempts: attempts
      )}
@@ -579,12 +581,6 @@ defmodule OliWeb.Attempt.AttemptLive do
     end)
   end
 
-  defp sorted_entries(data) when is_map(data) do
-    data |> Enum.to_list() |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
-  end
-
-  defp sorted_entries(_), do: []
-
   # ENUM opens a dropdown that needs overflow-visible to escape the row;
   # other values keep overflow-x-auto so long strings (e.g. customCss) scroll inline.
   defp value_column_class(%{"type" => @capi_type_enum}),
@@ -602,13 +598,29 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   # Mirrors Inspector's unflatten: groups "Input 1.Correct" under a nested "Input 1".
   # On scalar vs nested-path collision, both are kept (scalar under "<key> (value)").
+  # Returns pre-sorted {key, value} lists for nested groups.
   defp group_dotted_keys(data) when is_map(data) do
-    Enum.reduce(data, %{}, fn {k, v}, acc ->
+    data
+    |> Enum.reduce(%{}, fn {k, v}, acc ->
       deep_put(acc, String.split(to_string(k), "."), v)
     end)
+    |> sort_grouped()
   end
 
   defp group_dotted_keys(data), do: data
+
+  # CAPI variable maps are left as-is so capi_variable?/1 still detects them.
+  defp sort_grouped(data) when is_map(data) do
+    if capi_variable?(data) do
+      data
+    else
+      data
+      |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+      |> Enum.map(fn {k, v} -> {k, sort_grouped(v)} end)
+    end
+  end
+
+  defp sort_grouped(data), do: data
 
   defp deep_put(acc, [leaf], v) do
     case Map.get(acc, leaf) do

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -68,6 +68,7 @@ defmodule OliWeb.Attempt.AttemptLive do
 
     expanded_rows = MapSet.new()
     expanded_parts = MapSet.new()
+    %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids} = build_part_indexes(attempts)
 
     {:ok, model} = TableModel.new(attempts)
     model = build_expandable_table_model(model, attempts, expanded_rows, expanded_parts)
@@ -82,8 +83,24 @@ defmodule OliWeb.Attempt.AttemptLive do
        section: section,
        attempts: attempts,
        expanded_rows: expanded_rows,
-       expanded_parts: expanded_parts
+       expanded_parts: expanded_parts,
+       valid_part_ids: valid_part_ids,
+       row_part_ids: row_part_ids
      )}
+  end
+
+  # Rebuilt on mount and PubSub to replace O(n) scans with O(log n) lookups.
+  # row_part_ids also doubles as the row-existence guard for toggle_row.
+  defp build_part_indexes(attempts) do
+    valid_part_ids =
+      attempts
+      |> Enum.flat_map(fn a -> Enum.map(a.part_attempts, & &1.id) end)
+      |> MapSet.new()
+
+    row_part_ids =
+      Map.new(attempts, fn a -> {a.unique_id, Enum.map(a.part_attempts, & &1.id)} end)
+
+    %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids}
   end
 
   # "row_<id>" is the shared identity used by the chevron, row-click, expanded_rows
@@ -93,11 +110,13 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   # Responses/feedback are immutable after persistence — cache the grouped form
-  # so we skip the tree walk on every LV re-render.
+  # and sort part_attempts once to skip both on every re-render.
   defp precompute_grouped_responses(attempts) do
     Enum.map(attempts, fn a ->
       Map.update!(a, :part_attempts, fn parts ->
-        Enum.map(parts, fn p ->
+        parts
+        |> Enum.sort_by(& &1.part_id)
+        |> Enum.map(fn p ->
           p
           |> Map.put(:grouped_response, group_dotted_keys(p.response || %{}))
           |> Map.put(:grouped_feedback, group_dotted_keys(p.feedback || %{}))
@@ -141,8 +160,8 @@ defmodule OliWeb.Attempt.AttemptLive do
     row_id = "row_#{row.id}"
 
     if MapSet.member?(expanded_rows, row_id) do
-      sorted_parts = Enum.sort_by(row.part_attempts, & &1.part_id)
-      assigns = %{row_id: row_id, sorted_parts: sorted_parts, expanded_parts: expanded_parts}
+      # Pre-sorted by part_id upstream.
+      assigns = %{row_id: row_id, parts: row.part_attempts, expanded_parts: expanded_parts}
 
       ~H"""
       <div class="max-h-[65vh] overflow-y-auto">
@@ -158,7 +177,7 @@ defmodule OliWeb.Attempt.AttemptLive do
             </tr>
           </thead>
           <tbody>
-            <%= for p <- @sorted_parts do %>
+            <%= for p <- @parts do %>
               <tr>
                 <td class="px-3 py-1 pl-0">{p.part_id}</td>
                 <td class="px-3 py-1">{p.attempt_number}</td>
@@ -173,7 +192,7 @@ defmodule OliWeb.Attempt.AttemptLive do
         <div id={"responses-#{@row_id}"} class="mt-3">
           <div class="mb-2 flex items-center gap-3">
             <h3 class="m-0 text-base font-semibold text-Text-text-high">Student Responses</h3>
-            <%= if @sorted_parts != [] do %>
+            <%= if @parts != [] do %>
               <Button.button
                 id={"expand-all-#{@row_id}"}
                 variant={:text}
@@ -194,7 +213,7 @@ defmodule OliWeb.Attempt.AttemptLive do
               </Button.button>
             <% end %>
           </div>
-          <%= for p <- @sorted_parts do %>
+          <%= for p <- @parts do %>
             <.part_response_card part_attempt={p} expanded_parts={@expanded_parts} />
           <% end %>
         </div>
@@ -289,7 +308,7 @@ defmodule OliWeb.Attempt.AttemptLive do
                   <Icons.chevron_down
                     width="14"
                     height="14"
-                    class="fill-Icon-icon-default transition group-open/keygroup:rotate-180"
+                    class="fill-Icon-icon-default motion-safe:transition group-open/keygroup:rotate-180"
                   />
                   <span class="font-medium text-Text-text-high">{to_string(key)}</span>
                 </summary>
@@ -371,26 +390,24 @@ defmodule OliWeb.Attempt.AttemptLive do
     """
   end
 
-  def handle_event("toggle_row", %{"id" => "row_" <> id_str = unique_id}, socket) do
-    # Only accept "row_<int>" to cap expanded_rows MapSet growth.
-    case Integer.parse(id_str) do
-      {_, ""} ->
-        expanded_rows =
-          if MapSet.member?(socket.assigns.expanded_rows, unique_id) do
-            MapSet.delete(socket.assigns.expanded_rows, unique_id)
-          else
-            MapSet.put(socket.assigns.expanded_rows, unique_id)
-          end
+  def handle_event("toggle_row", %{"id" => unique_id}, socket) do
+    # Only accept known row ids to cap expanded_rows MapSet growth.
+    if Map.has_key?(socket.assigns.row_part_ids, unique_id) do
+      expanded_rows =
+        if MapSet.member?(socket.assigns.expanded_rows, unique_id) do
+          MapSet.delete(socket.assigns.expanded_rows, unique_id)
+        else
+          MapSet.put(socket.assigns.expanded_rows, unique_id)
+        end
 
-        table_model =
-          Map.update!(socket.assigns.table_model, :data, fn data ->
-            Map.put(data, :expanded_rows, expanded_rows)
-          end)
+      table_model =
+        Map.update!(socket.assigns.table_model, :data, fn data ->
+          Map.put(data, :expanded_rows, expanded_rows)
+        end)
 
-        {:noreply, assign(socket, table_model: table_model, expanded_rows: expanded_rows)}
-
-      _ ->
-        {:noreply, socket}
+      {:noreply, assign(socket, table_model: table_model, expanded_rows: expanded_rows)}
+    else
+      {:noreply, socket}
     end
   end
 
@@ -398,7 +415,7 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   def handle_event("toggle_part", %{"id" => id}, socket) do
     with id when is_integer(id) <- parse_part_id(id),
-         true <- known_part_id?(socket.assigns.attempts, id) do
+         true <- MapSet.member?(socket.assigns.valid_part_ids, id) do
       expanded_parts =
         if MapSet.member?(socket.assigns.expanded_parts, id) do
           MapSet.delete(socket.assigns.expanded_parts, id)
@@ -416,7 +433,7 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   def handle_event("expand_all_parts", %{"row" => unique_id}, socket) do
-    part_ids = part_ids_for_row(socket.assigns.attempts, unique_id)
+    part_ids = Map.get(socket.assigns.row_part_ids, unique_id, [])
 
     expanded_parts =
       Enum.reduce(part_ids, socket.assigns.expanded_parts, &MapSet.put(&2, &1))
@@ -428,7 +445,7 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   def handle_event("collapse_all_parts", %{"row" => unique_id}, socket) do
-    part_ids = part_ids_for_row(socket.assigns.attempts, unique_id)
+    part_ids = Map.get(socket.assigns.row_part_ids, unique_id, [])
 
     expanded_parts =
       Enum.reduce(part_ids, socket.assigns.expanded_parts, &MapSet.delete(&2, &1))
@@ -492,6 +509,8 @@ defmodule OliWeb.Attempt.AttemptLive do
       (refreshed_changed ++ carried_rest)
       |> Enum.sort_by(&{&1.resource_id, &1.attempt_number})
 
+    %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids} = build_part_indexes(attempts)
+
     table_model =
       socket.assigns.table_model
       |> build_expandable_table_model(
@@ -504,18 +523,14 @@ defmodule OliWeb.Attempt.AttemptLive do
     {:noreply,
      assign(socket,
        table_model: table_model,
+       valid_part_ids: valid_part_ids,
+       row_part_ids: row_part_ids,
        total_count: Enum.count(attempts),
        attempts: attempts
      )}
   end
 
   defp attach_unique_id(attempt), do: Map.put(attempt, :unique_id, "row_#{attempt.id}")
-
-  defp known_part_id?(attempts, id) do
-    Enum.any?(attempts, fn a ->
-      Enum.any?(a.part_attempts, &(&1.id == id))
-    end)
-  end
 
   defp get_attempts(resource_attempt_guid) do
     Repo.all(
@@ -533,21 +548,6 @@ defmodule OliWeb.Attempt.AttemptLive do
       )
     )
   end
-
-  defp part_ids_for_row(attempts, "row_" <> id_str) do
-    case Integer.parse(id_str) do
-      {id, ""} ->
-        case Enum.find(attempts, &(&1.id == id)) do
-          nil -> []
-          row -> Enum.map(row.part_attempts, & &1.id)
-        end
-
-      _ ->
-        []
-    end
-  end
-
-  defp part_ids_for_row(_attempts, _), do: []
 
   # Returns nil on non-integer input so the handler bails before mixing strings into the MapSet.
   defp parse_part_id(id) when is_integer(id), do: id

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -71,7 +71,7 @@ defmodule OliWeb.Attempt.AttemptLive do
     %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids} = build_part_indexes(attempts)
 
     {:ok, model} = TableModel.new(attempts)
-    model = build_expandable_table_model(model, attempts, expanded_rows, expanded_parts)
+    model = build_expandable_table_model(model, expanded_rows, expanded_parts)
 
     {:ok,
      assign(socket,
@@ -112,31 +112,35 @@ defmodule OliWeb.Attempt.AttemptLive do
   # Responses/feedback are immutable after persistence — cache the grouped form
   # and sort part_attempts once to skip both on every re-render.
   defp precompute_grouped_responses(attempts) do
-    Enum.map(attempts, fn a ->
-      Map.update!(a, :part_attempts, fn parts ->
-        parts
-        |> Enum.sort_by(& &1.part_id)
-        |> Enum.map(fn p ->
-          p
-          |> Map.put(:grouped_response, group_dotted_keys(p.response || %{}))
-          |> Map.put(:grouped_feedback, group_dotted_keys(p.feedback || %{}))
-        end)
-      end)
-    end)
+    for attempt <- attempts do
+      sorted_parts =
+        for part <- Enum.sort_by(attempt.part_attempts, & &1.part_id) do
+          part
+          |> Map.put(:grouped_response, group_dotted_keys(part.response || %{}))
+          |> Map.put(:grouped_feedback, group_dotted_keys(part.feedback || %{}))
+        end
+
+      %{attempt | part_attempts: sorted_parts}
+    end
   end
 
   # Uses :id (not :resource_id) as the row identity because retakes share resource_id
-  # across attempts but have distinct activity_attempt.id.
+  # but have distinct activity_attempt.id.
+  defp build_expandable_table_model(model, expanded_rows, expanded_parts) do
+    data =
+      Map.merge(model.data, %{
+        expandable_rows: true,
+        expandable_rows_id_field: :id,
+        expanded_rows: expanded_rows,
+        expanded_parts: expanded_parts
+      })
+
+    %{model | data: data}
+  end
+
   defp build_expandable_table_model(model, attempts, expanded_rows, expanded_parts) do
-    model
-    |> Map.put(:rows, attempts)
-    |> Map.update!(:data, fn data ->
-      data
-      |> Map.put(:expandable_rows, true)
-      |> Map.put(:expandable_rows_id_field, :id)
-      |> Map.put(:expanded_rows, expanded_rows)
-      |> Map.put(:expanded_parts, expanded_parts)
-    end)
+    %{model | rows: attempts}
+    |> build_expandable_table_model(expanded_rows, expanded_parts)
   end
 
   def render(assigns) do
@@ -152,82 +156,104 @@ defmodule OliWeb.Attempt.AttemptLive do
     """
   end
 
-  # StripedTable calls this with a plain assigns (no __changed__), so the template
-  # uses local vars; change tracking re-enters at each <.part_response_card>.
+  # StripedTable calls this via a captured function ref, so incoming assigns lack
+  # __changed__; build a fresh map — change tracking re-enters at each nested component.
   def render_row_details(assigns, row) do
-    expanded_rows = assigns.model.data[:expanded_rows] || MapSet.new()
-    expanded_parts = assigns.model.data[:expanded_parts] || MapSet.new()
     row_id = "row_#{row.id}"
 
-    if MapSet.member?(expanded_rows, row_id) do
-      # Pre-sorted by part_id upstream.
-      assigns = %{row_id: row_id, parts: row.part_attempts, expanded_parts: expanded_parts}
+    assigns = %{
+      is_expanded: MapSet.member?(assigns.model.data.expanded_rows, row_id),
+      row_id: row_id,
+      parts: row.part_attempts,
+      expanded_parts: assigns.model.data.expanded_parts
+    }
 
-      ~H"""
+    ~H"""
+    <%= if @is_expanded do %>
       <div class="max-h-[65vh] overflow-y-auto">
-        <table class="mb-3 border-collapse text-sm text-Text-text-high">
-          <caption class="sr-only">Part attempts summary</caption>
-          <thead>
-            <tr>
-              <th scope="col" class="px-3 py-1 pl-0 text-left font-semibold">Part id</th>
-              <th scope="col" class="px-3 py-1 text-left font-semibold">Attempt#</th>
-              <th scope="col" class="px-3 py-1 text-left font-semibold">State</th>
-              <th scope="col" class="px-3 py-1 text-left font-semibold">Score</th>
-              <th scope="col" class="px-3 py-1 text-left font-semibold">Out of</th>
-            </tr>
-          </thead>
-          <tbody>
-            <%= for p <- @parts do %>
-              <tr>
-                <td class="px-3 py-1 pl-0">{p.part_id}</td>
-                <td class="px-3 py-1">{p.attempt_number}</td>
-                <td class="px-3 py-1">{p.lifecycle_state}</td>
-                <td class="px-3 py-1">{p.score}</td>
-                <td class="px-3 py-1">{p.out_of}</td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
+        <.part_summary_table parts={@parts} />
+        <.student_responses_section
+          row_id={@row_id}
+          parts={@parts}
+          expanded_parts={@expanded_parts}
+        />
+      </div>
+    <% end %>
+    """
+  end
 
-        <div id={"responses-#{@row_id}"} class="mt-3">
-          <div class="mb-2 flex items-center gap-3">
-            <h3 class="m-0 text-base font-semibold text-Text-text-high">Student Responses</h3>
-            <%= if @parts != [] do %>
-              <Button.button
-                id={"expand-all-#{@row_id}"}
-                variant={:text}
-                size={:sm}
-                phx-click="expand_all_parts"
-                phx-value-row={@row_id}
-              >
-                Expand all
-              </Button.button>
-              <Button.button
-                id={"collapse-all-#{@row_id}"}
-                variant={:text}
-                size={:sm}
-                phx-click="collapse_all_parts"
-                phx-value-row={@row_id}
-              >
-                Collapse all
-              </Button.button>
-            <% end %>
-          </div>
-          <%= for p <- @parts do %>
-            <.part_response_card part_attempt={p} expanded_parts={@expanded_parts} />
-          <% end %>
+  defp part_summary_table(assigns) do
+    ~H"""
+    <table class="mb-3 border-collapse text-sm text-Text-text-high">
+      <caption class="sr-only">Part attempts summary</caption>
+      <thead>
+        <tr>
+          <th scope="col" class="px-3 py-1 pl-0 text-left font-semibold">Part id</th>
+          <th scope="col" class="px-3 py-1 text-left font-semibold">Attempt#</th>
+          <th scope="col" class="px-3 py-1 text-left font-semibold">State</th>
+          <th scope="col" class="px-3 py-1 text-left font-semibold">Score</th>
+          <th scope="col" class="px-3 py-1 text-left font-semibold">Out of</th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= for part <- @parts do %>
+          <tr>
+            <td class="px-3 py-1 pl-0">{part.part_id}</td>
+            <td class="px-3 py-1">{part.attempt_number}</td>
+            <td class="px-3 py-1">{part.lifecycle_state}</td>
+            <td class="px-3 py-1">{part.score}</td>
+            <td class="px-3 py-1">{part.out_of}</td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    """
+  end
+
+  defp student_responses_section(assigns) do
+    ~H"""
+    <div id={"responses-#{@row_id}"} class="mt-3">
+      <div class="mb-2 flex items-center gap-3">
+        <h3 class="m-0 text-base font-semibold text-Text-text-high">Student Responses</h3>
+        <div :if={@parts != []} class="flex items-center gap-3">
+          <Button.button
+            id={"expand-all-#{@row_id}"}
+            variant={:text}
+            size={:sm}
+            phx-click="expand_all_parts"
+            phx-value-row={@row_id}
+          >
+            Expand all
+          </Button.button>
+          <Button.button
+            id={"collapse-all-#{@row_id}"}
+            variant={:text}
+            size={:sm}
+            phx-click="collapse_all_parts"
+            phx-value-row={@row_id}
+          >
+            Collapse all
+          </Button.button>
         </div>
       </div>
-      """
-    else
-      assigns = %{}
-      ~H""
-    end
+      <.part_response_card
+        :for={part <- @parts}
+        part_attempt={part}
+        expanded_parts={@expanded_parts}
+      />
+    </div>
+    """
   end
 
   defp part_response_card(assigns) do
-    is_open = MapSet.member?(assigns.expanded_parts, assigns.part_attempt.id)
-    assigns = assign(assigns, :is_open, is_open)
+    part = assigns.part_attempt
+
+    assigns =
+      assign(assigns,
+        is_open: MapSet.member?(assigns.expanded_parts, part.id),
+        has_response: has_any_content?(part.response),
+        has_feedback: has_any_content?(part.feedback)
+      )
 
     ~H"""
     <div class="part-response-card mb-2 rounded border border-Border-border-subtle bg-Surface-surface-primary">
@@ -248,34 +274,22 @@ defmodule OliWeb.Attempt.AttemptLive do
               if(@is_open, do: " rotate-180", else: "")
           }
         />
-        <span class="mr-1 text-[0.7rem] uppercase tracking-wider text-Text-text-low">
-          Part
-        </span>
+        <span class="mr-1 text-[0.7rem] uppercase tracking-wider text-Text-text-low">Part</span>
         <code>{@part_attempt.part_id}</code>
         <span class="ml-2 text-sm text-Text-text-low">
           (attempt {@part_attempt.attempt_number})
         </span>
       </button>
-      <div
-        id={"part-body-#{@part_attempt.id}"}
-        class="p-2"
-        hidden={not @is_open}
-      >
-        <div :if={has_any_content?(@part_attempt.response)}>
+      <div id={"part-body-#{@part_attempt.id}"} class="p-2" hidden={not @is_open}>
+        <div :if={@has_response}>
           <div class="mb-1 text-sm text-Text-text-low">Response</div>
           <.render_grouped_map data={@part_attempt.grouped_response} part_id={@part_attempt.id} />
         </div>
-        <div :if={has_any_content?(@part_attempt.feedback)} class="mt-3">
+        <div :if={@has_feedback} class="mt-3">
           <div class="mb-1 text-sm text-Text-text-low">Feedback</div>
           <.render_grouped_map data={@part_attempt.grouped_feedback} part_id={@part_attempt.id} />
         </div>
-        <p
-          :if={
-            !has_any_content?(@part_attempt.response) and
-              !has_any_content?(@part_attempt.feedback)
-          }
-          class="m-0 text-sm text-Text-text-low"
-        >
+        <p :if={not (@has_response or @has_feedback)} class="m-0 text-sm text-Text-text-low">
           No response data recorded for this part attempt.
         </p>
       </div>
@@ -286,52 +300,68 @@ defmodule OliWeb.Attempt.AttemptLive do
   defp render_grouped_map(assigns) do
     ~H"""
     <ul class="m-0 list-none p-0">
-      <%= for {key, value} <- @data do %>
-        <li class="border-b border-Border-border-subtle py-1">
-          <%= cond do %>
-            <% capi_variable?(value) -> %>
-              <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
-                <span class="break-words font-medium text-Text-text-high">{to_string(key)}</span>
-                <div class={value_column_class(value)}>
-                  <.render_capi_value
-                    value={value["value"]}
-                    type={value["type"]}
-                    allowed_values={value["allowedValues"]}
-                    dom_id={
-                      safe_dom_id(
-                        "capi-#{@part_id}",
-                        value["id"] || value["key"] || to_string(key)
-                      )
-                    }
-                  />
-                </div>
-              </div>
-            <% is_list(value) and value != [] and Enum.all?(value, &match?({_, _}, &1)) -> %>
-              <details class="group/keygroup">
-                <summary class="flex cursor-pointer list-none items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden">
-                  <Icons.chevron_down
-                    width="14"
-                    height="14"
-                    class="fill-Icon-icon-default motion-safe:transition group-open/keygroup:rotate-180"
-                  />
-                  <span class="font-medium text-Text-text-high">{to_string(key)}</span>
-                </summary>
-                <div class="pl-4 pt-1">
-                  <.render_grouped_map data={value} part_id={@part_id} />
-                </div>
-              </details>
-            <% true -> %>
-              <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
-                <span class="break-words font-medium text-Text-text-high">{to_string(key)}</span>
-                <div class="min-w-0 overflow-x-auto whitespace-nowrap">
-                  <.render_value value={value} />
-                </div>
-              </div>
-          <% end %>
-        </li>
-      <% end %>
+      <li :for={{key, value} <- @data} class="border-b border-Border-border-subtle py-1">
+        <.grouped_map_row key={key} value={value} part_id={@part_id} />
+      </li>
     </ul>
     """
+  end
+
+  defp grouped_map_row(%{value: value} = assigns) do
+    cond do
+      capi_variable?(value) -> capi_row(assigns)
+      nested_group?(value) -> nested_group_row(assigns)
+      true -> scalar_row(assigns)
+    end
+  end
+
+  defp capi_row(assigns) do
+    ~H"""
+    <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
+      <span class="break-words font-medium text-Text-text-high">{to_string(@key)}</span>
+      <div class={value_column_class(@value)}>
+        <.render_capi_value
+          value={@value["value"]}
+          type={@value["type"]}
+          allowed_values={@value["allowedValues"]}
+          dom_id={safe_dom_id("capi-#{@part_id}", @value["id"] || @value["key"] || to_string(@key))}
+        />
+      </div>
+    </div>
+    """
+  end
+
+  defp nested_group_row(assigns) do
+    ~H"""
+    <details class="group/keygroup">
+      <summary class="flex cursor-pointer list-none items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden">
+        <Icons.chevron_down
+          width="14"
+          height="14"
+          class="fill-Icon-icon-default motion-safe:transition group-open/keygroup:rotate-180"
+        />
+        <span class="font-medium text-Text-text-high">{to_string(@key)}</span>
+      </summary>
+      <div class="pl-4 pt-1">
+        <.render_grouped_map data={@value} part_id={@part_id} />
+      </div>
+    </details>
+    """
+  end
+
+  defp scalar_row(assigns) do
+    ~H"""
+    <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
+      <span class="break-words font-medium text-Text-text-high">{to_string(@key)}</span>
+      <div class="min-w-0 overflow-x-auto whitespace-nowrap">
+        <.render_value value={@value} />
+      </div>
+    </div>
+    """
+  end
+
+  defp nested_group?(value) do
+    is_list(value) and value != [] and Enum.all?(value, &match?({_, _}, &1))
   end
 
   defp render_value(assigns) do
@@ -484,8 +514,7 @@ defmodule OliWeb.Attempt.AttemptLive do
     # Regroup only the changed attempt; others carry cached :grouped_* forward
     # to skip the tree walk on every PubSub tick.
     {changed, rest} =
-      get_attempts(socket.assigns.attempt_guid)
-      |> Enum.split_with(&(&1.attempt_guid == guid))
+      get_attempts(socket.assigns.attempt_guid) |> Enum.split_with(&(&1.attempt_guid == guid))
 
     refreshed_changed =
       changed
@@ -493,8 +522,7 @@ defmodule OliWeb.Attempt.AttemptLive do
       |> attach_unique_ids()
       |> precompute_grouped_responses()
 
-    cached_by_guid =
-      Map.new(socket.assigns.attempts, fn a -> {a.attempt_guid, a} end)
+    cached_by_guid = Map.new(socket.assigns.attempts, fn a -> {a.attempt_guid, a} end)
 
     carried_rest =
       Enum.map(rest, fn a ->
@@ -510,8 +538,7 @@ defmodule OliWeb.Attempt.AttemptLive do
       end)
 
     attempts =
-      (refreshed_changed ++ carried_rest)
-      |> Enum.sort_by(&{&1.resource_id, &1.attempt_number})
+      (refreshed_changed ++ carried_rest) |> Enum.sort_by(&{&1.resource_id, &1.attempt_number})
 
     %{valid_part_ids: valid_part_ids, row_part_ids: row_part_ids} = build_part_indexes(attempts)
 
@@ -594,11 +621,9 @@ defmodule OliWeb.Attempt.AttemptLive do
   defp value_column_class(_),
     do: "min-w-0 overflow-x-auto whitespace-nowrap"
 
-  # CAPI ids contain dots (e.g. "stage.cardsBioFuels.Mode") which CSS selectors
-  # read as class separators, breaking SelectDropdown's JS.toggle.
+  # Numeric hash — selector-safe; raw CAPI ids contain dots that break JS.toggle.
   defp safe_dom_id(prefix, raw) do
-    cleaned = raw |> to_string() |> String.replace(~r/[^A-Za-z0-9_-]/, "-")
-    "#{prefix}-#{cleaned}"
+    "#{prefix}-#{:erlang.phash2(to_string(raw))}"
   end
 
   # Mirrors Inspector's unflatten: groups "Input 1.Correct" under a nested "Input 1".
@@ -606,9 +631,7 @@ defmodule OliWeb.Attempt.AttemptLive do
   # Returns pre-sorted {key, value} lists for nested groups.
   defp group_dotted_keys(data) when is_map(data) do
     data
-    |> Enum.reduce(%{}, fn {k, v}, acc ->
-      deep_put(acc, String.split(to_string(k), "."), v)
-    end)
+    |> Enum.reduce(%{}, fn {k, v}, acc -> deep_put(acc, String.split(to_string(k), "."), v) end)
     |> sort_grouped()
   end
 

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -263,11 +263,11 @@ defmodule OliWeb.Attempt.AttemptLive do
       >
         <div :if={has_any_content?(@part_attempt.response)}>
           <div class="mb-1 text-sm text-Text-text-low">Response</div>
-          <.render_grouped_map data={@part_attempt.grouped_response} />
+          <.render_grouped_map data={@part_attempt.grouped_response} part_id={@part_attempt.id} />
         </div>
         <div :if={has_any_content?(@part_attempt.feedback)} class="mt-3">
           <div class="mb-1 text-sm text-Text-text-low">Feedback</div>
-          <.render_grouped_map data={@part_attempt.grouped_feedback} />
+          <.render_grouped_map data={@part_attempt.grouped_feedback} part_id={@part_attempt.id} />
         </div>
         <p
           :if={
@@ -297,13 +297,18 @@ defmodule OliWeb.Attempt.AttemptLive do
                     value={value["value"]}
                     type={value["type"]}
                     allowed_values={value["allowedValues"]}
-                    dom_id={safe_dom_id("capi", value["id"] || value["key"] || to_string(key))}
+                    dom_id={
+                      safe_dom_id(
+                        "capi-#{@part_id}",
+                        value["id"] || value["key"] || to_string(key)
+                      )
+                    }
                   />
                 </div>
               </div>
-            <% is_list(value) and value != [] -> %>
+            <% is_list(value) and value != [] and Enum.all?(value, &match?({_, _}, &1)) -> %>
               <details class="group/keygroup">
-                <summary class="flex cursor-pointer list-none items-center gap-2 [&::-webkit-details-marker]:hidden">
+                <summary class="flex cursor-pointer list-none items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden">
                   <Icons.chevron_down
                     width="14"
                     height="14"
@@ -312,7 +317,7 @@ defmodule OliWeb.Attempt.AttemptLive do
                   <span class="font-medium text-Text-text-high">{to_string(key)}</span>
                 </summary>
                 <div class="pl-4 pt-1">
-                  <.render_grouped_map data={value} />
+                  <.render_grouped_map data={value} part_id={@part_id} />
                 </div>
               </details>
             <% true -> %>

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -109,20 +109,49 @@ defmodule OliWeb.Attempt.AttemptLive do
     Enum.map(attempts, fn a -> Map.put(a, :unique_id, "row_#{a.id}") end)
   end
 
-  # Responses/feedback are immutable after persistence — cache the grouped form
-  # and sort part_attempts once to skip both on every re-render.
+  # Responses/feedback are immutable after persistence — cache the view-model
+  # and drop the raw fields so we don't carry both representations.
   defp precompute_grouped_responses(attempts) do
     for attempt <- attempts do
       sorted_parts =
         for part <- Enum.sort_by(attempt.part_attempts, & &1.part_id) do
-          part
-          |> Map.put(:grouped_response, group_dotted_keys(part.response || %{}))
-          |> Map.put(:grouped_feedback, group_dotted_keys(part.feedback || %{}))
+          grouped_response = build_grouped(part.response)
+          grouped_feedback = build_grouped(part.feedback)
+
+          %{part | response: nil, feedback: nil}
+          |> Map.put(:grouped_response, grouped_response)
+          |> Map.put(:grouped_feedback, grouped_feedback)
+          |> Map.put(:has_response, has_grouped_content?(grouped_response))
+          |> Map.put(:has_feedback, has_grouped_content?(grouped_feedback))
         end
 
       %{attempt | part_attempts: sorted_parts}
     end
   end
+
+  defp build_grouped(raw),
+    do: raw |> Kernel.||(%{}) |> group_dotted_keys() |> pre_encode_leaves()
+
+  # CapiVariables and {k,v} group lists pass through — own renderers downstream.
+  defp pre_encode_leaves([]), do: []
+
+  defp pre_encode_leaves(value) when is_list(value) do
+    if Enum.all?(value, &match?({_, _}, &1)) do
+      Enum.map(value, fn {k, v} -> {k, pre_encode_leaves(v)} end)
+    else
+      {:pre_encoded, Jason.encode!(value)}
+    end
+  end
+
+  defp pre_encode_leaves(value) when is_map(value) do
+    if capi_variable?(value), do: value, else: {:pre_encoded, Jason.encode!(value)}
+  end
+
+  defp pre_encode_leaves(value), do: value
+
+  defp has_grouped_content?([]), do: false
+  defp has_grouped_content?(list) when is_list(list), do: true
+  defp has_grouped_content?(_), do: false
 
   # Uses :id (not :resource_id) as the row identity because retakes share resource_id
   # but have distinct activity_attempt.id.
@@ -251,8 +280,8 @@ defmodule OliWeb.Attempt.AttemptLive do
     assigns =
       assign(assigns,
         is_open: MapSet.member?(assigns.expanded_parts, part.id),
-        has_response: has_any_content?(part.response),
-        has_feedback: has_any_content?(part.feedback)
+        has_response: part.has_response,
+        has_feedback: part.has_feedback
       )
 
     ~H"""
@@ -299,11 +328,14 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   defp render_grouped_map(assigns) do
     ~H"""
-    <ul class="m-0 list-none p-0">
-      <li :for={{key, value} <- @data} class="border-b border-Border-border-subtle py-1">
-        <.grouped_map_row key={key} value={value} part_id={@part_id} />
-      </li>
-    </ul>
+    <dl class="m-0 grid grid-cols-[2fr_3fr] items-start gap-x-4">
+      <.grouped_map_row
+        :for={{key, value} <- @data}
+        key={key}
+        value={value}
+        part_id={@part_id}
+      />
+    </dl>
     """
   end
 
@@ -317,46 +349,49 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   defp capi_row(assigns) do
     ~H"""
-    <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
-      <span class="break-words font-medium text-Text-text-high">{to_string(@key)}</span>
-      <div class={value_column_class(@value)}>
-        <.render_capi_value
-          value={@value["value"]}
-          type={@value["type"]}
-          allowed_values={@value["allowedValues"]}
-          dom_id={safe_dom_id("capi-#{@part_id}", @value["id"] || @value["key"] || to_string(@key))}
-        />
-      </div>
-    </div>
+    <dt class="break-words border-b border-Border-border-subtle py-1 font-medium text-Text-text-high">
+      {to_string(@key)}
+    </dt>
+    <dd class={"m-0 border-b border-Border-border-subtle py-1 #{value_column_class(@value)}"}>
+      <.render_capi_value
+        value={@value["value"]}
+        type={@value["type"]}
+        allowed_values={@value["allowedValues"]}
+        dom_id={safe_dom_id("capi-#{@part_id}", @value["id"] || @value["key"] || to_string(@key))}
+      />
+    </dd>
     """
   end
 
   defp nested_group_row(assigns) do
     ~H"""
-    <details class="group/keygroup">
-      <summary class="flex cursor-pointer list-none items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden">
-        <Icons.chevron_down
-          width="14"
-          height="14"
-          class="fill-Icon-icon-default motion-safe:transition group-open/keygroup:rotate-180"
-        />
-        <span class="font-medium text-Text-text-high">{to_string(@key)}</span>
-      </summary>
-      <div class="pl-4 pt-1">
-        <.render_grouped_map data={@value} part_id={@part_id} />
-      </div>
-    </details>
+    <dt class="col-span-2 border-b border-Border-border-subtle py-1">
+      <details class="group/keygroup">
+        <summary class="flex cursor-pointer list-none items-center gap-2 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden">
+          <Icons.chevron_down
+            width="14"
+            height="14"
+            class="fill-Icon-icon-default motion-safe:transition group-open/keygroup:rotate-180"
+          />
+          <span class="font-medium text-Text-text-high">{to_string(@key)}</span>
+        </summary>
+        <div class="pl-4 pt-1">
+          <.render_grouped_map data={@value} part_id={@part_id} />
+        </div>
+      </details>
+    </dt>
+    <dd class="sr-only">grouped sub-list</dd>
     """
   end
 
   defp scalar_row(assigns) do
     ~H"""
-    <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
-      <span class="break-words font-medium text-Text-text-high">{to_string(@key)}</span>
-      <div class="min-w-0 overflow-x-auto whitespace-nowrap">
-        <.render_value value={@value} />
-      </div>
-    </div>
+    <dt class="break-words border-b border-Border-border-subtle py-1 font-medium text-Text-text-high">
+      {to_string(@key)}
+    </dt>
+    <dd class="m-0 min-w-0 overflow-x-auto whitespace-nowrap border-b border-Border-border-subtle py-1">
+      <.render_value value={@value} />
+    </dd>
     """
   end
 
@@ -373,8 +408,7 @@ defmodule OliWeb.Attempt.AttemptLive do
     """
   end
 
-  # Dispatches on the declared CapiVariable type code — mirrors AutoDetectInput.tsx.
-  # NUMBER/ARRAY/BOOLEAN coerce stored strings back to their typed value before rendering.
+  # Type-driven dispatch mirrors assets/src/adaptivity/capi.ts — keep in sync.
   defp render_capi_value(%{type: @capi_type_enum, allowed_values: list} = assigns)
        when is_list(list) do
     options = Enum.map(list, fn v -> %{value: to_string(v), label: to_string(v)} end)
@@ -395,6 +429,7 @@ defmodule OliWeb.Attempt.AttemptLive do
       selected_value={@selected}
       push_on_select={false}
       readonly={true}
+      compact={true}
     />
     """
   end
@@ -490,8 +525,8 @@ defmodule OliWeb.Attempt.AttemptLive do
      |> update_table_model_expanded_parts(expanded_parts)}
   end
 
-  # Defensive no-op: push_on_select=false suppresses clicks, but the form's
-  # phx-change still needs a handler to avoid crashing on stray events.
+  # No-op: push_on_select=false suppresses clicks, but the form's phx-change
+  # still needs a handler to avoid crashing on stray events.
   def handle_event("capi_enum_readonly", _params, socket), do: {:noreply, socket}
 
   def handle_event("sort", %{"sort_by" => sort_by}, socket) do
@@ -613,13 +648,10 @@ defmodule OliWeb.Attempt.AttemptLive do
     end)
   end
 
-  # ENUM opens a dropdown that needs overflow-visible to escape the row;
-  # other values keep overflow-x-auto so long strings (e.g. customCss) scroll inline.
-  defp value_column_class(%{"type" => @capi_type_enum}),
-    do: "min-w-0 overflow-visible"
-
-  defp value_column_class(_),
-    do: "min-w-0 overflow-x-auto whitespace-nowrap"
+  # ENUM dropdown needs overflow-visible to escape the row; others scroll
+  # horizontally so long strings (e.g. customCss) don't break the card layout.
+  defp value_column_class(%{"type" => @capi_type_enum}), do: "min-w-0 overflow-visible"
+  defp value_column_class(_), do: "min-w-0 overflow-x-auto whitespace-nowrap"
 
   # Numeric hash — selector-safe; raw CAPI ids contain dots that break JS.toggle.
   defp safe_dom_id(prefix, raw) do
@@ -724,9 +756,8 @@ defmodule OliWeb.Attempt.AttemptLive do
 
   defp coerce_capi_array(v), do: v
 
-  defp has_any_content?(nil), do: false
-  defp has_any_content?(map) when is_map(map), do: map_size(map) > 0
-  defp has_any_content?(_), do: false
+  defp format_value_for_display({:pre_encoded, text}) when is_binary(text),
+    do: %{class: "font-mono", text: text}
 
   defp format_value_for_display(true),
     do: %{class: "text-Text-text-accent-green", text: "✓ true"}

--- a/lib/oli_web/live/attempt/attempt_live.ex
+++ b/lib/oli_web/live/attempt/attempt_live.ex
@@ -5,14 +5,25 @@ defmodule OliWeb.Attempt.AttemptLive do
   use OliWeb, :live_view
 
   alias OliWeb.Common.Breadcrumb
-  alias OliWeb.Common.SortableTable.Table
+  alias OliWeb.Common.SortableTable.StripedTable
   alias OliWeb.Common.Table.SortableTableModel
-  alias Oli.Delivery.Attempts.Core
+  alias OliWeb.Components.DesignTokens.Primitives.Button
+  alias OliWeb.Delivery.Content.SelectDropdown
+  alias OliWeb.Icons
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Sections.Mount
   alias Oli.Delivery.Attempts.PageLifecycle.Broadcaster
   alias OliWeb.Attempt.TableModel
   alias Oli.Delivery.Attempts.Core.{ActivityAttempt, ResourceAttempt}
+
+  # CapiVariableTypes codes — must stay in sync with assets/src/adaptivity/capi.ts.
+  @capi_type_number 1
+  @capi_type_string 2
+  @capi_type_array 3
+  @capi_type_boolean 4
+  @capi_type_enum 5
+  @capi_type_math_expr 6
+  @capi_type_array_point 7
 
   def set_breadcrumbs(type, section, guid) do
     type
@@ -31,92 +42,406 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   def mount(%{"section_slug" => section_slug, "attempt_guid" => attempt_guid}, _session, socket) do
+    # Admin-only; defense-in-depth in case the UI entry-point gate is ever bypassed.
     case Mount.for(section_slug, socket) do
+      {:admin, _, _} = result ->
+        if connected?(socket), do: Broadcaster.subscribe_to_attempt(attempt_guid)
+        do_mount(result, attempt_guid, socket)
+
       {:error, e} ->
         Mount.handle_error(socket, {:error, e})
 
-      {type, _, section} ->
-        Broadcaster.subscribe_to_attempt(attempt_guid)
+      {:user, _, _} ->
+        Mount.handle_error(socket, {:error, :unauthorized})
 
-        attempts =
-          get_attempts(attempt_guid)
-          |> Enum.map(fn a -> Map.put(a, :updated, false) end)
-
-        {:ok, model} = TableModel.new(attempts)
-        model = Map.put(model, :rows, attempts)
-
-        {:ok,
-         assign(socket,
-           attempt_guid: attempt_guid,
-           breadcrumbs: set_breadcrumbs(type, section, attempt_guid),
-           table_model: model,
-           total_count: Enum.count(attempts),
-           updates: [],
-           section: section,
-           attempts: attempts,
-           selected: nil,
-           content: nil
-         )}
+      {:author, _, _} ->
+        Mount.handle_error(socket, {:error, :unauthorized})
     end
+  end
+
+  defp do_mount({type, _, section}, attempt_guid, socket) do
+    attempts =
+      get_attempts(attempt_guid)
+      |> Enum.map(fn a -> Map.put(a, :updated, false) end)
+      |> attach_unique_ids()
+      |> precompute_grouped_responses()
+
+    expanded_rows = MapSet.new()
+    expanded_parts = MapSet.new()
+
+    {:ok, model} = TableModel.new(attempts)
+    model = build_expandable_table_model(model, attempts, expanded_rows, expanded_parts)
+
+    {:ok,
+     assign(socket,
+       attempt_guid: attempt_guid,
+       breadcrumbs: set_breadcrumbs(type, section, attempt_guid),
+       table_model: model,
+       total_count: Enum.count(attempts),
+       updates: [],
+       section: section,
+       attempts: attempts,
+       expanded_rows: expanded_rows,
+       expanded_parts: expanded_parts
+     )}
+  end
+
+  # "row_<id>" is the shared identity used by the chevron, row-click, expanded_rows
+  # MapSet, and StripedTable's details-row lookup. All four must agree.
+  defp attach_unique_ids(attempts) do
+    Enum.map(attempts, fn a -> Map.put(a, :unique_id, "row_#{a.id}") end)
+  end
+
+  # Responses/feedback are immutable after persistence — cache the grouped form
+  # so we skip the tree walk on every LV re-render.
+  defp precompute_grouped_responses(attempts) do
+    Enum.map(attempts, fn a ->
+      Map.update!(a, :part_attempts, fn parts ->
+        Enum.map(parts, fn p ->
+          p
+          |> Map.put(:grouped_response, group_dotted_keys(p.response || %{}))
+          |> Map.put(:grouped_feedback, group_dotted_keys(p.feedback || %{}))
+        end)
+      end)
+    end)
+  end
+
+  # Uses :id (not :resource_id) as the row identity because retakes share resource_id
+  # across attempts but have distinct activity_attempt.id.
+  defp build_expandable_table_model(model, attempts, expanded_rows, expanded_parts) do
+    model
+    |> Map.put(:rows, attempts)
+    |> Map.update!(:data, fn data ->
+      data
+      |> Map.put(:expandable_rows, true)
+      |> Map.put(:expandable_rows_id_field, :id)
+      |> Map.put(:expanded_rows, expanded_rows)
+      |> Map.put(:expanded_parts, expanded_parts)
+    end)
   end
 
   def render(assigns) do
     ~H"""
-    <div style="display: flex; flex-direction: row;">
-      <div style="flex-grow: 4;">
-        <Table.render model={@table_model} select="select" sort="sort" />
-      </div>
-      <div style="display: flex; flex-direction: column;">
-        <table :if={@selected}>
-          <tr>
-            <th>Part id</th>
-            <th>Attempt#</th>
-            <th>State</th>
-            <th>Score</th>
-            <th>Out of</th>
-          </tr>
-          <%= for p <- @selected.part_attempts do %>
+    <div style="padding: 0.5rem 1rem; overflow-x: auto;">
+      <StripedTable.render
+        model={@table_model}
+        sort="sort"
+        select="toggle_row"
+        details_render_fn={&render_row_details/2}
+      />
+    </div>
+    """
+  end
+
+  # StripedTable calls this with a plain assigns (no __changed__), so the template
+  # uses local vars; change tracking re-enters at each <.part_response_card>.
+  def render_row_details(assigns, row) do
+    expanded_rows = assigns.model.data[:expanded_rows] || MapSet.new()
+    expanded_parts = assigns.model.data[:expanded_parts] || MapSet.new()
+    row_id = "row_#{row.id}"
+
+    if MapSet.member?(expanded_rows, row_id) do
+      sorted_parts = Enum.sort_by(row.part_attempts, & &1.part_id)
+      assigns = %{row_id: row_id, sorted_parts: sorted_parts, expanded_parts: expanded_parts}
+
+      ~H"""
+      <div class="max-h-[65vh] overflow-y-auto">
+        <table class="mb-3 border-collapse text-sm text-Text-text-high">
+          <caption class="sr-only">Part attempts summary</caption>
+          <thead>
             <tr>
-              <td>{p.part_id}</td>
-              <td>{p.attempt_number}</td>
-              <td>{p.lifecycle_state}</td>
-              <td>{p.score}</td>
-              <td>{p.out_of}</td>
+              <th scope="col" class="px-3 py-1 pl-0 text-left font-semibold">Part id</th>
+              <th scope="col" class="px-3 py-1 text-left font-semibold">Attempt#</th>
+              <th scope="col" class="px-3 py-1 text-left font-semibold">State</th>
+              <th scope="col" class="px-3 py-1 text-left font-semibold">Score</th>
+              <th scope="col" class="px-3 py-1 text-left font-semibold">Out of</th>
             </tr>
-          <% end %>
+          </thead>
+          <tbody>
+            <%= for p <- @sorted_parts do %>
+              <tr>
+                <td class="px-3 py-1 pl-0">{p.part_id}</td>
+                <td class="px-3 py-1">{p.attempt_number}</td>
+                <td class="px-3 py-1">{p.lifecycle_state}</td>
+                <td class="px-3 py-1">{p.score}</td>
+                <td class="px-3 py-1">{p.out_of}</td>
+              </tr>
+            <% end %>
+          </tbody>
         </table>
-        <div style="margin-top: 30px; background: #DDDDDD;">
-          <code>
-            <pre :if={@content}>
-              <%= Jason.encode!(assigns.content, pretty: true) %>
-            </pre>
-          </code>
+
+        <div id={"responses-#{@row_id}"} class="mt-3">
+          <div class="mb-2 flex items-center gap-3">
+            <h3 class="m-0 text-base font-semibold text-Text-text-high">Student Responses</h3>
+            <%= if @sorted_parts != [] do %>
+              <Button.button
+                id={"expand-all-#{@row_id}"}
+                variant={:text}
+                size={:sm}
+                phx-click="expand_all_parts"
+                phx-value-row={@row_id}
+              >
+                Expand all
+              </Button.button>
+              <Button.button
+                id={"collapse-all-#{@row_id}"}
+                variant={:text}
+                size={:sm}
+                phx-click="collapse_all_parts"
+                phx-value-row={@row_id}
+              >
+                Collapse all
+              </Button.button>
+            <% end %>
+          </div>
+          <%= for p <- @sorted_parts do %>
+            <.part_response_card part_attempt={p} expanded_parts={@expanded_parts} />
+          <% end %>
         </div>
+      </div>
+      """
+    else
+      assigns = %{}
+      ~H""
+    end
+  end
+
+  defp part_response_card(assigns) do
+    is_open = MapSet.member?(assigns.expanded_parts, assigns.part_attempt.id)
+    assigns = assign(assigns, :is_open, is_open)
+
+    ~H"""
+    <div class="part-response-card mb-2 rounded border border-Border-border-subtle bg-Surface-surface-primary">
+      <button
+        id={"part-toggle-#{@part_attempt.id}"}
+        type="button"
+        class="flex w-full cursor-pointer items-center gap-2 rounded-t border-0 bg-Background-bg-secondary p-2 text-left text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus"
+        phx-click="toggle_part"
+        phx-value-id={@part_attempt.id}
+        aria-expanded={@is_open}
+        aria-controls={"part-body-#{@part_attempt.id}"}
+      >
+        <Icons.chevron_down
+          width="16"
+          height="16"
+          class={
+            "fill-Icon-icon-active motion-safe:transition" <>
+              if(@is_open, do: " rotate-180", else: "")
+          }
+        />
+        <span class="mr-1 text-[0.7rem] uppercase tracking-wider text-Text-text-low">
+          Part
+        </span>
+        <code>{@part_attempt.part_id}</code>
+        <span class="ml-2 text-sm text-Text-text-low">
+          (attempt {@part_attempt.attempt_number})
+        </span>
+      </button>
+      <div
+        id={"part-body-#{@part_attempt.id}"}
+        class="p-2"
+        hidden={not @is_open}
+      >
+        <div :if={has_any_content?(@part_attempt.response)}>
+          <div class="mb-1 text-sm text-Text-text-low">Response</div>
+          <.render_grouped_map data={@part_attempt.grouped_response} />
+        </div>
+        <div :if={has_any_content?(@part_attempt.feedback)} class="mt-3">
+          <div class="mb-1 text-sm text-Text-text-low">Feedback</div>
+          <.render_grouped_map data={@part_attempt.grouped_feedback} />
+        </div>
+        <p
+          :if={
+            !has_any_content?(@part_attempt.response) and
+              !has_any_content?(@part_attempt.feedback)
+          }
+          class="m-0 text-sm text-Text-text-low"
+        >
+          No response data recorded for this part attempt.
+        </p>
       </div>
     </div>
     """
   end
 
-  def handle_event("select", %{"id" => id} = _p, socket) do
-    {id, _} = Integer.parse(id)
+  # Recursive renderer on already-grouped data — no per-render regrouping.
+  defp render_grouped_map(assigns) do
+    ~H"""
+    <ul class="m-0 list-none p-0">
+      <%= for {key, value} <- sorted_entries(@data) do %>
+        <li class="border-b border-Border-border-subtle py-1">
+          <%= cond do %>
+            <% capi_variable?(value) -> %>
+              <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
+                <span class="break-words font-medium text-Text-text-high">{to_string(key)}</span>
+                <div class={value_column_class(value)}>
+                  <.render_capi_value
+                    value={value["value"]}
+                    type={value["type"]}
+                    allowed_values={value["allowedValues"]}
+                    dom_id={safe_dom_id("capi", value["id"] || value["key"] || to_string(key))}
+                  />
+                </div>
+              </div>
+            <% is_map(value) and map_size(value) > 0 -> %>
+              <details class="group/keygroup">
+                <summary class="flex cursor-pointer list-none items-center gap-2 [&::-webkit-details-marker]:hidden">
+                  <Icons.chevron_down
+                    width="14"
+                    height="14"
+                    class="fill-Icon-icon-default transition group-open/keygroup:rotate-180"
+                  />
+                  <span class="font-medium text-Text-text-high">{to_string(key)}</span>
+                </summary>
+                <div class="pl-4 pt-1">
+                  <.render_grouped_map data={value} />
+                </div>
+              </details>
+            <% true -> %>
+              <div class="grid grid-cols-[2fr_3fr] items-start gap-4">
+                <span class="break-words font-medium text-Text-text-high">{to_string(key)}</span>
+                <div class="min-w-0 overflow-x-auto whitespace-nowrap">
+                  <.render_value value={value} />
+                </div>
+              </div>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+    """
+  end
 
-    attempt = Core.get_activity_attempt_by(id: id)
+  defp render_value(assigns) do
+    formatted = format_value_for_display(assigns.value)
+    assigns = assign(assigns, :formatted, formatted)
 
-    content =
-      case attempt.transformed_model do
-        nil -> attempt.revision.content
-        _ -> attempt.transformed_model
-      end
+    ~H"""
+    <span class={@formatted.class}>{@formatted.text}</span>
+    """
+  end
 
-    table_model = Map.put(socket.assigns.table_model, :selected, id)
+  # Dispatches on the declared CapiVariable type code — mirrors AutoDetectInput.tsx.
+  # NUMBER/ARRAY/BOOLEAN coerce stored strings back to their typed value before rendering.
+  defp render_capi_value(%{type: @capi_type_enum, allowed_values: list} = assigns)
+       when is_list(list) do
+    options = Enum.map(list, fn v -> %{value: to_string(v), label: to_string(v)} end)
+
+    assigns =
+      assign(assigns,
+        options: options,
+        selected: to_string(assigns.value),
+        dom_id: Map.get(assigns, :dom_id, "capi-enum-#{System.unique_integer([:positive])}")
+      )
+
+    ~H"""
+    <SelectDropdown.render
+      id={@dom_id}
+      name="capi_enum"
+      phx_change="capi_enum_readonly"
+      options={@options}
+      selected_value={@selected}
+      push_on_select={false}
+      readonly={true}
+    />
+    """
+  end
+
+  defp render_capi_value(%{type: t, value: v} = assigns)
+       when t in [@capi_type_number, @capi_type_array, @capi_type_boolean] do
+    coerced = coerce_for_type(v, t)
+    assigns = assign(assigns, :coerced, coerced)
+
+    ~H"""
+    <.render_value value={@coerced} />
+    """
+  end
+
+  # STRING/MATH_EXPR/ARRAY_POINT: stored value already matches what the renderer expects.
+  defp render_capi_value(%{type: t} = assigns)
+       when t in [@capi_type_string, @capi_type_math_expr, @capi_type_array_point] do
+    ~H"""
+    <.render_value value={@value} />
+    """
+  end
+
+  # Fallback for nil/UNKNOWN(99)/ENUM-without-allowedValues/unrecognized types.
+  defp render_capi_value(assigns) do
+    ~H"""
+    <.render_value value={@value} />
+    """
+  end
+
+  def handle_event("toggle_row", %{"id" => "row_" <> id_str = unique_id}, socket) do
+    # Only accept "row_<int>" to cap expanded_rows MapSet growth.
+    case Integer.parse(id_str) do
+      {_, ""} ->
+        expanded_rows =
+          if MapSet.member?(socket.assigns.expanded_rows, unique_id) do
+            MapSet.delete(socket.assigns.expanded_rows, unique_id)
+          else
+            MapSet.put(socket.assigns.expanded_rows, unique_id)
+          end
+
+        table_model =
+          Map.update!(socket.assigns.table_model, :data, fn data ->
+            Map.put(data, :expanded_rows, expanded_rows)
+          end)
+
+        {:noreply, assign(socket, table_model: table_model, expanded_rows: expanded_rows)}
+
+      _ ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("toggle_row", _, socket), do: {:noreply, socket}
+
+  def handle_event("toggle_part", %{"id" => id}, socket) do
+    with id when is_integer(id) <- parse_part_id(id),
+         true <- known_part_id?(socket.assigns.attempts, id) do
+      expanded_parts =
+        if MapSet.member?(socket.assigns.expanded_parts, id) do
+          MapSet.delete(socket.assigns.expanded_parts, id)
+        else
+          MapSet.put(socket.assigns.expanded_parts, id)
+        end
+
+      {:noreply,
+       socket
+       |> assign(expanded_parts: expanded_parts)
+       |> update_table_model_expanded_parts(expanded_parts)}
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
+  def handle_event("expand_all_parts", %{"row" => unique_id}, socket) do
+    part_ids = part_ids_for_row(socket.assigns.attempts, unique_id)
+
+    expanded_parts =
+      Enum.reduce(part_ids, socket.assigns.expanded_parts, &MapSet.put(&2, &1))
 
     {:noreply,
-     assign(socket,
-       table_model: table_model,
-       content: content,
-       selected: Enum.find(socket.assigns.attempts, fn a -> a.id == id end)
-     )}
+     socket
+     |> assign(expanded_parts: expanded_parts)
+     |> update_table_model_expanded_parts(expanded_parts)}
   end
+
+  def handle_event("collapse_all_parts", %{"row" => unique_id}, socket) do
+    part_ids = part_ids_for_row(socket.assigns.attempts, unique_id)
+
+    expanded_parts =
+      Enum.reduce(part_ids, socket.assigns.expanded_parts, &MapSet.delete(&2, &1))
+
+    {:noreply,
+     socket
+     |> assign(expanded_parts: expanded_parts)
+     |> update_table_model_expanded_parts(expanded_parts)}
+  end
+
+  # Defensive no-op: push_on_select=false suppresses clicks, but the form's
+  # phx-change still needs a handler to avoid crashing on stray events.
+  def handle_event("capi_enum_readonly", _params, socket), do: {:noreply, socket}
 
   def handle_event("sort", %{"sort_by" => sort_by}, socket) do
     case sort_column_name(socket.assigns.table_model.column_specs, sort_by) do
@@ -135,25 +460,61 @@ defmodule OliWeb.Attempt.AttemptLive do
   end
 
   def handle_info({_, guid}, socket) do
-    attempts =
+    # Regroup only the changed attempt; others carry cached :grouped_* forward
+    # to skip the tree walk on every PubSub tick.
+    {changed, rest} =
       get_attempts(socket.assigns.attempt_guid)
-      |> Enum.map(fn a ->
-        case a.attempt_guid do
-          ^guid -> Map.put(a, :updated, true)
-          _ -> Map.put(a, :updated, false)
+      |> Enum.split_with(&(&1.attempt_guid == guid))
+
+    refreshed_changed =
+      changed
+      |> Enum.map(&Map.put(&1, :updated, true))
+      |> attach_unique_ids()
+      |> precompute_grouped_responses()
+
+    cached_by_guid =
+      Map.new(socket.assigns.attempts, fn a -> {a.attempt_guid, a} end)
+
+    carried_rest =
+      Enum.map(rest, fn a ->
+        case Map.get(cached_by_guid, a.attempt_guid) do
+          nil ->
+            # new row we haven't seen before — pay the grouping cost
+            [processed] = precompute_grouped_responses([Map.put(a, :updated, false)])
+            attach_unique_id(processed)
+
+          cached ->
+            Map.put(cached, :updated, false)
         end
       end)
 
+    attempts =
+      (refreshed_changed ++ carried_rest)
+      |> Enum.sort_by(&{&1.resource_id, &1.attempt_number})
+
     table_model =
       socket.assigns.table_model
-      |> Map.put(:rows, attempts)
+      |> build_expandable_table_model(
+        attempts,
+        socket.assigns.expanded_rows,
+        socket.assigns.expanded_parts
+      )
       |> SortableTableModel.sort()
 
     {:noreply,
      assign(socket,
        table_model: table_model,
-       total_count: Enum.count(attempts)
+       total_count: Enum.count(attempts),
+       attempts: attempts
      )}
+  end
+
+  defp attach_unique_id(attempt), do: Map.put(attempt, :unique_id, "row_#{attempt.id}")
+
+  defp known_part_id?(attempts, id) do
+    Enum.any?(attempts, fn a ->
+      Enum.any?(a.part_attempts, &(&1.id == id))
+    end)
   end
 
   defp get_attempts(resource_attempt_guid) do
@@ -173,6 +534,42 @@ defmodule OliWeb.Attempt.AttemptLive do
     )
   end
 
+  defp part_ids_for_row(attempts, "row_" <> id_str) do
+    case Integer.parse(id_str) do
+      {id, ""} ->
+        case Enum.find(attempts, &(&1.id == id)) do
+          nil -> []
+          row -> Enum.map(row.part_attempts, & &1.id)
+        end
+
+      _ ->
+        []
+    end
+  end
+
+  defp part_ids_for_row(_attempts, _), do: []
+
+  # Returns nil on non-integer input so the handler bails before mixing strings into the MapSet.
+  defp parse_part_id(id) when is_integer(id), do: id
+
+  defp parse_part_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {i, ""} -> i
+      _ -> nil
+    end
+  end
+
+  defp parse_part_id(_), do: nil
+
+  defp update_table_model_expanded_parts(socket, expanded_parts) do
+    table_model =
+      Map.update!(socket.assigns.table_model, :data, fn data ->
+        Map.put(data, :expanded_parts, expanded_parts)
+      end)
+
+    assign(socket, table_model: table_model)
+  end
+
   defp sort_column_name(column_specs, sort_by) do
     Enum.find_value(column_specs, fn %{name: name} ->
       case Atom.to_string(name) do
@@ -181,4 +578,141 @@ defmodule OliWeb.Attempt.AttemptLive do
       end
     end)
   end
+
+  defp sorted_entries(data) when is_map(data) do
+    data |> Enum.to_list() |> Enum.sort_by(fn {k, _v} -> to_string(k) end)
+  end
+
+  defp sorted_entries(_), do: []
+
+  # ENUM opens a dropdown that needs overflow-visible to escape the row;
+  # other values keep overflow-x-auto so long strings (e.g. customCss) scroll inline.
+  defp value_column_class(%{"type" => @capi_type_enum}),
+    do: "min-w-0 overflow-visible"
+
+  defp value_column_class(_),
+    do: "min-w-0 overflow-x-auto whitespace-nowrap"
+
+  # CAPI ids contain dots (e.g. "stage.cardsBioFuels.Mode") which CSS selectors
+  # read as class separators, breaking SelectDropdown's JS.toggle.
+  defp safe_dom_id(prefix, raw) do
+    cleaned = raw |> to_string() |> String.replace(~r/[^A-Za-z0-9_-]/, "-")
+    "#{prefix}-#{cleaned}"
+  end
+
+  # Mirrors Inspector's unflatten: groups "Input 1.Correct" under a nested "Input 1".
+  # On scalar vs nested-path collision, both are kept (scalar under "<key> (value)").
+  defp group_dotted_keys(data) when is_map(data) do
+    Enum.reduce(data, %{}, fn {k, v}, acc ->
+      deep_put(acc, String.split(to_string(k), "."), v)
+    end)
+  end
+
+  defp group_dotted_keys(data), do: data
+
+  defp deep_put(acc, [leaf], v) do
+    case Map.get(acc, leaf) do
+      existing when is_map(existing) and map_size(existing) > 0 ->
+        Map.put(acc, "#{leaf} (value)", v)
+
+      _ ->
+        Map.put(acc, leaf, v)
+    end
+  end
+
+  defp deep_put(acc, [head | rest], v) do
+    case Map.get(acc, head) do
+      nil ->
+        Map.put(acc, head, deep_put(%{}, rest, v))
+
+      existing when is_map(existing) ->
+        Map.put(acc, head, deep_put(existing, rest, v))
+
+      scalar ->
+        acc
+        |> Map.put("#{head} (value)", scalar)
+        |> Map.put(head, deep_put(%{}, rest, v))
+    end
+  end
+
+  # Detects the serialized CapiVariable shape the Janus runtime writes:
+  # requires (key OR id) + path + type + value.
+  defp capi_variable?(%{"key" => _, "path" => _, "type" => _, "value" => _}), do: true
+  defp capi_variable?(%{"id" => _, "path" => _, "type" => _, "value" => _}), do: true
+  defp capi_variable?(_), do: false
+
+  # Mirrors parseCapiValue / coerceCapiValue (capi.ts) for the cases where a
+  # stored value's shape differs from its declared type.
+  defp coerce_for_type(v, @capi_type_boolean), do: coerce_capi_boolean(v)
+  defp coerce_for_type(v, @capi_type_number), do: coerce_capi_number(v)
+  defp coerce_for_type(v, @capi_type_array), do: coerce_capi_array(v)
+  defp coerce_for_type(v, _), do: v
+
+  defp coerce_capi_boolean(true), do: true
+  defp coerce_capi_boolean(false), do: false
+  defp coerce_capi_boolean("true"), do: true
+  defp coerce_capi_boolean("false"), do: false
+  defp coerce_capi_boolean(1), do: true
+  defp coerce_capi_boolean(0), do: false
+  defp coerce_capi_boolean(v), do: v
+
+  defp coerce_capi_number(n) when is_number(n), do: n
+
+  defp coerce_capi_number(s) when is_binary(s) do
+    case Integer.parse(s) do
+      {i, ""} ->
+        i
+
+      _ ->
+        case Float.parse(s) do
+          {f, ""} -> f
+          _ -> s
+        end
+    end
+  end
+
+  defp coerce_capi_number(v), do: v
+
+  defp coerce_capi_array(list) when is_list(list), do: list
+
+  defp coerce_capi_array(s) when is_binary(s) do
+    case Jason.decode(s) do
+      {:ok, list} when is_list(list) -> list
+      _ -> s
+    end
+  end
+
+  defp coerce_capi_array(v), do: v
+
+  defp has_any_content?(nil), do: false
+  defp has_any_content?(map) when is_map(map), do: map_size(map) > 0
+  defp has_any_content?(_), do: false
+
+  defp format_value_for_display(true),
+    do: %{class: "text-Text-text-accent-green", text: "✓ true"}
+
+  defp format_value_for_display(false),
+    do: %{class: "text-Text-text-danger", text: "✗ false"}
+
+  defp format_value_for_display(nil),
+    do: %{class: "italic text-Text-text-low", text: "nil"}
+
+  defp format_value_for_display(v) when is_number(v),
+    do: %{class: "font-mono", text: to_string(v)}
+
+  # Renders empty string as explicit `""` to distinguish it from nil.
+  defp format_value_for_display(""),
+    do: %{class: "font-mono italic text-Text-text-low", text: ~s("")}
+
+  defp format_value_for_display(v) when is_binary(v),
+    do: %{class: "font-mono", text: v}
+
+  defp format_value_for_display(v) when is_list(v),
+    do: %{class: "font-mono", text: Jason.encode!(v)}
+
+  defp format_value_for_display(v) when is_map(v),
+    do: %{class: "font-mono", text: Jason.encode!(v)}
+
+  defp format_value_for_display(other),
+    do: %{class: "font-mono", text: inspect(other)}
 end

--- a/lib/oli_web/live/attempt/table_model.ex
+++ b/lib/oli_web/live/attempt/table_model.ex
@@ -2,11 +2,18 @@ defmodule OliWeb.Attempt.TableModel do
   use Phoenix.Component
 
   alias OliWeb.Common.Table.{ColumnSpec, Common, SortableTableModel}
+  alias OliWeb.Icons
 
   def new(members) do
     SortableTableModel.new(
       rows: members,
       column_specs: [
+        %ColumnSpec{
+          name: :chevron,
+          label: "",
+          sortable: false,
+          render_fn: &__MODULE__.render_chevron/3
+        },
         %ColumnSpec{
           name: :updated,
           label: "Updated",
@@ -14,8 +21,7 @@ defmodule OliWeb.Attempt.TableModel do
         },
         %ColumnSpec{
           name: :attempt_guid,
-          label: "Attempt Guid",
-          render_fn: &__MODULE__.render_attempts/3
+          label: "Attempt Guid"
         },
         %ColumnSpec{
           name: :resource_id,
@@ -52,7 +58,9 @@ defmodule OliWeb.Attempt.TableModel do
         }
       ],
       event_suffix: "",
-      id_field: [:id]
+      # Must match the chevron's phx-value-id and the expanded_rows MapSet keys
+      # — aligning all three lets row-click and chevron-click hit the same entry.
+      id_field: [:unique_id]
     )
   end
 
@@ -68,22 +76,32 @@ defmodule OliWeb.Attempt.TableModel do
     end
   end
 
-  def render_attempts(assigns, row, _) do
-    assigns = Map.merge(assigns, %{row: row})
+  def render_chevron(assigns, row, _) do
+    expanded_rows = assigns.model.data[:expanded_rows] || MapSet.new()
+    row_id = "row_#{row.id}"
+    is_expanded = MapSet.member?(expanded_rows, row_id)
 
-    if row.id == assigns.model.selected do
-      ~H"""
-      <div>
-        <strong>{@row.attempt_guid}</strong>
-      </div>
-      """
-    else
-      ~H"""
-      <div>
-        <span style="color: blue; cursor: pointer;"><u>{@row.attempt_guid}</u></span>
-      </div>
-      """
-    end
+    # Fresh assigns map (not Map.merge on incoming) preserves aria-expanded change tracking.
+    assigns = %{id: row_id, row: row, is_expanded: is_expanded}
+
+    ~H"""
+    <button
+      type="button"
+      id={"button_#{@id}"}
+      class="-m-1 flex items-center justify-center rounded border-0 bg-transparent p-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus"
+      aria-expanded={@is_expanded}
+      aria-controls={"details-#{@id}"}
+      aria-label={"Toggle details for attempt #{@row.attempt_number}"}
+      phx-click="toggle_row"
+      phx-value-id={@id}
+    >
+      <%= if @is_expanded do %>
+        <Icons.chevron_up class="fill-Text-text-high" />
+      <% else %>
+        <Icons.chevron_down class="fill-Text-text-high" />
+      <% end %>
+    </button>
+    """
   end
 
   def render(assigns) do

--- a/lib/oli_web/live/attempt/table_model.ex
+++ b/lib/oli_web/live/attempt/table_model.ex
@@ -10,7 +10,8 @@ defmodule OliWeb.Attempt.TableModel do
       column_specs: [
         %ColumnSpec{
           name: :chevron,
-          label: "",
+          label: "Details",
+          th_class: "sr-only",
           sortable: false,
           render_fn: &__MODULE__.render_chevron/3
         },

--- a/lib/oli_web/live/attempt/table_model.ex
+++ b/lib/oli_web/live/attempt/table_model.ex
@@ -91,7 +91,7 @@ defmodule OliWeb.Attempt.TableModel do
       class="-m-1 flex items-center justify-center rounded border-0 bg-transparent p-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus"
       aria-expanded={@is_expanded}
       aria-controls={"details-#{@id}"}
-      aria-label={"Toggle details for attempt #{@row.attempt_number}"}
+      aria-label={"Toggle details for #{@row.activity_title}, attempt #{@row.attempt_number}"}
       phx-click="toggle_row"
       phx-value-id={@id}
     >

--- a/lib/oli_web/live/common/sortable_table/striped_table.ex
+++ b/lib/oli_web/live/common/sortable_table/striped_table.ex
@@ -239,23 +239,23 @@ defmodule OliWeb.Common.SortableTable.StripedTable do
 
   defp render_details_row(assigns, row) do
     col_span = length(assigns.model.column_specs)
-    unique_id = "row_#{row.resource_id}"
-    # expanded_rows controls which details rows should start expanded.
+    # Default :resource_id preserves existing callers; callers with non-unique
+    # resource_ids (e.g. retakes) can opt into :id via model.data.
+    id_field = Map.get(assigns.model.data, :expandable_rows_id_field, :resource_id)
+    unique_id = "row_#{Map.get(row, id_field)}"
     expanded_rows = Map.get(assigns.model.data, :expanded_rows, MapSet.new())
     row_hidden = not MapSet.member?(expanded_rows, unique_id)
-    row_class = if row_hidden, do: "hidden", else: ""
 
     assigns =
       Map.merge(assigns, %{
         col_span: col_span,
         unique_id: unique_id,
         row: row,
-        row_class: row_class,
         row_hidden: row_hidden
       })
 
     ~H"""
-    <tr id={"details-#{@unique_id}"} class={@row_class} aria-hidden={@row_hidden}>
+    <tr id={"details-#{@unique_id}"} hidden={@row_hidden}>
       <td colspan={@col_span} class="bg-Table-table-hover p-4">
         <%= if @details_render_fn do %>
           {@details_render_fn.(assigns, @row)}

--- a/test/oli_web/live/attempt/attempt_live_test.exs
+++ b/test/oli_web/live/attempt/attempt_live_test.exs
@@ -1,13 +1,41 @@
 defmodule OliWeb.Attempt.AttemptLiveTest do
-  use ExUnit.Case, async: true
-  use OliWeb.ConnCase
+  use OliWeb.ConnCase, async: true
 
   import Phoenix.LiveViewTest
   import Oli.Factory
 
-  setup [:admin_conn]
+  alias Oli.Test.{AttemptBuilder, SectionBuilder}
+
+  describe "access control" do
+    test "redirects unauthenticated users", %{conn: conn} do
+      %{section: section, resource_attempt: resource_attempt} = build_attempt_graph()
+
+      assert {:error, {:redirect, _}} =
+               live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+    end
+
+    test "redirects a non-admin author", %{conn: conn} do
+      %{section: section, resource_attempt: resource_attempt} = build_attempt_graph()
+
+      conn = log_in_author(conn, insert(:author))
+
+      assert {:error, {:redirect, _}} =
+               live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+    end
+
+    test "redirects a learner-only user", %{conn: conn} do
+      %{section: section, resource_attempt: resource_attempt} = build_attempt_graph()
+
+      conn = log_in_user(conn, insert(:user))
+
+      assert {:error, {:redirect, _}} =
+               live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+    end
+  end
 
   describe "sorting activity attempts" do
+    setup [:admin_conn, :setup_sorted_attempts]
+
     test "ignores invalid sort keys" do
       {:ok, table_model} = OliWeb.Attempt.TableModel.new([])
       socket = %Phoenix.LiveView.Socket{assigns: %{table_model: table_model}}
@@ -25,56 +53,6 @@ defmodule OliWeb.Attempt.AttemptLiveTest do
       assert updated_socket.assigns.table_model.sort_order == table_model.sort_order
     end
 
-    setup do
-      section = insert(:section)
-      student = insert(:user)
-      page_revision = insert(:revision)
-
-      resource_access =
-        insert(:resource_access,
-          user: student,
-          section: section,
-          resource: page_revision.resource
-        )
-
-      resource_attempt =
-        insert(:resource_attempt,
-          resource_access: resource_access,
-          revision: page_revision,
-          attempt_guid: Ecto.UUID.generate()
-        )
-
-      early_revision = insert(:revision, title: "Early Screen")
-      middle_revision = insert(:revision, title: "Middle Screen")
-      late_revision = insert(:revision, title: "Late Screen")
-
-      insert(:activity_attempt,
-        resource_attempt: resource_attempt,
-        revision: middle_revision,
-        resource: middle_revision.resource,
-        attempt_number: 2,
-        date_evaluated: ~U[2024-01-02 12:00:00Z]
-      )
-
-      insert(:activity_attempt,
-        resource_attempt: resource_attempt,
-        revision: late_revision,
-        resource: late_revision.resource,
-        attempt_number: 3,
-        date_evaluated: ~U[2024-01-03 12:00:00Z]
-      )
-
-      insert(:activity_attempt,
-        resource_attempt: resource_attempt,
-        revision: early_revision,
-        resource: early_revision.resource,
-        attempt_number: 1,
-        date_evaluated: ~U[2024-01-01 12:00:00Z]
-      )
-
-      %{section: section, resource_attempt: resource_attempt}
-    end
-
     test "sorts by date evaluated", %{
       conn: conn,
       section: section,
@@ -87,12 +65,16 @@ defmodule OliWeb.Attempt.AttemptLiveTest do
       |> element("th[phx-click='sort'][phx-value-sort_by='date_evaluated']")
       |> render_click(%{sort_by: "date_evaluated"})
 
+      # Column indices: [1=chevron, 2=Updated, 3=Attempt Guid, 4=Resource Id,
+      # 5=Attempt Number, 6=Title, ...]. The "Title" column is nth-child(6).
+      # Rows alternate data/details because expandable_rows is enabled, so the
+      # last data row is nth-last-child(2) (the trailing details row is last).
       assert view
-             |> element("tbody tr:first-child td:nth-child(5)")
+             |> element("tbody tr:first-child td:nth-child(6)")
              |> render() =~ "Early Screen"
 
       assert view
-             |> element("tbody tr:last-child td:nth-child(5)")
+             |> element("tbody tr:nth-last-child(2) td:nth-child(6)")
              |> render() =~ "Late Screen"
 
       view
@@ -100,12 +82,660 @@ defmodule OliWeb.Attempt.AttemptLiveTest do
       |> render_click(%{sort_by: "date_evaluated"})
 
       assert view
-             |> element("tbody tr:first-child td:nth-child(5)")
+             |> element("tbody tr:first-child td:nth-child(6)")
              |> render() =~ "Late Screen"
 
       assert view
-             |> element("tbody tr:last-child td:nth-child(5)")
+             |> element("tbody tr:nth-last-child(2) td:nth-child(6)")
              |> render() =~ "Early Screen"
     end
+  end
+
+  describe "detail pane" do
+    setup [:admin_conn, :setup_attempts_with_responses]
+
+    test "does not render the Student Responses section before a row is selected", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      {:ok, _view, html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      refute html =~ "Student Responses"
+    end
+
+    test "selecting a row renders the student's response fields and typed values", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt,
+      mcq_activity: mcq_activity
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{mcq_activity.id}"})
+
+      # Heading present
+      assert html =~ "Student Responses"
+      assert html =~ "Response"
+
+      # Response keys rendered
+      assert html =~ "selectedChoice"
+      assert html =~ "selectedChoiceText"
+      assert html =~ "enabled"
+      assert html =~ "randomize"
+
+      # Typed value indicators — boolean true/false rendered as check/cross
+      assert html =~ "✓"
+      assert html =~ "✗"
+
+      # Response value text rendered
+      assert html =~ "Objects with longer half lives"
+    end
+
+    test "does not render raw authoring-model JSON", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt,
+      mcq_activity: mcq_activity
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{mcq_activity.id}"})
+
+      refute html =~ "activitiesRequiredForEvaluation"
+      refute html =~ ~s("authoring")
+      refute html =~ "<pre"
+    end
+
+    test "two different attempts render distinct response content", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt,
+      mcq_activity: mcq_activity,
+      text_activity: text_activity
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      # Expand MCQ only — its content is visible, text activity's is not (still collapsed).
+      mcq_html = render_click(view, "toggle_row", %{"id" => "row_#{mcq_activity.id}"})
+      assert mcq_html =~ "selectedChoice"
+      refute mcq_html =~ "Hello World"
+
+      # Collapse MCQ, then expand text — its content is visible, MCQ's is not.
+      _ = render_click(view, "toggle_row", %{"id" => "row_#{mcq_activity.id}"})
+      text_html = render_click(view, "toggle_row", %{"id" => "row_#{text_activity.id}"})
+      assert text_html =~ "Hello World"
+      refute text_html =~ "selectedChoice"
+    end
+
+    test "a part attempt with no response shows the fallback message", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt,
+      empty_activity: empty_activity
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{empty_activity.id}"})
+
+      assert html =~ "No response data recorded"
+    end
+
+    test "renders part cards sorted alphabetically by part_id regardless of insertion order",
+         %{conn: conn, section: section, resource_attempt: resource_attempt} do
+      # Insert parts in non-alphabetical order so we can verify the render sorts them
+      tree =
+        AttemptBuilder.add_activities(%{}, resource_attempt, [
+          {:activity_attempt, "Sort Test Screen",
+           [
+             {:part_attempt, "zebra", response: %{"x" => 1}},
+             {:part_attempt, "alpha", response: %{"y" => 2}},
+             {:part_attempt, "middle", response: %{"z" => 3}}
+           ]}
+        ])
+
+      activity = tree["Sort Test Screen"].activity
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      {alpha_pos, _} = :binary.match(html, "alpha")
+      {middle_pos, _} = :binary.match(html, "middle")
+      {zebra_pos, _} = :binary.match(html, "zebra")
+
+      assert alpha_pos < middle_pos,
+             "Expected 'alpha' to appear before 'middle' in the rendered output"
+
+      assert middle_pos < zebra_pos,
+             "Expected 'middle' to appear before 'zebra' in the rendered output"
+    end
+
+    test "unwraps a CapiVariable-shaped response entry into a single row", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      tree =
+        AttemptBuilder.add_activities(%{}, resource_attempt, [
+          {:activity_attempt, "CAPI Unwrap Screen",
+           [
+             {:part_attempt, "popTemp",
+              response: %{
+                "isOpen" => %{
+                  "key" => "isOpen",
+                  "path" => "act-id|stage.popTemp.isOpen",
+                  "type" => 4,
+                  "value" => false
+                }
+              }}
+           ]}
+        ])
+
+      activity = tree["CAPI Unwrap Screen"].activity
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # The variable name and its boolean-false indicator must both be present
+      assert html =~ "isOpen"
+      assert html =~ "✗"
+
+      # The CapiVariable metadata (key/path/type) must NOT be rendered as visible labels —
+      # the unwrap replaces the 4-level tree with one row.
+      refute html =~ "act-id|stage.popTemp.isOpen"
+
+      refute html =~
+               ~s(<summary style="cursor: pointer;">\n                <span style="font-weight: 600;">key</span>)
+    end
+
+    test "recurses into a plain nested map that is NOT a CapiVariable", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      tree =
+        AttemptBuilder.add_activities(%{}, resource_attempt, [
+          {:activity_attempt, "Plain Nested Screen",
+           [
+             {:part_attempt, "metadata_part",
+              response: %{
+                "metadata" => %{
+                  "answered_at" => "2026-04-20",
+                  "ip" => "192.168.0.1"
+                }
+              }}
+           ]}
+        ])
+
+      activity = tree["Plain Nested Screen"].activity
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # Both inner keys render with their values — recursion preserved.
+      assert html =~ "answered_at"
+      assert html =~ "2026-04-20"
+      assert html =~ "ip"
+      assert html =~ "192.168.0.1"
+      # Parent key also present
+      assert html =~ "metadata"
+    end
+
+    test "handles a mixed response (one CapiVariable + one plain nested map)", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      tree =
+        AttemptBuilder.add_activities(%{}, resource_attempt, [
+          {:activity_attempt, "Mixed Response Screen",
+           [
+             {:part_attempt, "mixed_part",
+              response: %{
+                "selectedChoice" => %{
+                  "key" => "selectedChoice",
+                  "path" => "act-id|stage.mixed_part.selectedChoice",
+                  "type" => 1,
+                  "value" => 3
+                },
+                "metadata" => %{"answered_at" => "2026-04-20"}
+              }}
+           ]}
+        ])
+
+      activity = tree["Mixed Response Screen"].activity
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # CapiVariable side: key + unwrapped numeric value, no path metadata
+      assert html =~ "selectedChoice"
+      assert html =~ ">3<"
+      refute html =~ "act-id|stage.mixed_part.selectedChoice"
+
+      # Nested-map side: parent + inner key + value all visible
+      assert html =~ "metadata"
+      assert html =~ "answered_at"
+      assert html =~ "2026-04-20"
+    end
+
+    test "tolerates CapiVariable entries with extra fields (allowedValues, etc.)", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      tree =
+        AttemptBuilder.add_activities(%{}, resource_attempt, [
+          {:activity_attempt, "CAPI With Extras Screen",
+           [
+             {:part_attempt, "status_part",
+              response: %{
+                "status" => %{
+                  "key" => "status",
+                  "path" => "act-id|stage.status_part.status",
+                  "type" => 5,
+                  "value" => "active",
+                  "allowedValues" => ["active", "inactive"]
+                }
+              }}
+           ]}
+        ])
+
+      activity = tree["CAPI With Extras Screen"].activity
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # With type-driven rendering (item 3), an ENUM CapiVariable shows its value
+      # plus an allowedValues caption. `inactive` now appears in that caption —
+      # what we still refute is that `allowedValues` renders as a *labeled nested
+      # row* (which would indicate the detector descended into extras).
+      assert html =~ "status"
+      assert html =~ "active"
+      assert html =~ "inactive"
+      refute html =~ ">allowedValues<"
+    end
+
+    # --- Item 3: type-driven value rendering ------------------------------------
+
+    test "renders a NUMBER-typed value via the declared type", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "num_part",
+          %{"count" => capi_var("count", 1, 42)}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "count"
+      assert html =~ ">42<"
+    end
+
+    test "renders a STRING-typed value as raw text (no surrounding quotes)", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "str_part",
+          %{"name" => capi_var("name", 2, "hello")}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "name"
+      assert html =~ "hello"
+      # Raw value, not `inspect`-quoted — the HEEx-escaped "&quot;hello&quot;" form
+      # should NOT appear.
+      refute html =~ "&quot;hello&quot;"
+    end
+
+    test "renders an ARRAY-typed value as JSON", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "arr_part",
+          %{"ids" => capi_var("ids", 3, [1, 2, 3])}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "ids"
+      assert html =~ "[1,2,3]"
+    end
+
+    test "renders a BOOLEAN-typed true value as check mark", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "bool_true_part",
+          %{"enabled" => capi_var("enabled", 4, true)}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "enabled"
+      assert html =~ "✓"
+    end
+
+    test "renders a BOOLEAN-typed false value as cross mark", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "bool_false_part",
+          %{"enabled" => capi_var("enabled", 4, false)}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "enabled"
+      assert html =~ "✗"
+    end
+
+    test "renders an ENUM-typed value with its allowedValues caption", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "enum_part",
+          %{
+            "mode" => capi_var("mode", 5, "edit", %{"allowedValues" => ["view", "edit", "admin"]})
+          }
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "mode"
+      # Rendered via OliWeb.Delivery.Content.SelectDropdown: the selected value
+      # appears as the dropdown label, and every allowedValue is an <option>
+      # button in the list, so all three strings must be present in the HTML.
+      assert html =~ "edit"
+      assert html =~ "view"
+      assert html =~ "admin"
+    end
+
+    test "renders a MATH_EXPR-typed value as text", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "math_part",
+          %{"expr" => capi_var("expr", 6, "2 + 2")}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "expr"
+      assert html =~ "2 + 2"
+    end
+
+    test "renders an ARRAY_POINT-typed value as JSON", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "pt_part",
+          %{"pts" => capi_var("pts", 7, [[0, 0], [1, 1]])}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      assert html =~ "pts"
+      assert html =~ "[[0,0],[1,1]]"
+    end
+
+    test "type BOOLEAN takes priority over a string-shaped value", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "divergence_bool_part",
+          %{"enabled" => capi_var("enabled", 4, "false")}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # Declared type wins — must render as the boolean cross, not as a quoted string.
+      assert html =~ "enabled"
+      assert html =~ "✗"
+    end
+
+    test "type NUMBER takes priority over a string-shaped value", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "divergence_num_part",
+          %{"count" => capi_var("count", 1, "42")}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # Must render inside a monospace value span. Both string and number rendering
+      # would include "42" in the output; what proves type-driven dispatch ran is
+      # the absence of the NO-LONGER-USED title="42" attribute that the pre-item-3
+      # string branch used to emit. With the current render, no type renders title.
+      assert html =~ ">42<"
+    end
+
+    test "type ARRAY takes priority over a string-shaped value", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "divergence_arr_part",
+          %{"ids" => capi_var("ids", 3, "[1,2,3]")}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # Must render as parsed array content (the JSON-encoded form).
+      assert html =~ "[1,2,3]"
+    end
+
+    test "unknown type falls back to Elixir-guard rendering", %{
+      conn: conn,
+      section: section,
+      resource_attempt: resource_attempt
+    } do
+      activity =
+        setup_part_with_capi_response(
+          resource_attempt,
+          "unknown_type_part",
+          %{"flag" => capi_var("flag", 99, true)}
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/sections/#{section.slug}/debugger/#{resource_attempt.attempt_guid}")
+
+      html = render_click(view, "toggle_row", %{"id" => "row_#{activity.id}"})
+
+      # With UNKNOWN(99) we fall back to the guard-based renderer; value is a
+      # boolean true at runtime, so the check mark should still appear.
+      assert html =~ "flag"
+      assert html =~ "✓"
+    end
+  end
+
+  # --- helpers -----------------------------------------------------------------
+
+  # Builds a CapiVariable-shape map matching the persisted Janus serialization:
+  # 4 required keys ({key, path, type, value}) + optional extras (e.g. allowedValues).
+  defp capi_var(key, type, value, extras \\ %{}) do
+    Map.merge(
+      %{
+        "key" => key,
+        "path" => "act-id|stage.test.#{key}",
+        "type" => type,
+        "value" => value
+      },
+      extras
+    )
+  end
+
+  # Inserts a fresh revision/activity_attempt/part_attempt chain under the given
+  # resource_attempt and returns the new activity_attempt so tests can `select` it.
+  defp setup_part_with_capi_response(resource_attempt, part_id, response) do
+    title = "Type Test - #{part_id}"
+
+    tree =
+      AttemptBuilder.add_activities(%{}, resource_attempt, [
+        {:activity_attempt, title, [{:part_attempt, part_id, response: response}]}
+      ])
+
+    tree[title].activity
+  end
+
+  defp build_attempt_graph do
+    tree =
+      %{}
+      |> SectionBuilder.build([{:section, "sec"}, {:user, "stu"}])
+      |> AttemptBuilder.build("sec", "stu", {:resource_attempt, "Page"})
+
+    %{
+      section: tree["sec"].section,
+      resource_attempt: tree["Page"].resource_attempt,
+      page_revision: tree["Page"].revision
+    }
+  end
+
+  defp setup_sorted_attempts(_ctx) do
+    tree =
+      %{}
+      |> SectionBuilder.build([{:section, "sec"}, {:user, "stu"}])
+      |> AttemptBuilder.build(
+        "sec",
+        "stu",
+        {:resource_attempt, "Page",
+         [
+           {:activity_attempt, "Middle Screen", [],
+            attempt_number: 2, date_evaluated: ~U[2024-01-02 12:00:00Z]},
+           {:activity_attempt, "Late Screen", [],
+            attempt_number: 3, date_evaluated: ~U[2024-01-03 12:00:00Z]},
+           {:activity_attempt, "Early Screen", [],
+            attempt_number: 1, date_evaluated: ~U[2024-01-01 12:00:00Z]}
+         ]}
+      )
+
+    %{section: tree["sec"].section, resource_attempt: tree["Page"].resource_attempt}
+  end
+
+  defp setup_attempts_with_responses(_ctx) do
+    tree =
+      %{}
+      |> SectionBuilder.build([{:section, "sec"}, {:user, "stu"}])
+      |> AttemptBuilder.build(
+        "sec",
+        "stu",
+        {:resource_attempt, "Page",
+         [
+           {:activity_attempt, "MCQ Screen",
+            [
+              {:part_attempt, "hypothesis",
+               response: %{
+                 "selectedChoice" => 3,
+                 "selectedChoiceText" => "Objects with longer half lives",
+                 "enabled" => true,
+                 "randomize" => false
+               }}
+            ]},
+           {:activity_attempt, "Text Screen",
+            [{:part_attempt, "__default", response: %{"input" => "Hello World"}}]},
+           {:activity_attempt, "Unanswered Screen", [{:part_attempt, "__default", response: nil}]}
+         ]}
+      )
+
+    %{
+      section: tree["sec"].section,
+      resource_attempt: tree["Page"].resource_attempt,
+      mcq_activity: tree["MCQ Screen"].activity,
+      text_activity: tree["Text Screen"].activity,
+      empty_activity: tree["Unanswered Screen"].activity
+    }
   end
 end

--- a/test/support/attempt_builder.ex
+++ b/test/support/attempt_builder.ex
@@ -1,0 +1,136 @@
+defmodule Oli.Test.AttemptBuilder do
+  @moduledoc """
+  Composable delivery-runtime builder for resource_attempt / activity_attempt /
+  part_attempt trees. Peer of `Oli.Test.HierarchyBuilder` and
+  `Oli.Test.SectionBuilder` — shares their title-keyed accumulator so tests
+  compose all three:
+
+      tree =
+        %{}
+        |> SectionBuilder.build([{:section, "chem"}, {:user, "stu1"}])
+        |> AttemptBuilder.build("chem", "stu1",
+          {:resource_attempt, "Page A", [
+            {:activity_attempt, "MCQ Screen", [
+              {:part_attempt, "hypothesis", response: %{"enabled" => true}}
+            ]},
+            {:activity_attempt, "Text Screen", [
+              {:part_attempt, "__default", response: %{"input" => "Hello"}}
+            ]}
+          ]}
+        )
+
+      # Then access any node by title:
+      tree["chem"].section
+      tree["Page A"].resource_attempt
+      tree["MCQ Screen"].activity
+
+  ## Supported node tuples
+
+  - `{:resource_attempt, revision_title}` — bare resource_attempt (no activities)
+  - `{:resource_attempt, revision_title, children}` — with activity_attempt children
+  - `{:activity_attempt, revision_title, parts}` — with part_attempt children
+  - `{:activity_attempt, revision_title, parts, opts}` — extra activity attrs
+  - `{:part_attempt, part_id}` — bare part_attempt
+  - `{:part_attempt, part_id, opts}` — with :response, :feedback, :attempt_number, etc.
+  """
+
+  import Oli.Factory
+
+  def build(tree, section_key, user_key, resource_attempt_spec) do
+    section = fetch!(tree, section_key, :section)
+    user = fetch!(tree, user_key, :user)
+    apply_resource(resource_attempt_spec, tree, section, user)
+  end
+
+  @doc """
+  Extends an existing resource_attempt with additional activity_attempt /
+  part_attempt children. Useful in tests that share a setup-built
+  resource_attempt and want to add per-test activities without rebuilding
+  the section/user/resource_attempt chain.
+  """
+  def add_activities(tree, resource_attempt, activity_specs) when is_list(activity_specs) do
+    Enum.reduce(activity_specs, tree, fn spec, acc ->
+      apply_activity(spec, acc, resource_attempt)
+    end)
+  end
+
+  defp apply_resource({:resource_attempt, title}, tree, section, user),
+    do: apply_resource({:resource_attempt, title, []}, tree, section, user)
+
+  defp apply_resource({:resource_attempt, title, children}, tree, section, user) do
+    page_revision = insert(:revision, title: title)
+
+    resource_access =
+      insert(:resource_access,
+        user: user,
+        section: section,
+        resource: page_revision.resource
+      )
+
+    resource_attempt =
+      insert(:resource_attempt,
+        resource_access: resource_access,
+        revision: page_revision,
+        attempt_guid: Ecto.UUID.generate()
+      )
+
+    tree =
+      Map.put(tree, title, %{
+        revision: page_revision,
+        resource_access: resource_access,
+        resource_attempt: resource_attempt
+      })
+
+    Enum.reduce(children, tree, fn child, acc -> apply_activity(child, acc, resource_attempt) end)
+  end
+
+  defp apply_activity({:activity_attempt, title, parts}, tree, resource_attempt),
+    do: apply_activity({:activity_attempt, title, parts, []}, tree, resource_attempt)
+
+  defp apply_activity({:activity_attempt, title, parts, opts}, tree, resource_attempt) do
+    revision = insert(:revision, title: title)
+
+    activity_attempt_attrs =
+      Keyword.merge(
+        [
+          resource_attempt: resource_attempt,
+          revision: revision,
+          resource: revision.resource,
+          attempt_number: 1
+        ],
+        opts
+      )
+
+    activity_attempt = insert(:activity_attempt, activity_attempt_attrs)
+
+    tree = Map.put(tree, title, %{revision: revision, activity: activity_attempt})
+
+    Enum.reduce(parts, tree, fn part, acc -> apply_part(part, acc, activity_attempt) end)
+  end
+
+  defp apply_part({:part_attempt, part_id}, tree, activity_attempt),
+    do: apply_part({:part_attempt, part_id, []}, tree, activity_attempt)
+
+  defp apply_part({:part_attempt, part_id, opts}, tree, activity_attempt) do
+    attrs =
+      Keyword.merge(
+        [activity_attempt: activity_attempt, part_id: part_id, attempt_number: 1],
+        opts
+      )
+
+    insert(:part_attempt, attrs)
+    tree
+  end
+
+  defp fetch!(tree, key, field) do
+    case tree do
+      %{^key => %{^field => value}} ->
+        value
+
+      _ ->
+        raise ArgumentError,
+              "AttemptBuilder: tree[#{inspect(key)}].#{field} not found. " <>
+                "Run SectionBuilder.build first to create the #{field}."
+    end
+  end
+end

--- a/test/support/section_builder.ex
+++ b/test/support/section_builder.ex
@@ -1,0 +1,44 @@
+defmodule Oli.Test.SectionBuilder do
+  @moduledoc """
+  Composable delivery-side builder for sections and users. Peer of
+  `Oli.Test.HierarchyBuilder` — shares its title-keyed tree accumulator so
+  tests can chain builders:
+
+      tree =
+        build_hierarchy(project, publication, author, {:container, "Root", [...]})
+        |> SectionBuilder.build([
+          {:section, "chem"},
+          {:user, "student1"}
+        ])
+        |> AttemptBuilder.build("chem", "student1", {:resource_attempt, "Root"})
+
+  Standalone use (no authoring hierarchy) is fine — just start with `%{}`.
+
+  ## Supported node tuples
+
+  - `{:section, key}` — inserts a section, stores under `tree[key].section`
+  - `{:section, key, opts}` — same, with extra attrs forwarded to the factory
+  - `{:user, key}` — inserts a user, stores under `tree[key].user`
+  - `{:user, key, opts}` — same, with extra attrs forwarded to the factory
+  """
+
+  import Oli.Factory
+
+  def build(tree \\ %{}, specs) when is_list(specs) do
+    Enum.reduce(specs, tree, &apply_node/2)
+  end
+
+  defp apply_node({:section, key}, tree), do: apply_node({:section, key, []}, tree)
+
+  defp apply_node({:section, key, opts}, tree) do
+    section = insert(:section, opts)
+    Map.put(tree, key, Map.merge(Map.get(tree, key, %{}), %{section: section}))
+  end
+
+  defp apply_node({:user, key}, tree), do: apply_node({:user, key, []}, tree)
+
+  defp apply_node({:user, key, opts}, tree) do
+    user = insert(:user, opts)
+    Map.put(tree, key, Map.merge(Map.get(tree, key, %{}), %{user: user}))
+  end
+end


### PR DESCRIPTION
## Summary

Ticket: [MER-5214](https://eliterate.atlassian.net/browse/MER-5214)


https://github.com/user-attachments/assets/4cd96832-df2b-467b-ae85-867331bb45fb


- Replaces the raw JSON blob in the adaptive debugger's detail pane (`/sections/:section_slug/debugger/:attempt_guid`) with a human-readable CAPI-state display per `part_attempt`, aligned with review-mode Inspector.
- Parts are alphabetized by `part_id`; values dispatch on the declared `CapiVariableTypes` code (NUMBER/STRING/ARRAY/BOOLEAN/ENUM/MATH_EXPR/ARRAY_POINT + UNKNOWN fallback) with stored-value coercion mirroring `parseCapiValue` in `assets/src/adaptivity/capi.ts`.
- Dotted keys (e.g. `"Input 1.Correct"`) are grouped into nested accordions, matching Inspector's `unflatten`.
- Per-part cards are server-controlled (`<div>` + `<button aria-expanded>` with `hidden={not @is_open}`), keyed by an `expanded_parts` MapSet on the socket. Expand all / Collapse all are single server events that update the MapSet in one pass. Nested key groups inside a part body still use native `<details>` — only the per-part card itself is server-driven.
- Server-side admin-only gate in `AttemptLive.mount/3` — defense-in-depth beyond the UI entry-point gate. Non-admin sessions (instructors, learners, authors) redirect; PubSub subscription is gated on `connected?(socket)`.
- Past-attempt navigation: retakes render as independent expandable rows, each with its own snapshotted CAPI state.

## Shared components extended (additive, no caller changes)

- `OliWeb.Common.SortableTable.StripedTable` — new `:expandable_rows_id_field` data key (default `:resource_id` preserves existing callers; debugger opts into `:id` because retakes share `resource_id`).
- `OliWeb.Delivery.Content.SelectDropdown` — new `push_on_select :boolean` and `readonly :boolean` attrs. Read-only ENUM rendering in the debugger uses both.

## Implementation notes

- **Server as sole source of open state for per-part cards.** Earlier iterations used native `<details>` + `phx-click` + `open={@is_open}`, which caused flicker/ping-pong on fast clicks (browser's native toggle racing with the server round-trip). Switched per-part cards to a plain `<div>` + `<button>` with `class`/`hidden` driven by the MapSet — no native state, no race. Nested key groups inside the body kept `<details>` because they live under an already-server-controlled card and don't share the racing surface.
- **Change-tracking gotcha.** Mutating HEEx assigns with `Map.put`/`Map.merge` silently disables Phoenix LiveView's change tracking (slots are encoded as static, morphdom never applies attribute changes). Replaced with `Phoenix.Component.assign/2,3`; for captured function boundaries (`&render_row_details/2` invoked from `StripedTable`, `&render_chevron/3` invoked from the table model), the template builds a fresh assigns map and lets HEEx component calls re-establish tracking.
- **Cached grouped form.** `group_dotted_keys` is precomputed once at load time and stored on each `part_attempt` as `:grouped_response` / `:grouped_feedback`. `handle_info` looks up cached forms by `attempt_guid` and only re-groups the changed attempt; other attempts carry their cached form forward.
- **O(log n) row + part guards.** `build_part_indexes` builds `valid_part_ids` (MapSet) and `row_part_ids` (Map) once per mount/PubSub. `toggle_row` rejects unknown row ids (caps `expanded_rows` MapSet growth); `toggle_part` rejects unknown part ids; `parse_part_id` rejects malformed input before the MapSet op.
- **Selector-safe dom ids.** Raw CAPI ids contain dots that break JS selectors, so per-CAPI-variable element ids are hashed via `:erlang.phash2`.
- **Overflow handling.** ENUM value cells use `overflow-visible` so the dropdown can escape its row; other values use `overflow-x-auto whitespace-nowrap` so long strings (e.g. `customCss`) scroll inline rather than break the card layout.
- **Shared row identity.** `"row_<activity_attempt.id>"` is the shared key used by the chevron's `phx-value-id`, the row-click event, the `expanded_rows` MapSet, and `StripedTable`'s details-row lookup. All four agree on the same string.

## Acceptance criteria

- [x] **AC1** — Clicking a row shows CAPI state information for that attempt (replaces raw JSON).
- [x] **AC2** — Display aligns with review mode's Inspector (alphabetized parts, typed values, nested groups, ENUM dropdown).
- [x] **AC3** — Admin can navigate to previous attempts on the same screen; each retake is a separate expandable row.
- [x] **AC4** — Debugger button / route admin-only (UI gate + server-side gate in `mount/3`).

## Test plan

- [x] `mix test test/oli_web/live/attempt/attempt_live_test.exs` — 27 tests covering access control (3), sort (2), and detail pane (22: CAPI unwrap, type-driven rendering, divergence cases, fallback).
- [ ] Manual (requires a section with an adaptive page and at least one resource_attempt with part_attempts):
  - [ ] Sign in as a content admin and navigate to `/sections/:slug/debugger/:resource_attempt_guid`
  - [ ] Expand any row → per-part cards render CAPI variables instead of raw JSON
  - [ ] Individual part toggle and Expand all / Collapse all work without flicker
  - [ ] For a part with an ENUM CAPI variable: open the dropdown, verify allowed options appear with ✓ on the selected, confirm no server event fires on selection (read-only)
  - [ ] For a resource with multiple retakes: each attempt row expands to distinct CAPI state
  - [ ] Long string values (e.g. `customCss`) scroll horizontally within their value column rather than breaking the card layout
  - [ ] Sign in as an instructor / learner / author → the same URL redirects (admin-only gate)
- [ ] PubSub live updates (requires the `live-debugging` feature flag enabled at `/admin/features`):
  - [ ] With the debugger open as admin, have a student submit a part attempt on the same resource_attempt
  - [ ] Matching row's **Updated** column flashes "UPDATED"; if expanded, per-part cards reflect the new response without losing open/collapsed state

## Out of scope

- App / Session / Variables panes (Inspector-only; derived from the live scripting runtime, not persisted per `part_attempt`).
- Write/edit capability (Inspector can `applyStateChange`; debugger is read-only by product decision).
- Full `parseCapiValue` normalization port — only the divergence cases under test are covered.
- Widening the gate to instructors — content-admin-only is the intended policy.

## Test infrastructure

Added two composable builders peer of `test/support/hierarchy_builder.ex`:
- `test/support/section_builder.ex` — section + user nodes
- `test/support/attempt_builder.ex` — resource_attempt / activity_attempt / part_attempt subtrees

Tests in `attempt_live_test.exs` migrated off inline `insert(...)` chains; the old ~60-line sort-setup block collapses to one declarative `AttemptBuilder.build` call.

[MER-5214]: https://eliterate.atlassian.net/browse/MER-5214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
