### PR TITLE
[BUG FIX] [MER-5597] Adjust assessment settings layout to prevent displacing search box

### DIFF
--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -103,8 +103,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
       {due_date_modal(assigns)}
       {available_date_modal(assigns)}
       {modal(@modal_assigns)}
-      <div class="flex flex-col space-y-4 lg:space-y-0 lg:flex-row lg:items-center lg:justify-between pr-6 mb-4">
-        <div class="flex flex-col pl-9">
+      <div class="flex flex-col gap-4 pr-6 mb-4 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
+        <div class="flex flex-col pl-9 lg:shrink-0">
           <h4 class="torus-h4 whitespace-nowrap">Assessment Settings</h4>
           <p>These are your current assessment settings.</p>
         </div>
@@ -112,13 +112,13 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           for="bulk_apply_settings"
           phx-target={@myself}
           phx-submit="bulk_apply"
-          class="ml-9 flex space-x-4 items-center lg:flex-col lg:pb-0 lg:pt-6 lg:items-start lg:space-x-0"
+          class="ml-9 flex min-w-0 max-w-full flex-col gap-2 lg:ml-0 lg:max-w-xl lg:pb-0 lg:pt-6 lg:items-start"
         >
-          <label>Copy and apply settings from one assessment to all:</label>
-          <div class="flex lg:space-x-4 lg:mt-2">
+          <label class="max-w-full">Copy and apply settings from one assessment to all:</label>
+          <div class="flex min-w-0 max-w-full flex-col gap-3 sm:flex-row sm:items-center lg:mt-2 lg:gap-4">
             <select
               id="assessment_select"
-              class="torus-select"
+              class="torus-select min-w-0 w-full max-w-full truncate sm:max-w-sm lg:max-w-md"
               name="assessment_id"
               phx-target={@myself}
               phx-change="select_assessment"
@@ -127,13 +127,14 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
                 :for={assessment <- @assessments}
                 selected={assessment.resource_id == @bulk_apply_selected_assessment_id}
                 value={assessment.resource_id}
+                title={assessment.name_with_container_label}
               >
                 {assessment.name_with_container_label}
               </option>
             </select>
             <button
               type="submit"
-              class="torus-button flex justify-center primary h-9 px-4 whitespace-nowrap lg:ml-4"
+              class="torus-button flex shrink-0 justify-center primary h-9 px-4 whitespace-nowrap"
             >
               Bulk apply
             </button>
@@ -143,7 +144,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           for="search"
           phx-target={@myself}
           phx-change="search_assessment"
-          class="pb-6 ml-9 sm:pb-0 w-56"
+          class="pb-6 ml-9 sm:pb-0 w-56 lg:ml-0 lg:shrink-0"
         >
           <SearchInput.render
             id="assessments_search_input"

--- a/lib/oli_web/live/sections/assessment_settings/settings_table.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table.ex
@@ -112,13 +112,13 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTable do
           for="bulk_apply_settings"
           phx-target={@myself}
           phx-submit="bulk_apply"
-          class="ml-9 flex min-w-0 max-w-full flex-col gap-2 lg:ml-0 lg:max-w-xl lg:pb-0 lg:pt-6 lg:items-start"
+          class="ml-9 flex min-w-0 max-w-full flex-col gap-2 lg:ml-0 lg:flex-1 lg:max-w-2xl lg:pb-0 lg:pt-6 lg:items-start xl:max-w-3xl"
         >
           <label class="max-w-full">Copy and apply settings from one assessment to all:</label>
-          <div class="flex min-w-0 max-w-full flex-col gap-3 sm:flex-row sm:items-center lg:mt-2 lg:gap-4">
+          <div class="flex min-w-0 max-w-full flex-col gap-3 sm:flex-row sm:items-center lg:mt-2 lg:w-full lg:gap-4">
             <select
               id="assessment_select"
-              class="torus-select min-w-0 w-full max-w-full truncate sm:max-w-sm lg:max-w-md"
+              class="torus-select min-w-0 w-full max-w-full truncate sm:max-w-sm lg:flex-1 lg:max-w-xl xl:max-w-2xl"
               name="assessment_id"
               phx-target={@myself}
               phx-change="select_assessment"


### PR DESCRIPTION
 ## Summary

Fixes [MER-5597](https://eliterate.atlassian.net/browse/MER-5597) by adjusting the Assessment Settings header layout so long assessment titles in the bulk-apply dropdown do not push the search field off screen. 

Note issue only occurs when section contains assessment with suitably long title, as in Real Chem.

  ## Changes

  - Constrained the bulk-apply form with responsive max widths.
  - Allowed the dropdown to grow on wider screens while still truncating overly long titles.
  - Prevented the search field from shrinking or being displaced in the right column.
  - Added title attributes to dropdown options so full assessment names remain available in the markup.
  
  ## Screenshot

<img width="1266" height="156" alt="Screenshot 2026-04-29 at 5 03 36 PM" src="https://github.com/user-attachments/assets/6f91897a-cee3-4e7b-907e-4248ecf42793" />


[MER-5597]: https://eliterate.atlassian.net/browse/MER-5597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ