### PR TITLE
[MER-5312] [ENHANCEMENT] Adaptive pages: resize adaptive iframe to content

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import useWindowSize from 'components/hooks/useWindowSize';
 import { getModeFromLocalStorage } from 'components/misc/DarkModeSelector';
@@ -61,6 +61,66 @@ export const shouldHideLessonFinishedCloseButton = (
   previewMode: boolean,
   displayApplicationChrome: boolean | undefined,
 ) => !!displayApplicationChrome && !previewMode;
+
+const adaptiveIframeHeightMessageType = 'oli:adaptive-content-height';
+const adaptiveIframeHeightRequestType = 'oli:request-adaptive-content-height';
+const minimumAdaptiveIframeHeight = 600;
+const adaptiveIframeContentSelectors = [
+  '.stageContainer',
+  '#stage-stage',
+  '.stage-content-wrapper',
+  '.content',
+  'oli-adaptive-delivery',
+  '[data-part-id]',
+].join(',');
+const adaptiveIframeFallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(
+  ',',
+);
+
+const isHTMLElement = (element?: Element | null): element is HTMLElement => {
+  const elementWindow = element?.ownerDocument.defaultView;
+
+  return !!elementWindow && element instanceof elementWindow.HTMLElement;
+};
+
+const getElementHeight = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  return Math.max(
+    element.scrollHeight || 0,
+    element.offsetHeight || 0,
+    element.getBoundingClientRect().height || 0,
+    element.getBoundingClientRect().bottom + window.scrollY,
+  );
+};
+
+const getMaxElementHeight = (elements: Element[]) =>
+  Math.max(...elements.map(getElementHeight), minimumAdaptiveIframeHeight);
+
+const getDocumentHeight = () =>
+  Math.max(getElementHeight(document.body), getElementHeight(document.documentElement));
+
+const getAdaptiveContentHeight = (contentElement?: HTMLElement | null) => {
+  const contentElements = Array.from(document.querySelectorAll(adaptiveIframeContentSelectors));
+  const measuredContentHeight =
+    contentElements.length > 0
+      ? getMaxElementHeight(contentElements)
+      : getMaxElementHeight([
+          ...(contentElement ? [contentElement] : []),
+          ...Array.from(document.querySelectorAll(adaptiveIframeFallbackContentSelectors)),
+          document.body,
+          document.documentElement,
+        ]);
+  const measuredDocumentHeight = getDocumentHeight();
+
+  if (measuredDocumentHeight > window.innerHeight + 1) {
+    return Math.max(measuredContentHeight, measuredDocumentHeight, minimumAdaptiveIframeHeight);
+  }
+
+  return measuredContentHeight;
+};
 
 const Delivery: React.FC<DeliveryProps> = ({
   userId,
@@ -228,6 +288,65 @@ const Delivery: React.FC<DeliveryProps> = ({
   const adaptiveDialogueBridgeEnabled = !!content?.advancedDelivery && !previewMode && !reviewMode;
   const currentActivityAttemptGuid =
     currentActivityTreeAttemptState?.[currentActivityTreeAttemptState.length - 1]?.attemptGuid;
+  const shouldReportAdaptiveIframeHeight = !!content?.displayApplicationChrome && !previewMode;
+  const deliveryRootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!shouldReportAdaptiveIframeHeight || window.parent === window) {
+      return;
+    }
+
+    let animationFrame: number | undefined;
+
+    const reportHeight = () => {
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+
+      animationFrame = window.requestAnimationFrame(() => {
+        window.parent.postMessage(
+          {
+            type: adaptiveIframeHeightMessageType,
+            height: getAdaptiveContentHeight(deliveryRootRef.current),
+          },
+          window.location.origin,
+        );
+      });
+    };
+
+    const handleHeightRequest = (event: MessageEvent) => {
+      if (
+        event.origin === window.location.origin &&
+        event.data?.type === adaptiveIframeHeightRequestType
+      ) {
+        reportHeight();
+      }
+    };
+
+    const resizeObserver =
+      'ResizeObserver' in window ? new ResizeObserver(reportHeight) : undefined;
+    if (deliveryRootRef.current) {
+      resizeObserver?.observe(deliveryRootRef.current);
+    }
+    resizeObserver?.observe(document.body);
+    resizeObserver?.observe(document.documentElement);
+    window.addEventListener('load', reportHeight);
+    window.addEventListener('resize', reportHeight);
+    window.addEventListener('message', handleHeightRequest);
+
+    reportHeight();
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('load', reportHeight);
+      window.removeEventListener('resize', reportHeight);
+      window.removeEventListener('message', handleHeightRequest);
+
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [shouldReportAdaptiveIframeHeight]);
 
   // this is something SS does.....
   const { width: windowWidth } = useWindowSize();
@@ -235,6 +354,8 @@ const Delivery: React.FC<DeliveryProps> = ({
   const showRestartDialog = restartLesson && (!reviewMode || (!graded && !previewMode));
   return (
     <div
+      ref={deliveryRootRef}
+      data-adaptive-delivery-root
       className={`${parentDivClasses.join(' ')} ${currentTheme} ${
         reviewMode && isInstructor ? 'instructor-preview' : ''
       }`}

--- a/assets/src/hooks/adaptive_iframe_resize.ts
+++ b/assets/src/hooks/adaptive_iframe_resize.ts
@@ -4,10 +4,15 @@ type AdaptiveIframeResizeHook = {
   handleMessage?: (event: MessageEvent) => void;
   handleLoad?: EventListener;
   requestHeightInterval?: number;
+  stableHeightCount?: number;
+  lastMeasuredHeight?: number;
 };
 
 const messageType = 'oli:adaptive-content-height';
 const minIframeHeight = 600;
+const maxIframeHeight = 20_000;
+const heightPollIntervalMs = 1000;
+const stableHeightLimit = 3;
 const contentSelectors = [
   '.stageContainer',
   '#stage-stage',
@@ -26,7 +31,14 @@ const applyHeight = (iframe: HTMLIFrameElement, height: number) => {
     return;
   }
 
-  iframe.style.height = `${Math.ceil(Math.max(height, minIframeHeight))}px`;
+  const nextHeight = Math.ceil(Math.min(Math.max(height, minIframeHeight), maxIframeHeight));
+  const nextStyleHeight = `${nextHeight}px`;
+
+  if (iframe.style.height !== nextStyleHeight) {
+    iframe.style.height = nextStyleHeight;
+  }
+
+  return nextHeight;
 };
 
 const isHTMLElement = (element?: Element | null): element is HTMLElement => {
@@ -87,16 +99,65 @@ const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
 };
 
 const applyMeasuredHeight = (iframe: HTMLIFrameElement) => {
-  applyHeight(iframe, measureIframeContentHeight(iframe));
+  return applyHeight(iframe, measureIframeContentHeight(iframe));
 };
 
 const requestHeight = (iframe: HTMLIFrameElement) => {
-  applyMeasuredHeight(iframe);
+  const height = applyMeasuredHeight(iframe);
 
   iframe.contentWindow?.postMessage(
     { type: 'oli:request-adaptive-content-height' },
     window.location.origin,
   );
+
+  return height;
+};
+
+const stopHeightPolling = (hook: AdaptiveIframeResizeHook) => {
+  if (hook.requestHeightInterval) {
+    window.clearInterval(hook.requestHeightInterval);
+  }
+
+  hook.requestHeightInterval = undefined;
+};
+
+const startHeightPolling = (hook: AdaptiveIframeResizeHook) => {
+  const iframe = hook.iframe;
+
+  stopHeightPolling(hook);
+  hook.stableHeightCount = 0;
+  hook.lastMeasuredHeight = undefined;
+
+  if (!iframe) {
+    return;
+  }
+
+  const pollHeight = () => {
+    if (hook.iframe !== iframe) {
+      stopHeightPolling(hook);
+      return;
+    }
+
+    const height = requestHeight(iframe);
+
+    if (!height) {
+      return;
+    }
+
+    if (height === hook.lastMeasuredHeight) {
+      hook.stableHeightCount = (hook.stableHeightCount || 0) + 1;
+    } else {
+      hook.stableHeightCount = 0;
+      hook.lastMeasuredHeight = height;
+    }
+
+    if ((hook.stableHeightCount || 0) >= stableHeightLimit) {
+      stopHeightPolling(hook);
+    }
+  };
+
+  pollHeight();
+  hook.requestHeightInterval = window.setInterval(pollHeight, heightPollIntervalMs);
 };
 
 const attachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
@@ -117,14 +178,23 @@ const attachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
       return;
     }
 
+    if (event.source !== iframe.contentWindow) {
+      return;
+    }
+
     if (event.data?.type !== messageType) {
       return;
     }
 
+    const previousHeight = iframe.style.height;
     applyHeight(iframe, Number(event.data.height));
+
+    if (iframe.style.height !== previousHeight) {
+      startHeightPolling(hook);
+    }
   };
 
-  const handleLoad: EventListener = () => requestHeight(iframe);
+  const handleLoad: EventListener = () => startHeightPolling(hook);
 
   hook.iframe = iframe;
   hook.handleMessage = handleMessage;
@@ -132,8 +202,7 @@ const attachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
 
   window.addEventListener('message', handleMessage);
   iframe.addEventListener('load', handleLoad);
-  requestHeight(iframe);
-  hook.requestHeightInterval = window.setInterval(() => requestHeight(iframe), 1000);
+  startHeightPolling(hook);
 };
 
 const detachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
@@ -145,14 +214,13 @@ const detachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
     hook.iframe.removeEventListener('load', hook.handleLoad);
   }
 
-  if (hook.requestHeightInterval) {
-    window.clearInterval(hook.requestHeightInterval);
-  }
+  stopHeightPolling(hook);
 
   hook.iframe = null;
   hook.handleMessage = undefined;
   hook.handleLoad = undefined;
-  hook.requestHeightInterval = undefined;
+  hook.stableHeightCount = undefined;
+  hook.lastMeasuredHeight = undefined;
 };
 
 export const AdaptiveIframeResize = {

--- a/assets/src/hooks/adaptive_iframe_resize.ts
+++ b/assets/src/hooks/adaptive_iframe_resize.ts
@@ -1,0 +1,170 @@
+type AdaptiveIframeResizeHook = {
+  el: HTMLElement;
+  iframe?: HTMLIFrameElement | null;
+  handleMessage?: (event: MessageEvent) => void;
+  handleLoad?: EventListener;
+  requestHeightInterval?: number;
+};
+
+const messageType = 'oli:adaptive-content-height';
+const minIframeHeight = 600;
+const contentSelectors = [
+  '.stageContainer',
+  '#stage-stage',
+  '.stage-content-wrapper',
+  '.content',
+  'oli-adaptive-delivery',
+  '[data-part-id]',
+].join(',');
+const fallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(',');
+
+const findIframe = (root: HTMLElement) =>
+  root.querySelector('#adaptive_content_iframe') as HTMLIFrameElement | null;
+
+const applyHeight = (iframe: HTMLIFrameElement, height: number) => {
+  if (!Number.isFinite(height) || height <= 0) {
+    return;
+  }
+
+  iframe.style.height = `${Math.ceil(Math.max(height, minIframeHeight))}px`;
+};
+
+const isHTMLElement = (element?: Element | null): element is HTMLElement => {
+  const elementWindow = element?.ownerDocument.defaultView;
+
+  return !!elementWindow && element instanceof elementWindow.HTMLElement;
+};
+
+const elementHeight = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const scrollY = element.ownerDocument.defaultView?.scrollY || 0;
+
+  return Math.max(
+    element.scrollHeight || 0,
+    element.offsetHeight || 0,
+    element.getBoundingClientRect().height || 0,
+    element.getBoundingClientRect().bottom + scrollY,
+  );
+};
+
+const maxElementHeight = (elements: Element[]) =>
+  Math.max(...elements.map(elementHeight), minIframeHeight);
+
+const documentHeight = (doc: Document) =>
+  Math.max(elementHeight(doc.body), elementHeight(doc.documentElement));
+
+const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
+  try {
+    const doc = iframe.contentDocument;
+
+    if (!doc) {
+      return 0;
+    }
+
+    const contentElements = Array.from(doc.querySelectorAll(contentSelectors));
+    const measuredContentHeight =
+      contentElements.length > 0
+        ? maxElementHeight(contentElements)
+        : maxElementHeight([
+            ...Array.from(doc.querySelectorAll(fallbackContentSelectors)),
+            doc.body,
+            doc.documentElement,
+          ]);
+    const measuredDocumentHeight = documentHeight(doc);
+    const iframeViewportHeight = iframe.getBoundingClientRect().height || iframe.clientHeight;
+
+    if (measuredDocumentHeight > iframeViewportHeight + 1) {
+      return Math.max(measuredContentHeight, measuredDocumentHeight, minIframeHeight);
+    }
+
+    return measuredContentHeight;
+  } catch (_e) {
+    return 0;
+  }
+};
+
+const applyMeasuredHeight = (iframe: HTMLIFrameElement) => {
+  applyHeight(iframe, measureIframeContentHeight(iframe));
+};
+
+const requestHeight = (iframe: HTMLIFrameElement) => {
+  applyMeasuredHeight(iframe);
+
+  iframe.contentWindow?.postMessage(
+    { type: 'oli:request-adaptive-content-height' },
+    window.location.origin,
+  );
+};
+
+const attachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
+  const iframe = findIframe(hook.el);
+
+  if (hook.iframe === iframe) {
+    return;
+  }
+
+  detachAdaptiveIframeResize(hook);
+
+  if (!iframe) {
+    return;
+  }
+
+  const handleMessage = (event: MessageEvent) => {
+    if (event.origin !== window.location.origin) {
+      return;
+    }
+
+    if (event.data?.type !== messageType) {
+      return;
+    }
+
+    applyHeight(iframe, Number(event.data.height));
+  };
+
+  const handleLoad: EventListener = () => requestHeight(iframe);
+
+  hook.iframe = iframe;
+  hook.handleMessage = handleMessage;
+  hook.handleLoad = handleLoad;
+
+  window.addEventListener('message', handleMessage);
+  iframe.addEventListener('load', handleLoad);
+  requestHeight(iframe);
+  hook.requestHeightInterval = window.setInterval(() => requestHeight(iframe), 1000);
+};
+
+const detachAdaptiveIframeResize = (hook: AdaptiveIframeResizeHook) => {
+  if (hook.handleMessage) {
+    window.removeEventListener('message', hook.handleMessage);
+  }
+
+  if (hook.iframe && hook.handleLoad) {
+    hook.iframe.removeEventListener('load', hook.handleLoad);
+  }
+
+  if (hook.requestHeightInterval) {
+    window.clearInterval(hook.requestHeightInterval);
+  }
+
+  hook.iframe = null;
+  hook.handleMessage = undefined;
+  hook.handleLoad = undefined;
+  hook.requestHeightInterval = undefined;
+};
+
+export const AdaptiveIframeResize = {
+  mounted(this: AdaptiveIframeResizeHook) {
+    attachAdaptiveIframeResize(this);
+  },
+
+  updated(this: AdaptiveIframeResizeHook) {
+    attachAdaptiveIframeResize(this);
+  },
+
+  destroyed(this: AdaptiveIframeResizeHook) {
+    detachAdaptiveIframeResize(this);
+  },
+};

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -1,5 +1,6 @@
 import LiveReact from 'phoenix_live_react';
 import { AdaptiveDialogueSync } from './adaptive_dialogue_sync';
+import { AdaptiveIframeResize } from './adaptive_iframe_resize';
 import { AdaptivePreviewPanel } from './adaptive_preview_panel';
 import { AnnotationBubbles } from './annotation_bubbles';
 import { AutoSelect } from './auto_select';
@@ -84,6 +85,7 @@ import { PauseOthersOnSelected, VideoPreview } from './video_preview';
 import { WakeUpDot } from './wakeup_dot';
 
 export const Hooks = {
+  AdaptiveIframeResize,
   AdaptivePreviewPanel,
   AdaptiveDialogueSync,
   AnnotationBubbles,

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1321,6 +1321,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
           <div
             class="flex justify-center items-start self-start w-full"
             id="adaptive_with_chrome_container"
+            phx-hook="AdaptiveIframeResize"
           >
             <iframe
               id="adaptive_content_iframe"
@@ -1394,6 +1395,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     <div
       class="flex justify-center items-start self-start w-full"
       id="adaptive_with_chrome_container"
+      phx-hook="AdaptiveIframeResize"
     >
       <iframe
         id="adaptive_content_iframe"

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -2720,6 +2720,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
                "Cookie Preferences"
              )
 
+      assert has_element?(
+               view,
+               "#adaptive_with_chrome_container[phx-hook='AdaptiveIframeResize'] #adaptive_content_iframe"
+             )
+
       viewport_actions =
         view
         |> render()


### PR DESCRIPTION
Fixes adaptive lessons displayed inside Torus navigation so the outer iframe dynamically resizes to the active adaptive screen content.

Adds a LiveView hook for the adaptive iframe container and a delivery-side height reporter that measures adaptive stage/content elements, allowing the frame to grow for tall screens and shrink again when navigating to shorter screens.


See: https://eliterate.atlassian.net/browse/MER-5312