### PR TITLE
[BUG FIX] [MER-5601] Fix various appsignals

### DIFF
--- a/lib/oli/lti/keyset_refresh_worker.ex
+++ b/lib/oli/lti/keyset_refresh_worker.ex
@@ -40,6 +40,9 @@ defmodule Oli.Lti.KeysetRefreshWorker do
           :ok ->
             {:ok, registration.id}
 
+          :discard ->
+            :discard
+
           {:error, reason} ->
             Logger.warning(
               "Failed to refresh keyset for registration #{registration.id}: #{inspect(reason)}"
@@ -92,11 +95,17 @@ defmodule Oli.Lti.KeysetRefreshWorker do
   end
 
   defp fetch_and_cache_keyset(nil) do
+    Logger.info("Discarding keyset refresh because registration was not found")
+
     # Discard job - registration doesn't exist (permanent failure)
     :discard
   end
 
   defp fetch_and_cache_keyset(%{key_set_url: nil} = registration) do
+    Logger.info(
+      "Discarding keyset refresh for registration #{registration.id} because key_set_url is not configured"
+    )
+
     Logger.warning(
       "Registration #{registration.id} has no key_set_url configured, skipping keyset refresh"
     )
@@ -117,15 +126,31 @@ defmodule Oli.Lti.KeysetRefreshWorker do
         :ok
 
       {:error, :invalid_url_no_scheme} ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: #{key_set_url} is missing a URL scheme"
+        )
+
         :discard
 
       {:error, :insecure_url_scheme} ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: #{key_set_url} uses an insecure URL scheme"
+        )
+
         :discard
 
       {:error, :invalid_url_no_host} ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: #{key_set_url} is missing a host"
+        )
+
         :discard
 
       {:error, {:http_error, status_code}} when status_code in 400..499 ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: HTTP #{status_code} client error fetching #{key_set_url}"
+        )
+
         Logger.error(
           "HTTP #{status_code} client error fetching keyset from #{key_set_url} - permanent failure"
         )
@@ -133,12 +158,24 @@ defmodule Oli.Lti.KeysetRefreshWorker do
         :discard
 
       {:error, :invalid_jwks_format} ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: invalid JWKS format from #{key_set_url}"
+        )
+
         :discard
 
       {:error, :json_decode_failed} ->
+        Logger.info(
+          "Discarding keyset refresh for registration #{registration_id}: JSON decode failed for #{key_set_url}"
+        )
+
         :discard
 
       {:error, reason} ->
+        Logger.info(
+          "Retrying keyset refresh for registration #{registration_id}: transient failure fetching #{key_set_url}"
+        )
+
         Logger.error("Failed to fetch keyset from #{key_set_url}: #{inspect(reason)}")
         {:error, reason}
     end

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -35,14 +35,13 @@ defmodule Oli.Rendering.Activity.Html do
     end
   end
 
-  defp render_missing_activity(context, activity, activity_map, activity_id, render_opts) do
-    {error_id, error_msg} =
-      log_error(
-        "ActivitySummary with id #{activity_id} missing from activity_map",
-        {activity, activity_map}
-      )
+  defp render_missing_activity(context, activity, _activity_map, activity_id, render_opts) do
 
     if render_opts.render_errors do
+
+      error_id = uuid() |> String.upcase()
+      error_msg = "ActivitySummary with id #{activity_id} missing from activity_map",
+
       error(context, activity, {:activity_missing, error_id, error_msg})
     else
       []

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -36,11 +36,9 @@ defmodule Oli.Rendering.Activity.Html do
   end
 
   defp render_missing_activity(context, activity, _activity_map, activity_id, render_opts) do
-
     if render_opts.render_errors do
-
       error_id = uuid() |> String.upcase()
-      error_msg = "ActivitySummary with id #{activity_id} missing from activity_map",
+      error_msg = "ActivitySummary with id #{activity_id} missing from activity_map"
 
       error(context, activity, {:activity_missing, error_id, error_msg})
     else

--- a/lib/oli_web/common/assent_auth_web.ex
+++ b/lib/oli_web/common/assent_auth_web.ex
@@ -190,8 +190,6 @@ defmodule OliWeb.Common.AssentAuthWeb do
     if assent_auth_module(config).email_confirmed?(user) do
       {:ok, false}
     else
-      deliver_user_confirmation_instructions(user, config)
-
       {:ok, true}
     end
   end

--- a/lib/oli_web/common/assent_auth_web.ex
+++ b/lib/oli_web/common/assent_auth_web.ex
@@ -236,10 +236,6 @@ defmodule OliWeb.Common.AssentAuthWeb do
     create_session.(conn, user)
   end
 
-  defp deliver_user_confirmation_instructions(user, config) do
-    config.deliver_user_confirmation_instructions.(user)
-  end
-
   defp get_user_by_provider_uid(provider, uid, config) do
     config.get_user_by_provider_uid.(provider, ensure_string(uid))
   end

--- a/lib/oli_web/controllers/launch_controller.ex
+++ b/lib/oli_web/controllers/launch_controller.ex
@@ -82,10 +82,10 @@ defmodule OliWeb.LaunchController do
           |> redirect(to: redirect_path)
 
         _error ->
-          render(conn, "enroll.html", error: "Something went wrong, please try again")
+          render_enroll(conn, params, "Something went wrong, please try again")
       end
     else
-      render(conn, "enroll.html", error: "ReCaptcha failed, please try again")
+      render_enroll(conn, params, "ReCaptcha failed, please try again")
     end
   end
 
@@ -112,6 +112,15 @@ defmodule OliWeb.LaunchController do
     conn
     |> redirect(
       to: ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path]}"
+    )
+  end
+
+  defp render_enroll(conn, params, error) do
+    render(conn, OliWeb.DeliveryView, "enroll.html",
+      section: Repo.preload(conn.assigns.section, [:base_project]),
+      from_invitation_link?: false,
+      auto_enroll_as_guest: Map.get(params, "auto_enroll_as_guest", true),
+      error: error
     )
   end
 

--- a/lib/oli_web/controllers/launch_controller.ex
+++ b/lib/oli_web/controllers/launch_controller.ex
@@ -116,7 +116,9 @@ defmodule OliWeb.LaunchController do
   end
 
   defp render_enroll(conn, params, error) do
-    render(conn, OliWeb.DeliveryView, "enroll.html",
+    conn
+    |> put_view(OliWeb.DeliveryView)
+    |> render("enroll.html",
       section: Repo.preload(conn.assigns.section, [:base_project]),
       from_invitation_link?: false,
       auto_enroll_as_guest: Map.get(params, "auto_enroll_as_guest", true),

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -115,20 +115,18 @@ defmodule Oli.Content.Activity.HtmlTest do
         "type" => "activity-reference"
       }
 
-      assert capture_log(fn ->
-               rendered_html =
-                 Activity.render(
-                   %Context{user: author, activity_map: activity_map},
-                   element,
-                   Activity.Html
-                 )
+      rendered_html =
+        Activity.render(
+          %Context{user: author, activity_map: activity_map},
+          element,
+          Activity.Html
+        )
 
-               rendered_html_string =
-                 Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+      rendered_html_string =
+        Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
-               assert rendered_html_string =~
-                        "<div class=\"alert alert-danger\">ActivitySummary with id 1 missing from activity_map"
-             end) =~ "ActivitySummary with id 1 missing from activity_map"
+      assert rendered_html_string =~
+               "<div class=\"alert alert-danger\">ActivitySummary with id 1 missing from activity_map"
     end
 
     test "includes pageState from extrinsic_state when present", %{author: author} do

--- a/test/oli_web/common/assent_auth_web_test.exs
+++ b/test/oli_web/common/assent_auth_web_test.exs
@@ -103,9 +103,8 @@ defmodule OliWeb.Common.AssentAuthWebTest do
           config
         )
 
-      # no confirmation email is sent for author params with missing email_verified
-      [%Oban.Job{args: %{"email" => %{"subject" => "Confirm your email"}}} | _] =
-        queued_email_jobs()
+      # no confirmation email is sent for OAuth-created users
+      Swoosh.TestAssertions.assert_no_email_sent()
     end
 
     test "handle_authorization_success/4 handles error", %{

--- a/test/oli_web/controllers/launch_controller_test.exs
+++ b/test/oli_web/controllers/launch_controller_test.exs
@@ -56,6 +56,25 @@ defmodule OliWeb.LaunchControllerTest do
                "You are being <a href=\"/sections/#{section.slug}/page/#{page_revision.slug}\">redirected"
     end
 
+    test "auto enroll endpoint renders enrollment page when recaptcha fails", %{
+      conn: conn,
+      section: section
+    } do
+      conn =
+        post(
+          conn,
+          ~p"/sections/#{section.slug}/auto_enroll",
+          %{
+            "g-recaptcha-response": ""
+          }
+        )
+
+      response = html_response(conn, 200)
+
+      assert response =~ "Enroll in Course Section"
+      assert response =~ "ReCaptcha failed, please try again"
+    end
+
     test "join endpoint redirects to section overview page if user is already enrolled", %{
       conn: conn,
       guest: guest,


### PR DESCRIPTION

KeysetRefreshWorker - properly handle `:discard` and add more logging
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/1034


ActiviytSummary - Here we simply stop logging to AppSignal.  This is a known issue with REAL Chem courses
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/78

SendEmail - Do not send confirmation email for Oauth users
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/982

No “enroll” template found
https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/exceptions/incidents/953/samples/618539ab2cf81d7e3cd051ca-973096435500699560117775288601

