### PR TITLE
[ENHANCEMENT] [MER-5669] Making the LTI launch more realistic 

### DIFF
--- a/assets/automation/tests/torus/lti/canvas_playwright.md
+++ b/assets/automation/tests/torus/lti/canvas_playwright.md
@@ -11,8 +11,9 @@ Last updated on May 28, 2026.
 The current LTI spec is `assets/automation/tests/torus/lti/launch.spec.ts`.
 
 It creates isolated Canvas state for each run, launches Tokamak through Canvas,
-creates a Torus LTI section from the first-launch setup wizard, and then deletes
-the temporary Canvas course.
+creates a Torus LTI section from the first-launch setup wizard, deletes that
+Torus section from the manage page, and then deletes the temporary Canvas
+course.
 
 The default source/project searched in Torus is:
 
@@ -30,8 +31,8 @@ The generated Torus section number is:
 
 - `lti-<timestamp>`
 
-Canvas cleanup is handled by the spec. Torus sections created in Tokamak are not
-currently cleaned up by the test.
+Canvas cleanup is handled by the spec. Successful runs also delete the Torus
+section from the manage page before deleting the temporary Canvas course.
 
 ## Required Local Environment
 
@@ -72,7 +73,8 @@ For each run it:
 4. Publishes the module.
 5. Publishes the module item.
 6. Launches the tool from the Canvas UI.
-7. Deletes the temporary Canvas course in a `finally` block.
+7. Deletes the Torus section from the manage page.
+8. Deletes the temporary Canvas course in a `finally` block.
 
 Read-only API inspection of the historical fixed course showed:
 
@@ -132,6 +134,11 @@ The current selectors rely on:
   `#section_preferred_scheduling_time`.
 - The modality label `Never, it's a self paced course`.
 - Final redirect to `/sections/:section_slug/manage`.
+- Manage page cleanup button `Delete Section`.
+- Delete confirmation modal `#delete_section_modal`.
+- Delete confirmation button `Delete this section`.
+- After deletion, Tokamak may redirect to `/sections` or back to
+  `/sections/new/:context_id` for the same LTI context.
 
 After selecting a source, the stepper collects the course name, course section
 number, modality, dates, and schedule details. Creating the section calls

--- a/assets/automation/tests/torus/lti/canvas_playwright.md
+++ b/assets/automation/tests/torus/lti/canvas_playwright.md
@@ -1,0 +1,196 @@
+# Canvas Playwright LTI Notes
+
+This note preserves the working assumptions for the Torus Canvas LTI launch
+automation. It is intentionally free of real credentials and should be updated
+when the Canvas setup or launch flow changes.
+
+Last updated on May 28, 2026.
+
+## Current Test
+
+The current LTI spec is `assets/automation/tests/torus/lti/launch.spec.ts`.
+
+It creates isolated Canvas state for each run, launches Tokamak through Canvas,
+creates a Torus LTI section from the first-launch setup wizard, and then deletes
+the temporary Canvas course.
+
+The default source/project searched in Torus is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+The generated Canvas course name is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE lti-<timestamp>`
+
+The generated Torus section name is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+The generated Torus section number is:
+
+- `lti-<timestamp>`
+
+Canvas cleanup is handled by the spec. Torus sections created in Tokamak are not
+currently cleaned up by the test.
+
+## Required Local Environment
+
+Do not commit real Canvas credentials or API tokens.
+
+The spec requires these local environment variables:
+
+- `CANVAS_UI_EMAIL`
+- `CANVAS_UI_PASSWORD`
+- `CANVAS_ACCOUNT_ID`
+- `CANVAS_API_TOKEN`
+
+Optional overrides:
+
+- `CANVAS_BASE_URL`, default `https://canvas.oli.cmu.edu`
+- `CANVAS_TOOL_NAME`, default `OLI Torus (tokamak)`
+- `CANVAS_TOOL_LAUNCH_URL`, default `https://tokamak.oli.cmu.edu/lti/launch`
+- `TORUS_LTI_SOURCE_TITLE`, default `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+As of May 28, 2026, the local Canvas API env values were validated without
+printing the token:
+
+- `CANVAS_BASE_URL` points at `https://canvas.oli.cmu.edu`.
+- `CANVAS_ACCOUNT_ID` is `1`.
+- The account API identifies account `1` as `Open Learning Initiative`.
+- The token can read account courses.
+- The token reports `manage_courses: true`, `manage_account_settings: true`,
+  and `manage_developer_keys: true`.
+
+## Canvas API Provisioning
+
+The spec uses the Canvas API to avoid relying on a pre-existing Canvas course.
+For each run it:
+
+1. Creates a course in the configured Canvas account.
+2. Creates a module named `Torus LTI Launch`.
+3. Creates an external tool module item for `OLI Torus (tokamak)`.
+4. Publishes the module.
+5. Publishes the module item.
+6. Launches the tool from the Canvas UI.
+7. Deletes the temporary Canvas course in a `finally` block.
+
+Read-only API inspection of the historical fixed course showed:
+
+- Account-level external tool id `68` is `OLI Torus (tokamak)`.
+- Tool launch URL is `https://tokamak.oli.cmu.edu/lti/launch`.
+- Course `682` has module `437`.
+- Module item `917` is type `ExternalTool`, content id `68`, published, and
+  configured with `new_tab: true`.
+
+A write smoke test confirmed that Canvas accepts this provisioning flow:
+
+1. `POST /api/v1/accounts/:account_id/courses`
+2. `POST /api/v1/courses/:course_id/modules`
+3. `POST /api/v1/courses/:course_id/modules/:module_id/items`
+4. `PUT /api/v1/courses/:course_id/modules/:module_id` with
+   `module[published]=true`
+5. `PUT /api/v1/courses/:course_id/modules/:module_id/items/:item_id` with
+   `module_item[published]=true`
+
+Canvas did not publish the module and item when `published=true` was sent only
+during creation, so the follow-up `PUT` requests are required.
+
+## Torus First-Launch Section Creation
+
+A disposable Canvas course launch was inspected on May 28, 2026. After Canvas
+launched `OLI Torus (tokamak)` for a new Canvas course with no existing Torus
+section, Torus redirected to:
+
+- `/sections/new/:context_id`
+
+The visible UI was the `New course set up` stepper with:
+
+- Step 1: `Select your source materials`
+- Step 2: `Name your course`
+- Step 3: `Course details`
+
+The first step is headed `Select source` and shows `Select Curriculum`, a search
+box, card/list view controls, pagination, and source cards. The `Next step`
+button is disabled until a source is selected.
+
+The source list comes from `Publishing.retrieve_visible_sources(user,
+institution)` for LTI launches. Source rows are either:
+
+- `publication:<id>` for a published project source
+- `product:<id>` for a template/product source
+
+The current selectors rely on:
+
+- `iframe[name="tool_content"]` when Canvas embeds the launch.
+- The visible `Load OLI Torus (tokamak) in a new window` button when Canvas
+  requires a popup/new tab launch.
+- Torus search placeholder `Search...`.
+- Search result summary text `Results filtered on "<source title>"`.
+- Source card links with `.course-card-link`.
+- Wizard fields `#section_title`, `#section_course_section_number`,
+  `#section_start_date`, `#section_end_date`, and
+  `#section_preferred_scheduling_time`.
+- The modality label `Never, it's a self paced course`.
+- Final redirect to `/sections/:section_slug/manage`.
+
+After selecting a source, the stepper collects the course name, course section
+number, modality, dates, and schedule details. Creating the section calls
+`Delivery.create_section(changeset, source, current_user, section_spec)`, where
+`section_spec` is an LTI section specification built from the latest LTI params
+for the launched Canvas context.
+
+## Historical Fixed Course
+
+The old version of this test used a fixed Canvas course and pre-existing Torus
+section. These details are retained only as debugging context:
+
+- Canvas course: `Second Test Second`
+- Canvas course path: `/courses/682`
+- Canvas module item path: `/courses/682/modules/items/917`
+- Tool link text: `OLI Torus (tokamak)`
+- The popup reached Torus at `/sections/second_test_second_w49b5/manage`.
+- The Torus section details page showed:
+  - Course Section ID `second_test_second_w49b5`
+  - Course Section Type `LTI`
+  - Institution `OLI Test Canvas testing`
+  - Instructor `Instructor, Dovid Playwright`
+
+Treat these ids and slugs as fixture details, not stable test design.
+
+## What To Inspect When Updating Selectors
+
+Codex does not automatically see the user's browser. To understand the current
+Canvas or Torus interface, inspect Playwright outputs from a local run:
+
+- `assets/automation/test-results/**/trace.zip`
+- `assets/automation/test-results/**/*.png`
+- `assets/automation/playwright-report/index.html`
+- Playwright locator errors and action logs
+- DOM or accessibility snapshots captured during debugging
+
+Prefer stable selectors in this order:
+
+- Accessible roles and names (`getByRole`, `getByLabel`, visible link names).
+- Stable frame names such as `iframe[name="tool_content"]`.
+- Stable app-controlled attributes, if present.
+- CSS or generated Canvas ids only when no better selector exists.
+
+## Run Command
+
+From `assets/automation`:
+
+```bash
+npm run pw -- tests/torus/lti/launch.spec.ts --project "Google Chrome"
+```
+
+If using a local env file from the repository root:
+
+```bash
+set -a
+source ../../oli.env
+set +a
+npm run pw -- tests/torus/lti/launch.spec.ts --project "Google Chrome"
+```
+
+Do not paste command output that includes credentials into tickets, docs, or PR
+comments.

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -328,11 +328,13 @@ type RoleScope = {
   locator(selector: string): Locator;
 };
 
-async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'getByRole'>) {
-  const acceptButton = scope.getByRole('button', { name: 'Accept' });
+async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'locator'>) {
+  const cookieModal = scope.locator('#cookie_consent_display');
+  const acceptButton = cookieModal.getByRole('button', { name: /^Accept$/ });
 
-  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await acceptButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
     await acceptButton.click();
+    await expect(cookieModal).toBeHidden({ timeout: 5_000 });
   }
 }
 
@@ -382,8 +384,12 @@ async function createTorusSectionFromLaunch(
 
 async function deleteTorusSectionFromManage(scope: RoleScope) {
   await waitForLiveView(scope);
+
   const deleteSectionButton = scope.getByRole('button', { name: 'Delete Section' });
   await expect(deleteSectionButton).toBeVisible({ timeout: 15_000 });
+
+  await acceptCookiesIfVisible(scope);
+
   await deleteSectionButton.click();
 
   const modal = scope.locator('#delete_section_modal');

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -1,5 +1,40 @@
 import { expect, Locator, Page, test } from '@playwright/test';
 
+type CanvasCourse = {
+  id: number;
+  name: string;
+  workflow_state?: string;
+  html_url?: string;
+};
+
+type CanvasModule = {
+  id: number;
+  name: string;
+  published?: boolean;
+};
+
+type CanvasModuleItem = {
+  id: number;
+  title: string;
+  type: string;
+  content_id?: number;
+  external_url?: string;
+  html_url?: string;
+  new_tab?: boolean;
+  published?: boolean;
+};
+
+type CanvasLaunchCourse = {
+  course: CanvasCourse;
+  module: CanvasModule;
+  item: CanvasModuleItem;
+};
+
+const DEFAULT_CANVAS_BASE_URL = 'https://canvas.oli.cmu.edu';
+const DEFAULT_TOOL_NAME = 'OLI Torus (tokamak)';
+const DEFAULT_TOOL_LAUNCH_URL = 'https://tokamak.oli.cmu.edu/lti/launch';
+const DEFAULT_TORUS_SOURCE_TITLE = 'PLAYWRIGHT_AUTOMATION_DONT_DELETE';
+
 const requireEnv = (name: string) => {
   const value = process.env[name];
 
@@ -11,63 +46,245 @@ const requireEnv = (name: string) => {
 };
 
 test('test simple LTI launch @nightly', async ({ page }) => {
+  test.setTimeout(120_000);
+
   const canvasEmail = requireEnv('CANVAS_UI_EMAIL');
   const canvasPassword = requireEnv('CANVAS_UI_PASSWORD');
-  const toolName = 'OLI Torus (tokamak)';
+  const canvasBaseUrl = process.env.CANVAS_BASE_URL || DEFAULT_CANVAS_BASE_URL;
+  const canvasAccountId = requireEnv('CANVAS_ACCOUNT_ID');
+  const canvasApiToken = requireEnv('CANVAS_API_TOKEN');
+  const toolName = process.env.CANVAS_TOOL_NAME || DEFAULT_TOOL_NAME;
+  const toolLaunchUrl = process.env.CANVAS_TOOL_LAUNCH_URL || DEFAULT_TOOL_LAUNCH_URL;
+  const torusSourceTitle = process.env.TORUS_LTI_SOURCE_TITLE || DEFAULT_TORUS_SOURCE_TITLE;
+  const runId = `lti-${Date.now()}`;
+  const sectionTitle = torusSourceTitle;
+  let launchCourse: CanvasLaunchCourse | null = null;
 
-  await page.goto('https://canvas.oli.cmu.edu/login/canvas');
-  await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
-  await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
-  await Promise.all([
-    page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
-    page.getByRole('button', { name: 'Log In' }).click(),
-  ]);
+  try {
+    launchCourse = await createCanvasLaunchCourse({
+      baseUrl: canvasBaseUrl,
+      accountId: canvasAccountId,
+      token: canvasApiToken,
+      courseName: `${torusSourceTitle} ${runId}`,
+      toolName,
+      toolLaunchUrl,
+    });
 
-  await page.getByRole('link', { name: 'Second Test Second', exact: true }).click();
-  await page.getByRole('main').getByRole('link', { name: toolName }).last().click();
+    await page.goto(`${canvasBaseUrl}/login/canvas`);
+    await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
+    await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
+    await Promise.all([
+      page.waitForURL(`${canvasBaseUrl}/?login_success=1`),
+      page.getByRole('button', { name: 'Log In' }).click(),
+    ]);
 
-  const toolFrame = page.frameLocator('iframe[name="tool_content"]');
-  const newWindowButton = await findNewWindowButton(page, toolName);
+    await page.goto(`${canvasBaseUrl}/courses/${launchCourse.course.id}`);
+    await Promise.all([
+      page.waitForURL(/\/courses\/\d+\/modules\/items\/\d+/, { timeout: 15_000 }),
+      page.getByRole('main').getByRole('link', { name: toolName }).last().click(),
+    ]);
+    await page.waitForLoadState('domcontentloaded');
 
-  if (newWindowButton != null) {
-    const currentUrl = page.url();
-    const popupPromise = page.waitForEvent('popup', { timeout: 10_000 }).catch(() => null);
-    const contextPagePromise = page
-      .context()
-      .waitForEvent('page', { timeout: 10_000 })
-      .catch(() => null);
-    const navigationPromise = page
-      .waitForURL((url) => url.toString() !== currentUrl, { timeout: 10_000 })
-      .then(() => page)
-      .catch(() => null);
+    const toolFrame = page.frameLocator('iframe[name="tool_content"]');
+    const newWindowButton = await findNewWindowButton(page, toolName);
 
-    await newWindowButton.click();
+    if (newWindowButton != null) {
+      const toolPage = await openToolInNewWindow(page, newWindowButton);
 
-    const toolPage =
-      (await Promise.race([popupPromise, contextPagePromise, navigationPromise])) ?? page;
+      await acceptCookiesIfVisible(toolPage);
+      await createTorusSectionFromLaunch(toolPage, {
+        sourceTitle: torusSourceTitle,
+        sectionTitle,
+        sectionNumber: runId,
+      });
 
-    await toolPage.waitForLoadState('domcontentloaded');
-    await toolPage.bringToFront();
-
-    const acceptButton = toolPage.getByRole('button', { name: 'Accept' });
-
-    if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await acceptButton.click();
+      await expect(toolPage).toHaveURL(/\/sections\/[^/]+\/manage$/, { timeout: 60_000 });
+      await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
+      await expect(toolPage.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+      return;
     }
 
-    await clickGoToCourseIfVisible(toolPage);
-    await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
-    return;
-  }
+    await acceptCookiesIfVisible(toolFrame);
+    await createTorusSectionFromLaunch(toolFrame, {
+      sourceTitle: torusSourceTitle,
+      sectionTitle,
+      sectionNumber: runId,
+    });
 
-  const acceptButton = toolFrame.getByRole('button', { name: 'Accept' });
-  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    await acceptButton.click();
+    await expect(toolFrame.getByRole('link', { name: 'Overview' })).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(toolFrame.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+  } finally {
+    if (launchCourse != null) {
+      await deleteCanvasCourse({
+        baseUrl: canvasBaseUrl,
+        token: canvasApiToken,
+        courseId: launchCourse.course.id,
+      });
+    }
   }
-
-  await clickGoToCourseIfVisible(toolFrame);
-  await expect(toolFrame.getByRole('link', { name: 'Overview' })).toBeVisible();
 });
+
+async function createCanvasLaunchCourse({
+  baseUrl,
+  accountId,
+  token,
+  courseName,
+  toolName,
+  toolLaunchUrl,
+}: {
+  baseUrl: string;
+  accountId: string;
+  token: string;
+  courseName: string;
+  toolName: string;
+  toolLaunchUrl: string;
+}): Promise<CanvasLaunchCourse> {
+  const course = await canvasApiRequest<CanvasCourse>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/accounts/${accountId}/courses`,
+    {
+      'course[name]': courseName,
+      'course[course_code]': courseName,
+      offer: 'true',
+    },
+  );
+
+  let module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules`,
+    {
+      'module[name]': 'Torus LTI Launch',
+    },
+  );
+
+  let item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items`,
+    {
+      'module_item[type]': 'ExternalTool',
+      'module_item[title]': toolName,
+      'module_item[external_url]': toolLaunchUrl,
+      'module_item[new_tab]': 'true',
+    },
+  );
+
+  module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}`,
+    {
+      'module[published]': 'true',
+    },
+  );
+
+  item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items/${item.id}`,
+    {
+      'module_item[published]': 'true',
+    },
+  );
+
+  return { course, module, item };
+}
+
+async function deleteCanvasCourse({
+  baseUrl,
+  token,
+  courseId,
+}: {
+  baseUrl: string;
+  token: string;
+  courseId: number;
+}) {
+  await canvasApiRequest(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
+    event: 'delete',
+  });
+}
+
+async function canvasApiRequest<T>(
+  baseUrl: string,
+  token: string,
+  method: string,
+  path: string,
+  params: Record<string, string> = {},
+): Promise<T> {
+  const url = new URL(path, baseUrl);
+  const options: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  if (method === 'GET') {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.append(key, value);
+    }
+  } else {
+    options.headers = {
+      ...options.headers,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    options.body = new URLSearchParams(params);
+  }
+
+  const response = await fetch(url, options);
+  const text = await response.text();
+  const body = parseCanvasResponse(text);
+
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${path} failed (${response.status}): ${
+        typeof body === 'string' ? body : JSON.stringify(body)
+      }`,
+    );
+  }
+
+  return body as T;
+}
+
+function parseCanvasResponse(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function openToolInNewWindow(page: Page, newWindowButton: Locator) {
+  const currentUrl = page.url();
+  const popupPromise = page.waitForEvent('popup', { timeout: 10_000 }).catch(() => null);
+  const contextPagePromise = page
+    .context()
+    .waitForEvent('page', { timeout: 10_000 })
+    .catch(() => null);
+  const navigationPromise = page
+    .waitForURL((url) => url.toString() !== currentUrl, { timeout: 10_000 })
+    .then(() => page)
+    .catch(() => null);
+
+  await newWindowButton.click();
+
+  const toolPage =
+    (await Promise.race([popupPromise, contextPagePromise, navigationPromise])) ?? page;
+
+  await toolPage.waitForLoadState('domcontentloaded');
+  await toolPage.bringToFront();
+
+  return toolPage;
+}
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -86,7 +303,9 @@ async function findNewWindowButton(page: Page, toolName: string) {
   for (const candidate of candidates) {
     const button = candidate.first();
 
-    if (await button.isVisible({ timeout: 3000 }).catch(() => false)) {
+    const timeout = candidate === candidates[0] ? 15_000 : 3000;
+
+    if (await button.isVisible({ timeout }).catch(() => false)) {
       return button;
     }
   }
@@ -96,12 +315,69 @@ async function findNewWindowButton(page: Page, toolName: string) {
 
 type RoleScope = {
   getByRole(role: 'button', options: { name: string | RegExp }): Locator;
+  getByPlaceholder(text: string | RegExp): Locator;
+  getByText(text: string | RegExp, options?: { exact?: boolean }): Locator;
+  locator(selector: string): Locator;
 };
 
-async function clickGoToCourseIfVisible(scope: RoleScope) {
-  const goToCourseButton = scope.getByRole('button', { name: /^Go to course$/i });
+async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'getByRole'>) {
+  const acceptButton = scope.getByRole('button', { name: 'Accept' });
 
-  if (await goToCourseButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
-    await goToCourseButton.click();
+  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await acceptButton.click();
   }
+}
+
+async function createTorusSectionFromLaunch(
+  scope: RoleScope,
+  {
+    sourceTitle,
+    sectionTitle,
+    sectionNumber,
+  }: { sourceTitle: string; sectionTitle: string; sectionNumber: string },
+) {
+  await expect(scope.getByText('Select source')).toBeVisible();
+  const searchInput = scope.getByPlaceholder('Search...');
+  await searchInput.fill('');
+  await searchInput.pressSequentially(sourceTitle, { delay: 20 });
+  await scope.getByRole('button', { name: 'Search' }).click();
+  await expect(scope.getByText(`Results filtered on "${sourceTitle}"`)).toBeVisible();
+
+  const sourceCard = scope
+    .locator('.course-card-link')
+    .filter({ has: scope.getByText(sourceTitle, { exact: true }) })
+    .first();
+
+  await expect(sourceCard).toBeVisible();
+  await sourceCard.click();
+  const nextStepButton = scope.getByRole('button', { name: 'Next step' });
+  await expect(nextStepButton).toBeEnabled();
+  await nextStepButton.click();
+
+  await expect(
+    scope.locator('#stepper_content').getByRole('heading', { name: 'Name your course' }),
+  ).toBeVisible();
+  await scope.locator('#section_title').fill(sectionTitle);
+  await scope.locator('#section_course_section_number').fill(sectionNumber);
+  await scope.getByText("Never, it's a self paced course", { exact: true }).click();
+  await expect(nextStepButton).toBeEnabled();
+  await nextStepButton.click();
+
+  await expect(
+    scope.locator('#stepper_content').getByRole('heading', { name: 'Course details' }),
+  ).toBeVisible();
+  await scope.locator('#section_start_date').fill(formatDatetimeLocal(daysFromNow(0)));
+  await scope.locator('#section_end_date').fill(formatDatetimeLocal(daysFromNow(365)));
+  await scope.locator('#section_preferred_scheduling_time').fill('09:00');
+  await scope.getByRole('button', { name: 'Create section' }).click();
+}
+
+function daysFromNow(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+function formatDatetimeLocal(date: Date) {
+  return date.toISOString().slice(0, 16);
 }

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -101,6 +101,8 @@ test('test simple LTI launch @nightly', async ({ page }) => {
       await expect(toolPage).toHaveURL(/\/sections\/[^/]+\/manage$/, { timeout: 60_000 });
       await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
       await expect(toolPage.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+      await deleteTorusSectionFromManage(toolPage);
+      await expect(toolPage).toHaveURL(/\/sections(?:$|\/new\/[^/]+$)/, { timeout: 15_000 });
       return;
     }
 
@@ -115,6 +117,12 @@ test('test simple LTI launch @nightly', async ({ page }) => {
       timeout: 60_000,
     });
     await expect(toolFrame.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+    await deleteTorusSectionFromManage(toolFrame);
+    await expect(
+      toolFrame
+        .getByText('Section successfully deleted.')
+        .or(toolFrame.getByText('New course set up')),
+    ).toBeVisible({ timeout: 15_000 });
   } finally {
     if (launchCourse != null) {
       await deleteCanvasCourse({
@@ -370,6 +378,23 @@ async function createTorusSectionFromLaunch(
   await scope.locator('#section_end_date').fill(formatDatetimeLocal(daysFromNow(365)));
   await scope.locator('#section_preferred_scheduling_time').fill('09:00');
   await scope.getByRole('button', { name: 'Create section' }).click();
+}
+
+async function deleteTorusSectionFromManage(scope: RoleScope) {
+  await waitForLiveView(scope);
+  const deleteSectionButton = scope.getByRole('button', { name: 'Delete Section' });
+  await expect(deleteSectionButton).toBeVisible({ timeout: 15_000 });
+  await deleteSectionButton.click();
+
+  const modal = scope.locator('#delete_section_modal');
+  await expect(modal).toBeVisible({ timeout: 15_000 });
+  await modal.getByRole('button', { name: 'Delete this section' }).click();
+}
+
+async function waitForLiveView(scope: Pick<RoleScope, 'locator'>) {
+  await expect(scope.locator('[data-phx-main].phx-connected').first()).toBeAttached({
+    timeout: 15_000,
+  });
 }
 
 function daysFromNow(days: number) {


### PR DESCRIPTION
Changed the existing LTI test to be more realistic.

Before:

- It depended on the existing Canvas course "Second Test Second."
- It only verified launch into an already-created Torus section.
- It prevented other users with different canvas creds from running it themselves unless they created a section titled "Second Test Second"
- Now:

- It creates a fresh Canvas course through the Canvas API for each run.
- It creates and publishes a module and OLI Torus (tokamak) external tool item.
- It launches Tokamak through Canvas like a real instructor would. (In a new window, not iframe)
- It searches for PLAYWRIGHT_AUTOMATION_DONT_DELETE.
- It completes the Torus first-launch section creation wizard.
- Accepts cookies if that modal appears
- It verifies the new section reaches the Torus manage page.
- It deletes the temporary Canvas course as well as it's torus section