### PR TITLE
[BUG FIX] [MER-5598] fix ingestion for empty bank selection logic

### DIFF
--- a/lib/oli/interop/ingest/processor/rewiring.ex
+++ b/lib/oli/interop/ingest/processor/rewiring.ex
@@ -96,6 +96,10 @@ defmodule Oli.Interop.Ingest.Processing.Rewiring do
     logic
   end
 
+  defp rewire_bank_selection_logic(logic, _id_map) when logic == %{} do
+    %{"conditions" => nil}
+  end
+
   defp rewire_bank_selection_logic(%{"conditions" => conditions} = logic, id_map) do
     rewired_conditions = rewire_logic_conditions(conditions, id_map)
     Map.put(logic, "conditions", rewired_conditions)
@@ -311,14 +315,7 @@ defmodule Oli.Interop.Ingest.Processing.Rewiring do
   defp prune_nil_nodes(%{} = map) do
     Enum.reduce(map, %{}, fn {key, value}, acc ->
       cleaned = prune_nil_nodes(value)
-
-      cond do
-        is_nil(cleaned) ->
-          acc
-
-        true ->
-          Map.put(acc, key, cleaned)
-      end
+      Map.put(acc, key, cleaned)
     end)
   end
 

--- a/lib/oli/interop/ingest/processor/rewiring.ex
+++ b/lib/oli/interop/ingest/processor/rewiring.ex
@@ -315,7 +315,17 @@ defmodule Oli.Interop.Ingest.Processing.Rewiring do
   defp prune_nil_nodes(%{} = map) do
     Enum.reduce(map, %{}, fn {key, value}, acc ->
       cleaned = prune_nil_nodes(value)
-      Map.put(acc, key, cleaned)
+
+      cond do
+        is_nil(value) ->
+          Map.put(acc, key, nil)
+
+        is_nil(cleaned) ->
+          acc
+
+        true ->
+          Map.put(acc, key, cleaned)
+      end
     end)
   end
 

--- a/test/oli/interop/ingest/processor/rewiring_test.exs
+++ b/test/oli/interop/ingest/processor/rewiring_test.exs
@@ -35,6 +35,24 @@ defmodule Oli.Interop.Ingest.Processing.RewiringTest do
       [one_activity] = result["model"]
       assert one_activity["activity_id"] == 101
     end
+
+    test "preserves null bank selection conditions while pruning missing activity references" do
+      content = %{
+        "model" => [
+          %{
+            "type" => "selection",
+            "id" => "275897104",
+            "logic" => %{"conditions" => nil}
+          },
+          %{"type" => "activity-reference", "activity_id" => 2}
+        ]
+      }
+
+      result = Rewiring.rewire_activity_references(content, %{})
+
+      [selection] = result["model"]
+      assert selection["logic"] == %{"conditions" => nil}
+    end
   end
 
   describe "rewire_report_activity_references/2" do
@@ -87,6 +105,18 @@ defmodule Oli.Interop.Ingest.Processing.RewiringTest do
       result = Rewiring.rewire_bank_selections(content, tag_map)
       [child] = result["logic"]["conditions"]["children"]
       assert child["value"] == [old_id]
+    end
+
+    test "repairs selection logic missing conditions" do
+      content = %{
+        "type" => "selection",
+        "id" => "275897104",
+        "logic" => %{}
+      }
+
+      result = Rewiring.rewire_bank_selections(content, %{})
+
+      assert result["logic"] == %{"conditions" => nil}
     end
   end
 


### PR DESCRIPTION
This addresses [MER-5598](https://eliterate.atlassian.net/browse/MER-5598) by fixing selection ingest to preserve correct json representation of empty logic condition list. Ingest will also repair malformed conditionless selection representations produced by earlier versions, so new export=>ingest cycle should repair malformed content resulting from earlier buggy export=>ingestion.

Root cause:

  During project ingest, `rewire_activity_references/2` used nil for two different meanings: an intentional JSON null from the exported page content, and an internal marker for an invalid activity-reference node that should be removed. After rewiring, `prune_nil_nodes/1 `recursively removed all nil values from the entire page content tree.

  For activity-bank selections with no criteria, the valid exported shape is:

  `"logic": { "conditions": null }`

  The broad pruning changed that during ingest to:

 ` "logic": {}`

  That malformed shape was then persisted and later re-exported as-is. Runtime selection parsing expects either `logic: null` or a `logic.conditions` key, so `logic: {}` caused `Logic.parse/1` to fail when LMS line-item update computed page score maximums.

  Changes:

  - lib/oli/interop/ingest/processor/rewiring.ex:99 now repairs already-malformed `logic: %{}` to `%{"conditions" => nil}` during bank-selection rewiring.
  - lib/oli/interop/ingest/processor/rewiring.ex:315 now preserves nil map values while still pruning removed nodes from lists.
  - test/oli/interop/ingest/processor/rewiring_test.exs:39 adds regressions for preserving valid empty conditions and repairing malformed empty logic.

[MER-5598]: https://eliterate.atlassian.net/browse/MER-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ