### PR TITLE
[BUG FIX] [MER-4439] Render collaborator reCAPTCHA via LiveView hook

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -357,8 +357,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
         title="Collaborators"
         description="Invite other authors by email to contribute to your project. Specify multiple separated by a comma."
       >
-        <script src="https://www.google.com/recaptcha/api.js">
-        </script>
         <.form
           :let={f}
           for={%Plug.Conn{}}
@@ -394,11 +392,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
                 )}
               </div>
             </div>
-            <div id="recaptcha" class="input-group mb-3" phx-update="ignore">
-              <div
-                class="g-recaptcha"
-                data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}
-              />
+            <div
+              id="recaptcha"
+              class="input-group mb-3"
+              phx-hook="Recaptcha"
+              data-sitekey={Application.fetch_env!(:oli, :recaptcha)[:site_key]}
+              phx-update="ignore"
+            >
             </div>
             {error_tag(f, :captcha)}
           </div>

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -46,6 +46,22 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       refute has_element?(view, "label", "Calculate embeddings on publish")
     end
 
+    test "renders collaborator invite reCAPTCHA with the LiveView hook", %{
+      conn: conn,
+      author: author
+    } do
+      project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(
+               view,
+               "#recaptcha[phx-hook='Recaptcha'][data-sitekey][phx-update='ignore']"
+             )
+
+      refute has_element?(view, "#recaptcha .g-recaptcha")
+    end
+
     test "project gets deleted correctly", %{conn: conn, author: author} do
       project = create_project_with_author(author)
 


### PR DESCRIPTION
Fixes the project overview collaborator invite form so reCAPTCHA renders on initial page load.

The form now uses the existing `Recaptcha` LiveView hook directly on the `#recaptcha` container instead of relying on Google’s `.g-recaptcha` auto-render behavior, which could miss LiveView-rendered markup until a failed invite attempt or page refresh.

See: https://eliterate.atlassian.net/browse/MER-4439