### PR TITLE
[ENHANCEMENT] [MER-5591] preserve dashboard layout for admins within session

### DIFF
--- a/lib/oli/instructor_dashboard.ex
+++ b/lib/oli/instructor_dashboard.ex
@@ -81,7 +81,7 @@ defmodule Oli.InstructorDashboard do
   Unknown persisted ids are ignored, duplicate ids are collapsed to the first
   occurrence, and newly visible sections are appended in default order.
   """
-  @spec resolve_section_layout(InstructorDashboardState.t() | nil, [String.t()]) ::
+  @spec resolve_section_layout(InstructorDashboardState.t() | map() | nil, [String.t()]) ::
           resolved_layout()
   def resolve_section_layout(state, default_section_ids) when is_list(default_section_ids) do
     default_section_ids = Enum.uniq(default_section_ids)

--- a/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
@@ -4131,18 +4131,24 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
     end
   end
 
-  # Same-scope patches should preserve the active LiveView layout state to keep
-  # admin layout customizations within-session when there is no instructor
-  # enrollment to persist to.
   defp dashboard_layout_state(socket, scope_selector) do
     previous_scope = Map.get(socket.assigns, :dashboard_scope)
 
-    if previous_scope == scope_selector and dashboard_layout_assigned?(socket) do
-      current_assigned_layout_state(socket)
-    else
-      current_layout_state(socket)
+    cond do
+      no_persisted_layout_state?(socket) and dashboard_layout_assigned?(socket) ->
+        current_assigned_layout_state(socket)
+
+      previous_scope == scope_selector and dashboard_layout_assigned?(socket) ->
+        current_assigned_layout_state(socket)
+
+      true ->
+        current_layout_state(socket)
     end
   end
+
+  # Preserve the active LiveView layout state to keep admin layout customizations
+  # within-session when there is no instructor enrollment to persist to.
+  defp no_persisted_layout_state?(socket), do: is_nil(socket.assigns[:instructor_enrollment])
 
   defp dashboard_layout_assigned?(socket) do
     Map.has_key?(socket.assigns, :dashboard_section_order) and

--- a/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
@@ -4134,6 +4134,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
   defp dashboard_layout_state(socket, scope_selector) do
     previous_scope = Map.get(socket.assigns, :dashboard_scope)
 
+    # Preserve the active LiveView layout state to keep admin layout customizations
+    # within-session when there is no instructor enrollment to persist to.
     cond do
       no_persisted_layout_state?(socket) and dashboard_layout_assigned?(socket) ->
         current_assigned_layout_state(socket)
@@ -4146,8 +4148,6 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
     end
   end
 
-  # Preserve the active LiveView layout state to keep admin layout customizations
-  # within-session when there is no instructor enrollment to persist to.
   defp no_persisted_layout_state?(socket), do: is_nil(socket.assigns[:instructor_enrollment])
 
   defp dashboard_layout_assigned?(socket) do

--- a/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/intelligent_dashboard_tab.ex
@@ -1210,7 +1210,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
     socket = ensure_initialized(socket)
     use_revisit? = not socket.assigns.dashboard_revisit_hydrated?
     {socket, dashboard_navigator_items} = ensure_dashboard_navigator_items(socket)
-    layout_state = current_layout_state(socket)
+    layout_state = dashboard_layout_state(socket, scope_selector)
     student_support_tile_state = parse_student_support_tile_state(params)
     assessments_tile_state = parse_assessments_tile_state(params)
     progress_tile_state = parse_progress_tile_state(params)
@@ -4129,6 +4129,33 @@ defmodule OliWeb.Delivery.InstructorDashboard.IntelligentDashboardTab do
       _ ->
         nil
     end
+  end
+
+  # Same-scope patches should preserve the active LiveView layout state to keep
+  # admin layout customizations within-session when there is no instructor
+  # enrollment to persist to.
+  defp dashboard_layout_state(socket, scope_selector) do
+    previous_scope = Map.get(socket.assigns, :dashboard_scope)
+
+    if previous_scope == scope_selector and dashboard_layout_assigned?(socket) do
+      current_assigned_layout_state(socket)
+    else
+      current_layout_state(socket)
+    end
+  end
+
+  defp dashboard_layout_assigned?(socket) do
+    Map.has_key?(socket.assigns, :dashboard_section_order) and
+      Map.has_key?(socket.assigns, :dashboard_collapsed_section_ids) and
+      Map.has_key?(socket.assigns, :dashboard_section_tile_layouts)
+  end
+
+  defp current_assigned_layout_state(socket) do
+    %{
+      section_order: socket.assigns.dashboard_section_order,
+      collapsed_section_ids: socket.assigns.dashboard_collapsed_section_ids,
+      section_tile_layouts: socket.assigns.dashboard_section_tile_layouts
+    }
   end
 
   defp build_dashboard_visible_sections(socket, layout_state) do

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -1019,6 +1019,39 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
     end
   end
 
+  describe "admin: insights > dashboard tab" do
+    setup [:admin_conn, :section_with_assessment]
+
+    test "preserves resized tile layout across same-scope filter patches without enrollment", %{
+      section: section,
+      conn: conn
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          ~p"/sections/#{section.slug}/instructor_dashboard/insights/dashboard?dashboard_scope=course"
+        )
+
+      clear_instructor_enrollment(view)
+      Repo.delete_all(InstructorDashboardState)
+
+      view
+      |> element("#learning-dashboard-engagement-group-tiles")
+      |> render_hook("dashboard_section_resized", %{section_id: "engagement", split: 58})
+
+      assert render(view) =~ ~s(data-dashboard-section-split="58")
+      assert Repo.all(InstructorDashboardState) == []
+
+      render_patch(
+        view,
+        ~p"/sections/#{section.slug}/instructor_dashboard/insights/dashboard?dashboard_scope=course&tile_support[filter]=active"
+      )
+
+      assert render(view) =~ ~s(data-dashboard-section-split="58")
+      assert Repo.all(InstructorDashboardState) == []
+    end
+  end
+
   defp assessment_id_for_title(html, title) do
     regex =
       ~r/phx-value-assessment_id="(?<id>\d+)".*?aria-label="Expand assessment #{Regex.escape(title)}"/s
@@ -1050,6 +1083,17 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
         socket
         |> Phoenix.Component.assign(:dashboard, dashboard)
         |> Phoenix.Component.assign(:summary_tile_state, summary_tile_state)
+      end)
+
+    :sys.replace_state(view.pid, fn _current_state -> new_state end)
+  end
+
+  defp clear_instructor_enrollment(view) do
+    state = :sys.get_state(view.pid)
+
+    new_state =
+      replace_liveview_sockets(state, fn socket ->
+        Phoenix.Component.assign(socket, :instructor_enrollment, nil)
       end)
 
     :sys.replace_state(view.pid, fn _current_state -> new_state end)

--- a/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live_test.exs
@@ -1022,10 +1022,13 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
   describe "admin: insights > dashboard tab" do
     setup [:admin_conn, :section_with_assessment]
 
-    test "preserves resized tile layout across same-scope filter patches without enrollment", %{
+    test "preserves resized tile layout within session without enrollment", %{
       section: section,
       conn: conn
     } do
+      {_, containers} = Helpers.get_containers(section)
+      container = hd(containers)
+
       {:ok, view, _html} =
         live(
           conn,
@@ -1045,6 +1048,14 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLiveTest do
       render_patch(
         view,
         ~p"/sections/#{section.slug}/instructor_dashboard/insights/dashboard?dashboard_scope=course&tile_support[filter]=active"
+      )
+
+      assert render(view) =~ ~s(data-dashboard-section-split="58")
+      assert Repo.all(InstructorDashboardState) == []
+
+      render_patch(
+        view,
+        ~p"/sections/#{section.slug}/instructor_dashboard/insights/dashboard?dashboard_scope=container:#{container.id}"
       )
 
       assert render(view) =~ ~s(data-dashboard-section-split="58")


### PR DESCRIPTION
Fixes dashboard layout customizations resetting on filter changes for admin viewers who do not have instructor enrollment-backed persisted dashboard state. [Ticket](https://eliterate.atlassian.net/browse/MER-5591)

This can happen when an admin viewer already has a delivery user session that is not enrolled as an instructor in the section being viewed. A common path to this state is:

  1. Admin opens one section, which may create/login a section-scoped hidden instructor delivery account. Dashboard layout changes in _this_ section will persist under the hidden instructor enrollment, so issue does not appear yet.
  3. Admin then opens another section in the same browser session.
  4. Admin authorization still succeeds through the admin author account.
  5. Dashboard layout persistence looks for an instructor enrollment for the current delivery user in the new section.
  6. Because that delivery user belongs to a different section, no enrollment-backed dashboard state is available.

  Previously, resizing a tile or expanding/collapsing a section in that state would update the visible dashboard, but a filter/search patch or scope change rebuilt layout from default state and lost the customization. The dashboard now reuses active LiveView layout state when no persisted layout state is available, keeping admin layout customizations intact within the current LiveView session. 
  
  Note, however, that full page reloads still reset to default layout in this case because there is no persisted admin layout state across sessions. Because layout persistence is currently enrollment-based, it was deemed not worth the change required to persist admin layout settings across sessions for this case. 

  Enrolled instructor behavior remains conservative: same-scope patches reuse in-memory layout, while scope changes continue to resolve from persisted/default layout state.
  
Note: The "common path" above depends on the fact that admin delivery routes can retain a stale section-scoped hidden instructor when an admin moves between sections. A broader fix would update `auto_enroll_admin/2` to swap stale hidden users for the current section’s hidden instructor, while preserving real delivery-user sessions. This might be quite generally desireable, however, modifying hidden user behavior is outside the scope of this ticket, so that is left for follow-up work. Also, the "common path" is not the only path to the buggy behavior, it can also arise if an ordinary (non-hidden) unenrolled instructor account is logged in at time of admin login.