### PR TITLE
[ENHANCEMENT] [MER-5656] Updates to Number Input Component in Advanced Author 

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
@@ -49,7 +49,7 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
 
   return (
     <div>
-      { label &&(
+      {label && (
         <label htmlFor={id} className="form-label">
           {label}
         </label>

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/RichLabelWidget.tsx
@@ -23,6 +23,7 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
   onBlur,
   disabled,
   readonly,
+  label,
 }) => {
   const [showModal, setShowModal] = useState(false);
   const currentValue: string = typeof value === 'string' ? value : '';
@@ -47,66 +48,73 @@ export const RichLabelWidget: React.FC<WidgetProps> = ({
   };
 
   return (
-    <div className="flex align-items-center gap-1">
-      <style>{`
-        .rich-label-widget-preview,
-        .rich-label-widget-preview p,
-        .rich-label-widget-preview div {
-          margin: 0;
-        }
-        .rich-label-widget-preview p,
-        .rich-label-widget-preview div {
-          line-height: 1.5;
-        }
-      `}</style>
-      {isRich ? (
-        /* Rich label — read-only preview matching DropdownOptionsEditor */
-        <div
-          id={id}
-          className="flex-1 form-control rich-label-widget-preview"
-          style={{
-            minHeight: 38,
-            cursor: 'default',
-            display: 'flex',
-            alignItems: 'center',
-          }}
-        >
-          <span dangerouslySetInnerHTML={{ __html: sanitized || '&nbsp;' }} />
-        </div>
-      ) : (
-        /* Plain text label — normal editable input */
-        <input
-          id={id}
-          type="text"
-          className="flex-1 form-control"
-          value={currentValue}
-          disabled={disabled || readonly}
-          onChange={handleInputChange}
-          onBlur={handleInputBlur}
-        />
+    <div>
+      { label &&(
+        <label htmlFor={id} className="form-label">
+          {label}
+        </label>
       )}
+      <div className="flex align-items-center gap-1">
+        <style>{`
+          .rich-label-widget-preview,
+          .rich-label-widget-preview p,
+          .rich-label-widget-preview div {
+            margin: 0;
+          }
+          .rich-label-widget-preview p,
+          .rich-label-widget-preview div {
+            line-height: 1.5;
+          }
+        `}</style>
+        {isRich ? (
+          /* Rich label — read-only preview matching DropdownOptionsEditor */
+          <div
+            id={id}
+            className="flex-1 form-control rich-label-widget-preview"
+            style={{
+              minHeight: 38,
+              cursor: 'default',
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <span dangerouslySetInnerHTML={{ __html: sanitized || '&nbsp;' }} />
+          </div>
+        ) : (
+          /* Plain text label — normal editable input */
+          <input
+            id={id}
+            type="text"
+            className="flex-1 form-control"
+            value={currentValue}
+            disabled={disabled || readonly}
+            onChange={handleInputChange}
+            onBlur={handleInputBlur}
+          />
+        )}
 
-      <div className="flex-none">
-        <button
-          type="button"
-          className="btn btn-link btn-sm p-1 text-nowrap"
-          disabled={disabled || readonly}
-          onClick={() => setShowModal(true)}
-          aria-label="Edit label formatting"
-          title="Edit label formatting (bold, italic, superscript, subscript)"
-        >
-          <i className="fa-solid fa-pen-to-square" />
-        </button>
+        <div className="flex-none">
+          <button
+            type="button"
+            className="btn btn-link btn-sm p-1 text-nowrap"
+            disabled={disabled || readonly}
+            onClick={() => setShowModal(true)}
+            aria-label="Edit label formatting"
+            title="Edit label formatting (bold, italic, superscript, subscript)"
+          >
+            <i className="fa-solid fa-pen-to-square" />
+          </button>
+        </div>
+
+        <JanusRichLabelEditorModal
+          show={showModal}
+          title="Edit label"
+          value={currentValue}
+          onHide={() => setShowModal(false)}
+          onSave={handleModalSave}
+          aria-label="Edit label with rich formatting"
+        />
       </div>
-
-      <JanusRichLabelEditorModal
-        show={showModal}
-        title="Edit label"
-        value={currentValue}
-        onHide={() => setShowModal(false)}
-        onSave={handleModalSave}
-        aria-label="Edit label with rich formatting"
-      />
     </div>
   );
 };

--- a/assets/src/components/parts/janus-input-number/schema.ts
+++ b/assets/src/components/parts/janus-input-number/schema.ts
@@ -10,7 +10,6 @@ import { correctOrRange, numericAdvancedFeedback } from '../parts-schemas';
 import { JanusAbsolutePositioned, JanusCustomCss } from '../types/parts';
 
 export interface InputNumberModel extends JanusAbsolutePositioned, JanusCustomCss {
-  fontSize?: number;
   maxValue: number;
   minValue: number;
   showLabel: boolean;
@@ -93,19 +92,10 @@ export const schema: JSONSchema7Object = {
     title: 'Custom CSS Class',
     type: 'string',
   },
-  fontSize: {
-    title: 'Font Size',
-    type: 'number',
-    default: 12,
-  },
-
-  maxValue: {
-    title: 'Max Value',
-    type: 'number',
-  },
-  minValue: {
-    title: 'Min Value',
-    type: 'number',
+  label: {
+    title: 'Label',
+    type: 'string',
+    description: 'text label for the input field',
   },
   showLabel: {
     title: 'Show Label',
@@ -113,15 +103,22 @@ export const schema: JSONSchema7Object = {
     description: 'specifies whether label is visible',
     default: true,
   },
-  label: {
-    title: 'Label',
-    type: 'string',
-    description: 'text label for the input field',
-  },
   unitsLabel: {
-    title: 'Unit Label',
+    title: 'Units',
     type: 'string',
     description: 'text label appended to the input',
+  },
+  prompt: {
+    title: 'Prompt',
+    type: 'string',
+  },
+  minValue: {
+    title: 'Min Value',
+    type: 'number',
+  },
+  maxValue: {
+    title: 'Max Value',
+    type: 'number',
   },
   enabled: {
     title: 'Enabled',
@@ -136,13 +133,10 @@ export const schema: JSONSchema7Object = {
     default: false,
   },
   enableScrollIncrement: {
-    title: 'Enable Scroll Increment',
+    title: 'Enable Increment Scrolling',
     type: 'boolean',
     description: 'specifies whether scroll increment should be enabled in number textbox',
     default: false,
-  },
-  prompt: {
-    type: 'string',
   },
 };
 


### PR DESCRIPTION
This update is based on ticket MER-5656, to make updates to the Number Input Component in Advanced Author (janus-input-number). The changes were to change the label names, render the some missing label names, and reorganize the component tab structure for easier user updates. 

The changes were: 
- Remove Field
- Remove the “Font Size” field from the settings panel.
Update Labels:
- Add the label “Label” to the currently unlabeled label text input field.
- Add the label “Units” to the units text input field.
- Capitalize the label “Prompt” (currently lowercase).
Rename:
- “Enable Scroll Increment” → “Enable Increment Scrolling”
- Update Component Ordering
Reorder the settings panel fields to the following sequence:
- Custom CSS Class
- Label
- Show Label
- Units
- Prompt
- Min Value
- Max Value
- Enabled
- Show Increment Arrows
- Enable Increment Scrolling

`schema.ts` 
Changes were primarily the label strings and reorganizing the structure of the schema json structure. 

`RichLabelWidget.tsx` 
RichLabelWidget needed to be updated to render the label correctly. Before there was no check to see if there was a label to then display, as there wasn't even a <label> in the return. The change was just to add a label prop, and then check to see if the prop is use to then display the label. 