### PR TITLE
[BUG FIX] [MER-5596] Fix misleading instructor feedback in adaptive assessment review

### DIFF
--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -256,6 +256,16 @@ defmodule OliWeb.Common.Utils do
   end
 
   @doc """
+    Extracts only manually-graded feedback text from an attempt.
+  """
+  def extract_manual_feedback_text(activity_attempts) do
+    activity_attempts
+    |> Enum.map(&extract_manual_from_activity_attempt/1)
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  @doc """
   Extracts the feedback text from an activity attempt, which contains multiple part attempts.
   """
   def extract_from_activity_attempt(%{part_attempts: part_attempts}) do
@@ -263,16 +273,17 @@ defmodule OliWeb.Common.Utils do
     |> Enum.map(&extract_from_part_attempt/1)
   end
 
+  defp extract_manual_from_activity_attempt(%{part_attempts: part_attempts}) do
+    part_attempts
+    |> Enum.filter(&manual_grading_part_attempt?/1)
+    |> Enum.map(&extract_from_part_attempt/1)
+  end
+
   @doc """
   Extracts the feedback text from a part attempt.
   """
-  def extract_from_part_attempt(%{feedback: feedback} = part_attempt) when is_map(feedback) do
-    if manual_grading_part_attempt?(part_attempt) do
-      extract_feedback_entries(feedback)
-    else
-      []
-    end
-  end
+  def extract_from_part_attempt(%{feedback: feedback}) when is_map(feedback),
+    do: extract_feedback_entries(feedback)
 
   def extract_from_part_attempt(%{feedback: nil}), do: []
 

--- a/lib/oli_web/live/common/utils.ex
+++ b/lib/oli_web/live/common/utils.ex
@@ -266,12 +266,21 @@ defmodule OliWeb.Common.Utils do
   @doc """
   Extracts the feedback text from a part attempt.
   """
-  def extract_from_part_attempt(%{feedback: feedback}) when is_map(feedback),
-    do: extract_feedback_entries(feedback)
+  def extract_from_part_attempt(%{feedback: feedback} = part_attempt) when is_map(feedback) do
+    if manual_grading_part_attempt?(part_attempt) do
+      extract_feedback_entries(feedback)
+    else
+      []
+    end
+  end
 
   def extract_from_part_attempt(%{feedback: nil}), do: []
 
   def extract_from_part_attempt(_), do: []
+
+  defp manual_grading_part_attempt?(%{grading_approach: :manual}), do: true
+  defp manual_grading_part_attempt?(%{grading_approach: "manual"}), do: true
+  defp manual_grading_part_attempt?(_), do: false
 
   defp extract_feedback_entries(%{"content" => content}) when is_list(content) do
     content

--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -237,7 +237,7 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
 
     feedback_texts =
       if assigns.is_adaptive,
-        do: Utils.extract_feedback_text(attempt.activity_attempts),
+        do: Utils.extract_manual_feedback_text(attempt.activity_attempts),
         else: []
 
     assigns = assign(assigns, feedback_texts: feedback_texts)

--- a/lib/oli_web/live/progress/page_attempt_summary.ex
+++ b/lib/oli_web/live/progress/page_attempt_summary.ex
@@ -57,7 +57,7 @@ defmodule OliWeb.Progress.PageAttemptSummary do
 
   def do_render(%{attempt: %{lifecycle_state: :evaluated}} = assigns) do
     attempt = Core.preload_activity_part_attempts(assigns.attempt)
-    feedback_texts = Utils.extract_feedback_text(attempt.activity_attempts)
+    feedback_texts = Utils.extract_manual_feedback_text(attempt.activity_attempts)
     assigns = assign(assigns, feedback_texts: feedback_texts)
 
     ~H"""

--- a/test/oli_web/common/utils_test.exs
+++ b/test/oli_web/common/utils_test.exs
@@ -273,7 +273,7 @@ defmodule OliWeb.Common.UtilsTest do
       assert Utils.extract_feedback_text(activity_attempts) == ["Incorrect, please try again."]
     end
 
-    test "ignores non-manual feedback entries" do
+    test "extracts feedback entries regardless of grading approach" do
       activity_attempts = [
         %{
           part_attempts: [
@@ -301,7 +301,49 @@ defmodule OliWeb.Common.UtilsTest do
         }
       ]
 
-      assert Utils.extract_feedback_text(activity_attempts) == ["Manual instructor feedback"]
+      assert Utils.extract_feedback_text(activity_attempts) == [
+               "Auto feedback",
+               "Manual instructor feedback"
+             ]
+    end
+  end
+
+  describe "extract_manual_feedback_text/1" do
+    test "includes only feedback entries from manually graded part attempts" do
+      activity_attempts = [
+        %{
+          part_attempts: [
+            %{
+              grading_approach: :automatic,
+              feedback: %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => "Auto feedback should be ignored"}],
+                    "id" => "p1",
+                    "type" => "p"
+                  }
+                ]
+              }
+            },
+            %{
+              grading_approach: :manual,
+              feedback: %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => "Manual feedback should be shown"}],
+                    "id" => "p2",
+                    "type" => "p"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+
+      assert Utils.extract_manual_feedback_text(activity_attempts) == [
+               "Manual feedback should be shown"
+             ]
     end
   end
 end

--- a/test/oli_web/common/utils_test.exs
+++ b/test/oli_web/common/utils_test.exs
@@ -101,6 +101,7 @@ defmodule OliWeb.Common.UtilsTest do
         %{
           part_attempts: [
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -112,6 +113,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -123,6 +125,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => %{
                   "model" => [
@@ -136,6 +139,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => %{
                   "some_other_case" => [
@@ -173,6 +177,7 @@ defmodule OliWeb.Common.UtilsTest do
         %{
           part_attempts: [
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -184,6 +189,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -195,6 +201,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -206,6 +213,7 @@ defmodule OliWeb.Common.UtilsTest do
               }
             },
             %{
+              grading_approach: :manual,
               feedback: %{
                 "content" => [
                   %{
@@ -228,6 +236,7 @@ defmodule OliWeb.Common.UtilsTest do
         %{
           part_attempts: [
             %{
+              grading_approach: :manual,
               feedback: %{
                 "id" => "builtin.feedback",
                 "partsLayout" => [
@@ -262,6 +271,37 @@ defmodule OliWeb.Common.UtilsTest do
       ]
 
       assert Utils.extract_feedback_text(activity_attempts) == ["Incorrect, please try again."]
+    end
+
+    test "ignores non-manual feedback entries" do
+      activity_attempts = [
+        %{
+          part_attempts: [
+            %{
+              grading_approach: :automatic,
+              feedback: %{
+                "content" => [
+                  %{"children" => [%{"text" => "Auto feedback"}], "id" => "p1", "type" => "p"}
+                ]
+              }
+            },
+            %{
+              grading_approach: :manual,
+              feedback: %{
+                "content" => [
+                  %{
+                    "children" => [%{"text" => "Manual instructor feedback"}],
+                    "id" => "p2",
+                    "type" => "p"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+
+      assert Utils.extract_feedback_text(activity_attempts) == ["Manual instructor feedback"]
     end
   end
 end

--- a/test/oli_web/live/progress/student_resource_view_live_test.exs
+++ b/test/oli_web/live/progress/student_resource_view_live_test.exs
@@ -225,6 +225,7 @@ defmodule OliWeb.Progress.StudentResourceViewLiveTest do
         Core.get_part_attempts_by_activity_attempts([activity_attempt.id]) |> hd()
 
       Core.update_part_attempt(part_attempt, %{
+        grading_approach: :manual,
         lifecycle_state: :evaluated,
         date_evaluated: DateTime.utc_now(),
         score: 1.0,


### PR DESCRIPTION
[MER-5596](https://eliterate.atlassian.net/browse/MER-5596)

## Summary

This PR fixes misleading feedback shown to students at the end of adaptive assessments.

Previously, system-generated feedback could appear under **Instructor Feedback**, which was confusing because that section should only show feedback provided by an instructor.

## What changed

- Updated feedback extraction logic to include only feedback from **manually graded** part attempts.
- As a result, adaptive/system-generated feedback is no longer shown in the student-facing **Instructor Feedback** section.

## Result

Students no longer see system-generated feedback incorrectly labeled as instructor feedback when completing/reviewing attempts.

[MER-5596]: https://eliterate.atlassian.net/browse/MER-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ