### PR TITLE
[BUG FIX] [MER-5586] explorations begin button not working

### DIFF
--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -190,6 +190,7 @@ defmodule Oli.Activities.AdaptiveParts do
     content
     |> stateful_non_scorable_part_definitions()
     |> Enum.map(&Map.get(&1, "id"))
+    |> Enum.reject(&is_nil/1)
     |> MapSet.new()
   end
 

--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -12,16 +12,35 @@ defmodule Oli.Activities.AdaptiveParts do
                          "janus-text-slider",
                          "janus-fill-blanks"
                        ])
+  @stateful_non_scorable_part_types MapSet.new([
+                                      "janus-navigation-button",
+                                      "janus-popup",
+                                      "janus-audio",
+                                      "janus-video",
+                                      "janus-image-carousel",
+                                      "janus-capi-iframe"
+                                    ])
 
   def scorable_part_types, do: @scorable_part_types
+  def stateful_non_scorable_part_types, do: @stateful_non_scorable_part_types
 
   def scorable_part_type?(type) when is_binary(type),
     do: MapSet.member?(@scorable_part_types, type)
 
   def scorable_part_type?(_), do: false
 
+  def stateful_non_scorable_part_type?(type) when is_binary(type),
+    do: MapSet.member?(@stateful_non_scorable_part_types, type)
+
+  def stateful_non_scorable_part_type?(_), do: false
+
   def scorable_part?(part) when is_map(part), do: scorable_part_type?(Map.get(part, "type"))
   def scorable_part?(_), do: false
+
+  def stateful_non_scorable_part?(part) when is_map(part),
+    do: stateful_non_scorable_part_type?(Map.get(part, "type"))
+
+  def stateful_non_scorable_part?(_), do: false
 
   def tracked_part?(content, part_id) when is_map(content) and is_binary(part_id) do
     MapSet.member?(tracked_part_ids(content), part_id)
@@ -124,7 +143,31 @@ defmodule Oli.Activities.AdaptiveParts do
   def tracked_part_definitions(_), do: []
 
   def tracked_part_ids(content) do
-    MapSet.union(scorable_part_ids(content), rule_scored_part_ids(content))
+    [
+      scorable_part_ids(content),
+      stateful_non_scorable_part_ids(content),
+      rule_scored_part_ids(content)
+    ]
+    |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+  end
+
+  def stateful_non_scorable_part_definitions(content) when is_map(content) do
+    merged_parts = merged_parts_by_id(content)
+
+    content
+    |> ordered_part_ids()
+    |> Enum.map(&Map.get(merged_parts, &1))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.filter(&stateful_non_scorable_part?/1)
+  end
+
+  def stateful_non_scorable_part_definitions(_), do: []
+
+  def stateful_non_scorable_part_ids(content) do
+    content
+    |> stateful_non_scorable_part_definitions()
+    |> Enum.map(&Map.get(&1, "id"))
+    |> MapSet.new()
   end
 
   def rule_scored_part_ids(content) when is_map(content) do

--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -51,6 +51,15 @@ defmodule Oli.Activities.AdaptiveParts do
 
   def tracked_part?(_, _), do: false
 
+  def persisted_part?(content, part_id) when is_map(content) and is_binary(part_id) do
+    MapSet.member?(persisted_part_ids(content), part_id)
+  end
+
+  def persisted_part?(content, %{"id" => part_id}) when is_map(content) and is_binary(part_id),
+    do: persisted_part?(content, part_id)
+
+  def persisted_part?(_, _), do: false
+
   def rule_scored_part?(content, part_id) when is_map(content) and is_binary(part_id) do
     MapSet.member?(rule_scored_part_ids(content), part_id)
   end
@@ -143,11 +152,25 @@ defmodule Oli.Activities.AdaptiveParts do
   def tracked_part_definitions(_), do: []
 
   def tracked_part_ids(content) do
-    [
-      scorable_part_ids(content),
-      stateful_non_scorable_part_ids(content),
-      rule_scored_part_ids(content)
-    ]
+    [scorable_part_ids(content), rule_scored_part_ids(content)]
+    |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+  end
+
+  def persisted_part_definitions(content) when is_map(content) do
+    merged_parts = merged_parts_by_id(content)
+    persisted_ids = persisted_part_ids(content)
+
+    content
+    |> ordered_part_ids()
+    |> Enum.filter(&MapSet.member?(persisted_ids, &1))
+    |> Enum.map(&Map.get(merged_parts, &1))
+    |> Enum.reject(&is_nil/1)
+  end
+
+  def persisted_part_definitions(_), do: []
+
+  def persisted_part_ids(content) do
+    [tracked_part_ids(content), stateful_non_scorable_part_ids(content)]
     |> Enum.reduce(MapSet.new(), &MapSet.union/2)
   end
 
@@ -230,7 +253,7 @@ defmodule Oli.Activities.AdaptiveParts do
     end
   end
 
-  def tracked_part_grading_approach(content, part) when is_map(content) and is_map(part) do
+  def persisted_part_grading_approach(content, part) when is_map(content) and is_map(part) do
     if rule_scored_part?(content, part) and not scorable_part?(part) do
       :automatic
     else
@@ -238,7 +261,7 @@ defmodule Oli.Activities.AdaptiveParts do
     end
   end
 
-  def tracked_part_grading_approach(_content, part), do: grading_approach(part)
+  def persisted_part_grading_approach(_content, part), do: grading_approach(part)
 
   defp ordered_part_ids(content) when is_map(content) do
     layout_ids =

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -305,7 +305,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
     payload =
       Enum.flat_map(adaptive_rows, fn %{id: activity_attempt_id, revision: revision} ->
         revision.content
-        |> AdaptiveParts.tracked_part_definitions()
+        |> AdaptiveParts.persisted_part_definitions()
         |> Enum.map(fn part ->
           %{
             part_id: Map.get(part, "id"),
@@ -317,7 +317,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
             hints: [],
             attempt_number: 1,
             lifecycle_state: :active,
-            grading_approach: AdaptiveParts.tracked_part_grading_approach(revision.content, part)
+            grading_approach:
+              AdaptiveParts.persisted_part_grading_approach(revision.content, part)
           }
         end)
       end)
@@ -341,7 +342,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
       |> Repo.all()
       |> Enum.reduce(%{}, fn {revision_id, revision}, acc ->
         if AdaptiveParts.adaptive_activity?(revision) do
-          Map.put(acc, revision_id, AdaptiveParts.tracked_part_ids(revision.content))
+          Map.put(acc, revision_id, AdaptiveParts.persisted_part_ids(revision.content))
         else
           acc
         end

--- a/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
+++ b/lib/oli_web/templates/page_delivery/advanced_delivery.html.eex
@@ -35,7 +35,7 @@
 
 <%= if Oli.Utils.LoadTesting.enabled?() do %>
 <!--
-__FINALIZATION_URL__<%= encode_url(Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @resource_attempt_guid)) %>__FINALIZATION_URL__
+__FINALIZATION_URL__<%= encode_url(Routes.page_lifecycle_path(@conn, :transition)) %>__FINALIZATION_URL__
 
 __ACTIVITY_ATTEMPTS__<%= encode_activity_attempts(@activity_type_slug_mapping, @latest_attempts) %>__ACTIVITY_ATTEMPTS__
 -->

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -145,7 +145,7 @@
 
   <%= if Oli.Utils.LoadTesting.enabled?() do %>
     <!--
-__FINALIZATION_URL__<%= encode_url(Routes.page_delivery_path(@conn, :finalize_attempt, @section_slug, @slug, @attempt_guid)) %>__FINALIZATION_URL__
+__FINALIZATION_URL__<%= encode_url(Routes.page_lifecycle_path(@conn, :transition)) %>__FINALIZATION_URL__
 
 __ACTIVITY_ATTEMPTS__<%= encode_activity_attempts(@activity_type_slug_mapping, @latest_attempts) %>__ACTIVITY_ATTEMPTS__
 -->

--- a/test/oli/activities/adaptive_parts_test.exs
+++ b/test/oli/activities/adaptive_parts_test.exs
@@ -26,11 +26,12 @@ defmodule Oli.Activities.AdaptivePartsTest do
     refute AdaptiveParts.scorable_part_type?("janus-text-flow")
   end
 
-  test "tracks explicitly rule-referenced non-native parts without broadening native scorable types" do
+  test "separates analytics-tracked parts from persisted-only stateful parts" do
     content = %{
       "partsLayout" => [
         %{"id" => "janus_mcq-1", "type" => "janus-mcq"},
         %{"id" => "janus_capi_iframe-1", "type" => "janus-capi-iframe"},
+        %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"},
         %{"id" => "janus_formula-1", "type" => "janus-formula"}
       ],
       "authoring" => %{
@@ -41,6 +42,7 @@ defmodule Oli.Activities.AdaptivePartsTest do
             "type" => "janus-capi-iframe",
             "gradingApproach" => "manual"
           },
+          %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"},
           %{"id" => "janus_formula-1", "type" => "janus-formula"}
         ],
         "rules" => [
@@ -67,12 +69,18 @@ defmodule Oli.Activities.AdaptivePartsTest do
     assert AdaptiveParts.tracked_part_ids(content) ==
              MapSet.new(["janus_mcq-1", "janus_capi_iframe-1"])
 
+    assert AdaptiveParts.persisted_part_ids(content) ==
+             MapSet.new(["janus_capi_iframe-1", "janus_mcq-1", "janus_navigation_button-1"])
+
     assert AdaptiveParts.rule_scored_part?(content, "janus_capi_iframe-1")
     assert AdaptiveParts.tracked_part?(content, "janus_capi_iframe-1")
     assert AdaptiveParts.tracked_part?(content, "janus_mcq-1")
+    refute AdaptiveParts.tracked_part?(content, "janus_navigation_button-1")
     refute AdaptiveParts.tracked_part?(content, "janus_formula-1")
 
-    assert AdaptiveParts.tracked_part_grading_approach(content, %{"id" => "janus_capi_iframe-1"}) ==
+    assert AdaptiveParts.persisted_part?(content, "janus_navigation_button-1")
+
+    assert AdaptiveParts.persisted_part_grading_approach(content, %{"id" => "janus_capi_iframe-1"}) ==
              :automatic
   end
 
@@ -98,7 +106,7 @@ defmodule Oli.Activities.AdaptivePartsTest do
       }
     }
 
-    assert AdaptiveParts.tracked_part_grading_approach(
+    assert AdaptiveParts.persisted_part_grading_approach(
              content,
              AdaptiveParts.part_definition(content, "janus_multi_line_text-1")
            ) == :manual

--- a/test/oli/activities/adaptive_parts_test.exs
+++ b/test/oli/activities/adaptive_parts_test.exs
@@ -111,4 +111,22 @@ defmodule Oli.Activities.AdaptivePartsTest do
              AdaptiveParts.part_definition(content, "janus_multi_line_text-1")
            ) == :manual
   end
+
+  test "ignores missing ids when collecting persisted-only stateful parts" do
+    content = %{
+      "partsLayout" => [
+        %{"id" => "janus_mcq-1", "type" => "janus-mcq"},
+        %{"type" => "janus-navigation-button"}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "janus_mcq-1", "type" => "janus-mcq", "gradingApproach" => "automatic"},
+          %{"type" => "janus-navigation-button"}
+        ]
+      }
+    }
+
+    assert AdaptiveParts.persisted_part_ids(content) == MapSet.new(["janus_mcq-1"])
+    refute MapSet.member?(AdaptiveParts.persisted_part_ids(content), nil)
+  end
 end

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -151,7 +151,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
       assert pa3.attempt_guid != pa1.attempt_guid
     end
 
-    test "adaptive attempt creation skips display-only parts" do
+    test "adaptive attempt creation keeps stateful non-scorable parts but skips display-only parts" do
       adaptive_registration = Activities.get_registration_by_slug("oli_adaptive")
 
       adaptive_content = %{
@@ -173,6 +173,36 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
                 %{"nodes" => [%{"text" => "Option 2"}]}
               ]
             }
+          },
+          %{
+            "id" => "janus_navigation_button-1",
+            "type" => "janus-navigation-button",
+            "custom" => %{"title" => "Begin"}
+          },
+          %{
+            "id" => "janus_popup-1",
+            "type" => "janus-popup",
+            "custom" => %{"title" => "Popup"}
+          },
+          %{
+            "id" => "janus_audio-1",
+            "type" => "janus-audio",
+            "custom" => %{"title" => "Audio"}
+          },
+          %{
+            "id" => "janus_video-1",
+            "type" => "janus-video",
+            "custom" => %{"title" => "Video"}
+          },
+          %{
+            "id" => "janus_image_carousel-1",
+            "type" => "janus-image-carousel",
+            "custom" => %{"title" => "Carousel"}
+          },
+          %{
+            "id" => "janus_capi_iframe-1",
+            "type" => "janus-capi-iframe",
+            "custom" => %{"title" => "Simulation"}
           }
         ],
         "authoring" => %{
@@ -182,7 +212,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
               "id" => "janus_mcq-1",
               "type" => "janus-mcq",
               "gradingApproach" => "automatic"
-            }
+            },
+            %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"},
+            %{"id" => "janus_popup-1", "type" => "janus-popup"},
+            %{"id" => "janus_audio-1", "type" => "janus-audio"},
+            %{"id" => "janus_video-1", "type" => "janus-video"},
+            %{"id" => "janus_image_carousel-1", "type" => "janus-image-carousel"},
+            %{"id" => "janus_capi_iframe-1", "type" => "janus-capi-iframe"}
           ]
         }
       }
@@ -251,11 +287,26 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
 
       {_activity_attempt, part_map} = Map.fetch!(attempts, adaptive_activity.resource.id)
 
-      assert Map.keys(part_map) == ["janus_mcq-1"]
+      assert Map.keys(part_map) |> Enum.sort() == [
+               "janus_audio-1",
+               "janus_capi_iframe-1",
+               "janus_image_carousel-1",
+               "janus_mcq-1",
+               "janus_navigation_button-1",
+               "janus_popup-1",
+               "janus_video-1"
+             ]
+
+      assert part_map["janus_audio-1"].grading_approach == :automatic
+      assert part_map["janus_capi_iframe-1"].grading_approach == :automatic
+      assert part_map["janus_image_carousel-1"].grading_approach == :automatic
+      assert part_map["janus_navigation_button-1"].grading_approach == :automatic
+      assert part_map["janus_popup-1"].grading_approach == :automatic
+      assert part_map["janus_video-1"].grading_approach == :automatic
       refute Map.has_key?(part_map, "janus_formula-1")
     end
 
-    test "adaptive attempt creation includes explicitly rule-scored non-native parts only" do
+    test "adaptive attempt creation includes explicitly rule-scored display-only parts only" do
       adaptive_registration = Activities.get_registration_by_slug("oli_adaptive")
 
       adaptive_content = %{


### PR DESCRIPTION
  ## Summary

  Fixes [MER-5586](https://eliterate.atlassian.net/browse/MER-5586) by restoring adaptive part attempts for stateful non-scorable parts.

  Adaptive attempt creation was narrowed in #6041  to only create part attempts for scorable parts and non-scorable parts referenced by scoring rules. That excluded parts like janus-navigation-button, which still use the normal adaptive persistence pipeline. As a result, explorations could fail to start or navigate because the client could not find a partAttemptGuid for those parts.

  This change adds a distinct set of stateful non-scorable adaptive parts that should receive part attempts for persistence, while remaining non-scorable.  It also separates adaptive persisted-part semantics from analytics-tracked semantics, so restoring runtime persistence does not broaden adaptive insights/response-summary behavior.

  This PR also incidentally includes a fix for stale load-testing-only finalize route references in delivery templates that could break local exploration launch when load testing mode is enabled*.

  ## Changes

  - add @stateful_non_scorable_part_types in Oli.Activities.AdaptiveParts
  - include these parts in adaptive tracked part attempt creation:
      - janus-navigation-button
      - janus-popup
      - janus-audio
      - janus-video
      - janus-image-carousel
      - janus-capi-iframe
 - split adaptive part classification into:
      - scorable parts
      - rule-scored parts
      - persisted stateful non-scorable parts
  - keep analytics / response-summary tracking scoped to scorable ∪ rule-scored
  - keep manual grading scoped to scorable parts only
  - update adaptive attempt creation to use persisted-part helpers rather than analytics-tracked helpers
  - expand adaptive parts and hierarchy tests to verify:
      - stateful non-scorable parts get part attempts
      - analytics-tracked adaptive parts do not broaden to include persisted-only stateful parts
      - display-only parts still do not get part attempts
  - replace stale load-testing template references to removed :finalize_attempt page delivery routes with the current page lifecycle transition route

  ## Root Cause

  Before #6041 , adaptive activities got part attempts from revision_parts, so all adaptive parts with authored part ids received attempts. After that change, adaptive activities only created part attempts for:

  - scorable adaptive parts
  - non-scorable parts referenced by scoring-relevant rules

  That excluded stateful UI parts that call onInit, onSave, or onSubmit but are not scored. For Real Chem explorations, the Begin button (janus-navigation-button) fell into that gap, causing missing attemptGuid values, failed /active saves, and broken navigation.
  
  A follow-on issue in the initial fix was that reusing the existing adaptive tracked_part? concept for persistence also broadened analytics semantics, because adaptive response summaries already use tracked_part? as their filter.  Updated version corrects that by introducing a separate persisted-part classification for runtime state compatibility.

  ## Verification
  Verified with focused tests:
  - mix test test/oli/delivery/attempts/hiearchy_test.exs

  ## Notes
  *The load-testing finalization route fix is separate from MER-5586 behavior. It only affects environments where load testing mode is enabled. It was surfacing during local adaptive exploration launch because the load testing config option had been set some time ago by a developer as a convenience because it has the effect of disabling the Captcha. Given changes in the system, there is no longer any URL that can do the job the stale route did during real load testing. The fix is just to prevent a crash when testing adaptive page delivery with this setting.

[MER-5586]: https://eliterate.atlassian.net/browse/MER-5586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ