### PR TITLE
[ENHANCEMENT] [MER-5614] Add scenario coverage for all non-adaptive activity types

### DIFF
--- a/test/scenarios/activities/activities_test.exs
+++ b/test/scenarios/activities/activities_test.exs
@@ -4,5 +4,62 @@ defmodule Oli.Scenarios.ActivitiesTest do
   Automatically discovers and runs all .scenario.yaml files in this directory.
   """
 
-  use Oli.Scenarios.ScenarioRunner
+  use Oli.DataCase
+
+  alias Oli.Scenarios
+  alias Oli.Scenarios.RuntimeOpts
+
+  @covered_activity_slugs MapSet.new([
+                            "oli_check_all_that_apply",
+                            "oli_custom_dnd",
+                            "oli_directed_discussion",
+                            "oli_file_upload",
+                            "oli_image_coding",
+                            "oli_image_hotspot",
+                            "oli_likert",
+                            "oli_logic_lab",
+                            "oli_multi_input",
+                            "oli_multiple_choice",
+                            "oli_ordering",
+                            "oli_response_multi",
+                            "oli_short_answer",
+                            "oli_vlab"
+                          ])
+
+  @scenario_dir Path.dirname(__ENV__.file)
+
+  test "scenarios cover every registered activity except adaptive and embed" do
+    registered_activity_slugs =
+      Oli.Activities.list_activity_registrations()
+      |> Enum.map(& &1.slug)
+      |> MapSet.new()
+      |> MapSet.difference(MapSet.new(["oli_adaptive", "oli_embedded"]))
+
+    assert MapSet.difference(registered_activity_slugs, @covered_activity_slugs) == MapSet.new()
+  end
+
+  for path <- Path.wildcard(Path.join(@scenario_dir, "*.scenario.yaml")) |> Enum.sort() do
+    name =
+      path
+      |> Path.basename(".scenario.yaml")
+      |> String.replace("_", " ")
+
+    @scenario_path path
+    test "scenario: #{name}" do
+      assert :ok = Scenarios.validate_file(@scenario_path)
+
+      result =
+        Scenarios.execute_file(
+          @scenario_path,
+          RuntimeOpts.build()
+        )
+
+      assert result.errors == []
+
+      failed_verifications =
+        Enum.filter(result.verifications, fn verification -> !verification.passed end)
+
+      assert failed_verifications == []
+    end
+  end
 end

--- a/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
+++ b/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
@@ -1,0 +1,424 @@
+# Scenario: Exercise scenario answer_question support for basic page activity types.
+# Adaptive and embed activities are intentionally excluded from this basic page workflow.
+
+- project:
+    name: "basic_page_activity_submissions"
+    title: "Basic Page Activity Submissions"
+    root:
+      children:
+        - page: "Mixed Practice"
+
+- create_activity:
+    project: "basic_page_activity_submissions"
+    title: "Multiple Choice Question"
+    virtual_id: "mcq"
+    type: "oli_multiple_choice"
+    content_format: "json"
+    content:
+      activityType: "oli_multiple_choice"
+      stem:
+        id: "mcq_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Choose the correct option."
+      choices:
+        - id: "a"
+          content:
+            - type: "p"
+              children:
+                - text: "Incorrect"
+        - id: "b"
+          content:
+            - type: "p"
+              children:
+                - text: "Correct"
+      authoring:
+        version: 2
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "mcq_correct"
+                rule: "input like {b}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "mcq_feedback_correct"
+                  content: []
+              - id: "mcq_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "mcq_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "basic_page_activity_submissions"
+    title: "Short Answer Question"
+    virtual_id: "short_answer"
+    type: "oli_short_answer"
+    content_format: "json"
+    content:
+      activityType: "oli_short_answer"
+      stem:
+        id: "short_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Type the expected answer."
+      inputType: "text"
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "short_correct"
+                rule: "input contains {scenario}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "short_feedback_correct"
+                  content: []
+              - id: "short_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "short_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "basic_page_activity_submissions"
+    title: "Check All That Apply Question"
+    virtual_id: "cata"
+    type: "oli_check_all_that_apply"
+    content_format: "json"
+    content:
+      activityType: "oli_check_all_that_apply"
+      stem:
+        id: "cata_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Select both correct options."
+      choices:
+        - id: "c1"
+          content:
+            - type: "p"
+              children:
+                - text: "Correct 1"
+        - id: "c2"
+          content:
+            - type: "p"
+              children:
+                - text: "Correct 2"
+        - id: "c3"
+          content:
+            - type: "p"
+              children:
+                - text: "Incorrect"
+      authoring:
+        version: 2
+        targeted: []
+        transformations: []
+        previewText: ""
+        correct:
+          - ["c1", "c2"]
+          - "cata_correct"
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "cata_correct"
+                rule: "input like {c1 c2}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "cata_feedback_correct"
+                  content: []
+              - id: "cata_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "cata_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "basic_page_activity_submissions"
+    title: "Ordering Question"
+    virtual_id: "ordering"
+    type: "oli_ordering"
+    content_format: "json"
+    content:
+      activityType: "oli_ordering"
+      stem:
+        id: "ordering_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Put the steps in order."
+      choices:
+        - id: "first"
+          content:
+            - type: "p"
+              children:
+                - text: "First"
+        - id: "second"
+          content:
+            - type: "p"
+              children:
+                - text: "Second"
+        - id: "third"
+          content:
+            - type: "p"
+              children:
+                - text: "Third"
+      authoring:
+        version: 2
+        targeted: []
+        transformations: []
+        previewText: ""
+        correct:
+          - ["first", "second", "third"]
+          - "ordering_correct"
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "ordering_correct"
+                rule: "input like {first second third}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "ordering_feedback_correct"
+                  content: []
+              - id: "ordering_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "ordering_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "basic_page_activity_submissions"
+    title: "Multi Input Question"
+    virtual_id: "multi_input"
+    type: "oli_multi_input"
+    content_format: "json"
+    content:
+      activityType: "oli_multi_input"
+      submitPerPart: false
+      multInputsPerPart: true
+      choices: []
+      inputs:
+        - id: "1637853221"
+          inputType: "text"
+          partId: "651271558"
+        - id: "2369651067"
+          inputType: "numeric"
+          partId: "651271558"
+      stem:
+        id: "multi_input_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Fill in both blanks: "
+              - type: "input_ref"
+                id: "1637853221"
+                children:
+                  - text: ""
+              - text: " and "
+              - type: "input_ref"
+                id: "2369651067"
+                children:
+                  - text: ""
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "651271558"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            targets: ["1637853221", "2369651067"]
+            responses:
+              - id: "multi_input_correct"
+                rule: "input_ref_1637853221 contains {answer} && input_ref_2369651067 = {1}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "multi_input_feedback_correct"
+                  content: []
+              - id: "multi_input_incorrect"
+                rule: "input_ref_1637853221 like {.*} && input_ref_2369651067 like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "multi_input_feedback_incorrect"
+                  content: []
+            hints: []
+
+- edit_page:
+    project: "basic_page_activity_submissions"
+    page: "Mixed Practice"
+    content: |
+      title: "Mixed Practice"
+      graded: false
+      blocks:
+        - type: activity_reference
+          virtual_id: "mcq"
+        - type: activity_reference
+          virtual_id: "short_answer"
+        - type: activity_reference
+          virtual_id: "cata"
+        - type: activity_reference
+          virtual_id: "ordering"
+        - type: activity_reference
+          virtual_id: "multi_input"
+
+- publish:
+    to: "basic_page_activity_submissions"
+    description: "Publish mixed basic activity page"
+
+- section:
+    name: "basic_page_activity_section"
+    title: "Basic Page Activity Section"
+    from: "basic_page_activity_submissions"
+
+- user:
+    name: "student"
+    type: "student"
+
+- enroll:
+    user: "student"
+    section: "basic_page_activity_section"
+    role: "student"
+
+- view_practice_page:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+
+- answer_question:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+    activity_virtual_id: "mcq"
+    response: "b"
+
+- assert:
+    activity_attempt:
+      section: "basic_page_activity_section"
+      student: "student"
+      page: "Mixed Practice"
+      activity_virtual_id: "mcq"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "b"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+    activity_virtual_id: "short_answer"
+    response: "scenario answer"
+
+- assert:
+    activity_attempt:
+      section: "basic_page_activity_section"
+      student: "student"
+      page: "Mixed Practice"
+      activity_virtual_id: "short_answer"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "scenario answer"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+    activity_virtual_id: "cata"
+    response: "c1 c2"
+
+- assert:
+    activity_attempt:
+      section: "basic_page_activity_section"
+      student: "student"
+      page: "Mixed Practice"
+      activity_virtual_id: "cata"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "c1 c2"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+    activity_virtual_id: "ordering"
+    response: "first second third"
+
+- assert:
+    activity_attempt:
+      section: "basic_page_activity_section"
+      student: "student"
+      page: "Mixed Practice"
+      activity_virtual_id: "ordering"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "first second third"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "basic_page_activity_section"
+    page: "Mixed Practice"
+    activity_virtual_id: "multi_input"
+    response: '{"1637853221":"answer","2369651067":"1"}'
+
+- assert:
+    activity_attempt:
+      section: "basic_page_activity_section"
+      student: "student"
+      page: "Mixed Practice"
+      activity_virtual_id: "multi_input"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: '{"1637853221":"answer","2369651067":"1"}'
+      answerable: false

--- a/test/scenarios/activities/remaining_activity_type_submissions.scenario.yaml
+++ b/test/scenarios/activities/remaining_activity_type_submissions.scenario.yaml
@@ -1,0 +1,652 @@
+# Scenario: Exercise the remaining registered activity types through scenarios.
+# Adaptive and embed activities are intentionally excluded from this workflow.
+
+- project:
+    name: "remaining_activity_type_submissions"
+    title: "Remaining Activity Type Submissions"
+    root:
+      children:
+        - page: "Additional Activity Practice"
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "File Upload Activity"
+    virtual_id: "file_upload"
+    type: "oli_file_upload"
+    content_format: "json"
+    content:
+      activityType: "oli_file_upload"
+      stem:
+        id: "file_upload_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Upload a file."
+      fileSpec:
+        maxCount: 1
+        accept: ""
+        maxSizeInBytes: 10485760
+      authoring:
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "average"
+            gradingApproach: "manual"
+            responses:
+              - id: "file_upload_response"
+                rule: "input like {.*}"
+                score: 0
+                feedback:
+                  id: "file_upload_feedback"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Image Hotspot Activity"
+    virtual_id: "image_hotspot"
+    type: "oli_image_hotspot"
+    content_format: "json"
+    content:
+      activityType: "oli_image_hotspot"
+      stem:
+        id: "image_hotspot_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Select the target hotspot."
+      imageURL: "https://example.com/test.png"
+      choices:
+        - id: "hotspot_1"
+          content:
+            - type: "p"
+              children:
+                - text: "Target hotspot"
+          shape: "rect"
+          x: 0
+          y: 0
+          width: 100
+          height: 100
+      authoring:
+        version: 2
+        targeted: []
+        transformations: []
+        previewText: ""
+        correct:
+          - ["hotspot_1"]
+          - "image_hotspot_correct"
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "image_hotspot_correct"
+                rule: "input like {hotspot_1}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "image_hotspot_feedback_correct"
+                  content: []
+              - id: "image_hotspot_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "image_hotspot_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Likert Activity"
+    virtual_id: "likert"
+    type: "oli_likert"
+    content_format: "json"
+    content:
+      activityType: "oli_likert"
+      stem:
+        id: "likert_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Choose a rating."
+      orderDescending: false
+      choices:
+        - id: "agree"
+          content:
+            - type: "p"
+              children:
+                - text: "Agree"
+        - id: "disagree"
+          content:
+            - type: "p"
+              children:
+                - text: "Disagree"
+      authoring:
+        version: 2
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "likert_selected"
+                rule: "input like {agree}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "likert_feedback_selected"
+                  content: []
+              - id: "likert_other"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "likert_feedback_other"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Custom Drag and Drop Activity"
+    virtual_id: "custom_dnd"
+    type: "oli_custom_dnd"
+    content_format: "json"
+    content:
+      activityType: "oli_custom_dnd"
+      stem:
+        id: "custom_dnd_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Drop the item into the target."
+      height: "400"
+      width: "600"
+      targetArea: "<div input_ref=\"input1\" class=\"target\"></div>"
+      layoutStyles: ""
+      initiators: "<div input_val=\"input1\" class=\"initiator\">Item</div>"
+      authoring:
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "input1"
+            scoringStrategy: "average"
+            gradingApproach: "automatic"
+            responses:
+              - id: "custom_dnd_correct"
+                rule: "input like {input1}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "custom_dnd_feedback_correct"
+                  content: []
+              - id: "custom_dnd_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "custom_dnd_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Response Multi Activity"
+    virtual_id: "response_multi"
+    type: "oli_response_multi"
+    content_format: "json"
+    content:
+      activityType: "oli_response_multi"
+      submitPerPart: false
+      multInputsPerPart: true
+      choices: []
+      inputs:
+        - id: "response_text"
+          inputType: "text"
+          partId: "response_multi_part"
+        - id: "response_number"
+          inputType: "numeric"
+          partId: "response_multi_part"
+      stem:
+        id: "response_multi_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Fill in both response multi inputs."
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "response_multi_part"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            targets: ["response_text", "response_number"]
+            responses:
+              - id: "response_multi_correct"
+                rule: "input_ref_response_text contains {answer} && input_ref_response_number = {1}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "response_multi_feedback_correct"
+                  content: []
+              - id: "response_multi_incorrect"
+                rule: "input_ref_response_text like {.*} && input_ref_response_number like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "response_multi_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Virtual Lab Activity"
+    virtual_id: "vlab"
+    type: "oli_vlab"
+    content_format: "json"
+    content:
+      activityType: "oli_vlab"
+      submitPerPart: false
+      multInputsPerPart: false
+      choices: []
+      inputs:
+        - id: "vlab_value"
+          inputType: "numeric"
+          partId: "vlab_part"
+      stem:
+        id: "vlab_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Provide the virtual lab value."
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "vlab_part"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            responses:
+              - id: "vlab_correct"
+                rule: "input_ref_vlab_value = {42}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "vlab_feedback_correct"
+                  content: []
+              - id: "vlab_incorrect"
+                rule: "input_ref_vlab_value like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "vlab_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Logic Lab Activity"
+    virtual_id: "logic_lab"
+    type: "oli_logic_lab"
+    content_format: "json"
+    content:
+      activityType: "oli_logic_lab"
+      stem:
+        id: "logic_lab_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Solve the logic exercise."
+      authoring:
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            responses:
+              - id: "logic_lab_correct"
+                rule: "input like {valid}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "logic_lab_feedback_correct"
+                  content: []
+              - id: "logic_lab_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "logic_lab_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Image Coding Activity"
+    virtual_id: "image_coding"
+    type: "oli_image_coding"
+    content_format: "json"
+    content:
+      activityType: "oli_image_coding"
+      stem:
+        id: "image_coding_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Submit image coding output."
+      isExample: false
+      starterCode: "starter"
+      solutionCode: "solution"
+      resourceURLs: []
+      tolerance: 1.0
+      regex: ""
+      feedback:
+        - id: "image_coding_feedback_incorrect"
+          content: []
+        - id: "image_coding_feedback_correct"
+          content: []
+      authoring:
+        previewText: ""
+        transformations: []
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            responses:
+              - id: "image_coding_correct"
+                rule: "input like {solution}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "image_coding_response_feedback_correct"
+                  content: []
+              - id: "image_coding_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "image_coding_response_feedback_incorrect"
+                  content: []
+            hints: []
+
+- create_activity:
+    project: "remaining_activity_type_submissions"
+    title: "Directed Discussion Activity"
+    virtual_id: "directed_discussion"
+    type: "oli_directed_discussion"
+    content_format: "json"
+    content:
+      activityType: "oli_directed_discussion"
+      stem:
+        id: "directed_discussion_stem"
+        content:
+          - type: "p"
+            children:
+              - text: "Participate in the discussion."
+      maxWords: 0
+      participation:
+        maxPosts: 0
+        maxReplies: 0
+        minPosts: 0
+        minReplies: 0
+        maxWordLength: 0
+      authoring:
+        version: 1
+        transformations: []
+        previewText: ""
+        parts:
+          - id: "1"
+            scoringStrategy: "best"
+            responses:
+              - id: "directed_discussion_default"
+                rule: "input like {.*}"
+                score: 0
+                feedback:
+                  id: "directed_discussion_feedback"
+                  content: []
+            hints: []
+
+- edit_page:
+    project: "remaining_activity_type_submissions"
+    page: "Additional Activity Practice"
+    content: |
+      title: "Additional Activity Practice"
+      graded: false
+      blocks:
+        - type: activity_reference
+          virtual_id: "file_upload"
+        - type: activity_reference
+          virtual_id: "image_hotspot"
+        - type: activity_reference
+          virtual_id: "likert"
+        - type: activity_reference
+          virtual_id: "custom_dnd"
+        - type: activity_reference
+          virtual_id: "response_multi"
+        - type: activity_reference
+          virtual_id: "vlab"
+        - type: activity_reference
+          virtual_id: "logic_lab"
+        - type: activity_reference
+          virtual_id: "image_coding"
+        - type: activity_reference
+          virtual_id: "directed_discussion"
+
+- publish:
+    to: "remaining_activity_type_submissions"
+    description: "Publish additional activity type page"
+
+- section:
+    name: "remaining_activity_type_section"
+    title: "Remaining Activity Type Section"
+    from: "remaining_activity_type_submissions"
+
+- user:
+    name: "student"
+    type: "student"
+
+- enroll:
+    user: "student"
+    section: "remaining_activity_type_section"
+    role: "student"
+
+- view_practice_page:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "file_upload"
+    response: "uploaded-file-placeholder"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "file_upload"
+      activity_lifecycle_state: "submitted"
+      part_lifecycle_state: "submitted"
+      response: "uploaded-file-placeholder"
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "image_hotspot"
+    response: "hotspot_1"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "image_hotspot"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "hotspot_1"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "likert"
+    response: "agree"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "likert"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "agree"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "custom_dnd"
+    response: "input1"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "custom_dnd"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "input1"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "response_multi"
+    response: '{"response_text":"answer","response_number":"1"}'
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "response_multi"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: '{"response_text":"answer","response_number":"1"}'
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "vlab"
+    response: '{"vlab_value":"42"}'
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "vlab"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: '{"vlab_value":"42"}'
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "logic_lab"
+    response: "valid"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "logic_lab"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "valid"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "image_coding"
+    response: "solution"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "image_coding"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      response: "solution"
+      answerable: false
+
+- answer_question:
+    student: "student"
+    section: "remaining_activity_type_section"
+    page: "Additional Activity Practice"
+    activity_virtual_id: "directed_discussion"
+    response: "participated"
+
+- assert:
+    activity_attempt:
+      section: "remaining_activity_type_section"
+      student: "student"
+      page: "Additional Activity Practice"
+      activity_virtual_id: "directed_discussion"
+      activity_lifecycle_state: "evaluated"
+      part_lifecycle_state: "evaluated"
+      score: 1.0
+      out_of: 1.0
+      part_score: 1.0
+      part_out_of: 1.0
+      answerable: false


### PR DESCRIPTION
Changes:
- Add scenario coverage for `answer_question` across every registered activity type except Adaptive and Embed.
- Add explicit coverage guard so newly registered non-excluded activity types fail the activities scenario suite until covered.
- Update the activities scenario runner to use direct `Oli.Scenarios.execute_file/2` execution with `RuntimeOpts.build/0`.


See: https://eliterate.atlassian.net/browse/MER-5614