### PR TITLE
[BUG FIX] [MER-5312] Adaptive pages: resize adaptive iframe to content

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -65,14 +65,9 @@ export const shouldHideLessonFinishedCloseButton = (
 const adaptiveIframeHeightMessageType = 'oli:adaptive-content-height';
 const adaptiveIframeHeightRequestType = 'oli:request-adaptive-content-height';
 const minimumAdaptiveIframeHeight = 600;
-const adaptiveIframeContentSelectors = [
-  '.stageContainer',
-  '#stage-stage',
-  '.stage-content-wrapper',
-  '.content',
-  'oli-adaptive-delivery',
-  '[data-part-id]',
-].join(',');
+const adaptiveIframeContentSelectors = ['.content', 'oli-adaptive-delivery', '[data-part-id]'].join(
+  ',',
+);
 const adaptiveIframeFallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(
   ',',
 );

--- a/assets/src/hooks/adaptive_iframe_resize.ts
+++ b/assets/src/hooks/adaptive_iframe_resize.ts
@@ -13,14 +13,7 @@ const minIframeHeight = 600;
 const maxIframeHeight = 20_000;
 const heightPollIntervalMs = 1000;
 const stableHeightLimit = 3;
-const contentSelectors = [
-  '.stageContainer',
-  '#stage-stage',
-  '.stage-content-wrapper',
-  '.content',
-  'oli-adaptive-delivery',
-  '[data-part-id]',
-].join(',');
+const contentSelectors = ['.content', 'oli-adaptive-delivery', '[data-part-id]'].join(',');
 const fallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(',');
 
 const findIframe = (root: HTMLElement) =>


### PR DESCRIPTION
Updates the adaptive iframe resize behavior for adaptive lessons shown inside Torus navigation.

The resize logic now measures the active adaptive content elements instead of viewport-sized wrapper containers, which avoids feedback loops where title/exploration pages could keep growing taller after each resize. It also keeps the iframe responsive across adaptive screen changes by using bounded stabilization polling instead of a permanent interval.

See: https://eliterate.atlassian.net/browse/MER-5312?focusedCommentId=50152