### PR TITLE
[ENHANCEMENT] [MER-5220] Curriculum direct page previewing and options/settings UI updates

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutHeader.tsx
@@ -96,11 +96,7 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
   const resourceSlug = useSelector(selectPageSlug);
 
   useEffect(() => {
-    if (isPreviewMode && !isInstructor) {
-      // return to authoring
-      setBackButtonUrl(`/authoring/project/${projectSlug}/resource/${resourceSlug}`);
-      setBackButtonText('Back to Authoring');
-    } else {
+    if (!(isPreviewMode && !isInstructor)) {
       // if no backUrl is provided, then set it to the section root url
       if (!backUrl) {
         setBackButtonUrl(window.location.href.split('/adaptive_lesson')[0]);
@@ -108,7 +104,7 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
 
       setBackButtonText('Go back to previous screen');
     }
-  }, [isPreviewMode]);
+  }, [backUrl, isInstructor, isPreviewMode, projectSlug, resourceSlug]);
 
   // Cleanup fullscreen state when component unmounts or fullscreen state changes
   useEffect(() => {
@@ -200,6 +196,10 @@ const DeckLayoutHeader: React.FC<DeckLayoutHeaderProps> = ({
               aria-pressed={isFullscreen}
             >
               {isFullscreen ? <MinimizeIcon /> : <MaximizeIcon />}
+            </button>
+          ) : showAuthorPreviewBackButton ? (
+            <button onClick={() => window.close()} title="Exit Preview" aria-label="Exit Preview">
+              <span className="fa fa-times">&nbsp;</span>
             </button>
           ) : (
             <a href={backButtonUrl} title={backButtonText}>

--- a/assets/test/delivery/deck_layout_header_test.tsx
+++ b/assets/test/delivery/deck_layout_header_test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import DeckLayoutHeader from 'apps/delivery/layouts/deck/DeckLayoutHeader';
 import {
   selectIsInstructor,
@@ -60,16 +60,19 @@ describe('DeckLayoutHeader', () => {
     jest.clearAllMocks();
   });
 
-  it('shows Back to Authoring instead of fullscreen controls in author preview', async () => {
+  it('shows Exit Preview instead of fullscreen controls in author preview', async () => {
     configureSelectors({ previewMode: true, isInstructor: false, displayApplicationChrome: true });
+
+    const closeSpy = jest.spyOn(window, 'close').mockImplementation(() => undefined);
 
     render(<DeckLayoutHeader pageName="Adaptive Preview" userName="Guest" />);
 
-    expect(await screen.findByTitle('Back to Authoring')).toHaveAttribute(
-      'href',
-      '/authoring/project/demo-project/resource/demo-page',
-    );
+    fireEvent.click(await screen.findByTitle('Exit Preview'));
+
+    expect(closeSpy).toHaveBeenCalled();
     expect(screen.queryByLabelText('Maximize')).not.toBeInTheDocument();
+
+    closeSpy.mockRestore();
   });
 
   it('keeps fullscreen controls for instructor preview with application chrome', () => {
@@ -78,6 +81,6 @@ describe('DeckLayoutHeader', () => {
     render(<DeckLayoutHeader pageName="Adaptive Preview" userName="Instructor" />);
 
     expect(screen.getByLabelText('Maximize')).toBeInTheDocument();
-    expect(screen.queryByTitle('Back to Authoring')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Exit Preview')).not.toBeInTheDocument();
   });
 });

--- a/lib/oli_web/live/curriculum/container/container_live_helpers.ex
+++ b/lib/oli_web/live/curriculum/container/container_live_helpers.ex
@@ -17,7 +17,7 @@ defmodule OliWeb.Curriculum.Container.ContainerLiveHelpers do
       id: "options_#{slug}",
       redirect_url: redirect_url,
       revision: revision,
-      title: "#{resource_type_label(revision) |> String.capitalize()} Options",
+      title: "#{resource_type_label(revision) |> String.capitalize()} Settings",
       form: form
     }
   end

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -8,6 +8,8 @@ defmodule OliWeb.Curriculum.Actions do
   alias Oli.ScopedFeatureFlags
   alias Oli.Accounts.Author
   alias Oli.Resources.ResourceType
+  alias OliWeb.Icons
+  alias OliWeb.Router.Helpers, as: Routes
   alias Phoenix.LiveView.JS
 
   attr(:child, :map, required: true)
@@ -22,24 +24,11 @@ defmodule OliWeb.Curriculum.Actions do
         <button
           class="btn dropdown-toggle"
           type="button"
+          aria-label="Options"
+          title="Options"
           phx-click={JS.toggle(to: "#dropdownMenu_#{@child.slug}")}
         >
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            data-prefix="fas"
-            data-icon="caret-down"
-            class="w-2"
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 320 512"
-          >
-            <path
-              fill="currentColor"
-              d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
-            >
-            </path>
-          </svg>
+          <Icons.vertical_dots class="text-gray-700 dark:text-gray-100" />
         </button>
         <div
           class="hidden dropdown-menu right-0"
@@ -54,7 +43,7 @@ defmodule OliWeb.Curriculum.Actions do
             role="show_options_modal"
             phx-value-slug={@child.slug}
           >
-            <i class="fas fa-sliders-h mr-1 flex-1"></i> Options
+            <i class="fas fa-sliders-h mr-1 flex-1"></i> Settings
           </button>
           <button
             type="button"
@@ -76,6 +65,14 @@ defmodule OliWeb.Curriculum.Actions do
               <i class="fas fa-copy mr-1"></i> Duplicate
             </button>
           <% end %>
+          <.link
+            :if={ResourceType.is_page(@child)}
+            class="dropdown-item"
+            href={preview_url(@project.slug, @child)}
+            target={preview_window_name(@project.slug)}
+          >
+            <i class="fas fa-eye mr-1"></i> Preview
+          </.link>
           <div class="dropdown-divider"></div>
           <.link
             :if={@revision_history_link}
@@ -112,6 +109,16 @@ defmodule OliWeb.Curriculum.Actions do
   end
 
   defp adaptive_duplication_available?(_project, _current_author), do: false
+
+  defp preview_url(project_slug, child) do
+    if ResourceType.is_adaptive_page(child) do
+      Routes.resource_path(OliWeb.Endpoint, :preview_fullscreen, project_slug, child.slug)
+    else
+      Routes.resource_path(OliWeb.Endpoint, :preview, project_slug, child.slug)
+    end
+  end
+
+  defp preview_window_name(project_slug), do: "preview-#{project_slug}"
 
   defp push_event_and_hide_dropdown(event, target_slug),
     do: JS.push(event) |> JS.toggle(to: "#dropdownMenu_#{target_slug}")

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -70,6 +70,7 @@ defmodule OliWeb.Curriculum.Actions do
             class="dropdown-item"
             href={preview_url(@project.slug, @child)}
             target={preview_window_name(@project.slug)}
+            rel="noopener noreferrer"
             aria-label="Preview, opens in a new window"
             title="Preview (opens in a new window)"
           >

--- a/lib/oli_web/live/curriculum/entries/actions.ex
+++ b/lib/oli_web/live/curriculum/entries/actions.ex
@@ -70,6 +70,8 @@ defmodule OliWeb.Curriculum.Actions do
             class="dropdown-item"
             href={preview_url(@project.slug, @child)}
             target={preview_window_name(@project.slug)}
+            aria-label="Preview, opens in a new window"
+            title="Preview (opens in a new window)"
           >
             <i class="fas fa-eye mr-1"></i> Preview
           </.link>

--- a/lib/oli_web/live/resources/pages_view.ex
+++ b/lib/oli_web/live/resources/pages_view.ex
@@ -446,7 +446,7 @@ defmodule OliWeb.Resources.PagesView do
         ),
       revision: revision,
       form: to_form(Resources.change_revision(revision)),
-      title: "#{resource_type_label(revision) |> String.capitalize()} Options"
+      title: "#{resource_type_label(revision) |> String.capitalize()} Settings"
     }
 
     {:noreply,

--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -239,7 +239,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
         ),
       revision: revision,
       form: to_form(Resources.change_revision(revision)),
-      title: "#{resource_type_label(revision) |> String.capitalize()} Options"
+      title: "#{resource_type_label(revision) |> String.capitalize()} Settings"
     }
 
     {:noreply,

--- a/test/oli_web/live/all_pages_live_test.exs
+++ b/test/oli_web/live/all_pages_live_test.exs
@@ -450,20 +450,20 @@ defmodule OliWeb.AllPagesLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{nested_page_revision.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
     end
 
@@ -517,7 +517,7 @@ defmodule OliWeb.AllPagesLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{nested_page_revision.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 

--- a/test/oli_web/live/curriculum/container_test.exs
+++ b/test/oli_web/live/curriculum/container_test.exs
@@ -262,7 +262,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       |> element(
         "div[phx-value-slug='#{revision_page_one.slug}'] button[role=\"show_options_modal\"]"
       )
-      |> render_click() =~ "Page Options"
+      |> render_click() =~ "Page Settings"
 
       assert has_element?(
                view,
@@ -489,20 +489,20 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
     end
 
@@ -517,20 +517,20 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Container Options"
+               "Container Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{unit.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Container Options"
+               "Container Settings"
              )
     end
 
@@ -564,7 +564,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
@@ -666,7 +666,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
@@ -730,7 +730,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
@@ -773,7 +773,7 @@ defmodule OliWeb.Curriculum.ContainerLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 

--- a/test/oli_web/live/workspaces/course_author/curriculum_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/curriculum_live_test.exs
@@ -153,6 +153,26 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
         "entry-title\">Copy of #{adaptive_page_revision.title}</span>"
     end
 
+    test "shows fullscreen preview action for adaptive pages", %{
+      conn: conn,
+      author: author,
+      project: project,
+      adaptive_page_revision: adaptive_page_revision
+    } do
+      conn =
+        recycle(conn)
+        |> log_in_author(author)
+        |> get("/workspaces/course_author/#{project.slug}/curriculum/")
+
+      {:ok, view, _html} = live(conn)
+
+      assert has_element?(
+               view,
+               ~s{div[phx-value-slug='#{adaptive_page_revision.slug}'] a[href='/authoring/project/#{project.slug}/preview_fullscreen/#{adaptive_page_revision.slug}']},
+               "Preview"
+             )
+    end
+
     test "shows an error flash when adaptive duplication fails", %{
       conn: conn,
       author: author,
@@ -405,7 +425,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
       |> element(
         "div[phx-value-slug='#{revision_page_one.slug}'] button[role=\"show_options_modal\"]"
       )
-      |> render_click() =~ "Page Options"
+      |> render_click() =~ "Page Settings"
 
       assert has_element?(
                view,
@@ -646,20 +666,20 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
     end
 
@@ -674,20 +694,53 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Container Options"
+               "Container Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{unit.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Container Options"
+               "Container Settings"
+             )
+    end
+
+    test "shows options trigger tooltip and page-only preview actions", %{
+      conn: conn,
+      project: project,
+      page_2: page_2,
+      unit: unit
+    } do
+      {:ok, view, _html} =
+        live(conn, ~p"/workspaces/course_author/#{project.slug}/curriculum")
+
+      assert has_element?(
+               view,
+               ~s{div[phx-value-slug='#{page_2.slug}'] button[title="Options"][aria-label="Options"]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{div[phx-value-slug='#{page_2.slug}'] button[role="show_options_modal"]},
+               "Settings"
+             )
+
+      assert has_element?(
+               view,
+               ~s{div[phx-value-slug='#{page_2.slug}'] a[href='/authoring/project/#{project.slug}/preview/#{page_2.slug}']},
+               "Preview"
+             )
+
+      refute has_element?(
+               view,
+               ~s{div[phx-value-slug='#{unit.slug}'] a[href*='/preview']},
+               "Preview"
              )
     end
 
@@ -730,7 +783,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
@@ -833,7 +886,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.CurriculumLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{page_2.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 

--- a/test/oli_web/live/workspaces/course_author/pages_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/pages_live_test.exs
@@ -439,20 +439,45 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLiveTest do
       refute view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
              )
 
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{nested_page_revision.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 
       assert view
              |> has_element?(
                ~s{div[id='options_modal-container'] h1[id="options_modal-title"]},
-               "Page Options"
+               "Page Settings"
+             )
+    end
+
+    test "shows preview actions for basic and adaptive pages", %{
+      admin: admin,
+      conn: conn,
+      project: project,
+      publication: publication,
+      nested_page_revision: nested_page_revision
+    } do
+      adaptive_page_revision = insert_adaptive_page(project, publication, admin)
+
+      {:ok, view, _html} =
+        live(conn, live_view_all_pages_route(project.slug))
+
+      assert has_element?(
+               view,
+               ~s{a[href="/authoring/project/#{project.slug}/preview/#{nested_page_revision.slug}"]},
+               "Preview"
+             )
+
+      assert has_element?(
+               view,
+               ~s{a[href="/authoring/project/#{project.slug}/preview_fullscreen/#{adaptive_page_revision.slug}"]},
+               "Preview"
              )
     end
 
@@ -516,7 +541,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLiveTest do
       view
       |> element(
         ~s{button[role="show_options_modal"][phx-value-slug="#{nested_page_revision.slug}"]},
-        "Options"
+        "Settings"
       )
       |> render_click()
 


### PR DESCRIPTION
## Summary

  This PR updates the Curriculum and All Pages authoring surfaces to:

  - replace the old caret trigger with a vertical three-dots options trigger
  - rename `Options` actions and modal titles to `Settings`
  - add a page-only `Preview` action
  - support preview for both basic and adaptive pages
  - keep adaptive author preview behavior aligned with regular preview expectations

  ## Problem

The curriculum entry action UI was inconsistent with the desired product language and did not provide direct page previewing from the curriculum surfaces.

  The requested changes were:

  - use a vertical three-dots icon instead of the down caret
  - show an `Options` tooltip on hover
  - rename the dropdown action from `Options` to `Settings`
  - rename modal titles to `Page Settings` / `Container Settings`
  - add a `Preview` action for page entries only
  - support both basic and adaptive page preview flows
  - do not show `Preview` for units/modules/containers

While wiring preview through shared curriculum actions, adaptive preview UX also needed to stay coherent with existing page preview behavior.

  ## What Changed

  ### Shared curriculum action trigger updates

  Updated the shared curriculum entry actions component to:

  - use the vertical three-dots trigger
  - expose `Options` via `title` and `aria-label`
  - rename the settings action from `Options` to `Settings`

  ### Direct page preview action

  Added a page-only `Preview` action to the shared dropdown.

  Behavior:

  - basic pages open:
    - `/authoring/project/:project_slug/preview/:revision_slug`
  - adaptive pages open:
    - `/authoring/project/:project_slug/preview_fullscreen/:revision_slug`

  The preview action is positioned directly after `Duplicate`.

  It is only rendered for pages, not for units/modules/containers.

  ### Settings modal title updates

  Renamed modal titles from `* Options` to `* Settings` in the shared authoring flows.

  ### Adaptive preview exit behavior

  Adaptive author preview now behaves more like regular page preview.

  Instead of showing a `Back to Authoring` control, fullscreen adaptive preview now shows an `Exit Preview` control that closes the preview window.

This avoids tying adaptive preview to a single authoring entry point now that preview can be launched from multiple locations.
