### PR TITLE
[FEATURE] [MER-5355] Consolidate instructor recommendation prompt flow

### DIFF
--- a/lib/oli/instructor_dashboard/recommendations/prompt.ex
+++ b/lib/oli/instructor_dashboard/recommendations/prompt.ex
@@ -4,6 +4,7 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
   """
 
   @version "recommendation_prompt_v1"
+  @data_placeholder "\#{data}"
   @default_no_signal_prompt """
   You are an expert learning engineer and instructor dashboard analyst. You will be given 1-5 datasets exported from an LMS/assessment system. Each dataset is presented as:
 
@@ -24,34 +25,64 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
   - A descriptor line explaining what it is
   - A Markdown table containing the data
 
-  Your job is to produce an actionable instructional insight. You must be precise, avoid speculation, and cite the dataset(s) and column names you used.
+  Your job is to produce an actionable instructional insight. You must be precise and avoid speculation. Instructors do not revise course content. They take actions like early intervention with students, providing additional materials, or focusing on a topic in class through hands-on activities.
 
-  Produce one instructional insight or recommendation total, expressed in one sentence (or at most two short sentences).
-  The insight should be the highest-impact finding an instructor or admin should act on right now.
+  ### What you have
 
-  When forming the insight, consider implicitly:
+  #{@data_placeholder}
+
+  ### Output requirements
+
+  Produce one instructional insight or recommendation total, expressed in fewer than 200 characters.
+  The insight should be the highest-impact finding that an instructor should act on right now.
+
+  When forming the insight, consider (implicitly -- do not enumerate):
 
   - Patterns across datasets (performance, attempts, hints, timing, engagement).
   - Evidence from specific dataset descriptors and column names.
   - Whether the issue concerns students, groups, concepts, or engagement behaviors.
   - What concrete instructor action would most directly address the issue.
+  - Where is the class in the schedule? Recommendations are most helpful when they relate to what we are now covering in the course.
 
-  Required constraints:
+  ###Required structure
+  - What's happening (signal)
+  - Why it matters (interpretation)
+  - What to consider doing (suggested action)
 
-  - The sentence must reference one dataset descriptor or one course content location.
+  ###Tone guidelines
+  - Supportive, not prescriptive
+  - Transparent, not "all-knowing"
+  - Acts like a trusted TA, not an evaluator
+  - Uses common language
+
+  #### Required constraints
+
   - Do not include bullet points, headings, or multiple recommendations.
   - Do not explain your reasoning step-by-step.
-  - If evidence is suggestive but not definitive, label it clearly as Inference within the sentence.
+  - Use plain language, no jargon
+  - If evidence is suggestive but not definitive, label it clearly as an inference within the sentence.
   - If no meaningful insight can be supported by the data, say so explicitly in one sentence.
+  - Round numbers to the hundredth decimal place
 
-  Rules:
+  #### Example format (illustrative only)
+
+  "Several students are progressing into Unit 4, but a sizable group is showing low proficiency on core plant biology objectives, particularly cell structure and photosynthesis. You may want to revisit these concepts or assign additional practice before moving further into the unit."
+
+  ###Example format (illustrative only)
+
+  "Proficiency is strong among students who reach Module 6 (92%), but only 72% have progressed this far. Consider sending a brief reminder or adjusting pacing to help more students reach this module."
+
+  #### Rules
 
   - Do not invent facts not supported by the tables.
+  - If the class is performing well, it is fine to point this out
   - If you make an inference, label it explicitly as Inference and explain the supporting evidence.
   - Prefer specific statements over generic advice.
-  - If there are multiple datasets, cross-reference them when the evidence supports the same conclusion.
+  - If there are multiple datasets, you should cross-reference them (e.g., connect performance to engagement).
   - If a dataset is empty or clearly incomplete, note it and proceed with what you have.
   - If very little student data is present, it is fine to state "There is no specific recommendation at this point in time, as there isn't enough student data"
+
+  Begin now.
   """
 
   @spec version() :: String.t()
@@ -62,9 +93,11 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
 
   @spec build_messages(map(), keyword()) :: [map()]
   def build_messages(input_contract, opts \\ []) when is_map(input_contract) do
+    rendered_prompt = input_contract |> system_prompt(opts) |> render_prompt(input_contract)
+
     [
-      %{role: :system, content: system_prompt(input_contract, opts)},
-      %{role: :user, content: user_prompt(input_contract)}
+      %{role: :system, content: rendered_prompt},
+      %{role: :user, content: "Begin now."}
     ]
   end
 
@@ -92,37 +125,22 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
 
   defp normalize_prompt_template(_), do: nil
 
-  defp user_prompt(input_contract) do
+  defp render_prompt(prompt_template, input_contract) do
     datasets =
       input_contract
       |> Map.get(:datasets, [])
       |> Enum.map(&render_dataset/1)
       |> Enum.join("\n\n")
 
-    signal_summary = Map.fetch!(input_contract, :signal_summary)
-    scope = Map.fetch!(input_contract, :scope)
-
-    """
-    Prompt version: #{Map.get(input_contract, :prompt_version, @version)}
-    Signal state: #{signal_summary.state}
-    No-signal reasons: #{Enum.join(Enum.map(signal_summary.reasons, &to_string/1), ", ")}
-    Scope: #{scope.scope_label} (#{scope.container_type})
-    Course: #{scope.course_title}
-
-    ### What you have
-
-    #{datasets}
-
-    ### Output requirements
-
-    Produce the final recommendation now.
-    """
-    |> String.trim()
+    if String.contains?(prompt_template, @data_placeholder) do
+      String.replace(prompt_template, @data_placeholder, datasets)
+    else
+      String.trim_trailing(prompt_template) <> "\n\n" <> datasets
+    end
   end
 
   defp render_dataset(dataset) do
     """
-    Dataset: #{Map.fetch!(dataset, :key)}
     Descriptor: #{Map.fetch!(dataset, :descriptor)}
     #{render_markdown_table(Map.get(dataset, :columns, []), Map.get(dataset, :rows, []))}
     """

--- a/lib/oli/instructor_dashboard/recommendations/prompt.ex
+++ b/lib/oli/instructor_dashboard/recommendations/prompt.ex
@@ -44,12 +44,12 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
   - What concrete instructor action would most directly address the issue.
   - Where is the class in the schedule? Recommendations are most helpful when they relate to what we are now covering in the course.
 
-  ###Required structure
+  ### Required structure
   - What's happening (signal)
   - Why it matters (interpretation)
   - What to consider doing (suggested action)
 
-  ###Tone guidelines
+  ### Tone guidelines
   - Supportive, not prescriptive
   - Transparent, not "all-knowing"
   - Acts like a trusted TA, not an evaluator
@@ -68,7 +68,7 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
 
   "Several students are progressing into Unit 4, but a sizable group is showing low proficiency on core plant biology objectives, particularly cell structure and photosynthesis. You may want to revisit these concepts or assign additional practice before moving further into the unit."
 
-  ###Example format (illustrative only)
+  ### Example format (illustrative only)
 
   "Proficiency is strong among students who reach Module 6 (92%), but only 72% have progressed this far. Consider sending a brief reminder or adjusting pacing to help more students reach this module."
 
@@ -95,10 +95,7 @@ defmodule Oli.InstructorDashboard.Recommendations.Prompt do
   def build_messages(input_contract, opts \\ []) when is_map(input_contract) do
     rendered_prompt = input_contract |> system_prompt(opts) |> render_prompt(input_contract)
 
-    [
-      %{role: :system, content: rendered_prompt},
-      %{role: :user, content: "Begin now."}
-    ]
+    [%{role: :system, content: rendered_prompt}]
   end
 
   defp system_prompt(input_contract, opts) do

--- a/test/oli/instructor_dashboard/recommendations/prompt_test.exs
+++ b/test/oli/instructor_dashboard/recommendations/prompt_test.exs
@@ -5,10 +5,9 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
 
   describe "build_messages/2" do
     test "builds a single rendered system prompt with interpolated datasets" do
-      [system_message, user_message] = Prompt.build_messages(input_contract_fixture())
+      [system_message] = Prompt.build_messages(input_contract_fixture())
 
       assert system_message.role == :system
-      assert user_message.role == :user
       assert system_message.content =~ "expert learning engineer and instructor dashboard analyst"
       assert system_message.content =~ "### What you have"
       assert system_message.content =~ "Descriptor: Scope overview"
@@ -17,11 +16,10 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
                "| course_title | scope_label | scope_type | items_in_scope | titles_preview |"
 
       refute system_message.content =~ "\#{data}"
-      assert user_message.content == "Begin now."
     end
 
     test "adds explicit no-signal guidance when the input contract is no-signal" do
-      [system_message, user_message] =
+      [system_message] =
         Prompt.build_messages(
           put_in(input_contract_fixture(), [:signal_summary, :state], :no_signal)
           |> put_in([:signal_summary, :reasons], [:no_students, :no_activity_data])
@@ -29,11 +27,10 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
 
       assert system_message.content =~ "signal_state=no_signal"
       assert system_message.content =~ "Return exactly one sentence"
-      assert user_message.content == "Begin now."
     end
 
     test "uses a custom prompt template and interpolates datasets when placeholder is present" do
-      [system_message, _user_message] =
+      [system_message] =
         Prompt.build_messages(input_contract_fixture(),
           prompt_template: "Custom header\n\n\#{data}\n\nCustom footer"
         )
@@ -45,7 +42,7 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
     end
 
     test "falls back to default prompt template when custom template is blank" do
-      [system_message, _user_message] =
+      [system_message] =
         Prompt.build_messages(input_contract_fixture(), prompt_template: "   ")
 
       assert system_message.content =~
@@ -57,7 +54,7 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
     end
 
     test "appends datasets at the end when custom template does not include placeholder" do
-      [system_message, _user_message] =
+      [system_message] =
         Prompt.build_messages(input_contract_fixture(),
           prompt_template: "Custom recommendation prompt"
         )

--- a/test/oli/instructor_dashboard/recommendations/prompt_test.exs
+++ b/test/oli/instructor_dashboard/recommendations/prompt_test.exs
@@ -4,22 +4,20 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
   alias Oli.InstructorDashboard.Recommendations.Prompt
 
   describe "build_messages/2" do
-    test "builds versioned system and user messages with dataset sections" do
+    test "builds a single rendered system prompt with interpolated datasets" do
       [system_message, user_message] = Prompt.build_messages(input_contract_fixture())
 
       assert system_message.role == :system
       assert user_message.role == :user
       assert system_message.content =~ "expert learning engineer and instructor dashboard analyst"
-      assert system_message.content =~ "Produce one instructional insight or recommendation total"
-      assert user_message.content =~ "Prompt version: recommendation_prompt_v1"
-      assert user_message.content =~ "### What you have"
-      assert user_message.content =~ "### Output requirements"
-      assert user_message.content =~ "Dataset: scope_overview"
+      assert system_message.content =~ "### What you have"
+      assert system_message.content =~ "Descriptor: Scope overview"
 
-      assert user_message.content =~
+      assert system_message.content =~
                "| course_title | scope_label | scope_type | items_in_scope | titles_preview |"
 
-      assert user_message.content =~ "Produce the final recommendation now."
+      refute system_message.content =~ "\#{data}"
+      assert user_message.content == "Begin now."
     end
 
     test "adds explicit no-signal guidance when the input contract is no-signal" do
@@ -31,23 +29,41 @@ defmodule Oli.InstructorDashboard.Recommendations.PromptTest do
 
       assert system_message.content =~ "signal_state=no_signal"
       assert system_message.content =~ "Return exactly one sentence"
-      assert user_message.content =~ "No-signal reasons: no_students, no_activity_data"
+      assert user_message.content == "Begin now."
     end
 
-    test "uses a custom system prompt when a prompt template is provided" do
+    test "uses a custom prompt template and interpolates datasets when placeholder is present" do
       [system_message, _user_message] =
         Prompt.build_messages(input_contract_fixture(),
-          prompt_template: "Custom recommendation prompt"
+          prompt_template: "Custom header\n\n\#{data}\n\nCustom footer"
         )
 
-      assert system_message.content == "Custom recommendation prompt"
+      assert system_message.content =~ "Custom header"
+      assert system_message.content =~ "Descriptor: Scope overview"
+      assert system_message.content =~ "Custom footer"
+      refute system_message.content =~ "\#{data}"
     end
 
     test "falls back to default prompt template when custom template is blank" do
       [system_message, _user_message] =
         Prompt.build_messages(input_contract_fixture(), prompt_template: "   ")
 
-      assert system_message.content == Prompt.default_template()
+      assert system_message.content =~
+               "You are an expert learning engineer and instructor dashboard analyst."
+
+      assert system_message.content =~ "### What you have"
+      assert system_message.content =~ "Descriptor: Scope overview"
+      refute system_message.content =~ "\#{data}"
+    end
+
+    test "appends datasets at the end when custom template does not include placeholder" do
+      [system_message, _user_message] =
+        Prompt.build_messages(input_contract_fixture(),
+          prompt_template: "Custom recommendation prompt"
+        )
+
+      assert system_message.content =~ "Custom recommendation prompt"
+      assert system_message.content =~ "Descriptor: Scope overview"
     end
   end
 

--- a/test/oli/instructor_dashboard/recommendations_test.exs
+++ b/test/oli/instructor_dashboard/recommendations_test.exs
@@ -163,11 +163,9 @@ defmodule Oli.InstructorDashboard.RecommendationsTest do
     assert recommendation.metadata.service_config_id == 7
     assert recommendation.metadata.provider_usage == %{tokens: 123}
 
-    assert %{"messages" => [system_message, user_message]} = latest.original_prompt
+    assert %{"messages" => [system_message]} = latest.original_prompt
     assert system_message["role"] == "system"
-    assert user_message["role"] == "user"
     assert system_message["content"] =~ "### What you have"
-    assert user_message["content"] == "Begin now."
   end
 
   test "reuses an in-flight generating instance for the same scope", %{

--- a/test/oli/instructor_dashboard/recommendations_test.exs
+++ b/test/oli/instructor_dashboard/recommendations_test.exs
@@ -166,7 +166,8 @@ defmodule Oli.InstructorDashboard.RecommendationsTest do
     assert %{"messages" => [system_message, user_message]} = latest.original_prompt
     assert system_message["role"] == "system"
     assert user_message["role"] == "user"
-    assert user_message["content"] =~ "Prompt version: recommendation_prompt_v1"
+    assert system_message["content"] =~ "### What you have"
+    assert user_message["content"] == "Begin now."
   end
 
   test "reuses an in-flight generating instance for the same scope", %{


### PR DESCRIPTION
[MER-5355](https://eliterate.atlassian.net/browse/MER-5355)

## Summary

This PR unifies how the instructor recommendation prompt is built so there is a single editable template that is processed at runtime with real datasets.

## What changed

- Consolidated the main recommendation prompt into a single template.
- Added post-processing to replace `#{data}` with the actual dataset block before sending the request to the model.
- Updated message construction so the main content lives in the rendered prompt.
- Kept a robust fallback when a custom template does not include `#{data}` (datasets are appended at the end).
- Updated tests to validate:
  - `#{data}` interpolation,
  - custom template behavior,
  - fallback behavior for blank templates or templates without the placeholder,
  - original prompt persistence under the new format.

## Note

The `no_signal` path keeps its dedicated branch to preserve current behavior when there is not enough data signal.

[MER-5355]: https://eliterate.atlassian.net/browse/MER-5355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ