### PR TITLE
[BUGFIX] [MER-3468] No padding on practice pages

### DIFF
--- a/assets/styles/common/purpose.scss
+++ b/assets/styles/common/purpose.scss
@@ -36,6 +36,11 @@
     .content-purpose-content {
       padding: 0px;
     }
+
+    &.has-activity-reference > .content-purpose-content {
+      padding-left: 32px;
+      padding-right: 32px;
+    }
   }
 
   &.checkpoint {

--- a/lib/oli/rendering/group/html.ex
+++ b/lib/oli/rendering/group/html.ex
@@ -11,6 +11,9 @@ defmodule Oli.Rendering.Group.Html do
   @behaviour Oli.Rendering.Group
 
   def group(%Context{} = context, next, %{"id" => id, "purpose" => purpose} = group) do
+    purpose = purpose || "none"
+    has_activity_reference = has_activity_reference?(group)
+
     trigger_button =
       case Map.get(group, "trigger") do
         nil ->
@@ -32,8 +35,13 @@ defmodule Oli.Rendering.Group.Html do
           trigger
       end
 
+    group_classes =
+      ["group", "content-purpose", purpose, has_activity_reference && "has-activity-reference"]
+      |> Enum.filter(& &1)
+      |> Enum.join(" ")
+
     [
-      ~s|<div id="#{id}" class="group content-purpose #{purpose}"><div class="flex content-purpose-label"><div class="flex-grow-1">#{Purposes.label_for(purpose)}</div><div>#{trigger_button}</div></div><div class="content-purpose-content content">|,
+      ~s|<div id="#{id}" class="#{group_classes}"><div class="flex content-purpose-label"><div class="flex-grow-1">#{Purposes.label_for(purpose)}</div><div>#{trigger_button}</div></div><div class="content-purpose-content content">|,
       next.(),
       "</div></div>\n"
     ]
@@ -57,4 +65,10 @@ defmodule Oli.Rendering.Group.Html do
   def error(%Context{} = context, element, error) do
     Error.render(context, element, error, Error.Html)
   end
+
+  defp has_activity_reference?(%{"children" => children}) when is_list(children) do
+    Enum.any?(children, &match?(%{"type" => "activity-reference"}, &1))
+  end
+
+  defp has_activity_reference?(_), do: false
 end

--- a/test/oli/rendering/group/html_test.exs
+++ b/test/oli/rendering/group/html_test.exs
@@ -15,7 +15,9 @@ defmodule Oli.Content.Group.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~ ~s|<div id="group-1" class="group content-purpose none">|
-      assert rendered_html_string =~ ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
+
+      assert rendered_html_string =~
+               ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
     end
 
     test "renders purposeful groups with purpose wrapper" do
@@ -27,9 +29,14 @@ defmodule Oli.Content.Group.HtmlTest do
 
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
-      assert rendered_html_string =~ ~s|<div id="group-2" class="group content-purpose learnbydoing">|
-      assert rendered_html_string =~ ~s|<div class="flex content-purpose-label"><div class="flex-grow-1">Learn by doing</div><div></div></div>|
-      assert rendered_html_string =~ ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
+      assert rendered_html_string =~
+               ~s|<div id="group-2" class="group content-purpose learnbydoing">|
+
+      assert rendered_html_string =~
+               ~s|<div class="flex content-purpose-label"><div class="flex-grow-1">Learn by doing</div><div></div></div>|
+
+      assert rendered_html_string =~
+               ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
     end
 
     test "marks none groups containing activities" do

--- a/test/oli/rendering/group/html_test.exs
+++ b/test/oli/rendering/group/html_test.exs
@@ -1,0 +1,49 @@
+defmodule Oli.Content.Group.HtmlTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Rendering.Context
+  alias Oli.Rendering.Group.Html
+
+  describe "html group renderer" do
+    test "renders purpose none with purpose wrapper" do
+      rendered_html =
+        Html.group(%Context{}, fn -> "<p>inner content</p>" end, %{
+          "id" => "group-1",
+          "purpose" => "none"
+        })
+
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      assert rendered_html_string =~ ~s|<div id="group-1" class="group content-purpose none">|
+      assert rendered_html_string =~ ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
+    end
+
+    test "renders purposeful groups with purpose wrapper" do
+      rendered_html =
+        Html.group(%Context{}, fn -> "<p>inner content</p>" end, %{
+          "id" => "group-2",
+          "purpose" => "learnbydoing"
+        })
+
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      assert rendered_html_string =~ ~s|<div id="group-2" class="group content-purpose learnbydoing">|
+      assert rendered_html_string =~ ~s|<div class="flex content-purpose-label"><div class="flex-grow-1">Learn by doing</div><div></div></div>|
+      assert rendered_html_string =~ ~s|<div class="content-purpose-content content"><p>inner content</p></div>|
+    end
+
+    test "marks none groups containing activities" do
+      rendered_html =
+        Html.group(%Context{}, fn -> "<p>inner content</p>" end, %{
+          "id" => "group-3",
+          "purpose" => "none",
+          "children" => [%{"type" => "activity-reference", "activity_id" => 1}]
+        })
+
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      assert rendered_html_string =~
+               ~s|<div id="group-3" class="group content-purpose none has-activity-reference">|
+    end
+  end
+end


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3468) to the ticket

## Summary

This fixes the missing horizontal padding on delivery activities rendered inside `group` blocks with `purpose: none`.

The root cause was that `purpose: none` groups still rendered with the `content-purpose` wrapper, and the existing styles for `.content-purpose.none` explicitly removed the inner padding. That worked for plain structural groups, but caused activities inside those groups to render flush against the container edges.

## Fix

- Keep the existing `content-purpose none` wrapper so the gray border remains intact
- Add a targeted `has-activity-reference` class for `none` groups that contain activity references
- Restore horizontal padding only for that subset of `none` groups

This keeps the historical styling behavior for normal `none` groups while fixing spacing for activity-based groups in delivery.

### Before
<img width="1273" height="764" alt="image" src="https://github.com/user-attachments/assets/04577111-6626-4b98-9b02-39f5d2efc2e0" />


### After
<img width="1273" height="764" alt="image" src="https://github.com/user-attachments/assets/15b7c0e5-94b5-405b-856d-41a739771802" />
