### PR TITLE
[BUG FIX] [MER-5604] Preserve adaptive stage wrapper DOM in Instructor Insights screen preview

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -94,6 +94,18 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
   if (pageContent?.custom?.backgroundImageScaleContent) {
     backgroundClasses.push('background-scaled');
   }
+  const insightsPreviewStageStyles: CSSProperties = useMemo(
+    () => ({
+      ...lessonStyles,
+      position: 'relative',
+      top: 'auto',
+      left: 'auto',
+      transform: 'none',
+      margin: '0 auto',
+      minHeight: lessonStyles.minHeight || 500,
+    }),
+    [lessonStyles],
+  );
   const getCustomClassAncestry = useCallback(() => {
     let className = '';
     if (currentActivityTree) {
@@ -899,11 +911,15 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
             style={{
               padding: `${insightsPreviewInset}px`,
               boxSizing: 'border-box',
-              display: 'flex',
-              justifyContent: 'center',
+              position: 'relative',
             }}
           >
-            <div className="stage-content-wrapper">{renderActivities()}</div>
+            <div className={backgroundClasses.join(' ')} style={backgroundStyles} />
+            <div className="stageContainer columnRestriction" style={insightsPreviewStageStyles}>
+              <div id="stage-stage">
+                <div className="stage-content-wrapper">{renderActivities()}</div>
+              </div>
+            </div>
           </div>
         ) : (
           <>

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -3,7 +3,10 @@ import { useDispatch, useSelector } from 'react-redux';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import DeckLayoutView from 'apps/delivery/layouts/deck/DeckLayoutView';
-import { selectHistoryNavigationActivity, selectLessonEnd } from 'apps/delivery/store/features/adaptivity/slice';
+import {
+  selectHistoryNavigationActivity,
+  selectLessonEnd,
+} from 'apps/delivery/store/features/adaptivity/slice';
 import {
   selectCurrentActivityTree,
   selectCurrentActivityTreeAttemptState,
@@ -24,9 +27,13 @@ jest.mock('react-redux', () => ({
   useSelector: jest.fn(),
 }));
 
-jest.mock('apps/delivery/components/ActivityRenderer', () => function MockActivityRenderer() {
-  return <div>activity</div>;
-});
+jest.mock(
+  'apps/delivery/components/ActivityRenderer',
+  () =>
+    function MockActivityRenderer() {
+      return <div>activity</div>;
+    },
+);
 jest.mock('apps/delivery/layouts/deck/DeckLayoutHeader', () => () => null);
 jest.mock('apps/delivery/layouts/deck/DeckLayoutFooter', () => () => null);
 

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -38,14 +38,18 @@ jest.mock('apps/delivery/layouts/deck/DeckLayoutHeader', () => () => null);
 jest.mock('apps/delivery/layouts/deck/DeckLayoutFooter', () => () => null);
 
 describe('DeckLayoutView', () => {
+  const emptyActivityTree: any[] = [];
+  const emptyAttemptTree: any[] = [];
+  const emptySequence: any[] = [];
+
   beforeEach(() => {
     (useDispatch as jest.Mock).mockReturnValue(jest.fn());
     (useSelector as jest.Mock).mockImplementation((selector) => {
       switch (selector) {
         case selectCurrentActivityTree:
-          return [];
+          return emptyActivityTree;
         case selectCurrentActivityTreeAttemptState:
-          return [];
+          return emptyAttemptTree;
         case selectPageSlug:
           return 'adaptive-page';
         case selectSectionSlug:
@@ -65,7 +69,7 @@ describe('DeckLayoutView', () => {
         case selectLessonEnd:
           return false;
         case selectSequence:
-          return [];
+          return emptySequence;
         default:
           return undefined;
       }

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import DeckLayoutView from 'apps/delivery/layouts/deck/DeckLayoutView';
+import { selectHistoryNavigationActivity, selectLessonEnd } from 'apps/delivery/store/features/adaptivity/slice';
+import {
+  selectCurrentActivityTree,
+  selectCurrentActivityTreeAttemptState,
+  selectSequence,
+} from 'apps/delivery/store/features/groups/selectors/deck';
+import {
+  selectBlobStorageProvider,
+  selectPageSlug,
+  selectResponsiveLayout,
+  selectReviewMode,
+  selectSectionSlug,
+  selectUserId,
+  selectUserName,
+} from 'apps/delivery/store/features/page/slice';
+
+jest.mock('react-redux', () => ({
+  useDispatch: jest.fn(),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('apps/delivery/components/ActivityRenderer', () => function MockActivityRenderer() {
+  return <div>activity</div>;
+});
+jest.mock('apps/delivery/layouts/deck/DeckLayoutHeader', () => () => null);
+jest.mock('apps/delivery/layouts/deck/DeckLayoutFooter', () => () => null);
+
+describe('DeckLayoutView', () => {
+  beforeEach(() => {
+    (useDispatch as jest.Mock).mockReturnValue(jest.fn());
+    (useSelector as jest.Mock).mockImplementation((selector) => {
+      switch (selector) {
+        case selectCurrentActivityTree:
+          return [];
+        case selectCurrentActivityTreeAttemptState:
+          return [];
+        case selectPageSlug:
+          return 'adaptive-page';
+        case selectSectionSlug:
+          return 'demo-section';
+        case selectUserId:
+          return 1;
+        case selectResponsiveLayout:
+          return false;
+        case selectBlobStorageProvider:
+          return null;
+        case selectUserName:
+          return 'Instructor';
+        case selectHistoryNavigationActivity:
+          return false;
+        case selectReviewMode:
+          return false;
+        case selectLessonEnd:
+          return false;
+        case selectSequence:
+          return [];
+        default:
+          return undefined;
+      }
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the standard stage wrapper structure for insights-only preview', () => {
+    const { container } = render(
+      <DeckLayoutView
+        pageTitle="Adaptive Preview"
+        previewMode={false}
+        pageContent={{
+          custom: {
+            insightsStageOnlyPreview: true,
+            defaultScreenWidth: 800,
+          },
+          customCss: '.stageContainer { color: red; }',
+        }}
+      />,
+    );
+
+    expect(container.querySelector('.stageContainer.columnRestriction')).toBeInTheDocument();
+    expect(container.querySelector('#stage-stage')).toBeInTheDocument();
+    expect(container.querySelector('.stage-content-wrapper')).toBeInTheDocument();
+    expect(container).toHaveTextContent('loading...');
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes an Instructor Insights regression where adaptive screen preview did not render custom CSS correctly.

The issue was not in the preview controller payload. The adaptive insights preview path was still passing the page content, including `customCss`, into delivery. The problem was in the delivery render branch for `insightsStageOnlyPreview`, which was using a stripped-down DOM structure that omitted the normal adaptive stage wrapper elements many authored styles rely on.

## What changed

The insights-only adaptive preview branch in `DeckLayoutView` now preserves the standard stage wrapper contract by rendering:

  - `.background`
  - `.stageContainer.columnRestriction`
  - `#stage-stage`
  - `.stage-content-wrapper`

This keeps the DOM hooks that authored/custom CSS expects while still avoiding the full delivery chrome used outside the insights preview.

Because the normal adaptive stage container is absolutely positioned for fullscreen delivery, the preview branch also applies a small preview-only style override so the restored stage wrapper remains properly contained inside the Instructor Insights preview card instead of escaping the layout.