### PR TITLE
[BUG FIX] [MER-5667] Fix reCAPTCHA visibility check for support modal

### DIFF
--- a/assets/src/hooks/recaptcha.ts
+++ b/assets/src/hooks/recaptcha.ts
@@ -2,15 +2,16 @@ import { isDarkMode } from 'utils/browser';
 
 type RecaptchaEl = HTMLElement & { dataset: DOMStringMap };
 
-const isVisible = (el: HTMLElement) => {
-  const modal = el.closest('[role="dialog"]') as HTMLElement | null;
-  const target = modal || el;
+const isStyleVisible = (style: CSSStyleDeclaration) =>
+  style.display !== 'none' && style.visibility !== 'hidden';
 
-  return (
-    !target.classList.contains('hidden') &&
-    target.offsetParent !== null &&
-    window.getComputedStyle(target).display !== 'none'
-  );
+const isVisible = (el: HTMLElement) => {
+  const modal = el.closest('[role="dialog"]')?.parentElement as HTMLElement | null;
+  const target = modal || el;
+  const targetStyle = window.getComputedStyle(target);
+  const elStyle = window.getComputedStyle(el);
+
+  return isStyleVisible(targetStyle) && isStyleVisible(elStyle);
 };
 
 const renderRecaptcha = (el: RecaptchaEl) => {
@@ -25,7 +26,11 @@ const renderRecaptcha = (el: RecaptchaEl) => {
   }
 
   const theme = el.getAttribute('data-theme') || (isDarkMode() ? 'dark' : 'light');
-  const widgetId = grecaptcha.render(el.id, { theme });
+  const sitekey = el.dataset.sitekey;
+
+  if (!sitekey) return false;
+
+  const widgetId = grecaptcha.render(el.id, { sitekey, theme });
 
   el.dataset.recaptchaRendered = 'true';
   el.dataset.recaptchaWidgetId = String(widgetId);


### PR DESCRIPTION
[MER-5667](https://eliterate.atlassian.net/browse/MER-5667)

## Summary

Fixes the reCAPTCHA rendering issue in the Tech Support modal.

The previous visibility check relied on `offsetParent`, which can be `null` for fixed-position modal content even when the modal is visible. As a result, the Recaptcha hook could skip rendering the widget, leaving the support form unable to submit successfully.

### Changes

- Updated the Recaptcha hook visibility check to use computed `display` / `visibility` styles instead of `offsetParent`.
- Passed the `sitekey` explicitly when calling `grecaptcha.render`.
- Kept the existing retry/observer behavior to wait for reCAPTCHA and modal visibility.


https://github.com/user-attachments/assets/831550cf-c10f-4235-a8e9-49d512b2d114



[MER-5667]: https://eliterate.atlassian.net/browse/MER-5667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ