### PR TITLE
[CHORE] [MER-0000] Fix Playwright admin logout menu

### DIFF
--- a/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
+++ b/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
@@ -10,7 +10,7 @@ export class MenuDropdownCO {
 
   constructor(page: Page) {
     this.menuButton = page.locator('#workspace-user-menu');
-    this.menuButtonAdmin = page.locator('#workspace-user-menu');
+    this.menuButtonAdmin = page.getByRole('button', { name: 'Playwright Admin profile' });
     this.workspaceMenu = page.locator('#workspace-user-menu-dropdown');
     this.adminPanelLink = this.workspaceMenu.getByRole('link', { name: 'Admin Panel' });
     this.signOutLink = page.getByRole('link', { name: 'Sign out' });
@@ -28,10 +28,12 @@ export class MenuDropdownCO {
     await this.adminPanelLink.click();
   }
 
-  async signOut() {
+  async signOut(isAdminScreen = false) {
+    const menuButton = isAdminScreen ? this.menuButtonAdmin : this.menuButton;
+
     // Try to open the dropdown (two attempts in case of stale click)
     for (let i = 0; i < 2; i++) {
-      await this.menuButton.click();
+      await menuButton.click();
       const visible = await this.workspaceMenu.waitFor({ state: 'visible', timeout: 1000 }).catch(() => false);
       if (visible) break;
     }

--- a/assets/automation/src/systems/torus/tasks/HomeTask.ts
+++ b/assets/automation/src/systems/torus/tasks/HomeTask.ts
@@ -58,7 +58,7 @@ export class HomeTask {
   @step('Logout')
   async logout(isAdminScreen = false) {
     await this.menu.open(isAdminScreen);
-    await this.menu.signOut();
+    await this.menu.signOut(isAdminScreen);
   }
 
   @step('Enter to Curriculum')


### PR DESCRIPTION
Updates the Playwright logout helper to use the admin profile menu when logging out from admin pages. Workspace logout behavior remains unchanged.