### PR TITLE
[BUG FIX] [MER-5595] Fix 500 error seen in Linking authoring account

### DIFF
--- a/lib/oli_web/author_auth.ex
+++ b/lib/oli_web/author_auth.ex
@@ -29,7 +29,9 @@ defmodule OliWeb.AuthorAuth do
 
     # Get the return path AFTER account linking to respect any changes made
     author_return_to =
-      params["request_path"] || get_session(conn, :author_return_to) || signed_in_path(conn)
+      redirect_path(params["request_path"]) ||
+        redirect_path(get_session(conn, :author_return_to)) ||
+        signed_in_path(conn)
 
     conn
     |> put_token_in_session(token)
@@ -135,7 +137,7 @@ defmodule OliWeb.AuthorAuth do
     end
 
     redirect_to =
-      params["request_path"] || ~p"/authors/log_in"
+      redirect_path(params["request_path"]) || ~p"/authors/log_in"
 
     conn
     |> renew_session()
@@ -410,6 +412,13 @@ defmodule OliWeb.AuthorAuth do
   defp maybe_store_return_to(conn), do: conn
 
   defp signed_in_path(_conn), do: ~p"/workspaces/course_author"
+
+  defp redirect_path(path) do
+    if valid_local_path?(path), do: path, else: nil
+  end
+
+  defp valid_local_path?("/" <> rest), do: rest != "" and not String.starts_with?(rest, "/")
+  defp valid_local_path?(_), do: false
 
   @doc """
   Stores the link_account_user_id (if specified) of the user account to link an

--- a/test/oli_web/live/link_account_live_test.exs
+++ b/test/oli_web/live/link_account_live_test.exs
@@ -79,6 +79,34 @@ defmodule OliWeb.LinkAccountLiveTest do
       assert redirected_to(conn) == ~p"/users/settings"
     end
 
+    test "falls back to account settings when the submitted request path is empty", %{conn: conn} do
+      user = insert(:user, author: nil)
+
+      conn = log_in_user(conn, user)
+
+      password = "123456789abcd"
+      author = Oli.Utils.Seeder.AccountsFixtures.author_fixture(%{password: password})
+
+      {:ok, lv, _html} = live(conn, ~p"/users/link_account")
+
+      form =
+        form(lv, "#link_account_form",
+          author: %{
+            email: author.email,
+            password: password,
+            link_account_user_id: "#{user.id}",
+            request_path: ""
+          }
+        )
+
+      conn = submit_form(form, conn)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
+               "Your authoring account has been linked to your user account."
+
+      assert redirected_to(conn) == ~p"/users/settings"
+    end
+
     test "redirects back to the provided request path after linking", %{conn: conn} do
       user = insert(:user, author: nil)
 


### PR DESCRIPTION
`AuthorAuth.log_in_author/3` now validates `request_path` before redirecting, so an empty submitted value falls back to the normal destination instead of raising Phoenix’s `redirect(to: "")` error. I applied the same redirect-path guard to author logout as well.

Tested locally and it fixes the issue.  