### PR TITLE
[BUG FIX] [MER-5602] restore popup add-component icons in adaptive authoring

### DIFF
--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -15,7 +15,7 @@ import { AuthoringRootState } from '../rootReducer';
 import { acquireEditingLock, releaseEditingLock } from './actions/locking';
 import { AppSlice } from './name';
 
-interface PartComponentRegistration {
+export interface PartComponentRegistration {
   slug: string;
   title: string;
   description: string;

--- a/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveAuthoring.tsx
@@ -206,6 +206,7 @@ const Adaptive = (
           onConfigurePart={handleConfigurePart}
           onCancelConfigurePart={handleCancelConfigurePart}
           configurePortalId={configurePortalId}
+          partComponentTypes={props.authoringContext?.partComponentTypes || []}
           onSelect={handlePartSelect}
         />
       </ModalContainer>

--- a/assets/src/components/activities/adaptive/components/authoring/AddPartToolbar.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/AddPartToolbar.tsx
@@ -1,12 +1,13 @@
 import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { ListGroup, Overlay, OverlayTrigger, Popover, Tooltip } from 'react-bootstrap';
 import { AnyPartComponent } from 'components/parts/types/parts';
+import type { PartComponentRegistration } from 'apps/authoring/store/app/slice';
 import guid from 'utils/guid';
 
 interface AddPartToolbarProps {
   partTypes: string[];
   priorityTypes?: string[];
-  availablePartComponents: any[];
+  availablePartComponents: readonly PartComponentRegistration[];
   onAdd: (part: AnyPartComponent) => void;
 }
 
@@ -23,8 +24,10 @@ const AddPartToolbar: React.FC<AddPartToolbarProps> = ({
     [availablePartComponents],
   );
 
-  const [priorityPartComponents, setPriorityPartComponents] = useState<any[]>([]);
-  const [otherPartComponents, setOtherPartComponents] = useState<any[]>([]);
+  const [priorityPartComponents, setPriorityPartComponents] = useState<PartComponentRegistration[]>(
+    [],
+  );
+  const [otherPartComponents, setOtherPartComponents] = useState<PartComponentRegistration[]>([]);
 
   const [showMorePartsMenu, setShowMorePartsMenu] = useState(false);
   const [morePartsMenuTarget, setMorePartsMenuTarget] = useState(null);
@@ -68,17 +71,17 @@ const AddPartToolbar: React.FC<AddPartToolbarProps> = ({
 
   useEffect(() => {
     const filteredByPriority = availableComponents
-      .filter((part: any) => partTypes[0] === '*' || partTypes.includes(part.slug))
-      .filter((part: any) => priorityTypes.includes(part.slug))
-      .sort((a: any, b: any) => {
+      .filter((part) => partTypes[0] === '*' || partTypes.includes(part.slug))
+      .filter((part) => priorityTypes.includes(part.slug))
+      .sort((a, b) => {
         const aIndex = priorityTypes.indexOf(a.slug);
         const bIndex = priorityTypes.indexOf(b.slug);
         return aIndex - bIndex;
       });
     setPriorityPartComponents(filteredByPriority);
     const remainder = availableComponents
-      .filter((part: any) => partTypes[0] === '*' || partTypes.includes(part.slug))
-      .filter((part: any) => !priorityTypes.includes(part.slug));
+      .filter((part) => partTypes[0] === '*' || partTypes.includes(part.slug))
+      .filter((part) => !priorityTypes.includes(part.slug));
     setOtherPartComponents(remainder);
   }, [availableComponents, partTypes, priorityTypes]);
 

--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -28,6 +28,7 @@ interface LayoutEditorProps {
   hostRef?: HTMLElement;
   configurePortalId?: string;
   responsiveLayout?: boolean;
+  partComponentTypes?: any[];
   onChange: (parts: AnyPartComponent[], selectedPartId?: string, isDeleted?: boolean) => void;
   onSelect: (partId: string) => void;
   onPartLayoutChange?: (partId: string, layoutData: Record<string, any>) => void;
@@ -569,6 +570,7 @@ const LayoutEditor: React.FC<LayoutEditorProps> = (props) => {
         mode: contexts.AUTHOR,
         host: containerRef.current,
         responsiveLayout: isResponsive,
+        partComponentTypes: props.partComponentTypes || [],
       },
     };
   };

--- a/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/LayoutEditor.tsx
@@ -7,6 +7,7 @@ import {
   defaultCapabilities,
 } from 'components/parts/types/parts';
 import ConfirmDelete from 'apps/authoring/components/Modal/DeleteConfirmationModal';
+import type { PartComponentRegistration } from 'apps/authoring/store/app/slice';
 import {
   NotificationContext,
   NotificationType,
@@ -28,7 +29,7 @@ interface LayoutEditorProps {
   hostRef?: HTMLElement;
   configurePortalId?: string;
   responsiveLayout?: boolean;
-  partComponentTypes?: any[];
+  partComponentTypes?: readonly PartComponentRegistration[];
   onChange: (parts: AnyPartComponent[], selectedPartId?: string, isDeleted?: boolean) => void;
   onSelect: (partId: string) => void;
   onPartLayoutChange?: (partId: string, layoutData: Record<string, any>) => void;

--- a/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
@@ -15,6 +15,7 @@ import partSchema, {
   transformModelToSchema as transformPartModelToSchema,
   transformSchemaToModel as transformPartSchemaToModel,
 } from 'apps/authoring/components/PropertyEditor/schemas/part';
+import type { PartComponentRegistration } from 'apps/authoring/store/app/slice';
 import {
   NotificationContext,
   NotificationType,
@@ -32,7 +33,7 @@ interface ScreenAuthorProps {
   onChange?: (screen: any) => void;
   responsiveLayout?: boolean;
   allowTriggers?: boolean;
-  partComponentTypes?: any[];
+  partComponentTypes?: readonly PartComponentRegistration[];
 }
 
 const screenSchema: JSONSchema7 = {

--- a/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
@@ -427,6 +427,7 @@ const ScreenAuthor: React.FC<ScreenAuthorProps> = ({
               onCancelConfigurePart={handlePartCancelConfigure}
               configurePortalId={configEditorId}
               responsiveLayout={responsiveLayout}
+              partComponentTypes={partComponentTypes}
             />
           </Col>
           <Col sm={3} className={styles.propertyEditor}>

--- a/assets/src/components/parts/janus-popup/PopupAuthor.tsx
+++ b/assets/src/components/parts/janus-popup/PopupAuthor.tsx
@@ -13,8 +13,16 @@ import PopupWindow from './PopupWindow';
 import { PopupModel } from './schema';
 import { ContextProps } from './types';
 
+interface DesignerProps {
+  screenModel: any;
+  onChange: (screen: any) => void;
+  portal: HTMLElement | null;
+  responsiveLayout: boolean;
+  partComponentTypes?: ContextProps['partComponentTypes'];
+}
+
 // eslint-disable-next-line react/display-name
-const Designer: React.FC<any> = React.memo(
+const Designer: React.FC<DesignerProps> = React.memo(
   ({ screenModel, onChange, portal, responsiveLayout, partComponentTypes }) => {
     return (
       portal &&

--- a/assets/src/components/parts/janus-popup/PopupAuthor.tsx
+++ b/assets/src/components/parts/janus-popup/PopupAuthor.tsx
@@ -15,7 +15,7 @@ import { ContextProps } from './types';
 
 // eslint-disable-next-line react/display-name
 const Designer: React.FC<any> = React.memo(
-  ({ screenModel, onChange, portal, responsiveLayout }) => {
+  ({ screenModel, onChange, portal, responsiveLayout, partComponentTypes }) => {
     return (
       portal &&
       ReactDOM.createPortal(
@@ -23,6 +23,7 @@ const Designer: React.FC<any> = React.memo(
           screen={screenModel}
           onChange={onChange}
           responsiveLayout={responsiveLayout}
+          partComponentTypes={partComponentTypes || []}
         />,
         portal,
       )
@@ -254,8 +255,6 @@ const PopupAuthor: React.FC<AuthorPartComponentProps<PopupModel>> = (props) => {
 
   const init = useCallback(async () => {
     const initResult = await props.onInit({ id, responses: [] });
-    console.log('PA INIT', { id, initResult });
-
     setContext((c) => ({ ...c, ...initResult.context }));
     //setting it to false for now until we fix the pop-up responsive layout issues
     setResponsiveLayout(false);
@@ -320,6 +319,7 @@ const PopupAuthor: React.FC<AuthorPartComponentProps<PopupModel>> = (props) => {
           onChange={handleScreenAuthorChange}
           portal={portalEl}
           responsiveLayout={responsiveLayout}
+          partComponentTypes={context.partComponentTypes}
         />
       )}
       <div className="popup-container" style={containerStyle}>

--- a/assets/src/components/parts/janus-popup/types.ts
+++ b/assets/src/components/parts/janus-popup/types.ts
@@ -3,6 +3,7 @@ export interface ContextProps {
   mode: string;
   host?: HTMLElement;
   responsiveLayout?: boolean;
+  partComponentTypes?: any[];
 }
 
 export interface InitResultProps {

--- a/assets/src/components/parts/janus-popup/types.ts
+++ b/assets/src/components/parts/janus-popup/types.ts
@@ -1,9 +1,11 @@
+import type { PartComponentRegistration } from 'apps/authoring/store/app/slice';
+
 export interface ContextProps {
   currentActivity: string;
   mode: string;
   host?: HTMLElement;
   responsiveLayout?: boolean;
-  partComponentTypes?: any[];
+  partComponentTypes?: readonly PartComponentRegistration[];
 }
 
 export interface InitResultProps {

--- a/assets/test/advanced_authoring/add_part_toolbar_gating_test.tsx
+++ b/assets/test/advanced_authoring/add_part_toolbar_gating_test.tsx
@@ -6,18 +6,28 @@ const aiTriggerPart = {
   slug: 'janus_ai_trigger',
   title: 'AI Activation Point',
   description: 'Opens DOT',
+  author: 'Test',
   icon: 'icon-AI.svg',
+  enabled: true,
+  global: true,
   authoring_element: 'janus-ai-trigger',
+  authoring_script: './authoring-entry.ts',
   delivery_element: 'janus-ai-trigger',
+  delivery_script: './delivery-entry.ts',
 };
 
 const imagePart = {
   slug: 'janus_image',
   title: 'Image',
   description: 'Static image',
+  author: 'Test',
   icon: 'icon-image.svg',
+  enabled: true,
+  global: true,
   authoring_element: 'janus-image',
+  authoring_script: './authoring-entry.ts',
   delivery_element: 'janus-image',
+  delivery_script: './delivery-entry.ts',
 };
 
 describe('AddPartToolbar', () => {

--- a/assets/test/parts/popup_author_part_components_test.tsx
+++ b/assets/test/parts/popup_author_part_components_test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+import PopupAuthor from '../../src/components/parts/janus-popup/PopupAuthor';
+
+const mockScreenAuthor = jest.fn((_: any) => <div data-testid="screen-author" />);
+
+jest.mock('../../src/components/activities/adaptive/components/authoring/ScreenAuthor', () => ({
+  __esModule: true,
+  default: (props: any) => mockScreenAuthor(props),
+}));
+
+const popupModel = {
+  width: 100,
+  height: 100,
+  visible: true,
+  defaultURL: 'info',
+  iconURL: '',
+  description: 'More information',
+  popup: {
+    id: 'popup-screen',
+    custom: {
+      width: 300,
+      height: 200,
+      x: 0,
+      y: 0,
+      z: 0,
+      palette: {},
+    },
+    partsLayout: [],
+  },
+};
+
+const textPartRegistration = {
+  slug: 'janus_text_flow',
+  title: 'Text',
+  description: 'Text block',
+  icon: 'icon-part-text.svg',
+  authoring_element: 'janus-text-flow',
+  delivery_element: 'janus-text-flow',
+};
+
+describe('PopupAuthor', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockScreenAuthor.mockClear();
+    document.body.innerHTML = '<div id="popup-portal"></div>';
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('passes available part registrations to the nested popup screen author', async () => {
+    render(
+      <PopupAuthor
+        id="popup-1"
+        type="janus-popup"
+        model={popupModel as any}
+        state={{}}
+        editMode={true}
+        configuremode={true}
+        portal="popup-portal"
+        onClick={jest.fn()}
+        onConfigure={jest.fn()}
+        onSaveConfigure={jest.fn()}
+        onCancelConfigure={jest.fn()}
+        onInit={jest.fn().mockResolvedValue({
+          context: {
+            partComponentTypes: [textPartRegistration],
+          },
+        })}
+        onReady={jest.fn().mockResolvedValue(undefined)}
+        onSave={jest.fn()}
+        onSubmit={jest.fn()}
+        onResize={jest.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(10);
+    });
+
+    expect(mockScreenAuthor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partComponentTypes: [textPartRegistration],
+      }),
+    );
+  });
+});

--- a/assets/test/parts/popup_author_part_components_test.tsx
+++ b/assets/test/parts/popup_author_part_components_test.tsx
@@ -34,9 +34,14 @@ const textPartRegistration = {
   slug: 'janus_text_flow',
   title: 'Text',
   description: 'Text block',
+  author: 'Test',
   icon: 'icon-part-text.svg',
+  enabled: true,
+  global: true,
   authoring_element: 'janus-text-flow',
+  authoring_script: './authoring-entry.ts',
   delivery_element: 'janus-text-flow',
+  delivery_script: './delivery-entry.ts',
 };
 
 describe('PopupAuthor', () => {


### PR DESCRIPTION
## Summary

  Fixes missing add-component icons when editing popup components in Advanced Authoring and Simple/Flowchart adaptive pages.

  ## Regression

  This regressed in `51f772ad5e`  #6286/ MER-4945, when `AddPartToolbar` stopped reading part registrations from the `window.partComponentTypes` global and started requiring explicit `availablePartComponents` props.

  The normal screen authoring path was updated, but the nested popup editor path was missed:

  `PopupAuthor -> Designer -> ScreenAuthor -> AddPartToolbar`

  As a result, popup editing rendered `ScreenAuthor` with an empty `partComponentTypes` list, so the text/image/audio/video/iframe add controls had no registered components to display.

  ## Changes

  - Propagate `partComponentTypes` through adaptive authoring context into `LayoutEditor`.
  - Include `partComponentTypes` in popup configure context.
  - Pass popup context registrations into the nested popup `ScreenAuthor`.
  - Add a regression test for the popup editor registration path.
  - Remove a noisy popup init debug log.

  ## Verification

  - `yarn test test/parts/popup_author_part_components_test.tsx --runInBand`
  - `yarn test test/advanced_authoring/add_part_toolbar_gating_test.tsx --runInBand`
  - `yarn check-types`
  - `eslint` on touched frontend/test files
