### PR TITLE
[ENHANCEMENT] [MER-5669] Add Canvas LTI launch provisioning test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,35 @@ update this file accordingly.
 
 ### Environment Configs
 
-| Name                        | Required | Description                                                                            |
-| --------------------------- | -------- | -------------------------------------------------------------------------------------- |
-| CANVAS_STUDENT_EMAIL        | No       | Canvas student email required by the grade passback Playwright smoke test              |
-| CANVAS_STUDENT_PASSWORD     | No       | Canvas student password required by the grade passback Playwright smoke test           |
-| CANVAS_INSTRUCTOR_EMAIL     | No       | Canvas instructor email required by the grade passback Playwright smoke test           |
-| CANVAS_INSTRUCTOR_PASSWORD  | No       | Canvas instructor password required by the grade passback Playwright smoke test        |
-| CANVAS_ADMIN_EMAIL          | No       | Canvas admin email alternative for the grade passback Playwright smoke test            |
-| CANVAS_ADMIN_PASSWORD       | No       | Canvas admin password alternative for the grade passback Playwright smoke test         |
-| CANVAS_LTI_LAUNCH_LINK_NAME | No       | Canvas LTI launch link name for the smoke test (Default: "OLI Torus (tokamak)")       |
+| Name                        | Required | Description                                                                     |
+| --------------------------- | -------- | ------------------------------------------------------------------------------- |
+| CANVAS_STUDENT_EMAIL        | No       | Canvas student email required by the grade passback Playwright smoke test       |
+| CANVAS_STUDENT_PASSWORD     | No       | Canvas student password required by the grade passback Playwright smoke test    |
+| CANVAS_INSTRUCTOR_EMAIL     | No       | Canvas instructor email required by Canvas LTI Playwright automation            |
+| CANVAS_INSTRUCTOR_PASSWORD  | No       | Canvas instructor password required by Canvas LTI Playwright automation         |
+| CANVAS_ADMIN_EMAIL          | No       | Canvas admin email alternative for the grade passback Playwright smoke test     |
+| CANVAS_ADMIN_PASSWORD       | No       | Canvas admin password alternative for the grade passback Playwright smoke test  |
+| CANVAS_LTI_LAUNCH_LINK_NAME | No       | Canvas LTI launch link name for the smoke test (Default: "OLI Torus (tokamak)") |
+| TORUS_BASE_URL              | No       | Torus base URL for Canvas LTI Playwright automation                             |
+| TORUS_ADMIN_EMAIL           | No       | Torus admin email required when running Canvas LTI Playwright automation        |
+| TORUS_ADMIN_PASSWORD        | No       | Torus admin password required when running Canvas LTI Playwright automation     |
+| CANVAS_BASE_URL             | No       | Canvas base URL for Canvas LTI Playwright automation                            |
+| CANVAS_ACCOUNT_ID           | No       | Canvas account ID required when running Canvas LTI Playwright automation        |
+| CANVAS_API_TOKEN            | No       | Canvas API token required when running Canvas LTI Playwright automation         |
+| CANVAS_INSTRUCTOR_USER_ID   | No       | Optional Canvas instructor user ID to enroll in generated test courses          |
+| CANVAS_LTI_TOOL_NAME        | No       | Canvas external tool name used by Canvas LTI Playwright automation              |
+| CANVAS_TOOL_LAUNCH_URL      | No       | Torus LTI launch URL used by Canvas LTI Playwright automation                   |
+| PLAYWRIGHT_SCENARIO_TOKEN   | No       | Scenario token for Playwright automation setup endpoints                        |
+| TORUS_LTI_PROJECT_TITLE     | No       | Optional title override for the temporary Torus LTI test project                |
 
 - `CANVAS_*` environment variables configure the Canvas-to-Torus grade passback Playwright
   smoke test. They are not required by the Torus application runtime. The student credentials
   and either instructor or admin credentials are required only when running this smoke test.
   The LTI launch link name is optional and defaults to `OLI Torus (tokamak)`.
+
+- Canvas LTI course-provisioning Playwright settings are local/test-runner configuration only
+  and are not required for the Torus application runtime. Do not commit real Canvas credentials
+  or API tokens.
 
 ### Infrastructure Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ update this file accordingly.
 | CANVAS_INSTRUCTOR_PASSWORD  | No       | Canvas instructor password required by Canvas LTI Playwright automation         |
 | CANVAS_ADMIN_EMAIL          | No       | Canvas admin email alternative for the grade passback Playwright smoke test     |
 | CANVAS_ADMIN_PASSWORD       | No       | Canvas admin password alternative for the grade passback Playwright smoke test  |
-| CANVAS_LTI_LAUNCH_LINK_NAME | No       | Canvas LTI launch link name for the smoke test (Default: "OLI Torus (tokamak)") |
 | TORUS_BASE_URL              | No       | Torus base URL for Canvas LTI Playwright automation                             |
 | TORUS_ADMIN_EMAIL           | No       | Torus admin email required when running Canvas LTI Playwright automation        |
 | TORUS_ADMIN_PASSWORD        | No       | Torus admin password required when running Canvas LTI Playwright automation     |
@@ -35,7 +34,7 @@ update this file accordingly.
 - `CANVAS_*` environment variables configure the Canvas-to-Torus grade passback Playwright
   smoke test. They are not required by the Torus application runtime. The student credentials
   and either instructor or admin credentials are required only when running this smoke test.
-  The LTI launch link name is optional and defaults to `OLI Torus (tokamak)`.
+  The Canvas LTI tool name is optional and defaults to `OLI Torus (tokamak)`.
 
 - Canvas LTI course-provisioning Playwright settings are local/test-runner configuration only
   and are not required for the Torus application runtime. Do not commit real Canvas credentials

--- a/assets/automation/src/systems/canvas/api/CanvasApi.ts
+++ b/assets/automation/src/systems/canvas/api/CanvasApi.ts
@@ -1,0 +1,210 @@
+export type CanvasCourse = {
+  id: number;
+  name: string;
+  workflow_state?: string;
+  html_url?: string;
+};
+
+export type CanvasModule = {
+  id: number;
+  name: string;
+  published?: boolean;
+};
+
+export type CanvasModuleItem = {
+  id: number;
+  title: string;
+  type: string;
+  content_id?: number;
+  external_url?: string;
+  html_url?: string;
+  new_tab?: boolean;
+  published?: boolean;
+};
+
+export type CanvasEnrollment = {
+  id: number;
+  user_id: number;
+  course_id: number;
+  type: string;
+  enrollment_state?: string;
+};
+
+export type CanvasLaunchCourse = {
+  course: CanvasCourse;
+  module: CanvasModule;
+  item: CanvasModuleItem;
+};
+
+export async function createCanvasLaunchCourse({
+  baseUrl,
+  accountId,
+  token,
+  courseName,
+  toolName,
+  toolLaunchUrl,
+  instructorUserId,
+}: {
+  baseUrl: string;
+  accountId: string;
+  token: string;
+  courseName: string;
+  toolName: string;
+  toolLaunchUrl: string;
+  instructorUserId?: string;
+}): Promise<CanvasLaunchCourse> {
+  const course = await canvasApiRequest<CanvasCourse>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/accounts/${accountId}/courses`,
+    {
+      'course[name]': courseName,
+      'course[course_code]': courseName,
+      offer: 'true',
+    },
+  );
+
+  if (instructorUserId) {
+    await enrollCanvasTeacher({
+      baseUrl,
+      token,
+      courseId: course.id,
+      userId: instructorUserId,
+    });
+  }
+
+  let module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules`,
+    {
+      'module[name]': 'Torus LTI Launch',
+    },
+  );
+
+  let item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items`,
+    {
+      'module_item[type]': 'ExternalTool',
+      'module_item[title]': toolName,
+      'module_item[external_url]': toolLaunchUrl,
+      'module_item[new_tab]': 'true',
+    },
+  );
+
+  module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}`,
+    {
+      'module[published]': 'true',
+    },
+  );
+
+  item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items/${item.id}`,
+    {
+      'module_item[published]': 'true',
+    },
+  );
+
+  return { course, module, item };
+}
+
+export async function deleteCanvasCourse({
+  baseUrl,
+  token,
+  courseId,
+}: {
+  baseUrl: string;
+  token: string;
+  courseId: number;
+}) {
+  await canvasApiRequest<unknown>(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
+    event: 'delete',
+  });
+}
+
+async function enrollCanvasTeacher({
+  baseUrl,
+  token,
+  courseId,
+  userId,
+}: {
+  baseUrl: string;
+  token: string;
+  courseId: number;
+  userId: string;
+}) {
+  await canvasApiRequest<CanvasEnrollment>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${courseId}/enrollments`,
+    {
+      'enrollment[user_id]': userId,
+      'enrollment[type]': 'TeacherEnrollment',
+      'enrollment[enrollment_state]': 'active',
+      'enrollment[notify]': 'false',
+    },
+  );
+}
+
+async function canvasApiRequest<T>(
+  baseUrl: string,
+  token: string,
+  method: string,
+  path: string,
+  params: Record<string, string> = {},
+): Promise<T> {
+  const url = new URL(path, baseUrl);
+  const options: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  if (method === 'GET') {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.append(key, value);
+    }
+  } else {
+    options.headers = {
+      ...options.headers,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    options.body = new URLSearchParams(params);
+  }
+
+  const response = await fetch(url, options);
+  const text = await response.text();
+  const body = parseCanvasResponse(text);
+
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${path} failed (${response.status}): ${
+        typeof body === 'string' ? body : JSON.stringify(body)
+      }`,
+    );
+  }
+
+  return body as T;
+}
+
+function parseCanvasResponse(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/assets/automation/src/systems/canvas/api/CanvasApi.ts
+++ b/assets/automation/src/systems/canvas/api/CanvasApi.ts
@@ -36,24 +36,65 @@ export type CanvasLaunchCourse = {
   item: CanvasModuleItem;
 };
 
-export async function createCanvasLaunchCourse({
-  baseUrl,
-  accountId,
-  token,
-  courseName,
-  toolName,
-  toolLaunchUrl,
-  instructorUserId,
-}: {
+type CanvasApiParams = {
   baseUrl: string;
-  accountId: string;
   token: string;
+};
+
+type CanvasApiMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export type CreateCanvasCourseParams = CanvasApiParams & {
+  accountId: string;
+  courseName: string;
+};
+
+export type EnrollCanvasTeacherParams = CanvasApiParams & {
+  courseId: number;
+  userId: string;
+};
+
+export type CreateCanvasModuleParams = CanvasApiParams & {
+  courseId: number;
+  moduleName: string;
+};
+
+export type CreateCanvasExternalToolModuleItemParams = CanvasApiParams & {
+  courseId: number;
+  moduleId: number;
+  toolName: string;
+  toolLaunchUrl: string;
+};
+
+export type PublishCanvasModuleParams = CanvasApiParams & {
+  courseId: number;
+  moduleId: number;
+};
+
+export type PublishCanvasModuleItemParams = CanvasApiParams & {
+  courseId: number;
+  moduleId: number;
+  itemId: number;
+};
+
+export type DeleteCanvasCourseParams = CanvasApiParams & {
+  courseId: number;
+};
+
+export type CreateCanvasLaunchCourseParams = CanvasApiParams & {
+  accountId: string;
   courseName: string;
   toolName: string;
   toolLaunchUrl: string;
   instructorUserId?: string;
-}): Promise<CanvasLaunchCourse> {
-  const course = await canvasApiRequest<CanvasCourse>(
+};
+
+export async function createCanvasCourse({
+  baseUrl,
+  accountId,
+  token,
+  courseName,
+}: CreateCanvasCourseParams): Promise<CanvasCourse> {
+  return canvasApiRequest<CanvasCourse>(
     baseUrl,
     token,
     'POST',
@@ -64,88 +105,15 @@ export async function createCanvasLaunchCourse({
       offer: 'true',
     },
   );
-
-  if (instructorUserId) {
-    await enrollCanvasTeacher({
-      baseUrl,
-      token,
-      courseId: course.id,
-      userId: instructorUserId,
-    });
-  }
-
-  let module = await canvasApiRequest<CanvasModule>(
-    baseUrl,
-    token,
-    'POST',
-    `/api/v1/courses/${course.id}/modules`,
-    {
-      'module[name]': 'Torus LTI Launch',
-    },
-  );
-
-  let item = await canvasApiRequest<CanvasModuleItem>(
-    baseUrl,
-    token,
-    'POST',
-    `/api/v1/courses/${course.id}/modules/${module.id}/items`,
-    {
-      'module_item[type]': 'ExternalTool',
-      'module_item[title]': toolName,
-      'module_item[external_url]': toolLaunchUrl,
-      'module_item[new_tab]': 'true',
-    },
-  );
-
-  module = await canvasApiRequest<CanvasModule>(
-    baseUrl,
-    token,
-    'PUT',
-    `/api/v1/courses/${course.id}/modules/${module.id}`,
-    {
-      'module[published]': 'true',
-    },
-  );
-
-  item = await canvasApiRequest<CanvasModuleItem>(
-    baseUrl,
-    token,
-    'PUT',
-    `/api/v1/courses/${course.id}/modules/${module.id}/items/${item.id}`,
-    {
-      'module_item[published]': 'true',
-    },
-  );
-
-  return { course, module, item };
 }
 
-export async function deleteCanvasCourse({
-  baseUrl,
-  token,
-  courseId,
-}: {
-  baseUrl: string;
-  token: string;
-  courseId: number;
-}) {
-  await canvasApiRequest<unknown>(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
-    event: 'delete',
-  });
-}
-
-async function enrollCanvasTeacher({
+export async function enrollCanvasTeacher({
   baseUrl,
   token,
   courseId,
   userId,
-}: {
-  baseUrl: string;
-  token: string;
-  courseId: number;
-  userId: string;
-}) {
-  await canvasApiRequest<CanvasEnrollment>(
+}: EnrollCanvasTeacherParams): Promise<CanvasEnrollment> {
+  return canvasApiRequest<CanvasEnrollment>(
     baseUrl,
     token,
     'POST',
@@ -159,10 +127,149 @@ async function enrollCanvasTeacher({
   );
 }
 
+export async function createCanvasModule({
+  baseUrl,
+  token,
+  courseId,
+  moduleName,
+}: CreateCanvasModuleParams): Promise<CanvasModule> {
+  return canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${courseId}/modules`,
+    {
+      'module[name]': moduleName,
+    },
+  );
+}
+
+export async function createCanvasExternalToolModuleItem({
+  baseUrl,
+  token,
+  courseId,
+  moduleId,
+  toolName,
+  toolLaunchUrl,
+}: CreateCanvasExternalToolModuleItemParams): Promise<CanvasModuleItem> {
+  return canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${courseId}/modules/${moduleId}/items`,
+    {
+      'module_item[type]': 'ExternalTool',
+      'module_item[title]': toolName,
+      'module_item[external_url]': toolLaunchUrl,
+      'module_item[new_tab]': 'true',
+    },
+  );
+}
+
+export async function publishCanvasModule({
+  baseUrl,
+  token,
+  courseId,
+  moduleId,
+}: PublishCanvasModuleParams): Promise<CanvasModule> {
+  return canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${courseId}/modules/${moduleId}`,
+    {
+      'module[published]': 'true',
+    },
+  );
+}
+
+export async function publishCanvasModuleItem({
+  baseUrl,
+  token,
+  courseId,
+  moduleId,
+  itemId,
+}: PublishCanvasModuleItemParams): Promise<CanvasModuleItem> {
+  return canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${courseId}/modules/${moduleId}/items/${itemId}`,
+    {
+      'module_item[published]': 'true',
+    },
+  );
+}
+
+export async function createCanvasLaunchCourse({
+  baseUrl,
+  accountId,
+  token,
+  courseName,
+  toolName,
+  toolLaunchUrl,
+  instructorUserId,
+}: CreateCanvasLaunchCourseParams): Promise<CanvasLaunchCourse> {
+  const course = await createCanvasCourse({
+    baseUrl,
+    accountId,
+    token,
+    courseName,
+  });
+
+  if (instructorUserId) {
+    await enrollCanvasTeacher({
+      baseUrl,
+      token,
+      courseId: course.id,
+      userId: instructorUserId,
+    });
+  }
+
+  let module = await createCanvasModule({
+    baseUrl,
+    token,
+    courseId: course.id,
+    moduleName: 'Torus LTI Launch',
+  });
+
+  let item = await createCanvasExternalToolModuleItem({
+    baseUrl,
+    token,
+    courseId: course.id,
+    moduleId: module.id,
+    toolName,
+    toolLaunchUrl,
+  });
+
+  module = await publishCanvasModule({
+    baseUrl,
+    token,
+    courseId: course.id,
+    moduleId: module.id,
+  });
+
+  item = await publishCanvasModuleItem({
+    baseUrl,
+    token,
+    courseId: course.id,
+    moduleId: module.id,
+    itemId: item.id,
+  });
+
+  return { course, module, item };
+}
+
+export async function deleteCanvasCourse({ baseUrl, token, courseId }: DeleteCanvasCourseParams) {
+  await canvasApiRequest<unknown>(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
+    event: 'delete',
+  });
+}
+
 async function canvasApiRequest<T>(
   baseUrl: string,
   token: string,
-  method: string,
+  method: CanvasApiMethod,
   path: string,
   params: Record<string, string> = {},
 ): Promise<T> {

--- a/assets/automation/src/systems/torus/pom/project/OverviewProjectPO.ts
+++ b/assets/automation/src/systems/torus/pom/project/OverviewProjectPO.ts
@@ -57,54 +57,47 @@ export class OverviewProjectPO {
       openAddActivitiesAndTools: async () => {
         const openButton = this.page.getByRole('button', { name: '+ Add Activities and Tools' });
         const modalRoot = this.page.locator('#add-activities-tools-modal');
-        const contentProbe = modalRoot
-          .getByRole('heading', { name: /add (advanced )?activities/i })
-          .or(modalRoot.getByText(/Activities and Tools/i));
+        const modalReady = modalRoot.getByRole('button', { name: 'Apply Changes' });
 
         // Wait for the trigger button to ensure the overview section finished rendering
         await openButton.waitFor({ state: 'visible', timeout: 5000 });
 
-        // Click and wait until the modal attaches & shows content (LiveView can drop the first click)
-        for (let i = 0; i < 3; i++) {
-          await openButton.click({ delay: 250 });
-
-          let attached = false;
-          try {
-            await modalRoot.waitFor({ state: 'attached', timeout: 1500 });
-            attached = true;
-          } catch {
-            attached = false;
+        // LiveView can occasionally drop the first click. If the modal opened, do not click
+        // the covered trigger again; wait for the modal action instead.
+        for (let i = 0; i < 4; i++) {
+          if (await modalReady.isVisible({ timeout: 500 }).catch(() => false)) {
+            return;
           }
 
-          const visible = attached ? await modalRoot.isVisible().catch(() => false) : false;
-          const hasContent = attached
-            ? await contentProbe
-                .count()
-                .then((c) => c > 0)
-                .catch(() => false)
-            : false;
+          await openButton.click({ delay: 100, timeout: 5000 }).catch(async (error) => {
+            if (await modalReady.isVisible({ timeout: 500 }).catch(() => false)) {
+              return;
+            }
 
-          console.log(
-            `Attempt ${i + 1}: modal attached=${attached}, visible=${visible}, hasContent=${hasContent}`,
-          );
+            throw error;
+          });
 
-          if (attached && (visible || hasContent)) break;
+          if (await modalReady.isVisible({ timeout: 3000 }).catch(() => false)) {
+            return;
+          }
+
           await this.page.waitForTimeout(200);
         }
 
         // Final guard so test fails fast with a clear message
-        const opened = await contentProbe
-          .first()
-          .isVisible()
-          .catch(() => false);
+        const opened = await modalReady.isVisible().catch(() => false);
         if (!opened) {
-          throw new Error('Add Activities & Tools modal did not become visible after 3 attempts');
+          throw new Error('Add Activities & Tools modal did not become visible after 4 attempts');
         }
       },
       applyChanges: async () => {
         const applyButton = this.page.getByRole('button', { name: 'Apply Changes' });
         await Verifier.expectIsVisible(applyButton);
+        await expect(applyButton).toBeEnabled();
         await applyButton.click();
+        await expect(this.page.locator('#add-activities-tools-modal')).toBeHidden({
+          timeout: 10_000,
+        });
       },
     };
   }

--- a/assets/automation/tests/torus/lti/canvas_playwright.md
+++ b/assets/automation/tests/torus/lti/canvas_playwright.md
@@ -11,8 +11,9 @@ Last updated on May 28, 2026.
 The current LTI spec is `assets/automation/tests/torus/lti/launch.spec.ts`.
 
 It creates isolated Canvas state for each run, launches Tokamak through Canvas,
-creates a Torus LTI section from the first-launch setup wizard, and then deletes
-the temporary Canvas course.
+creates a Torus LTI section from the first-launch setup wizard, deletes that
+Torus section from the manage page, and then deletes the temporary Canvas
+course.
 
 The default source/project searched in Torus is:
 
@@ -30,8 +31,8 @@ The generated Torus section number is:
 
 - `lti-<timestamp>`
 
-Canvas cleanup is handled by the spec. Torus sections created in Tokamak are not
-currently cleaned up by the test.
+Canvas cleanup is handled by the spec. Successful runs also delete the Torus
+section from the manage page before deleting the temporary Canvas course.
 
 ## Required Local Environment
 
@@ -72,7 +73,8 @@ For each run it:
 4. Publishes the module.
 5. Publishes the module item.
 6. Launches the tool from the Canvas UI.
-7. Deletes the temporary Canvas course in a `finally` block.
+7. Deletes the Torus section from the manage page.
+8. Deletes the temporary Canvas course in a `finally` block.
 
 Read-only API inspection of the historical fixed course showed:
 
@@ -132,6 +134,11 @@ The current selectors rely on:
   `#section_preferred_scheduling_time`.
 - The modality label `Never, it's a self paced course`.
 - Final redirect to `/sections/:section_slug/manage`.
+- Manage page cleanup button `Delete Section`.
+- Delete confirmation modal `#delete_section_modal`.
+- Delete confirmation button `Delete this section`.
+- After deletion, Tokamak may redirect to `/sections` or back to
+  `/sections/new/:context_id` for the same LTI context.
 
 After selecting a source, the stepper collects the course name, course section
 number, modality, dates, and schedule details. Creating the section calls

--- a/assets/automation/tests/torus/lti/canvas_playwright.md
+++ b/assets/automation/tests/torus/lti/canvas_playwright.md
@@ -1,0 +1,196 @@
+# Canvas Playwright LTI Notes
+
+This note preserves the working assumptions for the Torus Canvas LTI launch
+automation. It is intentionally free of real credentials and should be updated
+when the Canvas setup or launch flow changes.
+
+Last updated on May 28, 2026.
+
+## Current Test
+
+The current LTI spec is `assets/automation/tests/torus/lti/launch.spec.ts`.
+
+It creates isolated Canvas state for each run, launches Tokamak through Canvas,
+creates a Torus LTI section from the first-launch setup wizard, and then deletes
+the temporary Canvas course.
+
+The default source/project searched in Torus is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+The generated Canvas course name is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE lti-<timestamp>`
+
+The generated Torus section name is:
+
+- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+The generated Torus section number is:
+
+- `lti-<timestamp>`
+
+Canvas cleanup is handled by the spec. Torus sections created in Tokamak are not
+currently cleaned up by the test.
+
+## Required Local Environment
+
+Do not commit real Canvas credentials or API tokens.
+
+The spec requires these local environment variables:
+
+- `CANVAS_UI_EMAIL`
+- `CANVAS_UI_PASSWORD`
+- `CANVAS_ACCOUNT_ID`
+- `CANVAS_API_TOKEN`
+
+Optional overrides:
+
+- `CANVAS_BASE_URL`, default `https://canvas.oli.cmu.edu`
+- `CANVAS_TOOL_NAME`, default `OLI Torus (tokamak)`
+- `CANVAS_TOOL_LAUNCH_URL`, default `https://tokamak.oli.cmu.edu/lti/launch`
+- `TORUS_LTI_SOURCE_TITLE`, default `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+
+As of May 28, 2026, the local Canvas API env values were validated without
+printing the token:
+
+- `CANVAS_BASE_URL` points at `https://canvas.oli.cmu.edu`.
+- `CANVAS_ACCOUNT_ID` is `1`.
+- The account API identifies account `1` as `Open Learning Initiative`.
+- The token can read account courses.
+- The token reports `manage_courses: true`, `manage_account_settings: true`,
+  and `manage_developer_keys: true`.
+
+## Canvas API Provisioning
+
+The spec uses the Canvas API to avoid relying on a pre-existing Canvas course.
+For each run it:
+
+1. Creates a course in the configured Canvas account.
+2. Creates a module named `Torus LTI Launch`.
+3. Creates an external tool module item for `OLI Torus (tokamak)`.
+4. Publishes the module.
+5. Publishes the module item.
+6. Launches the tool from the Canvas UI.
+7. Deletes the temporary Canvas course in a `finally` block.
+
+Read-only API inspection of the historical fixed course showed:
+
+- Account-level external tool id `68` is `OLI Torus (tokamak)`.
+- Tool launch URL is `https://tokamak.oli.cmu.edu/lti/launch`.
+- Course `682` has module `437`.
+- Module item `917` is type `ExternalTool`, content id `68`, published, and
+  configured with `new_tab: true`.
+
+A write smoke test confirmed that Canvas accepts this provisioning flow:
+
+1. `POST /api/v1/accounts/:account_id/courses`
+2. `POST /api/v1/courses/:course_id/modules`
+3. `POST /api/v1/courses/:course_id/modules/:module_id/items`
+4. `PUT /api/v1/courses/:course_id/modules/:module_id` with
+   `module[published]=true`
+5. `PUT /api/v1/courses/:course_id/modules/:module_id/items/:item_id` with
+   `module_item[published]=true`
+
+Canvas did not publish the module and item when `published=true` was sent only
+during creation, so the follow-up `PUT` requests are required.
+
+## Torus First-Launch Section Creation
+
+A disposable Canvas course launch was inspected on May 28, 2026. After Canvas
+launched `OLI Torus (tokamak)` for a new Canvas course with no existing Torus
+section, Torus redirected to:
+
+- `/sections/new/:context_id`
+
+The visible UI was the `New course set up` stepper with:
+
+- Step 1: `Select your source materials`
+- Step 2: `Name your course`
+- Step 3: `Course details`
+
+The first step is headed `Select source` and shows `Select Curriculum`, a search
+box, card/list view controls, pagination, and source cards. The `Next step`
+button is disabled until a source is selected.
+
+The source list comes from `Publishing.retrieve_visible_sources(user,
+institution)` for LTI launches. Source rows are either:
+
+- `publication:<id>` for a published project source
+- `product:<id>` for a template/product source
+
+The current selectors rely on:
+
+- `iframe[name="tool_content"]` when Canvas embeds the launch.
+- The visible `Load OLI Torus (tokamak) in a new window` button when Canvas
+  requires a popup/new tab launch.
+- Torus search placeholder `Search...`.
+- Search result summary text `Results filtered on "<source title>"`.
+- Source card links with `.course-card-link`.
+- Wizard fields `#section_title`, `#section_course_section_number`,
+  `#section_start_date`, `#section_end_date`, and
+  `#section_preferred_scheduling_time`.
+- The modality label `Never, it's a self paced course`.
+- Final redirect to `/sections/:section_slug/manage`.
+
+After selecting a source, the stepper collects the course name, course section
+number, modality, dates, and schedule details. Creating the section calls
+`Delivery.create_section(changeset, source, current_user, section_spec)`, where
+`section_spec` is an LTI section specification built from the latest LTI params
+for the launched Canvas context.
+
+## Historical Fixed Course
+
+The old version of this test used a fixed Canvas course and pre-existing Torus
+section. These details are retained only as debugging context:
+
+- Canvas course: `Second Test Second`
+- Canvas course path: `/courses/682`
+- Canvas module item path: `/courses/682/modules/items/917`
+- Tool link text: `OLI Torus (tokamak)`
+- The popup reached Torus at `/sections/second_test_second_w49b5/manage`.
+- The Torus section details page showed:
+  - Course Section ID `second_test_second_w49b5`
+  - Course Section Type `LTI`
+  - Institution `OLI Test Canvas testing`
+  - Instructor `Instructor, Dovid Playwright`
+
+Treat these ids and slugs as fixture details, not stable test design.
+
+## What To Inspect When Updating Selectors
+
+Codex does not automatically see the user's browser. To understand the current
+Canvas or Torus interface, inspect Playwright outputs from a local run:
+
+- `assets/automation/test-results/**/trace.zip`
+- `assets/automation/test-results/**/*.png`
+- `assets/automation/playwright-report/index.html`
+- Playwright locator errors and action logs
+- DOM or accessibility snapshots captured during debugging
+
+Prefer stable selectors in this order:
+
+- Accessible roles and names (`getByRole`, `getByLabel`, visible link names).
+- Stable frame names such as `iframe[name="tool_content"]`.
+- Stable app-controlled attributes, if present.
+- CSS or generated Canvas ids only when no better selector exists.
+
+## Run Command
+
+From `assets/automation`:
+
+```bash
+npm run pw -- tests/torus/lti/launch.spec.ts --project "Google Chrome"
+```
+
+If using a local env file from the repository root:
+
+```bash
+set -a
+source ../../oli.env
+set +a
+npm run pw -- tests/torus/lti/launch.spec.ts --project "Google Chrome"
+```
+
+Do not paste command output that includes credentials into tickets, docs, or PR
+comments.

--- a/assets/automation/tests/torus/lti/canvas_playwright.md
+++ b/assets/automation/tests/torus/lti/canvas_playwright.md
@@ -10,29 +10,31 @@ Last updated on May 28, 2026.
 
 The current LTI spec is `assets/automation/tests/torus/lti/launch.spec.ts`.
 
-It creates isolated Canvas state for each run, launches Tokamak through Canvas,
-creates a Torus LTI section from the first-launch setup wizard, deletes that
-Torus section from the manage page, and then deletes the temporary Canvas
-course.
+It creates an isolated Torus source project and isolated Canvas state for each
+run, launches Tokamak through Canvas, creates a Torus LTI section from the
+first-launch setup wizard, deletes that Torus section from the manage page,
+deletes the temporary Canvas course, and then deletes the temporary Torus
+source project.
 
-The default source/project searched in Torus is:
+The default temporary Torus source project title is:
 
-- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+- `LTI_CANVAS_TEST lti-<timestamp>`
 
 The generated Canvas course name is:
 
-- `PLAYWRIGHT_AUTOMATION_DONT_DELETE lti-<timestamp>`
+- `LTI_CANVAS_TEST lti-<timestamp>`
 
 The generated Torus section name is:
 
-- `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+- `LTI_CANVAS_TEST lti-<timestamp>`
 
 The generated Torus section number is:
 
 - `lti-<timestamp>`
 
-Canvas cleanup is handled by the spec. Successful runs also delete the Torus
-section from the manage page before deleting the temporary Canvas course.
+Canvas and Torus source-project cleanup are handled by the spec. Successful
+runs also delete the Torus section from the manage page before deleting the
+temporary Canvas course.
 
 ## Required Local Environment
 
@@ -40,17 +42,31 @@ Do not commit real Canvas credentials or API tokens.
 
 The spec requires these local environment variables:
 
-- `CANVAS_UI_EMAIL`
-- `CANVAS_UI_PASSWORD`
+- `CANVAS_INSTRUCTOR_EMAIL`
+- `CANVAS_INSTRUCTOR_PASSWORD`
 - `CANVAS_ACCOUNT_ID`
 - `CANVAS_API_TOKEN`
+- `TORUS_ADMIN_EMAIL`
+- `TORUS_ADMIN_PASSWORD`
+
+Recommended:
+
+- `CANVAS_INSTRUCTOR_USER_ID`, used to enroll the dedicated Canvas test
+  instructor as a teacher in the generated course before launching the tool.
+
+The spec still accepts the older `CANVAS_UI_EMAIL` and `CANVAS_UI_PASSWORD`
+names as fallbacks during migration.
 
 Optional overrides:
 
 - `CANVAS_BASE_URL`, default `https://canvas.oli.cmu.edu`
-- `CANVAS_TOOL_NAME`, default `OLI Torus (tokamak)`
+- `CANVAS_LTI_TOOL_NAME`, default `OLI Torus (tokamak)`
 - `CANVAS_TOOL_LAUNCH_URL`, default `https://tokamak.oli.cmu.edu/lti/launch`
-- `TORUS_LTI_SOURCE_TITLE`, default `PLAYWRIGHT_AUTOMATION_DONT_DELETE`
+- `TORUS_BASE_URL`, default is derived from `CANVAS_TOOL_LAUNCH_URL`
+- `TORUS_LTI_PROJECT_TITLE`, default `LTI_CANVAS_TEST lti-<timestamp>`
+
+The spec still accepts the older `CANVAS_TOOL_NAME` name as a fallback during
+migration.
 
 As of May 28, 2026, the local Canvas API env values were validated without
 printing the token:
@@ -64,17 +80,24 @@ printing the token:
 
 ## Canvas API Provisioning
 
-The spec uses the Canvas API to avoid relying on a pre-existing Canvas course.
-For each run it:
+The spec uses the Torus UI and Canvas API to avoid relying on a pre-existing
+Torus source project or Canvas course. For each run it:
 
-1. Creates a course in the configured Canvas account.
-2. Creates a module named `Torus LTI Launch`.
-3. Creates an external tool module item for `OLI Torus (tokamak)`.
-4. Publishes the module.
-5. Publishes the module item.
-6. Launches the tool from the Canvas UI.
-7. Deletes the Torus section from the manage page.
-8. Deletes the temporary Canvas course in a `finally` block.
+1. Logs into the target Torus instance as the configured Torus admin.
+2. Creates a temporary Torus project.
+3. Adds a basic unscored practice page.
+4. Publishes the project.
+5. Sets project publishing visibility to `Open`.
+6. Creates a course in the configured Canvas account.
+7. Enrolls `CANVAS_INSTRUCTOR_USER_ID` as a teacher when configured.
+8. Creates a module named `Torus LTI Launch`.
+9. Creates an external tool module item for `OLI Torus (tokamak)`.
+10. Publishes the module.
+11. Publishes the module item.
+12. Launches the tool from the Canvas UI as the configured instructor.
+13. Deletes the Torus section from the manage page.
+14. Deletes the temporary Canvas course in a `finally` block.
+15. Deletes the temporary Torus source project in a `finally` block.
 
 Read-only API inspection of the historical fixed course showed:
 

--- a/assets/automation/tests/torus/lti/grade-passback.md
+++ b/assets/automation/tests/torus/lti/grade-passback.md
@@ -28,9 +28,9 @@ Set these variables in the environment where Playwright runs:
 
 Optional:
 
-- `CANVAS_LTI_LAUNCH_LINK_NAME`
+- `CANVAS_LTI_TOOL_NAME`
 
-If `CANVAS_LTI_LAUNCH_LINK_NAME` is not set, the test uses `OLI Torus (tokamak)`.
+If `CANVAS_LTI_TOOL_NAME` is not set, the test uses `OLI Torus (tokamak)`.
 
 No API key is required. The test reads the student name from the authenticated Canvas browser session after login.
 

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -45,10 +45,10 @@ const openCanvasCourse = async (page: Page) => {
 };
 
 // Opens the course in Canvas, launches Tokamak through the module item link, and returns the tool iframe.
-const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
+const launchTokamakFromCanvas = async (page: Page, toolName: string) => {
   await openCanvasCourse(page);
 
-  const launchLink = page.locator(`a.item_link[title="${launchLinkName}"]`);
+  const launchLink = page.locator(`a.item_link[title="${toolName}"]`);
   await expect(launchLink).toBeVisible();
   await launchLink.click();
 
@@ -59,8 +59,8 @@ const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
 };
 
 // Navigates inside Tokamak to the graded page whose score should be passed back.
-const openGradedPage = async (page: Page, launchLinkName: string) => {
-  const toolFrame = await launchTokamakFromCanvas(page, launchLinkName);
+const openGradedPage = async (page: Page, toolName: string) => {
+  const toolFrame = await launchTokamakFromCanvas(page, toolName);
 
   await toolFrame.getByRole('link', { name: 'Assignments' }).click();
   await toolFrame.getByRole('link', { name: gradedPageName }).click();
@@ -70,13 +70,9 @@ const openGradedPage = async (page: Page, launchLinkName: string) => {
 };
 
 // Starts or resumes the student's page attempt, answers the activities, and submits it.
-const completeStudentAttempt = async (
-  page: Page,
-  launchLinkName: string,
-  answers: StudentAnswers,
-) => {
+const completeStudentAttempt = async (page: Page, toolName: string, answers: StudentAnswers) => {
   // Open the Canvas course, launch Tokamak, and navigate to the graded page.
-  const toolFrame = await openGradedPage(page, launchLinkName);
+  const toolFrame = await openGradedPage(page, toolName);
 
   const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
   const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
@@ -231,7 +227,7 @@ test('passes Tokamak graded page score back to Canvas gradebook', async ({ brows
 
   const { email: studentEmail, password: studentPassword } = getCanvasStudentCredentials();
   const { email: instructorEmail, password: instructorPassword } = getCanvasInstructorCredentials();
-  const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
+  const toolName = process.env.CANVAS_LTI_TOOL_NAME ?? 'OLI Torus (tokamak)';
   const answers = buildRandomAnswers();
 
   const studentContext = await browser.newContext();
@@ -245,7 +241,7 @@ test('passes Tokamak graded page score back to Canvas gradebook', async ({ brows
     // Log in to Canvas as the student who will complete the graded page.
     await loginToCanvas(studentPage, studentEmail, studentPassword);
     const studentName = await getCanvasUserName(studentPage);
-    await completeStudentAttempt(studentPage, launchLinkName, answers);
+    await completeStudentAttempt(studentPage, toolName, answers);
 
     // Continue in the already logged-in instructor context after the student attempt is complete.
     await instructorLogin;

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -328,11 +328,13 @@ type RoleScope = {
   locator(selector: string): Locator;
 };
 
-async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'getByRole'>) {
-  const acceptButton = scope.getByRole('button', { name: 'Accept' });
+async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'locator'>) {
+  const cookieModal = scope.locator('#cookie_consent_display');
+  const acceptButton = cookieModal.getByRole('button', { name: /^Accept$/ });
 
-  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+  if (await acceptButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
     await acceptButton.click();
+    await expect(cookieModal).toBeHidden({ timeout: 5_000 });
   }
 }
 
@@ -382,8 +384,12 @@ async function createTorusSectionFromLaunch(
 
 async function deleteTorusSectionFromManage(scope: RoleScope) {
   await waitForLiveView(scope);
+
   const deleteSectionButton = scope.getByRole('button', { name: 'Delete Section' });
   await expect(deleteSectionButton).toBeVisible({ timeout: 15_000 });
+
+  await acceptCookiesIfVisible(scope);
+
   await deleteSectionButton.click();
 
   const modal = scope.locator('#delete_section_modal');

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -1,5 +1,40 @@
 import { expect, Locator, Page, test } from '@playwright/test';
 
+type CanvasCourse = {
+  id: number;
+  name: string;
+  workflow_state?: string;
+  html_url?: string;
+};
+
+type CanvasModule = {
+  id: number;
+  name: string;
+  published?: boolean;
+};
+
+type CanvasModuleItem = {
+  id: number;
+  title: string;
+  type: string;
+  content_id?: number;
+  external_url?: string;
+  html_url?: string;
+  new_tab?: boolean;
+  published?: boolean;
+};
+
+type CanvasLaunchCourse = {
+  course: CanvasCourse;
+  module: CanvasModule;
+  item: CanvasModuleItem;
+};
+
+const DEFAULT_CANVAS_BASE_URL = 'https://canvas.oli.cmu.edu';
+const DEFAULT_TOOL_NAME = 'OLI Torus (tokamak)';
+const DEFAULT_TOOL_LAUNCH_URL = 'https://tokamak.oli.cmu.edu/lti/launch';
+const DEFAULT_TORUS_SOURCE_TITLE = 'PLAYWRIGHT_AUTOMATION_DONT_DELETE';
+
 const requireEnv = (name: string) => {
   const value = process.env[name];
 
@@ -11,63 +46,245 @@ const requireEnv = (name: string) => {
 };
 
 test('test simple LTI launch @nightly', async ({ page }) => {
+  test.setTimeout(120_000);
+
   const canvasEmail = requireEnv('CANVAS_UI_EMAIL');
   const canvasPassword = requireEnv('CANVAS_UI_PASSWORD');
-  const toolName = 'OLI Torus (tokamak)';
+  const canvasBaseUrl = process.env.CANVAS_BASE_URL || DEFAULT_CANVAS_BASE_URL;
+  const canvasAccountId = requireEnv('CANVAS_ACCOUNT_ID');
+  const canvasApiToken = requireEnv('CANVAS_API_TOKEN');
+  const toolName = process.env.CANVAS_TOOL_NAME || DEFAULT_TOOL_NAME;
+  const toolLaunchUrl = process.env.CANVAS_TOOL_LAUNCH_URL || DEFAULT_TOOL_LAUNCH_URL;
+  const torusSourceTitle = process.env.TORUS_LTI_SOURCE_TITLE || DEFAULT_TORUS_SOURCE_TITLE;
+  const runId = `lti-${Date.now()}`;
+  const sectionTitle = torusSourceTitle;
+  let launchCourse: CanvasLaunchCourse | null = null;
 
-  await page.goto('https://canvas.oli.cmu.edu/login/canvas');
-  await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
-  await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
-  await Promise.all([
-    page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
-    page.getByRole('button', { name: 'Log In' }).click(),
-  ]);
+  try {
+    launchCourse = await createCanvasLaunchCourse({
+      baseUrl: canvasBaseUrl,
+      accountId: canvasAccountId,
+      token: canvasApiToken,
+      courseName: `${torusSourceTitle} ${runId}`,
+      toolName,
+      toolLaunchUrl,
+    });
 
-  await page.getByRole('link', { name: 'Second Test Second', exact: true }).click();
-  await page.getByRole('main').getByRole('link', { name: toolName }).last().click();
+    await page.goto(`${canvasBaseUrl}/login/canvas`);
+    await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
+    await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
+    await Promise.all([
+      page.waitForURL(`${canvasBaseUrl}/?login_success=1`),
+      page.getByRole('button', { name: 'Log In' }).click(),
+    ]);
 
-  const toolFrame = page.frameLocator('iframe[name="tool_content"]');
-  const newWindowButton = await findNewWindowButton(page, toolName);
+    await page.goto(`${canvasBaseUrl}/courses/${launchCourse.course.id}`);
+    await Promise.all([
+      page.waitForURL(/\/courses\/\d+\/modules\/items\/\d+/, { timeout: 15_000 }),
+      page.getByRole('main').getByRole('link', { name: toolName }).last().click(),
+    ]);
+    await page.waitForLoadState('domcontentloaded');
 
-  if (newWindowButton != null) {
-    const currentUrl = page.url();
-    const popupPromise = page.waitForEvent('popup', { timeout: 10_000 }).catch(() => null);
-    const contextPagePromise = page
-      .context()
-      .waitForEvent('page', { timeout: 10_000 })
-      .catch(() => null);
-    const navigationPromise = page
-      .waitForURL((url) => url.toString() !== currentUrl, { timeout: 10_000 })
-      .then(() => page)
-      .catch(() => null);
+    const toolFrame = page.frameLocator('iframe[name="tool_content"]');
+    const newWindowButton = await findNewWindowButton(page, toolName);
 
-    await newWindowButton.click();
+    if (newWindowButton != null) {
+      const toolPage = await openToolInNewWindow(page, newWindowButton);
 
-    const toolPage =
-      (await Promise.race([popupPromise, contextPagePromise, navigationPromise])) ?? page;
+      await acceptCookiesIfVisible(toolPage);
+      await createTorusSectionFromLaunch(toolPage, {
+        sourceTitle: torusSourceTitle,
+        sectionTitle,
+        sectionNumber: runId,
+      });
 
-    await toolPage.waitForLoadState('domcontentloaded');
-    await toolPage.bringToFront();
-
-    const acceptButton = toolPage.getByRole('button', { name: 'Accept' });
-
-    if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await acceptButton.click();
+      await expect(toolPage).toHaveURL(/\/sections\/[^/]+\/manage$/, { timeout: 60_000 });
+      await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
+      await expect(toolPage.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+      return;
     }
 
-    await clickGoToCourseIfVisible(toolPage);
-    await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
-    return;
-  }
+    await acceptCookiesIfVisible(toolFrame);
+    await createTorusSectionFromLaunch(toolFrame, {
+      sourceTitle: torusSourceTitle,
+      sectionTitle,
+      sectionNumber: runId,
+    });
 
-  const acceptButton = toolFrame.getByRole('button', { name: 'Accept' });
-  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    await acceptButton.click();
+    await expect(toolFrame.getByRole('link', { name: 'Overview' })).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(toolFrame.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+  } finally {
+    if (launchCourse != null) {
+      await deleteCanvasCourse({
+        baseUrl: canvasBaseUrl,
+        token: canvasApiToken,
+        courseId: launchCourse.course.id,
+      });
+    }
   }
-
-  await clickGoToCourseIfVisible(toolFrame);
-  await expect(toolFrame.getByRole('link', { name: 'Overview' })).toBeVisible();
 });
+
+async function createCanvasLaunchCourse({
+  baseUrl,
+  accountId,
+  token,
+  courseName,
+  toolName,
+  toolLaunchUrl,
+}: {
+  baseUrl: string;
+  accountId: string;
+  token: string;
+  courseName: string;
+  toolName: string;
+  toolLaunchUrl: string;
+}): Promise<CanvasLaunchCourse> {
+  const course = await canvasApiRequest<CanvasCourse>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/accounts/${accountId}/courses`,
+    {
+      'course[name]': courseName,
+      'course[course_code]': courseName,
+      offer: 'true',
+    },
+  );
+
+  let module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules`,
+    {
+      'module[name]': 'Torus LTI Launch',
+    },
+  );
+
+  let item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'POST',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items`,
+    {
+      'module_item[type]': 'ExternalTool',
+      'module_item[title]': toolName,
+      'module_item[external_url]': toolLaunchUrl,
+      'module_item[new_tab]': 'true',
+    },
+  );
+
+  module = await canvasApiRequest<CanvasModule>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}`,
+    {
+      'module[published]': 'true',
+    },
+  );
+
+  item = await canvasApiRequest<CanvasModuleItem>(
+    baseUrl,
+    token,
+    'PUT',
+    `/api/v1/courses/${course.id}/modules/${module.id}/items/${item.id}`,
+    {
+      'module_item[published]': 'true',
+    },
+  );
+
+  return { course, module, item };
+}
+
+async function deleteCanvasCourse({
+  baseUrl,
+  token,
+  courseId,
+}: {
+  baseUrl: string;
+  token: string;
+  courseId: number;
+}) {
+  await canvasApiRequest(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
+    event: 'delete',
+  });
+}
+
+async function canvasApiRequest<T>(
+  baseUrl: string,
+  token: string,
+  method: string,
+  path: string,
+  params: Record<string, string> = {},
+): Promise<T> {
+  const url = new URL(path, baseUrl);
+  const options: RequestInit = {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  };
+
+  if (method === 'GET') {
+    for (const [key, value] of Object.entries(params)) {
+      url.searchParams.append(key, value);
+    }
+  } else {
+    options.headers = {
+      ...options.headers,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    options.body = new URLSearchParams(params);
+  }
+
+  const response = await fetch(url, options);
+  const text = await response.text();
+  const body = parseCanvasResponse(text);
+
+  if (!response.ok) {
+    throw new Error(
+      `${method} ${path} failed (${response.status}): ${
+        typeof body === 'string' ? body : JSON.stringify(body)
+      }`,
+    );
+  }
+
+  return body as T;
+}
+
+function parseCanvasResponse(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function openToolInNewWindow(page: Page, newWindowButton: Locator) {
+  const currentUrl = page.url();
+  const popupPromise = page.waitForEvent('popup', { timeout: 10_000 }).catch(() => null);
+  const contextPagePromise = page
+    .context()
+    .waitForEvent('page', { timeout: 10_000 })
+    .catch(() => null);
+  const navigationPromise = page
+    .waitForURL((url) => url.toString() !== currentUrl, { timeout: 10_000 })
+    .then(() => page)
+    .catch(() => null);
+
+  await newWindowButton.click();
+
+  const toolPage =
+    (await Promise.race([popupPromise, contextPagePromise, navigationPromise])) ?? page;
+
+  await toolPage.waitForLoadState('domcontentloaded');
+  await toolPage.bringToFront();
+
+  return toolPage;
+}
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -86,7 +303,9 @@ async function findNewWindowButton(page: Page, toolName: string) {
   for (const candidate of candidates) {
     const button = candidate.first();
 
-    if (await button.isVisible({ timeout: 3000 }).catch(() => false)) {
+    const timeout = candidate === candidates[0] ? 15_000 : 3000;
+
+    if (await button.isVisible({ timeout }).catch(() => false)) {
       return button;
     }
   }
@@ -96,12 +315,69 @@ async function findNewWindowButton(page: Page, toolName: string) {
 
 type RoleScope = {
   getByRole(role: 'button', options: { name: string | RegExp }): Locator;
+  getByPlaceholder(text: string | RegExp): Locator;
+  getByText(text: string | RegExp, options?: { exact?: boolean }): Locator;
+  locator(selector: string): Locator;
 };
 
-async function clickGoToCourseIfVisible(scope: RoleScope) {
-  const goToCourseButton = scope.getByRole('button', { name: /^Go to course$/i });
+async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'getByRole'>) {
+  const acceptButton = scope.getByRole('button', { name: 'Accept' });
 
-  if (await goToCourseButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
-    await goToCourseButton.click();
+  if (await acceptButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await acceptButton.click();
   }
+}
+
+async function createTorusSectionFromLaunch(
+  scope: RoleScope,
+  {
+    sourceTitle,
+    sectionTitle,
+    sectionNumber,
+  }: { sourceTitle: string; sectionTitle: string; sectionNumber: string },
+) {
+  await expect(scope.getByText('Select source')).toBeVisible();
+  const searchInput = scope.getByPlaceholder('Search...');
+  await searchInput.fill('');
+  await searchInput.pressSequentially(sourceTitle, { delay: 20 });
+  await scope.getByRole('button', { name: 'Search' }).click();
+  await expect(scope.getByText(`Results filtered on "${sourceTitle}"`)).toBeVisible();
+
+  const sourceCard = scope
+    .locator('.course-card-link')
+    .filter({ has: scope.getByText(sourceTitle, { exact: true }) })
+    .first();
+
+  await expect(sourceCard).toBeVisible();
+  await sourceCard.click();
+  const nextStepButton = scope.getByRole('button', { name: 'Next step' });
+  await expect(nextStepButton).toBeEnabled();
+  await nextStepButton.click();
+
+  await expect(
+    scope.locator('#stepper_content').getByRole('heading', { name: 'Name your course' }),
+  ).toBeVisible();
+  await scope.locator('#section_title').fill(sectionTitle);
+  await scope.locator('#section_course_section_number').fill(sectionNumber);
+  await scope.getByText("Never, it's a self paced course", { exact: true }).click();
+  await expect(nextStepButton).toBeEnabled();
+  await nextStepButton.click();
+
+  await expect(
+    scope.locator('#stepper_content').getByRole('heading', { name: 'Course details' }),
+  ).toBeVisible();
+  await scope.locator('#section_start_date').fill(formatDatetimeLocal(daysFromNow(0)));
+  await scope.locator('#section_end_date').fill(formatDatetimeLocal(daysFromNow(365)));
+  await scope.locator('#section_preferred_scheduling_time').fill('09:00');
+  await scope.getByRole('button', { name: 'Create section' }).click();
+}
+
+function daysFromNow(days: number) {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
+}
+
+function formatDatetimeLocal(date: Date) {
+  return date.toISOString().slice(0, 16);
 }

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -1,39 +1,20 @@
-import { expect, Locator, Page, test } from '@playwright/test';
+import { Browser, expect, Locator, Page, test } from '@playwright/test';
+import { LoginPO } from '@pom/home/LoginPO';
+import {
+  createCanvasLaunchCourse,
+  deleteCanvasCourse,
+  type CanvasLaunchCourse,
+} from '../../../src/systems/canvas/api/CanvasApi';
 
-type CanvasCourse = {
-  id: number;
-  name: string;
-  workflow_state?: string;
-  html_url?: string;
-};
-
-type CanvasModule = {
-  id: number;
-  name: string;
-  published?: boolean;
-};
-
-type CanvasModuleItem = {
-  id: number;
+type TorusProject = {
   title: string;
-  type: string;
-  content_id?: number;
-  external_url?: string;
-  html_url?: string;
-  new_tab?: boolean;
-  published?: boolean;
-};
-
-type CanvasLaunchCourse = {
-  course: CanvasCourse;
-  module: CanvasModule;
-  item: CanvasModuleItem;
+  slug: string;
 };
 
 const DEFAULT_CANVAS_BASE_URL = 'https://canvas.oli.cmu.edu';
 const DEFAULT_TOOL_NAME = 'OLI Torus (tokamak)';
 const DEFAULT_TOOL_LAUNCH_URL = 'https://tokamak.oli.cmu.edu/lti/launch';
-const DEFAULT_TORUS_SOURCE_TITLE = 'PLAYWRIGHT_AUTOMATION_DONT_DELETE';
+const DEFAULT_TORUS_PROJECT_TITLE = 'LTI_CANVAS_TEST';
 
 const requireEnv = (name: string) => {
   const value = process.env[name];
@@ -45,29 +26,65 @@ const requireEnv = (name: string) => {
   return value;
 };
 
-test('test simple LTI launch @nightly', async ({ page }) => {
-  test.setTimeout(120_000);
+const firstEnv = (names: string[]) => {
+  for (const name of names) {
+    const value = process.env[name];
 
-  const canvasEmail = requireEnv('CANVAS_UI_EMAIL');
-  const canvasPassword = requireEnv('CANVAS_UI_PASSWORD');
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const requireFirstEnv = (names: string[]) => {
+  const value = firstEnv(names);
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${names.join(' or ')}`);
+  }
+
+  return value;
+};
+
+test('test simple LTI launch @nightly', async ({ browser, page }) => {
+  test.setTimeout(300_000);
+
+  const canvasEmail = requireFirstEnv(['CANVAS_INSTRUCTOR_EMAIL', 'CANVAS_UI_EMAIL']);
+  const canvasPassword = requireFirstEnv(['CANVAS_INSTRUCTOR_PASSWORD', 'CANVAS_UI_PASSWORD']);
   const canvasBaseUrl = process.env.CANVAS_BASE_URL || DEFAULT_CANVAS_BASE_URL;
   const canvasAccountId = requireEnv('CANVAS_ACCOUNT_ID');
   const canvasApiToken = requireEnv('CANVAS_API_TOKEN');
-  const toolName = process.env.CANVAS_TOOL_NAME || DEFAULT_TOOL_NAME;
+  const canvasInstructorUserId = process.env.CANVAS_INSTRUCTOR_USER_ID;
+  const toolName = firstEnv(['CANVAS_LTI_TOOL_NAME', 'CANVAS_TOOL_NAME']) || DEFAULT_TOOL_NAME;
   const toolLaunchUrl = process.env.CANVAS_TOOL_LAUNCH_URL || DEFAULT_TOOL_LAUNCH_URL;
-  const torusSourceTitle = process.env.TORUS_LTI_SOURCE_TITLE || DEFAULT_TORUS_SOURCE_TITLE;
+  const torusBaseUrl = process.env.TORUS_BASE_URL || new URL(toolLaunchUrl).origin;
+  const torusAdminEmail = requireEnv('TORUS_ADMIN_EMAIL');
+  const torusAdminPassword = requireEnv('TORUS_ADMIN_PASSWORD');
   const runId = `lti-${Date.now()}`;
-  const sectionTitle = torusSourceTitle;
+  const torusProjectTitle =
+    process.env.TORUS_LTI_PROJECT_TITLE || `${DEFAULT_TORUS_PROJECT_TITLE} ${runId}`;
+  const sectionTitle = torusProjectTitle;
   let launchCourse: CanvasLaunchCourse | null = null;
+  let torusProject: TorusProject | null = null;
 
   try {
+    torusProject = await createTorusFixtureProject(browser, {
+      baseUrl: torusBaseUrl,
+      adminEmail: torusAdminEmail,
+      adminPassword: torusAdminPassword,
+      title: torusProjectTitle,
+    });
+
     launchCourse = await createCanvasLaunchCourse({
       baseUrl: canvasBaseUrl,
       accountId: canvasAccountId,
       token: canvasApiToken,
-      courseName: `${torusSourceTitle} ${runId}`,
+      courseName: torusProject.title,
       toolName,
       toolLaunchUrl,
+      instructorUserId: canvasInstructorUserId,
     });
 
     await page.goto(`${canvasBaseUrl}/login/canvas`);
@@ -93,7 +110,7 @@ test('test simple LTI launch @nightly', async ({ page }) => {
 
       await acceptCookiesIfVisible(toolPage);
       await createTorusSectionFromLaunch(toolPage, {
-        sourceTitle: torusSourceTitle,
+        sourceTitle: torusProject.title,
         sectionTitle,
         sectionNumber: runId,
       });
@@ -108,7 +125,7 @@ test('test simple LTI launch @nightly', async ({ page }) => {
 
     await acceptCookiesIfVisible(toolFrame);
     await createTorusSectionFromLaunch(toolFrame, {
-      sourceTitle: torusSourceTitle,
+      sourceTitle: torusProject.title,
       sectionTitle,
       sectionNumber: runId,
     });
@@ -131,144 +148,303 @@ test('test simple LTI launch @nightly', async ({ page }) => {
         courseId: launchCourse.course.id,
       });
     }
+
+    if (torusProject != null) {
+      await deleteTorusFixtureProject(browser, {
+        baseUrl: torusBaseUrl,
+        adminEmail: torusAdminEmail,
+        adminPassword: torusAdminPassword,
+        project: torusProject,
+      });
+    }
   }
 });
 
-async function createCanvasLaunchCourse({
-  baseUrl,
-  accountId,
-  token,
-  courseName,
-  toolName,
-  toolLaunchUrl,
-}: {
-  baseUrl: string;
-  accountId: string;
-  token: string;
-  courseName: string;
-  toolName: string;
-  toolLaunchUrl: string;
-}): Promise<CanvasLaunchCourse> {
-  const course = await canvasApiRequest<CanvasCourse>(
+async function createTorusFixtureProject(
+  browser: Browser,
+  {
     baseUrl,
-    token,
-    'POST',
-    `/api/v1/accounts/${accountId}/courses`,
-    {
-      'course[name]': courseName,
-      'course[course_code]': courseName,
-      offer: 'true',
-    },
-  );
+    adminEmail,
+    adminPassword,
+    title,
+  }: { baseUrl: string; adminEmail: string; adminPassword: string; title: string },
+): Promise<TorusProject> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  let project: TorusProject | null = null;
 
-  let module = await canvasApiRequest<CanvasModule>(
-    baseUrl,
-    token,
-    'POST',
-    `/api/v1/courses/${course.id}/modules`,
-    {
-      'module[name]': 'Torus LTI Launch',
-    },
-  );
+  try {
+    await loginTorusAdmin(page, { baseUrl, email: adminEmail, password: adminPassword });
+    project = await createTorusProject(page, { baseUrl, title });
+    await addBasicUnscoredPage(page, { baseUrl, projectSlug: project.slug });
+    await publishTorusProject(page, { baseUrl, projectSlug: project.slug });
+    await openTorusProjectVisibility(page, { baseUrl, projectSlug: project.slug });
+    await logoutTorusAuthor(page);
 
-  let item = await canvasApiRequest<CanvasModuleItem>(
-    baseUrl,
-    token,
-    'POST',
-    `/api/v1/courses/${course.id}/modules/${module.id}/items`,
-    {
-      'module_item[type]': 'ExternalTool',
-      'module_item[title]': toolName,
-      'module_item[external_url]': toolLaunchUrl,
-      'module_item[new_tab]': 'true',
-    },
-  );
-
-  module = await canvasApiRequest<CanvasModule>(
-    baseUrl,
-    token,
-    'PUT',
-    `/api/v1/courses/${course.id}/modules/${module.id}`,
-    {
-      'module[published]': 'true',
-    },
-  );
-
-  item = await canvasApiRequest<CanvasModuleItem>(
-    baseUrl,
-    token,
-    'PUT',
-    `/api/v1/courses/${course.id}/modules/${module.id}/items/${item.id}`,
-    {
-      'module_item[published]': 'true',
-    },
-  );
-
-  return { course, module, item };
-}
-
-async function deleteCanvasCourse({
-  baseUrl,
-  token,
-  courseId,
-}: {
-  baseUrl: string;
-  token: string;
-  courseId: number;
-}) {
-  await canvasApiRequest(baseUrl, token, 'DELETE', `/api/v1/courses/${courseId}`, {
-    event: 'delete',
-  });
-}
-
-async function canvasApiRequest<T>(
-  baseUrl: string,
-  token: string,
-  method: string,
-  path: string,
-  params: Record<string, string> = {},
-): Promise<T> {
-  const url = new URL(path, baseUrl);
-  const options: RequestInit = {
-    method,
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  };
-
-  if (method === 'GET') {
-    for (const [key, value] of Object.entries(params)) {
-      url.searchParams.append(key, value);
+    return project;
+  } catch (error) {
+    if (project != null) {
+      await deleteTorusProject(page, { baseUrl, project }).catch(() => {});
     }
-  } else {
-    options.headers = {
-      ...options.headers,
-      'Content-Type': 'application/x-www-form-urlencoded',
-    };
-    options.body = new URLSearchParams(params);
+
+    throw error;
+  } finally {
+    await context.close();
   }
+}
 
-  const response = await fetch(url, options);
-  const text = await response.text();
-  const body = parseCanvasResponse(text);
+async function deleteTorusFixtureProject(
+  browser: Browser,
+  {
+    baseUrl,
+    adminEmail,
+    adminPassword,
+    project,
+  }: { baseUrl: string; adminEmail: string; adminPassword: string; project: TorusProject },
+) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
 
-  if (!response.ok) {
+  try {
+    await loginTorusAdmin(page, { baseUrl, email: adminEmail, password: adminPassword });
+    await deleteTorusProject(page, { baseUrl, project });
+    await logoutTorusAuthor(page);
+  } finally {
+    await context.close();
+  }
+}
+
+async function loginTorusAdmin(
+  page: Page,
+  { baseUrl, email, password }: { baseUrl: string; email: string; password: string },
+) {
+  const login = new LoginPO(page);
+
+  await page.goto(torusUrl(baseUrl, '/authors/log_in'));
+  await acceptCookiesIfVisible(page, 10_000);
+  await login.fillEmail(email);
+  await login.fillPassword(password);
+  await acceptCookiesIfVisible(page, 10_000);
+  await page.locator('#login_form button:has-text("Sign in")').click({ noWaitAfter: true });
+
+  const signedIn = await page
+    .waitForURL(/\/workspaces\/course_author(?:[/?#]|$)/, {
+      timeout: 30_000,
+      waitUntil: 'domcontentloaded',
+    })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!signedIn) {
+    const loginError = await page
+      .locator('.alert-danger, .alert-error, [role="alert"]')
+      .allInnerTexts()
+      .then((messages) =>
+        messages
+          .map((message) => message.trim())
+          .filter(Boolean)
+          .join(' '),
+      )
+      .catch(() => '');
+
     throw new Error(
-      `${method} ${path} failed (${response.status}): ${
-        typeof body === 'string' ? body : JSON.stringify(body)
-      }`,
+      `Torus admin sign-in did not reach Course Author${loginError ? `: ${loginError}` : ''}`,
     );
   }
 
-  return body as T;
+  await expect(page.locator('#button-new-project')).toBeVisible({ timeout: 30_000 });
 }
 
-function parseCanvasResponse(text: string) {
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
+async function logoutTorusAuthor(page: Page) {
+  const menuButton = page.locator('#workspace-user-menu, #user-account-menu').first();
+
+  if (!(await menuButton.isVisible({ timeout: 3000 }).catch(() => false))) {
+    return;
   }
+
+  await menuButton.click();
+
+  const menu = page.locator('#workspace-user-menu-dropdown, #user-account-menu-dropdown').first();
+  const signOut = menu.getByRole('link', { name: 'Sign out' }).first();
+
+  if (await signOut.isVisible({ timeout: 3000 }).catch(() => false)) {
+    await signOut.click();
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+  }
+}
+
+async function createTorusProject(
+  page: Page,
+  { baseUrl, title }: { baseUrl: string; title: string },
+): Promise<TorusProject> {
+  await page.goto(torusUrl(baseUrl, '/workspaces/course_author'));
+  await waitForLiveView(page);
+
+  const newProjectButton = page.locator('#button-new-project');
+  const projectTitleInput = page.locator('#project_title');
+
+  await expect(newProjectButton).toBeVisible({ timeout: 15_000 });
+  await clickUntilVisible(page, newProjectButton, projectTitleInput, 'new project form');
+  await projectTitleInput.fill(title);
+  await page.getByRole('button', { name: 'Create' }).click();
+  await expect(page.locator('.toolbar_nGbXING3')).toBeVisible({ timeout: 30_000 });
+
+  const slug = await page.locator('#project_slug').inputValue();
+
+  return { title, slug };
+}
+
+async function clickUntilVisible(
+  page: Page,
+  trigger: Locator,
+  target: Locator,
+  targetName: string,
+  maxAttempts = 5,
+  waitMs = 300,
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    await trigger.click({ force: true });
+
+    if (await target.isVisible({ timeout: 1500 }).catch(() => false)) {
+      return;
+    }
+
+    if (attempt < maxAttempts) {
+      await page.waitForTimeout(waitMs);
+    }
+  }
+
+  throw new Error(`${targetName} did not appear after ${maxAttempts} clicks`);
+}
+
+async function addBasicUnscoredPage(
+  page: Page,
+  { baseUrl, projectSlug }: { baseUrl: string; projectSlug: string },
+) {
+  const curriculumUrl = torusUrl(baseUrl, `/workspaces/course_author/${projectSlug}/curriculum`);
+
+  await page.goto(curriculumUrl);
+  await waitForLiveView(page);
+
+  const basicPracticeButton = page
+    .locator(
+      '#curriculum-create-actions button[data-create-page-action="true"][phx-value-type="Basic"][phx-value-scored="Unscored"]',
+    )
+    .first();
+
+  await expect(basicPracticeButton).toBeVisible({ timeout: 15_000 });
+  await expect(basicPracticeButton).toBeEnabled();
+  await basicPracticeButton.click();
+
+  const openedEditor = await page
+    .waitForURL(/\/curriculum\/[^/]+\/edit$/, { timeout: 30_000, waitUntil: 'domcontentloaded' })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!openedEditor) {
+    const flashError = await page
+      .locator('.alert-danger, .alert-error, [role="alert"]')
+      .allInnerTexts()
+      .then((messages) =>
+        messages
+          .map((message) => message.trim())
+          .filter(Boolean)
+          .join(' '),
+      )
+      .catch(() => '');
+
+    throw new Error(
+      `Torus page creation did not open the editor${flashError ? `: ${flashError}` : ''}`,
+    );
+  }
+
+  await page.goto(curriculumUrl);
+  await waitForLiveView(page);
+}
+
+async function publishTorusProject(
+  page: Page,
+  { baseUrl, projectSlug }: { baseUrl: string; projectSlug: string },
+) {
+  await page.goto(torusUrl(baseUrl, `/workspaces/course_author/${projectSlug}/publish`));
+  await waitForLiveView(page);
+
+  const autoPush = page.locator('#publication_auto_push_update');
+
+  if (
+    (await autoPush.isVisible({ timeout: 5000 }).catch(() => false)) &&
+    !(await autoPush.isChecked())
+  ) {
+    await autoPush.click();
+  }
+
+  const publishButton = page.locator('#button-publish');
+  await expect(publishButton).toBeEnabled({ timeout: 15_000 });
+  await publishButton.click();
+
+  const okButton = page.getByRole('button', { name: 'Ok' }).first();
+  const confirmationAppeared = await okButton
+    .waitFor({ state: 'visible', timeout: 15_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!confirmationAppeared) {
+    const flashError = await page
+      .locator('.alert-danger, .alert-error, [role="alert"]')
+      .allInnerTexts()
+      .then((messages) =>
+        messages
+          .map((message) => message.trim())
+          .filter(Boolean)
+          .join(' '),
+      )
+      .catch(() => '');
+
+    throw new Error(
+      `Torus publish confirmation did not appear${flashError ? `: ${flashError}` : ''}`,
+    );
+  }
+
+  await okButton.click();
+  await expect(page.getByText('Publish Successful!')).toBeVisible({ timeout: 30_000 });
+}
+
+async function openTorusProjectVisibility(
+  page: Page,
+  { baseUrl, projectSlug }: { baseUrl: string; projectSlug: string },
+) {
+  await page.goto(torusUrl(baseUrl, `/workspaces/course_author/${projectSlug}/overview`));
+  await expect(page.locator('.toolbar_nGbXING3')).toBeVisible({ timeout: 30_000 });
+
+  const visibilityRadio = page.locator('#visibility_option_global');
+
+  await expect(visibilityRadio).toBeVisible({ timeout: 15_000 });
+  await visibilityRadio.check();
+  await expect(visibilityRadio).toBeChecked();
+}
+
+async function deleteTorusProject(
+  page: Page,
+  { baseUrl, project }: { baseUrl: string; project: TorusProject },
+) {
+  await page.goto(torusUrl(baseUrl, `/workspaces/course_author/${project.slug}/overview`));
+  await expect(page.locator('.toolbar_nGbXING3')).toBeVisible({ timeout: 30_000 });
+  await page.getByRole('button', { name: 'Delete' }).click();
+
+  const deleteModal = page.locator('#delete-package-modal');
+
+  await expect(deleteModal).toBeVisible({ timeout: 15_000 });
+  await deleteModal.locator('#delete-confirm-title').fill(project.title);
+  await expect(deleteModal.locator('#delete-modal-submit')).toBeEnabled({ timeout: 5000 });
+
+  await Promise.all([
+    page.waitForURL(/\/workspaces\/course_author(?:\?|$)/, { timeout: 15_000 }),
+    deleteModal.locator('#delete-modal-submit').click(),
+  ]);
+}
+
+function torusUrl(baseUrl: string, path: string) {
+  return new URL(path, baseUrl).toString();
 }
 
 async function openToolInNewWindow(page: Page, newWindowButton: Locator) {
@@ -328,13 +504,37 @@ type RoleScope = {
   locator(selector: string): Locator;
 };
 
-async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'locator'>) {
+async function acceptCookiesIfVisible(scope: Pick<RoleScope, 'locator'>, timeout = 3000) {
   const cookieModal = scope.locator('#cookie_consent_display');
-  const acceptButton = cookieModal.getByRole('button', { name: /^Accept$/ });
+  const acceptButton = cookieModal.locator('button:has-text("Accept")').first();
+  const modalBackdrop = scope.locator('.modal-backdrop').first();
 
-  if (await acceptButton.isVisible({ timeout: 10_000 }).catch(() => false)) {
-    await acceptButton.click();
-    await expect(cookieModal).toBeHidden({ timeout: 5_000 });
+  const appeared = await acceptButton
+    .waitFor({ state: 'visible', timeout })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!appeared) {
+    return;
+  }
+
+  await acceptButton.click({ force: true });
+  await expect(cookieModal).toBeHidden({ timeout: 5_000 });
+
+  const backdropCleared = await modalBackdrop
+    .waitFor({ state: 'hidden', timeout: 5_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!backdropCleared) {
+    await scope.locator('.modal-backdrop').evaluateAll((backdrops) => {
+      backdrops.forEach((backdrop) => backdrop.remove());
+    });
+    await scope.locator('body').evaluate((body) => {
+      body.classList.remove('modal-open');
+      body.style.removeProperty('overflow');
+      body.style.removeProperty('padding-right');
+    });
   }
 }
 

--- a/assets/automation/tests/torus/lti/launch.spec.ts
+++ b/assets/automation/tests/torus/lti/launch.spec.ts
@@ -101,6 +101,8 @@ test('test simple LTI launch @nightly', async ({ page }) => {
       await expect(toolPage).toHaveURL(/\/sections\/[^/]+\/manage$/, { timeout: 60_000 });
       await expect(toolPage.getByRole('link', { name: 'Overview' })).toBeVisible();
       await expect(toolPage.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+      await deleteTorusSectionFromManage(toolPage);
+      await expect(toolPage).toHaveURL(/\/sections(?:$|\/new\/[^/]+$)/, { timeout: 15_000 });
       return;
     }
 
@@ -115,6 +117,12 @@ test('test simple LTI launch @nightly', async ({ page }) => {
       timeout: 60_000,
     });
     await expect(toolFrame.getByText(sectionTitle, { exact: true }).first()).toBeVisible();
+    await deleteTorusSectionFromManage(toolFrame);
+    await expect(
+      toolFrame
+        .getByText('Section successfully deleted.')
+        .or(toolFrame.getByText('New course set up')),
+    ).toBeVisible({ timeout: 15_000 });
   } finally {
     if (launchCourse != null) {
       await deleteCanvasCourse({
@@ -370,6 +378,23 @@ async function createTorusSectionFromLaunch(
   await scope.locator('#section_end_date').fill(formatDatetimeLocal(daysFromNow(365)));
   await scope.locator('#section_preferred_scheduling_time').fill('09:00');
   await scope.getByRole('button', { name: 'Create section' }).click();
+}
+
+async function deleteTorusSectionFromManage(scope: RoleScope) {
+  await waitForLiveView(scope);
+  const deleteSectionButton = scope.getByRole('button', { name: 'Delete Section' });
+  await expect(deleteSectionButton).toBeVisible({ timeout: 15_000 });
+  await deleteSectionButton.click();
+
+  const modal = scope.locator('#delete_section_modal');
+  await expect(modal).toBeVisible({ timeout: 15_000 });
+  await modal.getByRole('button', { name: 'Delete this section' }).click();
+}
+
+async function waitForLiveView(scope: Pick<RoleScope, 'locator'>) {
+  await expect(scope.locator('[data-phx-main].phx-connected').first()).toBeAttached({
+    timeout: 15_000,
+  });
 }
 
 function daysFromNow(days: number) {

--- a/oli.example.env
+++ b/oli.example.env
@@ -226,9 +226,30 @@ KNOWLEDGEBASE_URL="#"
 # Local development only. Do not set this in production.
 # PROJECT_EXPORT_LOCAL_OUTPUT_DIR=/path/to/export_directory
 
-## Canvas automation with Playwright
+## Canvas LTI Playwright automation
+## Copy these into your local oli.env and fill values from the team password manager.
+## Do not commit real credentials or API tokens.
+## Grade passback smoke tests use the student credentials and launch link name.
 # CANVAS_STUDENT_EMAIL=student@email.com
 # CANVAS_STUDENT_PASSWORD=student_password
 # CANVAS_INSTRUCTOR_EMAIL=instructor@email.com
 # CANVAS_INSTRUCTOR_PASSWORD=instructor_password
 # CANVAS_LTI_LAUNCH_LINK_NAME=OLI Torus (tokamak)
+
+## Canvas course provisioning tests also use the Torus admin and Canvas API settings.
+# TORUS_BASE_URL=https://tokamak.oli.cmu.edu
+# TORUS_ADMIN_EMAIL=torus-admin@example.edu
+# TORUS_ADMIN_PASSWORD=changeme
+
+# CANVAS_BASE_URL=https://canvas.oli.cmu.edu
+# CANVAS_ACCOUNT_ID=1
+# CANVAS_API_TOKEN=canvas-api-token
+# CANVAS_INSTRUCTOR_USER_ID=canvas-user-id
+# CANVAS_LTI_TOOL_NAME="OLI Torus (tokamak)"
+# CANVAS_TOOL_LAUNCH_URL="${TORUS_BASE_URL}/lti/launch"
+
+# PLAYWRIGHT_SCENARIO_TOKEN=my-token
+
+## Optional: override the temporary source project title. Leave unset for a unique
+## LTI_CANVAS_TEST lti-<timestamp> project each run.
+# TORUS_LTI_PROJECT_TITLE=LTI_CANVAS_TEST

--- a/oli.example.env
+++ b/oli.example.env
@@ -229,12 +229,11 @@ KNOWLEDGEBASE_URL="#"
 ## Canvas LTI Playwright automation
 ## Copy these into your local oli.env and fill values from the team password manager.
 ## Do not commit real credentials or API tokens.
-## Grade passback smoke tests use the student credentials and launch link name.
+## Grade passback smoke tests use the student credentials and Canvas LTI tool name.
 # CANVAS_STUDENT_EMAIL=student@email.com
 # CANVAS_STUDENT_PASSWORD=student_password
 # CANVAS_INSTRUCTOR_EMAIL=instructor@email.com
 # CANVAS_INSTRUCTOR_PASSWORD=instructor_password
-# CANVAS_LTI_LAUNCH_LINK_NAME=OLI Torus (tokamak)
 
 ## Canvas course provisioning tests also use the Torus admin and Canvas API settings.
 # TORUS_BASE_URL=https://tokamak.oli.cmu.edu


### PR DESCRIPTION
Adds a configurable end-to-end Canvas LTI launch test for Tokamak. The test creates a temporary Torus project, provisions a Canvas course via API, enrolls the configured instructor, launches the Tokamak LTI tool, verifies first-launch section setup, and cleans up the Canvas course, Torus section, and Torus project.

The PR also further strengthens the actions around the advanced activities modal.