### PR TITLE
[BUG FIX] [MER-5280] Fix page number and title vertical alignment

### DIFF
--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -68,11 +68,11 @@ defmodule OliWeb.Delivery.Student.Utils do
               </div>
             </div>
           </div>
-          <div role="page label" class="self-stretch justify-start items-start gap-2.5 inline-flex">
+          <div role="page label" class="self-stretch justify-start items-baseline gap-2.5 inline-flex">
             <div
               :if={@index}
               role="page numbering index"
-              class="text-Text-text-low text-[32px] sm:text-[40px] font-bold opacity-75"
+              class="text-Text-text-low text-[32px] sm:text-[40px] leading-[44px] font-bold opacity-75"
             >
               {@index}.
             </div>


### PR DESCRIPTION
Fixes the alignment:

<img width="958" height="386" alt="Screenshot 2026-05-06 at 8 36 49 AM" src="https://github.com/user-attachments/assets/743590e8-f4b7-4a81-beb3-56bb65f5296b" />
