### PR TITLE
[BUG FIX] [MER-5603] Adaptive review mode fidelity and review-semantics fixes

### DIFF
--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -111,11 +111,16 @@ export const buildReviewCompositeActivity = (activityTree: any[], attemptTree: a
     'partId',
   );
   const currentAttempt = attemptTree?.[attemptTree.length - 1];
+  const compositeActivityKey = `${activityTree.map((activity) => activity.id).join('_')}__${(
+    attemptTree || []
+  )
+    .map((attempt) => attempt?.attemptGuid || attempt?.activityId)
+    .join('_')}_review`;
 
   return [
     {
       ...currentActivity,
-      activityKey: `${currentActivity.id}_${currentActivity.id}_review`,
+      activityKey: compositeActivityKey,
       content: {
         ...currentActivity.content,
         partsLayout: mergedPartsLayout,

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -73,6 +73,21 @@ const dedupeById = (items: any[] = [], idKey: string) => {
   });
 };
 
+const dedupeByIdKeepLast = (items: any[] = [], idKey: string) => {
+  const deduped = new Map();
+
+  items.forEach((item) => {
+    const id = item?.[idKey];
+    if (!id) {
+      return;
+    }
+
+    deduped.set(id, item);
+  });
+
+  return Array.from(deduped.values());
+};
+
 export const buildReviewCompositeActivity = (activityTree: any[], attemptTree: any[]) => {
   if (!activityTree?.length) {
     return [];
@@ -91,7 +106,7 @@ export const buildReviewCompositeActivity = (activityTree: any[], attemptTree: a
     activityTree.flatMap((activity) => activity.authoring?.parts || []),
     'id',
   );
-  const mergedAttemptParts = dedupeById(
+  const mergedAttemptParts = dedupeByIdKeepLast(
     (attemptTree || []).flatMap((attempt) => attempt?.parts || []),
     'partId',
   );

--- a/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
+++ b/assets/src/apps/delivery/layouts/deck/DeckLayoutView.tsx
@@ -59,6 +59,71 @@ const sharedActivityInit = new Map();
 let sharedActivityPromise: any;
 const insightsPreviewInset = 16;
 
+const dedupeById = (items: any[] = [], idKey: string) => {
+  const seen = new Set();
+
+  return items.filter((item) => {
+    const id = item?.[idKey];
+    if (!id || seen.has(id)) {
+      return false;
+    }
+
+    seen.add(id);
+    return true;
+  });
+};
+
+export const buildReviewCompositeActivity = (activityTree: any[], attemptTree: any[]) => {
+  if (!activityTree?.length) {
+    return [];
+  }
+
+  const currentActivity = activityTree[activityTree.length - 1];
+  if (!currentActivity) {
+    return [];
+  }
+
+  const mergedPartsLayout = dedupeById(
+    activityTree.flatMap((activity) => activity.content?.partsLayout || []),
+    'id',
+  );
+  const mergedAuthoringParts = dedupeById(
+    activityTree.flatMap((activity) => activity.authoring?.parts || []),
+    'id',
+  );
+  const mergedAttemptParts = dedupeById(
+    (attemptTree || []).flatMap((attempt) => attempt?.parts || []),
+    'partId',
+  );
+  const currentAttempt = attemptTree?.[attemptTree.length - 1];
+
+  return [
+    {
+      ...currentActivity,
+      activityKey: `${currentActivity.id}_${currentActivity.id}_review`,
+      content: {
+        ...currentActivity.content,
+        partsLayout: mergedPartsLayout,
+      },
+      authoring: currentActivity.authoring
+        ? {
+            ...currentActivity.authoring,
+            parts: mergedAuthoringParts.length
+              ? mergedAuthoringParts
+              : currentActivity.authoring.parts,
+          }
+        : currentActivity.authoring,
+      attemptOverride: currentAttempt
+        ? {
+            ...currentAttempt,
+            parts: mergedAttemptParts,
+          }
+        : undefined,
+      reviewComposite: true,
+    },
+  ];
+};
+
 const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, previewMode }) => {
   const dispatch = useDispatch();
   const fieldRef = React.useRef<HTMLInputElement>(null);
@@ -331,9 +396,6 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       clearTimeout(timeout);
       sharedActivityPromise = null;
       if (historyModeNavigation || reviewMode) {
-        console.log(
-          '[AllActivitiesInit] historyModeNavigation or reviewMode is ON, clearing sharedActivityInit',
-        );
         sharedActivityInit.clear();
       }
     };
@@ -369,7 +431,15 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
 
   const handleActivityReady = useCallback(
     async (activityId: string | number, attemptGuid: string) => {
-      sharedActivityInit.set(activityId, true);
+      const rendersCompositeReview = reviewMode && (currentActivityTree?.length || 0) > 1;
+
+      if (rendersCompositeReview && currentActivityTree?.length) {
+        currentActivityTree.forEach((activity) => {
+          sharedActivityInit.set(activity.id, true);
+        });
+      } else {
+        sharedActivityInit.set(activityId, true);
+      }
       // BS: this is init state phase (mostly) and it needs to run AFTER every part
       // has already saved its "default" values or else the init state rules will just
       // get overwritten by them saving the default value
@@ -388,10 +458,10 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
         if (!historyModeNavigation || reviewMode) {
           await initCurrentActivity();
         }
-        if (historyModeNavigation) {
+        if (historyModeNavigation || reviewMode) {
           // We need to apply the initial state for `customCssClass` because it may contain logic
           // that dynamically applies styles like `display-none` to components.
-          // In history mode, the initial state isn't applied to the snapshot by default,
+          // In history and review modes, the initial state isn't applied to the snapshot by default,
           // so we must manually extract and apply any `customCssClass`-related state.
           const initState = await extractCustomCssClassFactsFromTree();
           if (initState?.length) {
@@ -413,8 +483,6 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
           },
         };
 
-        console.log('DECK HANDLE READY (ALL ACTIVITIES DONE INIT)', { context });
-
         sharedActivityPromise.resolve(context);
         dispatch(setInitPhaseComplete(true));
       }
@@ -428,6 +496,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       dispatch,
       historyModeNavigation,
       reviewMode,
+      currentActivityTree,
       initCurrentActivity,
     ],
   );
@@ -583,7 +652,11 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
     [reviewMode, sectionSlug],
   );
 
-  const [localActivityTree, setLocalActivityTree] = useState<any>(currentActivityTree);
+  const [localActivityTree, setLocalActivityTree] = useState<any>(() =>
+    reviewMode
+      ? buildReviewCompositeActivity(currentActivityTree || [], currentActivityAttemptTree || [])
+      : currentActivityTree,
+  );
   const [triggerWindowsScrollPosition, setTriggerWindowsScrollPosition] = useState(false);
   const [scrollPosition, setScrollPosition] = useState(0);
   const previousActivityIdRef = React.useRef<string | null>(null);
@@ -640,6 +713,13 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       }
 
       if (!currentLocalTree?.length) {
+        if (reviewMode) {
+          return buildReviewCompositeActivity(
+            currentActivityTree,
+            currentActivityAttemptTree || [],
+          );
+        }
+
         return currentActivityTree.map((activity) => ({
           ...activity,
           activityKey:
@@ -651,6 +731,13 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
 
       const currentLocalActivity = currentLocalTree[currentLocalTree.length - 1];
       if (!currentLocalActivity) {
+        if (reviewMode) {
+          return buildReviewCompositeActivity(
+            currentActivityTree,
+            currentActivityAttemptTree || [],
+          );
+        }
+
         return currentActivityTree.map((activity) => ({
           ...activity,
           activityKey:
@@ -663,9 +750,24 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
       // if the current and current local are the same, then we don't need to do anything
       if (currentLocalActivity.id === currentActivity.id) {
         setTriggerWindowsScrollPosition(false);
+        if (reviewMode) {
+          if (currentLocalActivity.reviewComposite) {
+            return currentLocalTree;
+          }
+
+          return buildReviewCompositeActivity(
+            currentActivityTree,
+            currentActivityAttemptTree || [],
+          );
+        }
+
         return currentLocalTree;
       }
       setTriggerWindowsScrollPosition(true);
+      if (reviewMode) {
+        return buildReviewCompositeActivity(currentActivityTree, currentActivityAttemptTree || []);
+      }
+
       return currentActivityTree.map((activity) => ({
         ...activity,
         activityKey: historyModeNavigation
@@ -673,7 +775,7 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
           : activity.id,
       }));
     });
-  }, [currentActivityTree, historyModeNavigation, reviewMode]);
+  }, [currentActivityTree, currentActivityAttemptTree, historyModeNavigation, reviewMode]);
 
   const lastFocusedAdaptiveRef = useRef<HTMLElement | null>(null);
 
@@ -821,9 +923,9 @@ const DeckLayoutView: React.FC<LayoutProps> = ({ pageTitle, pageContent, preview
     // too many times. instead we want to only send the "initial" attempt state
     // activities should then keep track of updates internally and if needed request updates
     const activities = localActivityTree.map((activity: any) => {
-      const attempt = currentActivityAttemptTree?.find(
-        (a) => a?.activityId === activity.resourceId,
-      );
+      const attempt =
+        activity.attemptOverride ||
+        currentActivityAttemptTree?.find((a) => a?.activityId === activity.resourceId);
       if (!attempt) {
         // this will happen but I think it should be OK because it will call this method again
         // when the attempt tree is updated, and next time it will have the state

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -307,7 +307,8 @@ export abstract class DeliveryElement<T extends ActivityModelSchema> extends HTM
         }
         resolve(result);
       };
-      if (this.review) {
+      const allowedInReview = name === 'activityReady';
+      if (this.review && !allowedInReview) {
         continuation(null, 'in review mode');
         return;
       }

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -21,7 +21,7 @@ const partInitResponseMap = new Map();
 const sharedPromiseMap = new Map();
 const sharedAttemptStateMap = new Map();
 
-const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
+export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
   const [activityId, _setActivityId] = useState<string>(
     props.model?.id || props.model?.activity_id || `unknown_activity`,
   );
@@ -107,7 +107,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
     let reject;
 
     if (!partsLayout.length) {
-      if (props.onReady && !isReviewMode) {
+      if (props.onReady) {
         props.onReady(props.state.attemptGuid);
       }
       setInit(true);
@@ -147,7 +147,6 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       }, {}),
     );
 
-    console.log('INIT AD', { activityId, props, sharedAttemptStateMap, sharedInitMap });
     sharedAttemptStateMap.set(activityId, props.state);
 
     setInit(true);
@@ -173,7 +172,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
         partsInitStatus,
       }); */
       if (partsLayout.every((part) => partsInitStatus[part.id] === true)) {
-        if (props.onReady && !isReviewMode) {
+        if (props.onReady) {
           const response: any = Array.from(partInitResponseMap);
           const readyResults: any = await props.onReady(currentAttemptState.attemptGuid, response);
           const { env, domain } = readyResults;
@@ -231,14 +230,6 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
           /* console.log('ACTIVITY READY RESULTS', { testRes, attemptStateMap }); */
           const snapshot = getLocalizedStateSnapshot([activityId], scriptEnv);
           // if for some reason this isn't defined, don't leave it hanging
-          console.log('PARTS READY NO ONREADY HOST (REVIEW MODE)', {
-            partId,
-            scriptEnv,
-            adaptivityDomain,
-            props,
-            snapshot,
-            currentAttemptState,
-          });
           const context = {
             snapshot,
             context: {
@@ -366,7 +357,9 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       // BS: this is the result from the layout pushed down, need to push down to part here?
       return result;
     } else {
-      console.warn('onSavePart not defined, not saving', { response, scriptEnv });
+      if (!isReviewMode) {
+        console.warn('onSavePart not defined, not saving', { response, scriptEnv });
+      }
       // should write to the scriptEnv so that all parts can have the full snapshot?
       const statePrefix = `${activityId}|stage`;
       const responseMap = response.input.reduce(
@@ -376,8 +369,7 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
         },
         {},
       );
-      const evalResult = evalAssignScript(responseMap, scriptEnv);
-      console.log(`[${id}] review mode save evalResult`, evalResult);
+      evalAssignScript(responseMap, scriptEnv);
       return {
         type: 'success',
         snapshot: getLocalizedStateSnapshot([activityId], scriptEnv),
@@ -407,7 +399,9 @@ const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       // BS: this is the result from the layout pushed down, need to push down to part here?
       return result;
     } else {
-      console.warn('onSubmitPart not defined, not submitting');
+      if (!isReviewMode) {
+        console.warn('onSubmitPart not defined, not submitting');
+      }
       return {
         type: 'success',
         snapshot: {},

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -12,6 +12,7 @@ import { PartComponentProps } from '../types/parts';
 import { NavButtonModel } from './schema';
 
 const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) => {
+  const { onInit, onReady, onSave, onSubmit, sectionSlug, resourceId } = props;
   const [state, setState] = useState<any[]>(Array.isArray(props.state) ? props.state : []);
   const [model, setModel] = useState<any>(Array.isArray(props.model) ? props.model : {});
   const [ready, setReady] = useState<boolean>(false);
@@ -66,7 +67,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     const dTransparent = pModel.transparent || '';
     setButtonTransparent(dTransparent);
 
-    const initResult = await props.onInit({
+    const initResult = await onInit({
       id,
       responses: [
         {
@@ -210,14 +211,14 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       return;
     }
     initialize(pModel);
-  }, [props]);
+  }, [props, onInit]);
 
   useEffect(() => {
     if (!ready) {
       return;
     }
-    props.onReady({ id, responses: [] });
-  }, [ready]);
+    onReady({ id, responses: [] });
+  }, [ready, onReady, id]);
 
   useEffect(() => {
     if (!props.notify) {
@@ -442,12 +443,12 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   const submitButtonSelection = (emitAiTrigger = false) => {
     if (emitAiTrigger && model.enableAiTrigger && hasAiTriggerPrompt(model.aiTriggerPrompt)) {
       // The custom element wrapper lowercases attribute names
-      const sectionSlug = (props as any).sectionslug ?? props.sectionSlug;
-      const resourceId =
-        (props as any).resourceid != null ? Number((props as any).resourceid) : props.resourceId;
+      const resolvedSectionSlug = (props as any).sectionslug ?? sectionSlug;
+      const resolvedResourceId =
+        (props as any).resourceid != null ? Number((props as any).resourceid) : resourceId;
       void invokeAdaptiveAiTrigger({
-        sectionSlug,
-        resourceId,
+        sectionSlug: resolvedSectionSlug,
+        resourceId: resolvedResourceId,
         triggerType: 'adaptive_component',
         data: {
           component_id: id,
@@ -456,7 +457,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       });
     }
 
-    props.onSubmit({
+    onSubmit({
       id: `${id}`,
       responses: [
         {
@@ -490,7 +491,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     }
 
     submitButtonSelection(false);
-    props.onSave({
+    onSave({
       id: `${id}`,
       responses: [
         {
@@ -505,7 +506,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
         },
       ],
     });
-  }, [buttonSelected, ready, id, props]);
+  }, [buttonSelected, ready, id, onSave, onSubmit]);
 
   const buttonProps = {
     title: buttonTitle,

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React, { CSSProperties, useCallback, useEffect, useState } from 'react';
+import React, { CSSProperties, useCallback, useEffect, useRef, useState } from 'react';
 import { CapiVariableTypes } from '../../../adaptivity/capi';
 import {
   NotificationType,
@@ -29,6 +29,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   const [buttonImageSrc, setButtonImageSrc] = useState('');
   const [imagePosition, setImagePosition] = useState('');
   const [_cssClass, setCssClass] = useState('');
+  const currentModeRef = useRef<string>(contexts.VIEWER);
 
   const initialize = useCallback(async (pModel) => {
     // set defaults
@@ -179,6 +180,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       setButtonTransparent(sTransparent);
     }
     //Instead of hardcoding REVIEW, we can make it an global interface and then importa that here.
+    currentModeRef.current = initResult.context.mode || contexts.VIEWER;
     if (initResult.context.mode === contexts.REVIEW) {
       setButtonEnabled(false);
     }
@@ -239,21 +241,23 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
             //This is so that on screens where the nav button is used to trigger some action on the current screen, and not navigate to a different screen,
             //the button will reset
             setButtonSelected(false);
-            props.onSave({
-              id: `${id}`,
-              responses: [
-                {
-                  key: 'Selected',
-                  type: CapiVariableTypes.BOOLEAN,
-                  value: false,
-                },
-                {
-                  key: 'selected',
-                  type: CapiVariableTypes.BOOLEAN,
-                  value: false,
-                },
-              ],
-            });
+            if (currentModeRef.current !== contexts.REVIEW) {
+              props.onSave({
+                id: `${id}`,
+                responses: [
+                  {
+                    key: 'Selected',
+                    type: CapiVariableTypes.BOOLEAN,
+                    value: false,
+                  },
+                  {
+                    key: 'selected',
+                    type: CapiVariableTypes.BOOLEAN,
+                    value: false,
+                  },
+                ],
+              });
+            }
             break;
           case NotificationType.STATE_CHANGED:
             {
@@ -319,6 +323,10 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
             break;
           case NotificationType.CONTEXT_CHANGED:
             {
+              const mode = payload?.context?.mode || payload?.mode;
+              if (mode) {
+                currentModeRef.current = mode;
+              }
               const { initStateFacts: changes } = payload;
               const sTitle = changes[`stage.${id}.title`];
               if (sTitle !== undefined) {
@@ -378,7 +386,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
                 setButtonTransparent(sTransparent);
               }
 
-              if (payload.mode === contexts.REVIEW) {
+              if (mode === contexts.REVIEW) {
                 setButtonEnabled(false);
               }
             }
@@ -465,8 +473,22 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
     });
   };
 
-  if (buttonSelected) {
+  useEffect(() => {
+    //TODO commenting for now. Need to revisit once state structure logic is in place
+    //handleStateChange(state);
+  }, [state]);
+
+  useEffect(() => {
+    if (!ready || !buttonSelected) {
+      return;
+    }
+
     setButtonSelected(false);
+
+    if (currentModeRef.current === contexts.REVIEW) {
+      return;
+    }
+
     submitButtonSelection(false);
     props.onSave({
       id: `${id}`,
@@ -483,12 +505,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
         },
       ],
     });
-  }
-
-  useEffect(() => {
-    //TODO commenting for now. Need to revisit once state structure logic is in place
-    //handleStateChange(state);
-  }, [state]);
+  }, [buttonSelected, ready, id, props]);
 
   const buttonProps = {
     title: buttonTitle,

--- a/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
+++ b/assets/src/components/parts/janus-navigation-button/NavigationButton.tsx
@@ -29,7 +29,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
   const [buttonImageSrc, setButtonImageSrc] = useState('');
   const [imagePosition, setImagePosition] = useState('');
   const [_cssClass, setCssClass] = useState('');
-  const currentModeRef = useRef<string>(contexts.VIEWER);
+  const isReviewModeRef = useRef(false);
 
   const initialize = useCallback(async (pModel) => {
     // set defaults
@@ -180,8 +180,8 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
       setButtonTransparent(sTransparent);
     }
     //Instead of hardcoding REVIEW, we can make it an global interface and then importa that here.
-    currentModeRef.current = initResult.context.mode || contexts.VIEWER;
-    if (initResult.context.mode === contexts.REVIEW) {
+    isReviewModeRef.current = initResult.context.mode === contexts.REVIEW;
+    if (isReviewModeRef.current) {
       setButtonEnabled(false);
     }
     setReady(true);
@@ -241,7 +241,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
             //This is so that on screens where the nav button is used to trigger some action on the current screen, and not navigate to a different screen,
             //the button will reset
             setButtonSelected(false);
-            if (currentModeRef.current !== contexts.REVIEW) {
+            if (!isReviewModeRef.current) {
               props.onSave({
                 id: `${id}`,
                 responses: [
@@ -324,8 +324,8 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
           case NotificationType.CONTEXT_CHANGED:
             {
               const mode = payload?.context?.mode || payload?.mode;
-              if (mode) {
-                currentModeRef.current = mode;
+              if (mode === contexts.REVIEW) {
+                isReviewModeRef.current = true;
               }
               const { initStateFacts: changes } = payload;
               const sTitle = changes[`stage.${id}.title`];
@@ -485,7 +485,7 @@ const NavigationButton: React.FC<PartComponentProps<NavButtonModel>> = (props) =
 
     setButtonSelected(false);
 
-    if (currentModeRef.current === contexts.REVIEW) {
+    if (isReviewModeRef.current) {
       return;
     }
 

--- a/assets/test/delivery/adaptive_delivery_test.tsx
+++ b/assets/test/delivery/adaptive_delivery_test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, waitFor } from '@testing-library/react';
+import { Environment } from 'janus-script';
+import { Adaptive } from 'components/activities/adaptive/AdaptiveDelivery';
+
+jest.mock('components/activities/adaptive/components/delivery/PartsLayoutRenderer', () => {
+  return function MockPartsLayoutRenderer(props: any) {
+    jest.requireActual('react').useEffect(() => {
+      props.parts.forEach((part: any) => {
+        props.onPartInit({ id: part.id, responses: [] });
+      });
+    }, []);
+
+    return null;
+  };
+});
+
+describe('AdaptiveDelivery', () => {
+  it('uses the normal host onReady path in review mode', async () => {
+    const onReady = jest.fn(() =>
+      Promise.resolve({
+        snapshot: { 'stage.part1.customCssClass': 'hidden' },
+        context: { mode: 'REVIEW' },
+        env: new Environment(),
+        domain: 'stage',
+      }),
+    );
+
+    render(
+      <Adaptive
+        mode="review"
+        model={{
+          id: 'adaptive_screen_1',
+          resourceId: 1,
+          content: {
+            custom: {},
+            partsLayout: [{ id: 'part1', type: 'janus-text-flow', custom: {} }],
+          },
+          authoring: { parts: [], transformations: [], previewText: '' },
+        }}
+        state={{
+          attemptGuid: 'attempt-1',
+          attemptNumber: 1,
+          activityId: 1,
+          dateEvaluated: null,
+          dateSubmitted: null,
+          score: null,
+          outOf: null,
+          parts: [],
+          hasMoreAttempts: true,
+          hasMoreHints: true,
+          groupId: null,
+        }}
+        context={{
+          graded: false,
+          batchScoring: false,
+          oneAtATime: false,
+          maxAttempts: 0,
+          scoringStrategyId: 0,
+          ordinal: 1,
+          sectionSlug: 'section-1',
+          projectSlug: '',
+          userId: 1,
+          groupId: null,
+          surveyId: null,
+          bibParams: null,
+          pageAttemptGuid: '',
+          showFeedback: null,
+          renderPointMarkers: false,
+          isAnnotationLevel: false,
+          variables: {},
+          pageLinkParams: {},
+          allowHints: false,
+          responsiveLayout: false,
+        }}
+        onReady={onReady as any}
+        onRequestHint={jest.fn() as any}
+        onSavePart={jest.fn() as any}
+        onSubmitPart={jest.fn() as any}
+        onResetPart={jest.fn() as any}
+        onSaveActivity={jest.fn() as any}
+        onSubmitActivity={jest.fn() as any}
+        onResetActivity={jest.fn() as any}
+        onSubmitEvaluations={jest.fn() as any}
+      />,
+    );
+
+    await waitFor(() => expect(onReady).toHaveBeenCalledWith('attempt-1', []));
+  });
+});

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
-import DeckLayoutView from 'apps/delivery/layouts/deck/DeckLayoutView';
+import DeckLayoutView, {
+  buildReviewCompositeActivity,
+} from 'apps/delivery/layouts/deck/DeckLayoutView';
 import {
   selectHistoryNavigationActivity,
   selectLessonEnd,
@@ -99,5 +101,54 @@ describe('DeckLayoutView', () => {
     expect(container.querySelector('#stage-stage')).toBeInTheDocument();
     expect(container.querySelector('.stage-content-wrapper')).toBeInTheDocument();
     expect(container).toHaveTextContent('loading...');
+  });
+
+  it('builds a single composed activity for layered adaptive review screens', () => {
+    const parentActivity = {
+      id: 'parent-screen',
+      resourceId: 1,
+      activityType: 'adaptive',
+      content: {
+        custom: {},
+        partsLayout: [{ id: 'progressBar', type: 'janus-progress', custom: {} }],
+      },
+      authoring: { parts: [{ id: 'progressBar' }], transformations: [], previewText: '' },
+    };
+    const childActivity = {
+      id: 'child-screen',
+      resourceId: 2,
+      activityType: 'adaptive',
+      content: {
+        custom: {},
+        partsLayout: [{ id: 'question1', type: 'janus-text-flow', custom: {} }],
+      },
+      authoring: { parts: [{ id: 'question1' }], transformations: [], previewText: '' },
+    };
+    const attemptTree = [
+      { activityId: 1, parts: [{ partId: 'progressBar', attemptGuid: 'part-parent' }] },
+      { activityId: 2, parts: [{ partId: 'question1', attemptGuid: 'part-child' }] },
+    ];
+    const layeredActivityTree = [parentActivity, childActivity];
+
+    const [composedActivity] = buildReviewCompositeActivity(layeredActivityTree, attemptTree);
+
+    expect(composedActivity).toEqual(
+      expect.objectContaining({
+        id: 'child-screen',
+        reviewComposite: true,
+        content: expect.objectContaining({
+          partsLayout: expect.arrayContaining([
+            expect.objectContaining({ id: 'progressBar' }),
+            expect.objectContaining({ id: 'question1' }),
+          ]),
+        }),
+        attemptOverride: expect.objectContaining({
+          parts: expect.arrayContaining([
+            expect.objectContaining({ partId: 'progressBar' }),
+            expect.objectContaining({ partId: 'question1' }),
+          ]),
+        }),
+      }),
+    );
   });
 });

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -125,8 +125,16 @@ describe('DeckLayoutView', () => {
       authoring: { parts: [{ id: 'question1' }], transformations: [], previewText: '' },
     };
     const attemptTree = [
-      { activityId: 1, parts: [{ partId: 'progressBar', attemptGuid: 'part-parent' }] },
-      { activityId: 2, parts: [{ partId: 'question1', attemptGuid: 'part-child' }] },
+      {
+        activityId: 1,
+        attemptGuid: 'attempt-parent',
+        parts: [{ partId: 'progressBar', attemptGuid: 'part-parent' }],
+      },
+      {
+        activityId: 2,
+        attemptGuid: 'attempt-child',
+        parts: [{ partId: 'question1', attemptGuid: 'part-child' }],
+      },
     ];
     const layeredActivityTree = [parentActivity, childActivity];
 
@@ -135,6 +143,7 @@ describe('DeckLayoutView', () => {
     expect(composedActivity).toEqual(
       expect.objectContaining({
         id: 'child-screen',
+        activityKey: 'parent-screen_child-screen__attempt-parent_attempt-child_review',
         reviewComposite: true,
         content: expect.objectContaining({
           partsLayout: expect.arrayContaining([

--- a/assets/test/delivery/deck_layout_view_test.tsx
+++ b/assets/test/delivery/deck_layout_view_test.tsx
@@ -151,4 +151,48 @@ describe('DeckLayoutView', () => {
       }),
     );
   });
+
+  it('keeps the latest duplicate attempt part state in review composition', () => {
+    const activityTree = [
+      {
+        id: 'screen-1',
+        resourceId: 1,
+        content: { partsLayout: [{ id: 'shared-part', type: 'janus-text-flow', custom: {} }] },
+        authoring: { parts: [{ id: 'shared-part' }], transformations: [], previewText: '' },
+      },
+    ];
+    const attemptTree = [
+      {
+        activityId: 1,
+        parts: [
+          {
+            partId: 'shared-part',
+            attemptGuid: 'older-guid',
+            response: { input: [{ value: 'old' }] },
+          },
+        ],
+      },
+      {
+        activityId: 1,
+        parts: [
+          {
+            partId: 'shared-part',
+            attemptGuid: 'newer-guid',
+            response: { input: [{ value: 'new' }] },
+          },
+        ],
+      },
+    ];
+
+    const [composedActivity] = buildReviewCompositeActivity(activityTree, attemptTree);
+    const [mergedPart] = composedActivity.attemptOverride.parts;
+
+    expect(mergedPart).toEqual(
+      expect.objectContaining({
+        partId: 'shared-part',
+        attemptGuid: 'newer-guid',
+        response: { input: [{ value: 'new' }] },
+      }),
+    );
+  });
 });

--- a/assets/test/parts/navigation_button_ai_trigger_test.tsx
+++ b/assets/test/parts/navigation_button_ai_trigger_test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { EventEmitter } from 'events';
 import { CapiVariableTypes } from '../../src/adaptivity/capi';
+import { NotificationType } from '../../src/apps/delivery/components/NotificationContext';
 import NavigationButton from '../../src/components/parts/janus-navigation-button/NavigationButton';
 
 jest.mock('../../src/data/persistence/trigger', () => ({
@@ -112,5 +114,53 @@ describe('NavigationButton AI trigger', () => {
 
     expect(onSave).not.toHaveBeenCalled();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('does not allow contextChanged payloads to re-enable save behavior after entering review mode', async () => {
+    const onSave = jest.fn(() => Promise.resolve({ type: 'success' }));
+    const notify = new EventEmitter();
+
+    render(
+      <NavigationButton
+        id="nav-button-review-context"
+        type="janus-navigation-button"
+        model={serializeModel({
+          title: 'Next',
+          ariaLabel: 'Next screen',
+          visible: true,
+          enabled: true,
+          selected: false,
+        })}
+        state="{}"
+        sectionSlug="section-1"
+        resourceId={101}
+        notify={notify as any}
+        onInit={() =>
+          Promise.resolve({
+            snapshot: {},
+            context: { mode: 'REVIEW' },
+          })
+        }
+        onReady={() => Promise.resolve({ type: 'success' })}
+        onSave={onSave}
+        onSubmit={() => Promise.resolve({ type: 'success' })}
+        onResize={() => Promise.resolve({ type: 'success' })}
+      />,
+    );
+
+    await screen.findByRole('button', { name: 'Next screen' });
+
+    await act(async () => {
+      notify.emit(NotificationType.CONTEXT_CHANGED, {
+        context: { mode: 'delivery' },
+        initStateFacts: {},
+      });
+    });
+
+    await act(async () => {
+      notify.emit(NotificationType.CHECK_COMPLETE, {});
+    });
+
+    expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/assets/test/parts/navigation_button_ai_trigger_test.tsx
+++ b/assets/test/parts/navigation_button_ai_trigger_test.tsx
@@ -163,5 +163,4 @@ describe('NavigationButton AI trigger', () => {
 
     expect(onSave).not.toHaveBeenCalled();
   });
-
 });

--- a/assets/test/parts/navigation_button_ai_trigger_test.tsx
+++ b/assets/test/parts/navigation_button_ai_trigger_test.tsx
@@ -74,4 +74,43 @@ describe('NavigationButton AI trigger', () => {
       },
     });
   });
+
+  it('does not attempt to save or submit in review mode when selected is true', async () => {
+    const onSave = jest.fn(() => Promise.resolve({ type: 'success' }));
+    const onSubmit = jest.fn(() => Promise.resolve({ type: 'success' }));
+
+    render(
+      <NavigationButton
+        id="nav-button-review"
+        type="janus-navigation-button"
+        model={serializeModel({
+          title: 'Next',
+          ariaLabel: 'Next screen',
+          visible: true,
+          enabled: true,
+          selected: true,
+        })}
+        state="{}"
+        sectionSlug="section-1"
+        resourceId={101}
+        onInit={() =>
+          Promise.resolve({
+            snapshot: {
+              'stage.nav-button-review.Selected': true,
+            },
+            context: { mode: 'REVIEW' },
+          })
+        }
+        onReady={() => Promise.resolve({ type: 'success' })}
+        onSave={onSave}
+        onSubmit={onSubmit}
+        onResize={() => Promise.resolve({ type: 'success' })}
+      />,
+    );
+
+    await screen.findByRole('button', { name: 'Next screen' });
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/assets/test/parts/navigation_button_ai_trigger_test.tsx
+++ b/assets/test/parts/navigation_button_ai_trigger_test.tsx
@@ -163,4 +163,5 @@ describe('NavigationButton AI trigger', () => {
 
     expect(onSave).not.toHaveBeenCalled();
   });
+
 });


### PR DESCRIPTION
## Summary

This PR fixes adaptive review mode so it more closely reproduces what is rendered in delivery and authoring while still preserving review semantics.

The main issues were:

  - adaptive review was bypassing the normal activity host initialization path
  - layered adaptive review could render multiple sibling `oli-adaptive-delivery` roots instead of one composed review screen
  - review mode was not replaying `customCssClass` init facts consistently
  - review-only navigation interactions were still attempting save/submit behavior

## What changed

### Review uses the normal adaptive host init path

Adaptive review now goes through the normal `activityReady` host flow instead of falling back to the review-only no-host path.

This keeps adaptive review aligned with delivery for:

  - activity initialization
  - init-state application
  - context propagation
  - adaptive layout setup

To support that, review mode now allows `activityReady` through the delivery element bridge while still blocking persistence-oriented actions.

### Layered adaptive review renders a single composed screen

Review mode no longer renders the full adaptive lineage as multiple sibling activity roots.

Instead, layered adaptive review is composed into a single rendered activity using:

  - merged `partsLayout`
  - merged authoring parts
  - merged attempt-part state

This removes duplicate `oli-adaptive-delivery` roots in review and brings the rendered structure closer to the authored/delivered adaptive page.

### Review replays `customCssClass` init facts

Review mode now reapplies `customCssClass` init facts the same way history mode does.

This fixes cases where authored adaptive styling depended on init-state-driven CSS classes that were present in delivery but missing in review.

### Review navigation no longer saves or submits

Navigation button behavior was hardened so review mode does not attempt to save or submit.

This preserves review semantics while avoiding review-only reinitialization churn and incorrect persistence attempts.