### PR TITLE
[BUG FIX] [MER-4326] Suspended enrollment message - Rework

### DIFF
--- a/lib/oli_web/controllers/lti_controller.ex
+++ b/lib/oli_web/controllers/lti_controller.ex
@@ -250,13 +250,22 @@ defmodule OliWeb.LtiController do
             lti_params["https://purl.imsglobal.org/spec/lti/claim/roles"]
           )
 
+        existing_enrollment =
+          Sections.get_enrollment(section.slug, user.id, filter_by_status: false)
+
         with :ok <- Sections.ensure_enrollment_allowed(user, section) do
-          case Sections.enroll(user.id, section.id, context_roles) do
-            {:ok, _enrollment} ->
+          case existing_enrollment do
+            %{status: :suspended} ->
               :ok
 
-            {:error, _changeset} ->
-              {:error, :failed_to_enroll_user_in_section}
+            _ ->
+              case Sections.enroll(user.id, section.id, context_roles) do
+                {:ok, _enrollment} ->
+                  :ok
+
+                {:error, _changeset} ->
+                  {:error, :failed_to_enroll_user_in_section}
+              end
           end
         end
     end

--- a/test/oli_web/controllers/lti_controller_test.exs
+++ b/test/oli_web/controllers/lti_controller_test.exs
@@ -417,6 +417,68 @@ defmodule OliWeb.LtiControllerTest do
       refute Oli.Repo.get_by(User, email: another_lti_user.email).name == new_name
     end
 
+    test "launch does not re-enroll a suspended learner", %{
+      conn: conn,
+      registration: registration,
+      deployment: deployment,
+      institution: institution
+    } do
+      platform_jwk = jwk_fixture()
+      cache_keyset_for_registration(registration, platform_jwk)
+
+      section =
+        insert(:section,
+          lti_1p3_deployment: deployment,
+          institution: institution,
+          context_id: "suspended-context",
+          status: :active
+        )
+
+      sub = Oli.Lti.TestHelpers.security_detail_data()["sub"]
+      email = Oli.Lti.TestHelpers.user_detail_data()["email"]
+      lti_user = insert(:user, %{sub: sub, email: email, independent_learner: false})
+
+      insert(:enrollment, user: lti_user, section: section, status: :suspended)
+
+      state = "suspended-launch-state"
+
+      conn =
+        init_launch_session(conn, state,
+          issuer: registration.issuer,
+          client_id: registration.client_id,
+          deployment_id: deployment.deployment_id
+        )
+
+      custom_header = %{"kid" => platform_jwk.kid}
+      signer = Joken.Signer.create("RS256", %{"pem" => platform_jwk.pem}, custom_header)
+
+      claims =
+        Oli.Lti.TestHelpers.all_default_claims()
+        |> Map.delete("iss")
+        |> Map.delete("aud")
+        |> put_in(
+          ["https://purl.imsglobal.org/spec/lti/claim/context", "id"],
+          section.context_id
+        )
+        |> put_in(
+          ["https://purl.imsglobal.org/spec/lti/claim/roles"],
+          ["http://purl.imsglobal.org/vocab/lis/v2/membership#Learner"]
+        )
+
+      {:ok, claims} =
+        Joken.Config.default_claims(iss: registration.issuer, aud: registration.client_id)
+        |> Joken.generate_claims(claims)
+
+      {:ok, id_token, _claims} = Joken.encode_and_sign(claims, signer)
+
+      _conn = post(conn, Routes.lti_path(conn, :launch, %{state: state, id_token: id_token}))
+
+      enrollment =
+        Sections.get_enrollment(section.slug, lti_user.id, filter_by_status: false)
+
+      assert enrollment.status == :suspended
+    end
+
     test "launch successful when aud claim is a list", %{
       conn: conn,
       registration: registration


### PR DESCRIPTION
[MER-4326](https://eliterate.atlassian.net/browse/MER-4326)

## Summary

This PR prevents suspended learners from being automatically re-enrolled during LMS (LTI) launch.

## What changed

  - Updated LTI launch enrollment flow in OliWeb.LtiController.enroll_user/3.
  - Added an existing-enrollment check (filter_by_status: false) before calling Sections.enroll/3.
  - If an enrollment already exists with status: :suspended, launch no longer re-enrolls the learner.
  - Added a regression test in lti_controller_test.exs to verify suspended learners remain suspended after a valid LTI launch.

## Why

We observed that launching from Canvas could change a suspended enrollment back to :enrolled, allowing access when it should remain blocked.

[MER-4326]: https://eliterate.atlassian.net/browse/MER-4326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ