### PR TITLE
[BUG FIX] [MER-5266] adjust position/style of download CSV button

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
@@ -27,7 +27,32 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
 
     ~H"""
     <div id="learning-dashboard" class="container mx-auto mb-10" phx-hook="Scroller">
-      <div class="mb-4">
+      <div class="-mt-9 mb-4 space-y-1.5">
+        <div class="flex justify-end">
+          <form
+            id="intelligent-dashboard-download-form"
+            phx-hook="BrowserTimezoneForm"
+            action={
+              ~p"/sections/#{@section.slug}/instructor_dashboard/downloads/intelligent_dashboard"
+            }
+            method="get"
+          >
+            <%= for {name, value} <- download_form_inputs(@params, @dashboard_scope, @browser_timezone) do %>
+              <input type="hidden" name={name} value={value} />
+            <% end %>
+            <button
+              type="submit"
+              class="inline-flex items-center gap-1.5 text-xs font-medium text-Text-text-button transition hover:text-Text-text-button hover:underline focus:outline-none focus:underline"
+              phx-disable-with="Preparing ZIP..."
+            >
+              <span class="inline-flex items-center justify-center text-current [&_svg]:h-4 [&_svg]:w-4">
+                <OliWeb.Icons.download stroke_class="stroke-current" />
+              </span>
+              <span>Download dashboard data (CSV)</span>
+            </button>
+          </form>
+        </div>
+
         <div class="flex flex-col items-center gap-3">
           <.live_component
             id="learning_dashboard_scope_navigator"
@@ -45,29 +70,6 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
       </div>
 
       <div id="learning-dashboard-shell" class="space-y-6">
-        <div class="flex justify-end">
-          <form
-            id="intelligent-dashboard-download-form"
-            phx-hook="BrowserTimezoneForm"
-            action={
-              ~p"/sections/#{@section.slug}/instructor_dashboard/downloads/intelligent_dashboard"
-            }
-            method="get"
-          >
-            <%= for {name, value} <- download_form_inputs(@params, @dashboard_scope, @browser_timezone) do %>
-              <input type="hidden" name={name} value={value} />
-            <% end %>
-            <button
-              type="submit"
-              class="inline-flex items-center gap-2 rounded-md border border-[#006CD9] px-4 py-2 text-sm font-medium text-[#006CD9] transition hover:bg-[#EAF4FF]"
-              phx-disable-with="Preparing ZIP..."
-            >
-              <span>Download dashboard data (CSV)</span>
-              <OliWeb.Icons.download />
-            </button>
-          </form>
-        </div>
-
         <.live_component
           id="learning_dashboard_summary_tile"
           module={SummaryTile}

--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
             <% end %>
             <button
               type="submit"
-              class="inline-flex items-center gap-1.5 text-xs font-medium text-Text-text-button transition hover:text-Text-text-button hover:underline focus:outline-none focus:underline"
+              class="inline-flex items-center gap-1.5 text-xs font-bold text-Text-text-button transition hover:text-Text-text-button hover:underline focus:outline-none focus:underline"
               phx-disable-with="Preparing ZIP..."
             >
               <span class="inline-flex items-center justify-center text-current [&_svg]:h-4 [&_svg]:w-4">

--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell.ex
@@ -27,7 +27,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
 
     ~H"""
     <div id="learning-dashboard" class="container mx-auto mb-10" phx-hook="Scroller">
-      <div class="-mt-9 mb-4 space-y-1.5">
+      <div class="-mt-10 mb-4 space-y-1.5">
         <div class="flex justify-end">
           <form
             id="intelligent-dashboard-download-form"

--- a/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell_test.exs
+++ b/test/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/shell_test.exs
@@ -41,6 +41,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Sh
 
     assert html =~ ~s(id="learning-dashboard-summary-tile")
     assert html =~ ~s(id="learning-dashboard-sections")
+    assert html =~ ~s(id="intelligent-dashboard-download-form")
     assert String.contains?(html, "Average Student Progress")
     assert String.contains?(html, "Students have not started yet.")
 

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -2433,6 +2433,65 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert has_element?(view, "button", "October 10, 2023")
     end
 
+    test "available date edits stay scoped to the current section",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      exception = set_student_exception(section, page_1.resource, student_1)
+      other_section = insert(:section)
+
+      other_exception =
+        set_student_exception(other_section, page_1.resource, student_1, %{
+          start_date: ~U[2023-09-01 16:00:00Z]
+        })
+
+      other_exception_id = other_exception.id
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_available_date_modal")
+      |> render_click("open", %{})
+
+      new_date = ~U[2023-10-10 16:00:00Z]
+
+      view
+      |> element("#student-available-date-form")
+      |> render_submit(%{start_date: new_date})
+
+      assert %Oli.Delivery.Settings.StudentException{start_date: ^new_date} =
+               Delivery.get_delivery_setting_by(%{
+                 section_id: section.id,
+                 resource_id: page_1.resource.id,
+                 user_id: student_1.id
+               })
+
+      assert %Oli.Delivery.Settings.StudentException{
+               id: ^other_exception_id,
+               start_date: ~U[2023-09-01 16:00:00Z]
+             } =
+               Delivery.get_delivery_setting_by(%{
+                 section_id: other_section.id,
+                 resource_id: page_1.resource.id,
+                 user_id: student_1.id
+               })
+    end
+
     test "preserves distance when setting available date after due date",
          %{
            conn: conn,


### PR DESCRIPTION
Adjusts the Intelligent Dashboard  "Download Dashboard Data (CSV)" button to match the MER-5266 Figma design more closely.

  The download action is now presented as a text link with a leading download icon, uses the same tokenized blue treatment as nearby dashboard navigation controls, and sits above the scope navigator with tighter vertical alignment to the Insights tab row.

<img width="1056" height="636" alt="Screenshot 2026-04-29 at 6 04 00 AM" src="https://github.com/user-attachments/assets/8590d83d-0e4f-43b6-8716-317eb6b7e253" />

