### PR TITLE
[BUG FIX] [MER-5606] Moving dashboard sections invalid error

### DIFF
--- a/assets/src/hooks/dashboard_section_chrome.ts
+++ b/assets/src/hooks/dashboard_section_chrome.ts
@@ -15,7 +15,9 @@ let draggedSectionId: string | null = null;
 let pendingKeyboardFocusSectionId: string | null = null;
 
 function orderedSectionIds(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll<SectionElement>(':scope > [data-dashboard-section-id]'))
+  return Array.from(
+    container.querySelectorAll<SectionElement>(':scope > [data-dashboard-section-id]'),
+  )
     .map((section) => section.dataset.dashboardSectionId)
     .filter(
       (sectionId): sectionId is string => typeof sectionId === 'string' && sectionId.length > 0,

--- a/assets/src/hooks/dashboard_section_chrome.ts
+++ b/assets/src/hooks/dashboard_section_chrome.ts
@@ -15,7 +15,7 @@ let draggedSectionId: string | null = null;
 let pendingKeyboardFocusSectionId: string | null = null;
 
 function orderedSectionIds(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll<SectionElement>('[data-dashboard-section-id]'))
+  return Array.from(container.querySelectorAll<SectionElement>(':scope > [data-dashboard-section-id]'))
     .map((section) => section.dataset.dashboardSectionId)
     .filter(
       (sectionId): sectionId is string => typeof sectionId === 'string' && sectionId.length > 0,
@@ -78,9 +78,9 @@ export function buildDroppedSectionOrder(
 
 function applySectionOrder(container: HTMLElement, sectionIds: string[]) {
   const sectionsById = new Map(
-    Array.from(container.querySelectorAll<SectionElement>('[data-dashboard-section-id]')).map(
-      (section) => [section.dataset.dashboardSectionId, section],
-    ),
+    Array.from(
+      container.querySelectorAll<SectionElement>(':scope > [data-dashboard-section-id]'),
+    ).map((section) => [section.dataset.dashboardSectionId, section]),
   );
 
   sectionIds.forEach((sectionId) => {


### PR DESCRIPTION
[MER-5606](https://eliterate.atlassian.net/browse/MER-5606)

## Summary

This PR fixes a drag-and-drop reorder bug in Instructor Dashboard section groups.

When section groups were expanded, reordering could fail with the flash message:

`Invalid dashboard section order.`

## What changed

- Updated section-order collection in the dashboard section drag/drop hook to only consider top-level section nodes.
- Updated DOM reordering logic to use the same top-level-only selection.

## Why this fixes the issue

Expanded groups include nested elements that also had `data-dashboard-section-id`, which caused duplicate section IDs to be included in reorder payloads.
The backend correctly rejected that payload as invalid.

By scoping selection to direct container children, reorder payloads now include only the intended unique section IDs.

## Result

Drag-and-drop reordering works correctly whether dashboard section groups are expanded or collapsed.


https://github.com/user-attachments/assets/5b849ca6-7d29-4f52-8b10-5ebce46f9f81









[MER-5606]: https://eliterate.atlassian.net/browse/MER-5606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ