### PR TITLE
[FEATURE] [MER-5609] Implement Publication Updates on Older Versions

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1420,25 +1420,30 @@ defmodule Oli.Delivery.Sections do
       iex> get_push_force_affected_sections(project_id, previous_publication_id)
       %{product_count: 1, section_count: 1}
   """
-  def get_push_force_affected_sections(project_id, previous_publication_id) do
+  def get_push_force_affected_sections(project_id, previous_publication_id, opts \\ []) do
     today = DateTime.utc_now()
+    constrain_to_latest = Keyword.get(opts, :constrain_to_latest, true)
 
-    Repo.one(
-      from(
-        section in Section,
-        join: spp in SectionsProjectsPublications,
-        on: section.id == spp.section_id,
-        where:
-          spp.project_id == ^project_id and section.status == :active and
-            spp.publication_id == ^previous_publication_id and
-            (is_nil(section.end_date) or section.end_date >= ^today),
-        select: %{
-          product_count: fragment("count(case when ? = 'blueprint' then 1 end)", section.type),
-          section_count: fragment("count(case when ? = 'enrollable' then 1 end)", section.type)
-        }
-      )
+    from(
+      section in Section,
+      join: spp in SectionsProjectsPublications,
+      on: section.id == spp.section_id,
+      where:
+        spp.project_id == ^project_id and section.status == :active and
+          (is_nil(section.end_date) or section.end_date >= ^today),
+      select: %{
+        product_count: fragment("count(case when ? = 'blueprint' then 1 end)", section.type),
+        section_count: fragment("count(case when ? = 'enrollable' then 1 end)", section.type)
+      }
     )
+    |> maybe_constrain_to_latest_publication(constrain_to_latest, previous_publication_id)
+    |> Repo.one()
   end
+
+  defp maybe_constrain_to_latest_publication(query, true, previous_publication_id),
+    do: where(query, [_section, spp], spp.publication_id == ^previous_publication_id)
+
+  defp maybe_constrain_to_latest_publication(query, _, _previous_publication_id), do: query
 
   @doc """
   For a section resource record, map its children SR records to resource ids,

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -1118,9 +1118,20 @@ defmodule Oli.Publishing do
     end
   end
 
-  def push_publication_update_to_sections(project, previous_publication, new_publication) do
+  def push_publication_update_to_sections(
+        project,
+        previous_publication,
+        new_publication,
+        opts \\ []
+      ) do
+    constrain_to_latest = Keyword.get(opts, :constrain_to_latest, true)
+
     with products_and_sections <-
-           fetch_products_and_sections_eligible_for_update(project.id, previous_publication.id) do
+           fetch_products_and_sections_eligible_for_update(
+             project.id,
+             previous_publication.id,
+             constrain_to_latest: constrain_to_latest
+           ) do
       # Diff publications up front as an optimization.
       # This will be used later by each update job to determine which update strategy to use
       DiffAgent.put(
@@ -1140,8 +1151,13 @@ defmodule Oli.Publishing do
     end
   end
 
-  def fetch_products_and_sections_eligible_for_update(project_id, previous_publication_id) do
+  def fetch_products_and_sections_eligible_for_update(
+        project_id,
+        previous_publication_id,
+        opts \\ []
+      ) do
     today = DateTime.utc_now()
+    constrain_to_latest = Keyword.get(opts, :constrain_to_latest, true)
 
     from(
       s in Section,
@@ -1149,13 +1165,18 @@ defmodule Oli.Publishing do
       on: s.id == spp.section_id,
       where:
         s.status == :active and spp.project_id == ^project_id and
-          spp.publication_id == ^previous_publication_id and
           (is_nil(s.end_date) or s.end_date >= ^today),
       order_by: s.id,
       select: %{section: s, current_publication_id: spp.publication_id}
     )
+    |> maybe_constrain_to_latest_publication(constrain_to_latest, previous_publication_id)
     |> Repo.all()
   end
+
+  defp maybe_constrain_to_latest_publication(query, true, previous_publication_id),
+    do: where(query, [_s, spp], spp.publication_id == ^previous_publication_id)
+
+  defp maybe_constrain_to_latest_publication(query, _, _previous_publication_id), do: query
 
   def get_all_mappings_for_resource(resource_id, project_slug) do
     Repo.all(

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -1152,25 +1152,37 @@ defmodule OliWeb.Components.Common do
   end
 
   attr :id, :string, required: true
-  attr :on_toggle, :string, required: true
+  attr :on_toggle, :string, default: nil
   attr :label, :string, default: nil
   attr :name, :string, default: nil
   attr :checked, :boolean, default: false
+  attr :disabled, :boolean, default: false
+  attr :form, :boolean, default: true
   attr :phx_target, :any, default: nil
   attr :with_confirmation, :boolean, default: false
-  attr :rest, :global, include: ~w(class disabled role)
+  attr :rest, :global, include: ~w(class role)
 
   def toggle_switch(assigns) do
+    assigns = assign(assigns, :input_id, "#{assigns.id}_checkbox")
+
     ~H"""
     <div {@rest}>
-      <form id={@id} phx-change={@on_toggle} phx-target={@phx_target} phx-auto-recover="ignore">
+      <form
+        :if={@form}
+        id={@id}
+        phx-change={@on_toggle}
+        phx-target={@phx_target}
+        phx-auto-recover="ignore"
+      >
         <label class="inline-flex items-center cursor-pointer">
           <input
-            id={"#{@id}_checkbox"}
+            id={@input_id}
             type="checkbox"
             name={@name}
+            value="true"
             class="sr-only peer"
             checked={@checked}
+            disabled={@disabled}
             phx-hook={if @with_confirmation, do: "ConditionalToggle"}
             data-checked={"#{@checked}"}
           />
@@ -1185,10 +1197,38 @@ defmodule OliWeb.Components.Common do
           <%= case @label do %>
             <% nil -> %>
             <% label -> %>
-              <span class="ms-3 text-sm">{label}</span>
+              <span class="ml-3 text-sm">{label}</span>
           <% end %>
         </label>
       </form>
+      <label :if={!@form} class="inline-flex items-center cursor-pointer">
+        <input :if={@name} type="hidden" name={@name} value="false" disabled={@disabled} />
+        <input
+          id={@input_id}
+          type="checkbox"
+          name={@name}
+          value="true"
+          class="sr-only peer"
+          checked={@checked}
+          disabled={@disabled}
+          phx-hook={if @with_confirmation, do: "ConditionalToggle"}
+          data-checked={"#{@checked}"}
+        />
+        <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4
+                    peer-focus:ring-primary-300 dark:peer-focus:ring-primary-800 rounded-full
+                    peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full
+                    peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px]
+                    after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5
+                    after:w-5 after:transition-transform dark:border-gray-600 peer-checked:bg-primary
+                    peer-disabled:cursor-not-allowed peer-disabled:opacity-50
+                    after:duration-300 after:ease-in-out transition-colors duration-300 ease-in-out">
+        </div>
+        <%= case @label do %>
+          <% nil -> %>
+          <% label -> %>
+            <span class="ml-3 text-sm">{label}</span>
+        <% end %>
+      </label>
     </div>
     """
   end

--- a/lib/oli_web/live/projects/publish_view.ex
+++ b/lib/oli_web/live/projects/publish_view.ex
@@ -43,11 +43,7 @@ defmodule OliWeb.Projects.PublishView do
     latest_published_publication =
       Publishing.get_latest_published_publication_by_slug(project_slug)
 
-    push_affected =
-      if is_nil(latest_published_publication),
-        do: %{product_count: 0, section_count: 0},
-        else:
-          Sections.get_push_force_affected_sections(project.id, latest_published_publication.id)
+    push_affected = calculate_push_affected(latest_published_publication, project.id)
 
     active_publication = Publishing.project_working_publication(project_slug)
 
@@ -118,6 +114,7 @@ defmodule OliWeb.Projects.PublishView do
        table_model: table_model,
        version_change: version_change,
        auto_update_sections: project.auto_update_sections,
+       include_out_of_date_sections: false,
        limit: 10
      )}
   end
@@ -153,6 +150,8 @@ defmodule OliWeb.Projects.PublishView do
               active_publication={@active_publication}
               active_publication_changes={@active_publication_changes}
               auto_update_sections={@auto_update_sections}
+              include_out_of_date_sections={@include_out_of_date_sections}
+              is_admin={@is_admin}
               description={@description}
               form_changed="form_changed"
               changeset={@changeset |> to_form()}
@@ -191,19 +190,25 @@ defmodule OliWeb.Projects.PublishView do
 
   def handle_event(
         "form_changed",
-        %{
-          "publication" => %{"auto_push_update" => auto_push_update, "description" => description}
-        },
+        %{"publication" => publication},
         socket
       ) do
     project = socket.assigns.project
-    auto_update_sections = string_to_bool(auto_push_update)
+    auto_update_sections = string_to_bool(Map.get(publication, "auto_push_update"))
+    include_out_of_date_sections = include_out_of_date_sections?(socket, publication)
+    constrain_to_latest = !include_out_of_date_sections
+
     Course.update_project(project, %{auto_update_sections: auto_update_sections})
 
     {:noreply,
      assign(socket,
        auto_update_sections: auto_update_sections,
-       description: description
+       description: Map.get(publication, "description", ""),
+       include_out_of_date_sections: include_out_of_date_sections,
+       push_affected:
+         calculate_push_affected(socket.assigns.latest_published_publication, project.id,
+           constrain_to_latest: constrain_to_latest
+         )
      )}
   end
 
@@ -223,7 +228,8 @@ defmodule OliWeb.Projects.PublishView do
         Publishing.push_publication_update_to_sections(
           project,
           previous_publication,
-          new_publication
+          new_publication,
+          constrain_to_latest: !include_out_of_date_sections?(socket, publication)
         )
       end
 
@@ -320,6 +326,25 @@ defmodule OliWeb.Projects.PublishView do
 
   defp string_to_bool("true"), do: true
   defp string_to_bool(_), do: false
+
+  defp include_out_of_date_sections?(socket, publication) do
+    socket.assigns.is_admin &&
+      string_to_bool(Map.get(publication, "auto_push_update")) &&
+      string_to_bool(Map.get(publication, "include_out_of_date_sections"))
+  end
+
+  defp calculate_push_affected(latest_published_publication, project_id, opts \\ [])
+
+  defp calculate_push_affected(nil, _project_id, _opts),
+    do: %{product_count: 0, section_count: 0}
+
+  defp calculate_push_affected(latest_published_publication, project_id, opts),
+    do:
+      Sections.get_push_force_affected_sections(
+        project_id,
+        latest_published_publication.id,
+        opts
+      )
 
   _docp = """
   Upsert page embeddings for the given changes and for the pages that not yet have embeddings calculated.

--- a/lib/oli_web/live/projects/versioning_details.ex
+++ b/lib/oli_web/live/projects/versioning_details.ex
@@ -8,6 +8,8 @@ defmodule OliWeb.Projects.VersioningDetails do
   attr(:auto_update_sections, :boolean, default: true)
   attr(:changeset, :any, required: true)
   attr(:has_changes, :boolean, required: true)
+  attr(:include_out_of_date_sections, :boolean, default: false)
+  attr(:is_admin, :boolean, default: false)
   attr(:latest_published_publication, :any, required: true)
   attr(:project, :map, required: true)
   attr(:publish_active, :any, required: true)
@@ -114,20 +116,39 @@ defmodule OliWeb.Projects.VersioningDetails do
         <% end %>
 
         <%= if @active_publication_changes do %>
-          <div class="my-3">
-            <.input
-              class="form-check-input"
-              type="checkbox"
-              field={@changeset[:auto_push_update]}
-              value={@auto_update_sections}
-              label="Automatically push this publication update to all templates and sections"
-            />
-          </div>
+          <.toggle_switch
+            id={@changeset[:auto_push_update].id}
+            class="my-3"
+            form={false}
+            checked={@auto_update_sections}
+            name={@changeset[:auto_push_update].name}
+            label="Automatically push this publication update to all templates and sections"
+          />
+          <.toggle_switch
+            :if={@is_admin}
+            id={@changeset[:include_out_of_date_sections].id}
+            class="my-3"
+            form={false}
+            checked={@include_out_of_date_sections}
+            disabled={!@auto_update_sections}
+            name={@changeset[:include_out_of_date_sections].name}
+            label="Include templates and sections on older versions"
+          />
         <% end %>
 
         <%= if @auto_update_sections do %>
           <div class="alert alert-warning" role="alert">
             <%= if @push_affected.section_count > 0 or @push_affected.product_count > 0 do %>
+              <%= if @include_out_of_date_sections do %>
+                <p class="font-bold mb-4">
+                  Updates will apply to all active templates and course sections for this project,
+                  including those on older versions.
+                </p>
+              <% else %>
+                <p class="font-bold mb-4">
+                  Updates will only apply to courses that match the latest version of this project.
+                </p>
+              <% end %>
               <h6>This force push update will affect:</h6>
               <ul class="mb-0">
                 <li>{@push_affected.section_count} course section(s)</li>

--- a/lib/oli_web/live/workspaces/course_author/publish/versioning_details.ex
+++ b/lib/oli_web/live/workspaces/course_author/publish/versioning_details.ex
@@ -10,6 +10,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.Publish.VersioningDetails do
   attr(:description, :string, default: "")
   attr(:form_changed, :any, required: true)
   attr(:has_changes, :boolean, required: true)
+  attr(:include_out_of_date_sections, :boolean, default: false)
+  attr(:is_admin, :boolean, default: false)
   attr(:latest_published_publication, :any, required: true)
   attr(:project, :map, required: true)
   attr(:publish_active, :any, required: true)
@@ -114,23 +116,39 @@ defmodule OliWeb.Workspaces.CourseAuthor.Publish.VersioningDetails do
         <% end %>
 
         <%= if @active_publication_changes do %>
-          <div class="my-3">
-            <.input
-              class="form-check-input"
-              type="checkbox"
-              field={@changeset[:auto_push_update]}
-              value={@auto_update_sections}
-              label="Automatically push this publication update to all templates and sections"
-            />
-          </div>
+          <.toggle_switch
+            id={@changeset[:auto_push_update].id}
+            class="my-3"
+            form={false}
+            checked={@auto_update_sections}
+            name={@changeset[:auto_push_update].name}
+            label="Automatically push this publication update to all templates and sections"
+          />
+          <.toggle_switch
+            :if={@is_admin}
+            id={@changeset[:include_out_of_date_sections].id}
+            class="my-3"
+            form={false}
+            checked={@include_out_of_date_sections}
+            disabled={!@auto_update_sections}
+            name={@changeset[:include_out_of_date_sections].name}
+            label="Include templates and sections on older versions"
+          />
         <% end %>
 
         <%= if @auto_update_sections do %>
           <div class="alert alert-warning" role="alert">
             <%= if @push_affected.section_count > 0 or @push_affected.product_count > 0 do %>
-              <p class="font-bold mb-4">
-                Updates will only apply to courses that match the latest version of this project.
-              </p>
+              <%= if @include_out_of_date_sections do %>
+                <p class="font-bold mb-4">
+                  Updates will apply to all active templates and course sections for this project,
+                  including those on older versions.
+                </p>
+              <% else %>
+                <p class="font-bold mb-4">
+                  Updates will only apply to courses that match the latest version of this project.
+                </p>
+              <% end %>
               <h6>This force push update will affect:</h6>
               <ul class="mb-0">
                 <li>{@push_affected.section_count} course section(s)</li>

--- a/lib/oli_web/live/workspaces/course_author/publish_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/publish_live.ex
@@ -61,6 +61,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
        changeset: Publishing.change_publication(active_publication),
        ctx: ctx,
        has_changes: has_changes,
+       include_out_of_date_sections: false,
        latest_published_publication: latest_published_publication,
        limit: 10,
        lti_connect_info: lti_connect_info,
@@ -107,6 +108,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
               active_publication={@active_publication}
               active_publication_changes={@active_publication_changes}
               auto_update_sections={@auto_update_sections}
+              include_out_of_date_sections={@include_out_of_date_sections}
+              is_admin={@is_admin}
               description={@description}
               form_changed="form_changed"
               changeset={@changeset |> to_form()}
@@ -145,19 +148,25 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
 
   def handle_event(
         "form_changed",
-        %{
-          "publication" => %{"auto_push_update" => auto_push_update, "description" => description}
-        },
+        %{"publication" => publication},
         socket
       ) do
     project = socket.assigns.project
-    auto_update_sections = string_to_bool(auto_push_update)
+    auto_update_sections = string_to_bool(Map.get(publication, "auto_push_update"))
+    include_out_of_date_sections = include_out_of_date_sections?(socket, publication)
+    constrain_to_latest = !include_out_of_date_sections
+
     Course.update_project(project, %{auto_update_sections: auto_update_sections})
 
     {:noreply,
      assign(socket,
        auto_update_sections: auto_update_sections,
-       description: description
+       description: Map.get(publication, "description", ""),
+       include_out_of_date_sections: include_out_of_date_sections,
+       push_affected:
+         calculate_push_affected(socket.assigns.latest_published_publication, project.id,
+           constrain_to_latest: constrain_to_latest
+         )
      )}
   end
 
@@ -175,7 +184,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
         Publishing.push_publication_update_to_sections(
           project,
           previous_publication,
-          new_publication
+          new_publication,
+          constrain_to_latest: !include_out_of_date_sections?(socket, publication)
         )
       end
 
@@ -267,6 +277,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
   defp string_to_bool("true"), do: true
   defp string_to_bool(_), do: false
 
+  defp include_out_of_date_sections?(socket, publication) do
+    socket.assigns.is_admin &&
+      string_to_bool(Map.get(publication, "auto_push_update")) &&
+      string_to_bool(Map.get(publication, "include_out_of_date_sections"))
+  end
+
   _docp = """
   Upsert page embeddings for the given changes and for the pages that not yet have embeddings calculated.
   """
@@ -322,12 +338,16 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLive do
     end
   end
 
-  defp calculate_push_affected(latest_published_publication, project_id),
+  defp calculate_push_affected(latest_published_publication, project_id, opts \\ []),
     do:
       if(is_nil(latest_published_publication),
         do: %{product_count: 0, section_count: 0},
         else:
-          Sections.get_push_force_affected_sections(project_id, latest_published_publication.id)
+          Sections.get_push_force_affected_sections(
+            project_id,
+            latest_published_publication.id,
+            opts
+          )
       )
 
   defp generate_lti_connect_info do

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -1471,6 +1471,33 @@ defmodule Oli.PublishingTest do
              ]
     end
 
+    test "fetch_products_and_sections_eligible_for_update can include older publication targets",
+         %{
+           proj: project,
+           pub: pub,
+           section2: section2
+         } do
+      older_publication = insert(:publication, project: project, published: yesterday())
+
+      section2
+      |> Ecto.assoc(:section_project_publications)
+      |> update(set: [publication_id: ^older_publication.id])
+      |> Repo.update_all([])
+
+      constrained_result =
+        Publishing.fetch_products_and_sections_eligible_for_update(project.id, pub.id)
+        |> Enum.map(& &1.section.id)
+
+      unconstrained_result =
+        Publishing.fetch_products_and_sections_eligible_for_update(project.id, pub.id,
+          constrain_to_latest: false
+        )
+        |> Enum.map(& &1.section.id)
+
+      refute section2.id in constrained_result
+      assert section2.id in unconstrained_result
+    end
+
     test "push_publication_update_to_sections creates update oban jobs", %{
       proj: project,
       pub: pub,

--- a/test/oli/sections_test.exs
+++ b/test/oli/sections_test.exs
@@ -637,6 +637,45 @@ defmodule Oli.SectionsTest do
       assert product_count == 1
     end
 
+    test "get_push_force_affected_sections/3 can include sections and products on older publications" do
+      %{publication: publication, project: project, unit_one_revision: _unit_one_revision} =
+        base_project_with_curriculum(%{})
+
+      older_publication = insert(:publication, project: project, published: yesterday())
+
+      current_section =
+        insert(:section,
+          base_project: project,
+          type: :enrollable,
+          start_date: yesterday(),
+          end_date: tomorrow()
+        )
+
+      out_of_date_section =
+        insert(:section,
+          base_project: project,
+          type: :enrollable,
+          start_date: yesterday(),
+          end_date: tomorrow()
+        )
+
+      {:ok, _sr} = Sections.create_section_resources(current_section, publication)
+
+      insert(:section_project_publication, %{
+        project: project,
+        section: out_of_date_section,
+        publication: older_publication
+      })
+
+      assert %{section_count: 1, product_count: 0} =
+               Sections.get_push_force_affected_sections(project.id, publication.id)
+
+      assert %{section_count: 2, product_count: 0} =
+               Sections.get_push_force_affected_sections(project.id, publication.id,
+                 constrain_to_latest: false
+               )
+    end
+
     test "get_push_force_affected_sections/2 does not return sections or products that will be affected by forcing the publication update" do
       %{publication: publication, project: project, unit_one_revision: _unit_one_revision} =
         base_project_with_curriculum(%{})

--- a/test/oli_web/live/workspaces/course_author/publish_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/publish_live_test.exs
@@ -231,6 +231,22 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLiveTest do
 
       assert html_response(conn, 200) =~ "Publication Details"
     end
+
+    test "does not show older version force push option", %{
+      conn: conn,
+      author: author,
+      project: project
+    } do
+      insert(:publication, project: project, published: yesterday())
+
+      conn = log_in_author(conn, author)
+      {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
+
+      refute has_element?(
+               view,
+               "input[name='publication[include_out_of_date_sections]']"
+             )
+    end
   end
 
   describe "user can access when is logged in as system admin" do
@@ -510,6 +526,120 @@ defmodule OliWeb.Workspaces.CourseAuthor.PublishLiveTest do
 
       assert has_element?(view, "li", "#{push_affected.product_count} template(s)")
       assert has_element?(view, "li", "#{push_affected.section_count} course section(s)")
+    end
+
+    test "admin can include older version sections and update affected count dynamically", %{
+      conn: conn,
+      project: project
+    } do
+      latest_publication = insert(:publication, project: project, published: now())
+      older_publication = insert(:publication, project: project, published: yesterday())
+
+      current_section =
+        insert(:section,
+          base_project: project,
+          type: :enrollable,
+          start_date: yesterday(),
+          end_date: tomorrow()
+        )
+
+      out_of_date_section =
+        insert(:section,
+          base_project: project,
+          type: :enrollable,
+          start_date: yesterday(),
+          end_date: tomorrow()
+        )
+
+      insert(:section_project_publication, %{
+        project: project,
+        section: current_section,
+        publication: latest_publication
+      })
+
+      insert(:section_project_publication, %{
+        project: project,
+        section: out_of_date_section,
+        publication: older_publication
+      })
+
+      {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
+
+      assert has_element?(
+               view,
+               "input[name='publication[include_out_of_date_sections]']"
+             )
+
+      view
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{
+          "auto_push_update" => "true",
+          "description" => "some description",
+          "include_out_of_date_sections" => "false"
+        }
+      })
+
+      assert has_element?(view, "li", "1 course section(s)")
+      assert has_element?(view, "p", "Updates will only apply to courses that match")
+
+      view
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{
+          "auto_push_update" => "true",
+          "description" => "some description",
+          "include_out_of_date_sections" => "true"
+        }
+      })
+
+      assert has_element?(view, "li", "4 course section(s)")
+
+      assert has_element?(
+               view,
+               "p",
+               "Updates will apply to all active templates and course sections"
+             )
+
+      view
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{
+          "auto_push_update" => "false",
+          "description" => "some description",
+          "include_out_of_date_sections" => "true"
+        }
+      })
+
+      assert has_element?(
+               view,
+               "input[name='publication[include_out_of_date_sections]'][disabled]"
+             )
+
+      refute has_element?(
+               view,
+               "input[name='publication[include_out_of_date_sections]'][checked]"
+             )
+    end
+
+    test "older version checkbox is disabled when force push is unchecked", %{
+      conn: conn,
+      project: project
+    } do
+      insert(:publication, project: project, published: now())
+
+      {:ok, view, _html} = live(conn, live_view_publish_route(project.slug))
+
+      view
+      |> element("form#versioning-details-form")
+      |> render_change(%{
+        "publication" => %{"auto_push_update" => "false", "description" => "some description"}
+      })
+
+      assert has_element?(
+               view,
+               "input[name='publication[include_out_of_date_sections]'][disabled]"
+             )
     end
 
     test "shows a message when course sections and products will not be affected by push forced publication",


### PR DESCRIPTION
[MER-5609](https://eliterate.atlassian.net/browse/MER-5609)

## Summary

Adds an admin-only publication push option that allows force-pushing a publication update to all active templates and course sections for a project, including those currently on older publication versions.

## Changes

- Added a `constrain_to_latest` option to publication push targeting.
  - Default behavior remains unchanged: only templates/sections on the previous latest publication are updated.
  - Admin override can now include active templates/sections on older versions.

- Updated affected-target counting to support both modes.
  - The publish UI now dynamically recalculates affected template and section counts when the admin override is toggled.

- Added an admin-only toggle under:
  `Automatically push this publication update to all templates and sections`
  - Hidden for non-admin authors.
  - Disabled when the main force-push toggle is off.
  - Automatically reset server-side when the main force-push option is disabled.

- Updated publish warning copy.
  - Constrained mode explains that updates only apply to courses matching the latest version.
  - Override mode explains that updates apply to all active templates and course sections, including older versions.

- Reused and extended the shared `toggle_switch` component so it can be rendered inside an existing form without nesting another form.


https://github.com/user-attachments/assets/ffba0ff5-1811-46cd-a121-5d195891750e



[MER-5609]: https://eliterate.atlassian.net/browse/MER-5609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ