### PR TITLE
[BUG FIX] [MER-5593] remove tooltip from intelligent dashboard support tile donut graphic

### DIFF
--- a/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/student_support_tile.ex
+++ b/lib/oli_web/components/delivery/instructor_dashboard/intelligent_dashboard/tiles/student_support_tile.ex
@@ -799,12 +799,7 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Ti
                 |> get_in([:chart, :light])
               end)
           }
-        },
-        "tooltip" => [
-          %{"field" => "label", "type" => "nominal", "title" => "Bucket"},
-          %{"field" => "count", "type" => "quantitative", "title" => "Students"},
-          %{"field" => "pct", "type" => "quantitative", "title" => "Percent"}
-        ]
+        }
       },
       "layer" => [
         %{

--- a/test/oli_web/components/delivery/instructor_dashboard/student_support_tile_test.exs
+++ b/test/oli_web/components/delivery/instructor_dashboard/student_support_tile_test.exs
@@ -57,6 +57,15 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.StudentSupportTileTest 
       refute has_element?(component, "#student_support_parameters_modal_student_support_tile")
     end
 
+    test "omits chart tooltip from the Vega-Lite spec", %{conn: conn} do
+      {:ok, _component, html} =
+        live_component_isolated(conn, StudentSupportTile, base_attrs(%{tile_state: tile_state()}))
+
+      spec = chart_spec_from_html(html)
+
+      refute Map.has_key?(spec["encoding"], "tooltip")
+    end
+
     test "renders parameterized thresholds and inactive copy", %{conn: conn} do
       projection =
         projection()
@@ -291,6 +300,15 @@ defmodule OliWeb.Components.Delivery.InstructorDashboard.StudentSupportTileTest 
     end)
 
     render(component)
+  end
+
+  defp chart_spec_from_html(html) do
+    html
+    |> Floki.parse_fragment!()
+    |> Floki.find("#student-support-chart-student_support_tile")
+    |> Floki.attribute("data-spec")
+    |> List.first()
+    |> Jason.decode!()
   end
 
   defp base_attrs(overrides) do


### PR DESCRIPTION
Addresses [MER-5593](https://eliterate.atlassian.net/browse/MER-5593) by removing the undesired tooltip over the donut graphic in the Student Support tile of the instructor intelligent dashboard. 

Designer clarified that no further mouse hover behavior is desired. 

[MER-5593]: https://eliterate.atlassian.net/browse/MER-5593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ