### PR TITLE
[BUG FIX] [MER-5664] Preserve unscored adaptive screen scores

### DIFF
--- a/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
+++ b/assets/src/apps/authoring/store/activities/actions/saveActivity.ts
@@ -19,7 +19,6 @@ import {
 import { selectSequence } from '../../../../delivery/store/features/groups/selectors/deck';
 import { generateRules } from '../../../components/Flowchart/rules/rule-compilation';
 import { notifyReadOnlyEditBlocked } from '../../../readOnlyNotifier';
-import { normalizeAdaptiveScreenMaxScore } from '../../../utils/adaptiveScoring';
 import { selectAppMode, selectProjectSlug, selectReadOnly } from '../../app/slice';
 import { updateSequenceItemFromActivity } from '../../groups/layouts/deck/actions/updateSequenceItemFromActivity';
 import { createUndoAction } from '../../history/slice';
@@ -82,12 +81,10 @@ export const saveActivity = createAsyncThunk(
         activity.authoring.variablesRequiredForEvaluation = variables;
       }
 
-      const normalizedActivity = normalizeAdaptiveScreenMaxScore(activity);
-
       const changeData: ActivityUpdate = {
-        title: normalizedActivity.title as string,
-        objectives: normalizedActivity.objectives as ObjectiveMap,
-        content: { ...normalizedActivity.content, authoring: normalizedActivity.authoring },
+        title: activity.title as string,
+        objectives: activity.objectives as ObjectiveMap,
+        content: { ...activity.content, authoring: activity.authoring },
         tags: activity.tags || [],
       };
 
@@ -97,7 +94,7 @@ export const saveActivity = createAsyncThunk(
       }
 
       if (!isReadOnlyMode) {
-        console.log('going to save acivity: ', { changeData, activity: normalizedActivity });
+        console.log('going to save acivity: ', { changeData, activity });
 
         const debouncedEdit = getDebouncedEdit(String(activity.id));
 
@@ -107,24 +104,20 @@ export const saveActivity = createAsyncThunk(
         }
 
         // grab the activity before it's updated for the score check
-        const oldActivityData = selectActivityById(
-          rootState,
-          normalizedActivity.resourceId as number,
-        );
+        const oldActivityData = selectActivityById(rootState, activity.resourceId as number);
 
         // update the activitiy before saving the page so that the score is correct
-        await dispatch(upsertActivity({ activity: normalizedActivity }));
+        await dispatch(upsertActivity({ activity }));
 
         const currentPage = selectCurrentPage(rootState);
 
         const updatePage =
-          normalizedActivity.title !== currentActivityState?.title ||
+          activity.title !== currentActivityState?.title ||
           (!currentPage.custom.scoreFixed &&
-            normalizedActivity.content?.custom.maxScore !==
-              oldActivityData?.content?.custom.maxScore);
+            activity.content?.custom.maxScore !== oldActivityData?.content?.custom.maxScore);
 
         if (updatePage) {
-          dispatch(updateSequenceItemFromActivity({ activity: normalizedActivity, group }));
+          dispatch(updateSequenceItemFromActivity({ activity, group }));
           await dispatch(savePage({}));
         }
 
@@ -132,7 +125,7 @@ export const saveActivity = createAsyncThunk(
           dispatch(
             createUndoAction({
               undo: [saveActivity({ activity: cloneDeep(currentActivityState), undoable: false })],
-              redo: [saveActivity({ activity: cloneDeep(normalizedActivity), undoable: false })],
+              redo: [saveActivity({ activity: cloneDeep(activity), undoable: false })],
             }),
           );
         }

--- a/assets/src/apps/authoring/utils/adaptiveScoring.ts
+++ b/assets/src/apps/authoring/utils/adaptiveScoring.ts
@@ -30,33 +30,9 @@ export const adaptiveScreenHasScorableInputs = (activity: any): boolean => {
 };
 
 export const normalizeAdaptiveScreenMaxScore = (activity: any): any => {
-  if (!adaptiveScreenHasScorableInputs(activity)) {
-    return activity;
-  }
-
-  const currentMaxScore = normalizeNumber(activity?.content?.custom?.maxScore);
-  if (currentMaxScore > 0) {
-    return activity;
-  }
-
-  return {
-    ...activity,
-    content: {
-      ...activity.content,
-      custom: {
-        ...(activity.content?.custom || {}),
-        maxScore: 1,
-      },
-    },
-  };
+  return activity;
 };
 
 export const effectiveAdaptiveScreenMaxScore = (activity: any): number => {
-  const currentMaxScore = normalizeNumber(activity?.content?.custom?.maxScore);
-
-  if (!adaptiveScreenHasScorableInputs(activity)) {
-    return currentMaxScore;
-  }
-
-  return currentMaxScore > 0 ? currentMaxScore : 1;
+  return normalizeNumber(activity?.content?.custom?.maxScore);
 };

--- a/assets/src/apps/authoring/utils/adaptiveScoring.ts
+++ b/assets/src/apps/authoring/utils/adaptiveScoring.ts
@@ -29,10 +29,6 @@ export const adaptiveScreenHasScorableInputs = (activity: any): boolean => {
   return partsLayout.some((part: any) => SCORABLE_ADAPTIVE_PART_TYPES.has(part?.type));
 };
 
-export const normalizeAdaptiveScreenMaxScore = (activity: any): any => {
-  return activity;
-};
-
 export const effectiveAdaptiveScreenMaxScore = (activity: any): number => {
   return normalizeNumber(activity?.content?.custom?.maxScore);
 };

--- a/assets/test/advanced_authoring/adaptive_scoring_test.ts
+++ b/assets/test/advanced_authoring/adaptive_scoring_test.ts
@@ -1,7 +1,4 @@
-import {
-  effectiveAdaptiveScreenMaxScore,
-  normalizeAdaptiveScreenMaxScore,
-} from '../../src/apps/authoring/utils/adaptiveScoring';
+import { effectiveAdaptiveScreenMaxScore } from '../../src/apps/authoring/utils/adaptiveScoring';
 
 const adaptiveActivity = (maxScore: unknown) => ({
   content: {
@@ -15,20 +12,17 @@ describe('adaptive scoring helpers', () => {
     const activity = adaptiveActivity(0);
 
     expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(0);
-    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
   });
 
   it('preserves positive authored scores for adaptive screens with scorable inputs', () => {
     const activity = adaptiveActivity(2);
 
     expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(2);
-    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
   });
 
   it('does not infer a score for adaptive screens with scorable inputs and no authored score', () => {
     const activity = adaptiveActivity(undefined);
 
     expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(0);
-    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
   });
 });

--- a/assets/test/advanced_authoring/adaptive_scoring_test.ts
+++ b/assets/test/advanced_authoring/adaptive_scoring_test.ts
@@ -1,0 +1,34 @@
+import {
+  effectiveAdaptiveScreenMaxScore,
+  normalizeAdaptiveScreenMaxScore,
+} from '../../src/apps/authoring/utils/adaptiveScoring';
+
+const adaptiveActivity = (maxScore: unknown) => ({
+  content: {
+    custom: { maxScore },
+    partsLayout: [{ id: 'dropdown_1', type: 'janus-dropdown' }],
+  },
+});
+
+describe('adaptive scoring helpers', () => {
+  it('preserves an explicitly unscored adaptive screen with scorable inputs', () => {
+    const activity = adaptiveActivity(0);
+
+    expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(0);
+    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
+  });
+
+  it('preserves positive authored scores for adaptive screens with scorable inputs', () => {
+    const activity = adaptiveActivity(2);
+
+    expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(2);
+    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
+  });
+
+  it('does not infer a score for adaptive screens with scorable inputs and no authored score', () => {
+    const activity = adaptiveActivity(undefined);
+
+    expect(effectiveAdaptiveScreenMaxScore(activity)).toBe(0);
+    expect(normalizeAdaptiveScreenMaxScore(activity)).toBe(activity);
+  });
+});

--- a/lib/oli/delivery/attempts/activity_lifecycle/adaptive_part_evaluation.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/adaptive_part_evaluation.ex
@@ -456,16 +456,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.AdaptivePartEvaluation do
   defp advanced_numeric_match?(_, _, _), do: false
 
   defp normalize_screen_out_of(scoring_context, total_out_of) do
-    max_score =
-      scoring_context
-      |> Map.get(:maxScore, 0)
-      |> normalize_number()
-      |> Kernel.||(0.0)
+    case scoring_context
+         |> Map.get(:maxScore)
+         |> normalize_number() do
+      max_score when is_number(max_score) and max_score >= 0 ->
+        max_score
 
-    cond do
-      max_score > 0 -> max_score
-      total_out_of > 0 -> total_out_of
-      true -> 0.0
+      _ ->
+        max(total_out_of, 0.0)
     end
   end
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -161,7 +161,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                   false ->
                     custom
                     |> Map.get("maxScore", 0)
-                    |> normalize_adaptive_max_score(activity_model, 1)
+                    |> normalize_adaptive_max_score(activity_model, 0)
                 end
 
               scoringContext = %{
@@ -672,7 +672,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
 
   defp adaptive_rule_screen_score(%{"score" => score, "out_of" => out_of}) do
     with screen_score when is_number(screen_score) <- normalize_adaptive_score(score),
-         screen_out_of when is_number(screen_out_of) and screen_out_of > 0 <-
+         screen_out_of when is_number(screen_out_of) and screen_out_of >= 0 <-
            normalize_adaptive_score(out_of) do
       {:ok, {screen_score |> max(0.0) |> min(screen_out_of), screen_out_of}}
     else

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -1465,7 +1465,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
              |> Map.get("text") == "Correct"
     end
 
-    test "uses a minimum screen out_of of 1 for adaptive screens with scorable inputs" do
+    test "preserves zero out_of for explicitly unscored adaptive screens with scorable inputs" do
       user = insert(:user)
       section = insert(:section)
 
@@ -1549,20 +1549,19 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
                  nil
                )
 
-      assert result["score"] == 1.0
-      assert result["out_of"] == 1.0
+      assert result["score"] == 0.0
+      assert result["out_of"] == 0.0
 
       updated_attempt =
         Core.get_activity_attempt_by(attempt_guid: setup.activity_attempt.attempt_guid)
 
-      assert updated_attempt.score == 1.0
-      assert updated_attempt.out_of == 1.0
+      assert updated_attempt.score == 0.0
+      assert updated_attempt.out_of == 0.0
 
       [updated_part_attempt] =
         Core.get_latest_part_attempts(setup.activity_attempt.attempt_guid)
 
-      assert updated_part_attempt.score == 1.0
-      assert updated_part_attempt.out_of == 1.0
+      assert updated_part_attempt.part_id == "dropdown_1"
     end
 
     test "falls back to rolled-up part scores when rules do not emit a screen score" do


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5664

## Summary

- Stop adaptive authoring from assigning a default score of 1 to screens just because they contain a scorable part type.
- Preserve explicitly unscored adaptive screens as `0/0` during adaptive activity evaluation.
- Add regression coverage for adaptive screens with scorable inputs and `maxScore` set to `0`, positive `maxScore`, and no authored score.

### Before

Can't reset `maxScore` to 0 once it is set to >= 1.

https://github.com/user-attachments/assets/53d432cd-07f8-4cc2-9f76-055b4be47108


The survey screen counts towards scoring (`total score = 6 = "Alien Preconception Survey" score (1) + "Preconceptions" screen score (5)`)
<img width="1910" height="505" alt="Screenshot 2026-05-29 at 8 50 15 AM" src="https://github.com/user-attachments/assets/bc7549b7-b729-4e52-9861-0c624fbbb0ac" />




### After

Can reset `maxScore` to 0.

https://github.com/user-attachments/assets/85348bd4-b587-41ad-a9c5-fc855cb6fa95


Only the "Preconceptions" screen counts towards scoring (`total score = 5 = "Preconceptions" screen score`)
<img width="1910" height="505" alt="Screenshot 2026-05-29 at 8 48 32 AM" src="https://github.com/user-attachments/assets/f797166f-2f2e-46b4-ad93-907dacd527d1" />



## Bug Origin

Recent adaptive analytics/manual grading work needed to identify adaptive inputs that can produce evaluation data. That introduced logic that conflated two concepts:

- A scorable part type is a component that can emit response/correctness data for evaluation, analytics, or manual grading.
- A scored screen is a screen that contributes points because the authored scoring configuration gives it a positive score.

Because those concepts were mixed, adaptive screens with MCQ/dropdown/etc. inputs were normalized to `maxScore: 1` even when the screen was intended to remain unscored.

## Fix Applied

- Keep scorable-part detection available for analytics/manual grading workflows, but stop using it to infer a screen score.
- Preserve authored adaptive screen scores directly in authoring total-score calculations.
- Allow adaptive rule evaluation to accept a screen-level `out_of` of `0` instead of falling back to part-score rollup.
- Keep legacy page grading clamps unchanged so this fix stays scoped to adaptive screen evaluation and authoring score normalization.

## Validation

- `mix test test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs test/oli/grading_test.exs test/oli/delivery/attempts/graded_test.exs`
- `yarn test advanced_authoring/adaptive_scoring_test.ts advanced_authoring/adaptive_scorable_part_types_test.ts`
- `mix test test/oli/delivery/attempts/activity_lifecycle test/oli/grading_test.exs test/oli/delivery/attempts/graded_test.exs test/oli/analytics/summary/response_label_test.exs test/oli/analytics/summary/upsert_test.exs`
- `yarn test advanced_authoring delivery/adaptive_iframe_resize_test.ts delivery/adaptive_delivery_test.tsx delivery/adaptive_dialogue_bridge_test.tsx`
- `git diff --check`
- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`

Note: `yarn --cwd assets run check-types` initially failed because the declared `vm2` package was missing from `assets/node_modules`; running `yarn --cwd assets install --frozen-lockfile` restored the dependency without lockfile changes, then the gate passed.
