### PR TITLE
[BUG FIX] [MER-5565] Fix adaptive scoring attempt count across page retakes

### DIFF
--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -34,6 +34,7 @@ import {
 import {
   selectPreviewMode,
   selectResourceAttemptGuid,
+  selectResourceAttemptNumber,
   selectReviewMode,
   selectSectionSlug,
 } from '../../page/slice';
@@ -102,6 +103,7 @@ export const triggerCheck = createAsyncThunk(
       const sectionSlug = selectSectionSlug(rootState);
       const blobStorageProvider = rootState.page.blobStorageProvider;
       const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
+      const resourceAttemptNumber = selectResourceAttemptNumber(rootState);
 
       const currentActivityTreeAttempts = selectCurrentActivityTreeAttemptState(rootState) || [];
       const currentAttempt = currentActivityTreeAttempts[currentActivityTreeAttempts?.length - 1];
@@ -304,7 +306,10 @@ export const triggerCheck = createAsyncThunk(
           }, {});
 
           const scoringContext: ScoringContext = {
-            currentAttemptNumber: currentAttempt?.attemptNumber || 1,
+            currentAttemptNumber: Math.max(
+              (currentAttempt?.attemptNumber || 1) - resourceAttemptNumber + 1,
+              1,
+            ),
             maxAttempt: currentActivity.content?.custom.maxAttempt || 0,
             maxScore: currentActivity.content?.custom.maxScore || 0,
             trapStateScoreScheme: currentActivity.content?.custom.trapStateScoreScheme || false,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -169,7 +169,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                 maxAttempt: Map.get(custom, "maxAttempt", 1),
                 trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
                 negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
-                currentAttemptNumber: attempt_number,
+                currentAttemptNumber:
+                  adaptive_scoring_attempt_number(attempt_number, resource_attempt.attempt_number),
                 isManuallyGraded: is_manually_graded
               }
 
@@ -421,6 +422,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
       %{pa | lifecycle_state: :submitted, date_submitted: now, updated_at: now}
     end)
   end
+
+  defp adaptive_scoring_attempt_number(activity_attempt_number, resource_attempt_number)
+       when is_integer(activity_attempt_number) and is_integer(resource_attempt_number) do
+    max(activity_attempt_number - resource_attempt_number + 1, 1)
+  end
+
+  defp adaptive_scoring_attempt_number(activity_attempt_number, _resource_attempt_number),
+    do: activity_attempt_number || 1
 
   defp evaluate_from_rules(
          section_slug,

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -332,6 +332,25 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
     Map.put(setup, :part_attempts, part_attempts)
   end
 
+  defp dropdown_part_inputs(%{part_attempts: [dropdown_attempt]}) do
+    [
+      %{
+        attempt_guid: dropdown_attempt.attempt_guid,
+        input: %StudentInput{
+          input: %{
+            "selectedIndex" => %{"path" => "stage.dropdown_1.selectedIndex", "value" => 2},
+            "selectedItem" => %{
+              "path" => "stage.dropdown_1.selectedItem",
+              "value" => "Option 2"
+            },
+            "value" => %{"path" => "stage.dropdown_1.value", "value" => "Option 2"}
+          }
+        },
+        timestamp: DateTime.utc_now()
+      }
+    ]
+  end
+
   describe "evaluate_activity/4 - activity type specialization routing" do
     test "routes to DirectedDiscussion.evaluate_activity for oli_directed_discussion activities" do
       user = insert(:user)
@@ -1902,6 +1921,168 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
 
       assert updated_attempt.score == 2.0
       assert updated_attempt.out_of == 2.0
+    end
+
+    test "scores adaptive attempts relative to the current page attempt" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 3, "maxAttempt" => 3},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"]
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => ["stage.dropdown_1.selectedIndex"],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "r.correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.dropdown_1.selectedIndex",
+                      "operator" => "equal",
+                      "value" => "2"
+                    }
+                  ]
+                },
+                "event" => %{
+                  "type" => "r.correct",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      first_try_on_third_page_attempt =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 3,
+          activity_attempt_number: 3
+        )
+
+      assert {:ok, first_try_result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 first_try_on_third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(first_try_on_third_page_attempt),
+                 nil
+               )
+
+      assert first_try_result["score"] == 3.0
+      assert first_try_result["out_of"] == 3.0
+
+      second_try_on_third_page_attempt =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 3,
+          activity_attempt_number: 4
+        )
+
+      assert {:ok, second_try_result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 second_try_on_third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(second_try_on_third_page_attempt),
+                 nil
+               )
+
+      assert second_try_result["score"] == 2.0
+      assert second_try_result["out_of"] == 3.0
+    end
+
+    test "preserves adaptive retry scoring within the first page attempt" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 3, "maxAttempt" => 3},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"]
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => ["stage.dropdown_1.selectedIndex"],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "r.correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.dropdown_1.selectedIndex",
+                      "operator" => "equal",
+                      "value" => "2"
+                    }
+                  ]
+                },
+                "event" => %{
+                  "type" => "r.correct",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      results =
+        Enum.map(1..3, fn activity_attempt_number ->
+          setup =
+            setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+              attempt_number: 1,
+              activity_attempt_number: activity_attempt_number
+            )
+
+          assert {:ok, result} =
+                   Evaluate.evaluate_activity(
+                     section.slug,
+                     setup.activity_attempt.attempt_guid,
+                     dropdown_part_inputs(setup),
+                     nil
+                   )
+
+          result
+        end)
+
+      assert Enum.map(results, & &1["score"]) == [3.0, 2.0, 1.0]
+      assert Enum.map(results, & &1["out_of"]) == [3.0, 3.0, 3.0]
     end
 
     test "respects explicit screen score mutations and copies them to submitted part inputs" do


### PR DESCRIPTION
Fixes adaptive attempt-based scoring so first tries on later page attempts are scored as attempt 1.

Adaptive activity attempts use an absolute attempt number that advances along with the page/resource attempt. For example, when a learner starts page attempt 3, the first adaptive activity attempt on that page can also have `attempt_number: 3`.

That absolute activity attempt number is useful for persistence, ordering, and analytics, but it is not the same thing as the learner’s try number within the current page attempt. Attempt-based adaptive scoring needs the screen-local try count:

- Page attempt 3, first try on the screen should score as try 1.
- Page attempt 3, second try on the screen should score as try 2.

Previously, adaptive scoring passed the absolute activity attempt number directly as `currentAttemptNumber`, so a first correct answer on page attempt 3 could be treated as try 3 and receive reduced credit.

This changes adaptive scoring to calculate the screen-local attempt number as:

`activity_attempt_number - resource_attempt_number + 1`

The same relative calculation is applied in the client-side adaptive check path.

See: https://eliterate.atlassian.net/browse/MER-5665