### PR TITLE
[ENHANCEMENT] [MER-5654] Removed non-functional 'font-size' field from Advancedd Author

### DIFF
--- a/assets/src/components/parts/janus-mcq/schema.ts
+++ b/assets/src/components/parts/janus-mcq/schema.ts
@@ -14,7 +14,6 @@ export interface McqItem {
   [key: string]: any;
 }
 export interface McqModel extends JanusAbsolutePositioned, JanusCustomCss {
-  fontSize?: number;
   overrideHeight?: boolean;
   layoutType: 'horizontalLayout' | 'verticalLayout';
   verticalGap: number;
@@ -38,11 +37,6 @@ export const schema: JSONSchema7Object = {
   customCssClass: {
     title: 'Custom CSS Class',
     type: 'string',
-  },
-  fontSize: {
-    title: 'Font Size',
-    type: 'number',
-    default: 12,
   },
   layoutType: {
     title: 'Layout',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "oli-torus",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "oli-torus",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
This pull request makes a small change to the `janus-mcq` component schema by removing the `fontSize` property from both the `McqModel` TypeScript interface and the JSON schema definition. 

The font size should be adjusted at the option level for each option in the MCQ. So this quick fix removes the fontSize option from the component panel. 

Link to ticket: https://eliterate.atlassian.net/browse/MER-5654