### PR TITLE
[BUG FIX] [MER-3479] Preserve logo aspect ratio and remove duplicate sidebar logos

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -68,7 +68,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       <.link
         :if={@include_logo}
         id="header_logo_button"
-        class="w-48"
+        class="w-[200px] p-2 px-4 flex items-center justify-center"
         navigate={logo_link_path(@preview_mode, @section, @ctx.user, @sidebar_expanded, @is_admin)}
       >
         <.logo_img section={@section} />
@@ -208,7 +208,10 @@ defmodule OliWeb.Components.Delivery.Layouts do
   def sidebar_nav(assigns) do
     ~H"""
     <div class="sticky top-0">
-      <nav id="desktop-nav-menu" class={["
+      <nav
+        id="desktop-nav-menu"
+        style="--header-height: 56px; --toggler-button-height: 24px; --main-links-height: 190px; --footer-buttons-height: 110px; "
+        class={["
         transition-all
         duration-100
         z-50
@@ -223,31 +226,10 @@ defmodule OliWeb.Components.Delivery.Layouts do
         shadow-sm
         bg-delivery-navbar
         dark:bg-delivery-navbar-dark
-        overflow-hidden
-      ", if(!@sidebar_expanded, do: "md:!w-[60px]")]} aria-expanded={"#{@sidebar_expanded}"}>
-        <div class="w-full">
-          <div
-            class={[
-              "h-14 w-48 py-2 flex shrink-0 border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]",
-              if(!@sidebar_expanded, do: "w-14")
-            ]}
-            tab-index="0"
-          >
-            <.link
-              id="logo_button"
-              navigate={
-                logo_link_path(
-                  @preview_mode,
-                  @section,
-                  @ctx.user,
-                  @sidebar_expanded,
-                  @is_admin
-                )
-              }
-            >
-              <.logo_img section={@section} />
-            </.link>
-          </div>
+      ", if(!@sidebar_expanded, do: "md:!w-[60px]")]}
+        aria-expanded={"#{@sidebar_expanded}"}
+      >
+        <div class="w-full mt-[var(--header-height)]">
           <.sidebar_toggler
             active={@active_tab}
             section={@section}
@@ -447,21 +429,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       ", if(!@sidebar_expanded, do: "md:!w-[60px]")]}
         aria-expanded={"#{@sidebar_expanded}"}
       >
-        <div class="w-full">
-          <div
-            class={[
-              "h-[var(--header-height)] w-48 py-2 flex shrink-0 border-b border-[#0F0D0F]/5 dark:border-[#0F0D0F]",
-              if(!@sidebar_expanded, do: "w-14")
-            ]}
-            tab-index="0"
-          >
-            <.link
-              id="logo_button"
-              navigate={logo_link_path(@preview_mode, nil, @ctx.user, @sidebar_expanded, @is_admin)}
-            >
-              <.logo_img />
-            </.link>
-          </div>
+        <div class="w-full mt-[var(--header-height)]">
           <.workspace_sidebar_toggler
             active_workspace={@active_workspace}
             active_view={@active_view}
@@ -943,12 +911,12 @@ defmodule OliWeb.Components.Delivery.Layouts do
     ~H"""
     <img
       src={@logo_src}
-      class="inline-block dark:hidden h-9 object-cover object-left"
+      class="inline-block dark:hidden max-h-9 max-w-full w-auto object-contain object-left"
       alt="OLI Torus logo"
     />
     <img
       src={@logo_src_dark}
-      class="hidden dark:inline-block h-9 object-cover object-left"
+      class="hidden dark:inline-block max-h-9 max-w-full w-auto object-contain object-left"
       alt="OLI Torus logo"
     />
     """

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -13,7 +13,7 @@
       sidebar_enabled={!@disable_sidebar?}
       include_logo
     />
-    <div class="absolute top-0 z-50">
+    <div class="absolute top-0">
       <Components.Delivery.Layouts.sidebar_nav
         :if={@section}
         ctx={@ctx}

--- a/test/oli_web/components/delivery/layouts_test.exs
+++ b/test/oli_web/components/delivery/layouts_test.exs
@@ -54,6 +54,18 @@ defmodule OliWeb.Components.Delivery.LayoutsTest do
     end
   end
 
+  describe "logo_img/1" do
+    test "renders workspace logos with contain sizing so aspect ratio is preserved" do
+      html = render_component(&Layouts.logo_img/1, %{section: nil})
+
+      assert html =~ "max-h-9"
+      assert html =~ "max-w-full"
+      assert html =~ "w-auto"
+      assert html =~ "object-contain"
+      refute html =~ "object-cover"
+    end
+  end
+
   describe "title/1" do
     test "renders resource title if provided" do
       assigns = %{resource_title: "Test Resource", rest: %{class: "custom-class"}}

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2893,7 +2893,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
   describe "sidebar menu" do
     setup [:user_conn, :create_elixir_project, :enroll_as_student, :mark_section_visited]
 
-    test "can see default logo", %{
+    test "can see default logo in the header", %{
       conn: conn,
       section: section
     } do
@@ -2901,16 +2901,16 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
-      assert element(view, "#logo_button") |> render() =~ "/images/oli_torus_logo.png"
+      assert element(view, "#header_logo_button") |> render() =~ "/images/oli_torus_logo.png"
     end
 
-    test "can see brand logo", %{
+    test "can see brand logo in the header", %{
       conn: conn,
       section: section
     } do
       {:ok, view, _html} = live(conn, Utils.learn_live_path(section.slug))
 
-      assert element(view, "#logo_button") |> render() =~ "www.logo.com"
+      assert element(view, "#header_logo_button") |> render() =~ "www.logo.com"
     end
 
     test "does not render Explorations, Practice and Collaboration links if those features are not enabled",
@@ -3095,7 +3095,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       assert_redirect(view, "/workspaces/student?sidebar_expanded=true")
     end
 
-    test "logo icon redirects to home page", %{
+    test "header logo redirects to home page", %{
       conn: conn,
       section: section
     } do
@@ -3103,7 +3103,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
         live(conn, Utils.learn_live_path(section.slug))
 
       view
-      |> element(~s{nav[id='desktop-nav-menu'] a[id="logo_button"]})
+      |> element("#header_logo_button")
       |> render_click()
 
       assert_redirect(view, "/sections/#{section.slug}?sidebar_expanded=true")


### PR DESCRIPTION
[Link](https://eliterate.atlassian.net/browse/MER-3479) to the ticket

## Summary

This change fixes branded logo rendering in workspace and delivery shells.

The original issue was that some logos were rendered with distorted proportions in the top-left corner. While addressing that, I also found that the logo was being rendered in both the header and the sidebar for workspace and delivery layouts. Since the header already owns that branding slot, the sidebar copy was redundant and created layout inconsistencies once the rendering was corrected.

## Changes

- Updated the shared logo renderer in `lib/oli_web/components/delivery/layouts.ex` to use `max-h-9 max-w-full w-auto object-contain` instead of `object-cover`, preserving aspect ratio for branded logos.
- Removed duplicate logo rendering from the workspace and delivery sidebars so the logo is rendered from the header only.
- Adjusted the delivery sidebar/header layout interaction so the header logo remains visible after removing the sidebar logo.
- Added regression coverage in `test/oli_web/components/delivery/layouts_test.exs` to assert contain-based sizing and guard against reintroducing `object-cover`.

## Verification
### Before
<img width="1259" height="533" alt="image" src="https://github.com/user-attachments/assets/2562834f-fbf3-466d-ba7e-45b0fe319368" />


### After
<img width="1259" height="533" alt="image" src="https://github.com/user-attachments/assets/b1f172af-abea-4c46-9125-afb932be41b0" />


- `mix test test/oli_web/components/delivery/layouts_test.exs`
- `mix format lib/oli_web/components/delivery/layouts.ex test/oli_web/components/delivery/layouts_test.exs`

Targeted test result:

- First run failed on the new regression test before the fix, as expected.
- Follow-up runs passed with `24 tests, 0 failures`.