### PR TITLE
[FEATURE] [MER-5653] Support activity bank scenario testing

### DIFF
--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -15,11 +15,13 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   alias Oli.Activities.Realizer.Query.Paging
   alias Oli.Activities.Realizer.Query.Result
   alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Accounts
   alias Oli.Authoring.Course
   alias Oli.Authoring.Editing.ActivityEditor
   alias Oli.Authoring.Editing.BankContext
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Delivery.Sections
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Revision
@@ -77,28 +79,37 @@ defmodule Oli.Authoring.Editing.ActivityBank do
          {:ok, %Paging{} = parsed_paging} <- parse_paging(paging),
          {:ok, publication} <-
            Publishing.project_working_publication(project_slug) |> trap_nil() do
-      query_publication(publication.id, parsed_logic, parsed_paging)
+      execute_publication_query(publication.id, parsed_logic, parsed_paging)
     else
       error -> error
     end
   end
 
   @doc """
-  Executes a paged Activity Bank query against a known publication.
+  Executes a paged Activity Bank query for an authorized delivery section preview.
 
-  This is useful when the caller has already resolved a publication, such as
-  delivery-preview flows.
+  This is useful when the caller has already resolved a publication and needs to
+  query against delivery section context.
   """
-  def query_publication(publication_id, %Logic{} = logic, %Paging{} = paging, opts \\ []) do
-    Query.execute(
-      logic,
-      %Source{
-        publication_id: publication_id,
-        blacklisted_activity_ids: Keyword.get(opts, :blacklisted_activity_ids, []),
-        section_slug: Keyword.get(opts, :section_slug, @default_query_source_section_slug)
-      },
-      paging
-    )
+  def query_section_publication(
+        section_slug,
+        user,
+        author,
+        publication_id,
+        %Logic{} = logic,
+        %Paging{} = paging,
+        opts \\ []
+      ) do
+    if Sections.is_instructor?(user, section_slug) or Accounts.at_least_content_admin?(author) do
+      execute_publication_query(
+        publication_id,
+        logic,
+        paging,
+        Keyword.put_new(opts, :section_slug, section_slug)
+      )
+    else
+      {:error, {:not_authorized}}
+    end
   end
 
   @doc """
@@ -237,8 +248,11 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   end
 
   defp get_banked_activities(project_slug, activity_resource_ids) do
-    Enum.reduce_while(activity_resource_ids, {:ok, []}, fn activity_resource_id, {:ok, acc} ->
-      case get_banked_activity(project_slug, activity_resource_id) do
+    project_slug
+    |> AuthoringResolver.from_resource_id(activity_resource_ids)
+    |> Enum.zip(activity_resource_ids)
+    |> Enum.reduce_while({:ok, []}, fn {revision, activity_resource_id}, {:ok, acc} ->
+      case validate_banked_activity_revision(revision, activity_resource_id) do
         {:ok, revision} -> {:cont, {:ok, [revision | acc]}}
         error -> {:halt, error}
       end
@@ -250,9 +264,15 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   end
 
   defp get_banked_activity(project_slug, activity_resource_id) do
+    project_slug
+    |> AuthoringResolver.from_resource_id(activity_resource_id)
+    |> validate_banked_activity_revision(activity_resource_id)
+  end
+
+  defp validate_banked_activity_revision(revision, activity_resource_id) do
     activity_type_id = ResourceType.id_for_activity()
 
-    case AuthoringResolver.from_resource_id(project_slug, activity_resource_id) do
+    case revision do
       %Revision{resource_type_id: ^activity_type_id, scope: :banked} = revision ->
         {:ok, revision}
 
@@ -266,6 +286,18 @@ defmodule Oli.Authoring.Editing.ActivityBank do
       nil ->
         {:error, "Activity resource '#{activity_resource_id}' not found in project"}
     end
+  end
+
+  defp execute_publication_query(publication_id, %Logic{} = logic, %Paging{} = paging, opts \\ []) do
+    Query.execute(
+      logic,
+      %Source{
+        publication_id: publication_id,
+        blacklisted_activity_ids: Keyword.get(opts, :blacklisted_activity_ids, []),
+        section_slug: Keyword.get(opts, :section_slug, @default_query_source_section_slug)
+      },
+      paging
+    )
   end
 
   defp normalize_bulk_create_attrs(project_slug, attrs_list) do

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -1,0 +1,179 @@
+defmodule Oli.Authoring.Editing.ActivityBank do
+  @moduledoc """
+  Application-layer operations for author-facing Activity Bank workflows.
+
+  This module keeps Activity Bank behavior available outside web controllers and
+  React UI orchestration so scenarios and tests can exercise the same business
+  operations directly.
+  """
+
+  import Oli.Authoring.Editing.Utils
+
+  alias Oli.Activities
+  alias Oli.Activities.Realizer.Logic
+  alias Oli.Activities.Realizer.Query
+  alias Oli.Activities.Realizer.Query.Paging
+  alias Oli.Activities.Realizer.Query.Result
+  alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Authoring.Course
+  alias Oli.Authoring.Editing.ActivityEditor
+  alias Oli.Authoring.Editing.BankContext
+  alias Oli.Authoring.Editing.PageEditor
+  alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Publishing
+  alias Oli.Resources.Revision
+  alias Oli.Resources.ResourceType
+
+  @default_query_source_section_slug ""
+
+  @doc """
+  Creates the context needed by the Activity Bank editor.
+  """
+  def context(project_slug, author) do
+    with {:ok, publication} <-
+           Publishing.project_working_publication(project_slug)
+           |> trap_nil(),
+         {:ok, objectives} <-
+           Publishing.get_published_objective_details(publication.id) |> trap_nil(),
+         {:ok, objectives_with_parent_reference} <-
+           PageEditor.construct_parent_references(objectives) |> trap_nil(),
+         {:ok, tags} <-
+           ResourceEditor.list(project_slug, author, ResourceType.id_for_tag()),
+         {:ok, %Result{totalCount: total_count}} <-
+           query(project_slug, author, %Logic{conditions: nil}, %Paging{limit: 1, offset: 0}) do
+      editor_map =
+        Activities.create_registered_activity_map(project_slug)
+        |> Enum.reject(fn {_key, entry} -> entry.isLtiActivity end)
+        |> Enum.into(%{})
+
+      project = Course.get_project_by_slug(project_slug)
+
+      {:ok,
+       %BankContext{
+         authorEmail: author.email,
+         projectSlug: project_slug,
+         editorMap: editor_map,
+         allObjectives: objectives_with_parent_reference,
+         allTags: Enum.map(tags, fn tag -> %{id: tag.resource_id, title: tag.title} end),
+         totalCount: total_count,
+         allowTriggers: project.allow_triggers
+       }}
+    else
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Executes a paged Activity Bank query for the project's working publication.
+
+  `logic` and `paging` may be already parsed structs or the JSON-like maps sent
+  by the Activity Bank client.
+  """
+  def query(project_slug, author, logic, paging) do
+    with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
+         {:ok} <- authorize_user(author, project),
+         {:ok, %Logic{} = parsed_logic} <- parse_logic(logic),
+         {:ok, %Paging{} = parsed_paging} <- parse_paging(paging),
+         {:ok, publication} <-
+           Publishing.project_working_publication(project_slug) |> trap_nil() do
+      query_publication(publication.id, parsed_logic, parsed_paging)
+    else
+      error -> error
+    end
+  end
+
+  @doc """
+  Executes a paged Activity Bank query against a known publication.
+
+  This is useful when the caller has already resolved a publication, such as
+  delivery-preview flows.
+  """
+  def query_publication(publication_id, %Logic{} = logic, %Paging{} = paging, opts \\ []) do
+    Query.execute(
+      logic,
+      %Source{
+        publication_id: publication_id,
+        blacklisted_activity_ids: Keyword.get(opts, :blacklisted_activity_ids, []),
+        section_slug: Keyword.get(opts, :section_slug, @default_query_source_section_slug)
+      },
+      paging
+    )
+  end
+
+  @doc """
+  Creates a single banked activity.
+  """
+  def create(project_slug, author, attrs) when is_map(attrs) do
+    ActivityEditor.create(
+      project_slug,
+      map_value(attrs, :activity_type_slug) || map_value(attrs, :type),
+      author,
+      map_value(attrs, :model) || map_value(attrs, :content) || %{},
+      map_value(attrs, :objectives) || [],
+      "banked",
+      map_value(attrs, :title),
+      map_value(attrs, :objective_map) || %{},
+      map_value(attrs, :tags) || []
+    )
+  end
+
+  @doc """
+  Creates multiple banked activities.
+  """
+  def create_bulk(project_slug, author, attrs_list) when is_list(attrs_list) do
+    ActivityEditor.create_bulk(project_slug, author, attrs_list, "banked")
+  end
+
+  @doc """
+  Updates a banked activity using the same ActivityEditor path as the UI.
+  """
+  def update(project_slug, author, activity_resource_id, attrs) when is_map(attrs) do
+    ActivityEditor.edit(
+      project_slug,
+      activity_resource_id,
+      activity_resource_id,
+      author.email,
+      attrs
+    )
+  end
+
+  @doc """
+  Deletes a banked activity using the same ActivityEditor path as the UI.
+  """
+  def delete(project_slug, author, activity_resource_id) do
+    ActivityEditor.delete(project_slug, activity_resource_id, activity_resource_id, author)
+  end
+
+  @doc """
+  Deletes multiple banked activities.
+  """
+  def delete_bulk(project_slug, author, activity_resource_ids)
+      when is_list(activity_resource_ids) do
+    ActivityEditor.delete_bulk(project_slug, activity_resource_ids, author)
+  end
+
+  @doc """
+  Serializes a banked activity revision in the shape expected by the Activity Bank UI.
+  """
+  def serialize_revision(%Revision{} = revision) do
+    %{
+      content: revision.content,
+      title: revision.title,
+      objectives: revision.objectives,
+      resource_id: revision.resource_id,
+      activity_type_id: revision.activity_type_id,
+      tags: revision.tags,
+      slug: revision.slug
+    }
+  end
+
+  defp parse_logic(%Logic{} = logic), do: {:ok, logic}
+  defp parse_logic(logic), do: Logic.parse(logic)
+
+  defp parse_paging(%Paging{} = paging), do: {:ok, paging}
+  defp parse_paging(paging), do: Paging.parse(paging)
+
+  defp map_value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+end

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -102,7 +102,9 @@ defmodule Oli.Authoring.Editing.ActivityBank do
         %Paging{} = paging,
         opts \\ []
       ) do
-    if (Sections.is_instructor?(user, section_slug) or Accounts.at_least_content_admin?(author)) and
+    content_admin? = not is_nil(author) and Accounts.at_least_content_admin?(author)
+
+    if (Sections.is_instructor?(user, section_slug) or content_admin?) and
          publication_belongs_to_section?(publication_id, section_slug) do
       execute_publication_query(
         publication_id,
@@ -122,7 +124,10 @@ defmodule Oli.Authoring.Editing.ActivityBank do
     with {:ok, _project} <- authorize_project(project_slug, author),
          {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
          {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives(attrs)),
+         {:ok, objective_map} <- resolve_objective_map(project_slug, objective_map(attrs)),
          {:ok, tag_ids} <- resolve_tag_references(project_slug, tags(attrs)) do
+      objective_ids = objectives_for_editor(objective_ids, objective_map)
+
       ActivityEditor.create(
         project_slug,
         activity_type_slug,
@@ -131,7 +136,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
         objective_ids,
         "banked",
         map_value(attrs, :title),
-        map_value(attrs, :objective_map) || %{},
+        objective_map,
         tag_ids
       )
     end
@@ -190,7 +195,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   """
   def update(project_slug, author, activity_resource_id, attrs) when is_map(attrs) do
     with {:ok, _project} <- authorize_project(project_slug, author),
-         {:ok, _revision} <- get_banked_activity(project_slug, activity_resource_id) do
+         {:ok, _revision} <- get_banked_activity(project_slug, activity_resource_id),
+         {:ok, attrs} <- normalize_update_attrs(project_slug, attrs) do
       ActivityEditor.edit(
         project_slug,
         activity_resource_id,
@@ -338,14 +344,17 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   defp normalize_bulk_create_attr(project_slug, attrs) when is_map(attrs) do
     with {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
          {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives(attrs)),
+         {:ok, objective_map} <- resolve_objective_map(project_slug, objective_map(attrs)),
          {:ok, tag_ids} <- resolve_tag_references(project_slug, tags(attrs)) do
+      objective_ids = objectives_for_editor(objective_ids, objective_map)
+
       {:ok,
        %{
          "activityTypeSlug" => activity_type_slug,
          "objectives" => objective_ids,
          "content" => map_value(attrs, :content) || map_value(attrs, :model) || %{},
          "title" => map_value(attrs, :title),
-         "objectiveMap" => objective_map(attrs),
+         "objectiveMap" => objective_map,
          "tags" => tag_ids
        }}
     end
@@ -373,6 +382,93 @@ defmodule Oli.Authoring.Editing.ActivityBank do
       Map.get(attrs, "activityTypeSlug") ||
       map_value(attrs, :type)
   end
+
+  defp normalize_update_attrs(project_slug, attrs) do
+    with {:ok, attrs} <- normalize_update_objectives(project_slug, attrs),
+         {:ok, attrs} <- normalize_update_objective_map(project_slug, attrs),
+         {:ok, attrs} <- normalize_update_tags(project_slug, attrs) do
+      {:ok, attrs}
+    end
+  end
+
+  defp normalize_update_objectives(project_slug, attrs) do
+    case fetch_map_value(attrs, :objectives) do
+      {:ok, objectives, key} when is_map(objectives) ->
+        with {:ok, objective_map} <- resolve_objective_map(project_slug, objectives) do
+          {:ok, Map.put(attrs, key, objective_map)}
+        end
+
+      {:ok, objectives, key} ->
+        with {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives) do
+          {:ok, Map.put(attrs, key, objective_ids)}
+        end
+
+      :error ->
+        {:ok, attrs}
+    end
+  end
+
+  defp normalize_update_objective_map(project_slug, attrs) do
+    case fetch_map_value(attrs, :objective_map) do
+      {:ok, objective_map, key} ->
+        with {:ok, objective_map} <- resolve_objective_map(project_slug, objective_map) do
+          attrs =
+            attrs
+            |> Map.delete(key)
+            |> Map.delete(:objective_map)
+            |> Map.delete("objective_map")
+            |> Map.delete(:objectiveMap)
+            |> Map.delete("objectiveMap")
+            |> Map.put("objectives", objective_map)
+
+          {:ok, attrs}
+        end
+
+      :error ->
+        {:ok, attrs}
+    end
+  end
+
+  defp normalize_update_tags(project_slug, attrs) do
+    case fetch_map_value(attrs, :tags) do
+      {:ok, tags, key} ->
+        with {:ok, tag_ids} <- resolve_tag_references(project_slug, tags) do
+          {:ok, Map.put(attrs, key, tag_ids)}
+        end
+
+      :error ->
+        {:ok, attrs}
+    end
+  end
+
+  defp resolve_objective_map(_project_slug, nil), do: {:ok, %{}}
+
+  defp resolve_objective_map(_project_slug, objective_map) when objective_map == %{},
+    do: {:ok, %{}}
+
+  defp resolve_objective_map(project_slug, objective_map) when is_map(objective_map) do
+    Enum.reduce_while(objective_map, {:ok, %{}}, fn {part_id, references}, {:ok, acc} ->
+      with true <- is_list(references),
+           {:ok, objective_ids} <- resolve_objective_references(project_slug, references) do
+        {:cont, {:ok, Map.put(acc, part_id, objective_ids)}}
+      else
+        false ->
+          {:halt, {:error, "Objective map entry '#{part_id}' references must be a list"}}
+
+        error ->
+          {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_objective_map(_project_slug, objective_map) do
+    {:error, "Objective map must be a map, got: #{inspect(objective_map)}"}
+  end
+
+  defp objectives_for_editor(objective_ids, objective_map) when objective_map == %{},
+    do: objective_ids
+
+  defp objectives_for_editor(_objective_ids, _objective_map), do: []
 
   defp resolve_resource_references(_project_slug, nil, _resource_type_id, _label), do: {:ok, []}
   defp resolve_resource_references(_project_slug, [], _resource_type_id, _label), do: {:ok, []}
@@ -433,5 +529,24 @@ defmodule Oli.Authoring.Editing.ActivityBank do
 
   defp map_value(map, key) when is_map(map) and is_atom(key) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp fetch_map_value(map, key) when is_map(map) and is_atom(key) do
+    cond do
+      Map.has_key?(map, key) ->
+        {:ok, Map.get(map, key), key}
+
+      Map.has_key?(map, Atom.to_string(key)) ->
+        {:ok, Map.get(map, Atom.to_string(key)), Atom.to_string(key)}
+
+      key == :objective_map and Map.has_key?(map, :objectiveMap) ->
+        {:ok, Map.get(map, :objectiveMap), :objectiveMap}
+
+      key == :objective_map and Map.has_key?(map, "objectiveMap") ->
+        {:ok, Map.get(map, "objectiveMap"), "objectiveMap"}
+
+      true ->
+        :error
+    end
   end
 end

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -248,10 +248,15 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   end
 
   defp get_banked_activities(project_slug, activity_resource_ids) do
-    project_slug
-    |> AuthoringResolver.from_resource_id(activity_resource_ids)
-    |> Enum.zip(activity_resource_ids)
-    |> Enum.reduce_while({:ok, []}, fn {revision, activity_resource_id}, {:ok, acc} ->
+    revisions_by_resource_id =
+      project_slug
+      |> AuthoringResolver.from_resource_id(activity_resource_ids)
+      |> Enum.reject(&is_nil/1)
+      |> Map.new(fn revision -> {revision.resource_id, revision} end)
+
+    Enum.reduce_while(activity_resource_ids, {:ok, []}, fn activity_resource_id, {:ok, acc} ->
+      revision = Map.get(revisions_by_resource_id, activity_resource_id)
+
       case validate_banked_activity_revision(revision, activity_resource_id) do
         {:ok, revision} -> {:cont, {:ok, [revision | acc]}}
         error -> {:halt, error}

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -22,8 +22,10 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionsProjectsPublications
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
+  alias Oli.Repo
   alias Oli.Resources.Revision
   alias Oli.Resources.ResourceType
 
@@ -100,7 +102,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
         %Paging{} = paging,
         opts \\ []
       ) do
-    if Sections.is_instructor?(user, section_slug) or Accounts.at_least_content_admin?(author) do
+    if (Sections.is_instructor?(user, section_slug) or Accounts.at_least_content_admin?(author)) and
+         publication_belongs_to_section?(publication_id, section_slug) do
       execute_publication_query(
         publication_id,
         logic,
@@ -303,6 +306,19 @@ defmodule Oli.Authoring.Editing.ActivityBank do
       },
       paging
     )
+  end
+
+  defp publication_belongs_to_section?(publication_id, section_slug) do
+    case Sections.get_section_by_slug(section_slug) do
+      nil ->
+        false
+
+      section ->
+        Repo.get_by(SectionsProjectsPublications,
+          section_id: section.id,
+          publication_id: publication_id
+        ) != nil
+    end
   end
 
   defp normalize_bulk_create_attrs(project_slug, attrs_list) do

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -21,6 +21,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Publishing
+  alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Revision
   alias Oli.Resources.ResourceType
 
@@ -104,24 +105,68 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Creates a single banked activity.
   """
   def create(project_slug, author, attrs) when is_map(attrs) do
-    ActivityEditor.create(
-      project_slug,
-      map_value(attrs, :activity_type_slug) || map_value(attrs, :type),
-      author,
-      map_value(attrs, :model) || map_value(attrs, :content) || %{},
-      map_value(attrs, :objectives) || [],
-      "banked",
-      map_value(attrs, :title),
-      map_value(attrs, :objective_map) || %{},
-      map_value(attrs, :tags) || []
-    )
+    with {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
+         {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives(attrs)),
+         {:ok, tag_ids} <- resolve_tag_references(project_slug, tags(attrs)) do
+      ActivityEditor.create(
+        project_slug,
+        activity_type_slug,
+        author,
+        map_value(attrs, :model) || map_value(attrs, :content) || %{},
+        objective_ids,
+        "banked",
+        map_value(attrs, :title),
+        map_value(attrs, :objective_map) || %{},
+        tag_ids
+      )
+    end
   end
 
   @doc """
   Creates multiple banked activities.
   """
   def create_bulk(project_slug, author, attrs_list) when is_list(attrs_list) do
-    ActivityEditor.create_bulk(project_slug, author, attrs_list, "banked")
+    with {:ok, normalized_attrs_list} <- normalize_bulk_create_attrs(project_slug, attrs_list) do
+      ActivityEditor.create_bulk(project_slug, author, normalized_attrs_list, "banked")
+    end
+  end
+
+  @doc """
+  Resolves an activity type reference to a registered activity type slug.
+  """
+  def resolve_activity_type_slug(attrs) when is_map(attrs) do
+    case activity_type_slug(attrs) do
+      nil ->
+        {:error, "Activity type is required"}
+
+      type when is_binary(type) ->
+        case Activities.get_registration_by_slug(type) do
+          nil -> {:error, "Unknown activity type: #{type}"}
+          registration -> {:ok, registration.slug}
+        end
+
+      type ->
+        {:error, "Activity type must be a string, got: #{inspect(type)}"}
+    end
+  end
+
+  @doc """
+  Resolves objective titles or IDs to objective resource IDs for a project.
+  """
+  def resolve_objective_references(project_slug, references) do
+    resolve_resource_references(
+      project_slug,
+      references,
+      ResourceType.id_for_objective(),
+      "Objective"
+    )
+  end
+
+  @doc """
+  Resolves tag titles or IDs to tag resource IDs for a project.
+  """
+  def resolve_tag_references(project_slug, references) do
+    resolve_resource_references(project_slug, references, ResourceType.id_for_tag(), "Tag")
   end
 
   @doc """
@@ -172,6 +217,92 @@ defmodule Oli.Authoring.Editing.ActivityBank do
 
   defp parse_paging(%Paging{} = paging), do: {:ok, paging}
   defp parse_paging(paging), do: Paging.parse(paging)
+
+  defp normalize_bulk_create_attrs(project_slug, attrs_list) do
+    Enum.reduce_while(attrs_list, {:ok, []}, fn attrs, {:ok, acc} ->
+      with {:ok, normalized} <- normalize_bulk_create_attr(project_slug, attrs) do
+        {:cont, {:ok, [normalized | acc]}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      error -> error
+    end
+  end
+
+  defp normalize_bulk_create_attr(project_slug, attrs) when is_map(attrs) do
+    with {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
+         {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives(attrs)),
+         {:ok, tag_ids} <- resolve_tag_references(project_slug, tags(attrs)) do
+      {:ok,
+       %{
+         "activityTypeSlug" => activity_type_slug,
+         "objectives" => objective_ids,
+         "content" => map_value(attrs, :content) || map_value(attrs, :model) || %{},
+         "title" => map_value(attrs, :title),
+         "tags" => tag_ids
+       }}
+    end
+  end
+
+  defp normalize_bulk_create_attr(_project_slug, attrs),
+    do: {:error, "Bulk activity data must be a map, got: #{inspect(attrs)}"}
+
+  defp objectives(attrs) do
+    map_value(attrs, :objectives) || []
+  end
+
+  defp tags(attrs) do
+    map_value(attrs, :tags) || []
+  end
+
+  defp activity_type_slug(attrs) do
+    map_value(attrs, :activity_type_slug) ||
+      Map.get(attrs, :activityTypeSlug) ||
+      Map.get(attrs, "activityTypeSlug") ||
+      map_value(attrs, :type)
+  end
+
+  defp resolve_resource_references(_project_slug, nil, _resource_type_id, _label), do: {:ok, []}
+  defp resolve_resource_references(_project_slug, [], _resource_type_id, _label), do: {:ok, []}
+
+  defp resolve_resource_references(project_slug, references, resource_type_id, label)
+       when is_list(references) do
+    Enum.reduce_while(references, {:ok, []}, fn reference, {:ok, acc} ->
+      case resolve_resource_reference(project_slug, reference, resource_type_id, label) do
+        {:ok, resource_id} -> {:cont, {:ok, acc ++ [resource_id]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_resource_references(_project_slug, references, _resource_type_id, label) do
+    {:error, "#{label} references must be a list, got: #{inspect(references)}"}
+  end
+
+  defp resolve_resource_reference(_project_slug, resource_id, _resource_type_id, _label)
+       when is_integer(resource_id),
+       do: {:ok, resource_id}
+
+  defp resolve_resource_reference(project_slug, reference, resource_type_id, label)
+       when is_binary(reference) do
+    case Integer.parse(reference) do
+      {resource_id, ""} ->
+        {:ok, resource_id}
+
+      _ ->
+        case AuthoringResolver.from_title(project_slug, reference, resource_type_id) do
+          [revision | _] -> {:ok, revision.resource_id}
+          [] -> {:error, "#{label} '#{reference}' not found in project"}
+        end
+    end
+  end
+
+  defp resolve_resource_reference(_project_slug, reference, _resource_type_id, label) do
+    {:error, "#{label} reference must be a title or resource ID, got: #{inspect(reference)}"}
+  end
 
   defp map_value(map, key) when is_map(map) and is_atom(key) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -7,6 +7,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   operations directly.
   """
 
+  import Ecto.Query, warn: false
   import Oli.Authoring.Editing.Utils
 
   alias Oli.Activities
@@ -22,6 +23,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionsProjectsPublications
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
@@ -103,8 +105,9 @@ defmodule Oli.Authoring.Editing.ActivityBank do
         opts \\ []
       ) do
     content_admin? = not is_nil(author) and Accounts.at_least_content_admin?(author)
+    instructor? = not is_nil(user) and Sections.is_instructor?(user, section_slug)
 
-    if (Sections.is_instructor?(user, section_slug) or content_admin?) and
+    if (instructor? or content_admin?) and
          publication_belongs_to_section?(publication_id, section_slug) do
       execute_publication_query(
         publication_id,
@@ -315,16 +318,12 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   end
 
   defp publication_belongs_to_section?(publication_id, section_slug) do
-    case Sections.get_section_by_slug(section_slug) do
-      nil ->
-        false
-
-      section ->
-        Repo.get_by(SectionsProjectsPublications,
-          section_id: section.id,
-          publication_id: publication_id
-        ) != nil
-    end
+    Repo.exists?(
+      from spp in SectionsProjectsPublications,
+        join: section in Section,
+        on: section.id == spp.section_id,
+        where: section.slug == ^section_slug and spp.publication_id == ^publication_id
+    )
   end
 
   defp normalize_bulk_create_attrs(project_slug, attrs_list) do

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -105,7 +105,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Creates a single banked activity.
   """
   def create(project_slug, author, attrs) when is_map(attrs) do
-    with {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
+    with {:ok, _project} <- authorize_project(project_slug, author),
+         {:ok, activity_type_slug} <- resolve_activity_type_slug(attrs),
          {:ok, objective_ids} <- resolve_objective_references(project_slug, objectives(attrs)),
          {:ok, tag_ids} <- resolve_tag_references(project_slug, tags(attrs)) do
       ActivityEditor.create(
@@ -126,7 +127,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Creates multiple banked activities.
   """
   def create_bulk(project_slug, author, attrs_list) when is_list(attrs_list) do
-    with {:ok, normalized_attrs_list} <- normalize_bulk_create_attrs(project_slug, attrs_list) do
+    with {:ok, _project} <- authorize_project(project_slug, author),
+         {:ok, normalized_attrs_list} <- normalize_bulk_create_attrs(project_slug, attrs_list) do
       ActivityEditor.create_bulk(project_slug, author, normalized_attrs_list, "banked")
     end
   end
@@ -173,20 +175,24 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Updates a banked activity using the same ActivityEditor path as the UI.
   """
   def update(project_slug, author, activity_resource_id, attrs) when is_map(attrs) do
-    ActivityEditor.edit(
-      project_slug,
-      activity_resource_id,
-      activity_resource_id,
-      author.email,
-      attrs
-    )
+    with {:ok, _project} <- authorize_project(project_slug, author) do
+      ActivityEditor.edit(
+        project_slug,
+        activity_resource_id,
+        activity_resource_id,
+        author.email,
+        attrs
+      )
+    end
   end
 
   @doc """
   Deletes a banked activity using the same ActivityEditor path as the UI.
   """
   def delete(project_slug, author, activity_resource_id) do
-    ActivityEditor.delete(project_slug, activity_resource_id, activity_resource_id, author)
+    with {:ok, _project} <- authorize_project(project_slug, author) do
+      ActivityEditor.delete(project_slug, activity_resource_id, activity_resource_id, author)
+    end
   end
 
   @doc """
@@ -194,7 +200,9 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   """
   def delete_bulk(project_slug, author, activity_resource_ids)
       when is_list(activity_resource_ids) do
-    ActivityEditor.delete_bulk(project_slug, activity_resource_ids, author)
+    with {:ok, _project} <- authorize_project(project_slug, author) do
+      ActivityEditor.delete_bulk(project_slug, activity_resource_ids, author)
+    end
   end
 
   @doc """
@@ -217,6 +225,13 @@ defmodule Oli.Authoring.Editing.ActivityBank do
 
   defp parse_paging(%Paging{} = paging), do: {:ok, paging}
   defp parse_paging(paging), do: Paging.parse(paging)
+
+  defp authorize_project(project_slug, author) do
+    with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
+         {:ok} <- authorize_user(author, project) do
+      {:ok, project}
+    end
+  end
 
   defp normalize_bulk_create_attrs(project_slug, attrs_list) do
     Enum.reduce_while(attrs_list, {:ok, []}, fn attrs, {:ok, acc} ->
@@ -272,25 +287,30 @@ defmodule Oli.Authoring.Editing.ActivityBank do
        when is_list(references) do
     Enum.reduce_while(references, {:ok, []}, fn reference, {:ok, acc} ->
       case resolve_resource_reference(project_slug, reference, resource_type_id, label) do
-        {:ok, resource_id} -> {:cont, {:ok, acc ++ [resource_id]}}
+        {:ok, resource_id} -> {:cont, {:ok, [resource_id | acc]}}
         error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, resource_ids} -> {:ok, Enum.reverse(resource_ids)}
+      error -> error
+    end
   end
 
   defp resolve_resource_references(_project_slug, references, _resource_type_id, label) do
     {:error, "#{label} references must be a list, got: #{inspect(references)}"}
   end
 
-  defp resolve_resource_reference(_project_slug, resource_id, _resource_type_id, _label)
-       when is_integer(resource_id),
-       do: {:ok, resource_id}
+  defp resolve_resource_reference(project_slug, resource_id, resource_type_id, label)
+       when is_integer(resource_id) do
+    resolve_project_resource_reference(project_slug, resource_id, resource_type_id, label)
+  end
 
   defp resolve_resource_reference(project_slug, reference, resource_type_id, label)
        when is_binary(reference) do
     case Integer.parse(reference) do
       {resource_id, ""} ->
-        {:ok, resource_id}
+        resolve_project_resource_reference(project_slug, resource_id, resource_type_id, label)
 
       _ ->
         case AuthoringResolver.from_title(project_slug, reference, resource_type_id) do
@@ -302,6 +322,19 @@ defmodule Oli.Authoring.Editing.ActivityBank do
 
   defp resolve_resource_reference(_project_slug, reference, _resource_type_id, label) do
     {:error, "#{label} reference must be a title or resource ID, got: #{inspect(reference)}"}
+  end
+
+  defp resolve_project_resource_reference(project_slug, resource_id, resource_type_id, label) do
+    case AuthoringResolver.from_resource_id(project_slug, resource_id) do
+      %Revision{resource_type_id: ^resource_type_id} ->
+        {:ok, resource_id}
+
+      %Revision{} ->
+        {:error, "#{label} resource '#{resource_id}' does not have the expected resource type"}
+
+      nil ->
+        {:error, "#{label} resource '#{resource_id}' not found in project"}
+    end
   end
 
   defp map_value(map, key) when is_map(map) and is_atom(key) do

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -175,7 +175,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Updates a banked activity using the same ActivityEditor path as the UI.
   """
   def update(project_slug, author, activity_resource_id, attrs) when is_map(attrs) do
-    with {:ok, _project} <- authorize_project(project_slug, author) do
+    with {:ok, _project} <- authorize_project(project_slug, author),
+         {:ok, _revision} <- get_banked_activity(project_slug, activity_resource_id) do
       ActivityEditor.edit(
         project_slug,
         activity_resource_id,
@@ -190,7 +191,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   Deletes a banked activity using the same ActivityEditor path as the UI.
   """
   def delete(project_slug, author, activity_resource_id) do
-    with {:ok, _project} <- authorize_project(project_slug, author) do
+    with {:ok, _project} <- authorize_project(project_slug, author),
+         {:ok, _revision} <- get_banked_activity(project_slug, activity_resource_id) do
       ActivityEditor.delete(project_slug, activity_resource_id, activity_resource_id, author)
     end
   end
@@ -200,7 +202,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   """
   def delete_bulk(project_slug, author, activity_resource_ids)
       when is_list(activity_resource_ids) do
-    with {:ok, _project} <- authorize_project(project_slug, author) do
+    with {:ok, _project} <- authorize_project(project_slug, author),
+         {:ok, _revisions} <- get_banked_activities(project_slug, activity_resource_ids) do
       ActivityEditor.delete_bulk(project_slug, activity_resource_ids, author)
     end
   end
@@ -230,6 +233,38 @@ defmodule Oli.Authoring.Editing.ActivityBank do
     with {:ok, project} <- Course.get_project_by_slug(project_slug) |> trap_nil(),
          {:ok} <- authorize_user(author, project) do
       {:ok, project}
+    end
+  end
+
+  defp get_banked_activities(project_slug, activity_resource_ids) do
+    Enum.reduce_while(activity_resource_ids, {:ok, []}, fn activity_resource_id, {:ok, acc} ->
+      case get_banked_activity(project_slug, activity_resource_id) do
+        {:ok, revision} -> {:cont, {:ok, [revision | acc]}}
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, revisions} -> {:ok, Enum.reverse(revisions)}
+      error -> error
+    end
+  end
+
+  defp get_banked_activity(project_slug, activity_resource_id) do
+    activity_type_id = ResourceType.id_for_activity()
+
+    case AuthoringResolver.from_resource_id(project_slug, activity_resource_id) do
+      %Revision{resource_type_id: ^activity_type_id, scope: :banked} = revision ->
+        {:ok, revision}
+
+      %Revision{resource_type_id: ^activity_type_id} ->
+        {:error, "Activity resource '#{activity_resource_id}' is not banked"}
+
+      %Revision{} ->
+        {:error,
+         "Activity resource '#{activity_resource_id}' does not have the expected resource type"}
+
+      nil ->
+        {:error, "Activity resource '#{activity_resource_id}' not found in project"}
     end
   end
 

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -329,6 +329,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
          "objectives" => objective_ids,
          "content" => map_value(attrs, :content) || map_value(attrs, :model) || %{},
          "title" => map_value(attrs, :title),
+         "objectiveMap" => objective_map(attrs),
          "tags" => tag_ids
        }}
     end
@@ -343,6 +344,11 @@ defmodule Oli.Authoring.Editing.ActivityBank do
 
   defp tags(attrs) do
     map_value(attrs, :tags) || []
+  end
+
+  defp objective_map(attrs) do
+    map_value(attrs, :objective_map) || Map.get(attrs, :objectiveMap) ||
+      Map.get(attrs, "objectiveMap") || %{}
   end
 
   defp activity_type_slug(attrs) do

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -1590,14 +1590,19 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          {:ok, publication} <-
            Publishing.project_working_publication(project_slug) |> trap_nil() do
       activities =
-        Enum.reduce(bulk_activity_data, [], fn %{
-                                                 "activityTypeSlug" => activity_type_slug,
-                                                 "objectives" => objectives,
-                                                 "content" => model,
-                                                 "title" => title,
-                                                 "tags" => tags
-                                               },
-                                               m ->
+        Enum.reduce(bulk_activity_data, [], fn activity_data, m ->
+          %{
+            "activityTypeSlug" => activity_type_slug,
+            "objectives" => objectives,
+            "content" => model,
+            "title" => title,
+            "tags" => tags
+          } = activity_data
+
+          objective_map =
+            Map.get(activity_data, "objectiveMap") || Map.get(activity_data, "objective_map") ||
+              %{}
+
           case process_create_activity(
                  project,
                  author,
@@ -1607,7 +1612,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
                  objectives,
                  model,
                  title,
-                 tags
+                 tags,
+                 objective_map
                ) do
             {:ok, activity} ->
               m ++ [%{activity_type_slug: activity_type_slug, activity: activity}]
@@ -1633,7 +1639,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          model,
          title,
          tags,
-         objective_map \\ %{}
+         objective_map
        ) do
     Repo.transaction(fn ->
       with {:ok, activity_type} <-

--- a/lib/oli/authoring/editing/bank_editor.ex
+++ b/lib/oli/authoring/editing/bank_editor.ex
@@ -3,64 +3,11 @@ defmodule Oli.Authoring.Editing.BankEditor do
   This module provides content editing facilities for banked activities.
 
   """
-  import Oli.Authoring.Editing.Utils
-  alias Oli.Publishing
-  alias Oli.Activities
-  alias Oli.Authoring.Editing.PageEditor
-  alias Oli.Activities.Realizer.Logic
-  alias Oli.Activities.Realizer.Query.Paging
-  alias Oli.Activities.Realizer.Query
-  alias Oli.Activities.Realizer.Query.Source
-  alias Oli.Activities.Realizer.Query.Result
-
-  import Ecto.Query, warn: false
 
   @doc """
   Creates the context necessary to power a client side activity bank editor.
   """
   def create_context(project_slug, author) do
-    with {:ok, publication} <-
-           Publishing.project_working_publication(project_slug)
-           |> trap_nil(),
-         {:ok, objectives} <-
-           Publishing.get_published_objective_details(publication.id) |> trap_nil(),
-         {:ok, objectives_with_parent_reference} <-
-           PageEditor.construct_parent_references(objectives) |> trap_nil(),
-         {:ok, tags} <-
-           Oli.Authoring.Editing.ResourceEditor.list(
-             project_slug,
-             author,
-             Oli.Resources.ResourceType.id_for_tag()
-           ),
-         {:ok, %Result{totalCount: totalCount}} <-
-           Query.execute(
-             %Logic{conditions: nil},
-             %Source{
-               publication_id: publication.id,
-               blacklisted_activity_ids: [],
-               section_slug: ""
-             },
-             %Paging{limit: 1, offset: 0}
-           ) do
-      editor_map =
-        Activities.create_registered_activity_map(project_slug)
-        |> Enum.reject(fn {_key, entry} -> entry.isLtiActivity end)
-        |> Enum.into(%{})
-
-      project = Oli.Authoring.Course.get_project_by_slug(project_slug)
-
-      {:ok,
-       %Oli.Authoring.Editing.BankContext{
-         authorEmail: author.email,
-         projectSlug: project_slug,
-         editorMap: editor_map,
-         allObjectives: objectives_with_parent_reference,
-         allTags: Enum.map(tags, fn t -> %{id: t.resource_id, title: t.title} end),
-         totalCount: totalCount,
-         allowTriggers: project.allow_triggers
-       }}
-    else
-      _ -> {:error, :not_found}
-    end
+    Oli.Authoring.Editing.ActivityBank.context(project_slug, author)
   end
 end

--- a/lib/oli/scenarios/directive_parser.ex
+++ b/lib/oli/scenarios/directive_parser.ex
@@ -1003,6 +1003,10 @@ defmodule Oli.Scenarios.DirectiveParser do
   defp validate_activity_bank_op("create_bulk", %{"activities" => activities})
        when is_list(activities) do
     Enum.each(activities, fn activity ->
+      unless is_map(activity) do
+        raise "activity_bank create_bulk activity must be a map, got: #{inspect(activity)}"
+      end
+
       case DirectiveValidator.validate_attributes(
              activity_bank_create_attrs(),
              activity,
@@ -1028,6 +1032,8 @@ defmodule Oli.Scenarios.DirectiveParser do
       "content_format",
       "content",
       "objectives",
+      "objective_map",
+      "objectiveMap",
       "tags"
     ]
   end

--- a/lib/oli/scenarios/directive_parser.ex
+++ b/lib/oli/scenarios/directive_parser.ex
@@ -20,6 +20,7 @@ defmodule Oli.Scenarios.DirectiveParser do
     UpdateDirective,
     CustomizeDirective,
     ActivityDirective,
+    ActivityBankDirective,
     EditPageDirective,
     ViewPracticePageDirective,
     VisitPageDirective,
@@ -481,6 +482,25 @@ defmodule Oli.Scenarios.DirectiveParser do
     end
   end
 
+  defp parse_directive(%{"activity_bank" => activity_bank_data}) do
+    allowed_attrs = ["project", "ops"]
+
+    case DirectiveValidator.validate_attributes(
+           allowed_attrs,
+           activity_bank_data,
+           "activity_bank"
+         ) do
+      :ok ->
+        %ActivityBankDirective{
+          project: activity_bank_data["project"],
+          ops: parse_activity_bank_ops(activity_bank_data["ops"] || [])
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
   defp parse_directive(%{"edit_page" => edit_data}) do
     # Validate attributes
     allowed_attrs = ["project", "page", "content"]
@@ -854,6 +874,7 @@ defmodule Oli.Scenarios.DirectiveParser do
          "update",
          "customize",
          "create_activity",
+         "activity_bank",
          "edit_page",
          "view_practice_page",
          "visit_page",
@@ -870,7 +891,7 @@ defmodule Oli.Scenarios.DirectiveParser do
          "bibliography",
          "hook"
        ] do
-      raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, use, collaborator, media, bibliography, hook"
+      raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, use, collaborator, media, bibliography, hook"
     else
       # This shouldn't happen as specific handlers above should match first
       raise "Internal error: unhandled directive '#{key}'"
@@ -895,6 +916,7 @@ defmodule Oli.Scenarios.DirectiveParser do
              "enroll",
              "institution",
              "create_activity",
+             "activity_bank",
              "edit_page",
              "view_practice_page",
              "visit_page",
@@ -921,8 +943,93 @@ defmodule Oli.Scenarios.DirectiveParser do
         [parse_directive(%{key => value})]
 
       {key, _value} ->
-        raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, certificate, discussion_post, class_note, complete_scored_page, certificate_action, use, collaborator, media, bibliography, hook"
+        raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, certificate, discussion_post, class_note, complete_scored_page, certificate_action, use, collaborator, media, bibliography, hook"
     end)
+  end
+
+  defp parse_activity_bank_ops(ops) when is_list(ops) do
+    Enum.map(ops, &parse_activity_bank_op/1)
+  end
+
+  defp parse_activity_bank_ops(_ops), do: raise("activity_bank ops must be a list")
+
+  defp parse_activity_bank_op(op) when is_map(op) and map_size(op) == 1 do
+    [{action, data}] = Map.to_list(op)
+
+    allowed_attrs =
+      case action do
+        "create" ->
+          activity_bank_create_attrs()
+
+        "create_bulk" ->
+          ["activities"]
+
+        "query" ->
+          ["name", "logic", "filters", "paging", "expect"]
+
+        "edit" ->
+          ["title", "virtual_id", "resource_id", "set"]
+
+        "delete" ->
+          ["title", "virtual_id", "resource_id"]
+
+        "duplicate" ->
+          ["title", "virtual_id", "resource_id", "new_title", "new_virtual_id"]
+
+        "assert" ->
+          ["result", "expect"]
+
+        _ ->
+          raise "Unrecognized activity_bank operation: '#{action}'. Valid operations are: create, create_bulk, query, edit, delete, duplicate, assert"
+      end
+
+    data = data || %{}
+    directive_name = "activity_bank #{action}"
+
+    case DirectiveValidator.validate_attributes(allowed_attrs, data, directive_name) do
+      :ok ->
+        validate_activity_bank_op(action, data)
+        %{action: action, data: data}
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
+  defp parse_activity_bank_op(_op) do
+    raise "activity_bank operations must be single-key maps"
+  end
+
+  defp validate_activity_bank_op("create_bulk", %{"activities" => activities})
+       when is_list(activities) do
+    Enum.each(activities, fn activity ->
+      case DirectiveValidator.validate_attributes(
+             activity_bank_create_attrs(),
+             activity,
+             "activity_bank create_bulk activity"
+           ) do
+        :ok -> :ok
+        {:error, msg} -> raise msg
+      end
+    end)
+  end
+
+  defp validate_activity_bank_op("create_bulk", _data),
+    do: raise("activity_bank create_bulk operation requires activities list")
+
+  defp validate_activity_bank_op(_action, _data), do: :ok
+
+  defp activity_bank_create_attrs do
+    [
+      "title",
+      "virtual_id",
+      "type",
+      "activity_type_slug",
+      "content_format",
+      "content",
+      "objectives",
+      "tags"
+    ]
   end
 
   defp parse_structure_assertion(nil), do: nil

--- a/lib/oli/scenarios/directive_types.ex
+++ b/lib/oli/scenarios/directive_types.ex
@@ -130,6 +130,15 @@ defmodule Oli.Scenarios.DirectiveTypes do
     ]
   end
 
+  defmodule ActivityBankDirective do
+    @moduledoc """
+    Executes Activity Bank operations for a project.
+    project: target project name
+    ops: ordered list of Activity Bank operations
+    """
+    defstruct [:project, :ops]
+  end
+
   defmodule EditPageDirective do
     @moduledoc """
     Edits an existing page's content from TorusDoc YAML.
@@ -327,6 +336,8 @@ defmodule Oli.Scenarios.DirectiveTypes do
               activities: %{},
               # {project_name, virtual_id} -> activity revision
               activity_virtual_ids: %{},
+              # named Activity Bank operation results
+              activity_bank_results: %{},
               # {user_name, section_name, page_title} -> AttemptState
               page_attempts: %{},
               # {user_name, section_name, page_title} -> FinalizationSummary

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -438,7 +438,8 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
          type: activity_type_slug,
          title: data["new_title"] || "#{revision.title} Copy",
          content: revision.content,
-         objectives: objective_ids(revision.objectives),
+         objectives: [],
+         objective_map: revision.objectives || %{},
          tags: revision.tags || []
        }}
     end
@@ -464,15 +465,6 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
       registration -> {:ok, registration.slug}
     end
   end
-
-  defp objective_ids(objectives) when is_map(objectives) do
-    objectives
-    |> Map.values()
-    |> List.flatten()
-    |> Enum.uniq()
-  end
-
-  defp objective_ids(_objectives), do: []
 
   defp ensure_activity_lock(project_slug, author, resource_id) do
     case Publishing.project_working_publication(project_slug) do

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -37,12 +37,19 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
           {:cont, {:ok, new_state, assertions}}
 
         {:ok, new_state, assertion_results} when is_list(assertion_results) ->
-          {:cont, {:ok, new_state, assertions ++ assertion_results}}
+          {:cont, {:ok, new_state, [assertion_results | assertions]}}
 
         {:error, reason} ->
           {:halt, {:error, reason}}
       end
     end)
+    |> case do
+      {:ok, final_state, assertions} ->
+        {:ok, final_state, assertions |> Enum.reverse() |> List.flatten()}
+
+      error ->
+        error
+    end
   end
 
   defp execute_op("create", data, project_name, built_project, author, state) do
@@ -102,14 +109,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
              revision.resource_id,
              Map.put_new(update, "releaseLock", true)
            ) do
-      {:ok,
-       put_activity(
-         state,
-         project_name,
-         updated_revision,
-         updated_revision.title,
-         data["virtual_id"]
-       )}
+      {:ok, update_activity(state, project_name, revision, updated_revision, data["virtual_id"])}
     end
   end
 
@@ -481,6 +481,16 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
     end
   end
 
+  defp update_activity(state, project_name, previous_revision, updated_revision, virtual_id) do
+    state
+    |> remove_activity_title(project_name, previous_revision.title)
+    |> put_activity(project_name, updated_revision, updated_revision.title, virtual_id)
+  end
+
+  defp remove_activity_title(state, project_name, title) do
+    %{state | activities: maybe_delete_key(state.activities, {project_name, title})}
+  end
+
   defp remove_activity(state, project_name, revision, data) do
     activities =
       state.activities
@@ -545,7 +555,8 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   defp excludes_expectation(expect, key, actual, name) do
     case Map.fetch(expect, key) do
       {:ok, expected} ->
-        present = Enum.filter(expected, &(&1 in actual))
+        actual_set = MapSet.new(actual)
+        present = Enum.filter(expected, &MapSet.member?(actual_set, &1))
         assertion(name, key, present == [], expected, actual)
 
       :error ->

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -1,14 +1,594 @@
 defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   @moduledoc """
-  Handles activity_bank directives.
-
-  Phase 3 wires the directive through schema, parser, and engine dispatch. Phase
-  4 will implement operation execution against Oli.Authoring.Editing.ActivityBank.
+  Handles activity_bank directives by executing author-facing Activity Bank
+  operations against the non-UI application boundary.
   """
 
-  alias Oli.Scenarios.DirectiveTypes.{ActivityBankDirective, ExecutionState}
+  alias Oli.Activities
+  alias Oli.Activities.Realizer.Query.Result
+  alias Oli.Authoring.Editing.ActivityBank
+  alias Oli.Authoring.Locks
+  alias Oli.Publishing
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Scenarios.DirectiveTypes.{ActivityBankDirective, ExecutionState, VerificationResult}
+  alias Oli.TorusDoc.ActivityConverter
 
-  def handle(%ActivityBankDirective{}, %ExecutionState{}) do
-    {:error, "activity_bank directive execution is not implemented yet"}
+  @default_paging %{"limit" => 25, "offset" => 0}
+
+  def handle(%ActivityBankDirective{} = directive, %ExecutionState{} = state) do
+    with {:ok, author} <- validate_author(state.current_author),
+         {:ok, project_name} <- validate_project_name(directive.project),
+         {:ok, built_project} <- get_project(project_name, state),
+         {:ok, final_state, assertions} <-
+           execute_ops(directive.ops || [], project_name, built_project, author, state) do
+      verification = build_verification(project_name, assertions)
+      {:ok, final_state, verification}
+    else
+      {:error, reason} ->
+        {:error, "Failed to execute activity_bank directive: #{format_error(reason)}"}
+    end
   end
+
+  defp execute_ops(ops, project_name, built_project, author, state) do
+    Enum.reduce_while(ops, {:ok, state, []}, fn %{action: action, data: data},
+                                                {:ok, acc_state, assertions} ->
+      case execute_op(action, data, project_name, built_project, author, acc_state) do
+        {:ok, new_state} ->
+          {:cont, {:ok, new_state, assertions}}
+
+        {:ok, new_state, assertion_results} when is_list(assertion_results) ->
+          {:cont, {:ok, new_state, assertions ++ assertion_results}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp execute_op("create", data, project_name, built_project, author, state) do
+    with {:ok, attrs} <- normalize_create_attrs(data),
+         {:ok, {revision, _content}} <-
+           ActivityBank.create(built_project.project.slug, author, attrs) do
+      {:ok, put_activity(state, project_name, revision, data["title"], data["virtual_id"])}
+    end
+  end
+
+  defp execute_op(
+         "create_bulk",
+         %{"activities" => activities},
+         project_name,
+         built_project,
+         author,
+         state
+       ) do
+    with {:ok, attrs_list} <- normalize_bulk_create_attrs(activities),
+         {:ok, created} <-
+           ActivityBank.create_bulk(built_project.project.slug, author, attrs_list) do
+      updated_state =
+        attrs_list
+        |> Enum.zip(created)
+        |> Enum.reduce(state, fn {attrs, %{activity: revision}}, acc ->
+          put_activity(acc, project_name, revision, attrs.title, attrs.virtual_id)
+        end)
+
+      {:ok, updated_state}
+    end
+  end
+
+  defp execute_op("query", data, _project_name, built_project, author, state) do
+    with {:ok, logic} <- query_logic(data, built_project),
+         {:ok, %Result{} = result} <-
+           ActivityBank.query(
+             built_project.project.slug,
+             author,
+             logic,
+             Map.get(data, "paging", @default_paging)
+           ),
+         assertion_results <- expectation_assertions(data["expect"], result, data["name"]) do
+      state = put_query_result(state, data["name"], result)
+      {:ok, state, assertion_results}
+    end
+  end
+
+  defp execute_op("edit", data, project_name, built_project, author, state) do
+    with {:ok, revision} <- resolve_activity(data, project_name, built_project, state),
+         {:ok, _lock} <-
+           ensure_activity_lock(built_project.project.slug, author, revision.resource_id),
+         {:ok, update} <- normalize_update(data["set"] || %{}, built_project),
+         {:ok, updated_revision} <-
+           ActivityBank.update(
+             built_project.project.slug,
+             author,
+             revision.resource_id,
+             Map.put_new(update, "releaseLock", true)
+           ) do
+      {:ok,
+       put_activity(
+         state,
+         project_name,
+         updated_revision,
+         updated_revision.title,
+         data["virtual_id"]
+       )}
+    end
+  end
+
+  defp execute_op("delete", data, project_name, built_project, author, state) do
+    with {:ok, revision} <- resolve_activity(data, project_name, built_project, state),
+         {:ok, _lock} <-
+           ensure_activity_lock(built_project.project.slug, author, revision.resource_id),
+         {:ok, _deleted_revision} <-
+           ActivityBank.delete(built_project.project.slug, author, revision.resource_id) do
+      {:ok, remove_activity(state, project_name, revision, data)}
+    end
+  end
+
+  defp execute_op("duplicate", data, project_name, built_project, author, state) do
+    with {:ok, revision} <- resolve_activity(data, project_name, built_project, state),
+         {:ok, attrs} <- duplicate_attrs(revision, data),
+         {:ok, {new_revision, _content}} <-
+           ActivityBank.create(built_project.project.slug, author, attrs) do
+      {:ok,
+       put_activity(
+         state,
+         project_name,
+         new_revision,
+         attrs.title,
+         data["new_virtual_id"]
+       )}
+    end
+  end
+
+  defp execute_op("assert", data, _project_name, _built_project, _author, state) do
+    case Map.get(state.activity_bank_results, data["result"]) do
+      nil ->
+        {:error, "Activity Bank result '#{data["result"]}' not found"}
+
+      %Result{} = result ->
+        {:ok, state, expectation_assertions(data["expect"], result, data["result"])}
+    end
+  end
+
+  defp execute_op(action, _data, _project_name, _built_project, _author, _state) do
+    {:error, "Unsupported activity_bank operation '#{action}'"}
+  end
+
+  defp normalize_create_attrs(data) do
+    with {:ok, content} <- parse_activity_content(data) do
+      {:ok,
+       %{
+         type: data["type"] || data["activity_type_slug"],
+         title: data["title"],
+         virtual_id: data["virtual_id"],
+         content: content,
+         objectives: data["objectives"] || [],
+         tags: data["tags"] || []
+       }}
+    end
+  end
+
+  defp normalize_bulk_create_attrs(activities) do
+    Enum.reduce_while(activities, {:ok, []}, fn data, {:ok, acc} ->
+      case normalize_create_attrs(data) do
+        {:ok, attrs} -> {:cont, {:ok, acc ++ [attrs]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp normalize_update(update, built_project) when is_map(update) do
+    update =
+      update
+      |> normalize_update_content()
+      |> normalize_update_objectives(built_project)
+      |> normalize_update_tags(built_project)
+
+    case update do
+      {:error, reason} -> {:error, reason}
+      normalized -> {:ok, normalized}
+    end
+  end
+
+  defp normalize_update(_update, _built_project), do: {:error, "edit set must be a map"}
+
+  defp normalize_update_content(%{"content" => _content} = update) do
+    case parse_activity_content(update) do
+      {:ok, content} -> Map.put(update, "content", content)
+      error -> error
+    end
+  end
+
+  defp normalize_update_content(update), do: update
+
+  defp normalize_update_objectives({:error, _} = error, _built_project), do: error
+
+  defp normalize_update_objectives(%{"objectives" => objectives} = update, built_project) do
+    case resolve_references(objectives, built_project.objectives_by_title || %{}, "Objective") do
+      {:ok, ids} -> Map.put(update, "objectives", ids)
+      error -> error
+    end
+  end
+
+  defp normalize_update_objectives(update, _built_project), do: update
+
+  defp normalize_update_tags({:error, _} = error, _built_project), do: error
+
+  defp normalize_update_tags(%{"tags" => tags} = update, built_project) do
+    case resolve_references(tags, built_project.tags_by_title || %{}, "Tag") do
+      {:ok, ids} -> Map.put(update, "tags", ids)
+      error -> error
+    end
+  end
+
+  defp normalize_update_tags(update, _built_project), do: update
+
+  defp parse_activity_content(%{"content" => content, "content_format" => "json"}),
+    do: {:ok, content}
+
+  defp parse_activity_content(%{"content" => content} = data)
+       when is_binary(content) do
+    type = data["type"] || data["activity_type_slug"] || "oli_multiple_choice"
+    yaml = ensure_activity_type(content, type)
+
+    case ActivityConverter.from_yaml(yaml) do
+      {:ok, json} -> {:ok, Map.drop(json, ["type", "objectives", "tags", "title"])}
+      {:error, reason} -> {:error, "Failed to parse activity YAML: #{reason}"}
+    end
+  end
+
+  defp parse_activity_content(%{"content" => content}) when is_map(content), do: {:ok, content}
+  defp parse_activity_content(_data), do: {:error, "Activity content is required"}
+
+  defp ensure_activity_type(yaml_content, type) do
+    if String.contains?(yaml_content, "type:") do
+      yaml_content
+    else
+      "type: \"#{type}\"\n#{yaml_content}"
+    end
+  end
+
+  defp query_logic(%{"logic" => logic}, _built_project) when is_map(logic), do: {:ok, logic}
+
+  defp query_logic(%{"filters" => filters}, built_project),
+    do: filters_to_logic(filters, built_project)
+
+  defp query_logic(_data, _built_project), do: {:ok, %{"conditions" => nil}}
+
+  defp filters_to_logic(filters, built_project) when is_map(filters) do
+    with {:ok, expressions} <- filter_expressions(filters, built_project) do
+      conditions =
+        case expressions do
+          [] -> nil
+          [expression] -> expression
+          expressions -> %{"operator" => "all", "children" => expressions}
+        end
+
+      {:ok, %{"conditions" => conditions}}
+    end
+  end
+
+  defp filters_to_logic(_filters, _built_project),
+    do: {:error, "Activity Bank filters must be a map"}
+
+  defp filter_expressions(filters, built_project) do
+    Enum.reduce_while(filters, {:ok, []}, fn {fact, expression}, {:ok, acc} ->
+      case filter_expression(fact, expression, built_project) do
+        {:ok, nil} -> {:cont, {:ok, acc}}
+        {:ok, parsed} -> {:cont, {:ok, acc ++ [parsed]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp filter_expression(fact, expression, built_project) when is_map(expression) do
+    case Map.to_list(expression) do
+      [{operator, value}] ->
+        with {:ok, resolved_value} <- resolve_filter_value(fact, value, built_project) do
+          {:ok, %{"fact" => fact, "operator" => operator, "value" => resolved_value}}
+        end
+
+      _ ->
+        {:error, "Activity Bank filter '#{fact}' must specify exactly one operator"}
+    end
+  end
+
+  defp filter_expression(fact, _expression, _built_project),
+    do: {:error, "Activity Bank filter '#{fact}' must be a map"}
+
+  defp resolve_filter_value("tags", value, built_project),
+    do: resolve_references(List.wrap(value), built_project.tags_by_title || %{}, "Tag")
+
+  defp resolve_filter_value("objectives", value, built_project),
+    do:
+      resolve_references(List.wrap(value), built_project.objectives_by_title || %{}, "Objective")
+
+  defp resolve_filter_value("type", value, _built_project) when is_list(value) do
+    Enum.reduce_while(value, {:ok, []}, fn type, {:ok, acc} ->
+      case resolve_activity_type_value(type) do
+        {:ok, id} -> {:cont, {:ok, acc ++ [id]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_filter_value("type", value, _built_project), do: resolve_activity_type_value(value)
+  defp resolve_filter_value("text", value, _built_project), do: {:ok, value}
+
+  defp resolve_filter_value(fact, _value, _built_project),
+    do: {:error, "Unsupported Activity Bank filter '#{fact}'"}
+
+  defp resolve_activity_type_value(value) when is_integer(value), do: {:ok, value}
+
+  defp resolve_activity_type_value(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {id, ""} ->
+        {:ok, id}
+
+      _ ->
+        case Activities.get_registration_by_slug(value) do
+          nil -> {:error, "Unknown activity type: #{value}"}
+          registration -> {:ok, registration.id}
+        end
+    end
+  end
+
+  defp resolve_activity_type_value(value),
+    do: {:error, "Activity type filter value must be a slug or ID, got: #{inspect(value)}"}
+
+  defp resolve_references(references, title_map, label) when is_list(references) do
+    Enum.reduce_while(references, {:ok, []}, fn reference, {:ok, acc} ->
+      case resolve_reference(reference, title_map, label) do
+        {:ok, id} -> {:cont, {:ok, acc ++ [id]}}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp resolve_references(references, _title_map, label),
+    do: {:error, "#{label} references must be a list, got: #{inspect(references)}"}
+
+  defp resolve_reference(value, _title_map, _label) when is_integer(value), do: {:ok, value}
+
+  defp resolve_reference(value, title_map, label) when is_binary(value) do
+    case Integer.parse(value) do
+      {id, ""} ->
+        {:ok, id}
+
+      _ ->
+        case Map.get(title_map, value) do
+          nil -> {:error, "#{label} '#{value}' not found in project"}
+          revision -> {:ok, revision.resource_id}
+        end
+    end
+  end
+
+  defp resolve_reference(value, _title_map, label),
+    do: {:error, "#{label} reference must be a title or resource ID, got: #{inspect(value)}"}
+
+  defp resolve_activity(%{"resource_id" => resource_id}, _project_name, built_project, _state)
+       when is_integer(resource_id) do
+    case AuthoringResolver.from_resource_id(built_project.project.slug, resource_id) do
+      nil -> {:error, "Activity resource '#{resource_id}' not found"}
+      revision -> {:ok, revision}
+    end
+  end
+
+  defp resolve_activity(%{"virtual_id" => virtual_id}, project_name, _built_project, state) do
+    case Map.get(state.activity_virtual_ids, {project_name, virtual_id}) do
+      nil -> {:error, "Activity with virtual_id '#{virtual_id}' not found"}
+      revision -> {:ok, revision}
+    end
+  end
+
+  defp resolve_activity(%{"title" => title}, project_name, built_project, state) do
+    case Map.get(state.activities, {project_name, title}) do
+      nil ->
+        case AuthoringResolver.from_title(
+               built_project.project.slug,
+               title,
+               Oli.Resources.ResourceType.id_for_activity()
+             ) do
+          [revision | _] -> {:ok, revision}
+          [] -> {:error, "Activity '#{title}' not found"}
+        end
+
+      revision ->
+        {:ok, revision}
+    end
+  end
+
+  defp resolve_activity(_data, _project_name, _built_project, _state),
+    do: {:error, "Activity operation requires title, virtual_id, or resource_id"}
+
+  defp duplicate_attrs(revision, data) do
+    with {:ok, activity_type_slug} <- activity_type_slug(revision.activity_type_id) do
+      {:ok,
+       %{
+         type: activity_type_slug,
+         title: data["new_title"] || "#{revision.title} Copy",
+         content: revision.content,
+         objectives: objective_ids(revision.objectives),
+         tags: revision.tags || []
+       }}
+    end
+  end
+
+  defp activity_type_slug(activity_type_id) do
+    case Activities.get_registration(activity_type_id) do
+      nil -> {:error, "Unknown activity type id: #{activity_type_id}"}
+      registration -> {:ok, registration.slug}
+    end
+  end
+
+  defp objective_ids(objectives) when is_map(objectives) do
+    objectives
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.uniq()
+  end
+
+  defp objective_ids(_objectives), do: []
+
+  defp ensure_activity_lock(project_slug, author, resource_id) do
+    case Publishing.project_working_publication(project_slug) do
+      nil ->
+        {:error, "Working publication not found for project '#{project_slug}'"}
+
+      publication ->
+        case Locks.acquire(project_slug, publication.id, resource_id, author.id) do
+          {:acquired} -> {:ok, :acquired}
+          {:updated} -> {:ok, :updated}
+          {:lock_not_acquired, details} -> {:error, {:lock_not_acquired, details}}
+          {:error} -> {:error, "Failed to acquire activity lock"}
+          {:error, reason} -> {:error, reason}
+          other -> {:error, other}
+        end
+    end
+  end
+
+  defp put_activity(state, project_name, revision, title, virtual_id) do
+    title = title || revision.title
+
+    state = %{
+      state
+      | activities: Map.put(state.activities, {project_name, title}, revision)
+    }
+
+    if virtual_id do
+      %{
+        state
+        | activity_virtual_ids:
+            Map.put(state.activity_virtual_ids, {project_name, virtual_id}, revision)
+      }
+    else
+      state
+    end
+  end
+
+  defp remove_activity(state, project_name, revision, data) do
+    activities =
+      state.activities
+      |> Map.delete({project_name, revision.title})
+      |> maybe_delete_key({project_name, data["title"]})
+
+    virtual_ids =
+      state.activity_virtual_ids
+      |> maybe_delete_key({project_name, data["virtual_id"]})
+
+    %{state | activities: activities, activity_virtual_ids: virtual_ids}
+  end
+
+  defp maybe_delete_key(map, {_project_name, nil}), do: map
+  defp maybe_delete_key(map, key), do: Map.delete(map, key)
+
+  defp put_query_result(state, nil, _result), do: state
+
+  defp put_query_result(state, name, result) do
+    %{state | activity_bank_results: Map.put(state.activity_bank_results, name, result)}
+  end
+
+  defp expectation_assertions(nil, _result, _name), do: []
+
+  defp expectation_assertions(expect, %Result{} = result, name) do
+    rows = result.rows || []
+    titles = Enum.map(rows, & &1.title)
+    resource_ids = Enum.map(rows, & &1.resource_id)
+
+    [
+      compare_expectation(expect, "total_count", result.totalCount, name),
+      compare_expectation(expect, "row_count", result.rowCount, name),
+      compare_expectation(expect, "titles", titles, name),
+      compare_expectation(expect, "resource_ids", resource_ids, name),
+      contains_expectation(expect, "contains_titles", titles, name),
+      excludes_expectation(expect, "not_titles", titles, name)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp compare_expectation(expect, key, actual, name) do
+    case Map.fetch(expect, key) do
+      {:ok, expected} ->
+        assertion(name, key, expected == actual, expected, actual)
+
+      :error ->
+        nil
+    end
+  end
+
+  defp contains_expectation(expect, key, actual, name) do
+    case Map.fetch(expect, key) do
+      {:ok, expected} ->
+        missing = expected -- actual
+        assertion(name, key, missing == [], expected, actual)
+
+      :error ->
+        nil
+    end
+  end
+
+  defp excludes_expectation(expect, key, actual, name) do
+    case Map.fetch(expect, key) do
+      {:ok, expected} ->
+        present = Enum.filter(expected, &(&1 in actual))
+        assertion(name, key, present == [], expected, actual)
+
+      :error ->
+        nil
+    end
+  end
+
+  defp assertion(result_name, key, passed, expected, actual) do
+    %{
+      result: result_name,
+      key: key,
+      passed: passed,
+      expected: expected,
+      actual: actual
+    }
+  end
+
+  defp build_verification(project_name, []),
+    do: %VerificationResult{
+      to: project_name,
+      passed: true,
+      message: "Activity Bank operations completed"
+    }
+
+  defp build_verification(project_name, assertions) do
+    failures = Enum.reject(assertions, & &1.passed)
+
+    %VerificationResult{
+      to: project_name,
+      passed: failures == [],
+      message: verification_message(assertions, failures),
+      expected: Enum.map(assertions, &Map.take(&1, [:result, :key, :expected])),
+      actual: Enum.map(assertions, &Map.take(&1, [:result, :key, :actual, :passed]))
+    }
+  end
+
+  defp verification_message(_assertions, []), do: "Activity Bank assertions passed"
+
+  defp verification_message(_assertions, failures) do
+    "Activity Bank assertions failed: " <>
+      Enum.map_join(failures, "; ", fn failure ->
+        "#{failure.key} expected #{inspect(failure.expected)}, got #{inspect(failure.actual)}"
+      end)
+  end
+
+  defp validate_author(nil), do: {:error, "No author available"}
+  defp validate_author(author), do: {:ok, author}
+
+  defp validate_project_name(nil), do: {:error, "Project name is required"}
+  defp validate_project_name(name) when is_binary(name), do: {:ok, name}
+  defp validate_project_name(_), do: {:error, "Project name must be a string"}
+
+  defp get_project(project_name, state) do
+    case Map.get(state.projects, project_name) do
+      nil -> {:error, "Project '#{project_name}' not found"}
+      built_project -> {:ok, built_project}
+    end
+  end
+
+  defp format_error(reason) when is_binary(reason), do: reason
+  defp format_error(reason), do: inspect(reason)
 end

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -165,6 +165,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
          virtual_id: data["virtual_id"],
          content: content,
          objectives: data["objectives"] || [],
+         objective_map: data["objective_map"] || data["objectiveMap"] || %{},
          tags: data["tags"] || []
        }}
     end
@@ -389,6 +390,17 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
     case AuthoringResolver.from_resource_id(built_project.project.slug, resource_id) do
       nil -> {:error, "Activity resource '#{resource_id}' not found"}
       revision -> {:ok, revision}
+    end
+  end
+
+  defp resolve_activity(%{"resource_id" => resource_id}, project_name, built_project, state)
+       when is_binary(resource_id) do
+    case Integer.parse(resource_id) do
+      {id, ""} ->
+        resolve_activity(%{"resource_id" => id}, project_name, built_project, state)
+
+      _ ->
+        {:error, "Activity resource_id must be an integer, got: #{inspect(resource_id)}"}
     end
   end
 

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -1,0 +1,14 @@
+defmodule Oli.Scenarios.Directives.ActivityBankHandler do
+  @moduledoc """
+  Handles activity_bank directives.
+
+  Phase 3 wires the directive through schema, parser, and engine dispatch. Phase
+  4 will implement operation execution against Oli.Authoring.Editing.ActivityBank.
+  """
+
+  alias Oli.Scenarios.DirectiveTypes.{ActivityBankDirective, ExecutionState}
+
+  def handle(%ActivityBankDirective{}, %ExecutionState{}) do
+    {:error, "activity_bank directive execution is not implemented yet"}
+  end
+end

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -499,13 +499,34 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   end
 
   defp update_activity(state, project_name, previous_revision, updated_revision, virtual_id) do
-    state
-    |> remove_activity_title(project_name, previous_revision.title)
-    |> put_activity(project_name, updated_revision, updated_revision.title, virtual_id)
+    state =
+      state
+      |> remove_activity_title(project_name, previous_revision.title)
+      |> put_activity(project_name, updated_revision, updated_revision.title, virtual_id)
+
+    virtual_ids =
+      update_activity_virtual_ids(
+        state.activity_virtual_ids,
+        project_name,
+        updated_revision.resource_id,
+        updated_revision
+      )
+
+    %{state | activity_virtual_ids: virtual_ids}
   end
 
   defp remove_activity_title(state, project_name, title) do
     %{state | activities: maybe_delete_key(state.activities, {project_name, title})}
+  end
+
+  defp update_activity_virtual_ids(virtual_ids, project_name, resource_id, updated_revision) do
+    Map.new(virtual_ids, fn
+      {{^project_name, _virtual_id} = key, %{resource_id: ^resource_id}} ->
+        {key, updated_revision}
+
+      entry ->
+        entry
+    end)
   end
 
   defp remove_activity(state, project_name, revision, data) do

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -101,9 +101,9 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
 
   defp execute_op("edit", data, project_name, built_project, author, state) do
     with {:ok, revision} <- resolve_activity(data, project_name, built_project, state),
+         {:ok, update} <- normalize_update(data["set"] || %{}, built_project),
          {:ok, _lock} <-
            ensure_activity_lock(built_project.project.slug, author, revision.resource_id),
-         {:ok, update} <- normalize_update(data["set"] || %{}, built_project),
          {:ok, updated_revision} <-
            ActivityBank.update(
              built_project.project.slug,

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -10,10 +10,12 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   alias Oli.Authoring.Locks
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
+  alias Oli.Resources.ResourceType
   alias Oli.Scenarios.DirectiveTypes.{ActivityBankDirective, ExecutionState, VerificationResult}
   alias Oli.TorusDoc.ActivityConverter
 
   @default_paging %{"limit" => 25, "offset" => 0}
+  @activity_resource_type_id ResourceType.id_for_activity()
 
   def handle(%ActivityBankDirective{} = directive, %ExecutionState{} = state) do
     with {:ok, author} <- validate_author(state.current_author),
@@ -125,6 +127,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
 
   defp execute_op("duplicate", data, project_name, built_project, author, state) do
     with {:ok, revision} <- resolve_activity(data, project_name, built_project, state),
+         {:ok, revision} <- validate_banked_activity(revision),
          {:ok, attrs} <- duplicate_attrs(revision, data),
          {:ok, {new_revision, _content}} <-
            ActivityBank.create(built_project.project.slug, author, attrs) do
@@ -429,6 +432,20 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
     end
   end
 
+  defp validate_banked_activity(%{resource_type_id: resource_type_id, scope: :banked} = revision)
+       when resource_type_id == @activity_resource_type_id do
+    {:ok, revision}
+  end
+
+  defp validate_banked_activity(%{resource_type_id: resource_type_id, resource_id: resource_id})
+       when resource_type_id == @activity_resource_type_id do
+    {:error, "Activity resource '#{resource_id}' is not banked"}
+  end
+
+  defp validate_banked_activity(%{resource_id: resource_id}) do
+    {:error, "Activity resource '#{resource_id}' does not have the expected resource type"}
+  end
+
   defp activity_type_slug(activity_type_id) do
     case Activities.get_registration(activity_type_id) do
       nil -> {:error, "Unknown activity type id: #{activity_type_id}"}
@@ -500,8 +517,16 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
     virtual_ids =
       state.activity_virtual_ids
       |> maybe_delete_key({project_name, data["virtual_id"]})
+      |> remove_activity_virtual_ids(project_name, revision.resource_id)
 
     %{state | activities: activities, activity_virtual_ids: virtual_ids}
+  end
+
+  defp remove_activity_virtual_ids(virtual_ids, project_name, resource_id) do
+    Map.reject(virtual_ids, fn
+      {{^project_name, _virtual_id}, %{resource_id: ^resource_id}} -> true
+      _ -> false
+    end)
   end
 
   defp maybe_delete_key(map, {_project_name, nil}), do: map

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -210,6 +210,10 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
 
   defp normalize_update_objectives({:error, _} = error, _built_project), do: error
 
+  defp normalize_update_objectives(%{"objectives" => objectives} = update, _built_project)
+       when is_map(objectives),
+       do: update
+
   defp normalize_update_objectives(%{"objectives" => objectives} = update, built_project) do
     case resolve_references(objectives, built_project.objectives_by_title || %{}, "Objective") do
       {:ok, ids} -> Map.put(update, "objectives", ids)
@@ -593,6 +597,9 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
 
   defp contains_expectation(expect, key, actual, name) do
     case Map.fetch(expect, key) do
+      {:ok, expected} when not is_list(expected) ->
+        assertion(name, key, false, "a list", expected)
+
       {:ok, expected} ->
         missing = expected -- actual
         assertion(name, key, missing == [], expected, actual)
@@ -604,6 +611,9 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
 
   defp excludes_expectation(expect, key, actual, name) do
     case Map.fetch(expect, key) do
+      {:ok, expected} when not is_list(expected) ->
+        assertion(name, key, false, "a list", expected)
+
       {:ok, expected} ->
         actual_set = MapSet.new(actual)
         present = Enum.filter(expected, &MapSet.member?(actual_set, &1))

--- a/lib/oli/scenarios/directives/activity_bank_handler.ex
+++ b/lib/oli/scenarios/directives/activity_bank_handler.ex
@@ -170,10 +170,14 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   defp normalize_bulk_create_attrs(activities) do
     Enum.reduce_while(activities, {:ok, []}, fn data, {:ok, acc} ->
       case normalize_create_attrs(data) do
-        {:ok, attrs} -> {:cont, {:ok, acc ++ [attrs]}}
+        {:ok, attrs} -> {:cont, {:ok, [attrs | acc]}}
         error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, attrs} -> {:ok, Enum.reverse(attrs)}
+      error -> error
+    end
   end
 
   defp normalize_update(update, built_project) when is_map(update) do
@@ -274,10 +278,14 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
     Enum.reduce_while(filters, {:ok, []}, fn {fact, expression}, {:ok, acc} ->
       case filter_expression(fact, expression, built_project) do
         {:ok, nil} -> {:cont, {:ok, acc}}
-        {:ok, parsed} -> {:cont, {:ok, acc ++ [parsed]}}
+        {:ok, parsed} -> {:cont, {:ok, [parsed | acc]}}
         error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, expressions} -> {:ok, Enum.reverse(expressions)}
+      error -> error
+    end
   end
 
   defp filter_expression(fact, expression, built_project) when is_map(expression) do
@@ -305,10 +313,14 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   defp resolve_filter_value("type", value, _built_project) when is_list(value) do
     Enum.reduce_while(value, {:ok, []}, fn type, {:ok, acc} ->
       case resolve_activity_type_value(type) do
-        {:ok, id} -> {:cont, {:ok, acc ++ [id]}}
+        {:ok, id} -> {:cont, {:ok, [id | acc]}}
         error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, ids} -> {:ok, Enum.reverse(ids)}
+      error -> error
+    end
   end
 
   defp resolve_filter_value("type", value, _built_project), do: resolve_activity_type_value(value)
@@ -338,10 +350,14 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandler do
   defp resolve_references(references, title_map, label) when is_list(references) do
     Enum.reduce_while(references, {:ok, []}, fn reference, {:ok, acc} ->
       case resolve_reference(reference, title_map, label) do
-        {:ok, id} -> {:cont, {:ok, acc ++ [id]}}
+        {:ok, id} -> {:cont, {:ok, [id | acc]}}
         error -> {:halt, error}
       end
     end)
+    |> case do
+      {:ok, ids} -> {:ok, Enum.reverse(ids)}
+      error -> error
+    end
   end
 
   defp resolve_references(references, _title_map, label),

--- a/lib/oli/scenarios/directives/activity_handler.ex
+++ b/lib/oli/scenarios/directives/activity_handler.ex
@@ -8,6 +8,7 @@ defmodule Oli.Scenarios.Directives.ActivityHandler do
   """
 
   alias Oli.Scenarios.DirectiveTypes.{ExecutionState, ActivityDirective}
+  alias Oli.Authoring.Editing.ActivityBank
   alias Oli.Authoring.Editing.ActivityEditor
   alias Oli.TorusDoc.ActivityConverter
   alias Oli.Activities
@@ -233,19 +234,34 @@ defmodule Oli.Scenarios.Directives.ActivityHandler do
     # Use provided title or extract from JSON
     final_title = title || Map.get(activity_json, "title", "Untitled Activity")
 
-    # Create the activity
-    case ActivityEditor.create(
-           project.slug,
-           activity_registration.slug,
-           author,
-           model,
-           final_objectives,
-           scope,
-           final_title,
-           # objective_map - empty for now
-           %{},
-           final_tags
-         ) do
+    create_result =
+      case scope do
+        "banked" ->
+          ActivityBank.create(project.slug, author, %{
+            type: activity_registration.slug,
+            model: model,
+            objectives: final_objectives,
+            title: final_title,
+            objective_map: %{},
+            tags: final_tags
+          })
+
+        _ ->
+          ActivityEditor.create(
+            project.slug,
+            activity_registration.slug,
+            author,
+            model,
+            final_objectives,
+            scope,
+            final_title,
+            # objective_map - empty for now
+            %{},
+            final_tags
+          )
+      end
+
+    case create_result do
       {:ok, {revision, resource}} ->
         {:ok, {revision, resource}}
 

--- a/lib/oli/scenarios/engine.ex
+++ b/lib/oli/scenarios/engine.ex
@@ -21,6 +21,7 @@ defmodule Oli.Scenarios.Engine do
     UpdateDirective,
     CustomizeDirective,
     ActivityDirective,
+    ActivityBankDirective,
     EditPageDirective,
     ViewPracticePageDirective,
     VisitPageDirective,
@@ -58,6 +59,7 @@ defmodule Oli.Scenarios.Engine do
     UpdateHandler,
     CustomizeHandler,
     ActivityHandler,
+    ActivityBankHandler,
     EditPageHandler,
     ViewPracticePageHandler,
     VisitPageHandler,
@@ -153,6 +155,7 @@ defmodule Oli.Scenarios.Engine do
           institutions: %{"default" => institution},
           activities: %{},
           activity_virtual_ids: %{},
+          activity_bank_results: %{},
           page_attempts: %{},
           finalized_attempts: %{},
           activity_evaluations: %{},
@@ -267,6 +270,10 @@ defmodule Oli.Scenarios.Engine do
 
   def execute_directive(%ActivityDirective{} = directive, state) do
     ActivityHandler.handle(directive, state)
+  end
+
+  def execute_directive(%ActivityBankDirective{} = directive, state) do
+    ActivityBankHandler.handle(directive, state)
   end
 
   def execute_directive(%EditPageDirective{} = directive, state) do

--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -5,8 +5,7 @@ defmodule OliWeb.ActivityBankController do
   alias OliWeb.Common.Breadcrumb
 
   alias Oli.Activities.Realizer.Logic
-  alias Oli.Activities.Realizer.Query
-  alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Authoring.Editing.ActivityBank
   alias Oli.Activities.Realizer.Query.Result
   alias OliWeb.Common.PagingParams
   alias Oli.Delivery.Page.PageContext
@@ -160,14 +159,11 @@ defmodule OliWeb.ActivityBankController do
        ) do
     case Logic.parse(logic) do
       {:ok, %Logic{} = logic} ->
-        case Query.execute(
+        case ActivityBank.query_publication(
+               publication_id,
                logic,
-               %Source{
-                 publication_id: publication_id,
-                 blacklisted_activity_ids: [],
-                 section_slug: section_slug
-               },
-               %Oli.Activities.Realizer.Query.Paging{offset: offset, limit: 5}
+               %Oli.Activities.Realizer.Query.Paging{offset: offset, limit: 5},
+               section_slug: section_slug
              ) do
           {:ok, %Result{rows: rows, totalCount: total}} ->
             {:ok, {revision, selection, rows, total}}

--- a/lib/oli_web/controllers/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/activity_bank_controller.ex
@@ -50,7 +50,7 @@ defmodule OliWeb.ActivityBankController do
       |> String.to_integer()
 
     if Oli.Delivery.Sections.is_instructor?(user, section_slug) or is_admin? do
-      case retrieve(section_slug, revision_slug, selection_id, offset) do
+      case retrieve(section_slug, revision_slug, selection_id, offset, user, author) do
         {:ok, {revision, selection, activities, total_count}} ->
           activities =
             Enum.map(activities, fn a ->
@@ -126,7 +126,7 @@ defmodule OliWeb.ActivityBankController do
     end
   end
 
-  defp retrieve(section_slug, revision_slug, selection_id, offset) do
+  defp retrieve(section_slug, revision_slug, selection_id, offset, user, author) do
     case Oli.Publishing.DeliveryResolver.from_revision_slug(section_slug, revision_slug) do
       nil ->
         {:error, {:not_found}}
@@ -145,7 +145,15 @@ defmodule OliWeb.ActivityBankController do
                 revision.resource_id
               )
 
-            parse_and_query(section_slug, selection, revision, publication_id, offset)
+            parse_and_query(
+              section_slug,
+              selection,
+              revision,
+              publication_id,
+              offset,
+              user,
+              author
+            )
         end
     end
   end
@@ -155,15 +163,19 @@ defmodule OliWeb.ActivityBankController do
          %{"logic" => logic} = selection,
          revision,
          publication_id,
-         offset
+         offset,
+         user,
+         author
        ) do
     case Logic.parse(logic) do
       {:ok, %Logic{} = logic} ->
-        case ActivityBank.query_publication(
+        case ActivityBank.query_section_publication(
+               section_slug,
+               user,
+               author,
                publication_id,
                logic,
-               %Oli.Activities.Realizer.Query.Paging{offset: offset, limit: 5},
-               section_slug: section_slug
+               %Oli.Activities.Realizer.Query.Paging{offset: offset, limit: 5}
              ) do
           {:ok, %Result{rows: rows, totalCount: total}} ->
             {:ok, {revision, selection, rows, total}}

--- a/lib/oli_web/controllers/api/activity_bank_controller.ex
+++ b/lib/oli_web/controllers/api/activity_bank_controller.ex
@@ -3,61 +3,29 @@ defmodule OliWeb.Api.ActivityBankController do
   Endpoints to provide paged access to a course project's banked activities.
   """
 
-  alias Oli.Activities.Realizer.Logic
-  alias Oli.Activities.Realizer.Query.Paging
-  alias Oli.Activities.Realizer.Query
-  alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Authoring.Editing.ActivityBank
   alias Oli.Activities.Realizer.Query.Result
-  alias Oli.Publishing
-
-  import Oli.Authoring.Editing.Utils
 
   use OliWeb, :controller
 
   def retrieve(conn, %{"project" => project_slug, "logic" => logic, "paging" => paging}) do
     author = conn.assigns[:current_author]
 
-    if Oli.Accounts.can_access_via_slug?(author, project_slug) do
-      with {:ok, %Logic{} = logic} <- Logic.parse(logic),
-           {:ok, %Paging{} = paging} <- Paging.parse(paging),
-           {:ok, publication} <-
-             Publishing.project_working_publication(project_slug) |> trap_nil(),
-           {:ok, %Result{rows: rows, rowCount: rowCount, totalCount: totalCount}} <-
-             Query.execute(
-               logic,
-               %Source{
-                 publication_id: publication.id,
-                 blacklisted_activity_ids: [],
-                 section_slug: ""
-               },
-               paging
-             ) do
-        json(conn, %{
-          "result" => "success",
-          "queryResult" => %{
-            rowCount: rowCount,
-            totalCount: totalCount,
-            rows: Enum.map(rows, fn r -> serialize_revision(r) end)
-          }
-        })
-      else
-        _ -> error(conn, 400, "Error in paging/filtering")
-      end
+    with true <- Oli.Accounts.can_access_via_slug?(author, project_slug),
+         {:ok, %Result{rows: rows, rowCount: rowCount, totalCount: totalCount}} <-
+           ActivityBank.query(project_slug, author, logic, paging) do
+      json(conn, %{
+        "result" => "success",
+        "queryResult" => %{
+          rowCount: rowCount,
+          totalCount: totalCount,
+          rows: Enum.map(rows, &ActivityBank.serialize_revision/1)
+        }
+      })
     else
-      error(conn, 403, "Forbidden")
+      false -> error(conn, 403, "Forbidden")
+      _ -> error(conn, 400, "Error in paging/filtering")
     end
-  end
-
-  defp serialize_revision(%Oli.Resources.Revision{} = revision) do
-    %{
-      content: revision.content,
-      title: revision.title,
-      objectives: revision.objectives,
-      resource_id: revision.resource_id,
-      activity_type_id: revision.activity_type_id,
-      tags: revision.tags,
-      slug: revision.slug
-    }
   end
 
   defp error(conn, code, reason) do

--- a/lib/oli_web/controllers/api/activity_controller.ex
+++ b/lib/oli_web/controllers/api/activity_controller.ex
@@ -194,7 +194,7 @@ defmodule OliWeb.Api.ActivityController do
            # optional:
            Map.get(conn.body_params, "title", nil),
            Map.get(conn.body_params, "objective_map", %{}),
-           Map.get(conn, "tags", [])
+           Map.get(conn.body_params, "tags", [])
          ) do
       {:ok, {%{slug: slug, resource_id: resource_id} = activity, _}} ->
         json(

--- a/priv/schemas/v0-1-0/scenario.schema.json
+++ b/priv/schemas/v0-1-0/scenario.schema.json
@@ -565,6 +565,230 @@
         }
       ]
     },
+    "resourceReference": {
+      "oneOf": [
+        { "type": "string" },
+        { "type": "integer" }
+      ]
+    },
+    "activityBankCreate": {
+      "type": "object",
+      "required": ["title", "content"],
+      "additionalProperties": false,
+      "properties": {
+        "title": { "type": "string" },
+        "virtual_id": { "type": "string" },
+        "type": { "type": "string" },
+        "activity_type_slug": { "type": "string" },
+        "content_format": {
+          "type": "string",
+          "enum": ["torusdoc", "json"]
+        },
+        "content": {
+          "oneOf": [
+            { "type": "string" },
+            { "type": "object" }
+          ]
+        },
+        "objectives": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/resourceReference" }
+        },
+        "tags": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/resourceReference" }
+        }
+      },
+      "anyOf": [
+        { "required": ["type"] },
+        { "required": ["activity_type_slug"] }
+      ]
+    },
+    "activityBankPaging": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "limit": { "type": "integer" },
+        "offset": { "type": "integer" }
+      }
+    },
+    "activityBankFilterExpression": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contains": {},
+        "does_not_contain": {},
+        "equals": {},
+        "does_not_equal": {}
+      },
+      "minProperties": 1,
+      "maxProperties": 1
+    },
+    "activityBankFilters": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "objectives": { "$ref": "#/definitions/activityBankFilterExpression" },
+        "tags": { "$ref": "#/definitions/activityBankFilterExpression" },
+        "type": { "$ref": "#/definitions/activityBankFilterExpression" },
+        "text": { "$ref": "#/definitions/activityBankFilterExpression" }
+      }
+    },
+    "activityBankExpectation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "total_count": { "type": "integer" },
+        "row_count": { "type": "integer" },
+        "titles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "contains_titles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "not_titles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "resource_ids": {
+          "type": "array",
+          "items": { "type": "integer" }
+        }
+      }
+    },
+    "activityBankOperation": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["create"],
+          "additionalProperties": false,
+          "properties": {
+            "create": { "$ref": "#/definitions/activityBankCreate" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["create_bulk"],
+          "additionalProperties": false,
+          "properties": {
+            "create_bulk": {
+              "type": "object",
+              "required": ["activities"],
+              "additionalProperties": false,
+              "properties": {
+                "activities": {
+                  "type": "array",
+                  "items": { "$ref": "#/definitions/activityBankCreate" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["query"],
+          "additionalProperties": false,
+          "properties": {
+            "query": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "name": { "type": "string" },
+                "logic": { "type": "object" },
+                "filters": { "$ref": "#/definitions/activityBankFilters" },
+                "paging": { "$ref": "#/definitions/activityBankPaging" },
+                "expect": { "$ref": "#/definitions/activityBankExpectation" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["edit"],
+          "additionalProperties": false,
+          "properties": {
+            "edit": {
+              "type": "object",
+              "required": ["set"],
+              "additionalProperties": false,
+              "properties": {
+                "title": { "type": "string" },
+                "virtual_id": { "type": "string" },
+                "resource_id": { "type": "integer" },
+                "set": { "type": "object" }
+              },
+              "anyOf": [
+                { "required": ["title"] },
+                { "required": ["virtual_id"] },
+                { "required": ["resource_id"] }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["delete"],
+          "additionalProperties": false,
+          "properties": {
+            "delete": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "title": { "type": "string" },
+                "virtual_id": { "type": "string" },
+                "resource_id": { "type": "integer" }
+              },
+              "anyOf": [
+                { "required": ["title"] },
+                { "required": ["virtual_id"] },
+                { "required": ["resource_id"] }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["duplicate"],
+          "additionalProperties": false,
+          "properties": {
+            "duplicate": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "title": { "type": "string" },
+                "virtual_id": { "type": "string" },
+                "resource_id": { "type": "integer" },
+                "new_title": { "type": "string" },
+                "new_virtual_id": { "type": "string" }
+              },
+              "anyOf": [
+                { "required": ["title"] },
+                { "required": ["virtual_id"] },
+                { "required": ["resource_id"] }
+              ]
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["assert"],
+          "additionalProperties": false,
+          "properties": {
+            "assert": {
+              "type": "object",
+              "required": ["expect"],
+              "additionalProperties": false,
+              "properties": {
+                "result": { "type": "string" },
+                "expect": { "$ref": "#/definitions/activityBankExpectation" }
+              }
+            }
+          }
+        }
+      ]
+    },
     "directive": {
       "oneOf": [
         {
@@ -868,6 +1092,25 @@
                 "tags": {
                   "type": "array",
                   "items": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["activity_bank"],
+          "additionalProperties": false,
+          "properties": {
+            "activity_bank": {
+              "type": "object",
+              "required": ["project", "ops"],
+              "additionalProperties": false,
+              "properties": {
+                "project": { "type": "string" },
+                "ops": {
+                  "type": "array",
+                  "items": { "$ref": "#/definitions/activityBankOperation" }
                 }
               }
             }

--- a/priv/schemas/v0-1-0/scenario.schema.json
+++ b/priv/schemas/v0-1-0/scenario.schema.json
@@ -594,6 +594,8 @@
           "type": "array",
           "items": { "$ref": "#/definitions/resourceReference" }
         },
+        "objective_map": { "type": "object" },
+        "objectiveMap": { "type": "object" },
         "tags": {
           "type": "array",
           "items": { "$ref": "#/definitions/resourceReference" }
@@ -716,7 +718,7 @@
               "properties": {
                 "title": { "type": "string" },
                 "virtual_id": { "type": "string" },
-                "resource_id": { "type": "integer" },
+                "resource_id": { "$ref": "#/definitions/resourceReference" },
                 "set": { "type": "object" }
               },
               "anyOf": [
@@ -738,7 +740,7 @@
               "properties": {
                 "title": { "type": "string" },
                 "virtual_id": { "type": "string" },
-                "resource_id": { "type": "integer" }
+                "resource_id": { "$ref": "#/definitions/resourceReference" }
               },
               "anyOf": [
                 { "required": ["title"] },
@@ -759,7 +761,7 @@
               "properties": {
                 "title": { "type": "string" },
                 "virtual_id": { "type": "string" },
-                "resource_id": { "type": "integer" },
+                "resource_id": { "$ref": "#/definitions/resourceReference" },
                 "new_title": { "type": "string" },
                 "new_virtual_id": { "type": "string" }
               },

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -29,6 +29,85 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
       assert Map.get(revision.objectives, "1") == [objective.resource_id]
       assert Map.get(revision.objectives, "2") == [objective.resource_id]
     end
+
+    test "rejects unauthorized authors before creating activity", %{
+      project: project
+    } do
+      unauthorized_author =
+        author_fixture(%{
+          email: "unauthorized#{System.unique_integer([:positive])}@test.com",
+          system_role_id: Oli.Accounts.SystemRole.role_id().author
+        })
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.create(project.slug, unauthorized_author, %{
+                 type: "oli_multiple_choice",
+                 title: "Unauthorized activity",
+                 content: activity_content()
+               })
+    end
+
+    test "accepts numeric objective and tag ids scoped to the project", %{
+      author: author,
+      objective: objective,
+      project: project,
+      tag: tag
+    } do
+      assert {:ok, {revision, _content}} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Created from ids",
+                 objectives: [objective.resource_id],
+                 tags: [tag.resource_id],
+                 content: activity_content()
+               })
+
+      assert revision.tags == [tag.resource_id]
+      assert Map.get(revision.objectives, "1") == [objective.resource_id]
+      assert Map.get(revision.objectives, "2") == [objective.resource_id]
+    end
+
+    test "rejects numeric objective and tag ids outside the project", %{
+      author: author,
+      project: project
+    } do
+      {:ok, other} = project_with_metadata(%{})
+      objective_error = "Objective resource '#{other.objective.resource_id}' not found in project"
+      tag_error = "Tag resource '#{other.tag.resource_id}' not found in project"
+
+      assert {:error, ^objective_error} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Cross-project objective",
+                 objectives: [other.objective.resource_id],
+                 content: activity_content()
+               })
+
+      assert {:error, ^tag_error} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Cross-project tag",
+                 tags: [other.tag.resource_id],
+                 content: activity_content()
+               })
+    end
+
+    test "rejects numeric ids with the wrong resource type", %{
+      author: author,
+      project: project,
+      tag: tag
+    } do
+      expected_error =
+        "Objective resource '#{tag.resource_id}' does not have the expected resource type"
+
+      assert {:error, ^expected_error} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Wrong type objective",
+                 objectives: [tag.resource_id],
+                 content: activity_content()
+               })
+    end
   end
 
   describe "create_bulk/3" do
@@ -55,6 +134,58 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
       assert revision.tags == [tag.resource_id]
       assert Map.get(revision.objectives, "1") == [objective.resource_id]
       assert Map.get(revision.objectives, "2") == [objective.resource_id]
+    end
+
+    test "rejects unauthorized authors before bulk creation", %{
+      project: project
+    } do
+      unauthorized_author =
+        author_fixture(%{
+          email: "unauthorized#{System.unique_integer([:positive])}@test.com",
+          system_role_id: Oli.Accounts.SystemRole.role_id().author
+        })
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.create_bulk(project.slug, unauthorized_author, [
+                 %{
+                   activityTypeSlug: "oli_multiple_choice",
+                   title: "Unauthorized bulk activity",
+                   content: activity_content()
+                 }
+               ])
+    end
+  end
+
+  describe "mutations" do
+    setup [:project_with_metadata]
+
+    test "rejects unauthorized authors before update and delete", %{
+      author: author,
+      project: project
+    } do
+      unauthorized_author =
+        author_fixture(%{
+          email: "unauthorized#{System.unique_integer([:positive])}@test.com",
+          system_role_id: Oli.Accounts.SystemRole.role_id().author
+        })
+
+      assert {:ok, {revision, _content}} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Authorized activity",
+                 content: activity_content()
+               })
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.update(project.slug, unauthorized_author, revision.resource_id, %{
+                 "title" => "Unauthorized update"
+               })
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.delete(project.slug, unauthorized_author, revision.resource_id)
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.delete_bulk(project.slug, unauthorized_author, [revision.resource_id])
     end
   end
 

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -1,0 +1,116 @@
+defmodule Oli.Authoring.Editing.ActivityBankTest do
+  use Oli.DataCase
+
+  alias Oli.Authoring.Editing.ActivityBank
+  alias Oli.Seeder
+
+  describe "query/4" do
+    setup [:project_with_activity_bank]
+
+    test "queries banked activities from JSON-like logic and paging maps", %{
+      author: author,
+      project: project
+    } do
+      assert {:ok, result} =
+               ActivityBank.query(
+                 project.slug,
+                 author,
+                 %{
+                   "conditions" => %{
+                     "fact" => "objectives",
+                     "operator" => "contains",
+                     "value" => [2]
+                   }
+                 },
+                 %{"limit" => 5, "offset" => 0}
+               )
+
+      assert result.totalCount == 1
+      assert result.rowCount == 1
+      assert [%{title: "Banked objective 2"}] = result.rows
+    end
+
+    test "does not return embedded or deleted activities", %{author: author, project: project} do
+      assert {:ok, result} =
+               ActivityBank.query(
+                 project.slug,
+                 author,
+                 %{"conditions" => nil},
+                 %{"limit" => 10, "offset" => 0}
+               )
+
+      assert Enum.map(result.rows, & &1.title) == ["Banked objective 1", "Banked objective 2"]
+      assert result.totalCount == 2
+    end
+  end
+
+  describe "context/2" do
+    setup [:project_with_activity_bank]
+
+    test "builds the Activity Bank editor context", %{author: author, project: project} do
+      assert {:ok, context} = ActivityBank.context(project.slug, author)
+
+      assert context.authorEmail == author.email
+      assert context.projectSlug == project.slug
+      assert context.totalCount == 2
+      assert is_map(context.editorMap)
+      assert is_list(context.allObjectives)
+      assert is_list(context.allTags)
+    end
+  end
+
+  defp project_with_activity_bank(_context) do
+    map = Seeder.base_project_with_resource2()
+
+    Seeder.create_activity(
+      %{
+        scope: :banked,
+        objectives: %{"1" => [1]},
+        title: "Banked objective 1",
+        content: %{model: %{stem: "this is the first question"}}
+      },
+      map.publication,
+      map.project,
+      map.author
+    )
+
+    Seeder.create_activity(
+      %{
+        scope: :banked,
+        objectives: %{"1" => [2]},
+        title: "Banked objective 2",
+        content: %{model: %{stem: "this is the second question"}}
+      },
+      map.publication,
+      map.project,
+      map.author
+    )
+
+    Seeder.create_activity(
+      %{
+        scope: :banked,
+        deleted: true,
+        objectives: %{"1" => [2]},
+        title: "Deleted banked",
+        content: %{model: %{stem: "this is deleted"}}
+      },
+      map.publication,
+      map.project,
+      map.author
+    )
+
+    Seeder.create_activity(
+      %{
+        scope: :embedded,
+        objectives: %{"1" => [2]},
+        title: "Embedded",
+        content: %{model: %{stem: "this is embedded"}}
+      },
+      map.publication,
+      map.project,
+      map.author
+    )
+
+    {:ok, map}
+  end
+end

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -112,6 +112,22 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
                  content: activity_content()
                })
     end
+
+    test "rejects objective map ids outside the project", %{
+      author: author,
+      project: project
+    } do
+      {:ok, other} = project_with_metadata(%{})
+      expected_error = "Objective resource '#{other.objective.resource_id}' not found in project"
+
+      assert {:error, ^expected_error} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Cross-project objective map",
+                 objective_map: %{"1" => [other.objective.resource_id]},
+                 content: activity_content()
+               })
+    end
   end
 
   describe "create_bulk/3" do
@@ -157,6 +173,24 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
 
       assert revision.scope == :banked
       assert revision.objectives == %{"1" => [objective.resource_id]}
+    end
+
+    test "rejects objective map ids outside the project", %{
+      author: author,
+      project: project
+    } do
+      {:ok, other} = project_with_metadata(%{})
+      expected_error = "Objective resource '#{other.objective.resource_id}' not found in project"
+
+      assert {:error, ^expected_error} =
+               ActivityBank.create_bulk(project.slug, author, [
+                 %{
+                   activityTypeSlug: "oli_multiple_choice",
+                   title: "Bulk cross-project objective map",
+                   objective_map: %{"1" => [other.objective.resource_id]},
+                   content: activity_content()
+                 }
+               ])
     end
 
     test "rejects unauthorized authors before bulk creation", %{
@@ -251,6 +285,40 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
                  "title" => "Updated tag"
                })
     end
+
+    test "rejects metadata update ids outside the project", %{
+      author: author,
+      project: project
+    } do
+      {:ok, other} = project_with_metadata(%{})
+
+      assert {:ok, {revision, _content}} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Metadata update target",
+                 content: activity_content()
+               })
+
+      expected_objective_error =
+        "Objective resource '#{other.objective.resource_id}' not found in project"
+
+      assert {:error, ^expected_objective_error} =
+               ActivityBank.update(project.slug, author, revision.resource_id, %{
+                 "objectives" => %{"1" => [other.objective.resource_id]}
+               })
+
+      assert {:error, ^expected_objective_error} =
+               ActivityBank.update(project.slug, author, revision.resource_id, %{
+                 "objective_map" => %{"1" => [other.objective.resource_id]}
+               })
+
+      expected_tag_error = "Tag resource '#{other.tag.resource_id}' not found in project"
+
+      assert {:error, ^expected_tag_error} =
+               ActivityBank.update(project.slug, author, revision.resource_id, %{
+                 "tags" => [other.tag.resource_id]
+               })
+    end
   end
 
   describe "query/4" do
@@ -314,6 +382,25 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
                  user,
                  author,
                  other.publication.id,
+                 %Logic{conditions: nil},
+                 %Paging{limit: 1, offset: 0}
+               )
+    end
+
+    test "query_section_publication handles nil authors as unauthorized", %{
+      project: project,
+      publication: publication
+    } do
+      section = insert(:section, base_project: project)
+      {:ok, section} = Oli.Delivery.Sections.create_section_resources(section, publication)
+      user = insert(:user)
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.query_section_publication(
+                 section.slug,
+                 user,
+                 nil,
+                 publication.id,
                  %Logic{conditions: nil},
                  %Paging{limit: 1, offset: 0}
                )

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -187,6 +187,47 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
       assert {:error, {:not_authorized}} =
                ActivityBank.delete_bulk(project.slug, unauthorized_author, [revision.resource_id])
     end
+
+    test "rejects non-banked resources before update and delete", %{
+      author: author,
+      project: project,
+      publication: publication,
+      tag: tag
+    } do
+      %{revision: embedded_revision} =
+        Seeder.create_activity(
+          %{
+            scope: :embedded,
+            title: "Embedded activity",
+            content: %{model: activity_content()}
+          },
+          publication,
+          project,
+          author
+        )
+
+      expected_scope_error =
+        "Activity resource '#{embedded_revision.resource_id}' is not banked"
+
+      assert {:error, ^expected_scope_error} =
+               ActivityBank.update(project.slug, author, embedded_revision.resource_id, %{
+                 "title" => "Updated embedded"
+               })
+
+      assert {:error, ^expected_scope_error} =
+               ActivityBank.delete(project.slug, author, embedded_revision.resource_id)
+
+      assert {:error, ^expected_scope_error} =
+               ActivityBank.delete_bulk(project.slug, author, [embedded_revision.resource_id])
+
+      expected_type_error =
+        "Activity resource '#{tag.resource_id}' does not have the expected resource type"
+
+      assert {:error, ^expected_type_error} =
+               ActivityBank.update(project.slug, author, tag.resource_id, %{
+                 "title" => "Updated tag"
+               })
+    end
   end
 
   describe "query/4" do

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -136,6 +136,25 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
       assert Map.get(revision.objectives, "2") == [objective.resource_id]
     end
 
+    test "preserves explicit objective maps for each item", %{
+      author: author,
+      objective: objective,
+      project: project
+    } do
+      assert {:ok, [%{activity: revision}]} =
+               ActivityBank.create_bulk(project.slug, author, [
+                 %{
+                   activityTypeSlug: "oli_multiple_choice",
+                   title: "Bulk created with objective map",
+                   objective_map: %{"1" => [objective.resource_id]},
+                   content: activity_content()
+                 }
+               ])
+
+      assert revision.scope == :banked
+      assert revision.objectives == %{"1" => [objective.resource_id]}
+    end
+
     test "rejects unauthorized authors before bulk creation", %{
       project: project
     } do

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -405,6 +405,30 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
                  %Paging{limit: 1, offset: 0}
                )
     end
+
+    test "query_section_publication allows content admins without a user", %{
+      project: project,
+      publication: publication
+    } do
+      section = insert(:section, base_project: project)
+      {:ok, section} = Oli.Delivery.Sections.create_section_resources(section, publication)
+
+      admin_author =
+        author_fixture(%{
+          email: "content-admin#{System.unique_integer([:positive])}@test.com",
+          system_role_id: Oli.Accounts.SystemRole.role_id().content_admin
+        })
+
+      assert {:ok, %Oli.Activities.Realizer.Query.Result{}} =
+               ActivityBank.query_section_publication(
+                 section.slug,
+                 nil,
+                 admin_author,
+                 publication.id,
+                 %Logic{conditions: nil},
+                 %Paging{limit: 1, offset: 0}
+               )
+    end
   end
 
   describe "context/2" do

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -1,6 +1,10 @@
 defmodule Oli.Authoring.Editing.ActivityBankTest do
   use Oli.DataCase
 
+  import Oli.Factory
+
+  alias Oli.Activities.Realizer.Logic
+  alias Oli.Activities.Realizer.Query.Paging
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Authoring.Editing.ActivityBank
   alias Oli.Resources.ResourceType
@@ -286,6 +290,33 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
 
       assert Enum.map(result.rows, & &1.title) == ["Banked objective 1", "Banked objective 2"]
       assert result.totalCount == 2
+    end
+
+    test "query_section_publication rejects publications not attached to the section", %{
+      author: author,
+      project: project,
+      publication: publication
+    } do
+      section = insert(:section, base_project: project)
+      {:ok, section} = Oli.Delivery.Sections.create_section_resources(section, publication)
+
+      user = insert(:user, author: author)
+
+      Oli.Delivery.Sections.enroll(user.id, section.id, [
+        Lti_1p3.Roles.ContextRoles.get_role(:context_instructor)
+      ])
+
+      {:ok, other} = project_with_activity_bank(%{})
+
+      assert {:error, {:not_authorized}} =
+               ActivityBank.query_section_publication(
+                 section.slug,
+                 user,
+                 author,
+                 other.publication.id,
+                 %Logic{conditions: nil},
+                 %Paging{limit: 1, offset: 0}
+               )
     end
   end
 

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -1,8 +1,62 @@
 defmodule Oli.Authoring.Editing.ActivityBankTest do
   use Oli.DataCase
 
+  alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Authoring.Editing.ActivityBank
+  alias Oli.Resources.ResourceType
   alias Oli.Seeder
+
+  describe "create/3" do
+    setup [:project_with_metadata]
+
+    test "creates a banked activity and resolves objective and tag titles", %{
+      author: author,
+      objective: objective,
+      project: project,
+      tag: tag
+    } do
+      assert {:ok, {revision, _content}} =
+               ActivityBank.create(project.slug, author, %{
+                 type: "oli_multiple_choice",
+                 title: "Created from titles",
+                 objectives: [objective.title],
+                 tags: [tag.title],
+                 content: activity_content()
+               })
+
+      assert revision.scope == :banked
+      assert revision.tags == [tag.resource_id]
+      assert Map.get(revision.objectives, "1") == [objective.resource_id]
+      assert Map.get(revision.objectives, "2") == [objective.resource_id]
+    end
+  end
+
+  describe "create_bulk/3" do
+    setup [:project_with_metadata]
+
+    test "creates banked activities and resolves metadata titles for each item", %{
+      author: author,
+      objective: objective,
+      project: project,
+      tag: tag
+    } do
+      assert {:ok, [%{activity: revision}]} =
+               ActivityBank.create_bulk(project.slug, author, [
+                 %{
+                   activityTypeSlug: "oli_multiple_choice",
+                   title: "Bulk created from titles",
+                   objectives: [objective.title],
+                   tags: [tag.title],
+                   content: activity_content()
+                 }
+               ])
+
+      assert revision.scope == :banked
+      assert revision.tags == [tag.resource_id]
+      assert Map.get(revision.objectives, "1") == [objective.resource_id]
+      assert Map.get(revision.objectives, "2") == [objective.resource_id]
+    end
+  end
 
   describe "query/4" do
     setup [:project_with_activity_bank]
@@ -112,5 +166,53 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
     )
 
     {:ok, map}
+  end
+
+  defp project_with_metadata(_context) do
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_objective("Objective A", :objective)
+
+    {:ok, tag} =
+      ResourceEditor.create(map.project.slug, map.author, ResourceType.id_for_tag(), %{
+        "title" => "Easy"
+      })
+
+    {:ok, Map.merge(map, %{objective: map.objective.revision, tag: tag})}
+  end
+
+  defp activity_content do
+    %{
+      "stem" => "1",
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "1",
+            "responses" => [
+              %{
+                "rule" => "input like {a}",
+                "score" => 10,
+                "id" => "r1",
+                "feedback" => %{"id" => "1", "content" => "yes"}
+              }
+            ],
+            "scoringStrategy" => "best"
+          },
+          %{
+            "id" => "2",
+            "responses" => [
+              %{
+                "rule" => "input like {a}",
+                "score" => 2,
+                "id" => "r1",
+                "feedback" => %{"id" => "4", "content" => "yes"}
+              }
+            ],
+            "scoringStrategy" => "best"
+          }
+        ],
+        "transformations" => []
+      }
+    }
   end
 end

--- a/test/oli_web/controllers/activity_controller_test.exs
+++ b/test/oli_web/controllers/activity_controller_test.exs
@@ -323,6 +323,26 @@ defmodule OliWeb.ActivityControllerTest do
            } = json_response(conn, 200)
   end
 
+  test "create persists tags from the request body", %{conn: conn, project: project} do
+    content = %{
+      "stem" => %{"content" => []},
+      "authoring" => %{"parts" => [%{"id" => "1"}]}
+    }
+
+    conn =
+      post(conn, Routes.activity_path(conn, :create, project.slug, "oli_short_answer"), %{
+        "model" => content,
+        "objectives" => [],
+        "tags" => [42],
+        "includeMetadata" => true
+      })
+
+    assert %{
+             "type" => "success",
+             "tags" => [42]
+           } = json_response(conn, 200)
+  end
+
   describe "get resource" do
     test "retrieves the unpublished activity", %{
       conn: conn,

--- a/test/scenarios/activities/activity_bank_create_activity_interop.scenario.yaml
+++ b/test/scenarios/activities/activity_bank_create_activity_interop.scenario.yaml
@@ -1,0 +1,70 @@
+# Scenario: Activity Bank interop with create_activity
+# Verifies activities created with create_activity scope: banked are queryable
+# through activity_bank, while embedded activities are excluded.
+
+- project:
+    name: "activity_bank_interop_project"
+    title: "Activity Bank Interop Project"
+    tags:
+      - "banked"
+      - "embedded"
+    root:
+      children:
+        - page: "Practice"
+
+- create_activity:
+    project: "activity_bank_interop_project"
+    title: "Create Activity Banked Question"
+    virtual_id: "created_banked"
+    scope: "banked"
+    type: "oli_multiple_choice"
+    tags: ["banked"]
+    content: |
+      stem_md: "Which activity should be in the Activity Bank?"
+      choices:
+        - id: "a"
+          body_md: "The banked one"
+          score: 1
+        - id: "b"
+          body_md: "The embedded one"
+          score: 0
+
+- create_activity:
+    project: "activity_bank_interop_project"
+    title: "Create Activity Embedded Question"
+    virtual_id: "created_embedded"
+    scope: "embedded"
+    type: "oli_multiple_choice"
+    tags: ["embedded"]
+    content: |
+      stem_md: "Which activity should stay out of the Activity Bank?"
+      choices:
+        - id: "a"
+          body_md: "The banked one"
+          score: 0
+        - id: "b"
+          body_md: "The embedded one"
+          score: 1
+
+- activity_bank:
+    project: "activity_bank_interop_project"
+    ops:
+      - query:
+          name: "all_banked_questions"
+          filters:
+            type:
+              contains: ["oli_multiple_choice"]
+          expect:
+            total_count: 1
+            row_count: 1
+            contains_titles: ["Create Activity Banked Question"]
+            not_titles: ["Create Activity Embedded Question"]
+      - query:
+          name: "banked_tag_questions"
+          filters:
+            tags:
+              contains: ["banked"]
+          expect:
+            total_count: 1
+            contains_titles: ["Create Activity Banked Question"]
+            not_titles: ["Create Activity Embedded Question"]

--- a/test/scenarios/activities/activity_bank_lifecycle_operations.scenario.yaml
+++ b/test/scenarios/activities/activity_bank_lifecycle_operations.scenario.yaml
@@ -1,0 +1,81 @@
+# Scenario: Activity Bank lifecycle operations
+# Verifies bulk creation, duplication, editing, deletion, and stored query assertions.
+
+- project:
+    name: "activity_bank_lifecycle_project"
+    title: "Activity Bank Lifecycle Project"
+    tags:
+      - "draft"
+      - "review"
+    root:
+      children:
+        - page: "Practice"
+
+- activity_bank:
+    project: "activity_bank_lifecycle_project"
+    ops:
+      - create_bulk:
+          activities:
+            - title: "Draft Question One"
+              virtual_id: "draft_one"
+              type: "oli_multiple_choice"
+              tags: ["draft"]
+              content: |
+                stem_md: "Draft question one?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+                  - id: "b"
+                    body_md: "No"
+                    score: 0
+            - title: "Draft Question Two"
+              virtual_id: "draft_two"
+              type: "oli_multiple_choice"
+              tags: ["draft"]
+              content: |
+                stem_md: "Draft question two?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+                  - id: "b"
+                    body_md: "No"
+                    score: 0
+      - duplicate:
+          virtual_id: "draft_one"
+          new_title: "Draft Question One Copy"
+          new_virtual_id: "draft_one_copy"
+      - edit:
+          virtual_id: "draft_one_copy"
+          set:
+            title: "Reviewed Question"
+            tags: ["review"]
+      - delete:
+          virtual_id: "draft_two"
+      - query:
+          name: "review_questions"
+          filters:
+            tags:
+              contains: ["review"]
+          expect:
+            total_count: 1
+            row_count: 1
+            contains_titles: ["Reviewed Question"]
+            not_titles: ["Draft Question One", "Draft Question Two"]
+      - query:
+          name: "remaining_bank_questions"
+          filters:
+            type:
+              contains: ["oli_multiple_choice"]
+          expect:
+            total_count: 2
+            row_count: 2
+            contains_titles: ["Draft Question One", "Reviewed Question"]
+            not_titles: ["Draft Question Two"]
+      - assert:
+          result: "remaining_bank_questions"
+          expect:
+            total_count: 2
+            contains_titles: ["Draft Question One", "Reviewed Question"]
+            not_titles: ["Draft Question Two"]

--- a/test/scenarios/activities/activity_bank_query_operations.scenario.yaml
+++ b/test/scenarios/activities/activity_bank_query_operations.scenario.yaml
@@ -1,0 +1,117 @@
+# Scenario: Activity Bank query operations
+# Verifies query filters for tags, objectives, activity type, and activity text.
+
+- project:
+    name: "activity_bank_query_project"
+    title: "Activity Bank Query Project"
+    tags:
+      - "easy"
+      - "geometry"
+      - "biology"
+    objectives:
+      - "Understand arithmetic"
+      - "Analyze shapes"
+      - "Explain cells"
+    root:
+      children:
+        - page: "Practice"
+
+- activity_bank:
+    project: "activity_bank_query_project"
+    ops:
+      - create:
+          title: "Easy Addition"
+          virtual_id: "easy_addition"
+          type: "oli_multiple_choice"
+          tags: ["easy"]
+          objectives: ["Understand arithmetic"]
+          content: |
+            stem_md: "What is 2 + 2?"
+            choices:
+              - id: "a"
+                body_md: "4"
+                score: 1
+              - id: "b"
+                body_md: "5"
+                score: 0
+      - create:
+          title: "Easy Geometry"
+          virtual_id: "easy_geometry"
+          type: "oli_multiple_choice"
+          tags: ["easy", "geometry"]
+          objectives: ["Analyze shapes"]
+          content: |
+            stem_md: "How many sides does a triangle have?"
+            choices:
+              - id: "a"
+                body_md: "3"
+                score: 1
+              - id: "b"
+                body_md: "4"
+                score: 0
+      - create:
+          title: "Cell Function"
+          virtual_id: "cell_function"
+          type: "oli_multiple_choice"
+          tags: ["biology"]
+          objectives: ["Explain cells"]
+          content: |
+            stem_md: "Which organelle is known as the mitochondria?"
+            choices:
+              - id: "a"
+                body_md: "Powerhouse of the cell"
+                score: 1
+              - id: "b"
+                body_md: "Cell wall"
+                score: 0
+      - query:
+          name: "easy_questions"
+          filters:
+            tags:
+              contains: ["easy"]
+          expect:
+            total_count: 2
+            row_count: 2
+            contains_titles: ["Easy Addition", "Easy Geometry"]
+            not_titles: ["Cell Function"]
+      - query:
+          name: "easy_geometry_questions"
+          filters:
+            tags:
+              contains: ["easy", "geometry"]
+          expect:
+            total_count: 1
+            contains_titles: ["Easy Geometry"]
+            not_titles: ["Easy Addition", "Cell Function"]
+      - query:
+          name: "arithmetic_objective_questions"
+          filters:
+            objectives:
+              equals: ["Understand arithmetic"]
+          expect:
+            total_count: 1
+            contains_titles: ["Easy Addition"]
+            not_titles: ["Easy Geometry", "Cell Function"]
+      - query:
+          name: "multiple_choice_questions"
+          filters:
+            type:
+              contains: ["oli_multiple_choice"]
+          expect:
+            total_count: 3
+            row_count: 3
+            contains_titles: ["Easy Addition", "Easy Geometry", "Cell Function"]
+      - query:
+          name: "biology_text_questions"
+          filters:
+            text:
+              contains: "mitochondria"
+          expect:
+            total_count: 1
+            contains_titles: ["Cell Function"]
+            not_titles: ["Easy Addition", "Easy Geometry"]
+      - assert:
+          result: "easy_questions"
+          expect:
+            total_count: 2
+            contains_titles: ["Easy Addition", "Easy Geometry"]

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -97,7 +97,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
               new_title: "Copied Question"
               new_virtual_id: "copy_q"
           - edit:
-              virtual_id: "copy_q"
+              title: "Copied Question"
               set:
                 title: "Edited Copy"
                 tags: ["review"]
@@ -127,6 +127,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
     refute Map.has_key?(result.state.activities, {"bank_project", "Copied Question"})
     refute Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "original_q"})
     assert Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "copy_q"})
+    assert result.state.activity_virtual_ids[{"bank_project", "copy_q"}].title == "Edited Copy"
   end
 
   test "reports failed expectations as verification failures" do

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -4,19 +4,158 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
   alias Oli.Scenarios.DirectiveParser
   alias Oli.Scenarios.Engine
 
-  test "activity_bank directive is dispatched with a clear phase 4 runtime error" do
+  test "creates banked activities and queries with tag filters and expectations" do
     yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        tags:
+          - "easy"
+          - "hard"
+        objectives:
+          - "Understand basics"
+        root:
+          children:
+            - page: "Practice"
+
     - activity_bank:
-        project: "demo"
+        project: "bank_project"
         ops:
+          - create:
+              title: "Easy Question"
+              virtual_id: "easy_q1"
+              type: "oli_multiple_choice"
+              tags: ["easy"]
+              objectives: ["Understand basics"]
+              content: |
+                stem_md: "What is 2 + 2?"
+                choices:
+                  - id: "a"
+                    body_md: "4"
+                    score: 1
+          - create:
+              title: "Hard Question"
+              virtual_id: "hard_q1"
+              type: "oli_multiple_choice"
+              tags: ["hard"]
+              content: |
+                stem_md: "What is 12 * 12?"
+                choices:
+                  - id: "a"
+                    body_md: "144"
+                    score: 1
           - query:
-              name: "all"
+              name: "easy_questions"
+              filters:
+                tags:
+                  contains: ["easy"]
+              expect:
+                total_count: 1
+                titles: ["Easy Question"]
+                not_titles: ["Hard Question"]
     """
 
-    directives = DirectiveParser.parse_yaml!(yaml)
-    result = Engine.execute(directives)
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
 
-    assert [{_directive, "activity_bank directive execution is not implemented yet"}] =
-             result.errors
+    assert result.errors == []
+    assert [verification] = result.verifications
+    assert verification.passed
+    assert Map.has_key?(result.state.activities, {"bank_project", "Easy Question"})
+    assert Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "easy_q1"})
+    assert Map.has_key?(result.state.activity_bank_results, "easy_questions")
+  end
+
+  test "supports bulk create, duplicate, edit, delete, and stored-result assertions" do
+    yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        tags:
+          - "easy"
+          - "review"
+        root:
+          children:
+            - page: "Practice"
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - create_bulk:
+              activities:
+                - title: "Original Question"
+                  virtual_id: "original_q"
+                  type: "oli_multiple_choice"
+                  tags: ["easy"]
+                  content: |
+                    stem_md: "Original?"
+                    choices:
+                      - id: "a"
+                        body_md: "Yes"
+                        score: 1
+          - duplicate:
+              virtual_id: "original_q"
+              new_title: "Copied Question"
+              new_virtual_id: "copy_q"
+          - edit:
+              virtual_id: "copy_q"
+              set:
+                title: "Edited Copy"
+                tags: ["review"]
+          - delete:
+              virtual_id: "original_q"
+          - query:
+              name: "review_questions"
+              filters:
+                tags:
+                  contains: ["review"]
+              expect:
+                total_count: 1
+                contains_titles: ["Edited Copy"]
+                not_titles: ["Original Question"]
+          - assert:
+              result: "review_questions"
+              expect:
+                titles: ["Edited Copy"]
+    """
+
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+    assert result.errors == []
+    assert [verification] = result.verifications
+    assert verification.passed
+    assert Map.has_key?(result.state.activities, {"bank_project", "Edited Copy"})
+    refute Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "original_q"})
+    assert Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "copy_q"})
+  end
+
+  test "reports failed expectations as verification failures" do
+    yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        tags:
+          - "easy"
+        root:
+          children:
+            - page: "Practice"
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - query:
+              name: "empty"
+              filters:
+                tags:
+                  contains: ["easy"]
+              expect:
+                total_count: 2
+    """
+
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+    assert result.errors == []
+    assert [verification] = result.verifications
+    refute verification.passed
+    assert verification.message =~ "total_count expected 2"
   end
 end

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -197,6 +197,58 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
     assert error =~ "is not banked"
   end
 
+  test "duplicate preserves per-part objective mappings" do
+    setup_yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        objectives:
+          - "Objective A"
+        root:
+          children:
+            - page: "Practice"
+    """
+
+    result = setup_yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+    assert result.errors == []
+
+    objective_id =
+      result.state.projects["bank_project"].objectives_by_title["Objective A"].resource_id
+
+    activity_yaml = """
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - create:
+              title: "Mapped Question"
+              virtual_id: "mapped_q"
+              type: "oli_multiple_choice"
+              objective_map:
+                "1": [#{objective_id}]
+              content: |
+                stem_md: "Mapped?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+          - duplicate:
+              virtual_id: "mapped_q"
+              new_title: "Mapped Question Copy"
+              new_virtual_id: "mapped_copy"
+    """
+
+    result =
+      activity_yaml
+      |> DirectiveParser.parse_yaml!()
+      |> Engine.execute(state: result.state)
+
+    assert result.errors == []
+
+    assert result.state.activities[{"bank_project", "Mapped Question Copy"}].objectives == %{
+             "1" => [objective_id]
+           }
+  end
+
   test "supports numeric string resource_id references" do
     yaml = """
     - project:

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -1,0 +1,22 @@
+defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios.DirectiveParser
+  alias Oli.Scenarios.Engine
+
+  test "activity_bank directive is dispatched with a clear phase 4 runtime error" do
+    yaml = """
+    - activity_bank:
+        project: "demo"
+        ops:
+          - query:
+              name: "all"
+    """
+
+    directives = DirectiveParser.parse_yaml!(yaml)
+    result = Engine.execute(directives)
+
+    assert [{_directive, "activity_bank directive execution is not implemented yet"}] =
+             result.errors
+  end
+end

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -124,6 +124,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
     assert [verification] = result.verifications
     assert verification.passed
     assert Map.has_key?(result.state.activities, {"bank_project", "Edited Copy"})
+    refute Map.has_key?(result.state.activities, {"bank_project", "Copied Question"})
     refute Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "original_q"})
     assert Map.has_key?(result.state.activity_virtual_ids, {"bank_project", "copy_q"})
   end

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -196,4 +196,52 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
     assert [{_directive, error}] = result.errors
     assert error =~ "is not banked"
   end
+
+  test "supports numeric string resource_id references" do
+    yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        root:
+          children:
+            - page: "Practice"
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - create:
+              title: "Resource ID Question"
+              virtual_id: "resource_q"
+              type: "oli_multiple_choice"
+              content: |
+                stem_md: "Original?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+    """
+
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+    assert result.errors == []
+
+    resource_id = result.state.activity_virtual_ids[{"bank_project", "resource_q"}].resource_id
+
+    edit_yaml = """
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - edit:
+              resource_id: "#{resource_id}"
+              set:
+                title: "Edited By Resource String"
+    """
+
+    result =
+      edit_yaml
+      |> DirectiveParser.parse_yaml!()
+      |> Engine.execute(state: result.state)
+
+    assert result.errors == []
+    assert Map.has_key?(result.state.activities, {"bank_project", "Edited By Resource String"})
+  end
 end

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -102,7 +102,7 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
                 title: "Edited Copy"
                 tags: ["review"]
           - delete:
-              virtual_id: "original_q"
+              title: "Original Question"
           - query:
               name: "review_questions"
               filters:
@@ -158,5 +158,41 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
     assert [verification] = result.verifications
     refute verification.passed
     assert verification.message =~ "total_count expected 2"
+  end
+
+  test "rejects duplicating non-banked activities into the activity bank" do
+    yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        root:
+          children:
+            - page: "Practice"
+
+    - create_activity:
+        project: "bank_project"
+        title: "Embedded Question"
+        virtual_id: "embedded_q"
+        scope: "embedded"
+        type: "oli_multiple_choice"
+        content: |
+          stem_md: "Embedded?"
+          choices:
+            - id: "a"
+              body_md: "Yes"
+              score: 1
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - duplicate:
+              virtual_id: "embedded_q"
+              new_title: "Copied Embedded"
+    """
+
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+    assert [{_directive, error}] = result.errors
+    assert error =~ "is not banked"
   end
 end

--- a/test/scenarios/directives/activity_bank_handler_test.exs
+++ b/test/scenarios/directives/activity_bank_handler_test.exs
@@ -249,6 +249,103 @@ defmodule Oli.Scenarios.Directives.ActivityBankHandlerTest do
            }
   end
 
+  test "edit supports per-part objective mappings through objectives" do
+    setup_yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        objectives:
+          - "Objective A"
+        root:
+          children:
+            - page: "Practice"
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - create:
+              title: "Mapped Question"
+              virtual_id: "mapped_q"
+              type: "oli_multiple_choice"
+              content: |
+                stem_md: "Mapped?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+    """
+
+    result = setup_yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+    assert result.errors == []
+
+    objective_id =
+      result.state.projects["bank_project"].objectives_by_title["Objective A"].resource_id
+
+    part_id =
+      result.state.activity_virtual_ids[{"bank_project", "mapped_q"}].content
+      |> get_in(["authoring", "parts"])
+      |> List.first()
+      |> Map.fetch!("id")
+
+    edit_yaml = """
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - edit:
+              virtual_id: "mapped_q"
+              set:
+                objectives:
+                  "#{part_id}": ["Objective A"]
+    """
+
+    result =
+      edit_yaml
+      |> DirectiveParser.parse_yaml!()
+      |> Engine.execute(state: result.state)
+
+    assert result.errors == []
+
+    assert result.state.activities[{"bank_project", "Mapped Question"}].objectives == %{
+             part_id => [objective_id]
+           }
+  end
+
+  test "invalid list expectation shapes fail assertions without crashing" do
+    yaml = """
+    - project:
+        name: "bank_project"
+        title: "Bank Project"
+        root:
+          children:
+            - page: "Practice"
+
+    - activity_bank:
+        project: "bank_project"
+        ops:
+          - create:
+              title: "Question"
+              type: "oli_multiple_choice"
+              content: |
+                stem_md: "Question?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+          - query:
+              name: "questions"
+              expect:
+                contains_titles: "Question"
+    """
+
+    result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+    assert result.errors == []
+    assert [verification] = result.verifications
+    refute verification.passed
+    assert verification.message =~ "contains_titles expected"
+  end
+
   test "supports numeric string resource_id references" do
     yaml = """
     - project:

--- a/test/scenarios/validation/invalid_attributes_test.exs
+++ b/test/scenarios/validation/invalid_attributes_test.exs
@@ -303,6 +303,23 @@ defmodule Oli.Scenarios.Validation.InvalidAttributesTest do
                    end
     end
 
+    test "activity_bank create_bulk activity with scalar item fails clearly" do
+      yaml = """
+      - activity_bank:
+          project: "project1"
+          ops:
+            - create_bulk:
+                activities:
+                  - "not an activity map"
+      """
+
+      assert_raise RuntimeError,
+                   ~r/activity_bank create_bulk activity must be a map/,
+                   fn ->
+                     DirectiveParser.parse_yaml!(yaml)
+                   end
+    end
+
     test "node with unknown structure fails" do
       yaml = """
       - project:

--- a/test/scenarios/validation/invalid_attributes_test.exs
+++ b/test/scenarios/validation/invalid_attributes_test.exs
@@ -249,6 +249,60 @@ defmodule Oli.Scenarios.Validation.InvalidAttributesTest do
                    end
     end
 
+    test "activity_bank directive with typo fails" do
+      yaml = """
+      - activity_bank:
+          project: "project1"
+          operation:
+            - query:
+                name: "all"
+      """
+
+      assert_raise RuntimeError,
+                   ~r/Unknown attributes in 'activity_bank' directive: \["operation"\]/,
+                   fn ->
+                     DirectiveParser.parse_yaml!(yaml)
+                   end
+    end
+
+    test "activity_bank operation with typo fails" do
+      yaml = """
+      - activity_bank:
+          project: "project1"
+          ops:
+            - query:
+                name: "all"
+                filter:
+                  tags:
+                    contains: ["easy"]
+      """
+
+      assert_raise RuntimeError,
+                   ~r/Unknown attributes in 'activity_bank query' directive: \["filter"\]/,
+                   fn ->
+                     DirectiveParser.parse_yaml!(yaml)
+                   end
+    end
+
+    test "activity_bank create_bulk activity with typo fails" do
+      yaml = """
+      - activity_bank:
+          project: "project1"
+          ops:
+            - create_bulk:
+                activities:
+                  - title: "Activity 1"
+                    type: "oli_multiple_choice"
+                    conent: "activity content"
+      """
+
+      assert_raise RuntimeError,
+                   ~r/Unknown attributes in 'activity_bank create_bulk activity' directive: \["conent"\]/,
+                   fn ->
+                     DirectiveParser.parse_yaml!(yaml)
+                   end
+    end
+
     test "node with unknown structure fails" do
       yaml = """
       - project:

--- a/test/scenarios/validation/schema_validation_test.exs
+++ b/test/scenarios/validation/schema_validation_test.exs
@@ -198,6 +198,64 @@ defmodule Oli.Scenarios.Validation.SchemaValidationTest do
     assert length(directives) == 12
   end
 
+  test "schema and parser accept activity_bank directives" do
+    yaml = """
+    - activity_bank:
+        project: "demo"
+        ops:
+          - create:
+              title: "Easy Question"
+              virtual_id: "easy_q1"
+              type: "oli_multiple_choice"
+              tags: ["easy", 42]
+              objectives: ["Understand basics"]
+              content: |
+                stem_md: "What is 2 + 2?"
+                choices:
+                  - id: "a"
+                    body_md: "4"
+                    score: 1
+          - create_bulk:
+              activities:
+                - title: "Bulk Question"
+                  activity_type_slug: "oli_multiple_choice"
+                  content_format: "json"
+                  content:
+                    stem: "Bulk"
+          - query:
+              name: "easy_questions"
+              filters:
+                tags:
+                  contains: ["easy"]
+              paging:
+                limit: 5
+                offset: 0
+              expect:
+                total_count: 1
+                titles: ["Easy Question"]
+          - edit:
+              virtual_id: "easy_q1"
+              set:
+                title: "Updated Easy Question"
+          - duplicate:
+              virtual_id: "easy_q1"
+              new_title: "Copy of Easy Question"
+              new_virtual_id: "easy_q1_copy"
+          - delete:
+              virtual_id: "easy_q1_copy"
+          - assert:
+              result: "easy_questions"
+              expect:
+                contains_titles: ["Easy Question"]
+    """
+
+    assert :ok = Scenarios.validate_yaml(yaml)
+    [directive] = DirectiveParser.parse_yaml!(yaml)
+
+    assert directive.project == "demo"
+    assert length(directive.ops) == 7
+  end
+
   test "schema accepts assessment settings student_exception directives" do
     yaml = """
     - student_exception:

--- a/test/support/scenarios/README.md
+++ b/test/support/scenarios/README.md
@@ -101,6 +101,7 @@ All directives are documented in detail in the linked documentation files.
 | | `product` | Create reusable course template | [products.md](docs/products.md#product) |
 | **Content** | | | |
 | | `create_activity` | Create standalone activity | [content_authoring.md](docs/content_authoring.md#create_activity) |
+| | `activity_bank` | Execute Activity Bank create/query/edit/delete workflows | [content_authoring.md](docs/content_authoring.md#activity_bank) |
 | | `edit_page` | Edit page content with TorusDoc | [content_authoring.md](docs/content_authoring.md#edit_page) |
 | **Students** | | | |
 | | `view_practice_page` | Simulate student viewing page | [student_simulation.md](docs/student_simulation.md#view_practice_page) |

--- a/test/support/scenarios/docs/content_authoring.md
+++ b/test/support/scenarios/docs/content_authoring.md
@@ -5,6 +5,7 @@ This document covers directives for creating and editing content using the Torus
 ## Table of Contents
 - [Overview](#overview)
 - [create_activity](#create_activity) - Create standalone activities
+- [activity_bank](#activity_bank) - Execute Activity Bank workflows
 - [edit_page](#edit_page) - Edit page content
 - [TorusDoc Format](#torusdoc-format)
 - [Virtual IDs](#virtual-ids)
@@ -20,6 +21,8 @@ TorusDoc is a YAML-based format for defining OLI content. It provides a human-re
 - Complex page structures with groups and surveys
 
 The `create_activity` and `edit_page` directives use TorusDoc to define content in test scenarios.
+The `activity_bank` directive exercises author-facing Activity Bank operations
+such as querying, duplicating, editing, and deleting banked activities.
 
 ---
 
@@ -176,6 +179,254 @@ Creates a standalone activity that can be referenced in pages.
 ```
 
 **Note**: Tags are attached by title. The project must have these tags defined before activities can reference them.
+
+---
+
+## activity_bank
+
+Executes ordered Activity Bank operations for a project. Use this directive when
+the behavior under test is the Activity Bank itself: bank queries, bulk creation,
+duplication, edits, deletes, and query result assertions.
+
+For simple setup where a scenario only needs a reusable banked activity, prefer
+`create_activity` with `scope: "banked"`. Activities created that way are still
+queryable by `activity_bank`.
+
+### Parameters
+
+- `project`: Target project name (required)
+- `ops`: Ordered list of Activity Bank operations (required)
+
+### Operations
+
+#### create
+
+Creates one banked activity through the Activity Bank path.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - create:
+          title: "Easy Addition"
+          virtual_id: "easy_addition"
+          type: "oli_multiple_choice"
+          tags: ["easy"]
+          objectives: ["Understand arithmetic"]
+          content: |
+            stem_md: "What is 2 + 2?"
+            choices:
+              - id: "a"
+                body_md: "4"
+                score: 1
+              - id: "b"
+                body_md: "5"
+                score: 0
+```
+
+`create` accepts the same activity content fields as `create_activity`: `title`,
+`virtual_id`, `type` or `activity_type_slug`, `content_format`, `content`,
+`objectives`, and `tags`.
+
+#### create_bulk
+
+Creates multiple banked activities in one operation.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - create_bulk:
+          activities:
+            - title: "Question One"
+              virtual_id: "q1"
+              type: "oli_multiple_choice"
+              content: |
+                stem_md: "Question one?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+            - title: "Question Two"
+              virtual_id: "q2"
+              type: "oli_multiple_choice"
+              content: |
+                stem_md: "Question two?"
+                choices:
+                  - id: "a"
+                    body_md: "Yes"
+                    score: 1
+```
+
+#### query
+
+Queries banked activities in the project's working publication. Query results can
+be named and reused by a later `assert` operation.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - query:
+          name: "easy_questions"
+          filters:
+            tags:
+              contains: ["easy"]
+          expect:
+            total_count: 2
+            contains_titles: ["Easy Addition", "Easy Geometry"]
+            not_titles: ["Cell Function"]
+```
+
+Supported friendly filters:
+
+- `tags`: `contains`, `does_not_contain`, `equals`, `does_not_equal`
+- `objectives`: `contains`, `does_not_contain`, `equals`, `does_not_equal`
+- `type`: `contains`, `does_not_contain`
+- `text`: `contains`
+
+Tag and objective filter values may use titles declared on the project. Type
+filters may use activity type slugs. For type filters, use a list with
+`contains`, for example:
+
+```yaml
+filters:
+  type:
+    contains: ["oli_multiple_choice"]
+```
+
+Advanced tests can pass raw Activity Bank realizer logic with `logic` instead of
+`filters`.
+
+#### edit
+
+Edits a banked activity by `virtual_id`, `title`, or `resource_id`.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - edit:
+          virtual_id: "q1"
+          set:
+            title: "Reviewed Question"
+            tags: ["review"]
+```
+
+`set` supports Activity Bank update fields such as `title`, `content`,
+`objectives`, and `tags`. The scenario handler acquires the authoring lock before
+editing, matching the UI lifecycle.
+
+#### delete
+
+Deletes a banked activity by `virtual_id`, `title`, or `resource_id`.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - delete:
+          virtual_id: "obsolete_question"
+```
+
+#### duplicate
+
+Duplicates a banked activity and optionally assigns a new scenario-local
+`virtual_id`.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - duplicate:
+          virtual_id: "q1"
+          new_title: "Question One Copy"
+          new_virtual_id: "q1_copy"
+```
+
+#### assert
+
+Asserts against a named query result produced earlier in the same `activity_bank`
+directive.
+
+```yaml
+- activity_bank:
+    project: "my_project"
+    ops:
+      - query:
+          name: "review_questions"
+          filters:
+            tags:
+              contains: ["review"]
+      - assert:
+          result: "review_questions"
+          expect:
+            total_count: 1
+            contains_titles: ["Reviewed Question"]
+```
+
+### Expectations
+
+Query and stored-result assertions support:
+
+- `total_count`: Total matching rows before paging
+- `row_count`: Rows returned for the current page
+- `titles`: Exact returned title list
+- `contains_titles`: Titles that must be present
+- `not_titles`: Titles that must be absent
+- `resource_ids`: Exact returned resource ID list
+
+Prefer title-based expectations in YAML. Resource IDs are generated at runtime
+and are mainly useful for lower-level tests.
+
+### Complete Example
+
+```yaml
+- project:
+    name: "bank_project"
+    title: "Bank Project"
+    tags:
+      - "draft"
+      - "review"
+    root:
+      children:
+        - page: "Practice"
+
+- activity_bank:
+    project: "bank_project"
+    ops:
+      - create:
+          title: "Draft Question"
+          virtual_id: "draft_q"
+          type: "oli_multiple_choice"
+          tags: ["draft"]
+          content: |
+            stem_md: "Draft question?"
+            choices:
+              - id: "a"
+                body_md: "Yes"
+                score: 1
+              - id: "b"
+                body_md: "No"
+                score: 0
+      - duplicate:
+          virtual_id: "draft_q"
+          new_title: "Reviewed Question"
+          new_virtual_id: "review_q"
+      - edit:
+          virtual_id: "review_q"
+          set:
+            tags: ["review"]
+      - query:
+          name: "review_questions"
+          filters:
+            tags:
+              contains: ["review"]
+          expect:
+            total_count: 1
+            contains_titles: ["Reviewed Question"]
+            not_titles: ["Draft Question"]
+```
 
 ---
 


### PR DESCRIPTION
## Summary

  Adds Activity Bank support to the scenario-based scripting/testing framework.

  This PR introduces an application-layer Activity Bank boundary, wires banked activity creation through it, adds a new activity_bank scenario directive, implements real Activity Bank operations in scenarios, and adds scenario coverage plus documentation.

  ## Changes

  - Added reusable Activity Bank operations outside the web/UI layer.
  - Normalized banked activity creation through the Activity Bank path.
  - Added activity_bank scenario directive schema, parser, validation, and engine dispatch.
  - Implemented scenario support for:
      - create
      - create_bulk
      - query
      - edit
      - delete
      - duplicate
      - assert
  - Added Activity Bank scenario coverage for:
      - query filters and expectations
      - lifecycle operations
      - create_activity scope: banked interop
      - embedded activities being excluded from bank queries
  - Documented the new directive in scenario-system docs.

  ## Verification

  - mix test test/scenarios/directives/activity_bank_handler_test.exs
  - mix test test/scenarios/activities/activities_test.exs
  - mix test test/scenarios/validation/schema_validation_test.exs
  - mix test test/scenarios/validation/invalid_attributes_test.exs
  - Per-file Oli.Scenarios.validate_file/1 checks for new scenario files
