### PR TITLE
[BUG FIX] [MER-5559] Scope student exception date edits to current section

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex
@@ -472,10 +472,22 @@ defmodule OliWeb.Sections.AssessmentSettings.StudentExceptionsTable do
   end
 
   def handle_event("edit_date", %{"user_id" => user_id}, socket) do
+    user_id = String.to_integer(user_id)
+
     selected_setting =
       Enum.find(socket.assigns.table_model.rows, fn s ->
-        s.user_id == String.to_integer(user_id)
+        s.user_id == user_id
       end)
+      |> case do
+        nil ->
+          nil
+
+        %{resource_id: resource_id} ->
+          case Settings.get_student_exception(resource_id, socket.assigns.section.id, user_id) do
+            nil -> nil
+            selected_setting -> Repo.preload(selected_setting, :user)
+          end
+      end
 
     {:noreply, assign(socket, selected_setting: selected_setting)}
   end

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -1703,6 +1703,62 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
       assert has_element?(view, "button", "October 10, 2023")
     end
 
+    test "due date edit is scoped to the current section",
+         %{
+           conn: conn,
+           section: section,
+           page_1: page_1,
+           student_1: student_1
+         } do
+      other_section = insert(:section)
+
+      set_student_exception(other_section, page_1.resource, student_1, %{
+        end_date: ~U[2023-10-01 16:00:00Z]
+      })
+
+      exception = set_student_exception(section, page_1.resource, student_1)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_overview_route(
+            section.slug,
+            "student_exceptions",
+            page_1.resource.id
+          )
+        )
+
+      view
+      |> with_target("#student_exceptions_table")
+      |> render_click("edit_date", %{user_id: "#{exception.user_id}"})
+
+      view
+      |> with_target("#student_due_date_modal")
+      |> render_click("open", %{})
+
+      new_date = ~U[2023-10-10 16:00:00Z]
+
+      view
+      |> element("#student-due-date-form")
+      |> render_submit(%{end_date: new_date})
+
+      assert has_element?(view, "button", "October 10, 2023")
+
+      assert %Delivery.Settings.StudentException{end_date: ^new_date} =
+               Delivery.get_delivery_setting_by(%{
+                 section_id: section.id,
+                 resource_id: page_1.resource.id,
+                 user_id: student_1.id
+               })
+
+      assert %Delivery.Settings.StudentException{end_date: ~U[2023-10-01 16:00:00Z]} =
+               Delivery.get_delivery_setting_by(%{
+                 section_id: other_section.id,
+                 resource_id: page_1.resource.id,
+                 user_id: student_1.id
+               })
+    end
+
     test "preserves distance when setting due date before available date",
          %{
            conn: conn,


### PR DESCRIPTION


Changes:
- Updated `lib/oli_web/live/sections/assessment_settings/student_exceptions_table.ex` so date editing reloads the selected exception by section_id, resource_id, and user_id.
- Added a regression test in `test/oli_web/live/sections/assessment_settings/settings_live_test.exs` covering same student/resource exceptions across two sections and verifying only the current section updates.
