### PR TITLE
[BUG FIX] [MER-5579] fix regressions in markdown editing

### DIFF
--- a/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
+++ b/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
@@ -86,7 +86,7 @@ const serializeToken =
       case 'br':
         return [{ text: '\n' }];
       case 'paragraph':
-        return [{ type: 'p', id: guid(), children: serializeTokens(token.tokens, context) as any }];
+        return serializeParagraph(token as Tokens.Paragraph, context);
       case 'heading':
         const depth = Math.max(1, Math.min(token.depth || 1, 6)) as 1 | 2 | 3 | 4 | 5 | 6;
         return [
@@ -108,6 +108,8 @@ const serializeToken =
         });
       case 'codespan':
         return [{ code: true, text: decodeHtmlEntities(token.text) }];
+      case 'link':
+        return serializeLink(token as Tokens.Link, context);
       case 'code':
         return serializeCode(token as Tokens.Code, context);
       case 'del':
@@ -137,6 +139,55 @@ const serializeToken =
 
 const serializeImage = (token: Tokens.Image, context: SerializationContext): AllModelElements[] => {
   return [Model.image(token.href, !token.text ? undefined : token.text)];
+};
+
+const emptyUnorderedListPattern = /^([*+-])\s*$/;
+const emptyOrderedListPattern = /^(\d+)\.\s*$/;
+
+const serializeEmptyListParagraph = (
+  token: Tokens.Paragraph,
+): AllModelElements[] | null => {
+  const lines = token.text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return null;
+  }
+
+  const unordered = lines.every((line) => emptyUnorderedListPattern.test(line));
+  if (unordered) {
+    return [Model.ul(lines.map(() => Model.li('')))];
+  }
+
+  const ordered = lines.every((line) => emptyOrderedListPattern.test(line));
+  if (ordered) {
+    return [Model.ol(lines.map(() => Model.li('')))];
+  }
+
+  return null;
+};
+
+const serializeParagraph = (
+  token: Tokens.Paragraph,
+  context: SerializationContext,
+): AllModelElements[] => {
+  const emptyList = serializeEmptyListParagraph(token);
+  if (emptyList) {
+    return emptyList;
+  }
+
+  return [{ type: 'p', id: guid(), children: serializeTokens(token.tokens, context) as any }];
+};
+
+const serializeLink = (
+  token: Tokens.Link,
+  context: SerializationContext,
+): AllModelElements[] => {
+  const link = Model.link(token.href);
+  link.children = serializeTokens(token.tokens, context) as any;
+  return [link];
 };
 
 const serializeCode = (

--- a/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
+++ b/assets/src/components/editing/markdown_editor/content_markdown_serializer.ts
@@ -144,9 +144,7 @@ const serializeImage = (token: Tokens.Image, context: SerializationContext): All
 const emptyUnorderedListPattern = /^([*+-])\s*$/;
 const emptyOrderedListPattern = /^(\d+)\.\s*$/;
 
-const serializeEmptyListParagraph = (
-  token: Tokens.Paragraph,
-): AllModelElements[] | null => {
+const serializeEmptyListParagraph = (token: Tokens.Paragraph): AllModelElements[] | null => {
   const lines = token.text
     .split('\n')
     .map((line) => line.trim())
@@ -181,10 +179,7 @@ const serializeParagraph = (
   return [{ type: 'p', id: guid(), children: serializeTokens(token.tokens, context) as any }];
 };
 
-const serializeLink = (
-  token: Tokens.Link,
-  context: SerializationContext,
-): AllModelElements[] => {
+const serializeLink = (token: Tokens.Link, context: SerializationContext): AllModelElements[] => {
   const link = Model.link(token.href);
   link.children = serializeTokens(token.tokens, context) as any;
   return [link];

--- a/assets/test/editor/markdown/markdown_round_trip_test.ts
+++ b/assets/test/editor/markdown/markdown_round_trip_test.ts
@@ -71,11 +71,7 @@ describe('Markdown round trip', () => {
       {
         type: 'p',
         id: '1',
-        children: [
-          { text: 'Visit ' },
-          link,
-          { text: ' today.' },
-        ],
+        children: [{ text: 'Visit ' }, link, { text: ' today.' }],
       },
     ]);
   });

--- a/assets/test/editor/markdown/markdown_round_trip_test.ts
+++ b/assets/test/editor/markdown/markdown_round_trip_test.ts
@@ -63,6 +63,27 @@ describe('Markdown round trip', () => {
     ]);
   });
 
+  it('should preserve links across markdown round trips', () => {
+    const link = Model.link('https://example.com');
+    link.children = [{ text: 'Example' }];
+
+    testRoundTrip([
+      {
+        type: 'p',
+        id: '1',
+        children: [
+          { text: 'Visit ' },
+          link,
+          { text: ' today.' },
+        ],
+      },
+    ]);
+  });
+
+  it('should preserve an empty unordered list item across markdown round trips', () => {
+    testRoundTrip([Model.ul([Model.li('')])]);
+  });
+
   it('should serialize and deserialize a paragraph with formatted text', () => {
     testRoundTrip([
       {

--- a/assets/test/editor/markdown/markdown_serializer_test.ts
+++ b/assets/test/editor/markdown/markdown_serializer_test.ts
@@ -62,6 +62,32 @@ describe('Markdown serializer', () => {
     );
   });
 
+  it('should serialize an empty unordered list item without paragraph crashes', () => {
+    const content = `- \n\n`;
+    expect(serializeMarkdown(content)).toEqual(
+      expectAnyId([
+        {
+          type: 'ul',
+          id: '1',
+          children: [Model.li('')],
+        },
+      ]),
+    );
+  });
+
+  it('should serialize an empty ordered list item without paragraph crashes', () => {
+    const content = `1. \n\n`;
+    expect(serializeMarkdown(content)).toEqual(
+      expectAnyId([
+        {
+          type: 'ol',
+          id: '1',
+          children: [Model.li('')],
+        },
+      ]),
+    );
+  });
+
   it('should serialize an image', () => {
     const content = `![Alt text](https://example.com/image.png)\n\n`;
     expect(serializeMarkdown(content)).toEqual(


### PR DESCRIPTION
In `assets/src/components/editing/markdown_editor/content_markdown_serializer.ts:86`, markdown link tokens are now converted back into a nodes instead of being treated as unknown inline text, which is why links were losing href on markdown/rich-text toggles. I also added a paragraph fallback for empty list delimiters so markdown like -  and 1.  round-trips to empty ul/ol items instead of collapsing into a plain paragraph marker.

Tested interactively and works as expected now.  

 