### PR TITLE
[ENHANCEMENT] [MER-4961] Rework Loading indicator for LLM generated feedback in adaptive pages

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/components/FeedbackRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/FeedbackRenderer.tsx
@@ -1,9 +1,5 @@
 import React, { Fragment, useCallback, useEffect, useState } from 'react';
 import PartsLayoutRenderer from '../../../../../components/activities/adaptive/components/delivery/PartsLayoutRenderer';
-import {
-  LoadingSpinner,
-  LoadingSpinnerSize,
-} from '../../../../../components/common/LoadingSpinner';
 
 interface FeedbackRendererProps {
   feedbacks: any[];
@@ -16,6 +12,94 @@ const AIGeneratedBadge = () => (
     <i className="fa fa-robot" aria-hidden="true" />
     <span>AI-generated</span>
   </div>
+);
+
+const AIThinkingSpinner = () => (
+  <svg
+    viewBox="0 0 30 30"
+    className="feedback-ai-thinking-spinner"
+    aria-hidden="true"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <rect
+      className="feedback-ai-spinner-segment s0"
+      x="12.8789"
+      y="10.0503"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(135 12.8789 10.0503)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s1"
+      x="10"
+      y="13"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(90 10 13)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s2"
+      x="10.0508"
+      y="17.1213"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(45 10.0508 17.1213)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s3"
+      x="13"
+      y="20"
+      width="4"
+      height="10"
+      rx="2"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s4"
+      x="27.0234"
+      y="24.1924"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(135 27.0234 24.1924)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s5"
+      x="30"
+      y="13"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(90 30 13)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s6"
+      x="24.1953"
+      y="2.97925"
+      width="4"
+      height="10"
+      rx="2"
+      transform="rotate(45 24.1953 2.97925)"
+      fill="currentColor"
+    />
+    <rect
+      className="feedback-ai-spinner-segment s7"
+      x="13"
+      width="4"
+      height="10"
+      rx="2"
+      fill="currentColor"
+    />
+  </svg>
 );
 
 const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({
@@ -50,6 +134,81 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({
           .feedback-item janus-text-flow {
             width: auto !important;
           }
+          .feedback-ai-pending {
+            align-items: flex-start;
+            display: flex !important;
+            flex-direction: column;
+            gap: 14px;
+          }
+          .feedback-ai-generated__loading {
+            align-items: center;
+            display: inline-flex;
+            gap: 8px;
+            line-height: 1.4;
+          }
+          .feedback-ai-thinking-spinner {
+            color: currentColor;
+            flex: 0 0 auto;
+            height: 22px;
+            width: 22px;
+          }
+          .feedback-ai-spinner-segment {
+            animation: feedback-ai-spinner-segment-fade 1.2s linear infinite;
+            opacity: 0.15;
+          }
+          .feedback-ai-spinner-segment.s0 {
+            animation-delay: 0s;
+          }
+          .feedback-ai-spinner-segment.s1 {
+            animation-delay: -0.15s;
+          }
+          .feedback-ai-spinner-segment.s2 {
+            animation-delay: -0.3s;
+          }
+          .feedback-ai-spinner-segment.s3 {
+            animation-delay: -0.45s;
+          }
+          .feedback-ai-spinner-segment.s4 {
+            animation-delay: -0.6s;
+          }
+          .feedback-ai-spinner-segment.s5 {
+            animation-delay: -0.75s;
+          }
+          .feedback-ai-spinner-segment.s6 {
+            animation-delay: -0.9s;
+          }
+          .feedback-ai-spinner-segment.s7 {
+            animation-delay: -1.05s;
+          }
+          @keyframes feedback-ai-spinner-segment-fade {
+            0% {
+              opacity: 1;
+            }
+            12.5% {
+              opacity: 0.87;
+            }
+            25% {
+              opacity: 0.75;
+            }
+            37.5% {
+              opacity: 0.63;
+            }
+            50% {
+              opacity: 0.51;
+            }
+            62.5% {
+              opacity: 0.39;
+            }
+            75% {
+              opacity: 0.27;
+            }
+            87.5% {
+              opacity: 0.15;
+            }
+            100% {
+              opacity: 0.15;
+            }
+          }
         `}
       </style>
       {pending ? (
@@ -61,9 +220,10 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({
           role="status"
         >
           <AIGeneratedBadge />
-          <LoadingSpinner size={LoadingSpinnerSize.Small} align="left">
-            Generating AI-generated feedback...
-          </LoadingSpinner>
+          <div className="feedback-ai-generated__loading">
+            <AIThinkingSpinner />
+            <span>Thinking...</span>
+          </div>
         </div>
       ) : (
         feedbacks.map((feedback, index) =>

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -85,6 +85,10 @@ const getActions = (container?: AdaptiveActionContainer | null): IAction[] => {
 export const hasPotentialLLMFeedbackRule = (rules: IAdaptiveRule[] = []) =>
   rules.some((rule) => getActions(rule.event).some(isLLMFeedbackActivationPointAction));
 
+export const activityHasPotentialLLMFeedback = (activity?: { [key: string]: any } | null) =>
+  activity?.hasPotentialLLMFeedback === true ||
+  hasPotentialLLMFeedbackRule(activity?.authoring?.rules || []);
+
 export const checkResultHasLLMFeedbackAction = (results: AdaptiveActionContainer[] = []) =>
   results.some((event) => getActions(event).some(isLLMFeedbackActivationPointAction));
 
@@ -138,9 +142,7 @@ export const triggerCheck = createAsyncThunk(
       const currentTriggerStamp = Date.now();
       await dispatch(setLastCheckTriggered({ timestamp: currentTriggerStamp }));
       const shouldShowPendingAIFeedback =
-        !isPreviewMode &&
-        !isReviewMode &&
-        hasPotentialLLMFeedbackRule(currentActivity?.authoring?.rules || []);
+        !isPreviewMode && !isReviewMode && activityHasPotentialLLMFeedback(currentActivity);
       await dispatch(setAIFeedbackPending({ pending: shouldShowPendingAIFeedback }));
 
       const treeActivityIds = currentActivityTree.map((a) => a.id);

--- a/assets/src/apps/delivery/store/features/groups/actions/deck.ts
+++ b/assets/src/apps/delivery/store/features/groups/actions/deck.ts
@@ -524,6 +524,7 @@ export const loadActivities = createAsyncThunk(
         resourceId: sequenceEntry.activity_id,
         content: isPreviewMode ? result.content : result.model,
         authoring: result.authoring || null,
+        hasPotentialLLMFeedback: !!result.hasPotentialLLMFeedback,
         activityType,
         title: result.title,
         attemptGuid: attemptEntry?.attemptGuid || '',

--- a/assets/test/delivery/feedback_renderer_test.tsx
+++ b/assets/test/delivery/feedback_renderer_test.tsx
@@ -5,14 +5,15 @@ import FeedbackRenderer from 'apps/delivery/layouts/deck/components/FeedbackRend
 
 describe('FeedbackRenderer', () => {
   it('renders a loading state while AI feedback is pending', () => {
-    render(<FeedbackRenderer feedbacks={[]} pending={true} snapshot={{}} />);
+    const { container } = render(<FeedbackRenderer feedbacks={[]} pending={true} snapshot={{}} />);
 
     const pendingStatus = screen.getByRole('status');
 
     expect(pendingStatus).toBeInTheDocument();
     expect(pendingStatus).toHaveAttribute('tabindex', '-1');
     expect(screen.getByText('AI-generated')).toBeInTheDocument();
-    expect(screen.getByText('Generating AI-generated feedback...')).toBeInTheDocument();
+    expect(screen.getByText('Thinking...')).toBeInTheDocument();
+    expect(container.querySelector('.feedback-ai-thinking-spinner')).toBeInTheDocument();
   });
 
   it('hides stale feedback content while AI feedback is still pending', () => {

--- a/assets/test/delivery/trigger_check_llm_feedback_test.ts
+++ b/assets/test/delivery/trigger_check_llm_feedback_test.ts
@@ -1,5 +1,6 @@
 import { IAdaptiveRule, IEvent } from 'apps/delivery/store/features/activities/slice';
 import {
+  activityHasPotentialLLMFeedback,
   checkResultHasLLMFeedbackAction,
   hasPotentialLLMFeedbackRule,
 } from 'apps/delivery/store/features/adaptivity/actions/triggerCheck';
@@ -51,6 +52,10 @@ describe('triggerCheck LLM feedback helpers', () => {
     ];
 
     expect(checkResultHasLLMFeedbackAction(results)).toBe(true);
+  });
+
+  it('uses the delivery-safe activity flag when authoring rules are pruned', () => {
+    expect(activityHasPotentialLLMFeedback({ hasPotentialLLMFeedback: true })).toBe(true);
   });
 
   it('ignores malformed activation-point actions without throwing', () => {

--- a/lib/oli/conversation/llm_feedback.ex
+++ b/lib/oli/conversation/llm_feedback.ex
@@ -117,6 +117,28 @@ defmodule Oli.Conversation.LLMFeedback do
   def find_llm_feedback_prompt(_), do: nil
 
   @doc """
+  Returns true when any adaptive rule can invoke LLM-generated feedback.
+  """
+  def has_potential_feedback_rule?(rules) when is_list(rules) do
+    Enum.any?(rules, fn
+      %{"event" => %{"params" => %{"actions" => actions}}} when is_list(actions) ->
+        Enum.any?(actions, fn
+          %{"type" => "activationPoint", "params" => %{"kind" => "feedback", "prompt" => prompt}}
+          when is_binary(prompt) and prompt != "" ->
+            true
+
+          _ ->
+            false
+        end)
+
+      _ ->
+        false
+    end)
+  end
+
+  def has_potential_feedback_rule?(_), do: false
+
+  @doc """
   Extract a human-readable representation of the student's input from part_inputs.
   """
   def extract_student_input(part_inputs) when is_list(part_inputs) do

--- a/lib/oli_web/controllers/api/attempt_controller.ex
+++ b/lib/oli_web/controllers/api/attempt_controller.ex
@@ -302,6 +302,8 @@ defmodule OliWeb.Api.AttemptController do
   end
 
   defp to_client_view(attempt) do
+    model = Attempts.select_model(attempt)
+
     latest_part_attempt_by_part =
       Enum.reduce(attempt.part_attempts, %{}, fn p, m ->
         case Map.get(m, p.part_id) do
@@ -326,7 +328,11 @@ defmodule OliWeb.Api.AttemptController do
       score: attempt.score,
       outOf: attempt.out_of,
       dateEvaluated: attempt.date_evaluated,
-      model: Attempts.select_model(attempt) |> Oli.Delivery.Page.ModelPruner.prune(),
+      hasPotentialLLMFeedback:
+        model
+        |> get_in(["authoring", "rules"])
+        |> Oli.Conversation.LLMFeedback.has_potential_feedback_rule?(),
+      model: model |> Oli.Delivery.Page.ModelPruner.prune(),
       partAttempts:
         Map.values(latest_part_attempt_by_part)
         |> Enum.map(fn pa ->

--- a/test/oli/conversation/llm_feedback_test.exs
+++ b/test/oli/conversation/llm_feedback_test.exs
@@ -180,6 +180,46 @@ defmodule Oli.Conversation.LLMFeedbackTest do
     end
   end
 
+  describe "has_potential_feedback_rule?/1" do
+    test "returns true when a rule has an LLM feedback activation point" do
+      rules = [
+        %{
+          "event" => %{
+            "params" => %{
+              "actions" => [
+                %{
+                  "type" => "activationPoint",
+                  "params" => %{"kind" => "feedback", "prompt" => "Guide the student"}
+                }
+              ]
+            }
+          }
+        }
+      ]
+
+      assert LLMFeedback.has_potential_feedback_rule?(rules)
+    end
+
+    test "returns false for missing or non-feedback activation points" do
+      refute LLMFeedback.has_potential_feedback_rule?(nil)
+
+      refute LLMFeedback.has_potential_feedback_rule?([
+               %{
+                 "event" => %{
+                   "params" => %{
+                     "actions" => [
+                       %{
+                         "type" => "activationPoint",
+                         "params" => %{"kind" => "dot", "prompt" => "Open DOT"}
+                       }
+                     ]
+                   }
+                 }
+               }
+             ])
+    end
+  end
+
   describe "extract_student_input/1" do
     test "extracts string value from student input" do
       part_inputs = [

--- a/test/oli_web/controllers/api/attempt_controller_test.exs
+++ b/test/oli_web/controllers/api/attempt_controller_test.exs
@@ -4,6 +4,7 @@ defmodule OliWeb.AttemptControllerTest do
   alias Oli.Seeder
   alias Oli.Activities.Model.Part
   alias Oli.Delivery.Attempts.Core
+  alias Oli.Resources
 
   describe "bulk activity attempt request" do
     setup [:setup_session]
@@ -30,6 +31,7 @@ defmodule OliWeb.AttemptControllerTest do
         Enum.find(attempts, fn a -> a["attemptGuid"] == map.activity_attempt1.attempt_guid end)
 
       assert length(first_activity_attempt["partAttempts"]) == 1
+      refute first_activity_attempt["hasPotentialLLMFeedback"]
 
       second_activity_attempt =
         Enum.find(attempts, fn a -> a["attemptGuid"] == map.activity_attempt2.attempt_guid end)
@@ -44,6 +46,48 @@ defmodule OliWeb.AttemptControllerTest do
 
       part3_attempt = Enum.find(part_attempts, fn p -> p["partId"] == "3" end)
       assert part3_attempt["attemptNumber"] == 2
+    end
+
+    test "includes a safe LLM feedback availability flag without exposing authoring rules", %{
+      conn: conn,
+      map: map
+    } do
+      rules = [
+        %{
+          "id" => "rule-llm-feedback",
+          "event" => %{
+            "params" => %{
+              "actions" => [
+                %{
+                  "type" => "activationPoint",
+                  "params" => %{
+                    "kind" => "feedback",
+                    "prompt" => "Guide the student without revealing the answer."
+                  }
+                }
+              ]
+            }
+          }
+        }
+      ]
+
+      content =
+        (map.adaptive_activity.revision.content || %{})
+        |> Map.put("authoring", %{"rules" => rules})
+
+      {:ok, _revision} =
+        Resources.update_revision(map.adaptive_activity.revision, %{content: content})
+
+      conn =
+        post(
+          conn,
+          Routes.attempt_path(conn, :bulk_retrieve, map.section.slug),
+          %{"attemptGuids" => [map.adaptive_activity_attempt1.attempt_guid]}
+        )
+
+      assert %{"result" => "success", "activityAttempts" => [attempt]} = json_response(conn, 200)
+      assert attempt["hasPotentialLLMFeedback"]
+      refute Map.has_key?(attempt["model"], "authoring")
     end
   end
 


### PR DESCRIPTION
- Fix the adaptive page AI-feedback loading state for learners.
- Move LLM-feedback availability detection to the server, where full authoring rules are still available.
- Add a safe `hasPotentialLLMFeedback` flag to attempt API responses without exposing pruned authoring data.
- Use that flag in delivery state so the feedback pop-up can show a pending state while AI feedback is being generated.
- Update the pending feedback UI to use the segmented “thinking” spinner and _Thinking..._ copy, matching the instructor intelligent dashboard pattern.

---

See: https://eliterate.atlassian.net/browse/MER-4961

---
https://github.com/user-attachments/assets/9d8ff374-5de5-4485-abb7-81ea3c29711b

