### PR TITLE
[BUG FIX] [MER-5608] Ignore basic assessment settings for adaptive pages

### DIFF
--- a/lib/oli/delivery/settings.ex
+++ b/lib/oli/delivery/settings.ex
@@ -206,7 +206,26 @@ defmodule Oli.Delivery.Settings do
       explanation_strategy: explanation_strategy,
       allow_hints: section_resource.allow_hints
     }
+    |> normalize_adaptive_settings(resolved_revision)
   end
+
+  defp normalize_adaptive_settings(
+         %Combined{} = settings,
+         %Revision{content: %{"advancedDelivery" => true}}
+       ) do
+    %Combined{
+      settings
+      | batch_scoring: true,
+        replacement_strategy: :none,
+        retake_mode: :normal,
+        assessment_mode: :traditional,
+        review_submission: :allow,
+        feedback_mode: :allow,
+        feedback_scheduled_date: nil
+    }
+  end
+
+  defp normalize_adaptive_settings(%Combined{} = settings, _), do: settings
 
   # This combines the settings found in the section resource with the settings
   # found in the student exception, giving precedence to the student exception when

--- a/lib/oli/delivery/settings/assessment_settings.ex
+++ b/lib/oli/delivery/settings/assessment_settings.ex
@@ -178,6 +178,7 @@ defmodule Oli.Delivery.Settings.AssessmentSettings do
         index: index + 1,
         name: rev.title,
         name_with_container_label: name_with_container_label,
+        is_adaptive: Map.get(rev.content, "advancedDelivery") == true,
         scheduling_type: sr.scheduling_type,
         password: sr.password,
         exceptions_count:

--- a/lib/oli/delivery/settings/assessment_settings.ex
+++ b/lib/oli/delivery/settings/assessment_settings.ex
@@ -178,7 +178,7 @@ defmodule Oli.Delivery.Settings.AssessmentSettings do
         index: index + 1,
         name: rev.title,
         name_with_container_label: name_with_container_label,
-        is_adaptive: Map.get(rev.content, "advancedDelivery") == true,
+        is_adaptive: Map.get(rev.content || %{}, "advancedDelivery") == true,
         scheduling_type: sr.scheduling_type,
         password: sr.password,
         exceptions_count:

--- a/lib/oli/delivery/settings/assessment_settings.ex
+++ b/lib/oli/delivery/settings/assessment_settings.ex
@@ -174,6 +174,7 @@ defmodule Oli.Delivery.Settings.AssessmentSettings do
         )
 
       Settings.combine(rev, sr, nil)
+      |> Map.from_struct()
       |> Map.merge(%{
         index: index + 1,
         name: rev.title,

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -387,7 +387,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                 <.input
                   type="select"
                   class="form-control custom-select"
-                  disabled={is_disabled(@form, @revision)}
+                  disabled={is_disabled(@form, @revision) or is_adaptive_page(@revision)}
                   field={@form[:batch_scoring]}
                   options={[{"Score at the end", "true"}, {"Score as you go", "false"}]}
                 />
@@ -405,6 +405,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                   aria-describedby="replacement_policy_description"
                   placeholder="Replacement Policy"
                   class="form-control custom-select"
+                  disabled={is_adaptive_page(@revision)}
                   field={@form[:replacement_strategy]}
                   options={[
                     {"None: All questions remain the same for all attempts", :none},
@@ -547,7 +548,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
               name="revision[retake_mode]"
               aria-describedby="retake_mode_description"
               placeholder="Retake Mode"
-              disabled={is_disabled(@form, @revision)}
+              disabled={is_disabled(@form, @revision) or is_adaptive_page(@revision)}
               class="form-control custom-select"
               field={@form[:retake_mode]}
               options={[
@@ -569,7 +570,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
               name="revision[assessment_mode]"
               aria-describedby="assessment_mode_description"
               placeholder="Presentation"
-              disabled={is_disabled(@form, @revision)}
+              disabled={is_disabled(@form, @revision) or is_adaptive_page(@revision)}
               class="form-control custom-select"
               field={@form[:assessment_mode]}
               options={[
@@ -1053,6 +1054,9 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
       !revision.graded
     end
   end
+
+  defp is_adaptive_page(revision),
+    do: Map.get(revision.content || %{}, "advancedDelivery") == true
 
   defp ai_enabled_checked(form, revision) do
     graded =

--- a/lib/oli_web/live/curriculum/entries/options_modal.ex
+++ b/lib/oli_web/live/curriculum/entries/options_modal.ex
@@ -405,7 +405,7 @@ defmodule OliWeb.Curriculum.OptionsModalContent do
                   aria-describedby="replacement_policy_description"
                   placeholder="Replacement Policy"
                   class="form-control custom-select"
-                  disabled={is_adaptive_page(@revision)}
+                  disabled={is_disabled(@form, @revision) or is_adaptive_page(@revision)}
                   field={@form[:replacement_strategy]}
                   options={[
                     {"None: All questions remain the same for all attempts", :none},

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -554,7 +554,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       class={if @disabled, do: "inline-block cursor-not-allowed", else: "inline-block"}
       phx-hook={if @disabled, do: "GlobalTooltip"}
       data-tooltip={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
-      aria-label={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
       aria-describedby={if @disabled, do: "#{@id}-description"}
       tabindex={if @disabled, do: "0"}
     >

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -306,7 +306,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"replacement_strategy-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "replacement_strategy", @id)}
       >
         <option selected={@replacement_strategy == :none} value={:none}>
           All questions remain the same for all attempts
@@ -370,7 +369,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"retake_mode-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "retake_mode", @id)}
       >
         <option selected={@retake_mode == :targeted} value={:targeted}>Targeted</option>
         <option selected={@retake_mode == :normal} value={:normal}>Normal</option>
@@ -393,7 +391,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"assessment_mode-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "assessment_mode", @id)}
       >
         <option selected={@assessment_mode == :traditional} value={:traditional}>Traditional</option>
         <option selected={@assessment_mode == :one_at_a_time} value={:one_at_a_time}>
@@ -418,7 +415,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"feedback_mode-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "feedback_mode", @id)}
       >
         <option selected={@feedback_mode == :allow} value={:allow}>Allow</option>
         <option selected={@feedback_mode == :disallow} value={:disallow}>Disallow</option>
@@ -442,7 +438,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"review_submission-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "review_submission", @id)}
       >
         <option selected={@review_submission == :allow} value={:allow}>Allow</option>
         <option selected={@review_submission == :disallow} value={:disallow}>Disallow</option>
@@ -537,7 +532,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"batch_scoring-#{@id}"}
         disabled={@is_adaptive}
-        aria-describedby={adaptive_setting_description_id(@is_adaptive, "batch_scoring", @id)}
       >
         <option selected={@batch_scoring} value="true">Score at the end</option>
         <option selected={!@batch_scoring} value="false">Score as you go</option>
@@ -561,6 +555,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       phx-hook={if @disabled, do: "GlobalTooltip"}
       data-tooltip={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
       aria-label={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
+      aria-describedby={if @disabled, do: "#{@id}-description"}
+      tabindex={if @disabled, do: "0"}
     >
       {render_slot(@inner_block)}
       <span :if={@disabled} id={"#{@id}-description"} class="sr-only">
@@ -575,11 +571,6 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
 
   defp adaptive_setting_class(true, class), do: class <> " pointer-events-none"
   defp adaptive_setting_class(false, class), do: class
-
-  defp adaptive_setting_description_id(true, setting, id),
-    do: "#{setting}-wrapper-#{id}-description"
-
-  defp adaptive_setting_description_id(false, _setting, _id), do: nil
 
   def render_allow_hints_column(assigns, assessment, _) do
     assigns =

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -7,6 +7,8 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
 
   use Phoenix.Component
 
+  @adaptive_setting_disabled_tooltip "This setting does not apply to adaptive pages"
+
   def new(
         assessments,
         section_slug,
@@ -294,18 +296,25 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     assigns =
       Map.merge(assigns, %{
         replacement_strategy: assessment.replacement_strategy,
-        id: assessment.resource_id
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
       })
 
     ~H"""
-    <select class="torus-select pr-32" name={"replacement_strategy-#{@id}"}>
-      <option selected={@replacement_strategy == :none} value={:none}>
-        All questions remain the same for all attempts
-      </option>
-      <option selected={@replacement_strategy == :dynamic} value={:dynamic}>
-        Dynamic questions regenerate a new question
-      </option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"replacement_strategy-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"replacement_strategy-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@replacement_strategy == :none} value={:none}>
+          All questions remain the same for all attempts
+        </option>
+        <option selected={@replacement_strategy == :dynamic} value={:dynamic}>
+          Dynamic questions regenerate a new question
+        </option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
 
@@ -348,13 +357,23 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
 
   def render_retake_mode_column(assigns, assessment, _) do
     assigns =
-      Map.merge(assigns, %{retake_mode: assessment.retake_mode, id: assessment.resource_id})
+      Map.merge(assigns, %{
+        retake_mode: assessment.retake_mode,
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
+      })
 
     ~H"""
-    <select class="torus-select pr-32" name={"retake_mode-#{@id}"}>
-      <option selected={@retake_mode == :targeted} value={:targeted}>Targeted</option>
-      <option selected={@retake_mode == :normal} value={:normal}>Normal</option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"retake_mode-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"retake_mode-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@retake_mode == :targeted} value={:targeted}>Targeted</option>
+        <option selected={@retake_mode == :normal} value={:normal}>Normal</option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
 
@@ -362,29 +381,46 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     assigns =
       Map.merge(assigns, %{
         assessment_mode: assessment.assessment_mode,
-        id: assessment.resource_id
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
       })
 
     ~H"""
-    <select class="torus-select pr-32" name={"assessment_mode-#{@id}"}>
-      <option selected={@assessment_mode == :traditional} value={:traditional}>Traditional</option>
-      <option selected={@assessment_mode == :one_at_a_time} value={:one_at_a_time}>
-        One at a time
-      </option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"assessment_mode-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"assessment_mode-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@assessment_mode == :traditional} value={:traditional}>Traditional</option>
+        <option selected={@assessment_mode == :one_at_a_time} value={:one_at_a_time}>
+          One at a time
+        </option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
 
   def render_view_feedback_column(assigns, assessment, _) do
     assigns =
-      Map.merge(assigns, %{feedback_mode: assessment.feedback_mode, id: assessment.resource_id})
+      Map.merge(assigns, %{
+        feedback_mode: assessment.feedback_mode,
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
+      })
 
     ~H"""
-    <select class="torus-select pr-32" name={"feedback_mode-#{@id}"}>
-      <option selected={@feedback_mode == :allow} value={:allow}>Allow</option>
-      <option selected={@feedback_mode == :disallow} value={:disallow}>Disallow</option>
-      <option selected={@feedback_mode == :scheduled} value={:scheduled}>Scheduled</option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"feedback_mode-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"feedback_mode-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@feedback_mode == :allow} value={:allow}>Allow</option>
+        <option selected={@feedback_mode == :disallow} value={:disallow}>Disallow</option>
+        <option selected={@feedback_mode == :scheduled} value={:scheduled}>Scheduled</option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
 
@@ -392,14 +428,21 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     assigns =
       Map.merge(assigns, %{
         review_submission: assessment.review_submission,
-        id: assessment.resource_id
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
       })
 
     ~H"""
-    <select class="torus-select pr-32" name={"review_submission-#{@id}"}>
-      <option selected={@review_submission == :allow} value={:allow}>Allow</option>
-      <option selected={@review_submission == :disallow} value={:disallow}>Disallow</option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"review_submission-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"review_submission-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@review_submission == :allow} value={:allow}>Allow</option>
+        <option selected={@review_submission == :disallow} value={:disallow}>Disallow</option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
 
@@ -479,16 +522,50 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
     assigns =
       Map.merge(assigns, %{
         batch_scoring: assessment.batch_scoring,
-        id: assessment.resource_id
+        id: assessment.resource_id,
+        is_adaptive: adaptive_page?(assessment)
       })
 
     ~H"""
-    <select class="torus-select pr-32" name={"batch_scoring-#{@id}"}>
-      <option selected={@batch_scoring} value="true">Score at the end</option>
-      <option selected={!@batch_scoring} value="false">Score as you go</option>
-    </select>
+    <.adaptive_setting_wrapper disabled={@is_adaptive} id={"batch_scoring-wrapper-#{@id}"}>
+      <select
+        class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
+        name={"batch_scoring-#{@id}"}
+        disabled={@is_adaptive}
+      >
+        <option selected={@batch_scoring} value="true">Score at the end</option>
+        <option selected={!@batch_scoring} value="false">Score as you go</option>
+      </select>
+    </.adaptive_setting_wrapper>
     """
   end
+
+  slot(:inner_block, required: true)
+  attr(:disabled, :boolean, required: true)
+  attr(:id, :string, required: true)
+
+  defp adaptive_setting_wrapper(assigns) do
+    assigns =
+      assign(assigns, :adaptive_setting_disabled_tooltip_text, @adaptive_setting_disabled_tooltip)
+
+    ~H"""
+    <div
+      id={@id}
+      class={if @disabled, do: "inline-block cursor-not-allowed", else: "inline-block"}
+      phx-hook={if @disabled, do: "GlobalTooltip"}
+      data-tooltip={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
+      aria-label={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
+    >
+      {render_slot(@inner_block)}
+    </div>
+    """
+  end
+
+  defp adaptive_page?(%{is_adaptive: true}), do: true
+  defp adaptive_page?(_), do: false
+
+  defp adaptive_setting_class(true, class), do: class <> " pointer-events-none"
+  defp adaptive_setting_class(false, class), do: class
 
   def render_allow_hints_column(assigns, assessment, _) do
     assigns =

--- a/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
+++ b/lib/oli_web/live/sections/assessment_settings/settings_table_model.ex
@@ -306,6 +306,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"replacement_strategy-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "replacement_strategy", @id)}
       >
         <option selected={@replacement_strategy == :none} value={:none}>
           All questions remain the same for all attempts
@@ -369,6 +370,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"retake_mode-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "retake_mode", @id)}
       >
         <option selected={@retake_mode == :targeted} value={:targeted}>Targeted</option>
         <option selected={@retake_mode == :normal} value={:normal}>Normal</option>
@@ -391,6 +393,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"assessment_mode-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "assessment_mode", @id)}
       >
         <option selected={@assessment_mode == :traditional} value={:traditional}>Traditional</option>
         <option selected={@assessment_mode == :one_at_a_time} value={:one_at_a_time}>
@@ -415,6 +418,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"feedback_mode-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "feedback_mode", @id)}
       >
         <option selected={@feedback_mode == :allow} value={:allow}>Allow</option>
         <option selected={@feedback_mode == :disallow} value={:disallow}>Disallow</option>
@@ -438,6 +442,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"review_submission-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "review_submission", @id)}
       >
         <option selected={@review_submission == :allow} value={:allow}>Allow</option>
         <option selected={@review_submission == :disallow} value={:disallow}>Disallow</option>
@@ -532,6 +537,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
         class={adaptive_setting_class(@is_adaptive, "torus-select pr-32")}
         name={"batch_scoring-#{@id}"}
         disabled={@is_adaptive}
+        aria-describedby={adaptive_setting_description_id(@is_adaptive, "batch_scoring", @id)}
       >
         <option selected={@batch_scoring} value="true">Score at the end</option>
         <option selected={!@batch_scoring} value="false">Score as you go</option>
@@ -557,6 +563,9 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
       aria-label={if @disabled, do: @adaptive_setting_disabled_tooltip_text}
     >
       {render_slot(@inner_block)}
+      <span :if={@disabled} id={"#{@id}-description"} class="sr-only">
+        {@adaptive_setting_disabled_tooltip_text}
+      </span>
     </div>
     """
   end
@@ -566,6 +575,11 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsTableModel do
 
   defp adaptive_setting_class(true, class), do: class <> " pointer-events-none"
   defp adaptive_setting_class(false, class), do: class
+
+  defp adaptive_setting_description_id(true, setting, id),
+    do: "#{setting}-wrapper-#{id}-description"
+
+  defp adaptive_setting_description_id(false, _setting, _id), do: nil
 
   def render_allow_hints_column(assigns, assessment, _) do
     assigns =

--- a/test/oli/delivery/settings_test.exs
+++ b/test/oli/delivery/settings_test.exs
@@ -63,6 +63,37 @@ defmodule Oli.Delivery.SettingsTest do
              Settings.new_attempt_allowed(%Combined{batch_scoring: false, max_attempts: 5}, 0, [])
   end
 
+  test "adaptive pages ignore basic-page-only assessment settings" do
+    revision = %Revision{
+      resource_id: 1,
+      content: %{"advancedDelivery" => true},
+      max_attempts: 5
+    }
+
+    section_resource = %SectionResource{
+      max_attempts: 5,
+      batch_scoring: false,
+      replacement_strategy: :dynamic,
+      retake_mode: :targeted,
+      assessment_mode: :one_at_a_time,
+      feedback_mode: :scheduled,
+      feedback_scheduled_date: ~U[2026-05-04 00:00:00Z],
+      review_submission: :disallow
+    }
+
+    combined = Settings.combine(revision, section_resource, nil)
+
+    assert combined.batch_scoring == true
+    assert combined.replacement_strategy == :none
+    assert combined.retake_mode == :normal
+    assert combined.assessment_mode == :traditional
+    assert combined.feedback_mode == :allow
+    assert combined.feedback_scheduled_date == nil
+    assert combined.review_submission == :allow
+
+    assert {:allowed} == Settings.new_attempt_allowed(combined, 1, [])
+  end
+
   test "was_late/2 never returns true when late submissions disallowed" do
     ra = %ResourceAttempt{
       inserted_at: ~U[2020-01-01 00:00:00Z]

--- a/test/oli_web/live/curriculum/entries/options_modal_content_test.exs
+++ b/test/oli_web/live/curriculum/entries/options_modal_content_test.exs
@@ -238,6 +238,44 @@ defmodule OliWeb.Curriculum.OptionsModalContentTest do
       refute has_element?(lcd, "input[name='revision[ai_enabled]'][type='checkbox'][checked]")
     end
 
+    test "disables basic-page-only options for adaptive pages", %{
+      conn: conn,
+      project: project,
+      page_revision: revision,
+      project_hierarchy: project_hierarchy
+    } do
+      adaptive_revision = %{
+        revision
+        | content: Map.put(revision.content || %{}, "advancedDelivery", true),
+          graded: true
+      }
+
+      form =
+        adaptive_revision
+        |> Oli.Resources.change_revision()
+        |> Phoenix.Component.to_form()
+
+      {:ok, lcd, _html} =
+        live_component_isolated(conn, OliWeb.Curriculum.OptionsModalContent, %{
+          revision: adaptive_revision,
+          redirect_url: "some_redirect_url",
+          project_hierarchy: project_hierarchy,
+          project: project,
+          validate: "validate-options",
+          submit: "save-options",
+          cancel: "restart_options_modal",
+          form: form
+        })
+
+      assert has_element?(lcd, ~s{select[name="revision[batch_scoring]"][disabled]})
+      assert has_element?(lcd, ~s{select[name="revision[replacement_strategy]"][disabled]})
+      assert has_element?(lcd, ~s{select[name="revision[retake_mode]"][disabled]})
+      assert has_element?(lcd, ~s{select[name="revision[assessment_mode]"][disabled]})
+
+      refute has_element?(lcd, ~s{select[name="revision[max_attempts]"][disabled]})
+      refute has_element?(lcd, ~s{select[name="revision[scoring_strategy_id]"][disabled]})
+    end
+
     test "renders poster image if the page revision has one", %{
       conn: conn,
       project: project,

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -820,7 +820,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
 
       assert has_element?(
                view,
-               ~s{#batch_scoring-wrapper-#{page_1.resource_id}[phx-hook="GlobalTooltip"][data-tooltip="#{tooltip}"] select[name="batch_scoring-#{page_1.resource_id}"][disabled][aria-describedby="batch_scoring-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#batch_scoring-wrapper-#{page_1.resource_id}[phx-hook="GlobalTooltip"][data-tooltip="#{tooltip}"][tabindex="0"][aria-describedby="batch_scoring-wrapper-#{page_1.resource_id}-description"] select[name="batch_scoring-#{page_1.resource_id}"][disabled]}
              )
 
       assert has_element?(
@@ -831,27 +831,27 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
 
       assert has_element?(
                view,
-               ~s{select[name="replacement_strategy-#{page_1.resource_id}"][disabled][aria-describedby="replacement_strategy-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#replacement_strategy-wrapper-#{page_1.resource_id}[tabindex="0"][aria-describedby="replacement_strategy-wrapper-#{page_1.resource_id}-description"] select[name="replacement_strategy-#{page_1.resource_id}"][disabled]}
              )
 
       assert has_element?(
                view,
-               ~s{select[name="retake_mode-#{page_1.resource_id}"][disabled][aria-describedby="retake_mode-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#retake_mode-wrapper-#{page_1.resource_id}[tabindex="0"][aria-describedby="retake_mode-wrapper-#{page_1.resource_id}-description"] select[name="retake_mode-#{page_1.resource_id}"][disabled]}
              )
 
       assert has_element?(
                view,
-               ~s{select[name="assessment_mode-#{page_1.resource_id}"][disabled][aria-describedby="assessment_mode-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#assessment_mode-wrapper-#{page_1.resource_id}[tabindex="0"][aria-describedby="assessment_mode-wrapper-#{page_1.resource_id}-description"] select[name="assessment_mode-#{page_1.resource_id}"][disabled]}
              )
 
       assert has_element?(
                view,
-               ~s{select[name="feedback_mode-#{page_1.resource_id}"][disabled][aria-describedby="feedback_mode-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#feedback_mode-wrapper-#{page_1.resource_id}[tabindex="0"][aria-describedby="feedback_mode-wrapper-#{page_1.resource_id}-description"] select[name="feedback_mode-#{page_1.resource_id}"][disabled]}
              )
 
       assert has_element?(
                view,
-               ~s{select[name="review_submission-#{page_1.resource_id}"][disabled][aria-describedby="review_submission-wrapper-#{page_1.resource_id}-description"]}
+               ~s{#review_submission-wrapper-#{page_1.resource_id}[tabindex="0"][aria-describedby="review_submission-wrapper-#{page_1.resource_id}-description"] select[name="review_submission-#{page_1.resource_id}"][disabled]}
              )
     end
 

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
 
   alias Oli.Delivery.{Settings, Sections}
   alias Oli.Delivery
+  alias Oli.Repo
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Resources.ResourceType
   alias Oli.Publishing.DeliveryResolver
@@ -789,6 +790,57 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
         "_target" => ["password-#{resource_id}"],
         "password-#{resource_id}" => password
       })
+    end
+
+    test "adaptive page basic-page-only settings are disabled with explanatory tooltip", %{
+      conn: conn,
+      section: section,
+      page_1: page_1
+    } do
+      page_1
+      |> Ecto.Changeset.change(%{
+        content: Map.put(page_1.content || %{}, "advancedDelivery", true)
+      })
+      |> Repo.update!()
+
+      section_resource = Sections.get_section_resource(section.id, page_1.resource_id)
+
+      Sections.update_section_resource(section_resource, %{
+        batch_scoring: false,
+        replacement_strategy: :dynamic,
+        retake_mode: :targeted,
+        assessment_mode: :one_at_a_time,
+        feedback_mode: :scheduled,
+        review_submission: :disallow
+      })
+
+      {:ok, view, _html} = live(conn, live_view_overview_route(section.slug, "settings", "all"))
+
+      tooltip = "This setting does not apply to adaptive pages"
+
+      assert has_element?(
+               view,
+               ~s{#batch_scoring-wrapper-#{page_1.resource_id}[phx-hook="GlobalTooltip"][data-tooltip="#{tooltip}"] select[name="batch_scoring-#{page_1.resource_id}"][disabled]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{select[name="replacement_strategy-#{page_1.resource_id}"][disabled]}
+             )
+
+      assert has_element?(view, ~s{select[name="retake_mode-#{page_1.resource_id}"][disabled]})
+
+      assert has_element?(
+               view,
+               ~s{select[name="assessment_mode-#{page_1.resource_id}"][disabled]}
+             )
+
+      assert has_element?(view, ~s{select[name="feedback_mode-#{page_1.resource_id}"][disabled]})
+
+      assert has_element?(
+               view,
+               ~s{select[name="review_submission-#{page_1.resource_id}"][disabled]}
+             )
     end
 
     test "exception count links to corresponding student exceptions for that assessment",

--- a/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
+++ b/test/oli_web/live/sections/assessment_settings/settings_live_test.exs
@@ -820,26 +820,38 @@ defmodule OliWeb.Sections.AssessmentSettings.SettingsLiveTest do
 
       assert has_element?(
                view,
-               ~s{#batch_scoring-wrapper-#{page_1.resource_id}[phx-hook="GlobalTooltip"][data-tooltip="#{tooltip}"] select[name="batch_scoring-#{page_1.resource_id}"][disabled]}
+               ~s{#batch_scoring-wrapper-#{page_1.resource_id}[phx-hook="GlobalTooltip"][data-tooltip="#{tooltip}"] select[name="batch_scoring-#{page_1.resource_id}"][disabled][aria-describedby="batch_scoring-wrapper-#{page_1.resource_id}-description"]}
              )
 
       assert has_element?(
                view,
-               ~s{select[name="replacement_strategy-#{page_1.resource_id}"][disabled]}
+               ~s{#batch_scoring-wrapper-#{page_1.resource_id}-description.sr-only},
+               tooltip
              )
-
-      assert has_element?(view, ~s{select[name="retake_mode-#{page_1.resource_id}"][disabled]})
 
       assert has_element?(
                view,
-               ~s{select[name="assessment_mode-#{page_1.resource_id}"][disabled]}
+               ~s{select[name="replacement_strategy-#{page_1.resource_id}"][disabled][aria-describedby="replacement_strategy-wrapper-#{page_1.resource_id}-description"]}
              )
-
-      assert has_element?(view, ~s{select[name="feedback_mode-#{page_1.resource_id}"][disabled]})
 
       assert has_element?(
                view,
-               ~s{select[name="review_submission-#{page_1.resource_id}"][disabled]}
+               ~s{select[name="retake_mode-#{page_1.resource_id}"][disabled][aria-describedby="retake_mode-wrapper-#{page_1.resource_id}-description"]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{select[name="assessment_mode-#{page_1.resource_id}"][disabled][aria-describedby="assessment_mode-wrapper-#{page_1.resource_id}-description"]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{select[name="feedback_mode-#{page_1.resource_id}"][disabled][aria-describedby="feedback_mode-wrapper-#{page_1.resource_id}-description"]}
+             )
+
+      assert has_element?(
+               view,
+               ~s{select[name="review_submission-#{page_1.resource_id}"][disabled][aria-describedby="review_submission-wrapper-#{page_1.resource_id}-description"]}
              )
     end
 


### PR DESCRIPTION
## Summary

Addresses [MER-5608](https://eliterate.atlassian.net/browse/MER-5608) to prevent adaptive pages from using settings that should only apply to basic pages, which in some cases can block operation. 

  - Normalizes adaptive page effective settings so basic-page-only assessment settings are ignored at runtime.
  - Disables non-applicable assessment settings for adaptive pages in the instructor assessment settings table.
  - Disables non-applicable adaptive page options in authoring.

  ## Testing

  - `mix test test/oli/delivery/settings_test.exs`
  - `mix test test/oli_web/live/sections/assessment_settings/settings_live_test.exs`
  - `mix test test/oli_web/live/curriculum/entries/options_modal_content_test.exs`



[MER-5608]: https://eliterate.atlassian.net/browse/MER-5608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ