### PR TITLE
[BUG FIX] [MER-5592] Info icon not appearing summary tile - Rework

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/summary_tile.ex
@@ -86,41 +86,70 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
                 class="h-full min-h-[10.375rem] rounded-2xl bg-Surface-surface-secondary py-6 pl-6 pr-[15px] text-Text-text-high shadow-[0px_2px_10px_0px_rgba(0,50,99,0.05)]"
               >
                 <div class="relative flex h-full flex-col">
-                  <div class="min-w-0 pr-8">
-                    <div class="min-h-[40px] min-w-0 space-y-1">
+                  <div :if={@show_recommendation} class="min-h-[40px] min-w-0">
+                    <div class="min-h-[40px] min-w-0">
                       <p class="font-open-sans text-[16px] font-bold leading-[16px] tracking-[0] text-Text-text-high">
                         {card_title_line_one(card.label)}
                       </p>
-                      <p class="whitespace-nowrap font-open-sans text-[16px] font-bold leading-[16px] tracking-[0] text-Text-text-high">
-                        {card_title_line_two(card.label)}
+                      <p class="font-open-sans text-[16px] font-bold leading-[16px] tracking-[0] text-Text-text-high">
+                        <span class="inline-flex items-center gap-3 align-middle pr-1">
+                          <span class="whitespace-nowrap">{card_title_line_two(card.label)}</span>
+                          <span class="group relative inline-flex items-center text-Text-text-high">
+                            <button
+                              id={"summary-tooltip-trigger-#{card.id}"}
+                              type="button"
+                              aria-label={"#{card.label} definition"}
+                              aria-describedby={"summary-tooltip-#{card.id}"}
+                              class="inline-flex h-5 w-5 items-center justify-center rounded-full transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                            >
+                              <span class="scale-[0.9]">
+                                <Icons.info />
+                              </span>
+                            </button>
+                            <span
+                              id={"summary-tooltip-#{card.id}"}
+                              role="tooltip"
+                              class="pointer-events-none absolute right-0 top-[calc(100%+8px)] z-20 hidden w-64 rounded-sm border border-Border-border-default bg-Surface-surface-background px-3 py-2 text-xs leading-4 text-Text-text-high shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] group-hover:block group-focus-within:block"
+                            >
+                              {tooltip_copy(card.tooltip_key)}
+                            </span>
+                          </span>
+                        </span>
                       </p>
                     </div>
+                  </div>
+
+                  <div :if={!@show_recommendation} class="min-h-[40px] min-w-0">
+                    <p class="font-open-sans text-[16px] font-bold leading-[20px] tracking-[0] text-Text-text-high">
+                      <span class="inline-flex items-center gap-1 align-middle">
+                        <span>{card.label}</span>
+                        <span class="group relative inline-flex items-center text-Text-text-high">
+                          <button
+                            id={"summary-tooltip-trigger-#{card.id}"}
+                            type="button"
+                            aria-label={"#{card.label} definition"}
+                            aria-describedby={"summary-tooltip-#{card.id}"}
+                            class="inline-flex h-5 w-5 items-center justify-center rounded-full transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                          >
+                            <span class="scale-[0.9]">
+                              <Icons.info />
+                            </span>
+                          </button>
+                          <span
+                            id={"summary-tooltip-#{card.id}"}
+                            role="tooltip"
+                            class="pointer-events-none absolute right-0 top-[calc(100%+8px)] z-20 hidden w-64 rounded-sm border border-Border-border-default bg-Surface-surface-background px-3 py-2 text-xs leading-4 text-Text-text-high shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] group-hover:block group-focus-within:block"
+                          >
+                            {tooltip_copy(card.tooltip_key)}
+                          </span>
+                        </span>
+                      </span>
+                    </p>
                   </div>
 
                   <p class="mt-3 font-open-sans text-[40px] font-semibold leading-[54px] tracking-[0] text-Text-text-high">
                     {card.value_text}
                   </p>
-
-                  <div class="group absolute right-0 top-5 shrink-0 text-Text-text-high">
-                    <button
-                      id={"summary-tooltip-trigger-#{card.id}"}
-                      type="button"
-                      aria-label={"#{card.label} definition"}
-                      aria-describedby={"summary-tooltip-#{card.id}"}
-                      class="inline-flex h-5 w-5 items-center justify-center rounded-full transition hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
-                    >
-                      <span class="scale-[0.9]">
-                        <Icons.info />
-                      </span>
-                    </button>
-                    <div
-                      id={"summary-tooltip-#{card.id}"}
-                      role="tooltip"
-                      class="pointer-events-none absolute right-0 top-[calc(100%+8px)] z-20 hidden w-64 rounded-sm border border-Border-border-default bg-Surface-surface-background px-3 py-2 text-xs leading-4 text-Text-text-high shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] group-hover:block group-focus-within:block"
-                    >
-                      {tooltip_copy(card.tooltip_key)}
-                    </div>
-                  </div>
                 </div>
               </section>
             <% end %>


### PR DESCRIPTION
[MER-5592](https://eliterate.atlassian.net/browse/MER-5592)

 ## Summary

This PR adjusts the title and info icon behavior in Summary metrics to match the expected design in both recommendation states.

### What changed

- Updated the title + info icon layout in metric cards.
- Implemented state-specific behavior:
  - **When AI recommendation is enabled**:
    - keeps the original two-line title pattern
    - keeps the info icon associated with the second line
  - **When AI recommendation is disabled**:
    - keeps title text and info icon on the same row
    - keeps vertical alignment between text and icon
    
### Visual Validation

- AI recommendations enabled

<img width="1558" height="304" alt="Captura de pantalla 2026-04-29 a la(s) 12 06 28 p  m" src="https://github.com/user-attachments/assets/a835d231-f727-4d03-a637-ba3b60122e42" />

---


- AI recommendations disabled

<img width="1228" height="288" alt="Captura de pantalla 2026-04-29 a la(s) 12 06 14 p  m" src="https://github.com/user-attachments/assets/da9efb81-a40d-4dc4-96e9-1aab3b08f67b" />


[MER-5592]: https://eliterate.atlassian.net/browse/MER-5592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ