### PR TITLE
[BUG FIX] [MER-5640] fix grace period banner layout

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -39,31 +39,31 @@
     <div id="flash_container" class="container mx-auto sticky top-[60px] z-40">
       <.flash_group flash={@flash} />
     </div>
-    <%= if @section do %>
-      {live_render(@socket, OliWeb.Dialogue.WindowLive,
-        session: %{"section_slug" => @section.slug},
-        id: "dialogue-window"
-      )}
-    <% end %>
     <div
       :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
       id="pay_early_message"
-      class="absolute z-50 system-banner flex flex-row alert alert-warning m-6"
+      class="system-banner flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between alert alert-warning mx-4 mt-4 md:mx-6"
       role="alert"
     >
       {OliWeb.LayoutView.pay_early_message(@paywall_summary)}
       <div class="flex whitespace-nowrap items-center">
-        <.link class="ml-8" href={Routes.payment_path(@socket, :guard, @section.slug)}>
+        <.link href={Routes.payment_path(@socket, :guard, @section.slug)}>
           Pay Now
         </.link>
         <button
-          class="ml-10 stroke-gray-500 hover:stroke-gray-400"
+          class="ml-6 stroke-gray-500 hover:stroke-gray-400"
           phx-click={JS.hide(to: "#pay_early_message")}
         >
           <OliWeb.Icons.close class="stroke-zinc-700" />
         </button>
       </div>
     </div>
+    <%= if @section do %>
+      {live_render(@socket, OliWeb.Dialogue.WindowLive,
+        session: %{"section_slug" => @section.slug},
+        id: "dialogue-window"
+      )}
+    <% end %>
     {@inner_content}
     <div class={[
       "px-4 mt-auto",

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -122,6 +122,25 @@
           </div>
         </div>
         <div
+          :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
+          id="pay_early_message"
+          class="system-banner flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between alert alert-warning mx-4 mt-4 md:mx-6"
+          role="alert"
+        >
+          {OliWeb.LayoutView.pay_early_message(@paywall_summary)}
+          <div class="flex whitespace-nowrap items-center">
+            <.link href={Routes.payment_path(@socket, :guard, @section.slug)}>
+              Pay Now
+            </.link>
+            <button
+              class="ml-6 stroke-gray-500 hover:stroke-gray-400"
+              phx-click={JS.hide(to: "#pay_early_message")}
+            >
+              <OliWeb.Icons.close class="stroke-zinc-700" />
+            </button>
+          </div>
+        </div>
+        <div
           :if={@section}
           id="page-content"
           phx-hook="PageContentHooks"
@@ -171,26 +190,6 @@
 
       <div class="flex flex-col">
         <div class="flex-1 flex flex-col min-h-0">
-          <div
-            :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
-            id="pay_early_message"
-            class="absolute z-50 system-banner flex flex-row alert alert-warning ml-32 m-6"
-            role="alert"
-          >
-            {OliWeb.LayoutView.pay_early_message(@paywall_summary)}
-            <div class="flex whitespace-nowrap items-center">
-              <.link class="ml-8" href={Routes.payment_path(@socket, :guard, @section.slug)}>
-                Pay Now
-              </.link>
-              <button
-                class="ml-10 stroke-gray-500 hover:stroke-gray-400"
-                phx-click={JS.hide(to: "#pay_early_message")}
-              >
-                <OliWeb.Icons.close class="stroke-zinc-700" />
-              </button>
-            </div>
-          </div>
-
           <div
             :if={assigns[:page_context]}
             class={

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -58,7 +58,26 @@
             </div>
           <% end %>
         </div>
-        <div class="sticky top-[55px] z-50">
+        <div
+          :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
+          id="pay_early_message"
+          class="system-banner flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between alert alert-warning mx-4 mt-4 md:mx-6"
+          role="alert"
+        >
+          {OliWeb.LayoutView.pay_early_message(@paywall_summary)}
+          <div class="flex whitespace-nowrap items-center">
+            <.link href={Routes.payment_path(@socket, :guard, @section.slug)}>
+              Pay Now
+            </.link>
+            <button
+              class="ml-6 stroke-gray-500 hover:stroke-gray-400"
+              phx-click={JS.hide(to: "#pay_early_message")}
+            >
+              <OliWeb.Icons.close class="stroke-zinc-700" />
+            </button>
+          </div>
+        </div>
+        <div class="sticky top-[55px] z-50 md:h-20 2xl:h-28">
           <% back_url =
             if assigns[:request_path] in [nil, ""] and @current_page != nil,
               do: ~p"/sections/#{@section.slug}/learn?target_resource_id=#{@current_page["id"]}",
@@ -118,25 +137,6 @@
             >
               <OliWeb.Delivery.Student.Lesson.Components.OutlineComponent.outline_icon />
               <span class="whitespace-nowrap">Course Content</span>
-            </button>
-          </div>
-        </div>
-        <div
-          :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
-          id="pay_early_message"
-          class="system-banner flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between alert alert-warning mx-4 mt-4 md:mx-6"
-          role="alert"
-        >
-          {OliWeb.LayoutView.pay_early_message(@paywall_summary)}
-          <div class="flex whitespace-nowrap items-center">
-            <.link href={Routes.payment_path(@socket, :guard, @section.slug)}>
-              Pay Now
-            </.link>
-            <button
-              class="ml-6 stroke-gray-500 hover:stroke-gray-400"
-              phx-click={JS.hide(to: "#pay_early_message")}
-            >
-              <OliWeb.Icons.close class="stroke-zinc-700" />
             </button>
           </div>
         </div>

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -861,7 +861,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, html} = live(conn, ~p"/sections/#{product.slug}")
+      {:ok, view, _html} = live(conn, ~p"/sections/#{product.slug}")
 
       assert has_element?(
                view,
@@ -869,7 +869,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                "You have 18 days left of your grace period for accessing this course"
              )
 
-      refute "absolute" in pay_early_message_classes(html)
+      refute "absolute" in pay_early_message_classes(render(view))
 
       # Grace period is over
       stub_current_time(~U[2024-11-13 20:00:00Z])

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -23,6 +23,15 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
     AttemptGroup
   }
 
+  defp pay_early_message_classes(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#pay_early_message")
+    |> Floki.attribute("class")
+    |> List.first()
+    |> String.split()
+  end
+
   defp enroll_as_student(%{user: user, section: section} = context) do
     Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
     context
@@ -852,13 +861,15 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, _html} = live(conn, ~p"/sections/#{product.slug}")
+      {:ok, view, html} = live(conn, ~p"/sections/#{product.slug}")
 
       assert has_element?(
                view,
                "div[id=pay_early_message]",
                "You have 18 days left of your grace period for accessing this course"
              )
+
+      refute "absolute" in pay_early_message_classes(html)
 
       # Grace period is over
       stub_current_time(~U[2024-11-13 20:00:00Z])

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -24,6 +24,15 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
 
   @default_selected_view :gallery
 
+  defp pay_early_message_classes(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#pay_early_message")
+    |> Floki.attribute("class")
+    |> List.first()
+    |> String.split()
+  end
+
   defp set_progress(section_id, resource_id, user_id, progress, revision) do
     {:ok, resource_access} =
       Core.track_access(resource_id, section_id, user_id)
@@ -852,13 +861,15 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, _html} = live(conn, Utils.learn_live_path(product.slug))
+      {:ok, view, html} = live(conn, Utils.learn_live_path(product.slug))
 
       assert has_element?(
                view,
                "div[id=pay_early_message]",
                "You have 18 days left of your grace period for accessing this course"
              )
+
+      refute "absolute" in pay_early_message_classes(html)
 
       # Grace period is over
       stub_current_time(~U[2024-11-13 20:00:00Z])

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -861,7 +861,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, html} = live(conn, Utils.learn_live_path(product.slug))
+      {:ok, view, _html} = live(conn, Utils.learn_live_path(product.slug))
 
       assert has_element?(
                view,
@@ -869,7 +869,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
                "You have 18 days left of your grace period for accessing this course"
              )
 
-      refute "absolute" in pay_early_message_classes(html)
+      refute "absolute" in pay_early_message_classes(render(view))
 
       # Grace period is over
       stub_current_time(~U[2024-11-13 20:00:00Z])

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -1125,7 +1125,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, html} = live(conn, Utils.lesson_live_path(product.slug, page_1.slug))
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(product.slug, page_1.slug))
       ensure_content_is_visible(view)
 
       assert has_element?(
@@ -1133,6 +1133,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
                "div[id=pay_early_message]",
                "You have 18 days left of your grace period for accessing this course"
              )
+
+      html = render(view)
 
       refute "absolute" in pay_early_message_classes(html)
       assert_pay_early_message_before_page_content(html)

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -17,6 +17,22 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
 
   @default_selected_view :gallery
 
+  defp pay_early_message_classes(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("#pay_early_message")
+    |> Floki.attribute("class")
+    |> List.first()
+    |> String.split()
+  end
+
+  defp assert_pay_early_message_before_page_content(html) do
+    {pay_early_message_index, _} = :binary.match(html, ~s(id="pay_early_message"))
+    {page_content_index, _} = :binary.match(html, ~s(id="page-content"))
+
+    assert pay_early_message_index < page_content_index
+  end
+
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, request_path \\ nil)
 
   defp live_view_adaptive_lesson_live_route(section_slug, revision_slug, nil) do
@@ -1109,7 +1125,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
           end_date: ~U[2024-11-30 20:00:00Z]
         })
 
-      {:ok, view, _html} = live(conn, Utils.lesson_live_path(product.slug, page_1.slug))
+      {:ok, view, html} = live(conn, Utils.lesson_live_path(product.slug, page_1.slug))
       ensure_content_is_visible(view)
 
       assert has_element?(
@@ -1117,6 +1133,9 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
                "div[id=pay_early_message]",
                "You have 18 days left of your grace period for accessing this course"
              )
+
+      refute "absolute" in pay_early_message_classes(html)
+      assert_pay_early_message_before_page_content(html)
 
       # Grace period is over
       stub_current_time(~U[2024-11-13 20:00:00Z])


### PR DESCRIPTION
## Summary

  Fixes the payment grace-period banner layout in student delivery views.

  The banner now renders in normal page flow instead of being absolutely positioned, and lesson pages place it above the lesson back navigation so it does not overlap with sticky page chrome.

  ## Cause

  The grace-period banner was rendered with `absolute` positioning inside student delivery layouts. On lesson pages it was also rendered in a separate sibling layout area from the main page content and used hard-coded offsets like `ml-32`.

  Because the page also has sticky/high-z-index delivery chrome, including the header and back navigation, the absolutely positioned banner could be obscured or visually collide with nearby controls.

  ## Changes

  - Removed absolute positioning from the grace-period payment banner.
  - Removed hard-coded banner offsets.
  - Moved the lesson-page banner into the main lesson shell above page content/back navigation.
  - Added regression assertions that the banner is not absolutely positioned.
  - Added lesson-page coverage that the banner renders before page content.

## Screenshot
<img width="1116" height="380" alt="Screenshot 2026-05-12 at 3 05 45 PM" src="https://github.com/user-attachments/assets/d4dcab6f-c7e1-4726-b056-992e468184ff" />
