### PR TITLE
[ENHANCEMENT] [MER-5636] Add subscript and superscript support to number input units

### DIFF
--- a/assets/src/components/parts/janus-input-number/InputNumber.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumber.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../../apps/delivery/components/NotificationContext';
 import { contexts } from '../../../types/applicationContext';
 import { countSigFigs, parseBool } from '../../../utils/common';
-import { sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
+import { htmlToPlainText, sanitizeRichLabelHtml } from '../../../utils/richOptionLabel';
 import { PartComponentProps } from '../types/parts';
 import './InputNumber.scss';
 import { InputNumberModel } from './schema';
@@ -297,7 +297,9 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = ({
 
     // Announce only value + units via live region
     if (normalizedValue !== '') {
-      setLiveAnnouncement(`${normalizedValue}${unitsLabel ? ` ${unitsLabel}` : ''}`);
+      setLiveAnnouncement(
+        `${normalizedValue}${unitsLabel ? ` ${htmlToPlainText(unitsLabel)}` : ''}`,
+      );
     } else {
       setLiveAnnouncement('');
     }
@@ -328,7 +330,7 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = ({
         {inputNumberValue !== '' &&
           !isNaN(Number(inputNumberValue)) &&
           `Current value: ${inputNumberValue}. `}
-        {unitsLabel && `Units: ${unitsLabel}. `}
+        {unitsLabel && `Units: ${htmlToPlainText(unitsLabel)}. `}
         {shouldAnnounceMinMax && typeof minValue === 'number' && `Minimum value: ${minValue}. `}
         {shouldAnnounceMinMax && typeof maxValue === 'number' && `Maximum value: ${maxValue}.`}
       </span>
@@ -366,9 +368,13 @@ const InputNumber: React.FC<PartComponentProps<InputNumberModel>> = ({
         }}
       />
       {unitsLabel && (
-        <span className="unitsLabel" aria-hidden="true">
-          {unitsLabel}
-        </span>
+        <span
+          className="unitsLabel"
+          aria-hidden="true"
+          dangerouslySetInnerHTML={{
+            __html: sanitizeRichLabelHtml(unitsLabel?.length > 0 ? unitsLabel : ''),
+          }}
+        />
       )}
     </div>
   ) : null;

--- a/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
+++ b/assets/src/components/parts/janus-input-number/InputNumberAuthor.tsx
@@ -57,7 +57,14 @@ const InputNumberAuthor: React.FC<AuthorPartComponentProps<InputNumberModel>> = 
         style={{ width: '100%', maxWidth: '100%', pointerEvents: 'none', boxSizing: 'border-box' }}
         className={`${showIncrementArrows ? '' : 'hideIncrementArrows'}`}
       />
-      {unitsLabel && <span className="unitsLabel">{unitsLabel}</span>}
+      {unitsLabel && (
+        <span
+          className="unitsLabel"
+          dangerouslySetInnerHTML={{
+            __html: sanitizeRichLabelHtml(unitsLabel?.length > 0 ? unitsLabel : ''),
+          }}
+        />
+      )}
     </div>
   );
 };

--- a/assets/src/components/parts/janus-input-number/schema.ts
+++ b/assets/src/components/parts/janus-input-number/schema.ts
@@ -27,6 +27,9 @@ export const simpleUiSchema = {
   label: {
     'ui:widget': 'RichLabelWidget',
   },
+  unitsLabel: {
+    'ui:widget': 'RichLabelWidget',
+  },
   minValue: {
     classNames: 'col-span-6',
   },
@@ -145,6 +148,9 @@ export const schema: JSONSchema7Object = {
 
 export const uiSchema = {
   label: {
+    'ui:widget': 'RichLabelWidget',
+  },
+  unitsLabel: {
     'ui:widget': 'RichLabelWidget',
   },
 };


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

We have already added this support in other areas of label etc and now adding it on the unit label in number input.

<img width="1888" height="879" alt="image" src="https://github.com/user-attachments/assets/d04dde05-d133-40b2-96cc-f1e87308de3f" />
