### PR TITLE
[BUG FIX] [MER-5312] Rework: Fix adaptive iframe height measurement

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -64,18 +64,32 @@ export const shouldHideLessonFinishedCloseButton = (
 
 const adaptiveIframeHeightMessageType = 'oli:adaptive-content-height';
 const adaptiveIframeHeightRequestType = 'oli:request-adaptive-content-height';
-const minimumAdaptiveIframeHeight = 600;
-const adaptiveIframeContentSelectors = ['.content', 'oli-adaptive-delivery', '[data-part-id]'].join(
+const minimumAdaptiveIframeHeight = 650;
+const adaptiveIframeContentSelectors = ['#stage-stage', '.stage-content-wrapper > .content'].join(
   ',',
 );
 const adaptiveIframeFallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(
   ',',
 );
+const adaptivePartTagPrefix = 'janus-';
+const adaptiveRootSelector = '[data-adaptive-delivery-root]';
 
 const isHTMLElement = (element?: Element | null): element is HTMLElement => {
   const elementWindow = element?.ownerDocument.defaultView;
 
   return !!elementWindow && element instanceof elementWindow.HTMLElement;
+};
+
+const finiteNumber = (value: unknown) => {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+};
+
+const usesResponsiveAdaptiveLayout = () => {
+  const root = document.querySelector(adaptiveRootSelector);
+
+  return root?.getAttribute('data-adaptive-responsive-layout') === 'true';
 };
 
 const getElementHeight = (element?: Element | null) => {
@@ -91,30 +105,85 @@ const getElementHeight = (element?: Element | null) => {
   );
 };
 
+const getElementVisualBottom = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  return element.getBoundingClientRect().bottom + window.scrollY;
+};
+
+const getAuthoredPartVisualBottom = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const modelAttribute = element.getAttribute('model');
+  const top = element.getBoundingClientRect().top + window.scrollY;
+
+  if (!modelAttribute) {
+    return getElementVisualBottom(element);
+  }
+
+  try {
+    const model = JSON.parse(modelAttribute);
+    const height = finiteNumber(model?.height);
+
+    return height === undefined ? getElementVisualBottom(element) : top + height;
+  } catch (_e) {
+    return getElementVisualBottom(element);
+  }
+};
+
+const getIntrinsicAdaptiveElementHeight = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const partElements = Array.from(element.querySelectorAll('*')).filter((child) =>
+    child.tagName.toLowerCase().startsWith(adaptivePartTagPrefix),
+  );
+
+  if (partElements.length === 0) {
+    return 0;
+  }
+
+  const partHeight = usesResponsiveAdaptiveLayout()
+    ? getElementVisualBottom
+    : getAuthoredPartVisualBottom;
+  const partContentHeight = Math.max(...partElements.map(partHeight), 0);
+
+  return partContentHeight;
+};
+
 const getMaxElementHeight = (elements: Element[]) =>
   Math.max(...elements.map(getElementHeight), minimumAdaptiveIframeHeight);
+
+const getMaxIntrinsicAdaptiveElementHeight = (elements: Element[]) =>
+  Math.max(...elements.map(getIntrinsicAdaptiveElementHeight), minimumAdaptiveIframeHeight);
 
 const getDocumentHeight = () =>
   Math.max(getElementHeight(document.body), getElementHeight(document.documentElement));
 
-const getAdaptiveContentHeight = (contentElement?: HTMLElement | null) => {
+export const getAdaptiveContentHeight = (contentElement?: HTMLElement | null) => {
   const contentElements = Array.from(document.querySelectorAll(adaptiveIframeContentSelectors));
-  const measuredContentHeight =
-    contentElements.length > 0
-      ? getMaxElementHeight(contentElements)
-      : getMaxElementHeight([
-          ...(contentElement ? [contentElement] : []),
-          ...Array.from(document.querySelectorAll(adaptiveIframeFallbackContentSelectors)),
-          document.body,
-          document.documentElement,
-        ]);
-  const measuredDocumentHeight = getDocumentHeight();
 
-  if (measuredDocumentHeight > window.innerHeight + 1) {
-    return Math.max(measuredContentHeight, measuredDocumentHeight, minimumAdaptiveIframeHeight);
+  if (contentElements.length > 0) {
+    return getMaxIntrinsicAdaptiveElementHeight(contentElements);
   }
 
-  return measuredContentHeight;
+  const fallbackContentElements = Array.from(
+    document.querySelectorAll(adaptiveIframeFallbackContentSelectors),
+  );
+
+  if (contentElement || fallbackContentElements.length > 0) {
+    return minimumAdaptiveIframeHeight;
+  }
+
+  const measuredContentHeight = getMaxElementHeight([...fallbackContentElements]);
+  const measuredDocumentHeight = getDocumentHeight();
+
+  return Math.max(measuredContentHeight, measuredDocumentHeight, minimumAdaptiveIframeHeight);
 };
 
 const Delivery: React.FC<DeliveryProps> = ({
@@ -351,6 +420,7 @@ const Delivery: React.FC<DeliveryProps> = ({
     <div
       ref={deliveryRootRef}
       data-adaptive-delivery-root
+      data-adaptive-responsive-layout={String(!!content?.custom?.responsiveLayout)}
       className={`${parentDivClasses.join(' ')} ${currentTheme} ${
         reviewMode && isInstructor ? 'instructor-preview' : ''
       }`}

--- a/assets/src/hooks/adaptive_iframe_resize.ts
+++ b/assets/src/hooks/adaptive_iframe_resize.ts
@@ -9,12 +9,14 @@ type AdaptiveIframeResizeHook = {
 };
 
 const messageType = 'oli:adaptive-content-height';
-const minIframeHeight = 600;
+const minIframeHeight = 650;
 const maxIframeHeight = 20_000;
 const heightPollIntervalMs = 1000;
 const stableHeightLimit = 3;
-const contentSelectors = ['.content', 'oli-adaptive-delivery', '[data-part-id]'].join(',');
+const contentSelectors = ['#stage-stage', '.stage-content-wrapper > .content'].join(',');
 const fallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(',');
+const adaptivePartTagPrefix = 'janus-';
+const adaptiveRootSelector = '[data-adaptive-delivery-root]';
 
 const findIframe = (root: HTMLElement) =>
   root.querySelector('#adaptive_content_iframe') as HTMLIFrameElement | null;
@@ -40,6 +42,18 @@ const isHTMLElement = (element?: Element | null): element is HTMLElement => {
   return !!elementWindow && element instanceof elementWindow.HTMLElement;
 };
 
+const finiteNumber = (value: unknown) => {
+  const numberValue = typeof value === 'number' ? value : Number(value);
+
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+};
+
+const usesResponsiveAdaptiveLayout = (doc: Document) => {
+  const root = doc.querySelector(adaptiveRootSelector);
+
+  return root?.getAttribute('data-adaptive-responsive-layout') === 'true';
+};
+
 const elementHeight = (element?: Element | null) => {
   if (!isHTMLElement(element)) {
     return 0;
@@ -55,13 +69,74 @@ const elementHeight = (element?: Element | null) => {
   );
 };
 
+const elementVisualBottom = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const scrollY = element.ownerDocument.defaultView?.scrollY || 0;
+
+  return element.getBoundingClientRect().bottom + scrollY;
+};
+
+const authoredPartVisualBottom = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const modelAttribute = element.getAttribute('model');
+  const scrollY = element.ownerDocument.defaultView?.scrollY || 0;
+  const top = element.getBoundingClientRect().top + scrollY;
+
+  if (!modelAttribute) {
+    return elementVisualBottom(element);
+  }
+
+  try {
+    const model = JSON.parse(modelAttribute);
+    const height = finiteNumber(model?.height);
+
+    return height === undefined ? elementVisualBottom(element) : top + height;
+  } catch (_e) {
+    return elementVisualBottom(element);
+  }
+};
+
+const intrinsicAdaptiveElementHeight = (
+  element?: Element | null,
+  useAuthoredPartBounds = false,
+) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  const partElements = Array.from(element.querySelectorAll('*')).filter((child) =>
+    child.tagName.toLowerCase().startsWith(adaptivePartTagPrefix),
+  );
+
+  if (partElements.length === 0) {
+    return 0;
+  }
+
+  const partHeight = useAuthoredPartBounds ? authoredPartVisualBottom : elementVisualBottom;
+  const partContentHeight = Math.max(...partElements.map(partHeight), 0);
+
+  return partContentHeight;
+};
+
 const maxElementHeight = (elements: Element[]) =>
   Math.max(...elements.map(elementHeight), minIframeHeight);
+
+const maxIntrinsicAdaptiveElementHeight = (elements: Element[], useAuthoredPartBounds = false) =>
+  Math.max(
+    ...elements.map((element) => intrinsicAdaptiveElementHeight(element, useAuthoredPartBounds)),
+    minIframeHeight,
+  );
 
 const documentHeight = (doc: Document) =>
   Math.max(elementHeight(doc.body), elementHeight(doc.documentElement));
 
-const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
+export const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
   try {
     const doc = iframe.contentDocument;
 
@@ -70,22 +145,21 @@ const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
     }
 
     const contentElements = Array.from(doc.querySelectorAll(contentSelectors));
-    const measuredContentHeight =
-      contentElements.length > 0
-        ? maxElementHeight(contentElements)
-        : maxElementHeight([
-            ...Array.from(doc.querySelectorAll(fallbackContentSelectors)),
-            doc.body,
-            doc.documentElement,
-          ]);
-    const measuredDocumentHeight = documentHeight(doc);
-    const iframeViewportHeight = iframe.getBoundingClientRect().height || iframe.clientHeight;
 
-    if (measuredDocumentHeight > iframeViewportHeight + 1) {
-      return Math.max(measuredContentHeight, measuredDocumentHeight, minIframeHeight);
+    if (contentElements.length > 0) {
+      return maxIntrinsicAdaptiveElementHeight(contentElements, !usesResponsiveAdaptiveLayout(doc));
     }
 
-    return measuredContentHeight;
+    const fallbackContentElements = Array.from(doc.querySelectorAll(fallbackContentSelectors));
+
+    if (fallbackContentElements.length > 0) {
+      return minIframeHeight;
+    }
+
+    const measuredContentHeight = maxElementHeight(fallbackContentElements);
+    const measuredDocumentHeight = documentHeight(doc);
+
+    return Math.max(measuredContentHeight, measuredDocumentHeight, minIframeHeight);
   } catch (_e) {
     return 0;
   }

--- a/assets/test/delivery/adaptive_iframe_resize_test.ts
+++ b/assets/test/delivery/adaptive_iframe_resize_test.ts
@@ -1,0 +1,98 @@
+import { measureIframeContentHeight } from 'hooks/adaptive_iframe_resize';
+
+const setElementHeight = (element: Element, height: number) => {
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: height });
+  Object.defineProperty(element, 'offsetHeight', { configurable: true, value: height });
+  setElementVisualBottom(element, height);
+};
+
+const setElementVisualBottom = (element: Element, bottom: number) => {
+  element.getBoundingClientRect = jest.fn(
+    () =>
+      ({
+        bottom,
+        height: bottom,
+        top: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect),
+  );
+};
+
+describe('AdaptiveIframeResize', () => {
+  it('uses the minimum height while adaptive stage content is still loading', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = '<div id="stage-stage"></div>';
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    setElementHeight(stage, 640);
+    setElementHeight(iframeDocument.body, 2000);
+    setElementHeight(iframeDocument.documentElement, 2000);
+
+    expect(measureIframeContentHeight(iframe)).toBe(650);
+
+    iframe.remove();
+  });
+
+  it('measures adaptive part bounds when the adaptive container has stretched with the iframe', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = `
+      <div id="stage-stage">
+        <div class="stage-content-wrapper">
+          <div class="content">
+            <janus-text-flow></janus-text-flow>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    const content = iframeDocument.querySelector('.content') as HTMLElement;
+    const textFlow = iframeDocument.querySelector('janus-text-flow') as HTMLElement;
+    setElementHeight(stage, 2000);
+    setElementHeight(content, 2000);
+    setElementHeight(textFlow, 740);
+    setElementHeight(iframeDocument.body, 2000);
+    setElementHeight(iframeDocument.documentElement, 2000);
+
+    expect(measureIframeContentHeight(iframe)).toBe(740);
+
+    iframe.remove();
+  });
+
+  it('ignores adaptive part scroll height that grows with nested iframe content', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-capi-iframe></janus-capi-iframe>
+      </div>
+    `;
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    const capiIframe = iframeDocument.querySelector('janus-capi-iframe') as HTMLElement;
+    capiIframe.setAttribute('model', JSON.stringify({ height: 740 }));
+    setElementHeight(stage, 3000);
+    setElementHeight(capiIframe, 3000);
+    setElementVisualBottom(capiIframe, 3000);
+    setElementHeight(iframeDocument.body, 3000);
+    setElementHeight(iframeDocument.documentElement, 3000);
+
+    expect(measureIframeContentHeight(iframe)).toBe(740);
+
+    iframe.remove();
+  });
+});

--- a/assets/test/delivery/delivery_height_test.ts
+++ b/assets/test/delivery/delivery_height_test.ts
@@ -1,0 +1,84 @@
+import { getAdaptiveContentHeight } from 'apps/delivery/Delivery';
+
+const setElementHeight = (element: Element, height: number) => {
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: height });
+  Object.defineProperty(element, 'offsetHeight', { configurable: true, value: height });
+  setElementVisualBottom(element, height);
+};
+
+const setElementVisualBottom = (element: Element, bottom: number) => {
+  element.getBoundingClientRect = jest.fn(
+    () =>
+      ({
+        bottom,
+        height: bottom,
+        top: 0,
+        left: 0,
+        right: 0,
+        width: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect),
+  );
+};
+
+describe('Delivery adaptive iframe height reporting', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('reports the minimum height while adaptive stage content is still loading', () => {
+    document.body.innerHTML = '<div id="stage-stage"></div>';
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    setElementHeight(stage, 640);
+    setElementHeight(document.body, 2000);
+    setElementHeight(document.documentElement, 2000);
+
+    expect(getAdaptiveContentHeight()).toBe(650);
+  });
+
+  it('measures adaptive part bounds when the adaptive container has stretched with the iframe', () => {
+    document.body.innerHTML = `
+      <div id="stage-stage">
+        <div class="stage-content-wrapper">
+          <div class="content">
+            <janus-text-flow></janus-text-flow>
+          </div>
+        </div>
+      </div>
+    `;
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    const content = document.querySelector('.content') as HTMLElement;
+    const textFlow = document.querySelector('janus-text-flow') as HTMLElement;
+    setElementHeight(stage, 2000);
+    setElementHeight(content, 2000);
+    setElementHeight(textFlow, 740);
+    setElementHeight(document.body, 2000);
+    setElementHeight(document.documentElement, 2000);
+
+    expect(getAdaptiveContentHeight()).toBe(740);
+  });
+
+  it('ignores adaptive part scroll height that grows with nested iframe content', () => {
+    document.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-capi-iframe></janus-capi-iframe>
+      </div>
+    `;
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    const capiIframe = document.querySelector('janus-capi-iframe') as HTMLElement;
+    capiIframe.setAttribute('model', JSON.stringify({ height: 740 }));
+    setElementHeight(stage, 3000);
+    setElementHeight(capiIframe, 3000);
+    setElementVisualBottom(capiIframe, 3000);
+    setElementHeight(document.body, 3000);
+    setElementHeight(document.documentElement, 3000);
+
+    expect(getAdaptiveContentHeight()).toBe(740);
+  });
+});


### PR DESCRIPTION
Fixes adaptive page iframe height calculation when adaptive pages are displayed within Torus navigation.

The resize logic now measures the adaptive stage content from the rendered janus-* parts instead of using stretched container or document height. For fixed-layout adaptive pages, it uses authored part bounds so nested iframe content cannot cause the parent iframe height to grow indefinitely. Responsive adaptive pages continue to use visual DOM bounds so existing responsive behavior is preserved.

Also updates the adaptive iframe minimum height to 650px to match MER-5312.





See: https://eliterate.atlassian.net/browse/MER-5312