### PR TITLE
[BUG FIX] [MER-4082] Properly handle structs

### DIFF
--- a/lib/oli/authoring/editing/adaptive_duplication.ex
+++ b/lib/oli/authoring/editing/adaptive_duplication.ex
@@ -18,6 +18,9 @@ defmodule Oli.Authoring.Editing.AdaptiveDuplication do
   alias Oli.Publishing.ChangeTracker
   alias Oli.Publishing.PublishedResource
   alias Oli.Repo
+  alias Oli.Resources.Collaboration.CollabSpaceConfig
+  alias Oli.Resources.ExplanationStrategy
+  alias Oli.Resources.Legacy
   alias Oli.Resources.{ResourceType, Revision}
   alias Oli.ScopedFeatureFlags
   alias Oli.Utils.Slug
@@ -710,9 +713,11 @@ defmodule Oli.Authoring.Editing.AdaptiveDuplication do
       retake_mode: source_revision.retake_mode,
       assessment_mode: source_revision.assessment_mode,
       parameters: source_revision.parameters,
-      legacy: embed_to_map(source_revision.legacy),
-      explanation_strategy: embed_to_map(source_revision.explanation_strategy),
-      collab_space_config: embed_to_map(source_revision.collab_space_config),
+      legacy: embed_to_struct(source_revision.legacy, Legacy),
+      explanation_strategy:
+        embed_to_struct(source_revision.explanation_strategy, ExplanationStrategy),
+      collab_space_config:
+        embed_to_struct(source_revision.collab_space_config, CollabSpaceConfig),
       scoring_strategy_id: source_revision.scoring_strategy_id,
       activity_type_id: source_revision.activity_type_id,
       primary_resource_id: source_revision.primary_resource_id,
@@ -723,9 +728,11 @@ defmodule Oli.Authoring.Editing.AdaptiveDuplication do
     }
   end
 
-  defp embed_to_map(nil), do: nil
-  defp embed_to_map(embed) when is_struct(embed), do: Map.from_struct(embed)
-  defp embed_to_map(embed) when is_map(embed), do: embed
+  defp embed_to_struct(nil, _module), do: nil
+  defp embed_to_struct(%module{} = embed, module), do: embed
+
+  defp embed_to_struct(embed, module) when is_map(embed),
+    do: struct(module, Map.delete(embed, :__struct__))
 
   defp update_nested_map(map, key, updater) when is_map(map) do
     case Map.fetch(map, key) do

--- a/test/oli/authoring/editing/adaptive_duplication_test.exs
+++ b/test/oli/authoring/editing/adaptive_duplication_test.exs
@@ -287,6 +287,11 @@ defmodule Oli.Authoring.Editing.AdaptiveDuplicationTest do
           author
         )
 
+      {:ok, screen_two_revision} =
+        Oli.Resources.update_revision(screen_two_revision, %{
+          legacy: %{id: "legacy-screen-2", path: "legacy/screen-2"}
+        })
+
       %{revision: screen_one_revision} =
         Seeder.create_activity(
           %{
@@ -368,6 +373,9 @@ defmodule Oli.Authoring.Editing.AdaptiveDuplicationTest do
 
       [duplicated_screen_one, duplicated_screen_two] =
         Publishing.get_unpublished_revisions(project, duplicated_screen_ids)
+
+      assert duplicated_screen_two.legacy.id == screen_two_revision.legacy.id
+      assert duplicated_screen_two.legacy.path == screen_two_revision.legacy.path
 
       assert duplicated_screen_one.children == [duplicated_screen_two.resource_id]
       assert duplicated_screen_one.activity_refs == [duplicated_screen_two.resource_id]


### PR DESCRIPTION
The issue was in `AdaptiveDuplication.insert_revisions/5`: the bulk insert row builder was converting embedded structs like `%Oli.Resources.Legacy{}` into plain maps.

`Repo.insert_all(Revision, ...)` does not cast embeds like a changeset does, so Ecto expected the embed struct and crashed on `%{id: nil, path: nil}`.

  Changed `lib/oli/authoring/editing/adaptive_duplication.ex` to preserve/rebuild embed structs for:

  - legacy
  - explanation_strategy
  - collab_space_config

I also updated `test/oli/authoring/editing/adaptive_duplication_test.exs` so an adaptive screen with a legacy embed is duplicated successfully and the duplicated screen retains that embed.