### PR TITLE
[BUG FIX] [MER-5588] Intelligent Dashboard Confusion Points

### DIFF
--- a/lib/oli/instructor_dashboard/data_snapshot/projections/progress/projector.ex
+++ b/lib/oli/instructor_dashboard/data_snapshot/projections/progress/projector.ex
@@ -13,6 +13,8 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.Projector do
   @spec build(Scope.t(), map(), map(), keyword()) :: map()
   def build(%Scope{} = scope, progress_bins_payload, scope_resources_payload, opts \\ []) do
     items = Map.get(scope_resources_payload, :items, [])
+    by_resource_bins = by_resource_bins(progress_bins_payload)
+    items = align_items_with_bins(items, by_resource_bins)
     total_students = Map.get(progress_bins_payload, :total_students, 0)
 
     %{
@@ -20,7 +22,7 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.Projector do
       class_size: total_students,
       completion_threshold: @default_completion_threshold,
       y_axis_mode: :count,
-      series_all: build_series(items, progress_bins_payload, total_students),
+      series_all: build_series(items, by_resource_bins, total_students),
       schedule_context: schedule_context(Keyword.get(opts, :schedule)),
       page_window: %{page: 1, per_page: @default_per_page, total_items: 0, total_pages: 0},
       schedule_marker: @empty_schedule,
@@ -58,14 +60,7 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.Projector do
     }
   end
 
-  defp build_series(items, progress_bins_payload, total_students) do
-    by_resource_bins =
-      Map.get(
-        progress_bins_payload,
-        :by_resource_bins,
-        Map.get(progress_bins_payload, :by_container_bins, %{})
-      )
-
+  defp build_series(items, by_resource_bins, total_students) do
     Enum.map(items, fn item ->
       %{
         container_id: item.resource_id,
@@ -78,6 +73,19 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.Projector do
         value: 0
       }
     end)
+  end
+
+  defp by_resource_bins(progress_bins_payload) do
+    Map.get(
+      progress_bins_payload,
+      :by_resource_bins,
+      Map.get(progress_bins_payload, :by_container_bins, %{})
+    )
+  end
+
+  defp align_items_with_bins(items, by_resource_bins) do
+    aligned_items = Enum.filter(items, &Map.has_key?(by_resource_bins, &1.resource_id))
+    if aligned_items == [], do: items, else: aligned_items
   end
 
   defp resource_type(resource_type_id) when resource_type_id == @page_type_id, do: :page

--- a/lib/oli/instructor_dashboard/data_snapshot/projections/progress/projector.ex
+++ b/lib/oli/instructor_dashboard/data_snapshot/projections/progress/projector.ex
@@ -83,6 +83,9 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.Projector do
     )
   end
 
+  defp align_items_with_bins(items, by_resource_bins) when map_size(by_resource_bins) == 0,
+    do: items
+
   defp align_items_with_bins(items, by_resource_bins) do
     aligned_items = Enum.filter(items, &Map.has_key?(by_resource_bins, &1.resource_id))
     if aligned_items == [], do: items, else: aligned_items

--- a/test/oli/instructor_dashboard/data_snapshot/projections/progress/projector_test.exs
+++ b/test/oli/instructor_dashboard/data_snapshot/projections/progress/projector_test.exs
@@ -123,5 +123,45 @@ defmodule Oli.InstructorDashboard.DataSnapshot.Projections.Progress.ProjectorTes
       assert projection.schedule_marker.container_id == 202
       assert projection.schedule_marker.visible? == true
     end
+
+    test "keeps only items that have matching progress bins to avoid deep-descendant leakage" do
+      {:ok, scope} = Scope.new(%{container_type: :course})
+
+      progress_bins_payload = %{
+        total_students: 10,
+        by_resource_bins: %{
+          101 => %{100 => 6},
+          202 => %{100 => 2}
+        }
+      }
+
+      scope_resources_payload = %{
+        items: [
+          %{
+            resource_id: 101,
+            resource_type_id: ResourceType.id_for_container(),
+            title: "Unit 1"
+          },
+          %{
+            resource_id: 202,
+            resource_type_id: ResourceType.id_for_container(),
+            title: "Unit 2"
+          },
+          %{
+            resource_id: 303,
+            resource_type_id: ResourceType.id_for_page(),
+            title: "Nested page that should not be on the axis"
+          }
+        ]
+      }
+
+      base_projection = Projector.build(scope, progress_bins_payload, scope_resources_payload)
+
+      projection = Projector.reproject(base_projection, %{completion_threshold: 100, page: 1})
+
+      assert projection.axis_label == "Course Units"
+      assert Enum.map(projection.series_all, & &1.container_id) == [101, 202]
+      assert Enum.map(projection.series_all, & &1.label) == ["Unit 1", "Unit 2"]
+    end
   end
 end


### PR DESCRIPTION
[MER-5588](https://eliterate.atlassian.net/browse/MER-5588)

## Context

In the Intelligent Dashboard, the Progress tile for the Entire course scope is built by combining scope_resources with progress bins to define the x-axis and bar values. scope_resources is also consumed by other dashboard projections.

## Problem

scope_resources may include descendants that are deeper than the level expected on the progress chart axis, while progress bins are computed for the effective axis of that view. This mismatch caused the tile to include items without matching bins, which were rendered as zero and made the Entire course view confusing (content shown with no data in the chart).

## Fix

The Progress projection was updated to align axis items with the resource_ids present in by_resource_bins, while preserving the original scope_resources order.
The change was implemented in the shared projection layer (progress/projector) rather than in tile presentation, so progress logic remains centralized in one source of truth.

[MER-5588]: https://eliterate.atlassian.net/browse/MER-5588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ