### PR TITLE
[CHORE] [MER-4780] Stop tailwind deprecated color warnings 

### DIFF
--- a/assets/tailwind.theme.js
+++ b/assets/tailwind.theme.js
@@ -1,6 +1,13 @@
 /* eslint-disable */
 const tailwindColors = require('tailwindcss/colors');
 
+// Filter out deprecated colors to suppress warnings on use
+delete tailwindColors.lightBlue;
+delete tailwindColors.warmGray;
+delete tailwindColors.trueGray;
+delete tailwindColors.coolGray;
+delete tailwindColors.blueGray;
+
 /**
  * Extend the default tailwind color palette by overriding specific colors.
  *


### PR DESCRIPTION
This tech debt PR  fixes the annoyance of the noisy tailwind deprecated color warnings logged on server startup. 

In fact, the deprecated color names are nowhere used in torus, so these are not fixed by updating names in our tailwind config as error message and ticket suggest. Rather the warnings arose because the list of colors loaded by 
`const tailwindColors = require('tailwindcss/colors');`
uses getter functions for the deprecated color entries (to give the warning), and the use of this array via spread syntax triggers those functions to issue the warnings. 

Simple fix is to remove the unneeded color entries from the list before using. 