### PR TITLE
[BUG FIX] [MER-5668] Render file upload submissions as download links in manual scoring

### DIFF
--- a/lib/oli_web/live/manual_grading/selected_submission.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission.ex
@@ -190,6 +190,36 @@ defmodule OliWeb.ManualGrading.SelectedSubmission do
     """
   end
 
+  defp render_response_view(%{kind: :files} = view) do
+    assigns = %{view: view}
+
+    ~H"""
+    <div class="rounded-xl bg-Surface-surface-secondary-muted px-4 py-4">
+      <div class="text-sm font-semibold text-Text-text-high">{@view.prompt}</div>
+      <div :if={@view.description} class="mt-1 text-sm text-Text-text-low">{@view.description}</div>
+
+      <div :if={@view.files == []} class="mt-4 text-sm text-Text-text-low">
+        No files uploaded
+      </div>
+
+      <div :if={@view.files != []} class="mt-4 space-y-3">
+        <a
+          :for={file <- @view.files}
+          href={file.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center justify-between gap-3 rounded-lg border border-Border-border-subtle bg-Surface-surface-primary px-4 py-3 text-sm font-medium text-Text-text-accent-blue hover:underline"
+        >
+          <span class="min-w-0 break-words">{file.name}</span>
+          <span class="shrink-0 text-xs font-semibold uppercase tracking-wide text-Text-text-low">
+            Download
+          </span>
+        </a>
+      </div>
+    </div>
+    """
+  end
+
   defp render_response_view(_view) do
     assigns = %{}
 

--- a/lib/oli_web/live/manual_grading/selected_submission.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission.ex
@@ -215,6 +215,7 @@ defmodule OliWeb.ManualGrading.SelectedSubmission do
           <span class="shrink-0 text-xs font-semibold uppercase tracking-wide text-Text-text-low">
             Open
           </span>
+          <span class="sr-only">(opens in a new tab)</span>
         </a>
       </div>
     </div>

--- a/lib/oli_web/live/manual_grading/selected_submission.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission.ex
@@ -208,11 +208,12 @@ defmodule OliWeb.ManualGrading.SelectedSubmission do
           href={file.url}
           target="_blank"
           rel="noopener noreferrer"
+          title={"Open #{file.name} in a new tab"}
           class="flex items-center justify-between gap-3 rounded-lg border border-Border-border-subtle bg-Surface-surface-primary px-4 py-3 text-sm font-medium text-Text-text-accent-blue hover:underline"
         >
           <span class="min-w-0 break-words">{file.name}</span>
           <span class="shrink-0 text-xs font-semibold uppercase tracking-wide text-Text-text-low">
-            Download
+            Open
           </span>
         </a>
       </div>

--- a/lib/oli_web/live/manual_grading/selected_submission_builder.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission_builder.ex
@@ -500,23 +500,51 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
 
   defp normalize_uploaded_file(_), do: nil
 
-  # Student-submitted responses are stored verbatim, so only allow http(s) urls
-  # to be rendered as links to avoid `javascript:`/`data:` injection in the grading UI.
-  defp safe_file_url(url) do
+  # Student-submitted responses are stored verbatim, so only render links for binary
+  # http(s) urls whose host matches the configured media host. This avoids crashing on
+  # malformed (non-binary) urls and prevents `javascript:`/`data:` or arbitrary external
+  # links (phishing) from being surfaced to graders.
+  defp safe_file_url(url) when is_binary(url) do
     case blank_to_nil(url) do
       nil ->
         nil
 
       trimmed ->
         case URI.parse(trimmed) do
-          %URI{scheme: scheme} when scheme in ["http", "https"] -> trimmed
-          _ -> nil
+          %URI{scheme: scheme, host: host}
+          when scheme in ["http", "https"] and is_binary(host) ->
+            if allowed_media_host?(host), do: trimmed, else: nil
+
+          _ ->
+            nil
         end
     end
   end
 
+  defp safe_file_url(_), do: nil
+
+  defp allowed_media_host?(host) do
+    case media_host() do
+      nil -> true
+      media_host -> host == media_host
+    end
+  end
+
+  defp media_host do
+    case Application.get_env(:oli, :media_url) do
+      url when is_binary(url) -> URI.parse(url).host
+      _ -> nil
+    end
+  end
+
   defp uploaded_file_name(file, url) do
-    blank_to_nil(Map.get(file, "name") || Map.get(file, :name)) ||
+    explicit_name =
+      case Map.get(file, "name") || Map.get(file, :name) do
+        name when is_binary(name) -> blank_to_nil(name)
+        _ -> nil
+      end
+
+    explicit_name ||
       blank_to_nil(url |> String.split("/") |> List.last()) ||
       "Attachment"
   end

--- a/lib/oli_web/live/manual_grading/selected_submission_builder.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission_builder.ex
@@ -479,7 +479,7 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
     }
   end
 
-  defp file_upload_description([]), do: "No files uploaded"
+  defp file_upload_description([]), do: nil
   defp file_upload_description([_]), do: "1 file submitted"
   defp file_upload_description(files), do: "#{length(files)} files submitted"
 
@@ -492,13 +492,28 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
   defp uploaded_files(_), do: []
 
   defp normalize_uploaded_file(file) when is_map(file) do
-    case blank_to_nil(Map.get(file, "url") || Map.get(file, :url)) do
+    case safe_file_url(Map.get(file, "url") || Map.get(file, :url)) do
       nil -> nil
       url -> %{name: uploaded_file_name(file, url), url: url}
     end
   end
 
   defp normalize_uploaded_file(_), do: nil
+
+  # Student-submitted responses are stored verbatim, so only allow http(s) urls
+  # to be rendered as links to avoid `javascript:`/`data:` injection in the grading UI.
+  defp safe_file_url(url) do
+    case blank_to_nil(url) do
+      nil ->
+        nil
+
+      trimmed ->
+        case URI.parse(trimmed) do
+          %URI{scheme: scheme} when scheme in ["http", "https"] -> trimmed
+          _ -> nil
+        end
+    end
+  end
 
   defp uploaded_file_name(file, url) do
     blank_to_nil(Map.get(file, "name") || Map.get(file, :name)) ||

--- a/lib/oli_web/live/manual_grading/selected_submission_builder.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission_builder.ex
@@ -180,6 +180,10 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
     build_regular_prose_view("oli_short_answer", attempt, part_attempt)
   end
 
+  defp build_submission_view("oli_file_upload", attempt, part_attempt, _metadata) do
+    build_file_upload_view(attempt, part_attempt)
+  end
+
   defp build_submission_view(activity_slug, attempt, part_attempt, _metadata) do
     case extract_input_value(part_attempt) do
       nil ->
@@ -462,6 +466,44 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
       description: "Submission data for this input",
       details: details
     }
+  end
+
+  defp build_file_upload_view(attempt, part_attempt) do
+    files = uploaded_files(part_attempt.response)
+
+    %{
+      kind: :files,
+      prompt: regular_prompt(attempt.revision.content) || "File Upload",
+      description: file_upload_description(files),
+      files: files
+    }
+  end
+
+  defp file_upload_description([]), do: "No files uploaded"
+  defp file_upload_description([_]), do: "1 file submitted"
+  defp file_upload_description(files), do: "#{length(files)} files submitted"
+
+  defp uploaded_files(%{"files" => files}) when is_list(files) do
+    files
+    |> Enum.map(&normalize_uploaded_file/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp uploaded_files(_), do: []
+
+  defp normalize_uploaded_file(file) when is_map(file) do
+    case blank_to_nil(Map.get(file, "url") || Map.get(file, :url)) do
+      nil -> nil
+      url -> %{name: uploaded_file_name(file, url), url: url}
+    end
+  end
+
+  defp normalize_uploaded_file(_), do: nil
+
+  defp uploaded_file_name(file, url) do
+    blank_to_nil(Map.get(file, "name") || Map.get(file, :name)) ||
+      blank_to_nil(url |> String.split("/") |> List.last()) ||
+      "Attachment"
   end
 
   defp regular_choice_description("oli_check_all_that_apply", _tokens),
@@ -829,7 +871,12 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
 
   defp format_submission_files(files) when is_list(files) do
     files
-    |> Enum.map(&Map.get(&1, "name", "Attachment"))
+    |> Enum.map(fn file ->
+      case normalize_uploaded_file(file) do
+        %{name: name} -> name
+        _ -> "Attachment"
+      end
+    end)
     |> empty_fallback("No files uploaded")
   end
 

--- a/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
+++ b/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
@@ -300,4 +300,55 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
              %{label: "blank2", value: "Venus", meta: nil}
            ]
   end
+
+  test "builds a files view with downloadable links for file upload activities" do
+    attempt = %{
+      activity_type_id: 14,
+      revision: %{
+        content: %{
+          "stem" => %{
+            "content" => [%{"type" => "p", "children" => [%{"text" => "Upload your essay"}]}]
+          }
+        }
+      }
+    }
+
+    part_attempt = %{
+      attempt_guid: "attempt-1",
+      part_id: "1",
+      response: %{
+        "input" => "",
+        "files" => [
+          %{
+            "url" => "https://uploads.example.com/abc123/essay.pdf",
+            "creationDate" => 1_700_000_000_000,
+            "fileSize" => 20480
+          },
+          %{
+            "url" => "https://uploads.example.com/def456/diagram.png",
+            "creationDate" => 1_700_000_100_000,
+            "fileSize" => 4096
+          }
+        ]
+      },
+      score: nil,
+      out_of: 5.0
+    }
+
+    submission =
+      SelectedSubmissionBuilder.build(
+        attempt,
+        [part_attempt],
+        "attempt-1",
+        %{14 => %{slug: "oli_file_upload"}}
+      )
+
+    assert submission.subtitle == "File Upload • Part ID: 1"
+    assert submission.response_view.kind == :files
+
+    assert submission.response_view.files == [
+             %{name: "essay.pdf", url: "https://uploads.example.com/abc123/essay.pdf"},
+             %{name: "diagram.png", url: "https://uploads.example.com/def456/diagram.png"}
+           ]
+  end
 end

--- a/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
+++ b/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
@@ -351,4 +351,81 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
              %{name: "diagram.png", url: "https://uploads.example.com/def456/diagram.png"}
            ]
   end
+
+  test "drops file entries whose url is not an http(s) link" do
+    attempt = %{
+      activity_type_id: 14,
+      revision: %{
+        content: %{
+          "stem" => %{
+            "content" => [%{"type" => "p", "children" => [%{"text" => "Upload your essay"}]}]
+          }
+        }
+      }
+    }
+
+    part_attempt = %{
+      attempt_guid: "attempt-1",
+      part_id: "1",
+      response: %{
+        "input" => "",
+        "files" => [
+          %{"url" => "javascript:alert(document.cookie)"},
+          %{"url" => "/relative/path/notes.pdf"},
+          %{"url" => "http://localhost:9000/torus-media-dev/essay.pdf"}
+        ]
+      },
+      score: nil,
+      out_of: 5.0
+    }
+
+    submission =
+      SelectedSubmissionBuilder.build(
+        attempt,
+        [part_attempt],
+        "attempt-1",
+        %{14 => %{slug: "oli_file_upload"}}
+      )
+
+    assert submission.response_view.kind == :files
+
+    # only the safe http(s) url survives; the javascript: and relative urls are dropped
+    assert submission.response_view.files == [
+             %{name: "essay.pdf", url: "http://localhost:9000/torus-media-dev/essay.pdf"}
+           ]
+  end
+
+  test "builds an empty files view with no description when nothing was uploaded" do
+    attempt = %{
+      activity_type_id: 14,
+      revision: %{
+        content: %{
+          "stem" => %{
+            "content" => [%{"type" => "p", "children" => [%{"text" => "Upload your essay"}]}]
+          }
+        }
+      }
+    }
+
+    part_attempt = %{
+      attempt_guid: "attempt-1",
+      part_id: "1",
+      response: %{"input" => "", "files" => []},
+      score: nil,
+      out_of: 5.0
+    }
+
+    submission =
+      SelectedSubmissionBuilder.build(
+        attempt,
+        [part_attempt],
+        "attempt-1",
+        %{14 => %{slug: "oli_file_upload"}}
+      )
+
+    assert submission.response_view.kind == :files
+    assert submission.response_view.files == []
+    # description is nil so the renderer's empty-state is the single source of the message
+    assert submission.response_view.description == nil
+  end
 end

--- a/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
+++ b/test/oli_web/live/manual_grading/selected_submission_builder_test.exs
@@ -320,12 +320,12 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
         "input" => "",
         "files" => [
           %{
-            "url" => "https://uploads.example.com/abc123/essay.pdf",
+            "url" => "http://localhost:9000/minio/oli-torus-media/abc123/essay.pdf",
             "creationDate" => 1_700_000_000_000,
             "fileSize" => 20480
           },
           %{
-            "url" => "https://uploads.example.com/def456/diagram.png",
+            "url" => "http://localhost:9000/minio/oli-torus-media/def456/diagram.png",
             "creationDate" => 1_700_000_100_000,
             "fileSize" => 4096
           }
@@ -347,12 +347,18 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
     assert submission.response_view.kind == :files
 
     assert submission.response_view.files == [
-             %{name: "essay.pdf", url: "https://uploads.example.com/abc123/essay.pdf"},
-             %{name: "diagram.png", url: "https://uploads.example.com/def456/diagram.png"}
+             %{
+               name: "essay.pdf",
+               url: "http://localhost:9000/minio/oli-torus-media/abc123/essay.pdf"
+             },
+             %{
+               name: "diagram.png",
+               url: "http://localhost:9000/minio/oli-torus-media/def456/diagram.png"
+             }
            ]
   end
 
-  test "drops file entries whose url is not an http(s) link" do
+  test "drops file entries with unsafe, external, or malformed urls" do
     attempt = %{
       activity_type_id: 14,
       revision: %{
@@ -370,9 +376,16 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
       response: %{
         "input" => "",
         "files" => [
+          # unsafe scheme
           %{"url" => "javascript:alert(document.cookie)"},
+          # relative (no host)
           %{"url" => "/relative/path/notes.pdf"},
-          %{"url" => "http://localhost:9000/torus-media-dev/essay.pdf"}
+          # external host (phishing) — http(s) but not the configured media host
+          %{"url" => "http://evil.example.com/malware.exe"},
+          # malformed: non-binary url must not crash the builder
+          %{"url" => 12345},
+          # the only legitimate file: matches the configured media host (localhost)
+          %{"url" => "http://localhost:9000/minio/oli-torus-media/essay.pdf"}
         ]
       },
       score: nil,
@@ -389,9 +402,9 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilderTest do
 
     assert submission.response_view.kind == :files
 
-    # only the safe http(s) url survives; the javascript: and relative urls are dropped
+    # only the safe, same-host http url survives; the rest are dropped (no crash)
     assert submission.response_view.files == [
-             %{name: "essay.pdf", url: "http://localhost:9000/torus-media-dev/essay.pdf"}
+             %{name: "essay.pdf", url: "http://localhost:9000/minio/oli-torus-media/essay.pdf"}
            ]
   end
 

--- a/test/oli_web/live/manual_grading/selected_submission_test.exs
+++ b/test/oli_web/live/manual_grading/selected_submission_test.exs
@@ -163,4 +163,54 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionTest do
     assert html =~ "enter"
     refute html =~ "text-2xl"
   end
+
+  test "renders uploaded files as downloadable links" do
+    html =
+      render_component(&SelectedSubmission.render/1, %{
+        submission: %{
+          title: "Question Response",
+          subtitle: "File Upload • Part ID: 1",
+          score: "Pending / 5.0",
+          response_view: %{
+            kind: :files,
+            prompt: "Upload your essay",
+            description: "2 files submitted",
+            files: [
+              %{name: "essay.pdf", url: "http://localhost:9000/torus-media-dev/essay.pdf"},
+              %{name: "diagram.png", url: "http://localhost:9000/torus-media-dev/diagram.png"}
+            ]
+          }
+        }
+      })
+
+    assert html =~ "Upload your essay"
+    assert html =~ "2 files submitted"
+    # filenames rendered, not the literal "Attachment"
+    assert html =~ "essay.pdf"
+    assert html =~ "diagram.png"
+    refute html =~ "Attachment"
+    # each file is a real download link to its url
+    assert html =~ ~s(href="http://localhost:9000/torus-media-dev/essay.pdf")
+    assert html =~ ~s(href="http://localhost:9000/torus-media-dev/diagram.png")
+  end
+
+  test "renders fallback when no files were uploaded" do
+    html =
+      render_component(&SelectedSubmission.render/1, %{
+        submission: %{
+          title: "Question Response",
+          subtitle: "File Upload • Part ID: 1",
+          score: "Pending / 5.0",
+          response_view: %{
+            kind: :files,
+            prompt: "Upload your essay",
+            description: "No files uploaded",
+            files: []
+          }
+        }
+      })
+
+    assert html =~ "No files uploaded"
+    refute html =~ "<a"
+  end
 end

--- a/test/oli_web/live/manual_grading/selected_submission_test.exs
+++ b/test/oli_web/live/manual_grading/selected_submission_test.exs
@@ -204,7 +204,7 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionTest do
           response_view: %{
             kind: :files,
             prompt: "Upload your essay",
-            description: "No files uploaded",
+            description: nil,
             files: []
           }
         }


### PR DESCRIPTION
Ticket: [MER-5668](https://eliterate.atlassian.net/browse/MER-5668)

## Problem
In the manual scoring screen, file upload submissions showed `FILES → Attachment` as plain text with no link. Instructors saw no files and assumed students hadn't uploaded anything — even though the files were submitted and stored.

## Cause
The manual grading "Student Submission" panel (`SelectedSubmissionBuilder`) had no handling for the `oli_file_upload` activity, so it fell into the generic value view. Its file summary looked up `file["name"]`, but uploaded file responses are stored as `%{"url" => ..., "fileSize" => ..., "creationDate" => ...}` with no `name` key — so every file rendered as the literal fallback text `"Attachment"`, and the `url` was discarded (no link).

## Fix
- `SelectedSubmissionBuilder`: added an `oli_file_upload` clause that builds a `:files` view, deriving each file's name from its `url` and keeping the `url`.
- `SelectedSubmission`: added a `:files` render clause that shows each file as a clickable download link (with a "No files uploaded" fallback).
- Also hardened the generic file summary to derive filenames from `url` instead of always showing `"Attachment"`.
- Added builder + renderer tests covering the file upload case.

### AFTER

<img width="1308" height="1011" alt="verification" src="https://github.com/user-attachments/assets/62501d95-3aca-4e44-949b-00b9fd144a5f" />


[MER-5668]: https://eliterate.atlassian.net/browse/MER-5668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ