### PR TITLE
[BUG FIX] [MER-5054] Fixes adaptive practice page scoring and author analytics

### DIFF
--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -555,8 +555,12 @@ export const check = async (
     //in case of incorrect answer if negative scoring is allowed then calculation will proceed.
     else if (isCorrect || scoringContext.negativeScoreAllowed) {
       const { maxScore, maxAttempt, currentAttemptNumber } = scoringContext;
-      const scorePerAttempt = maxScore / maxAttempt;
-      score = maxScore - scorePerAttempt * (currentAttemptNumber - 1);
+      if (maxAttempt <= 0) {
+        score = maxScore;
+      } else {
+        const scorePerAttempt = maxScore / maxAttempt;
+        score = maxScore - scorePerAttempt * (currentAttemptNumber - 1);
+      }
     }
     score = Math.min(score, scoringContext.maxScore || 0);
     if (!scoringContext.negativeScoreAllowed) {

--- a/assets/src/adaptivity/rules-engine.ts
+++ b/assets/src/adaptivity/rules-engine.ts
@@ -556,7 +556,7 @@ export const check = async (
     else if (isCorrect || scoringContext.negativeScoreAllowed) {
       const { maxScore, maxAttempt, currentAttemptNumber } = scoringContext;
       if (maxAttempt <= 0) {
-        score = maxScore;
+        score = isCorrect ? maxScore : 0;
       } else {
         const scorePerAttempt = maxScore / maxAttempt;
         score = maxScore - scorePerAttempt * (currentAttemptNumber - 1);

--- a/assets/test/adaptivity/rules_engine_test.ts
+++ b/assets/test/adaptivity/rules_engine_test.ts
@@ -167,6 +167,28 @@ describe('Rules Engine', () => {
     expect(out_of).toEqual(10);
   });
 
+  it('should not award full credit to incorrect answers when max attempts is zero and negative scoring is enabled', async () => {
+    const attempts = 4;
+    const maxScore = 10;
+    const maxAttempt = 0;
+    const negativeScoreAllowed = true;
+    const attemptScoringContext = getAttemptScoringContext(
+      attempts,
+      maxScore,
+      maxAttempt,
+      negativeScoreAllowed,
+    );
+    const { score, out_of, correct } = (await check(
+      mockState,
+      [defaultWrongRule],
+      attemptScoringContext,
+    )) as CheckResult;
+
+    expect(correct).toEqual(false);
+    expect(score).toEqual(0);
+    expect(out_of).toEqual(10);
+  });
+
   it('should not allow negative scores based on the flag', async () => {
     const attempts = 4;
     const maxScore = 1;

--- a/assets/test/adaptivity/rules_engine_test.ts
+++ b/assets/test/adaptivity/rules_engine_test.ts
@@ -152,6 +152,21 @@ describe('Rules Engine', () => {
     expect(out_of).toEqual(10);
   });
 
+  it('should use max score when max attempts is zero', async () => {
+    const attempts = 4;
+    const maxScore = 10;
+    const maxAttempt = 0;
+    const attemptScoringContext = getAttemptScoringContext(attempts, maxScore, maxAttempt);
+    const { score, out_of } = (await check(
+      mockState,
+      [defaultCorrectRule],
+      attemptScoringContext,
+    )) as CheckResult;
+
+    expect(score).toEqual(10);
+    expect(out_of).toEqual(10);
+  });
+
   it('should not allow negative scores based on the flag', async () => {
     const attempts = 4;
     const maxScore = 1;

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -206,6 +206,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
                   Enum.map(part_attempts, fn p ->
                     create_raw_part_attempt(
                       new_activity_attempt.id,
+                      new_activity_attempt.attempt_number,
                       p,
                       seed_state_from_previous,
                       datashop_session_id
@@ -257,6 +258,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
 
   defp create_raw_part_attempt(
          activity_attempt_id,
+         activity_attempt_attempt_number,
          previous_part_attempt,
          seed_state_from_previous,
          datashop_session_id
@@ -276,7 +278,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
       activity_attempt_id: activity_attempt_id,
       attempt_guid: UUID.uuid4(),
       datashop_session_id: datashop_session_id,
-      attempt_number: 1,
+      attempt_number: activity_attempt_attempt_number,
       inserted_at: now,
       updated_at: now,
       score: nil,

--- a/lib/oli/delivery/attempts/activity_lifecycle.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle.ex
@@ -353,13 +353,13 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
             |> Repo.one!()
 
           # Recount part attempts from the locked state
-          {attempt_count} =
+          {max_attempt_number} =
             Repo.one(
               from(p in PartAttempt,
                 where:
                   p.activity_attempt_id == ^locked_activity_attempt.id and
                     p.part_id == ^part_attempt.part_id,
-                select: {count(p.id)}
+                select: {max(p.attempt_number)}
               )
             )
 
@@ -387,7 +387,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle do
 
           case create_part_attempt(%{
                  attempt_guid: UUID.uuid4(),
-                 attempt_number: attempt_count + 1,
+                 attempt_number: (max_attempt_number || 0) + 1,
                  part_id: part_attempt.part_id,
                  grading_approach: part_attempt.grading_approach,
                  response: nil,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -81,6 +81,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   alias Oli.Delivery.Attempts.Core.ActivityAttempt
   alias Oli.Delivery.Snapshots
   alias Oli.Delivery.Evaluation.EvaluationContext
+  alias Oli.Activities.Model.Feedback
   alias Oli.Activities.Model
   alias Oli.Delivery.Experiments.LogWorker
   alias Oli.Delivery.Attempts.ActivityLifecycle.ApplyClientEvaluation
@@ -458,38 +459,38 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
            scoringContext
          ) do
       {:ok, decodedResults} ->
+        %{score: rolled_up_score, out_of: rolled_up_out_of} =
+          AdaptivePartEvaluation.evaluate(
+            activity_model,
+            rules,
+            scoringContext,
+            state,
+            part_inputs,
+            part_attempts
+          )
+
+        {activity_score, activity_out_of} =
+          determine_adaptive_activity_score(
+            decodedResults,
+            scoringContext,
+            rolled_up_score,
+            rolled_up_out_of
+          )
+
+        decodedResults =
+          decodedResults
+          |> Map.put("score", activity_score)
+          |> Map.put("out_of", activity_out_of)
+
+        client_evaluations =
+          to_rule_client_results(
+            activity_score,
+            activity_out_of,
+            rule_feedback(decodedResults),
+            part_inputs
+          )
+
         if scoringContext.isManuallyGraded do
-          %{
-            client_evaluations: client_evaluations,
-            rule_scored_attempt_guids: rule_scored_attempt_guids
-          } =
-            AdaptivePartEvaluation.evaluate(
-              activity_model,
-              rules,
-              scoringContext,
-              state,
-              part_inputs,
-              part_attempts
-            )
-
-          {activity_score, activity_out_of} =
-            determine_adaptive_activity_score(
-              decodedResults,
-              scoringContext,
-              nil,
-              nil
-            )
-
-          client_evaluations =
-            AdaptivePartEvaluation.override_rule_scored_client_evaluations(
-              client_evaluations,
-              part_attempts,
-              rule_scored_attempt_guids,
-              activity_score,
-              activity_out_of,
-              decodedResults
-            )
-
           with :ok <-
                  maybe_persist_mixed_adaptive_automatic_parts(
                    section_slug,
@@ -505,48 +506,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
               {:error, err}
           end
         else
-          %{
-            client_evaluations: client_evaluations,
-            rule_scored_attempt_guids: rule_scored_attempt_guids,
-            score: rolled_up_score,
-            out_of: rolled_up_out_of
-          } =
-            AdaptivePartEvaluation.evaluate(
-              activity_model,
-              rules,
-              scoringContext,
-              state,
-              part_inputs,
-              part_attempts
-            )
-
-          {activity_score, activity_out_of} =
-            determine_adaptive_activity_score(
-              decodedResults,
-              scoringContext,
-              rolled_up_score,
-              rolled_up_out_of
-            )
-
-          Logger.debug("Adaptive rollup score: #{rolled_up_score}")
-          Logger.debug("Adaptive rollup out_of: #{rolled_up_out_of}")
           Logger.debug("Adaptive activity score: #{activity_score}")
           Logger.debug("Adaptive activity out_of: #{activity_out_of}")
-
-          decodedResults =
-            decodedResults
-            |> Map.put("score", activity_score)
-            |> Map.put("out_of", activity_out_of)
-
-          client_evaluations =
-            AdaptivePartEvaluation.override_rule_scored_client_evaluations(
-              client_evaluations,
-              part_attempts,
-              rule_scored_attempt_guids,
-              activity_score,
-              activity_out_of,
-              decodedResults
-            )
 
           case ApplyClientEvaluation.apply(
                  section_slug,
@@ -577,6 +538,48 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
       {:error, err} ->
         Logger.error("Error in rule evaluation! #{err}")
         {:error, err}
+    end
+  end
+
+  defp to_rule_client_results(score, out_of, feedback, part_inputs) do
+    feedback =
+      feedback
+      |> Kernel.||(default_rule_feedback(score, out_of))
+      |> with_screen_rule_evaluation_source()
+
+    Enum.map(part_inputs, fn part_input ->
+      %{
+        attempt_guid: part_input.attempt_guid,
+        client_evaluation: %Oli.Delivery.Attempts.Core.ClientEvaluation{
+          input: part_input.input.input,
+          score: score,
+          out_of: out_of,
+          feedback: feedback
+        }
+      }
+    end)
+  end
+
+  defp with_screen_rule_evaluation_source(%{} = feedback) do
+    Map.put(
+      feedback,
+      "_torus",
+      Map.merge(Map.get(feedback, "_torus", %{}), %{"evaluation_source" => "screen_rule"})
+    )
+  end
+
+  defp with_screen_rule_evaluation_source(feedback), do: feedback
+
+  defp default_rule_feedback(score, out_of) do
+    cond do
+      is_number(out_of) and out_of > 0 and is_number(score) and score >= out_of ->
+        Feedback.from_text("Correct")
+
+      is_number(score) and score <= 0 ->
+        Feedback.from_text("Incorrect")
+
+      true ->
+        Feedback.from_text("Partially correct")
     end
   end
 
@@ -702,6 +705,21 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   end
 
   defp normalize_adaptive_score(_), do: nil
+
+  defp rule_feedback(%{"results" => results}) when is_list(results) do
+    Enum.find_value(results, fn result ->
+      result
+      |> get_in(["params", "actions"])
+      |> Kernel.||([])
+      |> Enum.find_value(fn action ->
+        if Map.get(action, "type") == "feedback",
+          do: get_in(action, ["params", "feedback"]),
+          else: nil
+      end)
+    end)
+  end
+
+  defp rule_feedback(_), do: nil
 
   defp assemble_full_adaptive_state(
          resource_attempt,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -561,11 +561,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   end
 
   defp with_screen_rule_evaluation_source(%{} = feedback) do
-    Map.put(
-      feedback,
-      "_torus",
-      Map.merge(Map.get(feedback, "_torus", %{}), %{"evaluation_source" => "screen_rule"})
-    )
+    Map.put(feedback, "_torus", %{"evaluation_source" => "screen_rule"})
   end
 
   defp with_screen_rule_evaluation_source(feedback), do: feedback

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -10,6 +10,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
   alias Oli.Delivery.Sections.Section
   alias Oli.Activities.AdaptiveParts
   alias Oli.Delivery.Attempts.ManualGrading.BrowseOptions
+  alias Oli.Delivery.Settings
   alias Oli.Resources.Revision
   alias Oli.Delivery.Attempts.Core
 
@@ -400,8 +401,34 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
     end
   end
 
-  defp maybe_finalize_resource_attempt(_, false, resource_attempt_guid),
-    do: {:ok, resource_attempt_guid}
+  defp maybe_finalize_resource_attempt(section, false, resource_attempt_guid) do
+    resource_attempt =
+      Oli.Delivery.Attempts.Core.get_resource_attempt(attempt_guid: resource_attempt_guid)
+      |> Oli.Repo.preload(:revision)
+
+    case resource_attempt do
+      %ResourceAttempt{lifecycle_state: :submitted, resource_access_id: resource_access_id} ->
+        resource_access = Oli.Repo.get(ResourceAccess, resource_access_id)
+
+        effective_settings =
+          Settings.get_combined_settings(
+            resource_attempt.revision,
+            section.id,
+            resource_access.user_id
+          )
+
+        case Oli.Delivery.Attempts.PageLifecycle.Graded.roll_up_activities_to_resource_attempt(
+               resource_attempt,
+               effective_settings
+             ) do
+          {:ok, _resource_attempt} -> {:ok, resource_attempt_guid}
+          other -> other
+        end
+
+      _ ->
+        {:ok, resource_attempt_guid}
+    end
+  end
 
   defp maybe_finalize_resource_attempt(section, true, resource_attempt_guid) do
     resource_attempt =

--- a/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/hierarchy.ex
@@ -198,7 +198,9 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
         |> Map.put(:scoreable, scoreable)
       end)
 
-    Enum.map(prototypes, fn prototype -> create_raw_activity_attempt(prototype) end)
+    Enum.map(prototypes, fn prototype ->
+      create_raw_activity_attempt(prototype, resource_attempt.attempt_number)
+    end)
     |> optimize_raw_attempts()
     |> bulk_create_activity_attempts(right_now, resource_attempt.id)
 
@@ -252,7 +254,12 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
         join: revision in Revision,
         on: revision.id == aa.revision_id,
         where: aa.resource_attempt_id == ^resource_attempt_id,
-        select: %{id: aa.id, revision_id: aa.revision_id, revision: revision}
+        select: %{
+          id: aa.id,
+          revision_id: aa.revision_id,
+          attempt_number: aa.attempt_number,
+          revision: revision
+        }
       )
       |> then(fn query ->
         case excluding_revision_ids do
@@ -282,7 +289,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
 
     query = """
       INSERT INTO part_attempts(part_id, activity_attempt_id, attempt_guid, datashop_session_id, inserted_at, updated_at, hints, attempt_number, lifecycle_state, grading_approach)
-      SELECT pm.part_id, a.id, gen_random_uuid(), $2, now(), now(), '{}'::varchar[], 1, 'active', (CASE WHEN pm.grading_approach IS NULL THEN
+      SELECT pm.part_id, a.id, gen_random_uuid(), $2, now(), now(), '{}'::varchar[], a.attempt_number, 'active', (CASE WHEN pm.grading_approach IS NULL THEN
       'automatic'
        ELSE
        pm.grading_approach
@@ -303,7 +310,11 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
       |> DateTime.truncate(:second)
 
     payload =
-      Enum.flat_map(adaptive_rows, fn %{id: activity_attempt_id, revision: revision} ->
+      Enum.flat_map(adaptive_rows, fn %{
+                                        id: activity_attempt_id,
+                                        attempt_number: attempt_number,
+                                        revision: revision
+                                      } ->
         revision.content
         |> AdaptiveParts.persisted_part_definitions()
         |> Enum.map(fn part ->
@@ -315,7 +326,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
             inserted_at: now,
             updated_at: now,
             hints: [],
-            attempt_number: 1,
+            attempt_number: attempt_number,
             lifecycle_state: :active,
             grading_approach:
               AdaptiveParts.persisted_part_grading_approach(revision.content, part)
@@ -394,12 +405,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
           where:
             aa1.resource_attempt_id == ^current_resource_id and
               aa1.revision_id in ^revision_ids,
-          select: %{id: aa1.id, revision_id: aa1.revision_id}
+          select: %{id: aa1.id, revision_id: aa1.revision_id, attempt_number: aa1.attempt_number}
         )
       )
       # 3. Pair together the response from the previous attempt with the activity attempt id
       #    from the current attempt to create bulk insert payloads for these new part attempt records
-      |> Enum.reduce([], fn %{id: id, revision_id: revision_id}, all ->
+      |> Enum.reduce([], fn %{id: id, revision_id: revision_id, attempt_number: attempt_number},
+                            all ->
         case Map.get(previous_state_by_revision_id, revision_id) do
           nil ->
             all
@@ -442,7 +454,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
                       nil
                     end,
                   hints: [],
-                  attempt_number: 1,
+                  attempt_number: attempt_number,
                   grading_approach: Atom.to_string(grading_approach)
                 }
               end
@@ -528,14 +540,15 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Hierarchy do
            aggregate_score: aggregate_score,
            aggregate_out_of: aggregate_out_of,
            attempt_number: attempt_number
-         } = prototype
+         } = prototype,
+         default_attempt_number
        ) do
     %{
       resource_attempt_id: {:placeholder, :resource_attempt_id},
       attempt_guid: UUID.uuid4(),
       attempt_number:
         if is_nil(attempt_number) do
-          1
+          default_attempt_number
         else
           attempt_number
         end,

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -16,6 +16,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
 
   alias Oli.Delivery.Attempts.Core.{ResourceAttempt}
   alias Oli.Delivery.Attempts.PageLifecycle.Common
+  alias Oli.Delivery.Attempts.PageLifecycle.Graded
 
   @moduledoc """
   Implementation of a page Lifecycle behaviour for ungraded pages.
@@ -64,11 +65,15 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
       }) do
     now = DateTime.utc_now()
 
-    update_resource_attempt(resource_attempt, %{
-      date_evaluated: now,
-      date_submitted: now,
-      lifecycle_state: :evaluated
-    })
+    update_attrs =
+      %{
+        date_evaluated: now,
+        date_submitted: now,
+        lifecycle_state: :evaluated
+      }
+      |> maybe_add_adaptive_rollup(resource_attempt)
+
+    update_resource_attempt(resource_attempt, update_attrs)
 
     {:ok,
      %FinalizationSummary{
@@ -163,4 +168,30 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   defp needs_new_attempt?(%{revision_id: revision_id}, %{id: id}) do
     revision_id != id
   end
+
+  defp maybe_add_adaptive_rollup(
+         attrs,
+         %ResourceAttempt{revision: %{content: %{"advancedDelivery" => true}}} = resource_attempt
+       ) do
+    activity_attempts =
+      Oli.Delivery.Attempts.Core.get_latest_activity_attempts(resource_attempt.id)
+
+    if Enum.all?(activity_attempts, fn activity_attempt ->
+         activity_attempt.lifecycle_state == :evaluated or !activity_attempt.scoreable
+       end) do
+      {score, out_of} =
+        activity_attempts
+        |> Enum.filter(& &1.scoreable)
+        |> Enum.reduce({0.0, 0.0}, fn activity_attempt, {score, out_of} ->
+          {score + (activity_attempt.score || 0.0), out_of + (activity_attempt.out_of || 0.0)}
+        end)
+        |> Graded.ensure_valid_grade()
+
+      Map.merge(attrs, %{score: score, out_of: out_of})
+    else
+      attrs
+    end
+  end
+
+  defp maybe_add_adaptive_rollup(attrs, _resource_attempt), do: attrs
 end

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -14,7 +14,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     Hierarchy
   }
 
-  alias Oli.Delivery.Attempts.Core.{ResourceAttempt}
+  alias Oli.Delivery.Attempts.Core.{ActivityAttempt, ResourceAttempt}
   alias Oli.Delivery.Attempts.PageLifecycle.Common
   alias Oli.Delivery.Attempts.PageLifecycle.Graded
 
@@ -66,19 +66,14 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     now = DateTime.utc_now()
 
     update_attrs =
-      %{
-        date_evaluated: now,
-        date_submitted: now,
-        lifecycle_state: :evaluated
-      }
-      |> maybe_add_adaptive_rollup(resource_attempt)
+      determine_finalization_attrs(resource_attempt, now)
 
-    update_resource_attempt(resource_attempt, update_attrs)
+    {:ok, updated_resource_attempt} = update_resource_attempt(resource_attempt, update_attrs)
 
     {:ok,
      %FinalizationSummary{
        graded: false,
-       lifecycle_state: :evaluated,
+       lifecycle_state: updated_resource_attempt.lifecycle_state,
        resource_access: nil,
        part_attempt_guids: nil,
        effective_settings: effective_settings
@@ -169,29 +164,75 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     revision_id != id
   end
 
-  defp maybe_add_adaptive_rollup(
-         attrs,
-         %ResourceAttempt{revision: %{content: %{"advancedDelivery" => true}}} = resource_attempt
+  defp determine_finalization_attrs(
+         %ResourceAttempt{revision: %{content: %{"advancedDelivery" => true}}} = resource_attempt,
+         now
+       ) do
+    adaptive_finalization_attrs(resource_attempt, now)
+  end
+
+  defp determine_finalization_attrs(_resource_attempt, now) do
+    %{
+      date_evaluated: now,
+      date_submitted: now,
+      lifecycle_state: :evaluated
+    }
+  end
+
+  defp adaptive_finalization_attrs(
+         %ResourceAttempt{revision: %{content: %{"advancedDelivery" => true}}} = resource_attempt,
+         now
        ) do
     activity_attempts =
       Oli.Delivery.Attempts.Core.get_latest_activity_attempts(resource_attempt.id)
 
-    if Enum.all?(activity_attempts, fn activity_attempt ->
-         activity_attempt.lifecycle_state == :evaluated or !activity_attempt.scoreable
-       end) do
-      {score, out_of} =
-        activity_attempts
-        |> Enum.filter(& &1.scoreable)
-        |> Enum.reduce({0.0, 0.0}, fn activity_attempt, {score, out_of} ->
-          {score + (activity_attempt.score || 0.0), out_of + (activity_attempt.out_of || 0.0)}
-        end)
-        |> Graded.ensure_valid_grade()
+    cond do
+      adaptive_all_evaluated?(activity_attempts) ->
+        {score, out_of} =
+          activity_attempts
+          |> Enum.filter(& &1.scoreable)
+          |> Enum.reduce({0.0, 0.0}, fn activity_attempt, {score, out_of} ->
+            {score + (activity_attempt.score || 0.0), out_of + (activity_attempt.out_of || 0.0)}
+          end)
+          |> Graded.ensure_valid_grade()
 
-      Map.merge(attrs, %{score: score, out_of: out_of})
-    else
-      attrs
+        %{
+          score: score,
+          out_of: out_of,
+          date_evaluated: now,
+          date_submitted: now,
+          lifecycle_state: :evaluated
+        }
+
+      adaptive_pending_manual_grading?(activity_attempts) ->
+        %{
+          score: nil,
+          out_of: nil,
+          date_evaluated: nil,
+          date_submitted: now,
+          lifecycle_state: :submitted
+        }
+
+      true ->
+        %{
+          date_evaluated: now,
+          date_submitted: now,
+          lifecycle_state: :evaluated
+        }
     end
   end
 
-  defp maybe_add_adaptive_rollup(attrs, _resource_attempt), do: attrs
+  defp adaptive_all_evaluated?(activity_attempts) do
+    Enum.all?(activity_attempts, fn activity_attempt ->
+      activity_attempt.lifecycle_state == :evaluated or !activity_attempt.scoreable
+    end)
+  end
+
+  defp adaptive_pending_manual_grading?(activity_attempts) do
+    Enum.any?(activity_attempts, &(&1.lifecycle_state == :submitted)) and
+      Enum.all?(activity_attempts, fn
+        %ActivityAttempt{lifecycle_state: lifecycle_state, scoreable: scoreable} ->
+          lifecycle_state in [:evaluated, :submitted] or !scoreable
+      end)
+  end
 end

--- a/lib/oli_web/components/delivery/activity_helpers.ex
+++ b/lib/oli_web/components/delivery/activity_helpers.ex
@@ -799,7 +799,11 @@ defmodule OliWeb.Delivery.ActivityHelpers do
                 <div class="flex items-center gap-3">
                   <div class={[
                     "h-3 w-3 rounded-full border",
-                    adaptive_choice_marker_classes(choice, @summary.grading_mode)
+                    adaptive_choice_marker_classes(
+                      choice,
+                      @summary.grading_mode,
+                      Map.get(@visualization, :neutral_choice_colors, false)
+                    )
                   ]}>
                   </div>
                   <div class="flex flex-wrap items-center gap-2">
@@ -831,7 +835,11 @@ defmodule OliWeb.Delivery.ActivityHelpers do
                 <div
                   class={[
                     "h-3 rounded-full transition-all",
-                    adaptive_choice_fill_classes(choice, @summary.grading_mode)
+                    adaptive_choice_fill_classes(
+                      choice,
+                      @summary.grading_mode,
+                      Map.get(@visualization, :neutral_choice_colors, false)
+                    )
                   ]}
                   style={"width: #{format_percentage_1(choice.ratio)}%; min-width: #{if choice.count > 0, do: "0.5rem", else: "0"};"}
                 >
@@ -900,9 +908,13 @@ defmodule OliWeb.Delivery.ActivityHelpers do
                   <div
                     class={[
                       "h-2 rounded-full transition-all",
-                      if(entry.correct == true,
-                        do: adaptive_correct_fill_class(),
-                        else: adaptive_incorrect_fill_class()
+                      Map.get(
+                        entry,
+                        :fill_class,
+                        if(entry.correct == true,
+                          do: adaptive_correct_fill_class(),
+                          else: adaptive_incorrect_fill_class()
+                        )
                       )
                     ]}
                     style={"width: #{format_percentage_1(entry.ratio)}%; min-width: #{if entry.count > 0, do: "0.4rem", else: "0"};"}
@@ -1006,6 +1018,12 @@ defmodule OliWeb.Delivery.ActivityHelpers do
         </div>
         <.render_adaptive_coverage summary={@summary} />
         <.render_adaptive_outcome_breakdown summary={@summary} />
+        <div
+          :if={Map.get(@visualization, :native_key_note)}
+          class="mt-3 rounded-lg bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-200"
+        >
+          {@visualization.native_key_note}
+        </div>
       </div>
     </div>
     """
@@ -1141,6 +1159,12 @@ defmodule OliWeb.Delivery.ActivityHelpers do
         </div>
         <.render_adaptive_coverage summary={@summary} />
         <.render_adaptive_outcome_breakdown summary={@summary} />
+        <div
+          :if={Map.get(@visualization, :native_key_note)}
+          class="mt-3 rounded-lg bg-emerald-50 px-3 py-2 text-xs font-medium text-emerald-800 dark:bg-emerald-500/10 dark:text-emerald-200"
+        >
+          {@visualization.native_key_note}
+        </div>
       </div>
     </div>
     """
@@ -1261,7 +1285,10 @@ defmodule OliWeb.Delivery.ActivityHelpers do
     """
   end
 
-  defp adaptive_choice_marker_classes(choice, grading_mode) when is_map(choice) do
+  defp adaptive_choice_marker_classes(_choice, _grading_mode, true),
+    do: adaptive_neutral_marker_class()
+
+  defp adaptive_choice_marker_classes(choice, grading_mode, _neutral?) when is_map(choice) do
     choice
     |> adaptive_choice_visual_state(grading_mode)
     |> adaptive_choice_marker_classes()
@@ -1289,7 +1316,10 @@ defmodule OliWeb.Delivery.ActivityHelpers do
   defp adaptive_choice_marker_classes(_),
     do: "border-slate-400 bg-slate-400 dark:border-slate-500 dark:bg-slate-500"
 
-  defp adaptive_choice_fill_classes(choice, grading_mode) when is_map(choice) do
+  defp adaptive_choice_fill_classes(_choice, _grading_mode, true),
+    do: adaptive_neutral_fill_class()
+
+  defp adaptive_choice_fill_classes(choice, grading_mode, _neutral?) when is_map(choice) do
     choice
     |> adaptive_choice_visual_state(grading_mode)
     |> adaptive_choice_fill_classes()
@@ -1326,31 +1356,40 @@ defmodule OliWeb.Delivery.ActivityHelpers do
     end
   end
 
-  defp adaptive_visualization_fill_class(%{grading_pending: true}),
+  defp adaptive_visualization_fill_class(_correctness_metrics, true),
+    do: adaptive_neutral_fill_class()
+
+  defp adaptive_visualization_fill_class(%{grading_pending: true}, _screen_rule_scored),
     do: "bg-slate-400 dark:bg-slate-500"
 
-  defp adaptive_visualization_fill_class(%{attempt_total_count: 0}),
+  defp adaptive_visualization_fill_class(%{attempt_total_count: 0}, _screen_rule_scored),
     do: "bg-slate-400 dark:bg-slate-500"
 
-  defp adaptive_visualization_fill_class(%{
-         evaluation_confidence: :inferred,
-         first_attempt_pct: pct
-       })
+  defp adaptive_visualization_fill_class(
+         %{
+           evaluation_confidence: :inferred,
+           first_attempt_pct: pct
+         },
+         _screen_rule_scored
+       )
        when pct >= 1.0,
        do: adaptive_correct_fill_class()
 
-  defp adaptive_visualization_fill_class(%{first_attempt_pct: pct}) when pct >= 1.0,
-    do: adaptive_correct_fill_class()
+  defp adaptive_visualization_fill_class(%{first_attempt_pct: pct}, _screen_rule_scored)
+       when pct >= 1.0,
+       do: adaptive_correct_fill_class()
 
-  defp adaptive_visualization_fill_class(%{first_attempt_pct: pct}) when pct <= 0.0,
-    do: adaptive_incorrect_fill_class()
+  defp adaptive_visualization_fill_class(%{first_attempt_pct: pct}, _screen_rule_scored)
+       when pct <= 0.0,
+       do: adaptive_incorrect_fill_class()
 
-  defp adaptive_visualization_fill_class(_),
+  defp adaptive_visualization_fill_class(_, _screen_rule_scored),
     do: adaptive_partial_fill_class()
 
   defp adaptive_correct_fill_class, do: "bg-emerald-500 dark:bg-emerald-400"
   defp adaptive_partial_fill_class, do: "bg-amber-500 dark:bg-amber-400"
   defp adaptive_incorrect_fill_class, do: "bg-rose-500 dark:bg-rose-400"
+  defp adaptive_neutral_fill_class, do: "bg-slate-400 dark:bg-slate-500"
 
   defp adaptive_correct_marker_class,
     do: "border-emerald-500 bg-emerald-500 dark:border-emerald-400 dark:bg-emerald-400"
@@ -1360,6 +1399,9 @@ defmodule OliWeb.Delivery.ActivityHelpers do
 
   defp adaptive_incorrect_marker_class,
     do: "border-rose-500 bg-rose-500 dark:border-rose-400 dark:bg-rose-400"
+
+  defp adaptive_neutral_marker_class,
+    do: "border-slate-400 bg-slate-400 dark:border-slate-500 dark:bg-slate-500"
 
   defp native_key_badge_classes do
     "inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-emerald-800 dark:bg-emerald-500/20 dark:text-emerald-200"
@@ -1766,10 +1808,11 @@ defmodule OliWeb.Delivery.ActivityHelpers do
          adaptive_part_analytics,
          response_summaries_by_activity_part
        ) do
+    activity_content = activity_attempt.revision.content
     parts_layout = activity_attempt.revision.content["partsLayout"] || []
 
     authored_parts =
-      AdaptiveParts.authored_parts_by_id(activity_attempt.revision.content)
+      AdaptiveParts.authored_parts_by_id(activity_content)
 
     resource_summaries = Map.get(activity_attempt, :resource_summaries, [])
 
@@ -1788,10 +1831,14 @@ defmodule OliWeb.Delivery.ActivityHelpers do
         part_id = Map.get(part, "id")
         part_definition = Map.merge(Map.get(authored_parts, part_id, %{}), part)
         resource_summary = Map.get(resource_summaries_by_part_id, part_id)
-        grading_mode = adaptive_part_grading_mode(part_definition)
 
         part_analytics =
           Map.get(adaptive_part_analytics, {activity_attempt.resource_id, part_id})
+
+        grading_mode = adaptive_part_grading_mode(part_definition)
+
+        screen_rule_scored =
+          adaptive_screen_rule_scored?(part_analytics, activity_content, part_definition)
 
         raw_responses =
           Map.get(
@@ -1828,11 +1875,20 @@ defmodule OliWeb.Delivery.ActivityHelpers do
             resource_summary,
             adaptive_part_prompt(part_definition, index),
             grading_mode,
-            part_analytics
+            part_analytics,
+            screen_rule_scored
           )
           |> Map.put(
             :fill_class,
-            adaptive_visualization_fill_class(correctness_metrics)
+            adaptive_visualization_fill_class(correctness_metrics, screen_rule_scored)
+          )
+          |> Map.put_new(
+            :native_key_note,
+            if(screen_rule_scored,
+              do:
+                "Screen rules determine correctness for this input. The chart shows what learners selected on their first attempt.",
+              else: nil
+            )
           )
 
         %{
@@ -2059,7 +2115,8 @@ defmodule OliWeb.Delivery.ActivityHelpers do
          resource_summary,
          prompt,
          grading_mode,
-         part_analytics
+         part_analytics,
+         screen_rule_scored
        ) do
     case Map.get(part, "type") do
       "janus-mcq" ->
@@ -2068,7 +2125,8 @@ defmodule OliWeb.Delivery.ActivityHelpers do
           responses,
           prompt,
           grading_mode,
-          part_analytics
+          part_analytics,
+          screen_rule_scored
         )
 
       "janus-dropdown" ->
@@ -2077,7 +2135,8 @@ defmodule OliWeb.Delivery.ActivityHelpers do
           responses,
           prompt,
           grading_mode,
-          part_analytics
+          part_analytics,
+          screen_rule_scored
         )
 
       "janus-input-number" ->
@@ -2353,19 +2412,28 @@ defmodule OliWeb.Delivery.ActivityHelpers do
     }
   end
 
-  defp build_adaptive_choice_distribution(part, responses, prompt, grading_mode, part_analytics) do
+  defp build_adaptive_choice_distribution(
+         part,
+         responses,
+         prompt,
+         grading_mode,
+         part_analytics,
+         screen_rule_scored
+       ) do
     config = Map.get(part, "custom", %{})
     choice_labels = extract_adaptive_choice_labels(config)
     correct_answers = Map.get(config, "correctAnswer", [])
     multiple_selection = Map.get(config, "multipleSelection", false)
     has_correctness_metadata = adaptive_mcq_has_correctness_metadata?(correct_answers)
+    show_native_correctness = has_correctness_metadata and not screen_rule_scored
 
     combination_entries =
       if multiple_selection do
         build_adaptive_mcq_combination_entries(
           responses,
           choice_labels,
-          correct_answers
+          correct_answers,
+          show_native_correctness
         )
       else
         []
@@ -2425,7 +2493,7 @@ defmodule OliWeb.Delivery.ActivityHelpers do
       combination_denominator_count:
         Enum.reduce(responses, 0, fn response_summary, total -> total + response_summary.count end),
       authored_correct_combination:
-        if(multiple_selection and has_correctness_metadata,
+        if(multiple_selection and show_native_correctness,
           do:
             adaptive_mcq_combination_label(
               correct_answers
@@ -2437,24 +2505,33 @@ defmodule OliWeb.Delivery.ActivityHelpers do
           else: nil
         ),
       combination_entries: combination_entries,
+      neutral_choice_colors: screen_rule_scored,
       native_key_note:
-        if(grading_mode == :manual and has_correctness_metadata,
-          do:
-            "Green answer-key badges show the native correct option. Credit-award badges show the recorded instructor grading decision.",
-          else: nil
-        ),
+        cond do
+          screen_rule_scored ->
+            "Screen rules determine correctness for this input. The chart shows what learners selected on their first attempt."
+
+          grading_mode == :manual and has_correctness_metadata ->
+            "Green answer-key badges show the native correct option. Credit-award badges show the recorded instructor grading decision."
+
+          true ->
+            nil
+        end,
       choices:
         Enum.with_index(choice_labels)
         |> Enum.map(fn {label, index} ->
           count = Map.get(counts, label, 0)
-          native_correct = Enum.at(correct_answers, index, false) == true
+
+          native_correct =
+            show_native_correctness and Enum.at(correct_answers, index, false) == true
 
           correctness =
             adaptive_choice_correctness(
               grading_mode,
-              has_correctness_metadata,
+              show_native_correctness,
               native_correct,
-              Map.get(outcome_counts, label, %{})
+              Map.get(outcome_counts, label, %{}),
+              screen_rule_scored
             )
 
           %{
@@ -2469,9 +2546,16 @@ defmodule OliWeb.Delivery.ActivityHelpers do
     }
   end
 
-  defp build_adaptive_mcq_combination_entries(responses, choice_labels, correct_answers) do
+  defp build_adaptive_mcq_combination_entries(
+         responses,
+         choice_labels,
+         correct_answers,
+         show_native_correctness
+       ) do
     correct_indexes = adaptive_mcq_correct_indexes(correct_answers)
-    has_correctness_metadata = adaptive_mcq_has_correctness_metadata?(correct_answers)
+
+    has_correctness_metadata =
+      show_native_correctness and adaptive_mcq_has_correctness_metadata?(correct_answers)
 
     denominator =
       Enum.reduce(responses, 0, fn response_summary, total -> total + response_summary.count end)
@@ -2505,6 +2589,13 @@ defmodule OliWeb.Delivery.ActivityHelpers do
             if(has_correctness_metadata,
               do: MapSet.equal?(MapSet.new(selected_indexes), correct_indexes),
               else: nil
+            ),
+          fill_class:
+            if(
+              has_correctness_metadata and
+                MapSet.equal?(MapSet.new(selected_indexes), correct_indexes),
+              do: adaptive_correct_fill_class(),
+              else: "bg-slate-400 dark:bg-slate-500"
             )
         },
         fn entry ->
@@ -2525,12 +2616,14 @@ defmodule OliWeb.Delivery.ActivityHelpers do
          responses,
          prompt,
          grading_mode,
-         part_analytics
+         part_analytics,
+         screen_rule_scored
        ) do
     config = Map.get(part, "custom", %{})
     option_labels = Map.get(config, "optionLabels", [])
     correct_index = get_in(part, ["custom", "correctAnswer"]) |> normalize_adaptive_choice_index()
     has_correctness_metadata = not is_nil(correct_index)
+    show_native_correctness = has_correctness_metadata and not screen_rule_scored
 
     counts =
       Enum.reduce(responses, %{}, fn response_summary, acc ->
@@ -2562,24 +2655,31 @@ defmodule OliWeb.Delivery.ActivityHelpers do
       summary: "Each bar shows how many learners selected that option on their first attempt.",
       denominator_count: denominator,
       denominator_label: "responses",
+      neutral_choice_colors: screen_rule_scored,
       native_key_note:
-        if(grading_mode == :manual and has_correctness_metadata,
-          do:
-            "Green answer-key badges show the native correct option. Credit-award badges show the recorded instructor grading decision.",
-          else: nil
-        ),
+        cond do
+          screen_rule_scored ->
+            "Screen rules determine correctness for this input. The chart shows what learners selected on their first attempt."
+
+          grading_mode == :manual and has_correctness_metadata ->
+            "Green answer-key badges show the native correct option. Credit-award badges show the recorded instructor grading decision."
+
+          true ->
+            nil
+        end,
       choices:
         Enum.with_index(option_labels, 1)
         |> Enum.map(fn {label, index} ->
           count = Map.get(counts, label, 0)
-          native_correct = correct_index == index
+          native_correct = show_native_correctness and correct_index == index
 
           correctness =
             adaptive_choice_correctness(
               grading_mode,
-              has_correctness_metadata,
+              show_native_correctness,
               native_correct,
-              Map.get(outcome_counts, label, %{})
+              Map.get(outcome_counts, label, %{}),
+              screen_rule_scored
             )
 
           %{
@@ -3437,15 +3537,20 @@ defmodule OliWeb.Delivery.ActivityHelpers do
          :automatic,
          has_correctness_metadata,
          explicit_correct,
-         outcome_counts
+         outcome_counts,
+         screen_rule_scored
        ) do
     case adaptive_choice_correctness_from_outcomes(outcome_counts) do
       nil ->
-        adaptive_choice_correctness_without_recorded_outcomes(
-          has_correctness_metadata,
-          explicit_correct,
-          outcome_counts
-        )
+        if screen_rule_scored do
+          nil
+        else
+          adaptive_choice_correctness_without_recorded_outcomes(
+            has_correctness_metadata,
+            explicit_correct,
+            outcome_counts
+          )
+        end
 
       correctness ->
         correctness
@@ -3456,9 +3561,18 @@ defmodule OliWeb.Delivery.ActivityHelpers do
          :manual,
          _has_correctness_metadata,
          _explicit_correct,
-         outcome_counts
+         outcome_counts,
+         _screen_rule_scored
        ) do
     adaptive_choice_correctness_from_outcomes(outcome_counts)
+  end
+
+  defp adaptive_screen_rule_scored?(%{screen_rule_sourced?: true}, _content, _part), do: true
+
+  defp adaptive_screen_rule_scored?(part_analytics, content, part) do
+    not Map.get(part_analytics || %{}, :screen_rule_sourced?, false) and
+      adaptive_part_grading_mode(part) == :automatic and
+      adaptive_score_driven_rules_active?(content)
   end
 
   defp adaptive_choice_correctness_from_outcomes(outcome_counts) do
@@ -3614,6 +3728,7 @@ defmodule OliWeb.Delivery.ActivityHelpers do
       response_label = ResponseLabel.build(part_attempt, "oli_adaptive")
       key = {row.activity_id, part_attempt.part_id}
       score_classification = classify_adaptive_part_attempt(part, part_attempt, response_label)
+      screen_rule_sourced? = adaptive_screen_rule_sourced_attempt?(part_attempt)
 
       if score_classification == :skipped do
         acc
@@ -3651,6 +3766,7 @@ defmodule OliWeb.Delivery.ActivityHelpers do
                 ever_partial: score_classification == :partial
               }
             },
+            screen_rule_sourced?: screen_rule_sourced?,
             attempt_count: 1,
             correct_count: if(correct, do: 1, else: 0),
             first_attempt_count: 1,
@@ -3720,6 +3836,8 @@ defmodule OliWeb.Delivery.ActivityHelpers do
                       )
                     end
                   ),
+                screen_rule_sourced?:
+                  Map.get(analytics, :screen_rule_sourced?, false) or screen_rule_sourced?,
                 attempt_count: analytics.attempt_count + 1,
                 correct_count: analytics.correct_count + if(correct, do: 1, else: 0),
                 first_attempt_count:
@@ -3780,6 +3898,58 @@ defmodule OliWeb.Delivery.ActivityHelpers do
        do: out_of > 0
 
   defp adaptive_recorded_score_meaningful?(_), do: false
+
+  defp adaptive_screen_rule_sourced_attempt?(%{
+         feedback: %{"_torus" => %{"evaluation_source" => "screen_rule"}}
+       }),
+       do: true
+
+  defp adaptive_screen_rule_sourced_attempt?(%{feedback: %{"_torus" => torus_meta}})
+       when is_map(torus_meta),
+       do: Map.get(torus_meta, "evaluation_source") == "screen_rule"
+
+  defp adaptive_screen_rule_sourced_attempt?(_), do: false
+
+  defp adaptive_score_driven_rules_active?(content) when is_map(content) do
+    rules =
+      content
+      |> Map.get("authoring", %{})
+      |> Map.get("rules", [])
+
+    trap_state_score_scheme? = get_in(content, ["custom", "trapStateScoreScheme"]) == true
+
+    Enum.any?(rules, fn rule ->
+      adaptive_enabled_rule?(rule) and
+        adaptive_score_driven_rule?(rule, trap_state_score_scheme?)
+    end)
+  end
+
+  defp adaptive_score_driven_rules_active?(_), do: false
+
+  defp adaptive_enabled_rule?(rule) when is_map(rule) do
+    Map.get(rule, "disabled") != true and Map.get(rule, :disabled) != true
+  end
+
+  defp adaptive_enabled_rule?(_), do: false
+
+  defp adaptive_score_driven_rule?(rule, true), do: adaptive_trap_state_score_rule?(rule)
+
+  defp adaptive_score_driven_rule?(rule, false) do
+    Map.get(rule, "default") != true and Map.get(rule, :default) != true
+  end
+
+  defp adaptive_trap_state_score_rule?(rule) when is_map(rule) do
+    rule
+    |> Map.get("event", Map.get(rule, :event, %{}))
+    |> Map.get("params", %{})
+    |> Map.get("actions", [])
+    |> Enum.any?(fn action ->
+      Map.get(action, "type") == "mutateState" and
+        get_in(action, ["params", "target"]) == "session.currentQuestionScore"
+    end)
+  end
+
+  defp adaptive_trap_state_score_rule?(_), do: false
 
   defp finalize_adaptive_part_analytics(analytics_by_part) do
     Enum.into(analytics_by_part, %{}, fn {key, analytics} ->

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -642,7 +642,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
              ] = result.client_evaluations
     end
 
-    test "uses rule-driven screen scoring while keeping part-level scores independent" do
+    test "copies the rule-driven screen score onto all submitted adaptive part inputs" do
       user = insert(:user)
       section = insert(:section)
 
@@ -796,12 +796,12 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
 
       [updated_dropdown_1, updated_dropdown_2] = updated_part_attempts
 
-      assert updated_dropdown_1.score == 1.0
-      assert updated_dropdown_1.out_of == 1.0
+      assert updated_dropdown_1.score == 2.0
+      assert updated_dropdown_1.out_of == 2.0
       assert updated_dropdown_1.lifecycle_state == :evaluated
 
-      assert updated_dropdown_2.score == 0.0
-      assert updated_dropdown_2.out_of == 1.0
+      assert updated_dropdown_2.score == 2.0
+      assert updated_dropdown_2.out_of == 2.0
       assert updated_dropdown_2.lifecycle_state == :evaluated
     end
 
@@ -929,8 +929,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
 
       assert updated_dropdown.grading_approach == :automatic
       assert updated_dropdown.lifecycle_state == :evaluated
-      assert updated_dropdown.score == 1.0
-      assert updated_dropdown.out_of == 1.0
+      assert updated_dropdown.score == 2.0
+      assert updated_dropdown.out_of == 2.0
 
       assert updated_essay.grading_approach == :manual
       assert updated_essay.lifecycle_state == :submitted
@@ -1076,6 +1076,9 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_part_attempt.out_of == 2.0
       assert updated_part_attempt.feedback["id"] == "rule-correct"
       assert updated_part_attempt.feedback["content"] == "Rule correct"
+
+      assert get_in(updated_part_attempt.feedback, ["_torus", "evaluation_source"]) ==
+               "screen_rule"
     end
 
     test "tracks explicitly rule-scored non-native parts and overrides them with the screen score" do
@@ -1238,14 +1241,16 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
         |> Enum.sort_by(& &1.part_id)
 
       assert updated_dropdown.part_id == "dropdown_1"
-      assert updated_dropdown.score == 0.0
-      assert updated_dropdown.out_of == 1.0
+      assert updated_dropdown.score == 2.0
+      assert updated_dropdown.out_of == 2.0
+      assert get_in(updated_dropdown.feedback, ["_torus", "evaluation_source"]) == "screen_rule"
 
       assert updated_iframe.part_id == "janus_capi_iframe-1"
       assert updated_iframe.score == 2.0
       assert updated_iframe.out_of == 2.0
       assert updated_iframe.feedback["id"] == "screen-correct"
       assert updated_iframe.feedback["content"] == "Screen correct"
+      assert get_in(updated_iframe.feedback, ["_torus", "evaluation_source"]) == "screen_rule"
     end
 
     test "falls back to generic feedback for rule-scored non-native parts when no screen feedback action is present" do
@@ -1784,7 +1789,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_attempt.out_of == 2.0
     end
 
-    test "respects explicit screen score mutations without overwriting part-level scores" do
+    test "respects explicit screen score mutations and copies them to submitted part inputs" do
       user = insert(:user)
       section = insert(:section)
 
@@ -1895,8 +1900,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       [updated_part_attempt] =
         Core.get_latest_part_attempts(setup.activity_attempt.attempt_guid)
 
-      assert updated_part_attempt.score == 1.0
-      assert updated_part_attempt.out_of == 1.0
+      assert updated_part_attempt.score == 10.0
+      assert updated_part_attempt.out_of == 10.0
     end
 
     test "falls back to authored fill-blanks answers when runtime correct is absent" do

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -1253,6 +1253,121 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert get_in(updated_iframe.feedback, ["_torus", "evaluation_source"]) == "screen_rule"
     end
 
+    test "overwrites authored _torus feedback metadata for rule-scored parts" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 2, "maxAttempt" => 1},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"]
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => ["stage.dropdown_1.selectedIndex"],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "r.correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.dropdown_1.selectedIndex",
+                      "operator" => "equal",
+                      "value" => "1"
+                    }
+                  ]
+                },
+                "event" => %{
+                  "type" => "r.correct",
+                  "params" => %{
+                    "actions" => [
+                      %{
+                        "type" => "feedback",
+                        "params" => %{
+                          "feedback" => %{
+                            "id" => "rule-correct",
+                            "content" => "Rule correct",
+                            "_torus" => "authored-metadata"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              },
+              %{
+                "id" => "r.incorrect",
+                "name" => "incorrect",
+                "disabled" => false,
+                "default" => true,
+                "correct" => false,
+                "conditions" => %{"all" => []},
+                "event" => %{
+                  "type" => "r.incorrect",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      setup = setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"])
+      [dropdown_attempt] = setup.part_attempts
+
+      part_inputs = [
+        %{
+          attempt_guid: dropdown_attempt.attempt_guid,
+          input: %StudentInput{
+            input: %{
+              "selectedIndex" => %{"path" => "stage.dropdown_1.selectedIndex", "value" => 1},
+              "selectedItem" => %{
+                "path" => "stage.dropdown_1.selectedItem",
+                "value" => "Option 1"
+              },
+              "value" => %{"path" => "stage.dropdown_1.value", "value" => "Option 1"}
+            }
+          },
+          timestamp: DateTime.utc_now()
+        }
+      ]
+
+      assert {:ok, result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 setup.activity_attempt.attempt_guid,
+                 part_inputs,
+                 nil
+               )
+
+      assert result["score"] == 2.0
+      assert result["out_of"] == 2.0
+
+      [updated_dropdown] = Core.get_latest_part_attempts(setup.activity_attempt.attempt_guid)
+
+      assert updated_dropdown.feedback["id"] == "rule-correct"
+      assert updated_dropdown.feedback["content"] == "Rule correct"
+      assert updated_dropdown.feedback["_torus"] == %{"evaluation_source" => "screen_rule"}
+    end
+
     test "falls back to generic feedback for rule-scored non-native parts when no screen feedback action is present" do
       user = insert(:user)
       section = insert(:section)

--- a/test/oli/delivery/attempts/attempt_reset_test.exs
+++ b/test/oli/delivery/attempts/attempt_reset_test.exs
@@ -171,6 +171,10 @@ defmodule Oli.Delivery.Attempts.ActivityResetTest do
 
       attempt = Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
       assert attempt.transformed_model == activity1_attempt.transformed_model
+      assert attempt.attempt_number == 2
+
+      [new_part_attempt] = Core.get_latest_part_attempts(attempt_state.attemptGuid)
+      assert new_part_attempt.attempt_number == 2
 
       part_inputs = [
         %{attempt_guid: part_attempt2.attempt_guid, input: %StudentInput{input: "1"}}

--- a/test/oli/delivery/attempts/attempt_reset_test.exs
+++ b/test/oli/delivery/attempts/attempt_reset_test.exs
@@ -228,5 +228,38 @@ defmodule Oli.Delivery.Attempts.ActivityResetTest do
       assert attempt.transformed_model == activity1_attempt.transformed_model
       assert attempt.selection_id == "test_selection_id"
     end
+
+    test "part resets stay monotonic after a second activity attempt is created", %{
+      ungraded_page_user1_activity1_attempt1: activity1_attempt,
+      section: section
+    } do
+      datashop_session_id_user1 = UUID.uuid4()
+
+      {:ok, {attempt_state, _}} =
+        ActivityLifecycle.reset_activity(
+          section.slug,
+          activity1_attempt.attempt_guid,
+          datashop_session_id_user1
+        )
+
+      reset_activity_attempt =
+        Core.get_activity_attempt_by(attempt_guid: attempt_state.attemptGuid)
+
+      [initial_part_attempt] = Core.get_latest_part_attempts(reset_activity_attempt.attempt_guid)
+
+      assert initial_part_attempt.attempt_number == 2
+
+      {:ok, part_state} =
+        ActivityLifecycle.reset_part(
+          reset_activity_attempt.attempt_guid,
+          initial_part_attempt.attempt_guid,
+          UUID.uuid4()
+        )
+
+      reset_part_attempt = Core.get_part_attempt_by(attempt_guid: part_state.attemptGuid)
+
+      assert reset_part_attempt.attempt_number == 3
+      assert reset_part_attempt.activity_attempt_id == reset_activity_attempt.id
+    end
   end
 end

--- a/test/oli/delivery/attempts/hiearchy_test.exs
+++ b/test/oli/delivery/attempts/hiearchy_test.exs
@@ -149,6 +149,34 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
       assert pa1.attempt_guid != pa2.attempt_guid
       assert pa3.attempt_guid != pa2.attempt_guid
       assert pa3.attempt_guid != pa1.attempt_guid
+
+      {:ok, resource_attempt_2} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: resource_attempt,
+          page_revision: p1.revision,
+          section_slug: section.slug,
+          datashop_session_id: UUID.uuid4(),
+          user: user,
+          audience_role: :student,
+          activity_provider: activity_provider,
+          blacklisted_activity_ids: [],
+          publication_id: pub.id,
+          effective_settings:
+            Oli.Delivery.Settings.get_combined_settings(p1.revision, section.id, user.id)
+        })
+
+      assert resource_attempt_2.attempt_number == 2
+
+      attempts = Hierarchy.get_latest_attempts(resource_attempt_2.id)
+
+      {act_attempt1_attempt2, part_map1_attempt2} = Map.get(attempts, a1.resource.id)
+      {act_attempt2_attempt2, part_map2_attempt2} = Map.get(attempts, a2.resource.id)
+
+      assert act_attempt1_attempt2.attempt_number == 2
+      assert act_attempt2_attempt2.attempt_number == 2
+      assert part_map1_attempt2["1"].attempt_number == 2
+      assert part_map2_attempt2["some_key"].attempt_number == 2
+      assert part_map2_attempt2["some_other_key"].attempt_number == 2
     end
 
     test "adaptive attempt creation keeps stateful non-scorable parts but skips display-only parts" do
@@ -304,6 +332,38 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.HierarchyTest do
       assert part_map["janus_popup-1"].grading_approach == :automatic
       assert part_map["janus_video-1"].grading_approach == :automatic
       refute Map.has_key?(part_map, "janus_formula-1")
+
+      {:ok, resource_attempt_2} =
+        Hierarchy.create(%VisitContext{
+          latest_resource_attempt: resource_attempt,
+          page_revision: adaptive_page.revision,
+          section_slug: map.section.slug,
+          datashop_session_id: UUID.uuid4(),
+          user: adaptive_user,
+          audience_role: :student,
+          activity_provider: &Oli.Delivery.ActivityProvider.provide/6,
+          blacklisted_activity_ids: [],
+          publication_id: map.publication.id,
+          effective_settings:
+            Oli.Delivery.Settings.get_combined_settings(
+              adaptive_page.revision,
+              map.section.id,
+              adaptive_user.id
+            )
+        })
+
+      assert resource_attempt_2.attempt_number == 2
+
+      {:ok, %AttemptState{attempt_hierarchy: attempts}} =
+        AttemptState.fetch_attempt_state(resource_attempt_2, adaptive_page.revision)
+
+      {activity_attempt_2, part_map_2} = Map.fetch!(attempts, adaptive_activity.resource.id)
+
+      assert activity_attempt_2.attempt_number == 2
+
+      assert Enum.all?(Map.values(part_map_2), fn part_attempt ->
+               part_attempt.attempt_number == 2
+             end)
     end
 
     test "adaptive attempt creation includes explicitly rule-scored display-only parts only" do

--- a/test/oli/delivery/attempts/manual_grading_test.exs
+++ b/test/oli/delivery/attempts/manual_grading_test.exs
@@ -624,6 +624,62 @@ defmodule Oli.Delivery.Attempts.ManualGradingTest do
     end
   end
 
+  describe "apply_manual_scoring/3 for submitted ungraded attempts" do
+    setup do
+      Seeder.base_project_with_resource2()
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_activity(
+        %{title: "activity manual ungraded"},
+        :publication,
+        :project,
+        :author,
+        :activity_a
+      )
+      |> Seeder.create_section_resources()
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1, lifecycle_state: :submitted},
+        :user1,
+        :page1,
+        :revision1,
+        :attempt1
+      )
+      |> add_submitted_activity(:attempt1, :activity_a, :attempt_1a)
+    end
+
+    test "evaluates the resource attempt once all manual grading is complete", %{
+      section: section,
+      attempt_1a: attempt_1a
+    } do
+      [attempt] =
+        ManualGrading.browse_submitted_attempts(
+          section,
+          %Paging{limit: 10, offset: 0},
+          %Sorting{field: :date_submitted, direction: :desc},
+          %BrowseOptions{
+            user_id: nil,
+            activity_id: nil,
+            page_id: nil,
+            graded: nil,
+            text_search: nil
+          }
+        )
+
+      assert {:ok, _} =
+               ManualGrading.apply_manual_scoring(
+                 section,
+                 attempt,
+                 create_score_feedbacks(attempt)
+               )
+
+      activity_attempt = Core.get_activity_attempt_by(id: attempt_1a.id)
+      assert activity_attempt.lifecycle_state == :evaluated
+
+      resource_attempt = Core.get_resource_attempt_by(attempt_guid: attempt.resource_attempt_guid)
+      assert resource_attempt.lifecycle_state == :evaluated
+    end
+  end
+
   describe "resolving stale submitted attempts" do
     setup do
       map = Seeder.base_project_with_resource2()

--- a/test/oli/delivery/attempts/page_lifecycle_test.exs
+++ b/test/oli/delivery/attempts/page_lifecycle_test.exs
@@ -318,6 +318,23 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
         :ungraded_attempt,
         :ungraded_activity_attempt
       )
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :ungraded_adaptive_page,
+        :ungraded_pending_attempt
+      )
+      |> Seeder.create_activity_attempt(
+        %{
+          attempt_number: 1,
+          lifecycle_state: :submitted,
+          transformed_model: screen_content,
+          scoreable: true
+        },
+        :adaptive_activity,
+        :ungraded_pending_attempt,
+        :ungraded_pending_activity_attempt
+      )
     end
 
     test "finalization rolls evaluated graded adaptive activity attempts to the resource attempt",
@@ -352,6 +369,30 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
       assert resource_attempt.lifecycle_state == :evaluated
       assert resource_attempt.score == 2.0
       assert resource_attempt.out_of == 4.0
+    end
+
+    test "ungraded adaptive finalization stays submitted when manual grading is still pending",
+         %{
+           section: section,
+           ungraded_pending_attempt: ungraded_pending_attempt
+         } do
+      datashop_session_id = UUID.uuid4()
+
+      assert {:ok, %FinalizationSummary{graded: false, lifecycle_state: :submitted}} =
+               PageLifecycle.finalize(
+                 section.slug,
+                 ungraded_pending_attempt.attempt_guid,
+                 datashop_session_id
+               )
+
+      resource_attempt =
+        Core.get_resource_attempt_by(attempt_guid: ungraded_pending_attempt.attempt_guid)
+
+      assert resource_attempt.lifecycle_state == :submitted
+      assert is_nil(resource_attempt.date_evaluated)
+      refute is_nil(resource_attempt.date_submitted)
+      assert is_nil(resource_attempt.score)
+      assert is_nil(resource_attempt.out_of)
     end
   end
 end

--- a/test/oli/delivery/attempts/page_lifecycle_test.exs
+++ b/test/oli/delivery/attempts/page_lifecycle_test.exs
@@ -211,4 +211,147 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
       refute is_nil(ra1.date_submitted)
     end
   end
+
+  describe "adaptive page attempt rollup" do
+    setup do
+      adaptive_registration = Oli.Activities.get_registration_by_slug("oli_adaptive")
+
+      screen_content = %{
+        "partsLayout" => [
+          %{
+            "id" => "part_1",
+            "type" => "janus-mcq",
+            "gradingApproach" => "automatic",
+            "custom" => %{
+              "title" => "MCQ 1",
+              "correctAnswer" => [true, false],
+              "mcqItems" => [
+                %{"nodes" => [%{"text" => "Option 1"}]},
+                %{"nodes" => [%{"text" => "Option 2"}]}
+              ]
+            }
+          }
+        ],
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "part_1",
+              "type" => "janus-mcq",
+              "gradingApproach" => "automatic"
+            }
+          ]
+        }
+      }
+
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.create_section()
+        |> Seeder.add_user(%{}, :user1)
+        |> Seeder.add_activity(
+          %{
+            title: "adaptive screen",
+            activity_type_id: adaptive_registration.id,
+            content: screen_content
+          },
+          :adaptive_activity
+        )
+        |> then(fn map ->
+          screen_ref = %{
+            "type" => "activity-reference",
+            "activity_id" => map.adaptive_activity.resource.id
+          }
+
+          map
+          |> Seeder.add_page(
+            %{
+              title: "graded adaptive page",
+              graded: true,
+              content: %{"advancedDelivery" => true, "model" => [screen_ref]}
+            },
+            :graded_adaptive_page
+          )
+          |> Seeder.add_page(
+            %{
+              title: "ungraded adaptive page",
+              graded: false,
+              content: %{"advancedDelivery" => true, "model" => [screen_ref]}
+            },
+            :ungraded_adaptive_page
+          )
+        end)
+        |> Seeder.create_section_resources()
+
+      map
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :graded_adaptive_page,
+        :graded_attempt
+      )
+      |> Seeder.create_activity_attempt(
+        %{
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          score: 3.0,
+          out_of: 4.0,
+          scoreable: true
+        },
+        :adaptive_activity,
+        :graded_attempt,
+        :graded_activity_attempt
+      )
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1},
+        :user1,
+        :ungraded_adaptive_page,
+        :ungraded_attempt
+      )
+      |> Seeder.create_activity_attempt(
+        %{
+          attempt_number: 1,
+          lifecycle_state: :evaluated,
+          score: 2.0,
+          out_of: 4.0,
+          scoreable: true
+        },
+        :adaptive_activity,
+        :ungraded_attempt,
+        :ungraded_activity_attempt
+      )
+    end
+
+    test "finalization rolls evaluated graded adaptive activity attempts to the resource attempt",
+         %{
+           section: section,
+           graded_attempt: graded_attempt
+         } do
+      datashop_session_id = UUID.uuid4()
+
+      {:ok, %FinalizationSummary{graded: true}} =
+        PageLifecycle.finalize(section.slug, graded_attempt.attempt_guid, datashop_session_id)
+
+      resource_attempt = Core.get_resource_attempt_by(attempt_guid: graded_attempt.attempt_guid)
+
+      assert resource_attempt.lifecycle_state == :evaluated
+      assert resource_attempt.score == 3.0
+      assert resource_attempt.out_of == 4.0
+    end
+
+    test "finalization rolls evaluated ungraded adaptive activity attempts to the resource attempt",
+         %{
+           section: section,
+           ungraded_attempt: ungraded_attempt
+         } do
+      datashop_session_id = UUID.uuid4()
+
+      {:ok, %FinalizationSummary{graded: false}} =
+        PageLifecycle.finalize(section.slug, ungraded_attempt.attempt_guid, datashop_session_id)
+
+      resource_attempt = Core.get_resource_attempt_by(attempt_guid: ungraded_attempt.attempt_guid)
+
+      assert resource_attempt.lifecycle_state == :evaluated
+      assert resource_attempt.score == 2.0
+      assert resource_attempt.out_of == 4.0
+    end
+  end
 end

--- a/test/oli_web/components/delivery/activity_helpers_test.exs
+++ b/test/oli_web/components/delivery/activity_helpers_test.exs
@@ -494,7 +494,7 @@ defmodule OliWeb.Delivery.ActivityHelpersTest do
              ]
     end
 
-    test "colors first-attempt response-pattern charts from first-attempt correctness, not eventual correctness" do
+    test "uses neutral response-pattern bars for rule-scored adaptive inputs" do
       adaptive_id = 99
 
       activities = [
@@ -567,7 +567,8 @@ defmodule OliWeb.Delivery.ActivityHelpersTest do
       assert summary.first_attempt_pct == 0.0
       assert summary.all_attempt_pct == 1.0
       assert summary.visualization.kind == :response_patterns
-      assert summary.visualization.fill_class == "bg-rose-500 dark:bg-rose-400"
+      assert summary.visualization.fill_class == "bg-slate-400 dark:bg-slate-500"
+      assert summary.visualization.native_key_note =~ "Screen rules determine correctness"
     end
 
     test "identifies adaptive multi-select mcq inputs and summarizes response combinations" do
@@ -2474,6 +2475,256 @@ defmodule OliWeb.Delivery.ActivityHelpersTest do
       assert choice2.correctness == false
       assert choice3.native_correct == false
       assert choice3.correctness == :partial
+    end
+
+    test "suppresses native answer-key semantics for automatic choice inputs when older rule-scored attempts lack provenance metadata" do
+      adaptive_id = 99
+
+      activities = [
+        %{
+          resource_id: 64,
+          revision: %{
+            activity_type_id: adaptive_id,
+            content: %{
+              "authoring" => %{
+                "parts" => [
+                  %{
+                    "id" => "part_mcq",
+                    "type" => "janus-mcq",
+                    "gradingApproach" => "automatic"
+                  }
+                ],
+                "rules" => [
+                  %{
+                    "id" => "r.correct",
+                    "disabled" => false,
+                    "correct" => true,
+                    "conditions" => %{
+                      "all" => [
+                        %{
+                          "fact" => "stage.part_mcq.input",
+                          "operator" => "equal",
+                          "value" => "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "partsLayout" => [
+                %{
+                  "id" => "part_mcq",
+                  "type" => "janus-mcq",
+                  "custom" => %{
+                    "title" => "Rule Scored MCQ",
+                    "correctAnswer" => [false, true, false],
+                    "mcqItems" => [
+                      %{"nodes" => [%{"text" => "Option 1"}]},
+                      %{"nodes" => [%{"text" => "Option 2"}]},
+                      %{"nodes" => [%{"text" => "Option 3"}]}
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          resource_summaries: [],
+          transformed_model: nil
+        }
+      ]
+
+      summary =
+        ActivityHelpers.stage_performance_details(
+          activities,
+          %{adaptive_id => %{slug: "oli_adaptive", title: "Adaptive"}},
+          [
+            %{
+              activity_id: 64,
+              part_id: "part_mcq",
+              response: "1",
+              count: 1,
+              correct_count: 1,
+              incorrect_count: 0,
+              partial_count: 0,
+              users: []
+            },
+            %{
+              activity_id: 64,
+              part_id: "part_mcq",
+              response: "2",
+              count: 1,
+              correct_count: 0,
+              incorrect_count: 1,
+              partial_count: 0,
+              users: []
+            },
+            %{
+              activity_id: 64,
+              part_id: "part_mcq",
+              response: "3",
+              count: 1,
+              correct_count: 0,
+              incorrect_count: 0,
+              partial_count: 1,
+              users: []
+            }
+          ],
+          %{
+            {64, "part_mcq"} => %{
+              responses: [
+                %{
+                  activity_id: 64,
+                  part_id: "part_mcq",
+                  response: "1",
+                  count: 1,
+                  correct_count: 1,
+                  incorrect_count: 0,
+                  partial_count: 0,
+                  users: []
+                },
+                %{
+                  activity_id: 64,
+                  part_id: "part_mcq",
+                  response: "2",
+                  count: 1,
+                  correct_count: 0,
+                  incorrect_count: 1,
+                  partial_count: 0,
+                  users: []
+                },
+                %{
+                  activity_id: 64,
+                  part_id: "part_mcq",
+                  response: "3",
+                  count: 1,
+                  correct_count: 0,
+                  incorrect_count: 0,
+                  partial_count: 1,
+                  users: []
+                }
+              ],
+              student_ids: MapSet.new([1, 2, 3]),
+              first_attempt_student_ids: MapSet.new([1, 2, 3]),
+              attempt_count: 3,
+              correct_count: 1,
+              first_attempt_count: 3,
+              first_attempt_correct_count: 1
+            }
+          }
+        )
+        |> hd()
+        |> Map.fetch!(:adaptive_input_summaries)
+        |> hd()
+
+      assert summary.visualization.neutral_choice_colors == true
+      assert summary.visualization.native_key_note =~ "Screen rules determine correctness"
+
+      assert Enum.all?(summary.visualization.choices, fn choice ->
+               choice.native_correct == false
+             end)
+
+      [choice1, choice2, choice3] = summary.visualization.choices
+      assert choice1.correctness == true
+      assert choice2.correctness == false
+      assert choice3.correctness == :partial
+    end
+
+    test "uses neutral response-pattern bars for automatic text inputs when older rule-scored attempts lack provenance metadata" do
+      adaptive_id = 99
+
+      activities = [
+        %{
+          resource_id: 65,
+          revision: %{
+            activity_type_id: adaptive_id,
+            content: %{
+              "authoring" => %{
+                "parts" => [
+                  %{
+                    "id" => "part_text",
+                    "type" => "janus-input-text",
+                    "gradingApproach" => "automatic"
+                  }
+                ],
+                "rules" => [
+                  %{
+                    "id" => "r.correct",
+                    "disabled" => false,
+                    "correct" => true,
+                    "conditions" => %{
+                      "all" => [
+                        %{
+                          "fact" => "stage.part_text.input",
+                          "operator" => "equal",
+                          "value" => "baby cow"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "partsLayout" => [
+                %{
+                  "id" => "part_text",
+                  "type" => "janus-input-text",
+                  "custom" => %{"title" => "Rule Scored Text"}
+                }
+              ]
+            }
+          },
+          resource_summaries: [],
+          transformed_model: nil
+        }
+      ]
+
+      summary =
+        ActivityHelpers.stage_performance_details(
+          activities,
+          %{adaptive_id => %{slug: "oli_adaptive", title: "Adaptive"}},
+          [
+            %{
+              activity_id: 65,
+              part_id: "part_text",
+              response: "baby cow",
+              label: "baby cow",
+              count: 1,
+              correct_count: 1,
+              incorrect_count: 0,
+              partial_count: 0,
+              users: []
+            }
+          ],
+          %{
+            {65, "part_text"} => %{
+              responses: [
+                %{
+                  activity_id: 65,
+                  part_id: "part_text",
+                  response: "baby cow",
+                  label: "baby cow",
+                  count: 1,
+                  correct_count: 1,
+                  incorrect_count: 0,
+                  partial_count: 0,
+                  users: []
+                }
+              ],
+              student_ids: MapSet.new([1]),
+              first_attempt_student_ids: MapSet.new([1]),
+              attempt_count: 1,
+              correct_count: 1,
+              first_attempt_count: 1,
+              first_attempt_correct_count: 1
+            }
+          }
+        )
+        |> hd()
+        |> Map.fetch!(:adaptive_input_summaries)
+        |> hd()
+
+      assert summary.visualization.kind == :response_patterns
+      assert summary.visualization.fill_class == "bg-slate-400 dark:bg-slate-500"
+      assert summary.visualization.native_key_note =~ "Screen rules determine correctness"
     end
   end
 


### PR DESCRIPTION
 ## Summary

This PR bundles a focused set of fixes for adaptive page behavior across delivery, scoring, analytics, authoring panels, and related runtime edge cases.

 ## Included fixes

### Adaptive evaluation and finalization

 It also improves adaptive finalization and rollup behavior so child adaptive results are reflected more consistently in page/resource attempts, and restores child attempt numbering so `activity_attempt` and `part_attempt` values no longer incorrectly reset to `1` when parent attempts have advanced.

### Adaptive scoring safety

This PR hardens non-trap-state adaptive scoring for invalid authored configuration.

In particular, when `maxAttempt = 0`, scoring now falls back to full-credit `maxScore` instead of flowing through a divide by-zero path that silently collapses the score to `0`.

### Adaptive insights and analytics presentation

This PR makes rule-scored adaptive inputs render more coherently in insights.

When screen rules are the correctness source, the UI no longer implies that native answer-key or native part-level correctness is authoritative. Instead, it suppresses misleading answer-key semantics, uses neutral coloring for left-side response distributions, and adds explanation copy so the panel clearly distinguishes between:

  - what learners selected
  - how screen rules determined correctness

This behavior was extended consistently across choice, text, and numeric-style adaptive input visualizations.