### PR TITLE
[BUG FIX] [MER-4182] Improve dark-mode assessment timer contrast

### DIFF
--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1506,7 +1506,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       <div
         id="countdown_timer_display"
         phx-update="ignore"
-        class="text-lg text-center absolute mt-4 top-2 right-6 font-['Open Sans'] tracking-tight text-zinc-700"
+        class="text-lg text-center absolute mt-4 top-2 right-6 font-['Open Sans'] tracking-tight text-zinc-700 dark:text-[#EEEBF5]"
         phx-hook="CountdownTimer"
         data-timer-id="countdown_timer_display"
         data-submit-button-id="submit_answers"
@@ -1522,7 +1522,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
         <div
           id="countdown_timer_display"
           phx-update="ignore"
-          class="text-lg text-center absolute mt-4 top-2 right-6 font-['Open Sans'] tracking-tight text-zinc-700"
+          class="text-lg text-center absolute mt-4 top-2 right-6 font-['Open Sans'] tracking-tight text-zinc-700 dark:text-[#EEEBF5]"
           phx-hook="EndDateTimer"
           data-timer-id="countdown_timer_display"
           data-submit-button-id="submit_answers"

--- a/lib/oli_web/templates/page_delivery/page.html.heex
+++ b/lib/oli_web/templates/page_delivery/page.html.heex
@@ -77,13 +77,21 @@
   <% end %>
 
   <%= if @review_mode == false and @time_limit > 0 and @graded do %>
-    <div id="countdown_timer_display" class="text-xl font-bold text-center sticky top-0"></div>
+    <div
+      id="countdown_timer_display"
+      class="text-xl font-bold text-center sticky top-0 dark:text-[#EEEBF5]"
+    >
+    </div>
     <script>
       OLI.initCountdownTimer('countdown_timer_display', 'submit_answers', <%= @time_limit %>, <%= @attempt_start_time %>, <%= @effective_end_time %>, <%= @auto_submit %>);
     </script>
   <% else %>
     <%= if @review_mode == false and !is_nil(@effective_end_time) and @graded do %>
-      <div id="countdown_timer_display" class="text-xl font-bold text-center sticky top-0"></div>
+      <div
+        id="countdown_timer_display"
+        class="text-xl font-bold text-center sticky top-0 dark:text-[#EEEBF5]"
+      >
+      </div>
       <script>
         OLI.initEndDateTimer('countdown_timer_display', 'submit_answers', <%= @effective_end_time %>, <%= @auto_submit %>);
       </script>

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1187,6 +1187,31 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       refute render(view) =~ "<div id=\"countdown_timer_display\""
     end
 
+    @tag isolation: "serializable"
+    test "timer uses higher contrast text in dark mode on graded pages", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: graded_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{time_limit: 20})
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      html = render(view)
+
+      assert html =~ ~s(id="countdown_timer_display")
+      assert html =~ "text-zinc-700"
+      assert html =~ "dark:text-[#EEEBF5]"
+    end
+
     test "can not see `reset answers` button on practice pages without activities", %{
       conn: conn,
       user: user,


### PR DESCRIPTION
Addresses [MER-4182](https://eliterate.atlassian.net/browse/MER-4182) by changing dark mode styling on assessment Time Remaining timer for better contrast.

  - Added dark:text-[#EEEBF5] to LiveView countdown timers and the legacy delivery template timer.
  - Added regression coverage for timed graded pages preserving light-mode text-zinc-700 and requiring dark:text-[#EEEBF5].



[MER-4182]: https://eliterate.atlassian.net/browse/MER-4182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ