### PR TITLE
[BUG FIX] [MER-5693] Fix adaptive CAPI manual scoring and insights

### DIFF
--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -51,6 +51,16 @@ defmodule Oli.Activities.AdaptiveParts do
 
   def tracked_part?(_, _), do: false
 
+  def response_summary_part?(content, part_id) when is_map(content) and is_binary(part_id) do
+    MapSet.member?(response_summary_part_ids(content), part_id)
+  end
+
+  def response_summary_part?(content, %{"id" => part_id})
+      when is_map(content) and is_binary(part_id),
+      do: response_summary_part?(content, part_id)
+
+  def response_summary_part?(_, _), do: false
+
   def persisted_part?(content, part_id) when is_map(content) and is_binary(part_id) do
     MapSet.member?(persisted_part_ids(content), part_id)
   end
@@ -156,6 +166,11 @@ defmodule Oli.Activities.AdaptiveParts do
     |> Enum.reduce(MapSet.new(), &MapSet.union/2)
   end
 
+  def response_summary_part_ids(content) do
+    [tracked_part_ids(content), manual_persisted_part_ids(content)]
+    |> Enum.reduce(MapSet.new(), &MapSet.union/2)
+  end
+
   def persisted_part_definitions(content) when is_map(content) do
     merged_parts = merged_parts_by_id(content)
     persisted_ids = persisted_part_ids(content)
@@ -175,15 +190,7 @@ defmodule Oli.Activities.AdaptiveParts do
   end
 
   def manual_gradeable_part_ids(content) when is_map(content) do
-    manual_persisted_part_ids =
-      content
-      |> persisted_part_definitions()
-      |> Enum.filter(&(grading_approach(&1) == :manual))
-      |> Enum.map(&Map.get(&1, "id"))
-      |> Enum.reject(&is_nil/1)
-      |> MapSet.new()
-
-    MapSet.union(scorable_part_ids(content), manual_persisted_part_ids)
+    MapSet.union(scorable_part_ids(content), manual_persisted_part_ids(content))
   end
 
   def manual_gradeable_part_ids(_), do: MapSet.new()
@@ -296,6 +303,17 @@ defmodule Oli.Activities.AdaptiveParts do
   end
 
   defp ordered_part_ids(_), do: []
+
+  defp manual_persisted_part_ids(content) when is_map(content) do
+    content
+    |> persisted_part_definitions()
+    |> Enum.filter(&(grading_approach(&1) == :manual))
+    |> Enum.map(&Map.get(&1, "id"))
+    |> Enum.reject(&is_nil/1)
+    |> MapSet.new()
+  end
+
+  defp manual_persisted_part_ids(_), do: MapSet.new()
 
   defp rule_scoring_relevant?(rule) when is_map(rule) do
     Map.get(rule, "disabled") != true and Map.get(rule, :disabled) != true

--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -174,6 +174,20 @@ defmodule Oli.Activities.AdaptiveParts do
     |> Enum.reduce(MapSet.new(), &MapSet.union/2)
   end
 
+  def manual_gradeable_part_ids(content) when is_map(content) do
+    manual_persisted_part_ids =
+      content
+      |> persisted_part_definitions()
+      |> Enum.filter(&(grading_approach(&1) == :manual))
+      |> Enum.map(&Map.get(&1, "id"))
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    MapSet.union(scorable_part_ids(content), manual_persisted_part_ids)
+  end
+
+  def manual_gradeable_part_ids(_), do: MapSet.new()
+
   def stateful_non_scorable_part_definitions(content) when is_map(content) do
     merged_parts = merged_parts_by_id(content)
 

--- a/lib/oli/analytics/summary.ex
+++ b/lib/oli/analytics/summary.ex
@@ -217,7 +217,7 @@ defmodule Oli.Analytics.Summary do
     Enum.filter(part_attempts, fn part_attempt ->
       case Map.get(registered_activities, part_attempt.activity_revision.activity_type_id) do
         %{slug: "oli_adaptive"} ->
-          AdaptiveParts.tracked_part?(
+          AdaptiveParts.response_summary_part?(
             part_attempt.activity_revision.content,
             part_attempt.part_id
           )

--- a/lib/oli/delivery/attempts/manual_grading.ex
+++ b/lib/oli/delivery/attempts/manual_grading.ex
@@ -373,7 +373,7 @@ defmodule Oli.Delivery.Attempts.ManualGrading do
          %{activity_type_id: activity_type_id, revision: revision}
        ) do
     if AdaptiveParts.adaptive_activity?(%{activity_type_id: activity_type_id}) do
-      allowed_part_ids = AdaptiveParts.scorable_part_ids(revision.content)
+      allowed_part_ids = AdaptiveParts.manual_gradeable_part_ids(revision.content)
       Enum.filter(part_attempts, &MapSet.member?(allowed_part_ids, &1.part_id))
     else
       part_attempts

--- a/lib/oli_web/components/delivery/activity_helpers.ex
+++ b/lib/oli_web/components/delivery/activity_helpers.ex
@@ -1825,7 +1825,10 @@ defmodule OliWeb.Delivery.ActivityHelpers do
       parts_layout
       |> Enum.with_index(1)
       |> Enum.filter(fn {part, _index} ->
-        AdaptiveParts.tracked_part?(activity_attempt.revision.content, Map.get(part, "id"))
+        AdaptiveParts.response_summary_part?(
+          activity_attempt.revision.content,
+          Map.get(part, "id")
+        )
       end)
       |> Enum.map(fn {part, index} ->
         part_id = Map.get(part, "id")
@@ -3722,7 +3725,8 @@ defmodule OliWeb.Delivery.ActivityHelpers do
     part_attempt = Map.put(row.part_attempt, :activity_revision, row.revision)
     part = AdaptiveParts.part_definition(row.revision.content, part_attempt.part_id)
 
-    if is_nil(part) or not AdaptiveParts.tracked_part?(row.revision.content, part_attempt.part_id) do
+    if is_nil(part) or
+         not AdaptiveParts.response_summary_part?(row.revision.content, part_attempt.part_id) do
       acc
     else
       response_label = ResponseLabel.build(part_attempt, "oli_adaptive")

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -622,7 +622,7 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
          %{activity_type_id: activity_type_id, revision: revision}
        ) do
     if AdaptiveParts.adaptive_activity?(%{activity_type_id: activity_type_id}) do
-      allowed_part_ids = AdaptiveParts.scorable_part_ids(revision.content)
+      allowed_part_ids = AdaptiveParts.manual_gradeable_part_ids(revision.content)
       Enum.filter(part_attempts, &MapSet.member?(allowed_part_ids, &1.part_id))
     else
       part_attempts

--- a/lib/oli_web/live/manual_grading/selected_submission_builder.ex
+++ b/lib/oli_web/live/manual_grading/selected_submission_builder.ex
@@ -197,7 +197,7 @@ defmodule OliWeb.ManualGrading.SelectedSubmissionBuilder do
   defp part_metadata(attempt, part_attempt, "oli_adaptive") do
     part = AdaptiveParts.part_definition(attempt.revision.content, part_attempt.part_id)
 
-    if AdaptiveParts.tracked_part?(attempt.revision.content, part_attempt.part_id) do
+    if AdaptiveParts.persisted_part?(attempt.revision.content, part_attempt.part_id) do
       %{family: :adaptive, part: part, type: part["type"]}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Oli.MixProject do
   def project do
     [
       app: :oli,
-      version: "0.33.1",
+      version: "0.33.2",
       elixir: "~> 1.19",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: elixirc_options(Mix.env()),

--- a/test/oli/activities/adaptive_parts_test.exs
+++ b/test/oli/activities/adaptive_parts_test.exs
@@ -84,6 +84,35 @@ defmodule Oli.Activities.AdaptivePartsTest do
              :automatic
   end
 
+  test "allows manually graded persisted stateful parts for manual grading" do
+    content = %{
+      "partsLayout" => [
+        %{"id" => "janus_mcq-1", "type" => "janus-mcq"},
+        %{"id" => "janus_capi_iframe-1", "type" => "janus-capi-iframe"},
+        %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "janus_mcq-1", "type" => "janus-mcq", "gradingApproach" => "automatic"},
+          %{
+            "id" => "janus_capi_iframe-1",
+            "type" => "janus-capi-iframe",
+            "gradingApproach" => "manual"
+          },
+          %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"}
+        ]
+      }
+    }
+
+    assert AdaptiveParts.manual_gradeable_part_ids(content) ==
+             MapSet.new(["janus_mcq-1", "janus_capi_iframe-1"])
+
+    refute MapSet.member?(
+             AdaptiveParts.manual_gradeable_part_ids(content),
+             "janus_navigation_button-1"
+           )
+  end
+
   test "prefers custom manual grading flags over stale authored gradingApproach metadata" do
     content = %{
       "partsLayout" => [

--- a/test/oli/activities/adaptive_parts_test.exs
+++ b/test/oli/activities/adaptive_parts_test.exs
@@ -113,6 +113,54 @@ defmodule Oli.Activities.AdaptivePartsTest do
            )
   end
 
+  test "includes tracked and manually graded persisted parts in response summaries" do
+    content = %{
+      "partsLayout" => [
+        %{"id" => "janus_mcq-1", "type" => "janus-mcq"},
+        %{"id" => "janus_rule_capi-1", "type" => "janus-capi-iframe"},
+        %{"id" => "janus_manual_capi-1", "type" => "janus-capi-iframe"},
+        %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"}
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "janus_mcq-1", "type" => "janus-mcq", "gradingApproach" => "automatic"},
+          %{
+            "id" => "janus_rule_capi-1",
+            "type" => "janus-capi-iframe",
+            "gradingApproach" => "automatic"
+          },
+          %{
+            "id" => "janus_manual_capi-1",
+            "type" => "janus-capi-iframe",
+            "gradingApproach" => "manual"
+          },
+          %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"}
+        ],
+        "rules" => [
+          %{
+            "id" => "r.correct",
+            "disabled" => false,
+            "conditions" => %{
+              "all" => [
+                %{
+                  "fact" => "stage.janus_rule_capi-1.simScore",
+                  "operator" => "equal",
+                  "value" => "100"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+
+    assert AdaptiveParts.response_summary_part_ids(content) ==
+             MapSet.new(["janus_mcq-1", "janus_rule_capi-1", "janus_manual_capi-1"])
+
+    assert AdaptiveParts.response_summary_part?(content, "janus_manual_capi-1")
+    refute AdaptiveParts.response_summary_part?(content, "janus_navigation_button-1")
+  end
+
   test "prefers custom manual grading flags over stale authored gradingApproach metadata" do
     content = %{
       "partsLayout" => [

--- a/test/oli/analytics/summary/upsert_test.exs
+++ b/test/oli/analytics/summary/upsert_test.exs
@@ -530,6 +530,128 @@ defmodule Oli.Analytics.Summary.UpsertTest do
       assert [{"janus_mcq-1", "1", "Option 1"}] = response_rows
     end
 
+    test "upsert_response_summaries includes manually graded persisted adaptive CAPI parts", %{
+      a1: a1,
+      project: project,
+      section: section,
+      page1: page1,
+      user1: user1
+    } do
+      adaptive_registration = Activities.get_registration_by_slug("oli_adaptive")
+
+      adaptive_content = %{
+        "partsLayout" => [
+          %{
+            "id" => "janus_capi_iframe-1",
+            "type" => "janus-capi-iframe",
+            "custom" => %{"title" => "Simulation"}
+          },
+          %{
+            "id" => "janus_navigation_button-1",
+            "type" => "janus-navigation-button",
+            "custom" => %{"title" => "Continue"}
+          }
+        ],
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "janus_capi_iframe-1",
+              "type" => "janus-capi-iframe",
+              "gradingApproach" => "manual"
+            },
+            %{"id" => "janus_navigation_button-1", "type" => "janus-navigation-button"}
+          ]
+        }
+      }
+
+      adaptive_resource_id = a1.resource.id
+
+      group = %AttemptGroup{
+        context: %Context{
+          user_id: user1.id,
+          host_name: "localhost",
+          section_id: section.id,
+          project_id: project.id,
+          publication_id: -1
+        },
+        part_attempts: [
+          %{
+            part_id: "janus_capi_iframe-1",
+            response: %{
+              "simScore" => %{
+                "path" => "screen|stage.janus_capi_iframe-1.simScore",
+                "value" => 85
+              },
+              "status" => %{
+                "path" => "screen|stage.janus_capi_iframe-1.status",
+                "value" => "reviewed"
+              }
+            },
+            score: 1,
+            lifecycle_state: :evaluated,
+            out_of: 1,
+            activity_revision: %{
+              objectives: %{},
+              content: adaptive_content,
+              resource_id: adaptive_resource_id,
+              activity_type_id: adaptive_registration.id
+            },
+            hints: [],
+            attempt_number: 1,
+            activity_attempt: %{
+              attempt_number: 1,
+              resource_id: adaptive_resource_id,
+              revision_id: 1
+            }
+          },
+          %{
+            part_id: "janus_navigation_button-1",
+            response: %{"input" => %{}},
+            score: nil,
+            lifecycle_state: :evaluated,
+            out_of: nil,
+            activity_revision: %{
+              objectives: %{},
+              content: adaptive_content,
+              resource_id: adaptive_resource_id,
+              activity_type_id: adaptive_registration.id
+            },
+            hints: [],
+            attempt_number: 1,
+            activity_attempt: %{
+              attempt_number: 1,
+              resource_id: adaptive_resource_id,
+              revision_id: 1
+            }
+          }
+        ],
+        activity_attempts: [],
+        resource_attempt: %{resource_id: page1.id}
+      }
+
+      Pipeline.init("adaptive-manual-capi-response-summary")
+      |> Map.put(:data, group)
+      |> Summary.upsert_response_summaries()
+
+      response_rows =
+        from(rpr in ResourcePartResponse,
+          where: rpr.resource_id == ^adaptive_resource_id,
+          select: {rpr.part_id, rpr.response, rpr.label}
+        )
+        |> Repo.all()
+
+      assert [
+               {"janus_capi_iframe-1", "simScore: 85; status: reviewed",
+                "simScore: 85; status: reviewed"}
+             ] = response_rows
+
+      assert %StudentResponse{user_id: user_id, page_id: page_id} =
+               Repo.one(from(sr in StudentResponse, limit: 1))
+
+      assert user_id == user1.id
+      assert page_id == page1.id
+    end
+
     test "upsert_response_summaries safely handles quoted part ids", %{
       a1: a1,
       project: project,

--- a/test/oli/delivery/attempts/manual_grading_test.exs
+++ b/test/oli/delivery/attempts/manual_grading_test.exs
@@ -624,6 +624,149 @@ defmodule Oli.Delivery.Attempts.ManualGradingTest do
     end
   end
 
+  describe "apply_manual_scoring/3 for adaptive manually graded CAPI parts" do
+    setup do
+      adaptive_registration = Oli.Activities.get_registration_by_slug("oli_adaptive")
+
+      adaptive_content = %{
+        "partsLayout" => [
+          %{
+            "id" => "janus_capi_iframe-1",
+            "type" => "janus-capi-iframe",
+            "custom" => %{"title" => "Simulation", "maxScore" => 1}
+          },
+          %{
+            "id" => "janus_navigation_button-1",
+            "type" => "janus-navigation-button",
+            "custom" => %{"title" => "Continue"}
+          }
+        ],
+        "authoring" => %{
+          "parts" => [
+            %{
+              "id" => "janus_capi_iframe-1",
+              "type" => "janus-capi-iframe",
+              "gradingApproach" => "manual",
+              "outOf" => 1
+            },
+            %{
+              "id" => "janus_navigation_button-1",
+              "type" => "janus-navigation-button",
+              "gradingApproach" => "automatic"
+            }
+          ]
+        }
+      }
+
+      map = Seeder.base_project_with_resource2()
+      Oli.Resources.update_revision(map.revision2, %{graded: true})
+
+      map
+      |> Seeder.create_section()
+      |> Seeder.add_user(%{}, :user1)
+      |> Seeder.add_activity(
+        %{
+          title: "adaptive CAPI manual",
+          activity_type_id: adaptive_registration.id,
+          content: adaptive_content
+        },
+        :activity_a
+      )
+      |> Seeder.create_section_resources()
+      |> Seeder.create_resource_attempt(
+        %{attempt_number: 1, lifecycle_state: :submitted},
+        :user1,
+        :page2,
+        :revision2,
+        :attempt1
+      )
+      |> Seeder.create_activity_attempt(
+        %{attempt_number: 1, transformed_model: %{some: :thing}, lifecycle_state: :submitted},
+        :activity_a,
+        :attempt1,
+        :attempt_1a
+      )
+      |> Seeder.create_part_attempt(
+        %{
+          attempt_number: 1,
+          grading_approach: :manual,
+          date_submitted: DateTime.utc_now(),
+          lifecycle_state: :submitted,
+          response: %{
+            "input" => [
+              %{"path" => "janus_capi_iframe-1.simScore", "value" => "85"}
+            ]
+          },
+          out_of: 1.0
+        },
+        %Part{id: "janus_capi_iframe-1", responses: [], hints: [], grading_approach: :manual},
+        :attempt_1a,
+        :capi_part_attempt
+      )
+      |> Seeder.create_part_attempt(
+        %{
+          attempt_number: 1,
+          grading_approach: :automatic,
+          lifecycle_state: :active,
+          response: %{}
+        },
+        %Part{
+          id: "janus_navigation_button-1",
+          responses: [],
+          hints: [],
+          grading_approach: :automatic
+        },
+        :attempt_1a,
+        :navigation_part_attempt
+      )
+    end
+
+    test "applies manual scoring to manually graded CAPI without requiring native inputs", %{
+      section: section,
+      attempt_1a: attempt_1a,
+      capi_part_attempt: capi_part_attempt
+    } do
+      results =
+        ManualGrading.browse_submitted_attempts(
+          section,
+          %Paging{limit: 1, offset: 0},
+          %Sorting{field: :date_submitted, direction: :desc},
+          %BrowseOptions{
+            user_id: nil,
+            activity_id: nil,
+            page_id: nil,
+            graded: nil,
+            text_search: nil
+          }
+        )
+
+      attempt = Enum.find(results, fn a -> a.id == attempt_1a.id end)
+
+      assert {:ok, [returned_guid]} =
+               ManualGrading.apply_manual_scoring(
+                 section,
+                 attempt,
+                 %{
+                   capi_part_attempt.attempt_guid => %{
+                     score: 1.0,
+                     out_of: 1.0,
+                     feedback: "CAPI work reviewed"
+                   }
+                 }
+               )
+
+      assert returned_guid == capi_part_attempt.attempt_guid
+
+      aa = Core.get_activity_attempt_by(id: attempt_1a.id)
+      assert aa.lifecycle_state == :evaluated
+
+      capi_part = Core.get_part_attempt_by(attempt_guid: capi_part_attempt.attempt_guid)
+      assert capi_part.lifecycle_state == :evaluated
+      assert capi_part.score == 1.0
+      assert capi_part.out_of == 1.0
+    end
+  end
+
   describe "apply_manual_scoring/3 for submitted ungraded attempts" do
     setup do
       Seeder.base_project_with_resource2()


### PR DESCRIPTION
## Summary

  Fixes adaptive CAPI manual scoring and analytics so manually graded CAPI-only adaptive pages can be scored and reflected in instructor insights.

  ## Changes

  - Allows manually graded persisted adaptive parts, including CAPI iframes, to appear in manual scoring even when they are not native scorable inputs.
  - Keeps non-gradeable stateful adaptive controls, such as navigation buttons, excluded from manual scoring and analytics.
  - Updates manual grading selection/apply logic to use shared adaptive manual-gradeable part eligibility.
  - Updates selected submission rendering so persisted adaptive parts are labeled/rendered with adaptive part metadata.
  - Updates analytics response-summary eligibility so manually graded CAPI parts create response and student-response summary rows.
  - Updates scored-page insight aggregation/rendering to include manually scored persisted adaptive CAPI summaries.

<img width="1555" height="1046" alt="Screenshot 2026-06-02 at 2 12 16 PM" src="https://github.com/user-attachments/assets/6b944740-589d-4ddd-a8e5-8be510e8fcc1" />

