### PR TITLE
[BUG FIX] [MER-5587] (Rework) Remove simple-author correctness and feedback controls from Advanced Author adaptive components

### DIFF
--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -252,7 +252,22 @@ const getExpertComponentUISchema = (instance: any, responsiveLayout: boolean) =>
 
 export const mergeAdaptiveExpertSchema = (expertSchema: any, _simpleSchema: any) => {
   if (!expertSchema) return {};
-  return expertSchema;
+
+  const merged = {
+    ...expertSchema,
+  };
+
+  [
+    'answer',
+    'advancedFeedback',
+    'anyCorrectAnswer',
+    'commonErrorFeedback',
+    'correctAnswer',
+    'correctFeedback',
+    'incorrectFeedback',
+  ].forEach((field) => delete merged[field]);
+
+  return merged;
 };
 
 export const mergeAdaptiveExpertUiSchema = (expertUiSchema: any, _simpleUiSchema: any) => {
@@ -262,6 +277,13 @@ export const mergeAdaptiveExpertUiSchema = (expertUiSchema: any, _simpleUiSchema
   };
 
   delete merged['ui:order'];
+  delete merged.answer;
+  delete merged.advancedFeedback;
+  delete merged.anyCorrectAnswer;
+  delete merged.commonErrorFeedback;
+  delete merged.correctAnswer;
+  delete merged.correctFeedback;
+  delete merged.incorrectFeedback;
 
   return merged;
 };

--- a/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
+++ b/assets/test/advanced_authoring/right_menu/component/adaptive_expert_schema_test.ts
@@ -1,4 +1,8 @@
 import {
+  schema as fibExpertSchema,
+  uiSchema as fibExpertUiSchema,
+} from 'components/parts/janus-fill-blanks/schema';
+import {
   schema as textInputExpertSchema,
   simpleSchema as textInputSimpleSchema,
 } from 'components/parts/janus-input-text/schema';
@@ -50,5 +54,15 @@ describe('advanced author adaptive component schemas', () => {
     expect(merged).not.toHaveProperty('commonErrorFeedback');
     expect(merged).not.toHaveProperty('mcqItems');
     expect(merged).not.toHaveProperty('ui:order');
+  });
+
+  it('does not expose simple-author feedback fields for fill in the blanks expert mode', () => {
+    const mergedSchema = mergeAdaptiveExpertSchema(fibExpertSchema, null);
+    const mergedUiSchema = mergeAdaptiveExpertUiSchema(fibExpertUiSchema, null);
+
+    expect(mergedSchema).not.toHaveProperty('correctFeedback');
+    expect(mergedSchema).not.toHaveProperty('incorrectFeedback');
+    expect(mergedUiSchema).not.toHaveProperty('correctFeedback');
+    expect(mergedUiSchema).not.toHaveProperty('incorrectFeedback');
   });
 });


### PR DESCRIPTION
## Summary

  This PR fixes a regression in **Advanced Author** where adaptive component panels were still exposing **Simple Author** scoring and feedback fields.

  Advanced Author should use **adaptivity rules** as the source of truth for correctness and feedback. Those component-level controls should not appear in the advanced component property panel.

  ## Problem

  Adaptive components in Advanced Author were showing simple-author fields such as:

  - `Correct Answer`
  - `Correct Feedback`
  - `Incorrect Feedback`
  - `Advanced Feedback`
  - `Any answer is correct`

  Most of that was already removed, but `Fill in the Blanks` was still showing:

  - `Correct feedback`
  - `Incorrect feedback`

  The remaining leak came from the component’s expert schema itself, not from the earlier simple/expert merge path.

  ## What Changed

  ### Advanced Author schema filtering

  Updated the Advanced Author component panel path so it strips simple-author scoring and feedback fields even if an expert schema declares them directly.

  Filtered fields now include:

  - `correctAnswer`
  - `answer`
  - `correctFeedback`
  - `incorrectFeedback`
  - `commonErrorFeedback`
  - `advancedFeedback`
  - `anyCorrectAnswer`

  This keeps Advanced Author aligned with rule-based authoring and avoids component-level scoring/feedback controls appearing in the wrong mode.

  ### Fill in the Blanks cleanup

  This specifically fixes the remaining `Fill in the Blanks` issue where `Correct feedback` and `Incorrect feedback` were still visible in Advanced Author.