### PR TITLE
[BUG FIX] [MER-5107] Reposition Support and Cookies on Adaptive Page Not Fullscreen - Rework

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -142,7 +142,7 @@
             <div
               :if={@view == :adaptive_with_chrome}
               id="adaptive-viewport-actions"
-              class="fixed bottom-6 left-16 z-[9999] flex flex-col items-start gap-1"
+              class="flex flex-col items-start gap-1 mt-6 mb-2 ml-4 md:ml-7 xl:ml-0"
             >
               <OliWeb.Components.Common.tech_support_button
                 id="tech-support"
@@ -154,10 +154,11 @@
               :if={@view != :adaptive_with_chrome}
               id="tech-support-wrapper"
               phx-hook="StickyTechSupportButton"
+              class="w-full md:container lg:px-10"
             >
               <OliWeb.Components.Common.tech_support_button
                 id="tech-support"
-                class="-ml-4 md:ml-7 xl:ml-0 xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
+                class="-ml-4 md:-ml-3 xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
               />
             </div>
             <OliWeb.Components.Footer.delivery_footer

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1175,7 +1175,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         |> Floki.raw_html()
 
       refute tech_support =~ ~r/(^|\s)fixed(\s|")/
-      assert tech_support =~ "-ml-4 md:ml-7 xl:ml-0"
+      assert tech_support =~ "-ml-4 md:-ml-3"
       assert tech_support =~ "xl:fixed xl:bottom-2 xl:left-10 xl:z-[999]"
     end
 
@@ -2696,10 +2696,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       refute outline =~ "Unit:"
     end
 
-    test "positions support and cookie preferences in viewport for adaptive with chrome", %{
-      conn: conn,
-      user: user
-    } do
+    test "positions support and cookie preferences in the footer area for adaptive with chrome",
+         %{
+           conn: conn,
+           user: user
+         } do
       %{section: section, adaptive_page: adaptive_page} = create_adaptive_with_chrome_section()
 
       Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
@@ -2710,7 +2711,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
       assert has_element?(
                view,
-               "#adaptive-viewport-actions.fixed #tech-support",
+               "#adaptive-viewport-actions #tech-support",
                "Support"
              )
 
@@ -2733,8 +2734,11 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
         |> Floki.raw_html()
 
       assert viewport_actions =~ "flex-col"
-      assert viewport_actions =~ "bottom-6 left-16"
+      assert viewport_actions =~ "mt-6 mb-2 ml-4 md:ml-7 xl:ml-0"
       assert viewport_actions =~ ~r/id="tech-support"(.|\n)*Cookie Preferences/
+      refute viewport_actions =~ ~r/(^|\s)fixed(\s|")/
+      refute viewport_actions =~ ~r/(^|\s)bottom-/
+      refute viewport_actions =~ ~r/(^|\s)left-/
       refute viewport_actions =~ "bg-delivery-body"
       refute viewport_actions =~ "border-gray"
 


### PR DESCRIPTION
[MER-5107](https://eliterate.atlassian.net/browse/MER-5107)

Reworks the original MER-5107 fix to address the overlap issue reported on adaptive pages. On smaller screens, the Support and Cookie Preferences controls were overlapping adaptive content, CC attributions, and previous/next navigation instead of sitting in the intended footer area.

This update makes the adaptive-page controls footer-bound rather than viewport-fixed, so they no longer float over page content while scrolling. It also keeps the responsive behavior separated between adaptive and non-adaptive pages, preserving the existing non-adaptive layout while applying adaptive-specific spacing and mobile visibility rules.

[MER-5107]: https://eliterate.atlassian.net/browse/MER-5107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ