### PR TITLE
Stabilize Playwright login and menu interactions

### DIFF
--- a/assets/automation/src/systems/torus/pom/home/LoginPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/LoginPO.ts
@@ -45,19 +45,49 @@ export class LoginPO {
   }
 
   async fillEmail(email: string) {
+    await this.waitForLoginForm();
     await this.emailInput.click();
     await this.emailInput.clear();
     await this.emailInput.fill(email);
+    await Verifier.expectToHaveValue(this.emailInput, email);
   }
 
   async fillPassword(password: string) {
+    await this.waitForLoginForm();
     await this.passwordInput.click();
     await this.passwordInput.clear();
     await this.passwordInput.fill(password);
+    await Verifier.expectToHaveValue(this.passwordInput, password);
+  }
+
+  async signIn(email: string, password: string) {
+    await this.waitForLoginForm();
+    await this.emailInput.fill(email);
+    await this.passwordInput.fill(password);
+    await Verifier.expectToHaveValue(this.emailInput, email);
+    await Verifier.expectToHaveValue(this.passwordInput, password);
+    await this.clickSignInButton();
   }
 
   async clickSignInButton() {
     await this.signInButton.click();
+  }
+
+  private async waitForLoginForm() {
+    await Waiter.waitForLoadState(this.page);
+
+    try {
+      await Waiter.waitFor(this.page.locator('div.phx-connected').first(), 'attached');
+      await Waiter.waitFor(this.page.locator('div.phx-loading').first(), 'detached');
+    } catch {
+      // Some login pages may render without a LiveView root; the form checks below are the source of truth.
+    }
+
+    await Waiter.waitFor(this.emailInput, 'visible');
+    await Waiter.waitFor(this.passwordInput, 'visible');
+    await Verifier.expectIsEnabled(this.emailInput);
+    await Verifier.expectIsEnabled(this.passwordInput);
+    await Verifier.expectIsEnabled(this.signInButton);
   }
 
   async selectRoleAccount(role: TypeUser) {

--- a/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
+++ b/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
@@ -7,17 +7,15 @@ export class MenuDropdownCO {
   private readonly workspaceMenu: Locator;
   private readonly adminPanelLink: Locator;
   private readonly workspaceSignOutLink: Locator;
-  private readonly adminSignOutButton: Locator;
-  private readonly adminSignOutLink: Locator;
+  private readonly page: Page;
 
   constructor(page: Page) {
+    this.page = page;
     this.menuButton = page.locator('#workspace-user-menu');
     this.menuButtonAdmin = page.getByRole('button', { name: 'Playwright Admin profile' });
     this.workspaceMenu = page.locator('#workspace-user-menu-dropdown');
     this.adminPanelLink = this.workspaceMenu.getByRole('link', { name: 'Admin Panel' });
     this.workspaceSignOutLink = this.workspaceMenu.getByRole('link', { name: 'Sign out' });
-    this.adminSignOutButton = page.getByRole('button', { name: 'Sign out' }).first();
-    this.adminSignOutLink = page.getByRole('link', { name: 'Sign out' }).first();
   }
 
   async open(isAdminScreen = false) {
@@ -63,10 +61,7 @@ export class MenuDropdownCO {
 
   private async isSignOutMenuVisible(isAdminScreen: boolean) {
     if (isAdminScreen) {
-      return (
-        (await this.adminSignOutButton.isVisible().catch(() => false)) ||
-        (await this.adminSignOutLink.isVisible().catch(() => false))
-      );
+      return (await this.findVisibleAdminSignOutControl()) !== undefined;
     }
 
     return await this.workspaceMenu.isVisible();
@@ -86,29 +81,43 @@ export class MenuDropdownCO {
   }
 
   private async waitForAdminSignOutControl() {
-    for (const control of [this.adminSignOutButton, this.adminSignOutLink]) {
-      const visible = await control
-        .waitFor({ state: 'visible', timeout: 1000 })
-        .then(() => true)
-        .catch(() => false);
+    const deadline = Date.now() + 1000;
 
-      if (visible) {
+    while (Date.now() < deadline) {
+      const control = await this.findVisibleAdminSignOutControl();
+
+      if (control) {
         return control;
       }
+
+      await this.page.waitForTimeout(100);
     }
 
     throw new Error('Admin sign-out control was not visible');
   }
 
   private async getAdminSignOutControl() {
-    if (await this.adminSignOutButton.isVisible().catch(() => false)) {
-      return this.adminSignOutButton;
+    const visibleControl = await this.findVisibleAdminSignOutControl();
+
+    return visibleControl ?? (await this.waitForAdminSignOutControl());
+  }
+
+  private async findVisibleAdminSignOutControl() {
+    for (const controls of [
+      this.page.getByRole('button', { name: 'Sign out' }),
+      this.page.getByRole('link', { name: 'Sign out' }),
+    ]) {
+      const count = await controls.count();
+
+      for (let i = 0; i < count; i++) {
+        const control = controls.nth(i);
+
+        if (await control.isVisible().catch(() => false)) {
+          return control;
+        }
+      }
     }
 
-    if (await this.adminSignOutLink.isVisible().catch(() => false)) {
-      return this.adminSignOutLink;
-    }
-
-    return await this.waitForAdminSignOutControl();
+    return undefined;
   }
 }

--- a/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
+++ b/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
@@ -6,22 +6,24 @@ export class MenuDropdownCO {
   private readonly menuButtonAdmin: Locator;
   private readonly workspaceMenu: Locator;
   private readonly adminPanelLink: Locator;
-  private readonly signOutControl: Locator;
+  private readonly workspaceSignOutLink: Locator;
+  private readonly adminSignOutButton: Locator;
+  private readonly adminSignOutLink: Locator;
 
   constructor(page: Page) {
     this.menuButton = page.locator('#workspace-user-menu');
     this.menuButtonAdmin = page.getByRole('button', { name: 'Playwright Admin profile' });
     this.workspaceMenu = page.locator('#workspace-user-menu-dropdown');
     this.adminPanelLink = this.workspaceMenu.getByRole('link', { name: 'Admin Panel' });
-    this.signOutControl = page
-      .getByRole('link', { name: 'Sign out' })
-      .or(page.getByRole('button', { name: 'Sign out' }));
+    this.workspaceSignOutLink = this.workspaceMenu.getByRole('link', { name: 'Sign out' });
+    this.adminSignOutButton = page.getByRole('button', { name: 'Sign out' }).first();
+    this.adminSignOutLink = page.getByRole('link', { name: 'Sign out' }).first();
   }
 
   async open(isAdminScreen = false) {
     if (isAdminScreen) {
       await this.menuButtonAdmin.click();
-      await Waiter.waitFor(this.signOutControl, 'visible');
+      await this.waitForAdminSignOutControl();
     } else {
       await this.menuButton.click();
       await Waiter.waitFor(this.workspaceMenu, 'visible');
@@ -35,20 +37,15 @@ export class MenuDropdownCO {
 
   async signOut(isAdminScreen = false) {
     const menuButton = isAdminScreen ? this.menuButtonAdmin : this.menuButton;
-    const menuContent = isAdminScreen ? this.signOutControl : this.workspaceMenu;
 
     // Try to open the dropdown (two attempts in case of stale click)
-    for (let i = 0; i < 2 && !(await menuContent.isVisible()); i++) {
+    for (let i = 0; i < 2 && !(await this.isSignOutMenuVisible(isAdminScreen)); i++) {
       await menuButton.click();
-      const visible = await menuContent
-        .waitFor({ state: 'visible', timeout: 1000 })
-        .catch(() => false);
+      const visible = await this.waitForSignOutMenu(isAdminScreen);
       if (visible) break;
     }
 
-    const link = isAdminScreen
-      ? this.signOutControl
-      : this.workspaceMenu.getByRole('link', { name: 'Sign out' });
+    const link = isAdminScreen ? await this.getAdminSignOutControl() : this.workspaceSignOutLink;
 
     // Preferred path: click the visible sign-out link
     const clicked = await link
@@ -59,8 +56,59 @@ export class MenuDropdownCO {
     if (clicked) return;
 
     // Fallback: clear session cookies and reload
-    const page = this.signOutControl.page();
+    const page = this.menuButton.page();
     await page.context().clearCookies();
     await page.goto('/');
+  }
+
+  private async isSignOutMenuVisible(isAdminScreen: boolean) {
+    if (isAdminScreen) {
+      return (
+        (await this.adminSignOutButton.isVisible().catch(() => false)) ||
+        (await this.adminSignOutLink.isVisible().catch(() => false))
+      );
+    }
+
+    return await this.workspaceMenu.isVisible();
+  }
+
+  private async waitForSignOutMenu(isAdminScreen: boolean) {
+    if (isAdminScreen) {
+      return await this.waitForAdminSignOutControl()
+        .then(() => true)
+        .catch(() => false);
+    }
+
+    return await this.workspaceMenu
+      .waitFor({ state: 'visible', timeout: 1000 })
+      .then(() => true)
+      .catch(() => false);
+  }
+
+  private async waitForAdminSignOutControl() {
+    for (const control of [this.adminSignOutButton, this.adminSignOutLink]) {
+      const visible = await control
+        .waitFor({ state: 'visible', timeout: 1000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (visible) {
+        return control;
+      }
+    }
+
+    throw new Error('Admin sign-out control was not visible');
+  }
+
+  private async getAdminSignOutControl() {
+    if (await this.adminSignOutButton.isVisible().catch(() => false)) {
+      return this.adminSignOutButton;
+    }
+
+    if (await this.adminSignOutLink.isVisible().catch(() => false)) {
+      return this.adminSignOutLink;
+    }
+
+    return await this.waitForAdminSignOutControl();
   }
 }

--- a/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
+++ b/assets/automation/src/systems/torus/pom/home/MenuDropdownCO.ts
@@ -6,39 +6,49 @@ export class MenuDropdownCO {
   private readonly menuButtonAdmin: Locator;
   private readonly workspaceMenu: Locator;
   private readonly adminPanelLink: Locator;
-  private readonly signOutLink: Locator;
+  private readonly signOutControl: Locator;
 
   constructor(page: Page) {
     this.menuButton = page.locator('#workspace-user-menu');
     this.menuButtonAdmin = page.getByRole('button', { name: 'Playwright Admin profile' });
     this.workspaceMenu = page.locator('#workspace-user-menu-dropdown');
     this.adminPanelLink = this.workspaceMenu.getByRole('link', { name: 'Admin Panel' });
-    this.signOutLink = page.getByRole('link', { name: 'Sign out' });
+    this.signOutControl = page
+      .getByRole('link', { name: 'Sign out' })
+      .or(page.getByRole('button', { name: 'Sign out' }));
   }
 
   async open(isAdminScreen = false) {
     if (isAdminScreen) {
       await this.menuButtonAdmin.click();
+      await Waiter.waitFor(this.signOutControl, 'visible');
     } else {
       await this.menuButton.click();
+      await Waiter.waitFor(this.workspaceMenu, 'visible');
     }
   }
 
   async goToAdminPanel() {
-    await this.adminPanelLink.click();
+    await Waiter.waitFor(this.adminPanelLink, 'visible');
+    await this.adminPanelLink.click({ force: true });
   }
 
   async signOut(isAdminScreen = false) {
     const menuButton = isAdminScreen ? this.menuButtonAdmin : this.menuButton;
+    const menuContent = isAdminScreen ? this.signOutControl : this.workspaceMenu;
 
     // Try to open the dropdown (two attempts in case of stale click)
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < 2 && !(await menuContent.isVisible()); i++) {
       await menuButton.click();
-      const visible = await this.workspaceMenu.waitFor({ state: 'visible', timeout: 1000 }).catch(() => false);
+      const visible = await menuContent
+        .waitFor({ state: 'visible', timeout: 1000 })
+        .catch(() => false);
       if (visible) break;
     }
 
-    const link = this.workspaceMenu.getByRole('link', { name: 'Sign out' });
+    const link = isAdminScreen
+      ? this.signOutControl
+      : this.workspaceMenu.getByRole('link', { name: 'Sign out' });
 
     // Preferred path: click the visible sign-out link
     const clicked = await link
@@ -49,7 +59,7 @@ export class MenuDropdownCO {
     if (clicked) return;
 
     // Fallback: clear session cookies and reload
-    const page = this.signOutLink.page();
+    const page = this.signOutControl.page();
     await page.context().clearCookies();
     await page.goto('/');
   }

--- a/assets/automation/src/systems/torus/tasks/HomeTask.ts
+++ b/assets/automation/src/systems/torus/tasks/HomeTask.ts
@@ -45,9 +45,7 @@ export class HomeTask {
     await this.loginpo.verifyTitle(dataUser.pageTitle);
     await this.loginpo.verifyRole(dataUser.role);
     await this.loginpo.verifyWelcomeText(dataUser.welcomeText);
-    await this.loginpo.fillEmail(dataUser.email);
-    await this.loginpo.fillPassword(dataUser.pass);
-    await this.loginpo.clickSignInButton();
+    await this.loginpo.signIn(dataUser.email, dataUser.pass);
     await this.loginpo.verifyWelcomeTitle(dataUser.welcomeTitle);
 
     if (role === 'administrator') {


### PR DESCRIPTION
Stabilizes flaky Playwright account tests by tightening login readiness checks and making workspace/admin menu interactions more reliable.

Changes:
- Wait for the login form and LiveView state before filling credentials.
- Fill and verify email/password before submitting.
- Wait for the workspace dropdown before interacting with workspace menu links.
- Handle the admin profile popover separately from the workspace dropdown.
- Force-click the visible Admin Panel link to avoid failures when the animated dropdown never becomes stable.

Validation:
- Ran focused ESLint checks on changed automation files.
- Ran focused Prettier checks on changed automation files.
- User account test passed locally.