### PR TITLE
[MER-5678] Avoid forcing CORS on uncaptioned videos

### DIFF
--- a/assets/src/components/parts/janus-video/Video.tsx
+++ b/assets/src/components/parts/janus-video/Video.tsx
@@ -268,8 +268,8 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
     Array.isArray(subtitles)
       ? subtitles
       : subtitles && typeof subtitles === 'object'
-        ? [subtitles]
-        : []
+      ? [subtitles]
+      : []
   )
     .filter((s: any) => s?.src)
     .map((s: any) => ({

--- a/assets/src/components/parts/janus-video/Video.tsx
+++ b/assets/src/components/parts/janus-video/Video.tsx
@@ -268,8 +268,8 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
     Array.isArray(subtitles)
       ? subtitles
       : subtitles && typeof subtitles === 'object'
-      ? [subtitles]
-      : []
+        ? [subtitles]
+        : []
   )
     .filter((s: any) => s?.src)
     .map((s: any) => ({
@@ -485,7 +485,7 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
       width="100%"
       height="100%"
       /* className={cssClass} */
-      crossOrigin="anonymous"
+      crossOrigin={subtitleTracks.length > 0 ? 'anonymous' : undefined}
       autoPlay={autoPlay}
       controls={!_videoIsCompleted || enableReplay}
       onEnded={handleVideoEnd}

--- a/assets/src/components/video_player/VideoPlayer.tsx
+++ b/assets/src/components/video_player/VideoPlayer.tsx
@@ -73,6 +73,7 @@ export const VideoPlayer: React.FC<{
     : { fluid: true };
 
   const hasCaptions = video.captions && video.captions.length > 0;
+  const crossOriginProps = hasCaptions ? { crossOrigin: 'anonymous' } : {};
 
   // Update segmentsRef whenever segments change
   useEffect(() => {
@@ -257,7 +258,7 @@ export const VideoPlayer: React.FC<{
       onClick={preventDefault}
       {...maybePointMarkerAttr(video, pointMarkerContext)}
     >
-      <Player poster={video.poster} {...sizeAttributes} ref={onPlayer} crossOrigin="anonymous">
+      <Player poster={video.poster} {...sizeAttributes} {...crossOriginProps} ref={onPlayer}>
         {/* To suppress keyboard shortcuts: use custom Shortcut component to override builtin default */}
         {/* Still need to suppress player ever activating to prevent keystrokes from being consumed */}
         <Shortcut clickable={false} dblclickable={false} shortcuts={[]} />

--- a/assets/src/components/video_player/video-react.d.ts
+++ b/assets/src/components/video_player/video-react.d.ts
@@ -293,7 +293,7 @@ declare module 'video-react' {
 
     children?: React.ReactNode;
 
-    crossOrigin: string;
+    crossOrigin?: string;
   }
 
   export interface ShortcutItem {


### PR DESCRIPTION
## Summary

Fixes a v33 adaptive video regression where externally hosted videos could fail to load because `janus-video` always requested them with `crossOrigin="anonymous"`.

The player now only sets `crossOrigin="anonymous"` when subtitles/captions are present, since cross-origin text tracks require CORS. Videos without subtitles can use the browser’s normal video loading behavior.

Also updates the local `video-react` type definition so `crossOrigin` is optional, matching actual usage.

## Notes

The reported videos are currently working after the external AWS bucket CORS configuration was updated. This hotfix prevents the same issue from affecting other externally hosted adaptive videos that do not use subtitles.

