### PR TITLE
[BUG FIX] [MER-5587] Hide simple-author adaptive fields from advanced author component panels

### DIFF
--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -5,10 +5,6 @@ import { JSONSchema7 } from 'json-schema';
 import { isEqual } from 'lodash';
 import { updatePart } from 'apps/authoring/store/parts/actions/updatePart';
 import { useToggle } from '../../../../components/hooks/useToggle';
-import {
-  isDefaultNumericCorrectAnswer,
-  requiresNumericCorrectAnswer,
-} from '../../../../components/parts/numericCorrectnessDefaults';
 import { PartAuthoringMode } from '../../../../components/parts/partsApi';
 import { clone } from '../../../../utils/common';
 import { IActivity } from '../../../delivery/store/features/activities/slice';
@@ -254,37 +250,14 @@ const getExpertComponentUISchema = (instance: any, responsiveLayout: boolean) =>
   return baseUiSchema; // default ui schema  for components that don't specify.
 };
 
-const mergeAdaptiveExpertSchema = (expertSchema: any, simpleSchema: any) => {
-  if (!simpleSchema) return expertSchema;
-
-  const expertProperties = schemaPropertyMap(expertSchema);
-  const simpleProperties = schemaPropertyMap(simpleSchema);
-
-  const mergedProperties = { ...simpleProperties, ...expertProperties };
-
-  const merged: any = { ...mergedProperties };
-
-  const mergedDefinitions = {
-    ...(simpleSchema?.definitions || {}),
-    ...(expertSchema?.definitions || {}),
-  };
-
-  if (Object.keys(mergedDefinitions).length > 0) {
-    merged.definitions = mergedDefinitions;
-  }
-
-  const allOf = [...(simpleSchema?.allOf || []), ...(expertSchema?.allOf || [])];
-  if (allOf.length > 0) {
-    merged.allOf = allOf;
-  }
-
-  return merged;
+export const mergeAdaptiveExpertSchema = (expertSchema: any, _simpleSchema: any) => {
+  if (!expertSchema) return {};
+  return expertSchema;
 };
 
-const mergeAdaptiveExpertUiSchema = (expertUiSchema: any, simpleUiSchema: any) => {
-  if (!simpleUiSchema) return expertUiSchema;
+export const mergeAdaptiveExpertUiSchema = (expertUiSchema: any, _simpleUiSchema: any) => {
+  if (!expertUiSchema) return {};
   const merged = {
-    ...simpleUiSchema,
     ...expertUiSchema,
   };
 
@@ -332,14 +305,6 @@ export const PartPropertyEditor: React.FC<Props> = ({
     () => findPartByIdInActivity(currentActivity, currentPartSelection),
     [currentActivity, currentPartSelection],
   );
-
-  const numericCorrectAnswerNeedsReview = useMemo(() => {
-    if (!selectedPartDef || !requiresNumericCorrectAnswer(selectedPartDef.type)) {
-      return false;
-    }
-
-    return isDefaultNumericCorrectAnswer(selectedPartDef.custom?.answer, selectedPartDef.custom);
-  }, [selectedPartDef]);
 
   const currentComponentData = useMemo(
     () => getComponentData(currentPartInstance, partDef),
@@ -493,12 +458,6 @@ export const PartPropertyEditor: React.FC<Props> = ({
           >
             <i className="fa-solid fa-circle-info"></i> How to Use This Component{' '}
           </a>
-        </Alert>
-      )}
-      {numericCorrectAnswerNeedsReview && (
-        <Alert variant="warning" className="part-documentation">
-          This numeric adaptive input was added with a default correct answer. Review the scoring
-          settings before publishing if the default value is not the intended answer.
         </Alert>
       )}
       {selectedPartDef && partEditMode === 'expert' && (

--- a/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
+++ b/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
@@ -1,0 +1,54 @@
+import {
+  mergeAdaptiveExpertSchema,
+  mergeAdaptiveExpertUiSchema,
+} from 'apps/authoring/components/RightMenu/PartPropertyEditor';
+import {
+  schema as mcqExpertSchema,
+  simpleSchema as mcqSimpleSchema,
+  simpleUiSchema as mcqSimpleUiSchema,
+  uiSchema as mcqExpertUiSchema,
+} from 'components/parts/janus-mcq/schema';
+import {
+  schema as textInputExpertSchema,
+  simpleSchema as textInputSimpleSchema,
+} from 'components/parts/janus-input-text/schema';
+
+describe('advanced author adaptive component schemas', () => {
+  it('does not inherit simple-author correctness and feedback fields for MCQ expert mode', () => {
+    const merged = mergeAdaptiveExpertSchema(mcqExpertSchema, mcqSimpleSchema);
+
+    expect(merged).not.toHaveProperty('correctAnswer');
+    expect(merged).not.toHaveProperty('correctFeedback');
+    expect(merged).not.toHaveProperty('incorrectFeedback');
+    expect(merged).not.toHaveProperty('commonErrorFeedback');
+    expect(merged).not.toHaveProperty('anyCorrectAnswer');
+    expect(merged).not.toHaveProperty('mcqItems');
+
+    expect(merged).toHaveProperty('layoutType');
+    expect(merged).toHaveProperty('multipleSelection');
+    expect(merged).toHaveProperty('randomize');
+  });
+
+  it('does not inherit simple-author correctness fields for text input expert mode', () => {
+    const merged = mergeAdaptiveExpertSchema(textInputExpertSchema, textInputSimpleSchema);
+
+    expect(merged).not.toHaveProperty('correctAnswer');
+    expect(merged).not.toHaveProperty('correctFeedback');
+    expect(merged).not.toHaveProperty('incorrectFeedback');
+
+    expect(merged).toHaveProperty('label');
+    expect(merged).toHaveProperty('prompt');
+    expect(merged).toHaveProperty('enabled');
+  });
+
+  it('does not inherit simple-author UI controls for MCQ expert mode', () => {
+    const merged = mergeAdaptiveExpertUiSchema(mcqExpertUiSchema, mcqSimpleUiSchema);
+
+    expect(merged).not.toHaveProperty('correctAnswer');
+    expect(merged).not.toHaveProperty('correctFeedback');
+    expect(merged).not.toHaveProperty('incorrectFeedback');
+    expect(merged).not.toHaveProperty('commonErrorFeedback');
+    expect(merged).not.toHaveProperty('mcqItems');
+    expect(merged).not.toHaveProperty('ui:order');
+  });
+});

--- a/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
+++ b/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
@@ -1,17 +1,17 @@
 import {
-  mergeAdaptiveExpertSchema,
-  mergeAdaptiveExpertUiSchema,
-} from 'apps/authoring/components/RightMenu/PartPropertyEditor';
-import {
-  schema as mcqExpertSchema,
-  simpleSchema as mcqSimpleSchema,
-  simpleUiSchema as mcqSimpleUiSchema,
-  uiSchema as mcqExpertUiSchema,
-} from 'components/parts/janus-mcq/schema';
-import {
   schema as textInputExpertSchema,
   simpleSchema as textInputSimpleSchema,
 } from 'components/parts/janus-input-text/schema';
+import {
+  schema as mcqExpertSchema,
+  uiSchema as mcqExpertUiSchema,
+  simpleSchema as mcqSimpleSchema,
+  simpleUiSchema as mcqSimpleUiSchema,
+} from 'components/parts/janus-mcq/schema';
+import {
+  mergeAdaptiveExpertSchema,
+  mergeAdaptiveExpertUiSchema,
+} from 'apps/authoring/components/RightMenu/PartPropertyEditor';
 
 describe('advanced author adaptive component schemas', () => {
   it('does not inherit simple-author correctness and feedback fields for MCQ expert mode', () => {


### PR DESCRIPTION
 ## Summary

  This PR fixes a regression where adaptive components in **Advanced Author** were showing **Simple Author** correctness and feedback controls in the component property panel.

  Advanced Author should rely on **adaptivity rules** for correctness, incorrectness, and feedback behavior. Those simple-author panel fields should not appear there.

  ## Problem

  For adaptive scorable components in Advanced Author, the right-side component panel was inheriting simple-author schema/UI fields such as:

  - `Correct Answer`
  - `Correct Feedback`
  - `Incorrect Feedback`
  - `Advanced Feedback`
  - `Any answer is correct`

  This affected components including:

  - Multiple choice
  - Text input
  - Dropdown
  - Fill in the blanks
  - Number input
  - Multiline text input
  - Slider (numeric)
  - Slider (text)

  That UI was misleading in Advanced Author because those fields are not the source of truth there; adaptivity rules are.

  ## What Changed

  ### Advanced Author schema/UI separation

  Updated the advanced-author property panel path so expert mode no longer merges simple-author adaptive fields into expert schemas and UI schemas.

  Changes in:
  - `assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx`

  Behavior now is:

  - **Simple Author** continues to use simple schemas/UI
  - **Advanced Author** uses only expert schemas/UI for adaptive components
  - simple-author correctness/feedback controls are no longer displayed in advanced-author component panels

  ### Numeric warning removal

  Removed the warning banner shown for numeric adaptive inputs and numeric sliders in the advanced author component panel.

  That warning was:

  > This numeric adaptive input was added with a default correct answer...

  Since those simple-author scoring affordances are no longer part of the advanced-author panel, the warning no longer belongs there.