### PR TITLE
[ENHANCEMENT] [MER-5107] Reposition Support and Cookies on Adaptive Page Not Fullscreen

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
@@ -111,6 +111,7 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
   useEffect(() => {
     const iframe = window.parent.document.getElementById('adaptive_content_iframe');
     const container = window.parent.document.getElementById('adaptive_with_chrome_container');
+    const viewportActions = window.parent.document.getElementById('adaptive-viewport-actions');
 
     if (!iframe || !container) return;
 
@@ -118,15 +119,18 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
     if (isFullscreen) {
       iframe.classList.add('fullscreen-iframe');
       container.classList.add('fullscreen-container');
+      viewportActions?.classList.add('hidden');
     } else {
       iframe.classList.remove('fullscreen-iframe');
       container.classList.remove('fullscreen-container');
+      viewportActions?.classList.remove('hidden');
     }
 
     // Cleanup function: ensure fullscreen classes are removed on unmount
     return () => {
       iframe.classList.remove('fullscreen-iframe');
       container.classList.remove('fullscreen-container');
+      viewportActions?.classList.remove('hidden');
     };
   }, [isFullscreen]);
 

--- a/assets/src/hooks/sticky_tech_support_button.ts
+++ b/assets/src/hooks/sticky_tech_support_button.ts
@@ -1,14 +1,15 @@
 /**
  * StickyTechSupportButton Hook
  *
- * Purpose: Manages the positioning behavior of the tech support button on large devices (≥1024px).
+ * Purpose: Manages the positioning behavior of the tech support button on desktop devices (≥1280px).
  *
  * Behavior:
  * - While scrolling: The button floats at a fixed position in the bottom-left corner of the viewport
  * - When the footer approaches: As the user scrolls and the footer comes within 10px of the viewport bottom,
  *   the button switches from fixed to absolute positioning, causing it to stop floating and stay positioned
  *   just above the footer element in the document flow
- * - On smaller devices: The hook does not apply any special positioning, allowing default styling to take effect
+ * - On mobile and tablet devices: The hook does not apply any special positioning, allowing the button
+ *   to appear in the page footer instead of following the scroll
  *
  * This creates a "sticky from bottom" effect where the button remains accessible while scrolling but gracefully
  * stops floating when it would otherwise overlap with the footer content.
@@ -18,11 +19,11 @@ export const StickyTechSupportButton = {
     const button = document.getElementById('tech-support');
     if (!button) return;
 
-    const isLargeDevice = () => window.innerWidth >= 1024; // lg breakpoint is 1024px
+    const isDesktop = () => window.innerWidth >= 1280; // xl breakpoint is 1280px
 
     const updateButtonPosition = () => {
-      if (!isLargeDevice()) {
-        // Reset to default on smaller devices - remove positioning classes
+      if (!isDesktop()) {
+        // Reset to default on mobile and tablet devices - remove positioning classes
         button.style.position = '';
         button.style.bottom = '';
         button.style.left = '';

--- a/lib/oli_web/components/footer.ex
+++ b/lib/oli_web/components/footer.ex
@@ -4,13 +4,14 @@ defmodule OliWeb.Components.Footer do
 
   attr :license, :map, default: nil
   attr :show_cookie_preferences, :boolean, default: true
+  attr :is_page, :boolean, default: false
 
   def delivery_footer(assigns) do
     ~H"""
     <footer class="w-full py-4 md:container lg:px-10 text-xs bg-delivery-footer dark:bg-delivery-footer-dark">
       <div class="flex flex-col">
         <div class="flex flex-col sm:flex-row gap-2">
-          <.cookie_preferences :if={@show_cookie_preferences} />
+          <.cookie_preferences :if={@show_cookie_preferences} class="hidden md:inline" />
           <.footer_part_1 />
           <.footer_part_2 />
         </div>

--- a/lib/oli_web/components/footer.ex
+++ b/lib/oli_web/components/footer.ex
@@ -2,16 +2,19 @@ defmodule OliWeb.Components.Footer do
   use Phoenix.Component
   use OliWeb, :verified_routes
 
+  attr :license, :map, default: nil
+  attr :show_cookie_preferences, :boolean, default: true
+
   def delivery_footer(assigns) do
     ~H"""
     <footer class="w-full py-4 md:container lg:px-10 text-xs bg-delivery-footer dark:bg-delivery-footer-dark">
       <div class="flex flex-col">
         <div class="flex flex-col sm:flex-row gap-2">
-          <.cookie_preferences />
+          <.cookie_preferences :if={@show_cookie_preferences} />
           <.footer_part_1 />
           <.footer_part_2 />
         </div>
-        <%= if Map.get(assigns, :license) do %>
+        <%= if @license do %>
           {OliWeb.LayoutView.render_license(@license)}
         <% end %>
       </div>
@@ -115,8 +118,13 @@ defmodule OliWeb.Components.Footer do
 
   attr :class, :string, default: ""
 
+  def cookie_preferences_link(assigns), do: cookie_preferences(assigns)
+
   defp cookie_preferences(assigns) do
-    assigns = assign(assigns, privacy_policies_url: privacy_policies_url())
+    assigns =
+      assigns
+      |> assign_new(:class, fn -> "" end)
+      |> assign(:privacy_policies_url, privacy_policies_url())
 
     ~H"""
     <div class="text-left shrink-0 relative z-10">

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -139,13 +139,31 @@
             "mb-20 px-4 mt-auto relative",
             if(assistant_available?(assigns), do: "mr-10 lg:mr-28", else: "")
           ]}>
-            <div id="tech-support-wrapper" phx-hook="StickyTechSupportButton">
+            <div
+              :if={@view == :adaptive_with_chrome}
+              id="adaptive-viewport-actions"
+              class="fixed bottom-6 left-16 z-[9999] flex flex-col items-start gap-1"
+            >
+              <OliWeb.Components.Common.tech_support_button
+                id="tech-support"
+                class="h-auto px-0 py-0"
+              />
+              <OliWeb.Components.Footer.cookie_preferences_link class="hidden md:inline-flex text-sm font-medium" />
+            </div>
+            <div
+              :if={@view != :adaptive_with_chrome}
+              id="tech-support-wrapper"
+              phx-hook="StickyTechSupportButton"
+            >
               <OliWeb.Components.Common.tech_support_button
                 id="tech-support"
                 class="-ml-4 lg:ml-0 lg:fixed lg:bottom-2 lg:left-10 lg:z-[999]"
               />
             </div>
-            <OliWeb.Components.Footer.delivery_footer license={assigns[:license]} />
+            <OliWeb.Components.Footer.delivery_footer
+              license={assigns[:license]}
+              show_cookie_preferences={@view != :adaptive_with_chrome}
+            />
           </div>
         </div>
       </div>

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -157,7 +157,7 @@
             >
               <OliWeb.Components.Common.tech_support_button
                 id="tech-support"
-                class="-ml-4 lg:ml-0 lg:fixed lg:bottom-2 lg:left-10 lg:z-[999]"
+                class="-ml-4 md:ml-7 xl:ml-0 xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
               />
             </div>
             <OliWeb.Components.Footer.delivery_footer

--- a/test/oli_web/components/footer_test.exs
+++ b/test/oli_web/components/footer_test.exs
@@ -19,5 +19,17 @@ defmodule OliWeb.Components.FooterTest do
       html = render_component(&Footer.delivery_footer/1, %{})
       refute html =~ ~s(id="license")
     end
+
+    test "hides cookie preferences link on mobile" do
+      html = render_component(&Footer.delivery_footer/1, %{})
+
+      assert html
+             |> Floki.parse_document!()
+             |> Floki.find("a")
+             |> Enum.any?(fn anchor ->
+               Floki.text(anchor) =~ "Cookie Preferences" and
+                 anchor |> Floki.attribute("class") |> Enum.join(" ") =~ "hidden md:inline"
+             end)
+    end
   end
 end

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1166,6 +1166,17 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       # Verify tech support button exists with correct id
       assert has_element?(view, "#tech-support")
+
+      tech_support =
+        view
+        |> render()
+        |> Floki.parse_document!()
+        |> Floki.find("#tech-support")
+        |> Floki.raw_html()
+
+      refute tech_support =~ ~r/(^|\s)fixed(\s|")/
+      assert tech_support =~ "-ml-4 md:ml-8 xl:ml-0"
+      assert tech_support =~ "xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
     end
 
     @tag isolation: "serializable"

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -2660,6 +2660,45 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       refute outline =~ "Unit:"
     end
 
+    test "positions support and cookie preferences in viewport for adaptive with chrome", %{
+      conn: conn,
+      user: user
+    } do
+      %{section: section, adaptive_page: adaptive_page} = create_adaptive_with_chrome_section()
+
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, adaptive_page.slug))
+      ensure_content_is_visible(view)
+
+      assert has_element?(
+               view,
+               "#adaptive-viewport-actions.fixed.bottom-8.left-10 #tech-support",
+               "Support"
+             )
+
+      assert has_element?(
+               view,
+               "#adaptive-viewport-actions a",
+               "Cookie Preferences"
+             )
+
+      viewport_actions =
+        view
+        |> render()
+        |> Floki.parse_document!()
+        |> Floki.find("#adaptive-viewport-actions")
+        |> Floki.raw_html()
+
+      assert viewport_actions =~ "flex-col"
+      assert viewport_actions =~ ~r/id="tech-support"(.|\n)*Cookie Preferences/
+      refute viewport_actions =~ "bg-delivery-body"
+      refute viewport_actions =~ "border-gray"
+
+      refute has_element?(view, "#tech-support-wrapper[phx-hook='StickyTechSupportButton']")
+    end
+
     test "omits prefixes for unnumbered units in the lesson popup outline", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1175,7 +1175,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         |> Floki.raw_html()
 
       refute tech_support =~ ~r/(^|\s)fixed(\s|")/
-      assert tech_support =~ "-ml-4 md:ml-8 xl:ml-0"
+      assert tech_support =~ "-ml-4 md:ml-7 xl:ml-0"
       assert tech_support =~ "xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
     end
 
@@ -2685,7 +2685,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert has_element?(
                view,
-               "#adaptive-viewport-actions.fixed.bottom-8.left-10 #tech-support",
+               "#adaptive-viewport-actions.fixed #tech-support",
                "Support"
              )
 
@@ -2703,6 +2703,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         |> Floki.raw_html()
 
       assert viewport_actions =~ "flex-col"
+      assert viewport_actions =~ "bottom-6 left-16"
       assert viewport_actions =~ ~r/id="tech-support"(.|\n)*Cookie Preferences/
       refute viewport_actions =~ "bg-delivery-body"
       refute viewport_actions =~ "border-gray"


### PR DESCRIPTION
[MER-5107](https://eliterate.atlassian.net/browse/MER-5107)

Updates adaptive page support and cookie preference controls so they appear only in the minimized adaptive-with-chrome view, are hidden in fullscreen, and match the intended bottom-left layout. Also refines responsive behavior so Cookie Preferences is hidden on mobile and the Support button remains footer-bound on mobile/tablet while staying sticky on desktop.





[MER-5107]: https://eliterate.atlassian.net/browse/MER-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ