### PR TITLE
[BUG FIX] [MER-5594] Add gating and assessment settings to template view

### DIFF
--- a/lib/oli_web/common/breadcrumb.ex
+++ b/lib/oli_web/common/breadcrumb.ex
@@ -254,6 +254,15 @@ defmodule OliWeb.Common.Breadcrumb do
   def product_overview_link(section, _, _project),
     do: ~p"/authoring/products/#{section.slug}"
 
+  @doc """
+  Returns the route-aware base URL for product/template pages.
+  """
+  def product_path_base(section, :workspaces, %Project{slug: project_slug}),
+    do: ~p"/workspaces/course_author/#{project_slug}/products/#{section.slug}"
+
+  def product_path_base(section, _, _project),
+    do: ~p"/authoring/products/#{section.slug}"
+
   def project_breadcrumb(project) do
     [
       Breadcrumb.new(%{

--- a/lib/oli_web/components/delivery/schedule_gating_assessement.ex
+++ b/lib/oli_web/components/delivery/schedule_gating_assessement.ex
@@ -45,8 +45,7 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessment do
     [
       {"Schedule", "schedule", "#{product_path_base}/schedule"},
       {"Assessment Settings", "assessment_settings",
-       "#{product_path_base}/assessment_settings/settings/all"},
-      {"Advanced Gating", "advanced_gating", "#{product_path_base}/gating_and_scheduling"}
+       "#{product_path_base}/assessment_settings/settings/all"}
     ]
   end
 

--- a/lib/oli_web/components/delivery/schedule_gating_assessement.ex
+++ b/lib/oli_web/components/delivery/schedule_gating_assessement.ex
@@ -3,11 +3,13 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessment do
 
   attr :section_slug, :string
   attr :uri, :string
+  attr :product_path_base, :string, default: nil
 
   def tabs(assigns) do
     assigns =
       assign(assigns,
-        active_tab: determine_tab(assigns[:uri])
+        active_tab: determine_tab(assigns[:uri]),
+        tabs: tabs_for(assigns)
       )
 
     ~H"""
@@ -19,12 +21,7 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessment do
             id="tabs-tab"
             role="tablist"
           >
-            <%= for {label, name, path} <- [
-              {"Schedule", "schedule", ~p"/sections/#{@section_slug}/schedule"},
-              {"Assessment Settings", "assessment_settings", ~p"/sections/#{@section_slug}/assessment_settings/settings/all"},
-              {"Student Exceptions", "student_exceptions", ~p"/sections/#{@section_slug}/assessment_settings/student_exceptions/all"},
-              {"Advanced Gating", "advanced_gating", ~p"/sections/#{@section_slug}/gating_and_scheduling"}
-              ] do %>
+            <%= for {label, name, path} <- @tabs do %>
               <li>
                 <%= if name == "schedule" do %>
                   <.link href={path} class={tab_class(@active_tab, name)}>
@@ -43,6 +40,29 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessment do
     </div>
     """
   end
+
+  defp tabs_for(%{product_path_base: product_path_base}) when is_binary(product_path_base) do
+    [
+      {"Schedule", "schedule", "#{product_path_base}/schedule"},
+      {"Assessment Settings", "assessment_settings",
+       "#{product_path_base}/assessment_settings/settings/all"}
+    ]
+  end
+
+  defp tabs_for(assigns) do
+    section_slug = assigns[:section_slug]
+
+    [
+      {"Schedule", "schedule", ~p"/sections/#{section_slug}/schedule"},
+      {"Assessment Settings", "assessment_settings",
+       ~p"/sections/#{section_slug}/assessment_settings/settings/all"},
+      {"Student Exceptions", "student_exceptions",
+       ~p"/sections/#{section_slug}/assessment_settings/student_exceptions/all"},
+      {"Advanced Gating", "advanced_gating", ~p"/sections/#{section_slug}/gating_and_scheduling"}
+    ]
+  end
+
+  defp determine_tab(nil), do: "schedule"
 
   defp determine_tab(uri) do
     cond do

--- a/lib/oli_web/components/delivery/schedule_gating_assessement.ex
+++ b/lib/oli_web/components/delivery/schedule_gating_assessement.ex
@@ -45,7 +45,8 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessment do
     [
       {"Schedule", "schedule", "#{product_path_base}/schedule"},
       {"Assessment Settings", "assessment_settings",
-       "#{product_path_base}/assessment_settings/settings/all"}
+       "#{product_path_base}/assessment_settings/settings/all"},
+      {"Advanced Gating", "advanced_gating", "#{product_path_base}/gating_and_scheduling"}
     ]
   end
 

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -2,11 +2,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   use OliWeb, :live_view
   use OliWeb.Common.Modal
 
+  alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings.AssessmentSettings
   alias OliWeb.Common.Breadcrumb
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Sections.Mount
+
+  on_mount OliWeb.LiveSessionPlugs.SetRouteName
 
   @impl true
   def mount(%{"section_slug" => section_slug} = _params, _session, socket) do
@@ -38,6 +41,19 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
     end
   end
 
+  defp set_breadcrumbs(_type, %{type: :blueprint} = section) do
+    [
+      Breadcrumb.new(%{
+        full_title: "Template Overview",
+        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.slug)
+      }),
+      Breadcrumb.new(%{
+        full_title: "Assessment Settings",
+        link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug, "all")
+      })
+    ]
+  end
+
   defp set_breadcrumbs(type, section) do
     OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
     |> breadcrumb(section)
@@ -54,8 +70,15 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_params(params, _, socket) do
-    socket = assign(socket, params: params, update_sort_order: true)
+  def handle_params(params, url, socket) do
+    socket =
+      assign(socket,
+        params: params,
+        uri: URI.parse(url).path,
+        update_sort_order: true,
+        product_path_base: product_path_base(socket.assigns.section, socket)
+      )
+
     {:noreply, socket}
   end
 
@@ -63,6 +86,12 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   def render(assigns) do
     ~H"""
     <div class="container mx-auto">
+      <OliWeb.Components.Delivery.ScheduleGatingAssessment.tabs
+        :if={@section.type == :blueprint}
+        section_slug={@section.slug}
+        uri={@uri}
+        product_path_base={@product_path_base}
+      />
       <div class="mb-5">
         <.live_component
           id="assessment_settings_table"
@@ -112,4 +141,17 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
        update_sort_order: update_sort_order
      )}
   end
+
+  defp product_path_base(
+         %{type: :blueprint, slug: section_slug},
+         %{assigns: %{route_name: :workspaces}} = socket
+       ) do
+    %Project{slug: project_slug} = socket.assigns.project
+    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+  end
+
+  defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),
+    do: ~p"/authoring/products/#{section_slug}"
+
+  defp product_path_base(_, _), do: nil
 end

--- a/lib/oli_web/live/sections/assessment_settings/settings_live.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_live.ex
@@ -2,7 +2,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   use OliWeb, :live_view
   use OliWeb.Common.Modal
 
-  alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Settings.AssessmentSettings
   alias OliWeb.Common.Breadcrumb
@@ -36,25 +35,29 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
              |> Enum.reject(fn s -> s.user_role_id != 4 end)
              |> Enum.sort(),
            assessments: AssessmentSettings.get_assessments(section, student_exceptions),
-           breadcrumbs: set_breadcrumbs(user_type, section)
+           user_type: user_type
          )}
     end
   end
 
-  defp set_breadcrumbs(_type, %{type: :blueprint} = section) do
+  defp set_breadcrumbs(_type, %{type: :blueprint} = section, socket) do
+    route_name = socket.assigns[:route_name]
+    project = socket.assigns[:project]
+    product_path_base = product_path_base(section, socket)
+
     [
       Breadcrumb.new(%{
         full_title: "Template Overview",
-        link: Routes.live_path(OliWeb.Endpoint, OliWeb.Products.DetailsView, section.slug)
+        link: Breadcrumb.product_overview_link(section, route_name, project)
       }),
       Breadcrumb.new(%{
         full_title: "Assessment Settings",
-        link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug, "all")
+        link: "#{product_path_base}/assessment_settings/settings/all"
       })
     ]
   end
 
-  defp set_breadcrumbs(type, section) do
+  defp set_breadcrumbs(type, section, _socket) do
     OliWeb.Sections.OverviewView.set_breadcrumbs(type, section)
     |> breadcrumb(section)
   end
@@ -76,7 +79,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
         params: params,
         uri: URI.parse(url).path,
         update_sort_order: true,
-        product_path_base: product_path_base(socket.assigns.section, socket)
+        product_path_base: product_path_base(socket.assigns.section, socket),
+        breadcrumbs: set_breadcrumbs(socket.assigns.user_type, socket.assigns.section, socket)
       )
 
     {:noreply, socket}
@@ -102,6 +106,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
           user={@user}
           ctx={@ctx}
           update_sort_order={@update_sort_order}
+          product_path_base={@product_path_base}
         />
       </div>
     </div>
@@ -143,11 +148,10 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLive do
   end
 
   defp product_path_base(
-         %{type: :blueprint, slug: section_slug},
+         %{type: :blueprint} = section,
          %{assigns: %{route_name: :workspaces}} = socket
        ) do
-    %Project{slug: project_slug} = socket.assigns.project
-    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+    Breadcrumb.product_path_base(section, :workspaces, socket.assigns.project)
   end
 
   defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -54,7 +54,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
         assigns.ctx,
         JS.push("edit_date", target: socket.assigns.myself),
         JS.push("edit_password", target: socket.assigns.myself),
-        JS.push("no_edit_password", target: socket.assigns.myself)
+        JS.push("no_edit_password", target: socket.assigns.myself),
+        nil,
+        include_student_exceptions?: assigns.section.type != :blueprint
       )
 
     table_model =
@@ -590,7 +592,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
         JS.push("edit_date", target: socket.assigns.myself),
         JS.push("edit_password", target: socket.assigns.myself),
         JS.push("no_edit_password", target: socket.assigns.myself),
-        edit_password_id
+        edit_password_id,
+        include_student_exceptions?: socket.assigns.section.type != :blueprint
       )
 
     {:noreply,

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -81,7 +81,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
        form_id: UUID.uuid4(),
        bulk_apply_selected_assessment_id:
          get_valid_assessment_id(assigns.assessments, params.bulk_apply_selected_assessment_id),
-       selected_assessment: nil
+       selected_assessment: nil,
+       product_path_base: assigns[:product_path_base]
      )}
   end
 
@@ -90,6 +91,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
   attr(:section, :map, required: true)
   attr(:ctx, :map, required: true)
   attr(:update_sort_order, :boolean, required: true)
+  attr(:product_path_base, :string, default: nil)
 
   attr(:flash, :map)
   attr(:table_model, :map)
@@ -434,11 +436,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     {:noreply,
      push_patch(socket,
        to:
-         Routes.live_path(
+         settings_path(
            socket,
-           OliWeb.Sections.AssessmentSettings.SettingsLive,
-           socket.assigns.section.slug,
-           :all,
            update_params(socket.assigns.params, %{
              bulk_apply_selected_assessment_id: String.to_integer(assessment_id)
            })
@@ -454,11 +453,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     {:noreply,
      push_patch(socket,
        to:
-         Routes.live_path(
+         settings_path(
            socket,
-           OliWeb.Sections.AssessmentSettings.SettingsLive,
-           socket.assigns.section.slug,
-           :all,
            update_params(socket.assigns.params, %{
              text_search: assessment_name,
              offset: 0,
@@ -522,11 +518,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     {:noreply,
      redirect(socket,
        to:
-         Routes.live_path(
+         settings_path(
            socket,
-           OliWeb.Sections.AssessmentSettings.SettingsLive,
-           socket.assigns.section.slug,
-           :all,
            update_params(socket.assigns.params, %{
              bulk_apply_selected_assessment_id: socket.assigns.bulk_apply_selected_assessment_id
            })
@@ -542,11 +535,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     {:noreply,
      push_patch(socket,
        to:
-         Routes.live_path(
+         settings_path(
            socket,
-           OliWeb.Sections.AssessmentSettings.SettingsLive,
-           socket.assigns.section.slug,
-           :all,
            update_params(socket.assigns.params, %{
              limit: limit,
              offset: offset,
@@ -564,11 +554,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
     {:noreply,
      push_patch(socket,
        to:
-         Routes.live_path(
+         settings_path(
            socket,
-           OliWeb.Sections.AssessmentSettings.SettingsLive,
-           socket.assigns.section.slug,
-           :all,
            update_params(socket.assigns.params, %{
              sort_by: String.to_existing_atom(sort_by),
              bulk_apply_selected_assessment_id: socket.assigns.bulk_apply_selected_assessment_id
@@ -939,6 +926,29 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           @default_params.bulk_apply_selected_assessment_id
         )
     }
+  end
+
+  defp settings_path(%{assigns: %{product_path_base: product_path_base}}, params)
+       when is_binary(product_path_base) do
+    query =
+      params
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> URI.encode_query()
+
+    case query do
+      "" -> "#{product_path_base}/assessment_settings/settings/all"
+      query -> "#{product_path_base}/assessment_settings/settings/all?#{query}"
+    end
+  end
+
+  defp settings_path(socket, params) do
+    Routes.live_path(
+      socket,
+      OliWeb.Sections.AssessmentSettings.SettingsLive,
+      socket.assigns.section.slug,
+      :all,
+      params
+    )
   end
 
   defp apply_filters(assessments, params) do

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -14,7 +14,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         on_edit_date,
         on_edit_password,
         on_no_edit_password,
-        edit_password_id \\ nil
+        edit_password_id \\ nil,
+        opts \\ []
       ) do
     column_specs = [
       %ColumnSpec{
@@ -145,6 +146,11 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         th_class: "whitespace-nowrap"
       }
     ]
+
+    column_specs =
+      if Keyword.get(opts, :include_student_exceptions?, true),
+        do: column_specs,
+        else: Enum.reject(column_specs, &(&1.name == :exceptions_count))
 
     SortableTableModel.new(
       rows: assessments,

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -9,10 +9,13 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Sections.Mount
   alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
+  alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Gating
   alias Oli.Delivery.Sections.Section
   alias OliWeb.Delivery.Sections.GatingAndScheduling.TableModel
   alias Oli.Delivery.Gating.GatingCondition
+
+  on_mount OliWeb.LiveSessionPlugs.SetRouteName
 
   @default_params %{sort_by: "numbering_index", limit: 25}
 
@@ -144,7 +147,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
     end
   end
 
-  def handle_params(params, _, socket) do
+  def handle_params(params, url, socket) do
     table_model =
       SortableTableModel.update_from_params(
         socket.assigns.table_model,
@@ -172,6 +175,8 @@ defmodule OliWeb.Sections.GatingAndScheduling do
      assign(socket,
        offset: offset,
        limit: limit,
+       uri: URI.parse(url).path,
+       product_path_base: product_path_base(socket.assigns.section, socket),
        table_model: table_model,
        total_count: total_count,
        text_search: text_search
@@ -181,6 +186,12 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   def render(assigns) do
     ~H"""
     <div class="container flex flex-col">
+      <OliWeb.Components.Delivery.ScheduleGatingAssessment.tabs
+        :if={@section.type == :blueprint}
+        section_slug={@section.slug}
+        uri={@uri}
+        product_path_base={@product_path_base}
+      />
       <div class="d-flex mb-3">
         <TextSearch.render id="text-search" />
         <div class="flex-grow-1"></div>
@@ -233,11 +244,15 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   defp link_new(assigns) do
     case assigns.parent_gate do
       nil ->
-        Routes.live_path(
-          OliWeb.Endpoint,
-          OliWeb.Sections.GatingAndScheduling.New,
-          assigns.section.slug
-        )
+        if assigns.product_path_base do
+          "#{assigns.product_path_base}/gating_and_scheduling/new"
+        else
+          Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Sections.GatingAndScheduling.New,
+            assigns.section.slug
+          )
+        end
 
       %GatingCondition{id: id} ->
         Routes.live_path(
@@ -272,12 +287,16 @@ defmodule OliWeb.Sections.GatingAndScheduling do
 
     path =
       if is_nil(socket.assigns.parent_gate) do
-        Routes.live_path(
-          socket,
-          __MODULE__,
-          socket.assigns.section.slug,
-          params
-        )
+        if socket.assigns.product_path_base do
+          "#{socket.assigns.product_path_base}/gating_and_scheduling?#{URI.encode_query(params)}"
+        else
+          Routes.live_path(
+            socket,
+            __MODULE__,
+            socket.assigns.section.slug,
+            params
+          )
+        end
       else
         Routes.live_path(
           socket,
@@ -294,4 +313,17 @@ defmodule OliWeb.Sections.GatingAndScheduling do
        replace: true
      )}
   end
+
+  defp product_path_base(
+         %{type: :blueprint, slug: section_slug},
+         %{assigns: %{route_name: :workspaces}} = socket
+       ) do
+    %Project{slug: project_slug} = socket.assigns.project
+    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+  end
+
+  defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),
+    do: ~p"/authoring/products/#{section_slug}"
+
+  defp product_path_base(_, _), do: nil
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -75,13 +75,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
         }),
         Breadcrumb.new(%{
           full_title: "Student Exceptions",
-          link:
-            Routes.live_path(
-              OliWeb.Endpoint,
-              __MODULE__,
-              section.slug,
-              parent_gate.id
-            )
+          link: ~p"/sections/#{section.slug}/gating_and_scheduling/exceptions/#{parent_gate.id}"
         })
       ]
   end
@@ -255,12 +249,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
         end
 
       %GatingCondition{id: id} ->
-        Routes.live_path(
-          OliWeb.Endpoint,
-          OliWeb.Sections.GatingAndScheduling.New,
-          assigns.section.slug,
-          id
-        )
+        ~p"/sections/#{assigns.section.slug}/gating_and_scheduling/new/#{id}"
     end
   end
 
@@ -298,13 +287,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
           )
         end
       else
-        Routes.live_path(
-          socket,
-          __MODULE__,
-          socket.assigns.section.slug,
-          socket.assigns.parent_gate.id,
-          params
-        )
+        ~p"/sections/#{socket.assigns.section.slug}/gating_and_scheduling/exceptions/#{socket.assigns.parent_gate.id}?#{params}"
       end
 
     {:noreply,

--- a/lib/oli_web/live/sections/gating_and_scheduling.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling.ex
@@ -9,7 +9,6 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   alias OliWeb.Common.Table.SortableTableModel
   alias OliWeb.Sections.Mount
   alias OliWeb.Common.{TextSearch, PagedTable, Breadcrumb}
-  alias Oli.Authoring.Course.Project
   alias Oli.Delivery.Gating
   alias Oli.Delivery.Sections.Section
   alias OliWeb.Delivery.Sections.GatingAndScheduling.TableModel
@@ -19,7 +18,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
 
   @default_params %{sort_by: "numbering_index", limit: 25}
 
-  def set_breadcrumbs(section, parent_gate, user_type) do
+  def set_breadcrumbs(section, parent_gate, user_type, product_path_base \\ nil) do
     first =
       case section do
         %Section{type: :blueprint} ->
@@ -34,30 +33,51 @@ defmodule OliWeb.Sections.GatingAndScheduling do
       end
 
     user_type
-    |> intermediate_breadcrumb(first, section)
-    |> breadcrumb(section)
-    |> breadcrumb_exceptions(section, parent_gate)
+    |> intermediate_breadcrumb(first, section, product_path_base)
+    |> breadcrumb(section, product_path_base)
+    |> breadcrumb_exceptions(section, parent_gate, product_path_base)
   end
 
-  def intermediate_breadcrumb(_user_type, previous, %Section{type: :blueprint} = section),
-    do: previous ++ OliWeb.Products.DetailsView.set_breadcrumbs(section)
-
-  def intermediate_breadcrumb(user_type, previous, section),
-    do: previous ++ OliWeb.Sections.OverviewView.set_breadcrumbs(user_type, section)
-
-  def breadcrumb(previous, section) do
+  def intermediate_breadcrumb(
+        _user_type,
+        previous,
+        %Section{type: :blueprint},
+        product_path_base
+      )
+      when is_binary(product_path_base) do
     previous ++
       [
         Breadcrumb.new(%{
-          full_title: "Advanced Gating",
-          link: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+          full_title: "Template Overview",
+          link: product_path_base
         })
       ]
   end
 
-  def breadcrumb_exceptions(previous, _, nil), do: previous
+  def intermediate_breadcrumb(
+        _user_type,
+        previous,
+        %Section{type: :blueprint} = section,
+        _product_path_base
+      ),
+      do: previous ++ OliWeb.Products.DetailsView.set_breadcrumbs(section)
 
-  def breadcrumb_exceptions(previous, section, parent_gate) do
+  def intermediate_breadcrumb(user_type, previous, section, _product_path_base),
+    do: previous ++ OliWeb.Sections.OverviewView.set_breadcrumbs(user_type, section)
+
+  def breadcrumb(previous, section, product_path_base) do
+    previous ++
+      [
+        Breadcrumb.new(%{
+          full_title: "Advanced Gating",
+          link: gating_path(section, product_path_base)
+        })
+      ]
+  end
+
+  def breadcrumb_exceptions(previous, _, nil, _product_path_base), do: previous
+
+  def breadcrumb_exceptions(previous, section, parent_gate, product_path_base) do
     %{title: resource_title} =
       Oli.Publishing.DeliveryResolver.from_resource_id(section.slug, parent_gate.resource_id)
 
@@ -65,17 +85,11 @@ defmodule OliWeb.Sections.GatingAndScheduling do
       [
         Breadcrumb.new(%{
           full_title: resource_title,
-          link:
-            Routes.live_path(
-              OliWeb.Endpoint,
-              OliWeb.Sections.GatingAndScheduling.Edit,
-              section.slug,
-              parent_gate.id
-            )
+          link: edit_path(section, parent_gate.id, product_path_base)
         }),
         Breadcrumb.new(%{
           full_title: "Student Exceptions",
-          link: ~p"/sections/#{section.slug}/gating_and_scheduling/exceptions/#{parent_gate.id}"
+          link: exceptions_path(section, parent_gate.id, product_path_base)
         })
       ]
   end
@@ -117,20 +131,25 @@ defmodule OliWeb.Sections.GatingAndScheduling do
 
     total_count = determine_total(rows)
 
-    {:ok, table_model} = TableModel.new(ctx, rows, section, is_nil(parent_gate))
+    product_path_base = product_path_base(section, socket)
+
+    {:ok, table_model} =
+      TableModel.new(ctx, rows, section, is_nil(parent_gate), product_path_base)
 
     socket
     |> assign(
       title: title,
       section: section,
-      breadcrumbs: set_breadcrumbs(section, parent_gate, user_type),
+      breadcrumbs: set_breadcrumbs(section, parent_gate, user_type, product_path_base),
       table_model: table_model,
       total_count: total_count,
       parent_gate: parent_gate,
       text_search: "",
       offset: 0,
       limit: @default_params.limit,
-      gating_condition: nil
+      gating_condition: nil,
+      product_path_base: product_path_base,
+      user_type: user_type
     )
   end
 
@@ -162,7 +181,14 @@ defmodule OliWeb.Sections.GatingAndScheduling do
         text_search
       )
 
-    table_model = Map.put(table_model, :rows, rows)
+    product_path_base = product_path_base(socket.assigns.section, socket)
+
+    table_model = %{
+      table_model
+      | rows: rows,
+        data: Map.put(table_model.data, :product_path_base, product_path_base)
+    }
+
     total_count = determine_total(rows)
 
     {:noreply,
@@ -170,7 +196,14 @@ defmodule OliWeb.Sections.GatingAndScheduling do
        offset: offset,
        limit: limit,
        uri: URI.parse(url).path,
-       product_path_base: product_path_base(socket.assigns.section, socket),
+       product_path_base: product_path_base,
+       breadcrumbs:
+         set_breadcrumbs(
+           socket.assigns.section,
+           socket.assigns.parent_gate,
+           socket.assigns.user_type,
+           product_path_base
+         ),
        table_model: table_model,
        total_count: total_count,
        text_search: text_search
@@ -249,7 +282,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
         end
 
       %GatingCondition{id: id} ->
-        ~p"/sections/#{assigns.section.slug}/gating_and_scheduling/new/#{id}"
+        new_exception_path(assigns.section, id, assigns.product_path_base)
     end
   end
 
@@ -287,7 +320,7 @@ defmodule OliWeb.Sections.GatingAndScheduling do
           )
         end
       else
-        ~p"/sections/#{socket.assigns.section.slug}/gating_and_scheduling/exceptions/#{socket.assigns.parent_gate.id}?#{params}"
+        "#{exceptions_path(socket.assigns.section, socket.assigns.parent_gate.id, socket.assigns.product_path_base)}?#{URI.encode_query(params)}"
       end
 
     {:noreply,
@@ -298,15 +331,46 @@ defmodule OliWeb.Sections.GatingAndScheduling do
   end
 
   defp product_path_base(
-         %{type: :blueprint, slug: section_slug},
+         %{type: :blueprint} = section,
          %{assigns: %{route_name: :workspaces}} = socket
        ) do
-    %Project{slug: project_slug} = socket.assigns.project
-    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+    Breadcrumb.product_path_base(section, :workspaces, socket.assigns.project)
   end
 
   defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),
     do: ~p"/authoring/products/#{section_slug}"
 
   defp product_path_base(_, _), do: nil
+
+  defp gating_path(_section, product_path_base) when is_binary(product_path_base),
+    do: "#{product_path_base}/gating_and_scheduling"
+
+  defp gating_path(section, _product_path_base),
+    do: Routes.live_path(OliWeb.Endpoint, __MODULE__, section.slug)
+
+  defp edit_path(_section, id, product_path_base) when is_binary(product_path_base),
+    do: "#{product_path_base}/gating_and_scheduling/edit/#{id}"
+
+  defp edit_path(section, id, _product_path_base),
+    do:
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Sections.GatingAndScheduling.Edit,
+        section.slug,
+        id
+      )
+
+  defp exceptions_path(_section, parent_gate_id, product_path_base)
+       when is_binary(product_path_base),
+       do: "#{product_path_base}/gating_and_scheduling/exceptions/#{parent_gate_id}"
+
+  defp exceptions_path(section, parent_gate_id, _product_path_base),
+    do: ~p"/sections/#{section.slug}/gating_and_scheduling/exceptions/#{parent_gate_id}"
+
+  defp new_exception_path(_section, parent_gate_id, product_path_base)
+       when is_binary(product_path_base),
+       do: "#{product_path_base}/gating_and_scheduling/new/#{parent_gate_id}"
+
+  defp new_exception_path(section, parent_gate_id, _product_path_base),
+    do: ~p"/sections/#{section.slug}/gating_and_scheduling/new/#{parent_gate_id}"
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/edit.ex
@@ -6,9 +6,13 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
   alias OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore
   alias OliWeb.Sections.GatingAndScheduling.Form
   alias Oli.Delivery.Gating
+  alias OliWeb.Common.Breadcrumb
+  alias Oli.Authoring.Course.Project
+
+  on_mount OliWeb.LiveSessionPlugs.SetRouteName
 
   def mount(
-        %{"id" => gating_condition_id, "section_slug" => section_slug},
+        %{"id" => gating_condition_id, "section_slug" => section_slug} = params,
         _session,
         socket
       ) do
@@ -26,6 +30,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
           end
 
         ctx = socket.assigns.ctx
+        product_path_base = product_path_base(section, params)
 
         {:ok,
          GatingConditionStore.init(
@@ -36,7 +41,8 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
            title,
            parent_gate_id,
            user_type,
-           id
+           id,
+           product_path_base
          )}
     end
   end
@@ -54,6 +60,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
         count_exceptions={@count_exceptions}
         create_or_update={:update}
         ctx={@ctx}
+        product_path_base={@product_path_base}
       />
     </div>
     """
@@ -61,4 +68,13 @@ defmodule OliWeb.Sections.GatingAndScheduling.Edit do
 
   def handle_event(event, params, socket),
     do: GatingConditionStore.handle_event(event, params, socket)
+
+  defp product_path_base(%{type: :blueprint} = section, %{"project_id" => project_slug}) do
+    Breadcrumb.product_path_base(section, :workspaces, %Project{slug: project_slug})
+  end
+
+  defp product_path_base(%{type: :blueprint} = section, _params),
+    do: Breadcrumb.product_path_base(section, nil, nil)
+
+  defp product_path_base(_section, _params), do: nil
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -157,12 +157,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
           <a
             class="btn btn-primary"
             href={
-              Routes.live_path(
-                OliWeb.Endpoint,
-                OliWeb.Sections.GatingAndScheduling,
-                assigns.section.slug,
-                assigns.gating_condition.id
-              )
+              ~p"/sections/#{assigns.section.slug}/gating_and_scheduling/exceptions/#{assigns.gating_condition.id}"
             }
           >
             Manage Student Exceptions

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -148,6 +148,8 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
 
   defp render_resource_selection(_assigns), do: nil
 
+  defp render_exceptions(%{section: %{type: :blueprint}}), do: nil
+
   defp render_exceptions(%{parent_gate: nil, gating_condition: gating_condition} = assigns) do
     if Map.has_key?(gating_condition, :id) do
       ~H"""

--- a/lib/oli_web/live/sections/gating_and_scheduling/form.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/form.ex
@@ -13,6 +13,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
   attr :count_exceptions, :integer, required: true
   attr :create_or_update, :atom, default: :create
   attr :ctx, :map
+  attr :product_path_base, :string, default: nil
 
   def render(assigns) do
     ~H"""
@@ -74,7 +75,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
         <div class="flex-grow-1"></div>
         <.link
           class="btn btn-outline-primary"
-          href={Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling, @section.slug)}
+          href={cancel_path(@section, @parent_gate, @product_path_base)}
         >
           Cancel
         </.link>
@@ -157,7 +158,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
           <a
             class="btn btn-primary"
             href={
-              ~p"/sections/#{assigns.section.slug}/gating_and_scheduling/exceptions/#{assigns.gating_condition.id}"
+              exceptions_path(assigns.section, assigns.gating_condition.id, assigns.product_path_base)
             }
           >
             Manage Student Exceptions
@@ -215,6 +216,21 @@ defmodule OliWeb.Sections.GatingAndScheduling.Form do
 
   defp create_or_update_name(:create), do: "Create"
   defp create_or_update_name(:update), do: "Update"
+
+  defp cancel_path(_section, nil, product_path_base) when is_binary(product_path_base),
+    do: "#{product_path_base}/gating_and_scheduling"
+
+  defp cancel_path(section, nil, _product_path_base),
+    do: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling, section.slug)
+
+  defp cancel_path(section, parent_gate, product_path_base),
+    do: exceptions_path(section, parent_gate.id, product_path_base)
+
+  defp exceptions_path(_section, gate_id, product_path_base) when is_binary(product_path_base),
+    do: "#{product_path_base}/gating_and_scheduling/exceptions/#{gate_id}"
+
+  defp exceptions_path(section, gate_id, _product_path_base),
+    do: ~p"/sections/#{section.slug}/gating_and_scheduling/exceptions/#{gate_id}"
 
   def maybe_resource_value(%{gating_condition: %{resource_title: resource_title}}),
     do: [value: resource_title]

--- a/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/gating_condition_store.ex
@@ -25,7 +25,8 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
         title,
         parent_gate_id,
         user_type,
-        gating_condition_id \\ nil
+        gating_condition_id \\ nil,
+        product_path_base \\ nil
       ) do
     parent_gate =
       case parent_gate_id do
@@ -100,13 +101,20 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
       count_exceptions: count_exceptions(parent_gate_id, gating_condition_id),
       title: title,
       section: section,
-      breadcrumbs: set_breadcrumbs(section, module, title, parent_gate, user_type),
-      gating_condition: gating_condition
+      breadcrumbs:
+        set_breadcrumbs(section, module, title, parent_gate, user_type, product_path_base),
+      gating_condition: gating_condition,
+      product_path_base: product_path_base
     )
   end
 
-  defp set_breadcrumbs(section, module, title, parent_gate, user_type) do
-    OliWeb.Sections.GatingAndScheduling.set_breadcrumbs(section, parent_gate, user_type)
+  defp set_breadcrumbs(section, module, title, parent_gate, user_type, product_path_base) do
+    OliWeb.Sections.GatingAndScheduling.set_breadcrumbs(
+      section,
+      parent_gate,
+      user_type,
+      product_path_base
+    )
     |> breadcrumb(section, module, title)
   end
 
@@ -126,6 +134,20 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
   end
 
   defp count_exceptions(_, _), do: nil
+
+  defp return_path(%{assigns: %{product_path_base: product_path_base, parent_gate: nil}})
+       when is_binary(product_path_base),
+       do: "#{product_path_base}/gating_and_scheduling"
+
+  defp return_path(%{assigns: %{product_path_base: product_path_base, parent_gate: parent_gate}})
+       when is_binary(product_path_base),
+       do: "#{product_path_base}/gating_and_scheduling/exceptions/#{parent_gate.id}"
+
+  defp return_path(%{assigns: %{section: section, parent_gate: nil}}),
+    do: Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling, section.slug)
+
+  defp return_path(%{assigns: %{section: section, parent_gate: parent_gate}}),
+    do: ~p"/sections/#{section.slug}/gating_and_scheduling/exceptions/#{parent_gate.id}"
 
   def handle_event("show-user-picker", _, socket) do
     %{section: section, ctx: ctx} = socket.assigns
@@ -561,14 +583,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
 
           socket
           |> put_flash(:info, "Gating condition successfully created.")
-          |> redirect(
-            to:
-              Routes.live_path(
-                OliWeb.Endpoint,
-                OliWeb.Sections.GatingAndScheduling,
-                section.slug
-              )
-          )
+          |> redirect(to: return_path(socket))
 
         {:error, %Ecto.Changeset{}} ->
           put_flash(
@@ -598,14 +613,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
 
           socket
           |> put_flash(:info, "Gating condition successfully updated.")
-          |> redirect(
-            to:
-              Routes.live_path(
-                OliWeb.Endpoint,
-                OliWeb.Sections.GatingAndScheduling,
-                section.slug
-              )
-          )
+          |> redirect(to: return_path(socket))
 
         {:error, %Ecto.Changeset{}} ->
           put_flash(
@@ -661,14 +669,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore do
         {:ok, _gating_condition, _} ->
           socket
           |> put_flash(:info, "Gating condition successfully deleted.")
-          |> redirect(
-            to:
-              Routes.live_path(
-                OliWeb.Endpoint,
-                OliWeb.Sections.GatingAndScheduling,
-                socket.assigns.section.slug
-              )
-          )
+          |> redirect(to: return_path(socket))
 
         {:error, %Ecto.Changeset{}} ->
           put_flash(

--- a/lib/oli_web/live/sections/gating_and_scheduling/new.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/new.ex
@@ -5,6 +5,10 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
   alias OliWeb.Sections.Mount
   alias OliWeb.Delivery.Sections.GatingAndScheduling.GatingConditionStore
   alias OliWeb.Sections.GatingAndScheduling.Form
+  alias OliWeb.Common.Breadcrumb
+  alias Oli.Authoring.Course.Project
+
+  on_mount OliWeb.LiveSessionPlugs.SetRouteName
 
   def mount(
         %{"section_slug" => section_slug} = params,
@@ -23,6 +27,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
           end
 
         ctx = socket.assigns.ctx
+        product_path_base = product_path_base(section, params)
 
         {:ok,
          GatingConditionStore.init(
@@ -32,7 +37,9 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
            ctx,
            title,
            parent_gate_id,
-           user_type
+           user_type,
+           nil,
+           product_path_base
          )}
     end
   end
@@ -49,6 +56,7 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
         parent_gate={@parent_gate}
         count_exceptions={@count_exceptions}
         ctx={@ctx}
+        product_path_base={@product_path_base}
       />
     </div>
     """
@@ -56,4 +64,13 @@ defmodule OliWeb.Sections.GatingAndScheduling.New do
 
   def handle_event(event, params, socket),
     do: GatingConditionStore.handle_event(event, params, socket)
+
+  defp product_path_base(%{type: :blueprint} = section, %{"project_id" => project_slug}) do
+    Breadcrumb.product_path_base(section, :workspaces, %Project{slug: project_slug})
+  end
+
+  defp product_path_base(%{type: :blueprint} = section, _params),
+    do: Breadcrumb.product_path_base(section, nil, nil)
+
+  defp product_path_base(_section, _params), do: nil
 end

--- a/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
+++ b/lib/oli_web/live/sections/gating_and_scheduling/table_model.ex
@@ -14,7 +14,13 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
     """
   end
 
-  def new(%SessionContext{} = ctx, gating_condition_rows, section, is_parent_gate?) do
+  def new(
+        %SessionContext{} = ctx,
+        gating_condition_rows,
+        section,
+        is_parent_gate?,
+        product_path_base \\ nil
+      ) do
     resource_column = %ColumnSpec{
       name: :title,
       label: "Resource",
@@ -53,7 +59,8 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
       id_field: [:id],
       data: %{
         section_slug: section.slug,
-        ctx: ctx
+        ctx: ctx,
+        product_path_base: product_path_base
       }
     )
   end
@@ -69,9 +76,7 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
     assigns = Map.merge(assigns, %{title: title, id: id})
 
     ~H"""
-    <.link href={
-      Routes.live_path(OliWeb.Endpoint, OliWeb.Sections.GatingAndScheduling.Edit, @section_slug, @id)
-    }>
+    <.link href={edit_path(@section_slug, @id, @product_path_base)}>
       {@title}
     </.link>
     """
@@ -229,18 +234,23 @@ defmodule OliWeb.Delivery.Sections.GatingAndScheduling.TableModel do
     ~H"""
     <%= if @user_id do %>
       <div>
-        <.link href={
-          Routes.live_path(
-            OliWeb.Endpoint,
-            OliWeb.Sections.GatingAndScheduling.Edit,
-            @section_slug,
-            @id
-          )
-        }>
+        <.link href={edit_path(@section_slug, @id, @product_path_base)}>
           {OliWeb.Common.Utils.name(@user)}
         </.link>
       </div>
     <% end %>
     """
   end
+
+  defp edit_path(_section_slug, id, product_path_base) when is_binary(product_path_base),
+    do: "#{product_path_base}/gating_and_scheduling/edit/#{id}"
+
+  defp edit_path(section_slug, id, _product_path_base),
+    do:
+      Routes.live_path(
+        OliWeb.Endpoint,
+        OliWeb.Sections.GatingAndScheduling.Edit,
+        section_slug,
+        id
+      )
 end

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -54,7 +54,7 @@ defmodule OliWeb.Sections.ScheduleView do
     end
   end
 
-  def handle_params(_params, _url, socket) do
+  def handle_params(_params, url, socket) do
     section = socket.assigns.section
     type = socket.assigns.user_type
 
@@ -74,6 +74,8 @@ defmodule OliWeb.Sections.ScheduleView do
     {:noreply,
      assign(socket,
        breadcrumbs: set_breadcrumbs(type, section, socket),
+       uri: URI.parse(url).path,
+       product_path_base: product_path_base(section, socket),
        appConfig: %{
          start_date: section.start_date,
          end_date: section.end_date,
@@ -96,7 +98,26 @@ defmodule OliWeb.Sections.ScheduleView do
 
   def render(assigns) do
     ~H"""
+    <Components.Delivery.ScheduleGatingAssessment.tabs
+      :if={@section.type == :blueprint}
+      section_slug={@section.slug}
+      uri={@uri}
+      product_path_base={@product_path_base}
+    />
     {React.component(@ctx, "Components.ScheduleEditor", @appConfig, id: "schedule-editor")}
     """
   end
+
+  defp product_path_base(
+         %{type: :blueprint, slug: section_slug},
+         %{assigns: %{route_name: :workspaces}} = socket
+       ) do
+    %Project{slug: project_slug} = socket.assigns.project
+    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+  end
+
+  defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),
+    do: ~p"/authoring/products/#{section_slug}"
+
+  defp product_path_base(_, _), do: nil
 end

--- a/lib/oli_web/live/sections/schedule_view.ex
+++ b/lib/oli_web/live/sections/schedule_view.ex
@@ -109,11 +109,10 @@ defmodule OliWeb.Sections.ScheduleView do
   end
 
   defp product_path_base(
-         %{type: :blueprint, slug: section_slug},
+         %{type: :blueprint} = section,
          %{assigns: %{route_name: :workspaces}} = socket
        ) do
-    %Project{slug: project_slug} = socket.assigns.project
-    ~p"/workspaces/course_author/#{project_slug}/products/#{section_slug}"
+    Breadcrumb.product_path_base(section, :workspaces, socket.assigns.project)
   end
 
   defp product_path_base(%{type: :blueprint, slug: section_slug}, _socket),

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -512,6 +512,13 @@ defmodule OliWeb.Router do
         as: :product_schedule
       )
 
+      live(
+        "/products/:section_slug/assessment_settings/settings/:assessment_id",
+        Sections.AssessmentSettings.SettingsLive,
+        :product_assessment_settings,
+        as: :product_assessment_settings
+      )
+
       live("/products/:section_slug/edit", Sections.EditView, :product_edit, as: :product_edit)
     end
 
@@ -1045,6 +1052,12 @@ defmodule OliWeb.Router do
           )
 
           live("/:section_slug/schedule", OliWeb.Sections.ScheduleView,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/assessment_settings/settings/:assessment_id",
+            OliWeb.Sections.AssessmentSettings.SettingsLive,
             metadata: %{route_name: :workspaces}
           )
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -519,6 +519,20 @@ defmodule OliWeb.Router do
         as: :product_assessment_settings
       )
 
+      live(
+        "/products/:section_slug/gating_and_scheduling",
+        Sections.GatingAndScheduling,
+        :product_gating_and_scheduling,
+        as: :product_gating_and_scheduling
+      )
+
+      live(
+        "/products/:section_slug/gating_and_scheduling/new",
+        Sections.GatingAndScheduling.New,
+        :product_gating_and_scheduling_new,
+        as: :product_gating_and_scheduling_new
+      )
+
       live("/products/:section_slug/edit", Sections.EditView, :product_edit, as: :product_edit)
     end
 
@@ -1058,6 +1072,18 @@ defmodule OliWeb.Router do
           live(
             "/:section_slug/assessment_settings/settings/:assessment_id",
             OliWeb.Sections.AssessmentSettings.SettingsLive,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/gating_and_scheduling",
+            OliWeb.Sections.GatingAndScheduling,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/gating_and_scheduling/new",
+            OliWeb.Sections.GatingAndScheduling.New,
             metadata: %{route_name: :workspaces}
           )
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -533,6 +533,27 @@ defmodule OliWeb.Router do
         as: :product_gating_and_scheduling_new
       )
 
+      live(
+        "/products/:section_slug/gating_and_scheduling/edit/:id",
+        Sections.GatingAndScheduling.Edit,
+        :product_gating_and_scheduling_edit,
+        as: :product_gating_and_scheduling_edit
+      )
+
+      live(
+        "/products/:section_slug/gating_and_scheduling/exceptions/:parent_gate_id",
+        Sections.GatingAndScheduling,
+        :product_gating_and_scheduling_exceptions,
+        as: :product_gating_and_scheduling_exceptions
+      )
+
+      live(
+        "/products/:section_slug/gating_and_scheduling/new/:parent_gate_id",
+        Sections.GatingAndScheduling.New,
+        :product_gating_and_scheduling_new_exception,
+        as: :product_gating_and_scheduling_new_exception
+      )
+
       live("/products/:section_slug/edit", Sections.EditView, :product_edit, as: :product_edit)
     end
 
@@ -1083,6 +1104,24 @@ defmodule OliWeb.Router do
 
           live(
             "/:section_slug/gating_and_scheduling/new",
+            OliWeb.Sections.GatingAndScheduling.New,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/gating_and_scheduling/edit/:id",
+            OliWeb.Sections.GatingAndScheduling.Edit,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/gating_and_scheduling/exceptions/:parent_gate_id",
+            OliWeb.Sections.GatingAndScheduling,
+            metadata: %{route_name: :workspaces}
+          )
+
+          live(
+            "/:section_slug/gating_and_scheduling/new/:parent_gate_id",
             OliWeb.Sections.GatingAndScheduling.New,
             metadata: %{route_name: :workspaces}
           )

--- a/test/oli_web/components/delivery/schedule_gating_assessment_test.exs
+++ b/test/oli_web/components/delivery/schedule_gating_assessment_test.exs
@@ -1,0 +1,34 @@
+defmodule OliWeb.Components.Delivery.ScheduleGatingAssessmentTest do
+  use OliWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+
+  alias OliWeb.Components.Delivery.ScheduleGatingAssessment
+
+  describe "tabs/1" do
+    test "does not show advanced gating for product settings" do
+      html =
+        render_component(&ScheduleGatingAssessment.tabs/1, %{
+          section_slug: "product-slug",
+          uri: "/authoring/products/product-slug/assessment_settings/settings/all",
+          product_path_base: "/authoring/products/product-slug"
+        })
+
+      assert html =~ "Schedule"
+      assert html =~ "Assessment Settings"
+      refute html =~ "Advanced Gating"
+      refute html =~ "/authoring/products/product-slug/gating_and_scheduling"
+    end
+
+    test "shows advanced gating for section settings" do
+      html =
+        render_component(&ScheduleGatingAssessment.tabs/1, %{
+          section_slug: "section-slug",
+          uri: "/sections/section-slug/schedule"
+        })
+
+      assert html =~ "Advanced Gating"
+      assert html =~ "/sections/section-slug/gating_and_scheduling"
+    end
+  end
+end

--- a/test/oli_web/components/delivery/schedule_gating_assessment_test.exs
+++ b/test/oli_web/components/delivery/schedule_gating_assessment_test.exs
@@ -6,7 +6,7 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessmentTest do
   alias OliWeb.Components.Delivery.ScheduleGatingAssessment
 
   describe "tabs/1" do
-    test "does not show advanced gating for product settings" do
+    test "shows advanced gating for product settings" do
       html =
         render_component(&ScheduleGatingAssessment.tabs/1, %{
           section_slug: "product-slug",
@@ -16,8 +16,8 @@ defmodule OliWeb.Components.Delivery.ScheduleGatingAssessmentTest do
 
       assert html =~ "Schedule"
       assert html =~ "Assessment Settings"
-      refute html =~ "Advanced Gating"
-      refute html =~ "/authoring/products/product-slug/gating_and_scheduling"
+      assert html =~ "Advanced Gating"
+      assert html =~ "/authoring/products/product-slug/gating_and_scheduling"
     end
 
     test "shows advanced gating for section settings" do


### PR DESCRIPTION
This PR adds both the Assessment Settings tab and the Advanced Gating tab to the "Scheduling and Assessment Settings" view for templates. 

Contrary to the assertion in the JIRA ticket, the Student Exceptions tab should **not** be present in that view (since there are never enrolled students in a template)