### PR TITLE
[ENHANCEMENT] [MER-5515] Consolidate gradebook cells to three states

### DIFF
--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -269,13 +269,8 @@ defmodule Oli.Delivery.Attempts.Core do
       |> Enum.map(& &1.resource_id)
 
     ResourceAccess
-    |> join(:left, [r], ra in ResourceAttempt, on: r.id == ra.resource_access_id)
     |> where([r], r.resource_id in ^graded_pages_resource_ids and r.section_id == ^section_id)
-    |> group_by([r], r.id)
     |> select([r], r)
-    |> select_merge([_r, ra], %{
-      resource_attempts_count: count(ra.id)
-    })
   end
 
   @doc """

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -269,8 +269,13 @@ defmodule Oli.Delivery.Attempts.Core do
       |> Enum.map(& &1.resource_id)
 
     ResourceAccess
+    |> join(:left, [r], ra in ResourceAttempt, on: r.id == ra.resource_access_id)
     |> where([r], r.resource_id in ^graded_pages_resource_ids and r.section_id == ^section_id)
+    |> group_by([r], r.id)
     |> select([r], r)
+    |> select_merge([_r, ra], %{
+      resource_attempts_count: count(ra.id)
+    })
   end
 
   @doc """

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -429,7 +429,7 @@ defmodule Oli.Grading do
   defp ensure_valid_number(_), do: 1.0
 
   def fetch_resource_accesses(section_id) do
-    Attempts.get_graded_resource_access_for_context(section_id)
+    fetch_gradebook_resource_accesses(section_id)
     |> Enum.reduce(%{}, fn resource_access, acc ->
       case acc[resource_access.resource_id] do
         nil ->
@@ -447,5 +447,27 @@ defmodule Oli.Grading do
           )
       end
     end)
+  end
+
+  defp fetch_gradebook_resource_accesses(section_id) do
+    graded_resource_ids =
+      SectionResourceDepot.graded_pages(section_id)
+      |> Enum.map(& &1.resource_id)
+
+    Repo.all(
+      from(
+        resource_access in ResourceAccess,
+        left_join: resource_attempt in Attempts.ResourceAttempt,
+        on: resource_access.id == resource_attempt.resource_access_id,
+        where:
+          resource_access.resource_id in ^graded_resource_ids and
+            resource_access.section_id == ^section_id,
+        group_by: resource_access.id,
+        select: resource_access,
+        select_merge: %{
+          resource_attempts_count: count(resource_attempt.id)
+        }
+      )
+    )
   end
 end

--- a/lib/oli/grading.ex
+++ b/lib/oli/grading.ex
@@ -200,14 +200,20 @@ defmodule Oli.Grading do
             score =
               with %{^user_id => student_resource_accesses} <-
                      resource_accesses[section_resource.resource_id],
-                   %ResourceAccess{score: score, out_of: out_of, was_late: was_late} <-
+                   %ResourceAccess{
+                     score: score,
+                     out_of: out_of,
+                     was_late: was_late,
+                     resource_attempts_count: resource_attempts_count
+                   } <-
                      student_resource_accesses do
                 %GradebookScore{
                   resource_id: section_resource.resource_id,
                   label: section_resource.title,
                   score: score,
                   out_of: out_of,
-                  was_late: was_late
+                  was_late: was_late,
+                  resource_attempts_count: resource_attempts_count
                 }
               else
                 _ ->
@@ -216,7 +222,8 @@ defmodule Oli.Grading do
                     label: section_resource.title,
                     score: nil,
                     out_of: nil,
-                    was_late: nil
+                    was_late: nil,
+                    resource_attempts_count: 0
                   }
               end
 
@@ -285,12 +292,23 @@ defmodule Oli.Grading do
         on:
           ra.section_id == ^section_id and ra.resource_id == sr.resource_id and
             ra.user_id == ^student_id,
+        left_join: resource_attempt in Attempts.ResourceAttempt,
+        on: resource_attempt.resource_access_id == ra.id,
         where:
           sec.id == ^section_id and
             sr.section_id == ^section_id and
             rev.deleted == false and
             rev.resource_type_id == ^resource_type_id and
             rev.graded == true,
+        group_by: [
+          rev.resource_id,
+          rev.title,
+          ra.score,
+          ra.out_of,
+          ra.was_late,
+          sr.numbering_index,
+          sr.title
+        ],
         select: %GradebookScore{
           resource_id: rev.resource_id,
           label: rev.title,
@@ -298,7 +316,8 @@ defmodule Oli.Grading do
           out_of: ra.out_of,
           was_late: ra.was_late,
           index: sr.numbering_index,
-          title: sr.title
+          title: sr.title,
+          resource_attempts_count: count(resource_attempt.id)
         }
       )
     )

--- a/lib/oli/grading/gradebook_score.ex
+++ b/lib/oli/grading/gradebook_score.ex
@@ -1,6 +1,15 @@
 defmodule Oli.Grading.GradebookScore do
   @enforce_keys [:resource_id, :label, :out_of]
-  defstruct [:resource_id, :label, :score, :out_of, :was_late, :index, :title]
+  defstruct [
+    :resource_id,
+    :label,
+    :score,
+    :out_of,
+    :was_late,
+    :index,
+    :title,
+    :resource_attempts_count
+  ]
 
   @type t() :: %__MODULE__{
           resource_id: integer,
@@ -9,6 +18,7 @@ defmodule Oli.Grading.GradebookScore do
           out_of: float | nil,
           was_late: boolean | nil,
           index: integer | nil,
-          title: String.t()
+          title: String.t(),
+          resource_attempts_count: integer | nil
         }
 end

--- a/lib/oli_web/live/grades/gradebook_table_model.ex
+++ b/lib/oli_web/live/grades/gradebook_table_model.ex
@@ -74,7 +74,8 @@ defmodule OliWeb.Grades.GradebookTableModel do
                  section_id: section.id,
                  score: score.score,
                  out_of: score.out_of,
-                 was_late: score.was_late
+                 was_late: score.was_late,
+                 resource_attempts_count: Map.get(score, :resource_attempts_count)
                }}
             end)
 
@@ -90,7 +91,8 @@ defmodule OliWeb.Grades.GradebookTableModel do
                  section_id: section.id,
                  score: score.score,
                  out_of: score.out_of,
-                 was_late: score.was_late
+                 was_late: score.was_late,
+                 resource_attempts_count: Map.get(score, :resource_attempts_count)
                }}
             end)
 
@@ -257,29 +259,15 @@ defmodule OliWeb.Grades.GradebookTableModel do
     assigns = Map.merge(assigns, %{row: row, resource_id: resource_id})
 
     case Map.get(row, resource_id) do
-      # Indicates that this student has never visited this resource
+      # Indicates that this student has never visited this resource and has no attempt
       nil ->
-        case assigns.show_all_links do
-          true ->
-            ~H"""
-            <a href={
-              Routes.live_path(
-                OliWeb.Endpoint,
-                OliWeb.Progress.StudentResourceView,
-                @row.section.slug,
-                @row.id,
-                @resource_id
-              )
-            }>
-              <span class="text-muted">Never Visited</span>
-            </a>
-            """
+        show_no_attempt(assigns)
 
-          _ ->
-            ""
-        end
+      # Indicates that this student has visited, but never started an assessment attempt
+      %ResourceAccess{score: nil, out_of: nil, resource_attempts_count: 0} ->
+        show_no_attempt(assigns)
 
-      # Indicates that this student has visited, but not completed this assessment
+      # Indicates that this student has started, but not completed this assessment
       %ResourceAccess{score: nil, out_of: nil} ->
         case assigns.show_all_links do
           true ->
@@ -304,6 +292,28 @@ defmodule OliWeb.Grades.GradebookTableModel do
       # We have a rolled-up grade from at least one attempt
       %ResourceAccess{} = resource_access ->
         show_score(assigns, row, resource_id, resource_access)
+    end
+  end
+
+  defp show_no_attempt(assigns) do
+    case assigns.show_all_links do
+      true ->
+        ~H"""
+        <a href={
+          Routes.live_path(
+            OliWeb.Endpoint,
+            OliWeb.Progress.StudentResourceView,
+            @row.section.slug,
+            @row.id,
+            @resource_id
+          )
+        }>
+          <span class="text-muted">No Attempt</span>
+        </a>
+        """
+
+      _ ->
+        ""
     end
   end
 

--- a/test/oli/grading_test.exs
+++ b/test/oli/grading_test.exs
@@ -253,14 +253,16 @@ defmodule Oli.GradingTest do
                 out_of: 20,
                 resource_id: revision1.resource_id,
                 score: 12,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               },
               %Grading.GradebookScore{
                 label: "Page two",
                 out_of: 5,
                 resource_id: revision2.resource_id,
                 score: 0,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               }
             ],
             user:
@@ -277,14 +279,16 @@ defmodule Oli.GradingTest do
                 out_of: 20,
                 resource_id: revision1.resource_id,
                 score: 20,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               },
               %Grading.GradebookScore{
                 label: "Page two",
                 out_of: 5,
                 resource_id: revision2.resource_id,
                 score: 3,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               }
             ],
             user:
@@ -301,14 +305,16 @@ defmodule Oli.GradingTest do
                 out_of: 20,
                 resource_id: revision1.resource_id,
                 score: 19,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               },
               %Grading.GradebookScore{
                 label: "Page two",
                 out_of: 5,
                 resource_id: revision2.resource_id,
                 score: 5,
-                was_late: false
+                was_late: false,
+                resource_attempts_count: 0
               }
             ],
             user:

--- a/test/oli_web/live/grades/gradebook_table_model_test.exs
+++ b/test/oli_web/live/grades/gradebook_table_model_test.exs
@@ -1,6 +1,8 @@
 defmodule OliWeb.Grades.GradebookTableModelTest do
   use ExUnit.Case, async: true
 
+  alias Oli.Delivery.Attempts.Core.ResourceAccess
+  alias OliWeb.Common.Table.ColumnSpec
   alias OliWeb.Grades.GradebookTableModel
 
   describe "render_grade_score/3" do
@@ -83,6 +85,110 @@ defmodule OliWeb.Grades.GradebookTableModelTest do
         |> IO.iodata_to_binary()
 
       assert html =~ "text-red-500"
+    end
+  end
+
+  describe "render_score/3" do
+    test "renders missing resource access as linked No Attempt" do
+      row = %{id: 1, section: %{slug: "test_section"}}
+      assigns = %{show_all_links: true}
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(
+          GradebookTableModel.render_score(assigns, row, %ColumnSpec{name: 10})
+        )
+        |> IO.iodata_to_binary()
+
+      assert html =~ "No Attempt"
+      assert html =~ ~s(href="/sections/test_section/progress/1/10")
+      refute html =~ "Never Visited"
+    end
+
+    test "renders visited assessment with no started attempts as linked No Attempt" do
+      row =
+        %{
+          id: 1,
+          section: %{slug: "test_section"}
+        }
+        |> Map.put(10, %ResourceAccess{
+          resource_id: 10,
+          user_id: 1,
+          section_id: 1,
+          score: nil,
+          out_of: nil,
+          resource_attempts_count: 0
+        })
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(
+          GradebookTableModel.render_score(%{show_all_links: true}, row, %ColumnSpec{name: 10})
+        )
+        |> IO.iodata_to_binary()
+
+      assert html =~ "No Attempt"
+      assert html =~ ~s(href="/sections/test_section/progress/1/10")
+      refute html =~ "Not Finished"
+    end
+
+    test "renders missing resource access as an empty cell when links are disabled" do
+      row = %{id: 1, section: %{slug: "test_section"}}
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(
+          GradebookTableModel.render_score(%{show_all_links: false}, row, %ColumnSpec{name: 10})
+        )
+        |> IO.iodata_to_binary()
+
+      assert html == ""
+    end
+
+    test "renders started but unsubmitted attempt as an empty cell when links are disabled" do
+      row =
+        %{
+          id: 1,
+          section: %{slug: "test_section"}
+        }
+        |> Map.put(10, %ResourceAccess{
+          resource_id: 10,
+          user_id: 1,
+          section_id: 1,
+          score: nil,
+          out_of: nil,
+          resource_attempts_count: 1
+        })
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(
+          GradebookTableModel.render_score(%{show_all_links: false}, row, %ColumnSpec{name: 10})
+        )
+        |> IO.iodata_to_binary()
+
+      assert html == ""
+    end
+
+    test "renders started but unsubmitted attempt as linked Not Finished" do
+      row =
+        %{
+          id: 1,
+          section: %{slug: "test_section"}
+        }
+        |> Map.put(10, %ResourceAccess{
+          resource_id: 10,
+          user_id: 1,
+          section_id: 1,
+          score: nil,
+          out_of: nil,
+          resource_attempts_count: 1
+        })
+
+      html =
+        Phoenix.HTML.Safe.to_iodata(
+          GradebookTableModel.render_score(%{show_all_links: true}, row, %ColumnSpec{name: 10})
+        )
+        |> IO.iodata_to_binary()
+
+      assert html =~ "Not Finished"
+      assert html =~ ~s(href="/sections/test_section/progress/1/10")
     end
   end
 end


### PR DESCRIPTION
This PR adjusts the instructor gradebook table display logic to show only three states:

1. Scored (score shows 5.0/5.0), (links to attempt summary page, means that an attempt was started and submitted)
2. Not Finished (links to in-progress attempt summary page, means that an attempt was started but never submitted)
3. No Attempt (Means that an attempt was never started despite "visit status.")

NOTE 1:  The MER ticket is wrong in that it asserts that the "No Attempt" state should NOT render a link.  A link is indeed needed here to allow the instructor to post a score on behalf of a student. 

NOTE 2:  The "Show all links" checkbox and feature still has to work with its original intent, which is when UNCHECKED the display only renders cells whose contents are scores.  This allows instructors to QUICKLY and EASILY see which students have completed which assessments.  Clicking "Show all links" to enable it then renders "Not Finished" and "No Attempt" cells with their clickable links 