### PR TITLE
[BUG FIX] [MER-5652] Adaptive Page - Can't undo moving a component

### DIFF
--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -35,7 +35,8 @@ export const saveActivity = createAsyncThunk(
     { dispatch, getState },
   ) => {
     try {
-      const { activity, undoable = true } = payload;
+      const { activity: payloadActivity, undoable = true, immediate } = payload;
+      const activity = cloneDeep(payloadActivity);
       const rootState = getState() as any;
       const projectSlug = selectProjectSlug(rootState);
       const resourceId = selectResourceId(rootState);
@@ -102,7 +103,7 @@ export const saveActivity = createAsyncThunk(
         const debouncedEdit = getDebouncedEdit(String(activity.id));
 
         debouncedEdit(projectSlug, resourceId, activity.resourceId as number, changeData, false);
-        if (payload.immediate) {
+        if (immediate) {
           await debouncedEdit.flush();
         }
 


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

After dragging a component, Undo failed with:

`TypeError: Cannot assign to read only property 'authoring'`

**Fix**: cloneDeep the payload at the start of saveActivity so mutations always run on a mutable copy.