### PR TITLE
[BUG FIX] [MER-4326] Suspended enrollment message

### DIFF
--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -42,7 +42,7 @@ defmodule OliWeb.DeliveryController do
   dashboard. If they are not allowed to configure the section, the student will be redirected to the
   page delivery.
   """
-  @suspended_message "Your access to this course has been suspended. Please contact your instructor."
+  @suspended_message "This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment."
 
   def index(conn, _params) do
     case conn.assigns.current_user do

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -260,7 +260,8 @@ defmodule OliWeb.DeliveryController do
 
     conn
     |> redirect(
-      to: ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path]}"
+      to:
+        ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, section_slug: section.slug]}"
     )
   end
 

--- a/lib/oli_web/controllers/launch_controller.ex
+++ b/lib/oli_web/controllers/launch_controller.ex
@@ -111,7 +111,8 @@ defmodule OliWeb.LaunchController do
 
     conn
     |> redirect(
-      to: ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path]}"
+      to:
+        ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, section_slug: section.slug]}"
     )
   end
 

--- a/lib/oli_web/live/lms_user_instructions_live.ex
+++ b/lib/oli_web/live/lms_user_instructions_live.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.LmsUserInstructionsLive do
         |> assign(:lms_course_titles, lms_course_titles)
         |> assign(:section_title, params["section_title"])
         |> assign(:logout_path, logout_path)
+        |> assign(:suspended?, suspended?(params["suspended"]))
 
       {:ok, socket}
     else
@@ -32,25 +33,39 @@ defmodule OliWeb.LmsUserInstructionsLive do
     <div id="lms_user_warning" class="container flex items-center justify-center h-[70vh]">
       <div class="grid grid-cols-12">
         <div class="col-span-12 text-center pt-4">
-          <p><i class="far fa-hand-paper" aria-hidden="true" style="font-size: 64px"></i></p>
-          <h2 class="mt-4 mb-4">Account Type Mismatch</h2>
-          <div class="my-10">
-            <p>
-              The account <strong>{"#{@current_user.email}"}</strong>
-              you use to access these courses
-              <i>
-                {if @lms_course_titles != [],
-                  do: "- #{Enum.join(@lms_course_titles, ", ")} -"}
-              </i>
-              only works with single sign-on through your school’s LMS.
-            </p>
-            <p>
-              <strong>{"#{@section_title}"}</strong>
-              requires you to use a login account. Please log out of your current account with the button below, visit the enrollment URL again, and create a new {VendorProperties.product_short_name()} account using either email and password, or Sign In With Google.
-            </p>
-          </div>
-          <%= link to: @logout_path, method: :delete, class: "btn btn-primary" do %>
-            <i class="fas fa-sign-out-alt me-1"></i> Log Out
+          <%= if @suspended? do %>
+            <p><i class="far fa-hand-paper" aria-hidden="true" style="font-size: 64px"></i></p>
+            <h2 class="mt-4 mb-4">Enrollment Suspended</h2>
+            <div class="my-10">
+              <p>
+                Your enrollment for <strong>{"#{@section_title}"}</strong> has been suspended.
+              </p>
+              <p>
+                Please contact your instructor or technical support for further details or to reinstate
+                your enrollment.
+              </p>
+            </div>
+          <% else %>
+            <p><i class="far fa-hand-paper" aria-hidden="true" style="font-size: 64px"></i></p>
+            <h2 class="mt-4 mb-4">Account Type Mismatch</h2>
+            <div class="my-10">
+              <p>
+                The account <strong>{"#{@current_user.email}"}</strong>
+                you use to access these courses
+                <i>
+                  {if @lms_course_titles != [],
+                    do: "- #{Enum.join(@lms_course_titles, ", ")} -"}
+                </i>
+                only works with single sign-on through your school’s LMS.
+              </p>
+              <p>
+                <strong>{"#{@section_title}"}</strong>
+                requires you to use a login account. Please log out of your current account with the button below, visit the enrollment URL again, and create a new {VendorProperties.product_short_name()} account using either email and password, or Sign In With Google.
+              </p>
+            </div>
+            <%= link to: @logout_path, method: :delete, class: "btn btn-primary" do %>
+              <i class="fas fa-sign-out-alt me-1"></i> Log Out
+            <% end %>
           <% end %>
         </div>
       </div>
@@ -64,4 +79,7 @@ defmodule OliWeb.LmsUserInstructionsLive do
   defp build_logout_path(request_path) do
     ~p"/users/log_out?#{[request_path: request_path]}"
   end
+
+  defp suspended?(value) when value in [true, "true", "1", 1], do: true
+  defp suspended?(_), do: false
 end

--- a/lib/oli_web/live/lms_user_instructions_live.ex
+++ b/lib/oli_web/live/lms_user_instructions_live.ex
@@ -19,7 +19,7 @@ defmodule OliWeb.LmsUserInstructionsLive do
         |> assign(:lms_course_titles, lms_course_titles)
         |> assign(:section_title, params["section_title"])
         |> assign(:logout_path, logout_path)
-        |> assign(:suspended?, suspended?(params["suspended"]))
+        |> assign(:suspended?, suspended?(socket.assigns.current_user, params["section_slug"]))
 
       {:ok, socket}
     else
@@ -80,6 +80,12 @@ defmodule OliWeb.LmsUserInstructionsLive do
     ~p"/users/log_out?#{[request_path: request_path]}"
   end
 
-  defp suspended?(value) when value in [true, "true", "1", 1], do: true
-  defp suspended?(_), do: false
+  defp suspended?(current_user, section_slug) when is_binary(section_slug) do
+    case Sections.get_enrollment(section_slug, current_user.id, filter_by_status: false) do
+      %{status: :suspended} -> true
+      _ -> false
+    end
+  end
+
+  defp suspended?(_current_user, _section_slug), do: false
 end

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -7,7 +7,7 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
 
-  @suspended_message "Your access to this course has been suspended. Please contact your instructor."
+  @suspended_message "This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment."
   @lti_only_message "This course is only available through your LMS."
 
   def on_mount(:default, %{"section_slug" => section_slug}, _session, socket) do
@@ -37,10 +37,19 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
             {:cont, assign(socket, is_enrolled: true)}
 
           section.registration_open && suspended?(enrollment) ->
-            {:halt,
-             socket
-             |> put_flash(:error, @suspended_message)
-             |> redirect(to: ~p"/users/log_in?request_path=%2Fsections%2F#{section.slug}")}
+            if user.independent_learner do
+              {:halt,
+               socket
+               |> put_flash(:error, @suspended_message)
+               |> redirect(to: ~p"/users/log_in?request_path=%2Fsections%2F#{section.slug}")}
+            else
+              {:halt,
+               socket
+               |> redirect(
+                 to:
+                   ~p"/lms_user_instructions?#{[section_title: section.title, request_path: "/sections/#{section.slug}", suspended: true]}"
+               )}
+            end
 
           section.registration_open &&
               match?(

--- a/lib/oli_web/live_session_plugs/require_enrollment.ex
+++ b/lib/oli_web/live_session_plugs/require_enrollment.ex
@@ -47,7 +47,7 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
                socket
                |> redirect(
                  to:
-                   ~p"/lms_user_instructions?#{[section_title: section.title, request_path: "/sections/#{section.slug}", suspended: true]}"
+                   ~p"/lms_user_instructions?#{[section_title: section.title, request_path: "/sections/#{section.slug}", section_slug: section.slug]}"
                )}
             end
 
@@ -70,7 +70,7 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollment do
              socket
              |> redirect(
                to:
-                 ~p"/lms_user_instructions?#{[section_title: section.title, request_path: "/sections/#{section.slug}"]}"
+                 ~p"/lms_user_instructions?#{[section_title: section.title, request_path: "/sections/#{section.slug}", section_slug: section.slug]}"
              )}
 
           section.registration_open ->

--- a/lib/oli_web/plugs/require_enrollment.ex
+++ b/lib/oli_web/plugs/require_enrollment.ex
@@ -40,7 +40,7 @@ defmodule OliWeb.Plugs.RequireEnrollment do
           conn
           |> redirect(
             to:
-              ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, suspended: true]}"
+              ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, section_slug: section.slug]}"
           )
           |> halt()
         end
@@ -65,7 +65,7 @@ defmodule OliWeb.Plugs.RequireEnrollment do
         conn
         |> redirect(
           to:
-            ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path]}"
+            ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, section_slug: section.slug]}"
         )
         |> halt()
 

--- a/lib/oli_web/plugs/require_enrollment.ex
+++ b/lib/oli_web/plugs/require_enrollment.ex
@@ -6,7 +6,7 @@ defmodule OliWeb.Plugs.RequireEnrollment do
 
   alias Oli.Delivery.Sections
 
-  @suspended_message "Your access to this course has been suspended. Please contact your instructor."
+  @suspended_message "This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment."
   @lti_only_message "This course is only available through your LMS."
 
   def init(opts), do: opts
@@ -29,10 +29,21 @@ defmodule OliWeb.Plugs.RequireEnrollment do
         conn
 
       section.registration_open && suspended?(enrollment) ->
-        conn
-        |> put_flash(:error, @suspended_message)
-        |> redirect(to: ~p"/users/log_in?request_path=%2Fsections%2F#{section.slug}")
-        |> halt()
+        if user.independent_learner do
+          conn
+          |> put_flash(:error, @suspended_message)
+          |> redirect(to: ~p"/users/log_in?request_path=%2Fsections%2F#{section.slug}")
+          |> halt()
+        else
+          request_path = build_request_path(conn)
+
+          conn
+          |> redirect(
+            to:
+              ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, suspended: true]}"
+          )
+          |> halt()
+        end
 
       section.registration_open &&
           match?(

--- a/lib/oli_web/plugs/restrict_lms_user_access.ex
+++ b/lib/oli_web/plugs/restrict_lms_user_access.ex
@@ -29,7 +29,7 @@ defmodule OliWeb.Plugs.RestrictLmsUserAccess do
       conn
       |> redirect(
         to:
-          ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path]}"
+          ~p"/lms_user_instructions?#{[section_title: section.title, request_path: request_path, section_slug: section.slug]}"
       )
       |> halt()
     else

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -188,7 +188,7 @@ defmodule OliWeb.DeliveryControllerTest do
                "/users/log_in?request_path=%2Fsections%2F#{section.slug}"
 
       assert Flash.get(conn.assigns.flash, :error) ==
-               "Your access to this course has been suspended. Please contact your instructor."
+               "This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment."
     end
   end
 

--- a/test/oli_web/live/lms_user_instructions_live_test.exs
+++ b/test/oli_web/live/lms_user_instructions_live_test.exs
@@ -23,7 +23,7 @@ defmodule OliWeb.LmsUserInstructionsLiveTest do
       {:ok, _view, html} =
         live(
           conn,
-          ~p"/lms_user_instructions?#{[section_title: "Independent Course", request_path: "/sections/independent/enroll"]}"
+          ~p"/lms_user_instructions?#{[section_title: "Independent Course", request_path: "/sections/independent/enroll", section_slug: "independent"]}"
         )
 
       assert html =~ "Account Type Mismatch"
@@ -43,7 +43,10 @@ defmodule OliWeb.LmsUserInstructionsLiveTest do
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
 
       {:ok, _view, html} =
-        live(conn, ~p"/lms_user_instructions?#{[section_title: "Independent Course"]}")
+        live(
+          conn,
+          ~p"/lms_user_instructions?#{[section_title: "Independent Course", section_slug: "independent"]}"
+        )
 
       {:ok, document} = Floki.parse_document(html)
 
@@ -53,17 +56,34 @@ defmodule OliWeb.LmsUserInstructionsLiveTest do
       assert logout_href == "/users/log_out"
     end
 
-    test "renders suspended enrollment message when requested", %{conn: conn} do
+    test "renders suspended enrollment message based on enrollment status", %{
+      conn: conn,
+      user: user
+    } do
+      section = insert(:section, slug: "independent")
+      insert(:enrollment, user: user, section: section, status: :suspended)
+
       {:ok, _view, html} =
         live(
           conn,
-          ~p"/lms_user_instructions?#{[section_title: "Independent Course", suspended: true]}"
+          ~p"/lms_user_instructions?#{[section_title: "Independent Course", request_path: "/sections/independent", section_slug: "independent"]}"
         )
 
       assert html =~ "Enrollment Suspended"
       assert html =~ "has been suspended"
       assert html =~ "Please contact your instructor or technical support"
       refute html =~ "Account Type Mismatch"
+    end
+
+    test "does not show suspended state without suspended enrollment", %{conn: conn} do
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/lms_user_instructions?#{[section_title: "Independent Course", request_path: "/sections/independent", section_slug: "independent"]}"
+        )
+
+      refute html =~ "Enrollment Suspended"
+      assert html =~ "Account Type Mismatch"
     end
   end
 

--- a/test/oli_web/live/lms_user_instructions_live_test.exs
+++ b/test/oli_web/live/lms_user_instructions_live_test.exs
@@ -52,6 +52,19 @@ defmodule OliWeb.LmsUserInstructionsLiveTest do
 
       assert logout_href == "/users/log_out"
     end
+
+    test "renders suspended enrollment message when requested", %{conn: conn} do
+      {:ok, _view, html} =
+        live(
+          conn,
+          ~p"/lms_user_instructions?#{[section_title: "Independent Course", suspended: true]}"
+        )
+
+      assert html =~ "Enrollment Suspended"
+      assert html =~ "has been suspended"
+      assert html =~ "Please contact your instructor or technical support"
+      refute html =~ "Account Type Mismatch"
+    end
   end
 
   test "redirects to home when no current user", %{conn: conn} do

--- a/test/oli_web/live_session_plugs/require_enrollment_test.exs
+++ b/test/oli_web/live_session_plugs/require_enrollment_test.exs
@@ -48,6 +48,7 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollmentTest do
            user: user
          } do
       section = insert(:section, registration_open: true)
+      user = %{user | independent_learner: true}
       insert(:enrollment, user: user, section: section, status: :suspended)
 
       socket = %LiveView.Socket{
@@ -74,7 +75,42 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollmentTest do
       assert redirected_to == "/users/log_in?request_path=%2Fsections%2F#{section.slug}"
 
       assert redirected_socket.assigns.flash["error"] ==
-               "Your access to this course has been suspended. Please contact your instructor."
+               "This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment."
+    end
+
+    test "redirects suspended LTI learner to LMS instructions", %{user: user} do
+      section = insert(:section, registration_open: true, title: "Intro Course")
+      user = %{user | independent_learner: false}
+      insert(:enrollment, user: user, section: section, status: :suspended)
+
+      socket = %LiveView.Socket{
+        endpoint: OliWeb.Endpoint,
+        assigns: %{
+          __changed__: %{},
+          current_user: user,
+          current_author: nil,
+          section: section,
+          flash: %{}
+        }
+      }
+
+      assert {:halt, redirected_socket} =
+               RequireEnrollment.on_mount(
+                 :default,
+                 %{"section_slug" => section.slug},
+                 %{},
+                 socket
+               )
+
+      assert {:redirect, %{to: redirected_to}} = redirected_socket.redirected
+      %URI{path: path, query: query} = URI.parse(redirected_to)
+      assert path == "/lms_user_instructions"
+
+      assert URI.decode_query(query) == %{
+               "request_path" => "/sections/#{section.slug}",
+               "section_title" => "Intro Course",
+               "suspended" => "true"
+             }
     end
 
     test "redirects to login when current_user is nil" do

--- a/test/oli_web/live_session_plugs/require_enrollment_test.exs
+++ b/test/oli_web/live_session_plugs/require_enrollment_test.exs
@@ -105,12 +105,13 @@ defmodule OliWeb.LiveSessionPlugs.RequireEnrollmentTest do
       assert {:redirect, %{to: redirected_to}} = redirected_socket.redirected
       %URI{path: path, query: query} = URI.parse(redirected_to)
       assert path == "/lms_user_instructions"
+      decoded_query = URI.decode_query(query)
 
-      assert URI.decode_query(query) == %{
-               "request_path" => "/sections/#{section.slug}",
-               "section_title" => "Intro Course",
-               "suspended" => "true"
-             }
+      assert decoded_query["request_path"] == "/sections/#{section.slug}"
+      assert decoded_query["section_title"] == "Intro Course"
+      assert decoded_query["section_slug"] == section.slug
+      refute Map.has_key?(decoded_query, "suspended_token")
+      refute Map.has_key?(decoded_query, "suspended")
     end
 
     test "redirects to login when current_user is nil" do


### PR DESCRIPTION
[MER-4326](https://eliterate.atlassian.net/browse/MER-4326)

## Summary

This PR updates suspended-enrollment handling to provide clear, role-appropriate behavior and messaging.

## What changed

- Added explicit suspended-enrollment handling by user type:
  - DD user (logged in): redirected through the existing flow to the student home.
  - LTI user (logged in): redirected to an LMS-facing HTML page with a suspended-enrollment message.
  - Not logged in: redirected to login.
- Updated suspended-enrollment copy to:
  - “This enrollment has been suspended. Please contact your instructor or technical support for further details or to reinstate the enrollment.”

## Outcome

Users with suspended enrollments now receive a clearer and more consistent experience, with messaging and redirects tailored to their access context.

[MER-4326]: https://eliterate.atlassian.net/browse/MER-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ