### PR TITLE
[BUG FIX] [MER-5612] Implement student progress CSV download

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1837,9 +1837,9 @@ defmodule Oli.Delivery.Sections do
   Returns per-page progress rows for a student in a section, including
   score/access/attempt metadata and timestamps.
   """
-  def student_progress_rows(section_slug, student_id) do
+  def student_progress_rows(%Section{} = section, student_id) do
     resource_accesses =
-      Oli.Delivery.Attempts.Core.get_resource_accesses(section_slug, student_id)
+      Oli.Delivery.Attempts.Core.get_resource_accesses(section.slug, student_id)
       |> Enum.reduce(%{}, fn r, m ->
         resource_access =
           case r.score do
@@ -1851,8 +1851,8 @@ defmodule Oli.Delivery.Sections do
       end)
 
     page_nodes =
-      section_slug
-      |> DeliveryResolver.full_hierarchy()
+      section
+      |> SectionResourceDepot.get_delivery_resolver_full_hierarchy()
       |> Hierarchy.flatten()
       |> Enum.filter(&(&1.revision.resource_type_id == ResourceType.id_for_page()))
 
@@ -1880,18 +1880,19 @@ defmodule Oli.Delivery.Sections do
       end)
 
     unordered_rows =
-      section_slug
-      |> fetch_all_pages(nil, :resource_id)
+      section.id
+      |> SectionResourceDepot.retrieve_schedule(:pages)
+      |> Enum.sort_by(& &1.resource_id)
       |> Enum.reject(&MapSet.member?(ordered_ids, &1.resource_id))
-      |> Enum.map(fn rev ->
-        ra = Map.get(resource_accesses, rev.resource_id)
+      |> Enum.map(fn section_resource ->
+        ra = Map.get(resource_accesses, section_resource.resource_id)
 
         %{
-          resource_id: rev.resource_id,
-          node: %{ancestors: [], revision: %{title: rev.title}, numbering: %{}},
+          resource_id: section_resource.resource_id,
+          node: %{ancestors: [], revision: %{title: section_resource.title}, numbering: %{}},
           index: nil,
-          title: rev.title,
-          type: if(rev.graded, do: "Scored", else: "Practice"),
+          title: section_resource.title,
+          type: if(section_resource.graded, do: "Scored", else: "Practice"),
           was_late: if(is_nil(ra), do: false, else: ra.was_late),
           score: if(is_nil(ra), do: nil, else: ra.score),
           out_of: if(is_nil(ra), do: nil, else: ra.out_of),

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1834,6 +1834,81 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Returns per-page progress rows for a student in a section, including
+  score/access/attempt metadata and timestamps.
+  """
+  def student_progress_rows(section_slug, student_id) do
+    resource_accesses =
+      Oli.Delivery.Attempts.Core.get_resource_accesses(section_slug, student_id)
+      |> Enum.reduce(%{}, fn r, m ->
+        resource_access =
+          case r.score do
+            nil -> r
+            _ -> Map.put(r, :score, round_score(r.score))
+          end
+
+        Map.put(m, r.resource_id, resource_access)
+      end)
+
+    page_nodes =
+      section_slug
+      |> DeliveryResolver.full_hierarchy()
+      |> Hierarchy.flatten()
+      |> Enum.filter(&(&1.revision.resource_type_id == ResourceType.id_for_page()))
+
+    ordered_ids = MapSet.new(page_nodes, & &1.revision.resource_id)
+
+    ordered_rows =
+      Enum.with_index(page_nodes, fn node, index ->
+        resource_id = node.revision.resource_id
+        ra = Map.get(resource_accesses, resource_id)
+
+        %{
+          resource_id: resource_id,
+          node: node,
+          index: index + 1,
+          title: node.revision.title,
+          type: if(node.revision.graded, do: "Scored", else: "Practice"),
+          was_late: if(is_nil(ra), do: false, else: ra.was_late),
+          score: if(is_nil(ra), do: nil, else: ra.score),
+          out_of: if(is_nil(ra), do: nil, else: ra.out_of),
+          number_attempts: if(is_nil(ra), do: 0, else: ra.resource_attempts_count),
+          number_accesses: if(is_nil(ra), do: 0, else: ra.access_count),
+          updated_at: if(is_nil(ra), do: nil, else: ra.updated_at),
+          inserted_at: if(is_nil(ra), do: nil, else: ra.inserted_at)
+        }
+      end)
+
+    unordered_rows =
+      section_slug
+      |> fetch_all_pages(nil, :resource_id)
+      |> Enum.reject(&MapSet.member?(ordered_ids, &1.resource_id))
+      |> Enum.map(fn rev ->
+        ra = Map.get(resource_accesses, rev.resource_id)
+
+        %{
+          resource_id: rev.resource_id,
+          node: %{ancestors: [], revision: %{title: rev.title}, numbering: %{}},
+          index: nil,
+          title: rev.title,
+          type: if(rev.graded, do: "Scored", else: "Practice"),
+          was_late: if(is_nil(ra), do: false, else: ra.was_late),
+          score: if(is_nil(ra), do: nil, else: ra.score),
+          out_of: if(is_nil(ra), do: nil, else: ra.out_of),
+          number_attempts: if(is_nil(ra), do: 0, else: ra.resource_attempts_count),
+          number_accesses: if(is_nil(ra), do: 0, else: ra.access_count),
+          updated_at: if(is_nil(ra), do: nil, else: ra.updated_at),
+          inserted_at: if(is_nil(ra), do: nil, else: ra.inserted_at)
+        }
+      end)
+
+    ordered_rows ++ unordered_rows
+  end
+
+  defp round_score(score) when is_float(score), do: Float.round(score, 2)
+  defp round_score(score), do: score
+
+  @doc """
   Fetches all non-deleted modules for a given section.
 
   ## Parameters

--- a/lib/oli_web/components/delivery/progress/progress.ex
+++ b/lib/oli_web/components/delivery/progress/progress.ex
@@ -74,7 +74,15 @@ defmodule OliWeb.Components.Delivery.Progress do
           </h4>
 
           <a
-            href="#"
+            href={
+              Routes.delivery_path(
+                OliWeb.Endpoint,
+                :download_student_progress,
+                @section_slug,
+                @student_id
+              )
+            }
+            download="student_progress.csv"
             class="flex items-center justify-center gap-x-2 text-Text-text-button font-bold"
           >
             Download CSV <Icons.download />

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -436,6 +436,48 @@ defmodule OliWeb.DeliveryController do
     end
   end
 
+  def download_student_progress(conn, %{"student_id" => student_id}) do
+    with {:ok, section} <- ensure_instructor_access(conn),
+         {student_id, ""} <- Integer.parse(student_id),
+         %{} <- Sections.get_enrollment(section.slug, student_id, filter_by_status: false) do
+      contents =
+        Sections.student_progress_rows(section.slug, student_id)
+        |> Enum.map(fn row ->
+          %{
+            index: row.index,
+            resource_title: row.title,
+            type: row.type,
+            score: format_student_progress_score(row),
+            attempts: row.number_attempts,
+            accesses: row.number_accesses,
+            first_visited: row.inserted_at,
+            last_visited: row.updated_at
+          }
+        end)
+        |> DataTable.new()
+        |> DataTable.headers(
+          index: "#",
+          resource_title: "Resource Title",
+          type: "Type",
+          score: "Score",
+          attempts: "# Attempts",
+          accesses: "# Accesses",
+          first_visited: "First Visited",
+          last_visited: "Last Visited"
+        )
+        |> DataTable.to_csv_content()
+
+      conn
+      |> put_resp_header("content-type", "text/csv")
+      |> send_download({:binary, contents},
+        filename: "#{section.slug}_student_#{student_id}_progress.csv"
+      )
+    else
+      {:error, :not_found} -> render_section_not_found(conn)
+      _ -> render_forbidden(conn)
+    end
+  end
+
   def download_learning_objectives(conn, _params) do
     with {:ok, section} <- ensure_instructor_access(conn) do
       contents =
@@ -761,6 +803,19 @@ defmodule OliWeb.DeliveryController do
       student_ids
     )
   end
+
+  defp format_student_progress_score(%{
+         type: "Scored",
+         score: score,
+         out_of: out_of,
+         was_late: was_late
+       })
+       when not is_nil(score) and not is_nil(out_of) do
+    base_score = "#{score} / #{out_of}"
+    if was_late, do: "#{base_score} (LATE)", else: base_score
+  end
+
+  defp format_student_progress_score(_), do: nil
 
   defp sort_data(results) do
     Enum.sort_by(

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -441,7 +441,7 @@ defmodule OliWeb.DeliveryController do
          {student_id, ""} <- Integer.parse(student_id),
          %{} <- Sections.get_enrollment(section.slug, student_id, filter_by_status: false) do
       contents =
-        Sections.student_progress_rows(section.slug, student_id)
+        Sections.student_progress_rows(section, student_id)
         |> Enum.map(fn row ->
           %{
             index: row.index,

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -92,7 +92,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
       socket
       |> assign(params: params, active_tab: String.to_existing_atom(params["active_tab"]))
       |> assign_new(:pages, fn ->
-        Sections.student_progress_rows(socket.assigns.section.slug, socket.assigns.student.id)
+        Sections.student_progress_rows(socket.assigns.section, socket.assigns.student.id)
       end)
 
     {:noreply, socket}

--- a/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/student_dashboard/student_dashboard_live.ex
@@ -4,9 +4,6 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
 
   require Logger
 
-  import Ecto.Query, warn: false
-  import OliWeb.Common.Utils
-
   alias OliWeb.Delivery.InstructorDashboard.HTMLComponents
   alias OliWeb.Delivery.StudentDashboard.Components.Helpers
   alias Oli.Delivery.Sections
@@ -95,7 +92,7 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
       socket
       |> assign(params: params, active_tab: String.to_existing_atom(params["active_tab"]))
       |> assign_new(:pages, fn ->
-        get_page_nodes(socket.assigns.section.slug, socket.assigns.student.id)
+        Sections.student_progress_rows(socket.assigns.section.slug, socket.assigns.student.id)
       end)
 
     {:noreply, socket}
@@ -274,93 +271,6 @@ defmodule OliWeb.Delivery.StudentDashboard.StudentDashboardLive do
 
         {total_count, containers_with_metrics}
     end
-  end
-
-  defp get_page_nodes(section_slug, student_id) do
-    resource_accesses =
-      Oli.Delivery.Attempts.Core.get_resource_accesses(
-        section_slug,
-        student_id
-      )
-      |> Enum.reduce(%{}, fn r, m ->
-        # limit score decimals to two significant figures, rounding up
-        r =
-          case r.score do
-            nil -> r
-            _ -> Map.put(r, :score, format_score(r.score))
-          end
-
-        Map.put(m, r.resource_id, r)
-      end)
-
-    hierarchy = Oli.Publishing.DeliveryResolver.full_hierarchy(section_slug)
-
-    page_nodes =
-      hierarchy
-      |> Oli.Delivery.Hierarchy.flatten()
-      |> Enum.filter(fn node ->
-        node.revision.resource_type_id ==
-          Oli.Resources.ResourceType.id_for_page()
-      end)
-
-    ordered_pages =
-      Enum.with_index(page_nodes, fn node, index ->
-        ra = Map.get(resource_accesses, node.revision.resource_id)
-
-        %{
-          resource_id: node.revision.resource_id,
-          node: node,
-          index: index + 1,
-          title: node.revision.title,
-          type: if(node.revision.graded, do: "Scored", else: "Practice"),
-          was_late: if(is_nil(ra), do: false, else: ra.was_late),
-          score: if(is_nil(ra), do: nil, else: ra.score),
-          out_of: if(is_nil(ra), do: nil, else: ra.out_of),
-          number_attempts: if(is_nil(ra), do: 0, else: ra.resource_attempts_count),
-          number_accesses: if(is_nil(ra), do: 0, else: ra.access_count),
-          updated_at: if(is_nil(ra), do: nil, else: ra.updated_at),
-          inserted_at: if(is_nil(ra), do: nil, else: ra.inserted_at)
-        }
-      end)
-
-    ordered_pages_set = Enum.into(ordered_pages, MapSet.new(), fn page -> page.resource_id end)
-
-    page_id = Oli.Resources.ResourceType.id_for_page()
-
-    unordered =
-      from(
-        [s: s, sr: sr, rev: rev] in Oli.Publishing.DeliveryResolver.section_resource_revisions(
-          section_slug
-        ),
-        where: rev.resource_type_id == ^page_id,
-        select: %{
-          title: rev.title,
-          graded: rev.graded,
-          resource_id: rev.resource_id
-        }
-      )
-      |> Oli.Repo.all()
-      |> Enum.filter(fn row -> !MapSet.member?(ordered_pages_set, row.resource_id) end)
-      |> Enum.map(fn row ->
-        ra = Map.get(resource_accesses, row.resource_id)
-
-        %{
-          resource_id: row.resource_id,
-          node: %{ancestors: [], revision: %{title: row.title}, numbering: %{}},
-          index: nil,
-          title: row.title,
-          type: if(row.graded, do: "Scored", else: "Practice"),
-          was_late: if(is_nil(ra), do: false, else: ra.was_late),
-          score: if(is_nil(ra), do: nil, else: ra.score),
-          out_of: if(is_nil(ra), do: nil, else: ra.out_of),
-          number_attempts: if(is_nil(ra), do: 0, else: ra.resource_attempts_count),
-          number_accesses: if(is_nil(ra), do: 0, else: ra.access_count),
-          updated_at: if(is_nil(ra), do: nil, else: ra.updated_at),
-          inserted_at: if(is_nil(ra), do: nil, else: ra.inserted_at)
-        }
-      end)
-
-    ordered_pages ++ unordered
   end
 
   defp async_calculate_proficiency(section, student_id) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1304,6 +1304,7 @@ defmodule OliWeb.Router do
     get("/downloads/intelligent_dashboard", DeliveryController, :download_intelligent_dashboard)
     get("/downloads/course_content", DeliveryController, :download_course_content_info)
     get("/downloads/students_progress", DeliveryController, :download_students_progress)
+    get("/downloads/student_progress/:student_id", DeliveryController, :download_student_progress)
     get("/downloads/learning_objectives", DeliveryController, :download_learning_objectives)
     get("/downloads/quiz_scores", DeliveryController, :download_quiz_scores)
     get("/downloads/scored_pages", DeliveryController, :download_scored_pages)

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -644,7 +644,9 @@ defmodule OliWeb.DeliveryControllerTest do
       conn =
         conn
         |> log_in_user(instructor)
-        |> get(~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/not-a-number")
+        |> get(
+          ~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/not-a-number"
+        )
 
       assert conn.status == 403
     end

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -590,6 +590,93 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "download_student_progress" do
+    test "downloads student-specific progress csv", %{conn: conn} do
+      %{instructor: instructor, section: section, student1: student} =
+        prepare_student_progress_data()
+
+      conn =
+        conn
+        |> log_in_user(instructor)
+        |> get(
+          ~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/#{student.id}"
+        )
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "attachment; filename=\"#{section.slug}_student_#{student.id}_progress.csv\""
+             ]
+
+      assert get_resp_header(conn, "content-type") == ["text/csv"]
+      assert response(conn, 200)
+
+      [headers | rows] = NimbleCSV.RFC4180.parse_string(conn.resp_body, skip_headers: false)
+
+      assert headers == [
+               "#",
+               "Resource Title",
+               "Type",
+               "Score",
+               "# Attempts",
+               "# Accesses",
+               "First Visited",
+               "Last Visited"
+             ]
+
+      assert length(rows) > 0
+    end
+
+    test "returns 403 for learners", %{conn: conn} do
+      %{section: section, student1: student} = prepare_student_progress_data()
+
+      conn =
+        conn
+        |> log_in_user(student)
+        |> get(
+          ~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/#{student.id}"
+        )
+
+      assert conn.status == 403
+    end
+
+    test "returns 403 when student id is invalid", %{conn: conn} do
+      %{instructor: instructor, section: section} = prepare_student_progress_data()
+
+      conn =
+        conn
+        |> log_in_user(instructor)
+        |> get(~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/not-a-number")
+
+      assert conn.status == 403
+    end
+
+    test "returns 403 when target user is not enrolled in the section", %{conn: conn} do
+      %{instructor: instructor, section: section} = prepare_student_progress_data()
+      outsider = user_fixture()
+
+      conn =
+        conn
+        |> log_in_user(instructor)
+        |> get(
+          ~p"/sections/#{section.slug}/instructor_dashboard/downloads/student_progress/#{outsider.id}"
+        )
+
+      assert conn.status == 403
+    end
+
+    test "redirects to not found for invalid section", %{conn: conn} do
+      %{instructor: instructor, student1: student} = prepare_student_progress_data()
+
+      conn =
+        conn
+        |> log_in_user(instructor)
+        |> get(
+          ~p"/sections/invalid_section_slug/instructor_dashboard/downloads/student_progress/#{student.id}"
+        )
+
+      assert response(conn, 404)
+    end
+  end
+
   describe "download_quiz_scores" do
     setup [:setup_lti_session]
 


### PR DESCRIPTION
[MER-5612](https://eliterate.atlassian.net/browse/MER-5612)

## Summary

This PR implements CSV download support for the `Progress` tab in the `Student Dashboard`. Previously, the `Download CSV` action was not implemented, so clicking it did nothing.

## What changed

- Added a student-specific progress download endpoint.
- Wired the Download CSV button in the Progress tab to that endpoint.
- Implemented CSV generation with one row per course page, including:
  - resource
  - type
  - score
  - attempts
  - accesses
  - first visited / last visited
- Consolidated progress row-building logic into a shared function to avoid duplication between LiveView and controller.
- Added access validation to ensure the requested student belongs to the section.

## Result

CSV download for `Student Dashboard > Progress` now works correctly and is no longer a placeholder/no-op action.

[MER-5612]: https://eliterate.atlassian.net/browse/MER-5612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ