### PR TITLE
[BUG FIX] [MER-5565] Fix adaptive scoring attempt count across page

### DIFF
--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -34,6 +34,7 @@ import {
 import {
   selectPreviewMode,
   selectResourceAttemptGuid,
+  selectResourceAttemptNumber,
   selectReviewMode,
   selectSectionSlug,
 } from '../../page/slice';
@@ -102,6 +103,7 @@ export const triggerCheck = createAsyncThunk(
       const sectionSlug = selectSectionSlug(rootState);
       const blobStorageProvider = rootState.page.blobStorageProvider;
       const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
+      const resourceAttemptNumber = selectResourceAttemptNumber(rootState);
 
       const currentActivityTreeAttempts = selectCurrentActivityTreeAttemptState(rootState) || [];
       const currentAttempt = currentActivityTreeAttempts[currentActivityTreeAttempts?.length - 1];
@@ -304,7 +306,10 @@ export const triggerCheck = createAsyncThunk(
           }, {});
 
           const scoringContext: ScoringContext = {
-            currentAttemptNumber: currentAttempt?.attemptNumber || 1,
+            currentAttemptNumber: Math.max(
+              (currentAttempt?.attemptNumber || 1) - resourceAttemptNumber + 1,
+              1,
+            ),
             maxAttempt: currentActivity.content?.custom.maxAttempt || 0,
             maxScore: currentActivity.content?.custom.maxScore || 0,
             trapStateScoreScheme: currentActivity.content?.custom.trapStateScoreScheme || false,

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -34,6 +34,7 @@ import {
 import {
   selectPreviewMode,
   selectResourceAttemptGuid,
+  selectResourceAttemptNumber,
   selectReviewMode,
   selectSectionSlug,
 } from '../../page/slice';
@@ -102,6 +103,7 @@ export const triggerCheck = createAsyncThunk(
       const sectionSlug = selectSectionSlug(rootState);
       const blobStorageProvider = rootState.page.blobStorageProvider;
       const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
+      const resourceAttemptNumber = selectResourceAttemptNumber(rootState);
 
       const currentActivityTreeAttempts = selectCurrentActivityTreeAttemptState(rootState) || [];
       const currentAttempt = currentActivityTreeAttempts[currentActivityTreeAttempts?.length - 1];
@@ -303,17 +305,11 @@ export const triggerCheck = createAsyncThunk(
             return acc;
           }, {});
 
-          const parsedAttemptNumber = Number(
-            getValue(`${currentActivity.id}|session.attemptNumber`, defaultGlobalEnv) ||
-              getValue('session.attemptNumber', defaultGlobalEnv) ||
-              1,
-          );
-          const localAttemptNumber = Number.isFinite(parsedAttemptNumber)
-            ? Math.max(parsedAttemptNumber, 1)
-            : 1;
-
           const scoringContext: ScoringContext = {
-            currentAttemptNumber: localAttemptNumber,
+            currentAttemptNumber: Math.max(
+              (currentAttempt?.attemptNumber || 1) - resourceAttemptNumber + 1,
+              1,
+            ),
             maxAttempt: currentActivity.content?.custom.maxAttempt || 0,
             maxScore: currentActivity.content?.custom.maxScore || 0,
             trapStateScoreScheme: currentActivity.content?.custom.trapStateScoreScheme || false,

--- a/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
+++ b/assets/src/apps/delivery/store/features/adaptivity/actions/triggerCheck.ts
@@ -34,7 +34,6 @@ import {
 import {
   selectPreviewMode,
   selectResourceAttemptGuid,
-  selectResourceAttemptNumber,
   selectReviewMode,
   selectSectionSlug,
 } from '../../page/slice';
@@ -103,7 +102,6 @@ export const triggerCheck = createAsyncThunk(
       const sectionSlug = selectSectionSlug(rootState);
       const blobStorageProvider = rootState.page.blobStorageProvider;
       const resourceAttemptGuid = selectResourceAttemptGuid(rootState);
-      const resourceAttemptNumber = selectResourceAttemptNumber(rootState);
 
       const currentActivityTreeAttempts = selectCurrentActivityTreeAttemptState(rootState) || [];
       const currentAttempt = currentActivityTreeAttempts[currentActivityTreeAttempts?.length - 1];
@@ -305,11 +303,17 @@ export const triggerCheck = createAsyncThunk(
             return acc;
           }, {});
 
-          const scoringContext: ScoringContext = {
-            currentAttemptNumber: Math.max(
-              (currentAttempt?.attemptNumber || 1) - resourceAttemptNumber + 1,
+          const parsedAttemptNumber = Number(
+            getValue(`${currentActivity.id}|session.attemptNumber`, defaultGlobalEnv) ||
+              getValue('session.attemptNumber', defaultGlobalEnv) ||
               1,
-            ),
+          );
+          const localAttemptNumber = Number.isFinite(parsedAttemptNumber)
+            ? Math.max(parsedAttemptNumber, 1)
+            : 1;
+
+          const scoringContext: ScoringContext = {
+            currentAttemptNumber: localAttemptNumber,
             maxAttempt: currentActivity.content?.custom.maxAttempt || 0,
             maxScore: currentActivity.content?.custom.maxScore || 0,
             trapStateScoreScheme: currentActivity.content?.custom.trapStateScoreScheme || false,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -169,7 +169,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                 maxAttempt: Map.get(custom, "maxAttempt", 1),
                 trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
                 negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
-                currentAttemptNumber: attempt_number,
+                currentAttemptNumber:
+                  adaptive_scoring_attempt_number(attempt_number, resource_attempt.attempt_number),
                 isManuallyGraded: is_manually_graded
               }
 
@@ -421,6 +422,14 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
       %{pa | lifecycle_state: :submitted, date_submitted: now, updated_at: now}
     end)
   end
+
+  defp adaptive_scoring_attempt_number(activity_attempt_number, resource_attempt_number)
+       when is_integer(activity_attempt_number) and is_integer(resource_attempt_number) do
+    max(activity_attempt_number - resource_attempt_number + 1, 1)
+  end
+
+  defp adaptive_scoring_attempt_number(activity_attempt_number, _resource_attempt_number),
+    do: activity_attempt_number || 1
 
   defp evaluate_from_rules(
          section_slug,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -123,10 +123,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
 
         _ ->
           # Continue with standard evaluation logic
-          %ActivityAttempt{
-            resource_attempt: resource_attempt,
-            attempt_number: attempt_number
-          } = activity_attempt
+          %ActivityAttempt{resource_attempt: resource_attempt} = activity_attempt
 
           activity_model = select_model(activity_attempt)
           part_attempts = get_latest_part_attempts(activity_attempt_guid)
@@ -169,8 +166,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                 maxAttempt: Map.get(custom, "maxAttempt", 1),
                 trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
                 negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
-                currentAttemptNumber:
-                  adaptive_scoring_attempt_number(attempt_number, resource_attempt.attempt_number),
+                currentAttemptNumber: adaptive_scoring_attempt_number(activity_attempt),
                 isManuallyGraded: is_manually_graded
               }
 
@@ -423,13 +419,26 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     end)
   end
 
-  defp adaptive_scoring_attempt_number(activity_attempt_number, resource_attempt_number)
-       when is_integer(activity_attempt_number) and is_integer(resource_attempt_number) do
-    max(activity_attempt_number - resource_attempt_number + 1, 1)
+  defp adaptive_scoring_attempt_number(%ActivityAttempt{
+         id: activity_attempt_id,
+         resource_attempt_id: resource_attempt_id,
+         resource_id: resource_id,
+         attempt_number: attempt_number
+       })
+       when is_integer(activity_attempt_id) and is_integer(resource_attempt_id) and
+              is_integer(resource_id) and is_integer(attempt_number) do
+    Repo.one(
+      from(a in ActivityAttempt,
+        where:
+          a.resource_attempt_id == ^resource_attempt_id and
+            a.resource_id == ^resource_id and
+            a.attempt_number <= ^attempt_number,
+        select: count(a.id)
+      )
+    ) || 1
   end
 
-  defp adaptive_scoring_attempt_number(activity_attempt_number, _resource_attempt_number),
-    do: activity_attempt_number || 1
+  defp adaptive_scoring_attempt_number(_activity_attempt), do: 1
 
   defp evaluate_from_rules(
          section_slug,

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -123,7 +123,10 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
 
         _ ->
           # Continue with standard evaluation logic
-          %ActivityAttempt{resource_attempt: resource_attempt} = activity_attempt
+          %ActivityAttempt{
+            resource_attempt: resource_attempt,
+            attempt_number: attempt_number
+          } = activity_attempt
 
           activity_model = select_model(activity_attempt)
           part_attempts = get_latest_part_attempts(activity_attempt_guid)
@@ -166,7 +169,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
                 maxAttempt: Map.get(custom, "maxAttempt", 1),
                 trapStateScoreScheme: Map.get(custom, "trapStateScoreScheme", false),
                 negativeScoreAllowed: Map.get(custom, "negativeScoreAllowed", false),
-                currentAttemptNumber: adaptive_scoring_attempt_number(activity_attempt),
+                currentAttemptNumber:
+                  adaptive_scoring_attempt_number(attempt_number, resource_attempt.attempt_number),
                 isManuallyGraded: is_manually_graded
               }
 
@@ -419,26 +423,13 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
     end)
   end
 
-  defp adaptive_scoring_attempt_number(%ActivityAttempt{
-         id: activity_attempt_id,
-         resource_attempt_id: resource_attempt_id,
-         resource_id: resource_id,
-         attempt_number: attempt_number
-       })
-       when is_integer(activity_attempt_id) and is_integer(resource_attempt_id) and
-              is_integer(resource_id) and is_integer(attempt_number) do
-    Repo.one(
-      from(a in ActivityAttempt,
-        where:
-          a.resource_attempt_id == ^resource_attempt_id and
-            a.resource_id == ^resource_id and
-            a.attempt_number <= ^attempt_number,
-        select: count(a.id)
-      )
-    ) || 1
+  defp adaptive_scoring_attempt_number(activity_attempt_number, resource_attempt_number)
+       when is_integer(activity_attempt_number) and is_integer(resource_attempt_number) do
+    max(activity_attempt_number - resource_attempt_number + 1, 1)
   end
 
-  defp adaptive_scoring_attempt_number(_activity_attempt), do: 1
+  defp adaptive_scoring_attempt_number(activity_attempt_number, _resource_attempt_number),
+    do: activity_attempt_number || 1
 
   defp evaluate_from_rules(
          section_slug,

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -351,33 +351,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
     ]
   end
 
-  defp add_adaptive_activity_attempt(setup, activity_revision, part_ids, activity_attempt_number) do
-    activity_attempt =
-      %Core.ActivityAttempt{
-        attempt_guid: Ecto.UUID.generate(),
-        attempt_number: activity_attempt_number,
-        resource_id: activity_revision.resource_id,
-        revision_id: activity_revision.id,
-        resource_attempt_id: setup.resource_attempt.id,
-        lifecycle_state: :active,
-        scoreable: true
-      }
-      |> Oli.Repo.insert!()
-      |> Oli.Repo.preload([:revision, :resource_attempt])
-
-    part_attempts =
-      Enum.map(part_ids, fn part_id ->
-        insert(:part_attempt,
-          activity_attempt: activity_attempt,
-          part_id: part_id,
-          attempt_number: activity_attempt_number,
-          lifecycle_state: :active
-        )
-      end)
-
-    %{setup | activity_attempt: activity_attempt, part_attempts: part_attempts}
-  end
-
   describe "evaluate_activity/4 - activity type specialization routing" do
     test "routes to DirectedDiscussion.evaluate_activity for oli_directed_discussion activities" do
       user = insert(:user)
@@ -1950,7 +1923,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_attempt.out_of == 2.0
     end
 
-    test "scores adaptive attempts by counting attempts within the current page attempt" do
+    test "scores adaptive attempts relative to the current page attempt" do
       user = insert(:user)
       section = insert(:section)
 
@@ -2002,16 +1975,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
           }
         })
 
-      first_page_attempt =
-        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
-          attempt_number: 1,
-          activity_attempt_number: 1
-        )
-
-      add_adaptive_activity_attempt(first_page_attempt, activity_revision, ["dropdown_1"], 2)
-      add_adaptive_activity_attempt(first_page_attempt, activity_revision, ["dropdown_1"], 3)
-
-      third_page_attempt =
+      first_try_on_third_page_attempt =
         setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
           attempt_number: 3,
           activity_attempt_number: 3
@@ -2020,8 +1984,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert {:ok, first_try_result} =
                Evaluate.evaluate_activity(
                  section.slug,
-                 third_page_attempt.activity_attempt.attempt_guid,
-                 dropdown_part_inputs(third_page_attempt),
+                 first_try_on_third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(first_try_on_third_page_attempt),
                  nil
                )
 
@@ -2029,7 +1993,10 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert first_try_result["out_of"] == 3.0
 
       second_try_on_third_page_attempt =
-        add_adaptive_activity_attempt(third_page_attempt, activity_revision, ["dropdown_1"], 4)
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 3,
+          activity_attempt_number: 4
+        )
 
       assert {:ok, second_try_result} =
                Evaluate.evaluate_activity(
@@ -2095,27 +2062,13 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
           }
         })
 
-      setup =
-        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
-          attempt_number: 1,
-          activity_attempt_number: 1
-        )
-
       results =
         Enum.map(1..3, fn activity_attempt_number ->
           setup =
-            case activity_attempt_number do
-              1 ->
-                setup
-
-              activity_attempt_number ->
-                add_adaptive_activity_attempt(
-                  setup,
-                  activity_revision,
-                  ["dropdown_1"],
-                  activity_attempt_number
-                )
-            end
+            setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+              attempt_number: 1,
+              activity_attempt_number: activity_attempt_number
+            )
 
           assert {:ok, result} =
                    Evaluate.evaluate_activity(

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -351,6 +351,33 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
     ]
   end
 
+  defp add_adaptive_activity_attempt(setup, activity_revision, part_ids, activity_attempt_number) do
+    activity_attempt =
+      %Core.ActivityAttempt{
+        attempt_guid: Ecto.UUID.generate(),
+        attempt_number: activity_attempt_number,
+        resource_id: activity_revision.resource_id,
+        revision_id: activity_revision.id,
+        resource_attempt_id: setup.resource_attempt.id,
+        lifecycle_state: :active,
+        scoreable: true
+      }
+      |> Oli.Repo.insert!()
+      |> Oli.Repo.preload([:revision, :resource_attempt])
+
+    part_attempts =
+      Enum.map(part_ids, fn part_id ->
+        insert(:part_attempt,
+          activity_attempt: activity_attempt,
+          part_id: part_id,
+          attempt_number: activity_attempt_number,
+          lifecycle_state: :active
+        )
+      end)
+
+    %{setup | activity_attempt: activity_attempt, part_attempts: part_attempts}
+  end
+
   describe "evaluate_activity/4 - activity type specialization routing" do
     test "routes to DirectedDiscussion.evaluate_activity for oli_directed_discussion activities" do
       user = insert(:user)
@@ -1923,7 +1950,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_attempt.out_of == 2.0
     end
 
-    test "scores adaptive attempts relative to the current page attempt" do
+    test "scores adaptive attempts by counting attempts within the current page attempt" do
       user = insert(:user)
       section = insert(:section)
 
@@ -1975,7 +2002,16 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
           }
         })
 
-      first_try_on_third_page_attempt =
+      first_page_attempt =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 1,
+          activity_attempt_number: 1
+        )
+
+      add_adaptive_activity_attempt(first_page_attempt, activity_revision, ["dropdown_1"], 2)
+      add_adaptive_activity_attempt(first_page_attempt, activity_revision, ["dropdown_1"], 3)
+
+      third_page_attempt =
         setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
           attempt_number: 3,
           activity_attempt_number: 3
@@ -1984,8 +2020,8 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert {:ok, first_try_result} =
                Evaluate.evaluate_activity(
                  section.slug,
-                 first_try_on_third_page_attempt.activity_attempt.attempt_guid,
-                 dropdown_part_inputs(first_try_on_third_page_attempt),
+                 third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(third_page_attempt),
                  nil
                )
 
@@ -1993,10 +2029,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert first_try_result["out_of"] == 3.0
 
       second_try_on_third_page_attempt =
-        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
-          attempt_number: 3,
-          activity_attempt_number: 4
-        )
+        add_adaptive_activity_attempt(third_page_attempt, activity_revision, ["dropdown_1"], 4)
 
       assert {:ok, second_try_result} =
                Evaluate.evaluate_activity(
@@ -2062,13 +2095,27 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
           }
         })
 
+      setup =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 1,
+          activity_attempt_number: 1
+        )
+
       results =
         Enum.map(1..3, fn activity_attempt_number ->
           setup =
-            setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
-              attempt_number: 1,
-              activity_attempt_number: activity_attempt_number
-            )
+            case activity_attempt_number do
+              1 ->
+                setup
+
+              activity_attempt_number ->
+                add_adaptive_activity_attempt(
+                  setup,
+                  activity_revision,
+                  ["dropdown_1"],
+                  activity_attempt_number
+                )
+            end
 
           assert {:ok, result} =
                    Evaluate.evaluate_activity(

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -332,6 +332,25 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
     Map.put(setup, :part_attempts, part_attempts)
   end
 
+  defp dropdown_part_inputs(%{part_attempts: [dropdown_attempt]}) do
+    [
+      %{
+        attempt_guid: dropdown_attempt.attempt_guid,
+        input: %StudentInput{
+          input: %{
+            "selectedIndex" => %{"path" => "stage.dropdown_1.selectedIndex", "value" => 2},
+            "selectedItem" => %{
+              "path" => "stage.dropdown_1.selectedItem",
+              "value" => "Option 2"
+            },
+            "value" => %{"path" => "stage.dropdown_1.value", "value" => "Option 2"}
+          }
+        },
+        timestamp: DateTime.utc_now()
+      }
+    ]
+  end
+
   describe "evaluate_activity/4 - activity type specialization routing" do
     test "routes to DirectedDiscussion.evaluate_activity for oli_directed_discussion activities" do
       user = insert(:user)
@@ -1902,6 +1921,168 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
 
       assert updated_attempt.score == 2.0
       assert updated_attempt.out_of == 2.0
+    end
+
+    test "scores adaptive attempts relative to the current page attempt" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 3, "maxAttempt" => 3},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"]
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => ["stage.dropdown_1.selectedIndex"],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "r.correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.dropdown_1.selectedIndex",
+                      "operator" => "equal",
+                      "value" => "2"
+                    }
+                  ]
+                },
+                "event" => %{
+                  "type" => "r.correct",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      first_try_on_third_page_attempt =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 3,
+          activity_attempt_number: 3
+        )
+
+      assert {:ok, first_try_result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 first_try_on_third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(first_try_on_third_page_attempt),
+                 nil
+               )
+
+      assert first_try_result["score"] == 3.0
+      assert first_try_result["out_of"] == 3.0
+
+      second_try_on_third_page_attempt =
+        setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+          attempt_number: 3,
+          activity_attempt_number: 4
+        )
+
+      assert {:ok, second_try_result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 second_try_on_third_page_attempt.activity_attempt.attempt_guid,
+                 dropdown_part_inputs(second_try_on_third_page_attempt),
+                 nil
+               )
+
+      assert second_try_result["score"] == 2.0
+      assert second_try_result["out_of"] == 3.0
+    end
+
+    test "preserves adaptive retry scoring within the first page attempt" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 3, "maxAttempt" => 3},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"]
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => ["stage.dropdown_1.selectedIndex"],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "r.correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.dropdown_1.selectedIndex",
+                      "operator" => "equal",
+                      "value" => "2"
+                    }
+                  ]
+                },
+                "event" => %{
+                  "type" => "r.correct",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      results =
+        Enum.map(1..3, fn activity_attempt_number ->
+          setup =
+            setup_adaptive_activity_attempt(user, section, activity_revision, ["dropdown_1"],
+              attempt_number: 1,
+              activity_attempt_number: activity_attempt_number
+            )
+
+          assert {:ok, result} =
+                   Evaluate.evaluate_activity(
+                     section.slug,
+                     setup.activity_attempt.attempt_guid,
+                     dropdown_part_inputs(setup),
+                     nil
+                   )
+
+          result
+        end)
+
+      assert Enum.map(results, & &1["score"]) == [3.0, 2.0, 1.0]
+      assert Enum.map(results, & &1["out_of"]) == [3.0, 3.0, 3.0]
     end
 
     test "respects explicit screen score mutations and copies them to submitted part inputs" do


### PR DESCRIPTION
Fixes adaptive attempt-based scoring so first tries on later page attempts are scored as attempt 1.

Adaptive activity attempts use an absolute attempt number that advances along with the page/resource attempt. For example, when a learner starts page attempt 3, the first adaptive activity attempt on that page can also have `attempt_number: 3`.

That absolute activity attempt number is useful for persistence, ordering, and analytics, but it is not the same thing as the learner’s try number within the current page attempt. Attempt-based adaptive scoring needs the screen-local try count:

- Page attempt 3, first try on the screen should score as try 1.
- Page attempt 3, second try on the screen should score as try 2.

Previously, adaptive scoring passed the absolute activity attempt number directly as `currentAttemptNumber`, so a first correct answer on page attempt 3 could be treated as try 3 and receive reduced credit.

This changes adaptive scoring to calculate the screen-local attempt number as:

`activity_attempt_number - resource_attempt_number + 1`

The same relative calculation is applied in the client-side adaptive check path.

See: https://eliterate.atlassian.net/browse/MER-5665