### PR TITLE
[BUG FIX] [MER-5621] Manage Section screen still says Product

### DIFF
--- a/lib/oli_web/live/sections/overview_view.ex
+++ b/lib/oli_web/live/sections/overview_view.ex
@@ -148,7 +148,7 @@ defmodule OliWeb.Sections.OverviewView do
         </div>
         <%= unless is_nil(@section.blueprint_id) do %>
           <div class="flex flex-col form-group">
-            <label>Product</label>
+            <label>Template</label>
             <a
               href={
                 Routes.live_path(

--- a/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/manage/manage_tab_test.exs
@@ -79,6 +79,26 @@ defmodule OliWeb.Delivery.InstructorDashboard.ManageTabTest do
                "Manage Certificate Settings"
              )
     end
+
+    test "shows template label for sections created from a template", %{
+      instructor: instructor,
+      conn: conn
+    } do
+      template = insert(:section, type: :blueprint)
+
+      section =
+        insert(:section,
+          type: :enrollable,
+          blueprint_id: template.id
+        )
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, live_view_manage_route(section.slug))
+
+      assert has_element?(view, "label", "Template")
+      refute has_element?(view, "label", "Product")
+    end
   end
 
   describe "admin" do


### PR DESCRIPTION
[MER-5621](https://eliterate.atlassian.net/browse/MER-5621)

## Summary

This PR fixes the Manage Section label for template-based sections.

### Changes

- Updated the label in the Manage Section details panel from “Product” to “Template” when the section is linked to a blueprint/template.
- Added coverage in Manage tab tests to verify:
  - Template label is shown
  - Product label is not shown

### Visual Validation

<img width="1438" height="625" alt="Captura de pantalla 2026-05-07 a la(s) 7 16 14 p  m" src="https://github.com/user-attachments/assets/8c4ab67b-ab0b-4ae3-b6ed-277b17227245" />

  
  

[MER-5621]: https://eliterate.atlassian.net/browse/MER-5621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ