### PR TITLE
[BUG FIX] [MER-5649] Adaptive page - Can't add video on popup component

### DIFF
--- a/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
@@ -259,7 +259,7 @@ const ScreenAuthor: React.FC<ScreenAuthorProps> = ({
           }
 
           if (partInstance.getUiSchema) {
-            const customPartUiSchema = partInstance.getUiSchema();
+            const customPartUiSchema = partInstance.getUiSchema('nested');
             const mergedUiSchema = {
               'ui:title': 'Selected Part',
               ...baseUiSchema,

--- a/assets/src/components/parts/janus-video/authoring-entry.ts
+++ b/assets/src/components/parts/janus-video/authoring-entry.ts
@@ -8,6 +8,8 @@ import VideoAuthor from './VideoAuthor';
 import {
   adaptivitySchema,
   createSchema,
+  nestedSimpleUiSchema,
+  nestedUiSchema,
   schema,
   simpleSchema,
   simpleUISchema,
@@ -30,7 +32,10 @@ register(VideoAuthor, manifest.authoring.element, observedAttributes, {
   },
   customApi: {
     getSchema: (mode: PartAuthoringMode) => (mode === 'simple' ? simpleSchema : schema),
-    getUiSchema: (mode: PartAuthoringMode) => (mode === 'simple' ? simpleUISchema : uiSchema),
+    getUiSchema: (mode: PartAuthoringMode) => {
+      if (mode === 'nested') return nestedUiSchema;
+      return mode === 'simple' ? simpleUISchema : uiSchema;
+    },
     createSchema,
     getAdaptivitySchema: async () => adaptivitySchema,
   },

--- a/assets/src/components/parts/janus-video/authoring-entry.ts
+++ b/assets/src/components/parts/janus-video/authoring-entry.ts
@@ -8,7 +8,6 @@ import VideoAuthor from './VideoAuthor';
 import {
   adaptivitySchema,
   createSchema,
-  nestedSimpleUiSchema,
   nestedUiSchema,
   schema,
   simpleSchema,

--- a/assets/src/components/parts/janus-video/schema.ts
+++ b/assets/src/components/parts/janus-video/schema.ts
@@ -164,6 +164,20 @@ export const uiSchema = {
   },
 };
 
+export const nestedUiSchema = {
+  ...uiSchema,
+  subtitles: {
+    classNames: 'col-span-12 video-subtitles',
+  },
+};
+
+export const nestedSimpleUiSchema = {
+  ...simpleUISchema,
+  subtitles: {
+    classNames: 'col-span-12 video-subtitles',
+  },
+};
+
 export const adaptivitySchema = {
   hasStarted: CapiVariableTypes.BOOLEAN,
   autoPlay: CapiVariableTypes.BOOLEAN,

--- a/assets/src/components/parts/partsApi.ts
+++ b/assets/src/components/parts/partsApi.ts
@@ -12,4 +12,4 @@ export const customEvents = {
   onSetData: 'setData',
 };
 
-export type PartAuthoringMode = 'expert' | 'simple';
+export type PartAuthoringMode = 'expert' | 'simple' | 'nested';


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

In the recent changes, the main authoring uses `JanusSubtitlesManager` for video subtitles, which opens the media manager and depends on Redux (`useSelector for projectSlug`).

Popup configure renders parts through ScreenAuthor inside a web component boundary, so that UI is not wrapped in a Redux Provider. Using JanusSubtitlesManager there caused:

`could not find react-redux context value; please ensure the component is wrapped in a <Provider>`

For popup/nested editing, we switched video subtitles back to the previous audio-style setup: basic RJSF array fields where authors paste caption URLs manually. This is done via a nested UI schema (getUiSchema('nested') in ScreenAuthor) that omits JanusSubtitlesManager.

Main page property panel behavior is unchanged — full subtitle manager and media picker remain there.