### PR TITLE
[ENHANCEMENT] [MER-4434] Replace page creation redirect with push_navigate

### DIFF
--- a/lib/oli_web/live/workspaces/course_author/pages_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/pages_live.ex
@@ -23,7 +23,6 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
   alias OliWeb.Curriculum.{OptionsModalContent, HyperlinkDependencyModal}
   alias OliWeb.Router.Helpers, as: Routes
   alias OliWeb.Workspaces.CourseAuthor.Pages.TableModel, as: PagesTableModel
-  alias OliWeb.Workspaces.CourseAuthor.Curriculum.EditorLive
 
   @default_limit 25
 
@@ -387,9 +386,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.PagesLive do
            project
          ) do
       {:ok, %Revision{slug: slug}} ->
-        # redirect to new page
         {:noreply,
-         redirect(socket, to: Routes.live_path(OliWeb.Endpoint, EditorLive, project.slug, slug))}
+         push_navigate(socket,
+           to: ~p"/workspaces/course_author/#{project.slug}/curriculum/#{slug}/edit"
+         )}
 
       {:error, %Ecto.Changeset{} = _changeset} ->
         {:noreply, put_flash(socket, :error, "Could not create new page")}


### PR DESCRIPTION
[MER-4434](https://eliterate.atlassian.net/browse/MER-4434)

## Summary

Replaces the full-page `redirect` used after creating a page from `PagesLive` with LiveView `push_navigate`.

This keeps the user in the LiveView navigation flow and avoids the unnecessary full reload when opening the newly created page editor.

### Changes

- Updated `PagesLive` `create_page` handling to navigate with `push_navigate`
- Uses the verified route to the new page editor: `/workspaces/course_author/:project_slug/curriculum/:revision_slug/edit`


https://github.com/user-attachments/assets/e49f82f5-878e-46bc-88f0-447e8bcf3879



[MER-4434]: https://eliterate.atlassian.net/browse/MER-4434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ