### PR TITLE
[BUG FIX] [MER-5590] Fix SRD reload bad patterns

### DIFF
--- a/lib/oli/delivery/depot_coordinator.ex
+++ b/lib/oli/delivery/depot_coordinator.ex
@@ -10,12 +10,4 @@ defmodule Oli.Delivery.DepotCoordinator do
 
   def init_if_necessary(%DepotDesc{} = depot_desc, table_id, caller_module),
     do: get().init_if_necessary(depot_desc, table_id, caller_module)
-
-  def refresh(%DepotDesc{} = depot_desc, table_id, caller_module) do
-    clear(depot_desc, table_id)
-
-    Task.Supervisor.start_child(Oli.TaskSupervisor, fn ->
-      init_if_necessary(depot_desc, table_id, caller_module)
-    end)
-  end
 end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -3724,10 +3724,9 @@ defmodule Oli.Delivery.Sections do
       # reset any section cached data
       SectionCache.clear(section.slug)
 
-      Oli.Delivery.DepotCoordinator.refresh(
+      Oli.Delivery.DepotCoordinator.clear(
         Oli.Delivery.Sections.SectionResourceDepot.depot_desc(),
-        section_id,
-        Oli.Delivery.Sections.SectionResourceDepot
+        section_id
       )
 
       # guarantee a deleted assessment is not required for gaining a certificate

--- a/lib/oli/delivery/sections/section_resource_depot.ex
+++ b/lib/oli/delivery/sections/section_resource_depot.ex
@@ -289,7 +289,6 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
       SectionResourceMigration.migrate(section_id)
     end
 
-    Depot.create_table(@depot_desc, section_id)
     load(section_id)
   end
 
@@ -306,7 +305,19 @@ defmodule Oli.Delivery.Sections.SectionResourceDepot do
 
     results = Repo.all(query)
 
+    create_table_unless_exists(section_id)
     Depot.clear_and_set(@depot_desc, section_id, results)
+  end
+
+  defp create_table_unless_exists(section_id) do
+    if Depot.table_exists?(@depot_desc, section_id) do
+      :ok
+    else
+      Depot.create_table(@depot_desc, section_id)
+      :ok
+    end
+  rescue
+    ArgumentError -> :ok
   end
 
   defp hydrate_objective_children(objectives_section_resources) do

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -80,10 +80,9 @@ defmodule Oli.Delivery.Sections.Updates do
       {:ok, _} ->
         Oli.Delivery.Sections.SectionCache.clear(section.slug)
 
-        Oli.Delivery.DepotCoordinator.refresh(
+        Oli.Delivery.DepotCoordinator.clear(
           Oli.Delivery.Sections.SectionResourceDepot.depot_desc(),
-          section_id,
-          Oli.Delivery.Sections.SectionResourceDepot
+          section_id
         )
 
         Broadcaster.broadcast_update_progress(section.id, new_publication.id, :complete)

--- a/lib/oli/delivery/sections/updates.ex
+++ b/lib/oli/delivery/sections/updates.ex
@@ -15,7 +15,8 @@ defmodule Oli.Delivery.Sections.Updates do
 
   alias Oli.Delivery.Sections.{
     Section,
-    SectionResource
+    SectionResource,
+    SectionResourceMigration
   }
 
   @section_resources_on_conflict {:replace_all_except,
@@ -69,6 +70,7 @@ defmodule Oli.Delivery.Sections.Updates do
       Oli.Repo.transaction(fn ->
         case do_update(section, project.id, current_publication, new_publication) do
           {:ok, _} ->
+            SectionResourceMigration.migrate(section.id)
             do_post_processing_steps(section, project)
 
           e ->


### PR DESCRIPTION
This seems to be a timing bug, but one that was immediately able to reproduced locally.  

I believe this should fix the issue (it does locally):

Removes `DepotCoordinator.refresh/3` and replaces its usages with `DepotCoordinator.clear/2`, returning SRD invalidation to the intended lazy-re build model where delivery reads call `init_if_necessary/3`.

Also tightens `SectionResourceDepot` table initialization by delaying ETS table creation until after section resources are loaded from the database. The table is now created immediately before `Depot.clear_and_set/3`, reducing the window where a table can exist but contain no rows. Table creation is wrapped in a create-unless-exists helper to tolerate concurrent initializers.