### PR TITLE
[BUG FIX] [MER-5697] Send certificate email after automatic PDF generation

### DIFF
--- a/lib/oli/delivery/granted_certificates.ex
+++ b/lib/oli/delivery/granted_certificates.ex
@@ -245,14 +245,37 @@ defmodule Oli.Delivery.GrantedCertificates do
     |> Oban.insert_all()
   end
 
-  defp certificate_email_template_assigns(
-         :earned,
-         granted_certificate,
-         student,
-         section,
-         guid,
-         _instructor_email
-       ) do
+  @doc """
+  Builds the `template_assigns` map for a certificate status email
+  (`:earned` -> `student_approval`, `:denied` -> `student_denial`).
+
+  Single source of truth for what each certificate email template requires, so
+  callers cannot drift out of sync with the template (e.g. omit `certificate_label`).
+  """
+  @spec certificate_email_template_assigns(
+          :earned,
+          %GrantedCertificate{},
+          %Oli.Accounts.User{},
+          %Oli.Delivery.Sections.Section{},
+          binary(),
+          term()
+        ) :: map()
+  @spec certificate_email_template_assigns(
+          :denied,
+          term(),
+          %Oli.Accounts.User{},
+          %Oli.Delivery.Sections.Section{},
+          term(),
+          String.t()
+        ) :: map()
+  def certificate_email_template_assigns(
+        :earned,
+        granted_certificate,
+        student,
+        section,
+        guid,
+        _instructor_email
+      ) do
     %{
       student_name: OliWeb.Common.Utils.name(student),
       platform_name: Oli.Branding.brand_name(section),
@@ -262,14 +285,14 @@ defmodule Oli.Delivery.GrantedCertificates do
     }
   end
 
-  defp certificate_email_template_assigns(
-         :denied,
-         _granted_certificate,
-         student,
-         section,
-         _guid,
-         instructor_email
-       ) do
+  def certificate_email_template_assigns(
+        :denied,
+        _granted_certificate,
+        student,
+        section,
+        _guid,
+        instructor_email
+      ) do
     %{
       student_name: OliWeb.Common.Utils.name(student),
       platform_name: Oli.Branding.brand_name(section),

--- a/lib/oli/delivery/sections/certificates/workers/generate_pdf.ex
+++ b/lib/oli/delivery/sections/certificates/workers/generate_pdf.ex
@@ -8,7 +8,6 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.GeneratePdf do
   """
 
   use Oban.Worker, queue: :certificate_pdf, max_attempts: 3
-  use OliWeb, :verified_routes
 
   alias Oli.Delivery.GrantedCertificates
   alias Oli.Repo
@@ -38,16 +37,14 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.GeneratePdf do
             granted_certificate.guid,
             granted_certificate.user.email,
             "student_approval",
-            %{
-              student_name: OliWeb.Common.Utils.name(granted_certificate.user),
-              course_name: section.title,
-              certificate_link:
-                Phoenix.VerifiedRoutes.url(
-                  OliWeb.Endpoint,
-                  ~p"/sections/#{section.slug}/certificate/#{granted_certificate.guid}"
-                ),
-              platform_name: Oli.Branding.brand_name(section)
-            }
+            GrantedCertificates.certificate_email_template_assigns(
+              :earned,
+              granted_certificate,
+              granted_certificate.user,
+              section,
+              granted_certificate.guid,
+              nil
+            )
           )
         end
 

--- a/test/oli/delivery/granted_certificates_test.exs
+++ b/test/oli/delivery/granted_certificates_test.exs
@@ -436,6 +436,66 @@ defmodule Oli.Delivery.GrantedCertificatesTest do
     end
   end
 
+  describe "certificate_email_template_assigns/6" do
+    test "the :earned assigns include certificate_label and omit instructor_email" do
+      section = insert(:section)
+      student = insert(:user)
+      gc = insert(:granted_certificate, with_distinction: false)
+
+      assigns =
+        GrantedCertificates.certificate_email_template_assigns(
+          :earned,
+          gc,
+          student,
+          section,
+          gc.guid,
+          "some_instructor@test.com"
+        )
+
+      assert assigns.certificate_label == "Certificate of Completion"
+      assert assigns.student_name == OliWeb.Common.Utils.name(student)
+      assert assigns.course_name == section.title
+      refute Map.has_key?(assigns, :instructor_email)
+    end
+
+    test "the :earned assigns use the distinction label when with_distinction is true" do
+      section = insert(:section)
+      student = insert(:user)
+      gc = insert(:granted_certificate, with_distinction: true)
+
+      assigns =
+        GrantedCertificates.certificate_email_template_assigns(
+          :earned,
+          gc,
+          student,
+          section,
+          gc.guid,
+          nil
+        )
+
+      assert assigns.certificate_label == "Certificate with Distinction"
+    end
+
+    test "the :denied assigns include instructor_email and omit certificate_label" do
+      section = insert(:section)
+      student = insert(:user)
+      gc = insert(:granted_certificate, state: :denied)
+
+      assigns =
+        GrantedCertificates.certificate_email_template_assigns(
+          :denied,
+          gc,
+          student,
+          section,
+          gc.guid,
+          "some_instructor@test.com"
+        )
+
+      assert assigns.instructor_email == "some_instructor@test.com"
+      refute Map.has_key?(assigns, :certificate_label)
+    end
+  end
+
   describe "certificate_pending_email_notification_count/1" do
     test "returns the count of granted certificates that have not been emailed to the students yet" do
       section = insert(:section)

--- a/test/oli/delivery/sections/certificates/workers/generate_pdf_test.exs
+++ b/test/oli/delivery/sections/certificates/workers/generate_pdf_test.exs
@@ -5,9 +5,11 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.GeneratePdfTest do
 
   import Oli.Factory
   import Mox
+  import Swoosh.TestAssertions
 
   alias Oli.Delivery.GrantedCertificates
   alias Oli.Delivery.Sections.Certificates.Workers.GeneratePdf
+  alias Oli.Delivery.Sections.Certificates.Workers.Mailer
 
   describe "Generate Pdf worker" do
     test "generates a pdf for that granted certificate when the job is performed" do
@@ -89,6 +91,72 @@ defmodule Oli.Delivery.Sections.Certificates.Workers.GeneratePdfTest do
           }
         }
       )
+    end
+
+    test "the enqueued Mailer job sends the student email with the certificate label (no distinction)" do
+      section = insert(:section, certificate_enabled: true)
+      certificate = insert(:certificate, section: section)
+      user = insert(:user)
+
+      attrs = %{
+        state: :earned,
+        user_id: user.id,
+        certificate_id: certificate.id,
+        with_distinction: false,
+        guid: UUID.uuid4()
+      }
+
+      {:ok, gc} = GrantedCertificates.create_granted_certificate(attrs)
+
+      expect(Oli.Test.MockAws, :request, 1, fn operation ->
+        assert operation.data.certificate_id == gc.guid
+        {:ok, %{"statusCode" => 200, "body" => %{"s3Path" => "foo/bar"}}}
+      end)
+
+      perform_job(GeneratePdf, %{"granted_certificate_id" => gc.id, "send_email?" => true})
+
+      # Performing the Mailer job built by GeneratePdf must not crash on a missing
+      # `certificate_label` assign, and must render the label in the email body.
+      [mailer_job] = all_enqueued(worker: Mailer)
+      assert :ok = perform_job(Mailer, mailer_job.args)
+
+      assert_email_sent(fn email ->
+        assert Enum.any?(email.to, fn {_name, addr} -> addr == user.email end)
+        assert email.subject == "Congratulations You've Earned a Certificate of Completion"
+        assert email.html_body =~ "Certificate of Completion"
+      end)
+    end
+
+    test "the enqueued Mailer job sends the student email with the certificate label (with distinction)" do
+      section = insert(:section, certificate_enabled: true)
+      certificate = insert(:certificate, section: section)
+      user = insert(:user)
+
+      attrs = %{
+        state: :earned,
+        user_id: user.id,
+        certificate_id: certificate.id,
+        with_distinction: true,
+        guid: UUID.uuid4()
+      }
+
+      {:ok, gc} = GrantedCertificates.create_granted_certificate(attrs)
+
+      expect(Oli.Test.MockAws, :request, 1, fn operation ->
+        assert operation.data.certificate_id == gc.guid
+        {:ok, %{"statusCode" => 200, "body" => %{"s3Path" => "foo/bar"}}}
+      end)
+
+      perform_job(GeneratePdf, %{"granted_certificate_id" => gc.id, "send_email?" => true})
+
+      [mailer_job] = all_enqueued(worker: Mailer)
+      assert :ok = perform_job(Mailer, mailer_job.args)
+
+      assert_email_sent(fn email ->
+        assert Enum.any?(email.to, fn {_name, addr} -> addr == user.email end)
+        assert email.subject == "Congratulations You've Earned a Certificate with Distinction"
+        assert email.html_body =~ "Certificate with Distinction"
+      end)
     end
 
     test "does not enqueue a Mailer job after creating the pdf if `send_email?` flag is set to false" do


### PR DESCRIPTION
## Problem
Students stopped receiving the "Congratulations, You've Earned a Certificate" email when they earn a certificate. They may not learn they earned it, and can lose access once an LTI section is archived/expired.

Ticket: [MER-5697](https://eliterate.atlassian.net/browse/MER-5697) (triage: [TRIAGE-2304](https://eliterate.atlassian.net/browse/TRIAGE-2304))

## Root cause
Regression from f4fa4fca67 (MER-5153), which made the approval email template require a new `certificate_label` assign. Three callers were updated, but the automatic post-PDF-generation path was not. Its Mailer job therefore crashed at render (`assign @certificate_label not available`), retried 3x, then was
silently discarded — no email, no visible error.

How identified: traced the [MER-5153](https://eliterate.atlassian.net/browse/MER-5153) diff and found the template contract change reached every approval caller except the automatic `GeneratePdf` path.

## Solution
- Fix: the automatic email path now supplies `certificate_label`.
- Hardening: removed the duplicated assigns map so all certificate emails build their assigns through one source of truth — a caller can't drift out of sync with the template again.

Implementation:
- Made `GrantedCertificates.certificate_email_template_assigns/6` public — the single builder for `:earned`/`:denied` template assigns (+ `@doc`, overloaded `@spec`).
- `GeneratePdf` worker calls that builder instead of hand-rolling its own map (which omitted `certificate_label`).

## Testing Instructions
The previous tests only asserted the Mailer job was *enqueued*, never executed it — that gap let this ship. New tests *perform* the job.

    # Red before the fix, green after:
    mix test test/oli/delivery/sections/certificates/workers/generate_pdf_test.exs:121 \
             test/oli/delivery/sections/certificates/workers/generate_pdf_test.exs:130

    # Builder contract tests:
    mix test test/oli/delivery/granted_certificates_test.exs

Manual:
- Earn a certificate (no distinction) → student receives the achievement email labeled "Certificate of Completion".
- Earn a certificate with distinction → same email labeled "Certificate with Distinction".

## Risk & rollback
Low. Change is an additive assign + new tests; no behavior change to the bulk or manual approval paths. Revert = single commit (this PR).

## Scope
Hotfix kept minimal. Version bump (0.33.1 -> 0.33.2) intentionally excluded — owned by Raphael's [MER-5693](https://eliterate.atlassian.net/browse/MER-5693) PR.


[MER-5697]: https://eliterate.atlassian.net/browse/MER-5697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TRIAGE-2304]: https://eliterate.atlassian.net/browse/TRIAGE-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-5153]: https://eliterate.atlassian.net/browse/MER-5153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-5693]: https://eliterate.atlassian.net/browse/MER-5693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ