### PR TITLE
[ENHANCEMENT] [MER-5213] Open adaptive author preview on the currently selected screen

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -5,7 +5,10 @@ import { isFirefox } from 'utils/browser';
 import { AppsignalContext, ErrorBoundary } from '../../components/common/ErrorBoundary';
 import { initAppSignal, updateAppSignalMetadata } from '../../utils/appsignal';
 import { IActivity, selectAllActivities } from '../delivery/store/features/activities/slice';
-import { selectSequence } from '../delivery/store/features/groups/selectors/deck';
+import {
+  selectCurrentSequenceId,
+  selectSequence,
+} from '../delivery/store/features/groups/selectors/deck';
 import { AuthoringExpertPageEditor } from './AuthoringExpertPageEditor';
 import { AuthoringFlowchartPageEditor } from './AuthoringFlowchartPageEditor';
 import { ModalContainer } from './components/AdvancedAuthoringModal';
@@ -57,6 +60,21 @@ export interface AuthoringProps {
   initialSidebarExpanded: boolean;
 }
 
+export const buildAdaptivePreviewUrl = (url: string, currentSequenceId?: string | null) => {
+  if (!currentSequenceId) {
+    return url;
+  }
+
+  const previewUrl = new URL(url, window.location.origin);
+  previewUrl.searchParams.set('preview_sequence_id', currentSequenceId);
+
+  if (previewUrl.origin === window.location.origin) {
+    return `${previewUrl.pathname}${previewUrl.search}${previewUrl.hash}`;
+  }
+
+  return previewUrl.toString();
+};
+
 const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const {
     paths,
@@ -88,6 +106,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
   const isReadOnly = useSelector(selectReadOnly);
   const activities = useSelector(selectAllActivities);
   const sequence = useSelector(selectSequence);
+  const currentSequenceId = useSelector(selectCurrentSequenceId);
   const hasReadonlyBootstrapActivities = activities.some(
     (activity) =>
       typeof activity.resourceId === 'string' &&
@@ -441,15 +460,19 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
         url: string;
         window_name: string;
       };
+      const previewUrl =
+        content.content?.advancedDelivery === true
+          ? buildAdaptivePreviewUrl(detail.url, currentSequenceId)
+          : detail.url;
 
       if (!isFlowchartMode) {
-        openPreviewWindow(detail.url, detail.window_name);
+        openPreviewWindow(previewUrl, detail.window_name);
         return;
       }
 
       const previewWindow = window.open('', detail.window_name);
       previewRequestRef.current = {
-        url: detail.url,
+        url: previewUrl,
         windowName: detail.window_name,
         previewWindow,
       };
@@ -468,12 +491,19 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
         return;
       }
 
-      openPreviewWindow(detail.url, detail.window_name, previewWindow);
+      openPreviewWindow(previewUrl, detail.window_name, previewWindow);
     };
 
     window.addEventListener('phx:authoring_preview_requested', onPreviewRequested);
     return () => window.removeEventListener('phx:authoring_preview_requested', onPreviewRequested);
-  }, [activities, dispatch, isFlowchartMode, sequence]);
+  }, [
+    activities,
+    content.content?.advancedDelivery,
+    currentSequenceId,
+    dispatch,
+    isFlowchartMode,
+    sequence,
+  ]);
 
   const onAcceptInvalidPreview = () => {
     if (previewRequestRef.current) {

--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -37,6 +37,7 @@ export interface DeliveryProps {
   resourceAttemptGuid: string;
   resourceAttemptNumber?: number;
   activityGuidMapping: any;
+  previewSequenceId?: string;
   previewMode?: boolean;
   isInstructor: boolean;
   enableHistory?: boolean;
@@ -56,6 +57,11 @@ export interface DeliveryProps {
   debuggerURL?: string;
 }
 
+export const shouldHideLessonFinishedCloseButton = (
+  previewMode: boolean,
+  displayApplicationChrome: boolean | undefined,
+) => !!displayApplicationChrome && !previewMode;
+
 const Delivery: React.FC<DeliveryProps> = ({
   userId,
   userName,
@@ -68,6 +74,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   resourceAttemptState,
   resourceAttemptNumber = 1,
   activityGuidMapping,
+  previewSequenceId,
   signoutUrl,
   activityTypes = [],
   previewMode = false,
@@ -189,6 +196,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         resourceAttemptState,
         resourceAttemptNumber,
         activityGuidMapping,
+        previewSequenceId,
         previewMode: !!previewMode,
         isInstructor,
         activityTypes,
@@ -212,7 +220,10 @@ const Delivery: React.FC<DeliveryProps> = ({
   }
   const dialogImageUrl = content?.custom?.logoutPanelImageURL;
   const dialogMessage = content?.custom?.logoutMessage;
-  const fullscreen = !content?.displayApplicationChrome;
+  const hideLessonFinishedCloseButton = shouldHideLessonFinishedCloseButton(
+    !!previewMode,
+    content?.displayApplicationChrome,
+  );
   const insightsStageOnlyPreview = !!content?.custom?.insightsStageOnlyPreview;
   const adaptiveDialogueBridgeEnabled = !!content?.advancedDelivery && !previewMode && !reviewMode;
   const currentActivityAttemptGuid =
@@ -248,7 +259,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         <LessonFinishedDialog
           imageUrl={dialogImageUrl}
           message={dialogMessage}
-          hideCloseButton={!fullscreen}
+          hideCloseButton={hideLessonFinishedCloseButton}
         />
       ) : null}
       <DeadlineTimer deadline={localDeadline} lateSubmit={lateSubmit} overviewURL={overviewURL} />

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
@@ -88,6 +88,9 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
   const [backButtonUrl, setBackButtonUrl] = useState(backUrl);
   const [backButtonText, setBackButtonText] = useState('Back to Overview');
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const showAuthorPreviewBackButton = isPreviewMode && !isInstructor;
+  const showFullscreenToggle =
+    !!currentPage?.displayApplicationChrome && !showAuthorPreviewBackButton;
 
   const projectSlug = useSelector(selectSectionSlug);
   const resourceSlug = useSelector(selectPageSlug);
@@ -189,7 +192,7 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
           }
           `}
           </style>
-          {currentPage.displayApplicationChrome ? (
+          {showFullscreenToggle ? (
             <button
               onClick={toggleFullscreen}
               title={isFullscreen ? 'Minimize' : 'Maximize'}

--- a/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
+++ b/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
@@ -27,6 +27,20 @@ import {
   setScore,
 } from '../slice';
 
+export const resolveInitialPreviewSequenceId = (
+  previewMode: boolean,
+  previewSequenceId: string | undefined,
+  sequence: { custom: { sequenceId: string } }[],
+) => {
+  if (!previewMode || !previewSequenceId) {
+    return null;
+  }
+
+  return sequence.some((entry) => entry.custom.sequenceId === previewSequenceId)
+    ? previewSequenceId
+    : null;
+};
+
 export const loadInitialPageState = createAsyncThunk(
   `${PageSlice}/loadInitialPageState`,
   async (params: PageState, thunkApi) => {
@@ -202,7 +216,17 @@ export const loadInitialPageState = createAsyncThunk(
         /* console.log('RESUME SEQUENCE ID', { resumeSequenceId }); */
         dispatch(navigateToActivity(resumeSequenceId));
       } else {
-        dispatch(navigateToFirstActivity());
+        const previewSequenceId = resolveInitialPreviewSequenceId(
+          !!params.previewMode,
+          params.previewSequenceId,
+          sequence as { custom: { sequenceId: string } }[],
+        );
+
+        if (previewSequenceId) {
+          dispatch(navigateToActivity(previewSequenceId));
+        } else {
+          dispatch(navigateToFirstActivity());
+        }
       }
     }
   },

--- a/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
+++ b/assets/src/apps/delivery/store/features/page/actions/loadInitialPageState.ts
@@ -41,6 +41,42 @@ export const resolveInitialPreviewSequenceId = (
     : null;
 };
 
+export const seedPreviewVisitHistory = (
+  sessionState: Record<string, any>,
+  sequence: { custom: { sequenceId: string; isBank?: boolean; isLayer?: boolean } }[],
+  previewSequenceId: string | null,
+) => {
+  if (!previewSequenceId) {
+    return sessionState;
+  }
+
+  const previewSequenceIndex = sequence.findIndex(
+    (entry) => entry.custom.sequenceId === previewSequenceId,
+  );
+
+  if (previewSequenceIndex <= 0) {
+    return sessionState;
+  }
+
+  const priorNavigableEntries = sequence
+    .slice(0, previewSequenceIndex)
+    .filter((entry) => !entry.custom.isBank && !entry.custom.isLayer);
+  const now = Date.now();
+
+  priorNavigableEntries.forEach((entry, index) => {
+    const visitKey = `session.visits.${entry.custom.sequenceId}`;
+    const timestampKey = `session.visitTimestamps.${entry.custom.sequenceId}`;
+
+    sessionState[visitKey] = Math.max(Number(sessionState[visitKey] || 0), 1);
+
+    if (!sessionState[timestampKey]) {
+      sessionState[timestampKey] = now - (priorNavigableEntries.length - index) * 1000;
+    }
+  });
+
+  return sessionState;
+};
+
 export const loadInitialPageState = createAsyncThunk(
   `${PageSlice}/loadInitialPageState`,
   async (params: PageState, thunkApi) => {
@@ -128,6 +164,22 @@ export const loadInitialPageState = createAsyncThunk(
       }
 
       // update scripting env with session state
+      const initialPreviewSequenceId = resolveInitialPreviewSequenceId(
+        !!params.previewMode,
+        params.previewSequenceId,
+        sequence as { custom: { sequenceId: string; isBank?: boolean; isLayer?: boolean } }[],
+      );
+
+      if (params.previewMode) {
+        seedPreviewVisitHistory(
+          sessionState,
+          sequence as {
+            custom: { sequenceId: string; isBank?: boolean; isLayer?: boolean };
+          }[],
+          initialPreviewSequenceId,
+        );
+      }
+
       const assignScript = getAssignScript(sessionState, defaultGlobalEnv);
       const { result: _scriptResult } = evalScript(assignScript, defaultGlobalEnv);
       //No need to wite anything to server in REVIEW mode
@@ -216,14 +268,8 @@ export const loadInitialPageState = createAsyncThunk(
         /* console.log('RESUME SEQUENCE ID', { resumeSequenceId }); */
         dispatch(navigateToActivity(resumeSequenceId));
       } else {
-        const previewSequenceId = resolveInitialPreviewSequenceId(
-          !!params.previewMode,
-          params.previewSequenceId,
-          sequence as { custom: { sequenceId: string } }[],
-        );
-
-        if (previewSequenceId) {
-          dispatch(navigateToActivity(previewSequenceId));
+        if (initialPreviewSequenceId) {
+          dispatch(navigateToActivity(initialPreviewSequenceId));
         } else {
           dispatch(navigateToFirstActivity());
         }

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -15,6 +15,7 @@ export interface PageState {
   resourceAttemptGuid: string;
   resourceAttemptNumber: number;
   activityGuidMapping: any;
+  previewSequenceId?: string;
   previewMode: boolean;
   isInstructor: boolean;
   enableHistory: boolean;
@@ -45,6 +46,7 @@ const initialState: PageState = {
   resourceAttemptNumber: 1,
   resourceAttemptState: {},
   activityGuidMapping: {},
+  previewSequenceId: undefined,
   previewMode: false,
   isInstructor: false,
   enableHistory: false,
@@ -83,6 +85,7 @@ const pageSlice = createSlice({
       state.resourceAttemptNumber = action.payload.resourceAttemptNumber || 1;
       state.resourceAttemptState = action.payload.resourceAttemptState;
       state.activityGuidMapping = action.payload.activityGuidMapping;
+      state.previewSequenceId = action.payload.previewSequenceId;
       state.previewMode = !!action.payload.previewMode;
       state.isInstructor = !!action.payload.isInstructor;
       state.activityTypes = action.payload.activityTypes;

--- a/assets/test/apps/authoring/adaptive_preview_url_test.ts
+++ b/assets/test/apps/authoring/adaptive_preview_url_test.ts
@@ -1,0 +1,21 @@
+import { buildAdaptivePreviewUrl } from 'apps/authoring/Authoring';
+
+describe('buildAdaptivePreviewUrl', () => {
+  test('adds preview_sequence_id for adaptive preview handoff', () => {
+    expect(buildAdaptivePreviewUrl('/authoring/project/demo/preview/page-slug', 'screen_2')).toBe(
+      '/authoring/project/demo/preview/page-slug?preview_sequence_id=screen_2',
+    );
+  });
+
+  test('preserves existing query params when adding preview_sequence_id', () => {
+    expect(
+      buildAdaptivePreviewUrl('/authoring/project/demo/preview/page-slug?foo=bar', 'screen_2'),
+    ).toBe('/authoring/project/demo/preview/page-slug?foo=bar&preview_sequence_id=screen_2');
+  });
+
+  test('returns the original url when there is no selected sequence', () => {
+    expect(buildAdaptivePreviewUrl('/authoring/project/demo/preview/page-slug')).toBe(
+      '/authoring/project/demo/preview/page-slug',
+    );
+  });
+});

--- a/assets/test/delivery/deck_layout_header_test.tsx
+++ b/assets/test/delivery/deck_layout_header_test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import DeckLayoutHeader from 'apps/delivery/layouts/deck/DeckLayoutHeader';
+import {
+  selectIsInstructor,
+  selectPageContent,
+  selectPageSlug,
+  selectPreviewMode,
+  selectResourceAttemptNumber,
+  selectReviewMode,
+  selectScore,
+  selectSectionSlug,
+} from 'apps/delivery/store/features/page/slice';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('apps/delivery/layouts/deck/components/EverappMenu', () => () => null);
+jest.mock('apps/delivery/layouts/deck/components/OptionsPanel', () => () => null);
+jest.mock('apps/delivery/layouts/deck/components/ReviewModeNavigation', () => () => null);
+
+describe('DeckLayoutHeader', () => {
+  const configureSelectors = ({
+    previewMode,
+    isInstructor,
+    displayApplicationChrome,
+  }: {
+    previewMode: boolean;
+    isInstructor: boolean;
+    displayApplicationChrome: boolean;
+  }) => {
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      switch (selector) {
+        case selectScore:
+          return 0;
+        case selectPageContent:
+          return { advancedDelivery: true, displayApplicationChrome, custom: { everApps: [] } };
+        case selectResourceAttemptNumber:
+          return 1;
+        case selectPreviewMode:
+          return previewMode;
+        case selectIsInstructor:
+          return isInstructor;
+        case selectReviewMode:
+          return false;
+        case selectSectionSlug:
+          return 'demo-project';
+        case selectPageSlug:
+          return 'demo-page';
+        default:
+          return undefined;
+      }
+    });
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows Back to Authoring instead of fullscreen controls in author preview', async () => {
+    configureSelectors({ previewMode: true, isInstructor: false, displayApplicationChrome: true });
+
+    render(<DeckLayoutHeader pageName="Adaptive Preview" userName="Guest" />);
+
+    expect(await screen.findByTitle('Back to Authoring')).toHaveAttribute(
+      'href',
+      '/authoring/project/demo-project/resource/demo-page',
+    );
+    expect(screen.queryByLabelText('Maximize')).not.toBeInTheDocument();
+  });
+
+  it('keeps fullscreen controls for instructor preview with application chrome', () => {
+    configureSelectors({ previewMode: true, isInstructor: true, displayApplicationChrome: true });
+
+    render(<DeckLayoutHeader pageName="Adaptive Preview" userName="Instructor" />);
+
+    expect(screen.getByLabelText('Maximize')).toBeInTheDocument();
+    expect(screen.queryByTitle('Back to Authoring')).not.toBeInTheDocument();
+  });
+});

--- a/assets/test/delivery/delivery_lesson_finished_dialog_test.ts
+++ b/assets/test/delivery/delivery_lesson_finished_dialog_test.ts
@@ -1,0 +1,15 @@
+import { shouldHideLessonFinishedCloseButton } from 'apps/delivery/Delivery';
+
+describe('shouldHideLessonFinishedCloseButton', () => {
+  it('keeps the close button visible in preview mode even when application chrome is enabled', () => {
+    expect(shouldHideLessonFinishedCloseButton(true, true)).toBe(false);
+  });
+
+  it('hides the close button for chrome-enabled non-preview delivery', () => {
+    expect(shouldHideLessonFinishedCloseButton(false, true)).toBe(true);
+  });
+
+  it('keeps the close button visible for chromeless delivery', () => {
+    expect(shouldHideLessonFinishedCloseButton(false, false)).toBe(false);
+  });
+});

--- a/assets/test/delivery/load_initial_page_state_test.ts
+++ b/assets/test/delivery/load_initial_page_state_test.ts
@@ -1,4 +1,7 @@
-import { resolveInitialPreviewSequenceId } from 'apps/delivery/store/features/page/actions/loadInitialPageState';
+import {
+  resolveInitialPreviewSequenceId,
+  seedPreviewVisitHistory,
+} from 'apps/delivery/store/features/page/actions/loadInitialPageState';
 
 describe('resolveInitialPreviewSequenceId', () => {
   const sequence = [{ custom: { sequenceId: 'screen_1' } }, { custom: { sequenceId: 'screen_2' } }];
@@ -13,5 +16,43 @@ describe('resolveInitialPreviewSequenceId', () => {
 
   test('returns null when the selected preview sequence id is not in the sequence', () => {
     expect(resolveInitialPreviewSequenceId(true, 'screen_3', sequence as any)).toBeNull();
+  });
+});
+
+describe('seedPreviewVisitHistory', () => {
+  test('seeds prior navigable screens as visited for preview history', () => {
+    const sessionState = {
+      'session.visits.screen_1': 0,
+      'session.visits.screen_2': 0,
+      'session.visits.screen_3': 0,
+    };
+    const sequence = [
+      { custom: { sequenceId: 'screen_1' } },
+      { custom: { sequenceId: 'bank_1', isBank: true } },
+      { custom: { sequenceId: 'screen_2' } },
+      { custom: { sequenceId: 'layer_1', isLayer: true } },
+      { custom: { sequenceId: 'screen_3' } },
+    ];
+
+    const seeded = seedPreviewVisitHistory(sessionState, sequence as any, 'screen_3');
+
+    expect(seeded['session.visits.screen_1']).toBe(1);
+    expect(seeded['session.visits.screen_2']).toBe(1);
+    expect(seeded['session.visits.screen_3']).toBe(0);
+    expect(seeded['session.visitTimestamps.screen_1']).toBeGreaterThan(0);
+    expect(seeded['session.visitTimestamps.screen_2']).toBeGreaterThan(
+      seeded['session.visitTimestamps.screen_1'],
+    );
+    expect(seeded['session.visitTimestamps.bank_1']).toBeUndefined();
+    expect(seeded['session.visitTimestamps.layer_1']).toBeUndefined();
+  });
+
+  test('leaves state unchanged when preview starts on the first screen', () => {
+    const sessionState = { 'session.visits.screen_1': 0 };
+    const sequence = [{ custom: { sequenceId: 'screen_1' } }];
+
+    const seeded = seedPreviewVisitHistory(sessionState, sequence as any, 'screen_1');
+
+    expect(seeded).toEqual({ 'session.visits.screen_1': 0 });
   });
 });

--- a/assets/test/delivery/load_initial_page_state_test.ts
+++ b/assets/test/delivery/load_initial_page_state_test.ts
@@ -1,0 +1,17 @@
+import { resolveInitialPreviewSequenceId } from 'apps/delivery/store/features/page/actions/loadInitialPageState';
+
+describe('resolveInitialPreviewSequenceId', () => {
+  const sequence = [{ custom: { sequenceId: 'screen_1' } }, { custom: { sequenceId: 'screen_2' } }];
+
+  test('returns the selected preview sequence id when it exists in preview mode', () => {
+    expect(resolveInitialPreviewSequenceId(true, 'screen_2', sequence as any)).toBe('screen_2');
+  });
+
+  test('returns null when preview mode is disabled', () => {
+    expect(resolveInitialPreviewSequenceId(false, 'screen_2', sequence as any)).toBeNull();
+  });
+
+  test('returns null when the selected preview sequence id is not in the sequence', () => {
+    expect(resolveInitialPreviewSequenceId(true, 'screen_3', sequence as any)).toBeNull();
+  });
+});

--- a/lib/oli_web/components/delivery/adaptive_iframe.ex
+++ b/lib/oli_web/components/delivery/adaptive_iframe.ex
@@ -21,9 +21,22 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
     {content_width + @chrome_width, content_height + @chrome_height}
   end
 
-  def preview(project_slug, revision) do
+  def preview(project_slug, revision, opts \\ []) do
     size = get_size(revision.content)
-    url = Routes.resource_path(OliWeb.Endpoint, :preview_fullscreen, project_slug, revision.slug)
+
+    base_url =
+      Routes.resource_path(OliWeb.Endpoint, :preview_fullscreen, project_slug, revision.slug)
+
+    query_params =
+      %{}
+      |> maybe_put_query_param("preview_sequence_id", Keyword.get(opts, :preview_sequence_id))
+
+    url =
+      case map_size(query_params) do
+        0 -> base_url
+        _ -> base_url <> "?" <> URI.encode_query(query_params)
+      end
+
     iframe(url, size)
   end
 

--- a/lib/oli_web/controllers/resource_controller.ex
+++ b/lib/oli_web/controllers/resource_controller.ex
@@ -136,6 +136,7 @@ defmodule OliWeb.ResourceController do
         resourceAttemptState: nil,
         resourceAttemptGuid: nil,
         activityGuidMapping: nil,
+        previewSequenceId: conn.params["preview_sequence_id"],
         previousPageURL: nil,
         nextPageURL: nil,
         previewMode: true
@@ -148,9 +149,11 @@ defmodule OliWeb.ResourceController do
          project_slug,
          _transformed_content,
          _author,
-         _options
+         options
        ) do
-    AdaptiveIFrame.preview(project_slug, revision)
+    AdaptiveIFrame.preview(project_slug, revision,
+      preview_sequence_id: Keyword.get(options, :preview_sequence_id)
+    )
   end
 
   defp render_content_html(_revision, project_slug, transformed_content, author, options) do
@@ -224,6 +227,7 @@ defmodule OliWeb.ResourceController do
                   transformed_content,
                   author,
                   preview: true,
+                  preview_sequence_id: conn.params["preview_sequence_id"],
                   graded: revision.graded,
                   bib_app_params: bib_references
                 ),

--- a/lib/oli_web/live/workspaces/course_author/editor_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/editor_live.ex
@@ -700,6 +700,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.Curriculum.EditorLive do
 
   defp creation_mode_hint(_params, _context), do: nil
 
+  defp preview_url(%{assigns: %{context: %{content: %{"advancedDelivery" => true}}}} = socket),
+    do:
+      "/authoring/project/#{socket.assigns.project_slug}/preview_fullscreen/#{socket.assigns.revision_slug}"
+
   defp preview_url(socket),
     do:
       "/authoring/project/#{socket.assigns.project_slug}/preview/#{socket.assigns.revision_slug}"

--- a/test/oli_web/components/delivery/adaptive_iframe_test.exs
+++ b/test/oli_web/components/delivery/adaptive_iframe_test.exs
@@ -52,4 +52,21 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrameTest do
     assert iframe =~ "page_revision_id=101"
     assert iframe =~ "screen_revision_id=202"
   end
+
+  test "preview/3 carries preview_sequence_id for author preview iframe routes" do
+    revision = %Revision{
+      slug: "adaptive-page",
+      content: %{
+        "custom" => %{"defaultScreenHeight" => 640, "defaultScreenWidth" => 960}
+      }
+    }
+
+    iframe =
+      AdaptiveIFrame.preview("authoring_project", revision,
+        preview_sequence_id: "screen_sequence_123"
+      )
+
+    assert iframe =~
+             ~s(src="/authoring/project/authoring_project/preview_fullscreen/adaptive-page?preview_sequence_id=screen_sequence_123")
+  end
 end

--- a/test/oli_web/controllers/resource_controller_test.exs
+++ b/test/oli_web/controllers/resource_controller_test.exs
@@ -122,6 +122,25 @@ defmodule OliWeb.ResourceControllerTest do
                "<div data-react-class=\"Components.Delivery\" data-react-props=\""
     end
 
+    test "threads adaptive preview_sequence_id into advanced lesson preview props", %{
+      conn: conn,
+      project: project,
+      adaptive_page_revision: adaptive_page_revision
+    } do
+      conn =
+        get(
+          conn,
+          Routes.resource_path(conn, :preview, project.slug, adaptive_page_revision.slug, %{
+            "preview_sequence_id" => "screen_sequence_123"
+          })
+        )
+
+      html = html_response(conn, 200)
+
+      assert html =~ "previewSequenceId"
+      assert html =~ "screen_sequence_123"
+    end
+
     test "renders page preview with next page links", %{
       conn: conn,
       project: project,

--- a/test/oli_web/live/workspaces/course_author/editor_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/editor_live_test.exs
@@ -127,6 +127,23 @@ defmodule OliWeb.Workspaces.CourseAuthor.Curriculum.EditorLiveTest do
       assert has_element?(view, "#authoring_editor-container")
     end
 
+    test "advanced author preview requests the fullscreen adaptive preview route", %{
+      conn: conn,
+      project: project,
+      adaptive_page_revision: adaptive_page_revision
+    } do
+      expected_url =
+        "/authoring/project/#{project.slug}/preview_fullscreen/#{adaptive_page_revision.slug}"
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug, adaptive_page_revision.slug))
+      render_hook(view, "survey_scripts_loaded", %{})
+      render_hook(view, "authoring_preview_state_changed", %{"enabled" => true})
+
+      render_click(element(view, "button[phx-click=\"request_authoring_preview\"]"))
+
+      assert_push_event(view, "authoring_preview_requested", %{url: ^expected_url})
+    end
+
     test "keeps preview disabled until the editor is ready", %{
       conn: conn,
       project: project,


### PR DESCRIPTION
## Summary

  This PR updates adaptive authoring preview so clicking `Preview` opens the preview on the screen the author is currently editing, instead of always starting from the first screen.

  It also preserves the expected fullscreen author preview experience and fixes a few preview-only regressions uncovered while wiring the current-screen handoff through delivery.

  ## Problem

  Before this change, adaptive author preview always started on the first screen, regardless of which screen the author had selected in advanced authoring.

  That created two problems:

  - authors previewing later screens had to manually click through earlier screens just to inspect the screen they were editing
  - the preview behavior no longer matched authoring context

  While implementing current-screen preview, a few preview-specific regressions also surfaced:

  - adaptive preview could open in the wrapped preview shell instead of the fullscreen adaptive route
  - author preview could show the fullscreen maximize/minimize affordance instead of `Back to Authoring`
  - preview completion could hide the close button on the lesson-finished dialog
  - starting preview on a later screen could make earlier screens unavailable to preview history/back navigation

  ## What Changed

  ### Preview opens on the selected adaptive screen

  The authoring app now appends the currently selected adaptive `sequenceId` to the preview URL as:

  - `preview_sequence_id=<sequenceId>`

  This is only added for adaptive pages.