### PR TITLE
[ENHANCEMENT] [MER-5605] allow admin cert edits

### DIFF
--- a/lib/oli_web/live/certificates/certificate_settings_live.ex
+++ b/lib/oli_web/live/certificates/certificate_settings_live.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Certificates.CertificatesSettingsLive do
   use OliWeb, :live_view
 
+  alias Oli.Accounts
   alias Oli.Delivery.Certificates
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
@@ -52,7 +53,7 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
       socket
       |> assign(params: params)
       |> assign(active_tab: params["active_tab"])
-      |> assign(read_only: route_info[:access] == :read_only)
+      |> assign(read_only: read_only?(route_info[:access], socket.assigns.current_author))
       |> assign(graded_pages: [])
       |> assign(table_model: CertificatesIssuedTableModel.new(ctx, [], section.slug))
       |> assigns_for(:breadcrumbs)
@@ -171,7 +172,9 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
             checked={Ecto.Changeset.get_field(@section_changeset, :certificate_enabled)}
           />
           <div class="grow shrink basis-0 text-base font-medium">
-            Enable certificate capabilities for this template
+            Enable certificate capabilities for this {if @route_name == :delivery,
+              do: "section",
+              else: "template"}
           </div>
         </.form>
         <.tabs
@@ -302,6 +305,9 @@ defmodule OliWeb.Certificates.CertificatesSettingsLive do
         {:noreply, assign(socket, section_changeset: changeset)}
     end
   end
+
+  defp read_only?(:read_only, author), do: !Accounts.is_admin?(author)
+  defp read_only?(_, _author), do: false
 
   def handle_info({:certificate_updated, certificate}, socket) do
     {:noreply, assign(socket, certificate: certificate)}

--- a/lib/oli_web/live/certificates/components/design_tab.ex
+++ b/lib/oli_web/live/certificates/components/design_tab.ex
@@ -276,6 +276,11 @@ defmodule OliWeb.Certificates.Components.DesignTab do
   end
 
   @impl true
+  def handle_event(event, _params, %{assigns: %{read_only: true}} = socket)
+      when event in ["validate", "cancel", "save", "remove_logo"] do
+    {:noreply, socket}
+  end
+
   def handle_event("validate", %{"certificate" => params}, socket) do
     base = socket.assigns.certificate_changeset.data || %Certificate{}
 

--- a/lib/oli_web/live/certificates/components/thresholds_tab.ex
+++ b/lib/oli_web/live/certificates/components/thresholds_tab.ex
@@ -242,6 +242,17 @@ defmodule OliWeb.Certificates.Components.ThresholdsTab do
     """
   end
 
+  def handle_event(event, _params, %{assigns: %{read_only: true}} = socket)
+      when event in [
+             "validate",
+             "save_certificate",
+             "toggle_selected",
+             "select_all_pages",
+             "deselect_all_pages"
+           ] do
+    {:noreply, socket}
+  end
+
   def handle_event("validate", %{"certificate" => certificate_params}, socket) do
     changeset =
       cast_certificate_params(

--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -233,7 +233,7 @@ defmodule OliWeb.Sections.OverviewView do
             This section <b>does {unless @section.certificate_enabled, do: "not"}</b>
             currently produce a certificate.
           </div>
-          <div :if={@section.certificate_enabled}>
+          <div :if={@section.certificate_enabled or @is_admin}>
             <a href={~p"/sections/#{@section.slug}/certificate_settings"}>
               Manage Certificate Settings
             </a>

--- a/test/oli_web/live/certificates/certificate_settings_live_test.exs
+++ b/test/oli_web/live/certificates/certificate_settings_live_test.exs
@@ -14,6 +14,10 @@ defmodule OliWeb.Certificates.CertificateSettingsLiveTest do
     ~p"/authoring/products/#{product_slug}/certificate_settings"
   end
 
+  defp delivery_lv_route(section_slug) do
+    ~p"/sections/#{section_slug}/certificate_settings"
+  end
+
   describe "certificate settings live - workspaces" do
     setup do
       project = insert(:project)
@@ -160,6 +164,63 @@ defmodule OliWeb.Certificates.CertificateSettingsLiveTest do
                "div[data-phx-component='1']",
                "Customize the conditions students must meet to receive a certificate."
              )
+    end
+  end
+
+  describe "certificate settings live - delivery section" do
+    setup do
+      section =
+        insert(:section, %{certificate_enabled: true, open_and_free: true, type: :enrollable})
+
+      certificate = insert(:certificate, section: section)
+
+      {:ok, %{section: section, certificate: certificate}}
+    end
+
+    test "renders certificate settings read only for instructors", ctx do
+      %{conn: conn, section: section} = ctx
+      {:ok, conn: conn, instructor: instructor} = instructor_conn(%{conn: conn})
+
+      Sections.enroll(instructor.id, section.id, [
+        Lti_1p3.Roles.ContextRoles.get_role(:context_instructor)
+      ])
+
+      {:ok, view, _html} = live(conn, delivery_lv_route(section.slug))
+
+      assert has_element?(view, "fieldset[disabled]")
+      refute has_element?(view, "button", "Save Thresholds")
+    end
+
+    test "allows any admin to edit certificate settings in a section", ctx do
+      %{conn: conn, section: section, certificate: certificate} = ctx
+      {:ok, conn: conn, content_admin: _admin} = content_admin_conn(%{conn: conn})
+
+      {:ok, view, _html} = live(conn, delivery_lv_route(section.slug))
+
+      refute has_element?(view, "fieldset[disabled]")
+      assert has_element?(view, "button", "Save Thresholds")
+
+      view
+      |> element("#certificate_form")
+      |> render_submit(%{
+        "certificate" => %{
+          "min_percentage_for_completion" => "70",
+          "min_percentage_for_distinction" => "90",
+          "required_discussion_posts" => "3",
+          "required_class_notes" => "4",
+          "section_id" => "#{section.id}",
+          "requires_instructor_approval" => "true",
+          "assessments_apply_to" => "all"
+        }
+      })
+
+      updated_certificate = Oli.Delivery.Certificates.get_certificate(certificate.id)
+
+      assert updated_certificate.min_percentage_for_completion == 70
+      assert updated_certificate.min_percentage_for_distinction == 90
+      assert updated_certificate.required_discussion_posts == 3
+      assert updated_certificate.required_class_notes == 4
+      assert updated_certificate.requires_instructor_approval
     end
   end
 end

--- a/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
@@ -63,5 +63,38 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageTabTest do
       # Collab Space Group gets rendered
       assert render(view) =~ "Collaborative Space"
     end
+
+    test "does not show certificate settings link when certificates are disabled", %{
+      instructor: instructor,
+      section: section,
+      conn: conn
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, live_view_manage_route(section.slug))
+
+      refute has_element?(
+               view,
+               "a[href='/sections/#{section.slug}/certificate_settings']",
+               "Manage Certificate Settings"
+             )
+    end
+  end
+
+  describe "admin" do
+    setup [:admin_conn]
+
+    test "can access certificate settings when certificates are disabled", %{conn: conn} do
+      section =
+        insert(:section, %{certificate_enabled: false, open_and_free: true, type: :enrollable})
+
+      {:ok, view, _html} = live(conn, live_view_manage_route(section.slug))
+
+      assert has_element?(
+               view,
+               "a[href='/sections/#{section.slug}/certificate_settings']",
+               "Manage Certificate Settings"
+             )
+    end
   end
 end


### PR DESCRIPTION
This PR adds editing support to the Certificate view, only for Admin users.  

Tested locally and allows edits after section is created.  