### PR TITLE
[BUG FIX] [MER-5615] Prevent remixing projects with shared resources

### DIFF
--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -295,6 +295,7 @@ defmodule Oli.Delivery.Remix do
       on: existing.resource_id == candidate.resource_id,
       where: candidate.project_id in ^candidate_project_ids,
       where: existing.project_id in ^existing_project_ids,
+      where: candidate.project_id != existing.project_id,
       limit: 1,
       select: true
     )

--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -19,6 +19,7 @@ defmodule Oli.Delivery.Remix do
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Hierarchy
   alias Oli.Delivery.Hierarchy.HierarchyNode
+  alias Oli.Authoring.Course.ProjectResource
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Publishing.{PublishedResource, Publications.Publication}
@@ -166,45 +167,49 @@ defmodule Oli.Delivery.Remix do
   `selection` is a list of {publication_id, resource_id} tuples.
   `published_resources_by_resource_id_by_pub` is a map of pub_id => %{rid => %PublishedResource{}}.
   """
-  @spec add_materials(State.t(), list({pos_integer(), pos_integer()}), map()) :: {:ok, State.t()}
+  @spec add_materials(State.t(), list({pos_integer(), pos_integer()}), map()) ::
+          {:ok, State.t()} | {:error, term()}
   def add_materials(%State{} = state, selection, published_resources_by_resource_id_by_pub) do
-    hierarchy =
-      state.hierarchy
-      |> Hierarchy.add_materials_to_hierarchy(
-        state.active,
-        selection,
-        published_resources_by_resource_id_by_pub
-      )
-      |> Hierarchy.finalize()
+    with :ok <- validate_no_shared_project_resources(state, selection) do
+      hierarchy =
+        state.hierarchy
+        |> Hierarchy.add_materials_to_hierarchy(
+          state.active,
+          selection,
+          published_resources_by_resource_id_by_pub
+        )
+        |> Hierarchy.finalize()
 
-    # update pinned publications similar to LiveView behavior
-    pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
+      # update pinned publications similar to LiveView behavior
+      pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
 
-    pinned_project_publications =
-      Enum.reduce(selection, state.pinned_project_publications, fn {pub_id, _rid}, acc ->
-        case Map.fetch(pub_by_id, pub_id) do
-          {:ok, pub} -> Map.put_new(acc, pub.project_id, pub)
-          :error -> acc
-        end
-      end)
+      pinned_project_publications =
+        Enum.reduce(selection, state.pinned_project_publications, fn {pub_id, _rid}, acc ->
+          case Map.fetch(pub_by_id, pub_id) do
+            {:ok, pub} -> Map.put_new(acc, pub.project_id, pub)
+            :error -> acc
+          end
+        end)
 
-    active = Hierarchy.find_in_hierarchy(hierarchy, state.active.uuid)
+      active = Hierarchy.find_in_hierarchy(hierarchy, state.active.uuid)
 
-    {:ok,
-     %State{
-       state
-       | hierarchy: hierarchy,
-         active: active,
-         has_unsaved_changes: true,
-         pinned_project_publications: pinned_project_publications
-     }}
+      {:ok,
+       %State{
+         state
+         | hierarchy: hierarchy,
+           active: active,
+           has_unsaved_changes: true,
+           pinned_project_publications: pinned_project_publications
+       }}
+    end
   end
 
   @doc """
   Convenience: add materials with publication lookups and canonical ordering preserved
   per original publication hierarchy.
   """
-  @spec add_materials(State.t(), list({pos_integer(), pos_integer()})) :: {:ok, State.t()}
+  @spec add_materials(State.t(), list({pos_integer(), pos_integer()})) ::
+          {:ok, State.t()} | {:error, term()}
   def add_materials(%State{} = state, selection) do
     unique_pub_ids = selection |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
     pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
@@ -226,6 +231,89 @@ defmodule Oli.Delivery.Remix do
       end)
 
     add_materials(state, selection, published_resources_by_resource_id_by_pub)
+  end
+
+  defp validate_no_shared_project_resources(%State{} = _state, []), do: :ok
+
+  defp validate_no_shared_project_resources(%State{} = state, selection) do
+    candidate_project_ids =
+      selection
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.uniq()
+      |> project_ids_for_publication_ids(state.available_publications)
+
+    existing_project_ids =
+      [state.section.base_project_id | Map.keys(state.pinned_project_publications)]
+      |> Enum.uniq()
+
+    cond do
+      projects_share_resources_within?(candidate_project_ids) ->
+        {:error, :selected_projects_share_resources}
+
+      projects_share_resources?(candidate_project_ids, existing_project_ids) ->
+        {:error, :shared_project_resources}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp project_ids_for_publication_ids(publication_ids, available_publications) do
+    pub_by_id = Map.new(available_publications, &{&1.id, &1.project_id})
+
+    {project_ids, missing_pub_ids} =
+      Enum.reduce(publication_ids, {[], []}, fn pub_id, {project_ids, missing_pub_ids} ->
+        case Map.fetch(pub_by_id, pub_id) do
+          {:ok, project_id} -> {[project_id | project_ids], missing_pub_ids}
+          :error -> {project_ids, [pub_id | missing_pub_ids]}
+        end
+      end)
+
+    missing_project_ids =
+      case missing_pub_ids do
+        [] ->
+          []
+
+        ids ->
+          from(pub in Publication,
+            where: pub.id in ^ids,
+            select: pub.project_id
+          )
+          |> Repo.all()
+      end
+
+    (project_ids ++ missing_project_ids)
+    |> Enum.uniq()
+  end
+
+  defp projects_share_resources?([], _existing_project_ids), do: false
+  defp projects_share_resources?(_candidate_project_ids, []), do: false
+
+  defp projects_share_resources?(candidate_project_ids, existing_project_ids) do
+    from(candidate in ProjectResource,
+      join: existing in ProjectResource,
+      on: existing.resource_id == candidate.resource_id,
+      where: candidate.project_id in ^candidate_project_ids,
+      where: existing.project_id in ^existing_project_ids,
+      limit: 1,
+      select: true
+    )
+    |> Repo.exists?()
+  end
+
+  defp projects_share_resources_within?(project_ids) when length(project_ids) < 2, do: false
+
+  defp projects_share_resources_within?(project_ids) do
+    from(left in ProjectResource,
+      join: right in ProjectResource,
+      on: right.resource_id == left.resource_id,
+      where: left.project_id in ^project_ids,
+      where: right.project_id in ^project_ids,
+      where: left.project_id < right.project_id,
+      limit: 1,
+      select: true
+    )
+    |> Repo.exists?()
   end
 
   defp build_resource_index_for_pub_map(pr_by_rid, pub) do

--- a/lib/oli/delivery/remix.ex
+++ b/lib/oli/delivery/remix.ex
@@ -19,7 +19,6 @@ defmodule Oli.Delivery.Remix do
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Hierarchy
   alias Oli.Delivery.Hierarchy.HierarchyNode
-  alias Oli.Authoring.Course.ProjectResource
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Publishing.{PublishedResource, Publications.Publication}
@@ -171,36 +170,7 @@ defmodule Oli.Delivery.Remix do
           {:ok, State.t()} | {:error, term()}
   def add_materials(%State{} = state, selection, published_resources_by_resource_id_by_pub) do
     with :ok <- validate_no_shared_project_resources(state, selection) do
-      hierarchy =
-        state.hierarchy
-        |> Hierarchy.add_materials_to_hierarchy(
-          state.active,
-          selection,
-          published_resources_by_resource_id_by_pub
-        )
-        |> Hierarchy.finalize()
-
-      # update pinned publications similar to LiveView behavior
-      pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
-
-      pinned_project_publications =
-        Enum.reduce(selection, state.pinned_project_publications, fn {pub_id, _rid}, acc ->
-          case Map.fetch(pub_by_id, pub_id) do
-            {:ok, pub} -> Map.put_new(acc, pub.project_id, pub)
-            :error -> acc
-          end
-        end)
-
-      active = Hierarchy.find_in_hierarchy(hierarchy, state.active.uuid)
-
-      {:ok,
-       %State{
-         state
-         | hierarchy: hierarchy,
-           active: active,
-           has_unsaved_changes: true,
-           pinned_project_publications: pinned_project_publications
-       }}
+      add_validated_materials(state, selection, published_resources_by_resource_id_by_pub)
     end
   end
 
@@ -211,110 +181,182 @@ defmodule Oli.Delivery.Remix do
   @spec add_materials(State.t(), list({pos_integer(), pos_integer()})) ::
           {:ok, State.t()} | {:error, term()}
   def add_materials(%State{} = state, selection) do
-    unique_pub_ids = selection |> Enum.map(&elem(&1, 0)) |> Enum.uniq()
+    unique_pub_ids = add_material_publication_ids(selection)
     pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
 
-    published_resources_by_resource_id_by_pub =
-      Publishing.get_published_resources_for_publications(unique_pub_ids)
+    with :ok <- validate_publication_ids_available(unique_pub_ids, pub_by_id),
+         :ok <- validate_no_shared_project_resources(state, selection) do
+      published_resources_by_resource_id_by_pub =
+        Publishing.get_published_resources_for_publications(unique_pub_ids)
 
-    # Build index per pub for canonical order
-    index_by_pub =
-      Map.new(unique_pub_ids, fn pub_id ->
-        pub = Map.fetch!(pub_by_id, pub_id)
-        pr_by_rid = Map.fetch!(published_resources_by_resource_id_by_pub, pub_id)
-        {pub_id, build_resource_index_for_pub_map(pr_by_rid, pub)}
+      # Build index per pub for canonical order
+      index_by_pub =
+        Map.new(unique_pub_ids, fn pub_id ->
+          pub = Map.fetch!(pub_by_id, pub_id)
+          pr_by_rid = Map.fetch!(published_resources_by_resource_id_by_pub, pub_id)
+          {pub_id, build_resource_index_for_pub_map(pr_by_rid, pub)}
+        end)
+
+      selection =
+        Enum.sort_by(selection, fn {pub_id, rid} ->
+          Map.get(index_by_pub[pub_id], rid, :infinity)
+        end)
+
+      add_validated_materials(state, selection, published_resources_by_resource_id_by_pub)
+    end
+  end
+
+  defp add_validated_materials(
+         %State{} = state,
+         selection,
+         published_resources_by_resource_id_by_pub
+       ) do
+    hierarchy =
+      state.hierarchy
+      |> Hierarchy.add_materials_to_hierarchy(
+        state.active,
+        selection,
+        published_resources_by_resource_id_by_pub
+      )
+      |> Hierarchy.finalize()
+
+    # update pinned publications similar to LiveView behavior
+    pub_by_id = Map.new(state.available_publications, &{&1.id, &1})
+
+    pinned_project_publications =
+      Enum.reduce(selection, state.pinned_project_publications, fn {pub_id, _rid}, acc ->
+        case Map.fetch(pub_by_id, pub_id) do
+          {:ok, pub} -> Map.put_new(acc, pub.project_id, pub)
+          :error -> acc
+        end
       end)
 
-    selection =
-      Enum.sort_by(selection, fn {pub_id, rid} ->
-        Map.get(index_by_pub[pub_id], rid, :infinity)
-      end)
+    active = Hierarchy.find_in_hierarchy(hierarchy, state.active.uuid)
 
-    add_materials(state, selection, published_resources_by_resource_id_by_pub)
+    {:ok,
+     %State{
+       state
+       | hierarchy: hierarchy,
+         active: active,
+         has_unsaved_changes: true,
+         pinned_project_publications: pinned_project_publications
+     }}
   end
 
   defp validate_no_shared_project_resources(%State{} = _state, []), do: :ok
 
   defp validate_no_shared_project_resources(%State{} = state, selection) do
-    candidate_project_ids =
-      selection
-      |> Enum.map(&elem(&1, 0))
-      |> Enum.uniq()
-      |> project_ids_for_publication_ids(state.available_publications)
+    with {:ok, candidate_project_ids} <-
+           selection
+           |> Enum.map(&elem(&1, 0))
+           |> Enum.uniq()
+           |> project_ids_for_publication_ids(state.available_publications) do
+      existing_project_ids =
+        [state.section.base_project_id | Map.keys(state.pinned_project_publications)]
+        |> Enum.uniq()
 
-    existing_project_ids =
-      [state.section.base_project_id | Map.keys(state.pinned_project_publications)]
-      |> Enum.uniq()
-
-    cond do
-      projects_share_resources_within?(candidate_project_ids) ->
-        {:error, :selected_projects_share_resources}
-
-      projects_share_resources?(candidate_project_ids, existing_project_ids) ->
-        {:error, :shared_project_resources}
-
-      true ->
-        :ok
+      case shared_project_resource_conflict(candidate_project_ids, existing_project_ids) do
+        :selected_projects_share_resources -> {:error, :selected_projects_share_resources}
+        :shared_project_resources -> {:error, :shared_project_resources}
+        nil -> :ok
+      end
     end
   end
 
   defp project_ids_for_publication_ids(publication_ids, available_publications) do
     pub_by_id = Map.new(available_publications, &{&1.id, &1.project_id})
 
-    {project_ids, missing_pub_ids} =
-      Enum.reduce(publication_ids, {[], []}, fn pub_id, {project_ids, missing_pub_ids} ->
-        case Map.fetch(pub_by_id, pub_id) do
-          {:ok, project_id} -> {[project_id | project_ids], missing_pub_ids}
-          :error -> {project_ids, [pub_id | missing_pub_ids]}
-        end
-      end)
+    with :ok <- validate_publication_ids_available(publication_ids, pub_by_id) do
+      project_ids =
+        publication_ids
+        |> Enum.map(&Map.fetch!(pub_by_id, &1))
+        |> Enum.uniq()
 
-    missing_project_ids =
-      case missing_pub_ids do
-        [] ->
-          []
+      {:ok, project_ids}
+    end
+  end
 
-        ids ->
-          from(pub in Publication,
-            where: pub.id in ^ids,
-            select: pub.project_id
-          )
-          |> Repo.all()
-      end
+  defp shared_project_resource_conflict([], _existing_project_ids), do: nil
 
-    (project_ids ++ missing_project_ids)
+  defp shared_project_resource_conflict(
+         [_project_id] = candidate_project_ids,
+         existing_project_ids
+       ) do
+    if existing_projects_share_resources?(candidate_project_ids, existing_project_ids) do
+      :shared_project_resources
+    end
+  end
+
+  defp shared_project_resource_conflict(candidate_project_ids, existing_project_ids) do
+    shared_project_resource_conflict_sql = """
+    SELECT
+      EXISTS (
+        SELECT 1
+        FROM projects_resources candidate
+        JOIN projects_resources other
+          ON other.resource_id = candidate.resource_id
+        WHERE candidate.project_id = ANY($1)
+          AND other.project_id = ANY($1)
+          AND candidate.project_id <> other.project_id
+      ),
+      EXISTS (
+        SELECT 1
+        FROM projects_resources candidate
+        JOIN projects_resources other
+          ON other.resource_id = candidate.resource_id
+        WHERE candidate.project_id = ANY($1)
+          AND other.project_id = ANY($2)
+          AND candidate.project_id <> other.project_id
+      )
+    """
+
+    %{rows: [[selected_projects_conflict?, existing_projects_conflict?]]} =
+      Repo.query!(shared_project_resource_conflict_sql, [
+        candidate_project_ids,
+        existing_project_ids
+      ])
+
+    cond do
+      selected_projects_conflict? -> :selected_projects_share_resources
+      existing_projects_conflict? -> :shared_project_resources
+      true -> nil
+    end
+  end
+
+  defp existing_projects_share_resources?(candidate_project_ids, existing_project_ids) do
+    existing_project_conflict_sql = """
+    SELECT EXISTS (
+      SELECT 1
+      FROM projects_resources candidate
+      JOIN projects_resources other
+        ON other.resource_id = candidate.resource_id
+      WHERE candidate.project_id = ANY($1)
+        AND other.project_id = ANY($2)
+        AND candidate.project_id <> other.project_id
+    )
+    """
+
+    %{rows: [[existing_projects_conflict?]]} =
+      Repo.query!(existing_project_conflict_sql, [
+        candidate_project_ids,
+        existing_project_ids
+      ])
+
+    existing_projects_conflict?
+  end
+
+  defp add_material_publication_ids(selection) do
+    selection
+    |> Enum.map(&elem(&1, 0))
     |> Enum.uniq()
   end
 
-  defp projects_share_resources?([], _existing_project_ids), do: false
-  defp projects_share_resources?(_candidate_project_ids, []), do: false
-
-  defp projects_share_resources?(candidate_project_ids, existing_project_ids) do
-    from(candidate in ProjectResource,
-      join: existing in ProjectResource,
-      on: existing.resource_id == candidate.resource_id,
-      where: candidate.project_id in ^candidate_project_ids,
-      where: existing.project_id in ^existing_project_ids,
-      where: candidate.project_id != existing.project_id,
-      limit: 1,
-      select: true
-    )
-    |> Repo.exists?()
-  end
-
-  defp projects_share_resources_within?(project_ids) when length(project_ids) < 2, do: false
-
-  defp projects_share_resources_within?(project_ids) do
-    from(left in ProjectResource,
-      join: right in ProjectResource,
-      on: right.resource_id == left.resource_id,
-      where: left.project_id in ^project_ids,
-      where: right.project_id in ^project_ids,
-      where: left.project_id < right.project_id,
-      limit: 1,
-      select: true
-    )
-    |> Repo.exists?()
+  defp validate_publication_ids_available(publication_ids, pub_by_id) do
+    if Enum.any?(publication_ids, &(not Map.has_key?(pub_by_id, &1))) do
+      {:error, :unavailable_publication}
+    else
+      :ok
+    end
   end
 
   defp build_resource_index_for_pub_map(pr_by_rid, pub) do

--- a/lib/oli_web/live/delivery/remix/add_materials_modal.ex
+++ b/lib/oli_web/live/delivery/remix/add_materials_modal.ex
@@ -21,6 +21,7 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
   attr :publications_table_model, :any
   attr :publications_table_model_params, :any
   attr :publications_table_model_total_count, :integer, default: 0
+  attr :error_message, :string, default: nil
 
   def render(assigns) do
     assigns = assign(assigns, :add_disabled, Enum.empty?(assigns.selection))
@@ -50,6 +51,27 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
           <OliWeb.Icons.close_sm class="w-5 h-5 stroke-current" />
         </button>
       </:header_actions>
+
+      <div
+        :if={@error_message}
+        class="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-red-900"
+        role="alert"
+      >
+        <div class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-red-600 text-xs font-bold leading-none">
+          !
+        </div>
+        <p class="flex-1 text-sm font-medium leading-5">
+          {@error_message}
+        </p>
+        <button
+          type="button"
+          class="size-5 shrink-0 text-red-800 hover:text-red-950"
+          phx-click="AddMaterialsModal.dismiss_error"
+          aria-label="Dismiss error"
+        >
+          <OliWeb.Icons.close_sm class="h-5 w-5 stroke-current" />
+        </button>
+      </div>
 
       <HierarchyPicker.render
         id="hierarchy_picker"

--- a/lib/oli_web/live/delivery/remix/add_materials_modal.ex
+++ b/lib/oli_web/live/delivery/remix/add_materials_modal.ex
@@ -77,7 +77,10 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
             class="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-red-900"
             role="alert"
           >
-            <div class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-red-600 text-xs font-bold leading-none">
+            <div
+              class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-red-600 text-xs font-bold leading-none"
+              aria-hidden="true"
+            >
               !
             </div>
             <p class="flex-1 text-sm font-medium leading-5">

--- a/lib/oli_web/live/delivery/remix/add_materials_modal.ex
+++ b/lib/oli_web/live/delivery/remix/add_materials_modal.ex
@@ -85,7 +85,7 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
             </p>
             <button
               type="button"
-              class="size-5 shrink-0 text-red-800 hover:text-red-950"
+              class="flex size-10 shrink-0 items-center justify-center text-red-800 hover:text-red-950"
               phx-click="AddMaterialsModal.dismiss_error"
               aria-label="Dismiss error"
             >

--- a/lib/oli_web/live/delivery/remix/add_materials_modal.ex
+++ b/lib/oli_web/live/delivery/remix/add_materials_modal.ex
@@ -52,27 +52,6 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
         </button>
       </:header_actions>
 
-      <div
-        :if={@error_message}
-        class="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-red-900"
-        role="alert"
-      >
-        <div class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-red-600 text-xs font-bold leading-none">
-          !
-        </div>
-        <p class="flex-1 text-sm font-medium leading-5">
-          {@error_message}
-        </p>
-        <button
-          type="button"
-          class="size-5 shrink-0 text-red-800 hover:text-red-950"
-          phx-click="AddMaterialsModal.dismiss_error"
-          aria-label="Dismiss error"
-        >
-          <OliWeb.Icons.close_sm class="h-5 w-5 stroke-current" />
-        </button>
-      </div>
-
       <HierarchyPicker.render
         id="hierarchy_picker"
         select_mode={:multiple}
@@ -92,25 +71,48 @@ defmodule OliWeb.Delivery.Remix.AddMaterialsModal do
       />
 
       <:custom_footer>
-        <div class="flex items-center justify-end gap-4 mt-4">
-          <span :if={length(@selection) > 0} class="text-sm text-zinc-500 mr-auto">
-            {length(@selection)} items selected
-          </span>
-          <Button.button
-            variant={:secondary}
-            size={:sm}
-            phx-click={JS.push("close_add_materials_modal")}
+        <div class="mt-4 space-y-4">
+          <div
+            :if={@error_message}
+            class="flex items-start gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-red-900"
+            role="alert"
           >
-            Cancel
-          </Button.button>
-          <Button.button
-            variant={:primary}
-            size={:sm}
-            phx-click="AddMaterialsModal.add"
-            disabled={@add_disabled}
-          >
-            Add
-          </Button.button>
+            <div class="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border border-red-600 text-xs font-bold leading-none">
+              !
+            </div>
+            <p class="flex-1 text-sm font-medium leading-5">
+              {@error_message}
+            </p>
+            <button
+              type="button"
+              class="size-5 shrink-0 text-red-800 hover:text-red-950"
+              phx-click="AddMaterialsModal.dismiss_error"
+              aria-label="Dismiss error"
+            >
+              <OliWeb.Icons.close_sm class="h-5 w-5 stroke-current" />
+            </button>
+          </div>
+
+          <div class="flex items-center justify-end gap-4">
+            <span :if={length(@selection) > 0} class="text-sm text-zinc-500 mr-auto">
+              {length(@selection)} items selected
+            </span>
+            <Button.button
+              variant={:secondary}
+              size={:sm}
+              phx-click={JS.push("close_add_materials_modal")}
+            >
+              Cancel
+            </Button.button>
+            <Button.button
+              variant={:primary}
+              size={:sm}
+              phx-click="AddMaterialsModal.add"
+              disabled={@add_disabled}
+            >
+              Add
+            </Button.button>
+          </div>
         </div>
       </:custom_footer>
     </Modal.modal>

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -673,14 +673,21 @@ defmodule OliWeb.Delivery.RemixSection do
         {:noreply,
          put_add_materials_error(
            socket,
-           "Materials from this course cannot be added because it shares resources with the base course or another course already added. Choose a different source course or deselect the conflicting materials, then try again."
+           "Materials from this course cannot be added because this source course shares resources with the base course or another course already added. Choose a different source course, then try again."
          )}
 
       {:error, :selected_projects_share_resources} ->
         {:noreply,
          put_add_materials_error(
            socket,
-           "Materials from these courses cannot be added together because the selected courses share resources. Deselect materials from one of the conflicting courses, then try again."
+           "Materials from these courses cannot be added together because the selected source courses share resources. Select materials from one source course at a time, then try again."
+         )}
+
+      {:error, :unavailable_publication} ->
+        {:noreply,
+         put_add_materials_error(
+           socket,
+           "Selected materials are no longer available. Close this dialog, reopen Add Materials, and try again."
          )}
     end
   end

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -646,7 +646,8 @@ defmodule OliWeb.Delivery.RemixSection do
       pages_table_model: socket.assigns.pages_table_model,
       publications_table_model: socket.assigns.publications_table_model,
       publications_table_model_total_count: socket.assigns.publications_table_model_total_count,
-      publications_table_model_params: socket.assigns.publications_table_model_params
+      publications_table_model_params: socket.assigns.publications_table_model_params,
+      error_message: nil
     }
 
     {:noreply, assign(socket, modal_assigns: modal_assigns, show_add_materials_modal: true)}
@@ -670,20 +671,23 @@ defmodule OliWeb.Delivery.RemixSection do
 
       {:error, :shared_project_resources} ->
         {:noreply,
-         put_flash(
+         put_add_materials_error(
            socket,
-           :error,
            "Materials from this course cannot be added because it shares resources with the base course or another course already added."
          )}
 
       {:error, :selected_projects_share_resources} ->
         {:noreply,
-         put_flash(
+         put_add_materials_error(
            socket,
-           :error,
            "Materials from these courses cannot be added together because the selected courses share resources."
          )}
     end
+  end
+
+  def handle_event("AddMaterialsModal.dismiss_error", _, socket) do
+    {:noreply,
+     assign(socket, modal_assigns: clear_add_materials_error(socket.assigns.modal_assigns))}
   end
 
   def handle_event("close_add_materials_modal", _, socket) do
@@ -715,7 +719,8 @@ defmodule OliWeb.Delivery.RemixSection do
         active: hierarchy,
         selected_publication: publication,
         pages_table_model: Map.put(modal_assigns.pages_table_model, :rows, section_pages),
-        pages_table_model_total_count: total_count
+        pages_table_model_total_count: total_count,
+        error_message: nil
     }
 
     modal_assigns = Map.put(modal_assigns, :exclude_resource_ids, exclude_ids)
@@ -729,7 +734,8 @@ defmodule OliWeb.Delivery.RemixSection do
     modal_assigns = %{
       modal_assigns
       | hierarchy: nil,
-        active: nil
+        active: nil,
+        error_message: nil
     }
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
@@ -742,7 +748,8 @@ defmodule OliWeb.Delivery.RemixSection do
 
     modal_assigns = %{
       modal_assigns
-      | active: active
+      | active: active,
+        error_message: nil
     }
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
@@ -770,7 +777,8 @@ defmodule OliWeb.Delivery.RemixSection do
           xor(
             selection,
             {publication.id, item.revision.resource_id}
-          )
+          ),
+        error_message: nil
     }
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
@@ -798,7 +806,8 @@ defmodule OliWeb.Delivery.RemixSection do
           xor(
             selection,
             {publication.id, item.revision.resource_id}
-          )
+          ),
+        error_message: nil
     }
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
@@ -807,7 +816,10 @@ defmodule OliWeb.Delivery.RemixSection do
   def handle_event("HierarchyPicker.update_hierarchy_tab", %{"tab_name" => tab_name}, socket) do
     %{modal_assigns: modal_assigns} = socket.assigns
 
-    modal_assigns = Map.put(modal_assigns, :active_tab, String.to_existing_atom(tab_name))
+    modal_assigns =
+      modal_assigns
+      |> Map.put(:active_tab, String.to_existing_atom(tab_name))
+      |> clear_add_materials_error()
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
   end
@@ -1230,6 +1242,20 @@ defmodule OliWeb.Delivery.RemixSection do
     preselected
     |> Enum.filter(fn {pub_id, _rid} -> pub_id == pub.id end)
     |> Enum.map(fn {_pub_id, rid} -> rid end)
+  end
+
+  defp put_add_materials_error(socket, message) do
+    assign(socket,
+      modal_assigns:
+        socket.assigns.modal_assigns
+        |> Map.put(:error_message, message)
+    )
+  end
+
+  defp clear_add_materials_error(nil), do: nil
+
+  defp clear_add_materials_error(modal_assigns) do
+    Map.put(modal_assigns, :error_message, nil)
   end
 
   defp valid_internal_path?(target) when is_binary(target) do

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -673,14 +673,14 @@ defmodule OliWeb.Delivery.RemixSection do
         {:noreply,
          put_add_materials_error(
            socket,
-           "Materials from this course cannot be added because it shares resources with the base course or another course already added."
+           "Materials from this course cannot be added because it shares resources with the base course or another course already added. Choose a different source course or deselect the conflicting materials, then try again."
          )}
 
       {:error, :selected_projects_share_resources} ->
         {:noreply,
          put_add_materials_error(
            socket,
-           "Materials from these courses cannot be added together because the selected courses share resources."
+           "Materials from these courses cannot be added together because the selected courses share resources. Deselect materials from one of the conflicting courses, then try again."
          )}
     end
   end
@@ -816,12 +816,18 @@ defmodule OliWeb.Delivery.RemixSection do
   def handle_event("HierarchyPicker.update_hierarchy_tab", %{"tab_name" => tab_name}, socket) do
     %{modal_assigns: modal_assigns} = socket.assigns
 
-    modal_assigns =
-      modal_assigns
-      |> Map.put(:active_tab, String.to_existing_atom(tab_name))
-      |> clear_add_materials_error()
+    case hierarchy_tab(tab_name) do
+      {:ok, active_tab} ->
+        modal_assigns =
+          modal_assigns
+          |> Map.put(:active_tab, active_tab)
+          |> clear_add_materials_error()
 
-    {:noreply, assign(socket, modal_assigns: modal_assigns)}
+        {:noreply, assign(socket, modal_assigns: modal_assigns)}
+
+      :error ->
+        {:noreply, socket}
+    end
   end
 
   def handle_event("HierarchyPicker.pages_text_search", %{"text_search" => text_search}, socket) do
@@ -1257,6 +1263,10 @@ defmodule OliWeb.Delivery.RemixSection do
   defp clear_add_materials_error(modal_assigns) do
     Map.put(modal_assigns, :error_message, nil)
   end
+
+  defp hierarchy_tab("curriculum"), do: {:ok, :curriculum}
+  defp hierarchy_tab("all_pages"), do: {:ok, :all_pages}
+  defp hierarchy_tab(_), do: :error
 
   defp valid_internal_path?(target) when is_binary(target) do
     uri = URI.parse(target)

--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -655,18 +655,35 @@ defmodule OliWeb.Delivery.RemixSection do
   def handle_event("AddMaterialsModal.add", _, socket) do
     %{remix_state: state, modal_assigns: %{selection: selection}} = socket.assigns
 
-    {:ok, state} = Remix.add_materials(state, selection)
+    case Remix.add_materials(state, selection) do
+      {:ok, state} ->
+        {:noreply,
+         assign(socket,
+           hierarchy: state.hierarchy,
+           active: state.active,
+           pinned_project_publications: state.pinned_project_publications,
+           has_unsaved_changes: true,
+           remix_state: state,
+           show_add_materials_modal: false,
+           modal_assigns: nil
+         )}
 
-    {:noreply,
-     assign(socket,
-       hierarchy: state.hierarchy,
-       active: state.active,
-       pinned_project_publications: state.pinned_project_publications,
-       has_unsaved_changes: true,
-       remix_state: state,
-       show_add_materials_modal: false,
-       modal_assigns: nil
-     )}
+      {:error, :shared_project_resources} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Materials from this course cannot be added because it shares resources with the base course or another course already added."
+         )}
+
+      {:error, :selected_projects_share_resources} ->
+        {:noreply,
+         put_flash(
+           socket,
+           :error,
+           "Materials from these courses cannot be added together because the selected courses share resources."
+         )}
+    end
   end
 
   def handle_event("close_add_materials_modal", _, socket) do

--- a/test/oli/delivery/remix/ops_test.exs
+++ b/test/oli/delivery/remix/ops_test.exs
@@ -33,6 +33,8 @@ defmodule Oli.Delivery.Remix.OpsTest do
         revision: r,
         author: author
       })
+
+      insert(:project_resource, %{project_id: project.id, resource_id: r.resource_id})
     end)
 
     section = insert(:section, base_project: project, title: "S1")
@@ -76,29 +78,7 @@ defmodule Oli.Delivery.Remix.OpsTest do
 
   test "add_materials appends from other publication", %{state: state} do
     # create another project/pub with one page
-    author = insert(:author)
-    proj = insert(:project, authors: [author])
-
-    page =
-      insert(:revision, %{resource_type_id: Oli.Resources.ResourceType.id_for_page(), title: "NP"})
-
-    root =
-      insert(:revision, %{
-        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
-        title: "R2",
-        children: [page.resource_id]
-      })
-
-    pub = insert(:publication, %{project: proj, root_resource_id: root.resource_id})
-
-    Enum.each([root, page], fn r ->
-      insert(:published_resource, %{
-        publication: pub,
-        resource: r.resource,
-        revision: r,
-        author: author
-      })
-    end)
+    %{pub: pub, page: page} = publication_with_page("NP")
 
     pr_by_pub = Publishing.get_published_resources_for_publications([pub.id])
     sel = [{pub.id, page.resource_id}]
@@ -109,11 +89,95 @@ defmodule Oli.Delivery.Remix.OpsTest do
     assert Enum.any?(state.active.children, &(&1.revision.title == "NP"))
   end
 
+  test "add_materials rejects materials from a project sharing resources with base project", %{
+    state: state
+  } do
+    base_page = hd(state.active.children).revision
+    %{pub: pub} = publication_with_page("Clone Page", shared_page: base_page)
+    pr_by_pub = Publishing.get_published_resources_for_publications([pub.id])
+
+    assert {:error, :shared_project_resources} =
+             Remix.add_materials(state, [{pub.id, base_page.resource_id}], pr_by_pub)
+  end
+
+  test "add_materials rejects materials sharing resources with an already remixed project", %{
+    state: state
+  } do
+    %{pub: first_pub, page: first_page} = publication_with_page("First Source")
+    state = %{state | available_publications: [first_pub | state.available_publications]}
+
+    assert {:ok, state} = Remix.add_materials(state, [{first_pub.id, first_page.resource_id}])
+
+    %{pub: second_pub} = publication_with_page("Second Source", shared_page: first_page)
+    pr_by_pub = Publishing.get_published_resources_for_publications([second_pub.id])
+
+    assert {:error, :shared_project_resources} =
+             Remix.add_materials(state, [{second_pub.id, first_page.resource_id}], pr_by_pub)
+  end
+
+  test "add_materials rejects a batch containing projects that share resources", %{state: state} do
+    %{pub: first_pub, page: first_page} = publication_with_page("First Source")
+    %{pub: second_pub, page: second_page} = publication_with_page("Second Source")
+
+    insert(:project_resource, %{
+      project_id: second_pub.project_id,
+      resource_id: first_page.resource_id
+    })
+
+    pr_by_pub = Publishing.get_published_resources_for_publications([first_pub.id, second_pub.id])
+
+    assert {:error, :selected_projects_share_resources} =
+             Remix.add_materials(
+               state,
+               [{first_pub.id, first_page.resource_id}, {second_pub.id, second_page.resource_id}],
+               pr_by_pub
+             )
+  end
+
   defp find_sr(h, uuid) do
     if h.uuid == uuid do
       h.section_resource
     else
       h.children |> Enum.map(&find_sr(&1, uuid)) |> Enum.find(& &1)
     end
+  end
+
+  defp publication_with_page(page_title, opts \\ []) do
+    author = insert(:author)
+    project = insert(:project, authors: [author])
+
+    page =
+      case Keyword.get(opts, :shared_page) do
+        nil ->
+          insert(:revision, %{
+            resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+            title: page_title
+          })
+
+        shared_page ->
+          shared_page
+      end
+
+    root =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.id_for_container(),
+        title: "Root #{page_title}",
+        children: [page.resource_id]
+      })
+
+    pub = insert(:publication, %{project: project, root_resource_id: root.resource_id})
+
+    Enum.each([root, page], fn r ->
+      insert(:published_resource, %{
+        publication: pub,
+        resource: r.resource,
+        revision: r,
+        author: author
+      })
+
+      insert(:project_resource, %{project_id: project.id, resource_id: r.resource_id})
+    end)
+
+    %{project: project, pub: pub, root: root, page: page}
   end
 end

--- a/test/oli/delivery/remix/ops_test.exs
+++ b/test/oli/delivery/remix/ops_test.exs
@@ -115,6 +115,35 @@ defmodule Oli.Delivery.Remix.OpsTest do
              Remix.add_materials(state, [{second_pub.id, first_page.resource_id}], pr_by_pub)
   end
 
+  test "add_materials allows adding more materials from an already remixed project", %{
+    state: state
+  } do
+    %{pub: pub, page: first_page} = publication_with_page("First Source")
+
+    second_page =
+      insert(:revision, %{
+        resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+        title: "Second Source"
+      })
+
+    insert(:published_resource, %{
+      publication: pub,
+      resource: second_page.resource,
+      revision: second_page,
+      author: insert(:author)
+    })
+
+    insert(:project_resource, %{project_id: pub.project_id, resource_id: second_page.resource_id})
+
+    state = %{state | available_publications: [pub | state.available_publications]}
+
+    assert {:ok, state} = Remix.add_materials(state, [{pub.id, first_page.resource_id}])
+    assert {:ok, state} = Remix.add_materials(state, [{pub.id, second_page.resource_id}])
+
+    assert Enum.any?(state.active.children, &(&1.revision.title == "First Source"))
+    assert Enum.any?(state.active.children, &(&1.revision.title == "Second Source"))
+  end
+
   test "add_materials rejects a batch containing projects that share resources", %{state: state} do
     %{pub: first_pub, page: first_page} = publication_with_page("First Source")
     %{pub: second_pub, page: second_page} = publication_with_page("Second Source")

--- a/test/oli/delivery/remix/ops_test.exs
+++ b/test/oli/delivery/remix/ops_test.exs
@@ -79,6 +79,7 @@ defmodule Oli.Delivery.Remix.OpsTest do
   test "add_materials appends from other publication", %{state: state} do
     # create another project/pub with one page
     %{pub: pub, page: page} = publication_with_page("NP")
+    state = make_publication_available(state, pub)
 
     pr_by_pub = Publishing.get_published_resources_for_publications([pub.id])
     sel = [{pub.id, page.resource_id}]
@@ -94,21 +95,34 @@ defmodule Oli.Delivery.Remix.OpsTest do
   } do
     base_page = hd(state.active.children).revision
     %{pub: pub} = publication_with_page("Clone Page", shared_page: base_page)
+    state = make_publication_available(state, pub)
     pr_by_pub = Publishing.get_published_resources_for_publications([pub.id])
 
     assert {:error, :shared_project_resources} =
              Remix.add_materials(state, [{pub.id, base_page.resource_id}], pr_by_pub)
   end
 
+  test "add_materials rejects materials from unavailable publications", %{state: state} do
+    %{pub: pub, page: page} = publication_with_page("Unavailable Source")
+    pr_by_pub = Publishing.get_published_resources_for_publications([pub.id])
+
+    assert {:error, :unavailable_publication} =
+             Remix.add_materials(state, [{pub.id, page.resource_id}], pr_by_pub)
+
+    assert {:error, :unavailable_publication} =
+             Remix.add_materials(state, [{pub.id, page.resource_id}])
+  end
+
   test "add_materials rejects materials sharing resources with an already remixed project", %{
     state: state
   } do
     %{pub: first_pub, page: first_page} = publication_with_page("First Source")
-    state = %{state | available_publications: [first_pub | state.available_publications]}
+    state = make_publication_available(state, first_pub)
 
     assert {:ok, state} = Remix.add_materials(state, [{first_pub.id, first_page.resource_id}])
 
     %{pub: second_pub} = publication_with_page("Second Source", shared_page: first_page)
+    state = make_publication_available(state, second_pub)
     pr_by_pub = Publishing.get_published_resources_for_publications([second_pub.id])
 
     assert {:error, :shared_project_resources} =
@@ -135,7 +149,7 @@ defmodule Oli.Delivery.Remix.OpsTest do
 
     insert(:project_resource, %{project_id: pub.project_id, resource_id: second_page.resource_id})
 
-    state = %{state | available_publications: [pub | state.available_publications]}
+    state = make_publication_available(state, pub)
 
     assert {:ok, state} = Remix.add_materials(state, [{pub.id, first_page.resource_id}])
     assert {:ok, state} = Remix.add_materials(state, [{pub.id, second_page.resource_id}])
@@ -147,6 +161,8 @@ defmodule Oli.Delivery.Remix.OpsTest do
   test "add_materials rejects a batch containing projects that share resources", %{state: state} do
     %{pub: first_pub, page: first_page} = publication_with_page("First Source")
     %{pub: second_pub, page: second_page} = publication_with_page("Second Source")
+    state = make_publication_available(state, first_pub)
+    state = make_publication_available(state, second_pub)
 
     insert(:project_resource, %{
       project_id: second_pub.project_id,
@@ -169,6 +185,10 @@ defmodule Oli.Delivery.Remix.OpsTest do
     else
       h.children |> Enum.map(&find_sr(&1, uuid)) |> Enum.find(& &1)
     end
+  end
+
+  defp make_publication_available(state, pub) do
+    %{state | available_publications: [pub | state.available_publications]}
   end
 
   defp publication_with_page(page_title, opts \\ []) do


### PR DESCRIPTION
 ## Summary

Addresses [MER-5516](https://eliterate.atlassian.net/browse/MER-5615) by preventing remixing course materials from projects that share underlying resources with the section’s base project, already-remixed projects, or other projects selected in the same Add Materials action.

  ## Details

  - Adds a remix-domain guard that checks projects_resources intersections before adding materials.
  - Blocks candidate projects that overlap with the base project or already pinned/remixed projects.
  - Blocks a single add batch containing multiple candidate projects that share resources
    with each other. (The typical flow through Add Materials modal would not give rise to this, but it
     _is_ possible. Also the underlying API allows it so it should be dealt with)
  - Shows error messages in Add Materials modal without dismissing, near Add Materials button to ensure visibility, with distinct error messages for target overlap vs selected-source overlap.
  
Note: Continues to allow additional materials to be added from a project that has already been remixed into the section: the new guard only blocks resource overlap across distinct projects. 

  ## Testing

  - mix test test/oli/delivery/remix
  
  ## Video

https://github.com/user-attachments/assets/76d56c34-d552-4db8-a491-5475e8c3e9c8



[MER-5516]: https://eliterate.atlassian.net/browse/MER-5516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ