### PR TITLE
[FEATURE] [MER-5396] Automated Canvas-to-Torus Grade Passback Smoke Test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ For a complete list of changes and release notes, please refer to the [GitHub re
 If a PR is opened that adds a new environment config or requires infrastructure changes, please
 update this file accordingly.
 
+## 0.34.0
+
+### Environment Configs
+
+| Name                        | Required | Description                                                                            |
+| --------------------------- | -------- | -------------------------------------------------------------------------------------- |
+| CANVAS_STUDENT_EMAIL        | No       | Canvas student email required by the grade passback Playwright smoke test              |
+| CANVAS_STUDENT_PASSWORD     | No       | Canvas student password required by the grade passback Playwright smoke test           |
+| CANVAS_INSTRUCTOR_EMAIL     | No       | Canvas instructor email required by the grade passback Playwright smoke test           |
+| CANVAS_INSTRUCTOR_PASSWORD  | No       | Canvas instructor password required by the grade passback Playwright smoke test        |
+| CANVAS_ADMIN_EMAIL          | No       | Canvas admin email alternative for the grade passback Playwright smoke test            |
+| CANVAS_ADMIN_PASSWORD       | No       | Canvas admin password alternative for the grade passback Playwright smoke test         |
+| CANVAS_LTI_LAUNCH_LINK_NAME | No       | Canvas LTI launch link name for the smoke test (Default: "OLI Torus (tokamak)")       |
+
+- `CANVAS_*` environment variables configure the Canvas-to-Torus grade passback Playwright
+  smoke test. They are not required by the Torus application runtime. The student credentials
+  and either instructor or admin credentials are required only when running this smoke test.
+  The LTI launch link name is optional and defaults to `OLI Torus (tokamak)`.
+
+### Infrastructure Changes
+
+None
+
+---
+
 ## 0.33.0
 
 ### Environment Configs

--- a/assets/automation/tests/support/testConfig.ts
+++ b/assets/automation/tests/support/testConfig.ts
@@ -1,0 +1,21 @@
+// Reads a required environment variable and fails fast when it is missing.
+export const requireEnv = (name: string) => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+};
+
+// Reads the first available environment variable from a list of supported names.
+export const requireAnyEnv = (names: string[]) => {
+  const foundName = names.find((name) => process.env[name]);
+
+  if (!foundName) {
+    throw new Error(`Missing required environment variable. Expected one of: ${names.join(', ')}`);
+  }
+
+  return process.env[foundName] as string;
+};

--- a/assets/automation/tests/torus/lti/grade-passback.md
+++ b/assets/automation/tests/torus/lti/grade-passback.md
@@ -1,0 +1,67 @@
+# Grade Passback Test
+
+This document covers `grade-passback.spec.ts`, the Playwright scenario that verifies Tokamak passes a graded page score back to the Canvas gradebook.
+
+## What The Test Does
+
+The test:
+
+1. Logs in to Canvas as the student.
+2. Resolves the student display name from Canvas after login.
+3. Opens the LTI launch link.
+4. Navigates to the graded page.
+5. Starts or resumes the attempt if needed.
+6. Submits the student response.
+7. Logs in to Canvas as the instructor.
+8. Polls the gradebook until the passed-back score appears.
+
+The student name is not hardcoded. It is read from Canvas through the authenticated browser session.
+
+## Required Environment Variables
+
+Set these variables in the environment where Playwright runs:
+
+- `CANVAS_STUDENT_EMAIL`
+- `CANVAS_STUDENT_PASSWORD`
+- `CANVAS_ADMIN_EMAIL` or `CANVAS_INSTRUCTOR_EMAIL`
+- `CANVAS_ADMIN_PASSWORD` or `CANVAS_INSTRUCTOR_PASSWORD`
+
+Optional:
+
+- `CANVAS_LTI_LAUNCH_LINK_NAME`
+
+If `CANVAS_LTI_LAUNCH_LINK_NAME` is not set, the test uses `OLI Torus (tokamak)`.
+
+No API key is required. The test reads the student name from the authenticated Canvas browser session after login.
+
+## Canvas Prerequisites
+
+The Canvas environment must already have:
+
+- The course `Playwright Test Course`
+- The LTI launch link configured in the course navigation
+- The graded page `Graded page for graded passback`
+- A student account enrolled in the course
+- An instructor or admin account with access to the course gradebook
+
+The test expects the graded page to be available and configured for grade passback.
+
+## How To Run
+
+Run the test from `assets/automation`:
+
+```bash
+npx playwright test tests/torus/lti/grade-passback.spec.ts
+```
+
+## Behavior Notes
+
+- If the graded page already has an attempt in progress, the test resumes it instead of failing.
+- If the gradebook is still loading, the test waits and retries until the score appears or the timeout is reached.
+- The gradebook polling timeout is 3 minutes.
+
+## Troubleshooting
+
+- If the test fails before login, verify the Canvas credentials and the required environment variables.
+- If the student name lookup fails, verify the student account can log in successfully and reach `/api/v1/users/self`.
+- If the score never appears in the instructor gradebook, verify the activity is configured for passback and that Canvas has time to process the result.

--- a/assets/automation/tests/torus/lti/grade-passback.md
+++ b/assets/automation/tests/torus/lti/grade-passback.md
@@ -39,7 +39,7 @@ No API key is required. The test reads the student name from the authenticated C
 The Canvas environment must already have:
 
 - The course `Playwright Test Course`
-- The LTI launch link configured in the course navigation
+- The `OLI Torus (tokamak)` module item link inside the course modules page
 - The graded page `Graded page for graded passback`
 - A student account enrolled in the course
 - An instructor or admin account with access to the course gradebook

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -1,11 +1,14 @@
 import { type Page, expect, test } from '@playwright/test';
 
-import { requireAnyEnv, requireEnv } from '../../support/testConfig';
-import { loginToCanvas } from './support/canvas';
+import {
+  getCanvasInstructorCredentials,
+  getCanvasStudentCredentials,
+  getCanvasUserName,
+  loginToCanvas,
+} from './support/canvas';
 
 const gradedPageName = 'Graded page for graded passback';
 const courseName = 'Playwright Test Course';
-const studentName = 'Santi Student';
 const gradePassbackTimeout = 180_000;
 const testTimeout = 240_000;
 
@@ -101,7 +104,7 @@ const completeStudentAttempt = async (
 };
 
 // Reads the score from Canvas' simple HTML gradebook table for the configured student.
-const getSimpleGradebookScore = async (page: Page) => {
+const getSimpleGradebookScore = async (page: Page, studentName: string) => {
   const studentRow = page
     .locator('table tr', {
       has: page.locator('.student-grades-link', { hasText: studentName }),
@@ -116,8 +119,8 @@ const getSimpleGradebookScore = async (page: Page) => {
 };
 
 // Reads the student's gradebook score, supporting both Canvas' simple table and SlickGrid views.
-const getGradebookScore = async (page: Page) => {
-  const simpleGradebookScore = await getSimpleGradebookScore(page);
+const getGradebookScore = async (page: Page, studentName: string) => {
+  const simpleGradebookScore = await getSimpleGradebookScore(page, studentName);
 
   if (simpleGradebookScore) {
     return simpleGradebookScore;
@@ -182,7 +185,7 @@ const getGradebookScore = async (page: Page) => {
 };
 
 // Waits until Canvas finishes loading enough gradebook data to show the configured student row.
-const waitForGradebookStudent = async (page: Page) =>
+const waitForGradebookStudent = async (page: Page, studentName: string) =>
   page
     .locator('.student-grades-link', { hasText: studentName })
     .first()
@@ -191,26 +194,26 @@ const waitForGradebookStudent = async (page: Page) =>
     .catch(() => false);
 
 // Polls Canvas as the instructor until the gradebook shows the expected passed-back score.
-const verifyInstructorGrade = async (page: Page, expectedScore: string) => {
+const verifyInstructorGrade = async (page: Page, expectedScore: string, studentName: string) => {
   await openCanvasCourse(page);
   await page.getByRole('link', { name: 'Grades', exact: true }).click();
-  await waitForGradebookStudent(page);
+  await waitForGradebookStudent(page, studentName);
 
   await expect
     .poll(
       async () => {
-        if (!(await waitForGradebookStudent(page))) {
+        if (!(await waitForGradebookStudent(page, studentName))) {
           return '';
         }
 
-        const score = await getGradebookScore(page);
+        const score = await getGradebookScore(page, studentName);
 
         if (score === expectedScore) {
           return expectedScore;
         }
 
         await page.reload({ waitUntil: 'domcontentloaded' });
-        await waitForGradebookStudent(page);
+        await waitForGradebookStudent(page, studentName);
 
         return score ?? '';
       },
@@ -223,10 +226,8 @@ const verifyInstructorGrade = async (page: Page, expectedScore: string) => {
 test('passes Tokamak graded page score back to Canvas gradebook', async ({ browser }) => {
   test.setTimeout(testTimeout);
 
-  const studentEmail = requireEnv('CANVAS_STUDENT_EMAIL');
-  const studentPassword = requireEnv('CANVAS_STUDENT_PASSWORD');
-  const instructorEmail = requireAnyEnv(['CANVAS_ADMIN_EMAIL', 'CANVAS_INSTRUCTOR_EMAIL']);
-  const instructorPassword = requireAnyEnv(['CANVAS_ADMIN_PASSWORD', 'CANVAS_INSTRUCTOR_PASSWORD']);
+  const { email: studentEmail, password: studentPassword } = getCanvasStudentCredentials();
+  const { email: instructorEmail, password: instructorPassword } = getCanvasInstructorCredentials();
   const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
   const answers = buildRandomAnswers();
 
@@ -240,11 +241,12 @@ test('passes Tokamak graded page score back to Canvas gradebook', async ({ brows
 
     // Log in to Canvas as the student who will complete the graded page.
     await loginToCanvas(studentPage, studentEmail, studentPassword);
+    const studentName = await getCanvasUserName(studentPage);
     await completeStudentAttempt(studentPage, launchLinkName, answers);
 
     // Continue in the already logged-in instructor context after the student attempt is complete.
     await instructorLogin;
-    await verifyInstructorGrade(instructorPage, answers.expectedScore);
+    await verifyInstructorGrade(instructorPage, answers.expectedScore, studentName);
   } finally {
     await Promise.all([studentContext.close(), instructorContext.close()]);
   }

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -1,5 +1,6 @@
-import { expect, type Page, test } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
 
+// Reads a required environment variable and fails fast when it is missing.
 const requireEnv = (name: string) => {
   const value = process.env[name];
 
@@ -10,6 +11,7 @@ const requireEnv = (name: string) => {
   return value;
 };
 
+// Reads the first available environment variable from a list of supported names.
 const requireAnyEnv = (names: string[]) => {
   const foundName = names.find((name) => process.env[name]);
 
@@ -26,15 +28,19 @@ const studentName = 'Santi Student';
 const gradePassbackTimeout = 180_000;
 const testTimeout = 240_000;
 
+// Normalizes UI text so gradebook comparisons are resilient to extra whitespace.
+const normalize = (value: string | null | undefined) => value?.replace(/\s+/g, ' ').trim() ?? '';
+
 type StudentAnswers = {
   selectedChoice: 'Choice A' | 'Choice B';
-  textAnswer: 'answer' | 'Incorrect answer';
+  textAnswer: 'answer' | 'incorrect';
   expectedScore: string;
 };
 
+// Chooses a random valid/invalid answer pair and calculates the score Torus should pass back.
 const buildRandomAnswers = (): StudentAnswers => {
   const selectedChoice = Math.random() < 0.5 ? 'Choice A' : 'Choice B';
-  const textAnswer = Math.random() < 0.5 ? 'answer' : 'Incorrect answer';
+  const textAnswer = Math.random() < 0.5 ? 'answer' : 'incorrect';
   const expectedScore = String(
     Number(selectedChoice === 'Choice A') + Number(textAnswer === 'answer'),
   );
@@ -42,6 +48,7 @@ const buildRandomAnswers = (): StudentAnswers => {
   return { selectedChoice, textAnswer, expectedScore };
 };
 
+// Logs into Canvas with the given credentials and waits for the successful-login redirect.
 const loginToCanvas = async (page: Page, email: string, password: string) => {
   await page.goto('https://canvas.oli.cmu.edu/login/canvas');
   await page.getByRole('textbox', { name: 'Email' }).fill(email);
@@ -52,6 +59,7 @@ const loginToCanvas = async (page: Page, email: string, password: string) => {
   ]);
 };
 
+// Opens the Canvas course card used by this LTI grade passback test.
 const openCanvasCourse = async (page: Page) => {
   const courseLink = page
     .locator('a.ic-DashboardCard__link', {
@@ -63,6 +71,7 @@ const openCanvasCourse = async (page: Page) => {
   await courseLink.click();
 };
 
+// Opens the course in Canvas, launches Tokamak through LTI, and returns the tool iframe.
 const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
   await openCanvasCourse(page);
   await page.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
@@ -73,6 +82,7 @@ const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
   return toolFrame;
 };
 
+// Navigates inside Tokamak to the graded page whose score should be passed back.
 const openGradedPage = async (page: Page, launchLinkName: string) => {
   const toolFrame = await launchTokamakFromCanvas(page, launchLinkName);
 
@@ -83,6 +93,7 @@ const openGradedPage = async (page: Page, launchLinkName: string) => {
   return toolFrame;
 };
 
+// Starts or resumes the student's page attempt, answers the activities, and submits it.
 const completeStudentAttempt = async (
   page: Page,
   launchLinkName: string,
@@ -92,14 +103,18 @@ const completeStudentAttempt = async (
   const toolFrame = await openGradedPage(page, launchLinkName);
 
   const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
-  await expect(beginAttemptButton).toBeVisible();
-  await beginAttemptButton.click();
+  const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
+
+  await expect(beginAttemptButton.or(answerTextbox).first()).toBeVisible({ timeout: 10_000 });
+
+  if (await beginAttemptButton.isVisible()) {
+    await beginAttemptButton.click();
+  }
 
   // Complete the graded page with the selected responses.
   await expect(toolFrame.getByText(answers.selectedChoice)).toBeVisible();
   await toolFrame.getByText(answers.selectedChoice).click();
 
-  const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
   await expect(answerTextbox).toBeVisible();
   await answerTextbox.fill(answers.textAnswer);
 
@@ -115,13 +130,37 @@ const completeStudentAttempt = async (
   await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
 };
 
-const getGradebookScore = async (page: Page) =>
-  page.evaluate(
+// Reads the score from Canvas' simple HTML gradebook table for the configured student.
+const getSimpleGradebookScore = async (page: Page) => {
+  const studentRow = page
+    .locator('table tr', {
+      has: page.locator('.student-grades-link', { hasText: studentName }),
+    })
+    .first();
+
+  if (!(await studentRow.isVisible({ timeout: 1_000 }).catch(() => false))) {
+    return null;
+  }
+
+  return normalize(await studentRow.locator('td').nth(1).textContent());
+};
+
+// Reads the student's gradebook score, supporting both Canvas' simple table and SlickGrid views.
+const getGradebookScore = async (page: Page) => {
+  const simpleGradebookScore = await getSimpleGradebookScore(page);
+
+  if (simpleGradebookScore) {
+    return simpleGradebookScore;
+  }
+
+  return page.evaluate(
     ({ assignmentName, learnerName }) => {
+      // Normalizes text inside the browser context where Node helpers are unavailable.
       const normalize = (value: string | null | undefined) =>
         value?.replace(/\s+/g, ' ').trim() ?? '';
       const assignmentLabel = normalize(assignmentName);
 
+      // Checks element visibility from geometry because SlickGrid keeps hidden cells in the DOM.
       const isVisible = (element: Element) => {
         const rect = element.getBoundingClientRect();
 
@@ -170,20 +209,27 @@ const getGradebookScore = async (page: Page) =>
     },
     { assignmentName: gradedPageName, learnerName: studentName },
   );
+};
 
+// Waits until Canvas finishes loading enough gradebook data to show the configured student row.
+const waitForGradebookStudent = async (page: Page) =>
+  page
+    .locator('.student-grades-link', { hasText: studentName })
+    .first()
+    .waitFor({ state: 'visible', timeout: 30_000 })
+    .then(() => true)
+    .catch(() => false);
+
+// Polls Canvas as the instructor until the gradebook shows the expected passed-back score.
 const verifyInstructorGrade = async (page: Page, expectedScore: string) => {
   await openCanvasCourse(page);
   await page.getByRole('link', { name: 'Grades', exact: true }).click();
+  await waitForGradebookStudent(page);
 
   await expect
     .poll(
       async () => {
-        const studentResult = page
-          .locator('.student-grades-link', { hasText: studentName })
-          .first();
-
-        if (!(await studentResult.isVisible({ timeout: 5_000 }).catch(() => false))) {
-          await page.reload();
+        if (!(await waitForGradebookStudent(page))) {
           return '';
         }
 
@@ -193,15 +239,17 @@ const verifyInstructorGrade = async (page: Page, expectedScore: string) => {
           return expectedScore;
         }
 
-        await page.reload();
+        await page.reload({ waitUntil: 'domcontentloaded' });
+        await waitForGradebookStudent(page);
 
-        return '';
+        return score ?? '';
       },
       { timeout: gradePassbackTimeout, intervals: [5_000, 10_000, 15_000] },
     )
     .toBe(expectedScore);
 };
 
+// End-to-end LTI grade passback flow from student submission to instructor gradebook verification.
 test('passes Tokamak graded page score back to Canvas gradebook', async ({ browser }) => {
   test.setTimeout(testTimeout);
 

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -44,10 +44,13 @@ const openCanvasCourse = async (page: Page) => {
   await courseLink.click();
 };
 
-// Opens the course in Canvas, launches Tokamak through LTI, and returns the tool iframe.
+// Opens the course in Canvas, launches Tokamak through the module item link, and returns the tool iframe.
 const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
   await openCanvasCourse(page);
-  await page.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
+
+  const launchLink = page.locator(`a.item_link[title="${launchLinkName}"]`);
+  await expect(launchLink).toBeVisible();
+  await launchLink.click();
 
   const toolFrame = page.frameLocator('iframe[name="tool_content"]');
   await expect(toolFrame.locator('body')).toBeVisible();

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -22,6 +22,25 @@ const requireAnyEnv = (names: string[]) => {
 
 const gradedPageName = 'Graded page for graded passback';
 const courseName = 'Playwright Test Course';
+const studentName = 'Santi Student';
+const gradePassbackTimeout = 180_000;
+const testTimeout = 240_000;
+
+type StudentAnswers = {
+  selectedChoice: 'Choice A' | 'Choice B';
+  textAnswer: 'answer' | 'Incorrect answer';
+  expectedScore: string;
+};
+
+const buildRandomAnswers = (): StudentAnswers => {
+  const selectedChoice = Math.random() < 0.5 ? 'Choice A' : 'Choice B';
+  const textAnswer = Math.random() < 0.5 ? 'answer' : 'Incorrect answer';
+  const expectedScore = String(
+    Number(selectedChoice === 'Choice A') + Number(textAnswer === 'answer'),
+  );
+
+  return { selectedChoice, textAnswer, expectedScore };
+};
 
 const loginToCanvas = async (page: Page, email: string, password: string) => {
   await page.goto('https://canvas.oli.cmu.edu/login/canvas');
@@ -44,14 +63,154 @@ const openCanvasCourse = async (page: Page) => {
   await courseLink.click();
 };
 
-test('student completes Tokamak graded page launched from Canvas', async ({ browser }) => {
-  test.setTimeout(120_000);
+const launchTokamakFromCanvas = async (page: Page, launchLinkName: string) => {
+  await openCanvasCourse(page);
+  await page.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
+
+  const toolFrame = page.frameLocator('iframe[name="tool_content"]');
+  await expect(toolFrame.locator('body')).toBeVisible();
+
+  return toolFrame;
+};
+
+const openGradedPage = async (page: Page, launchLinkName: string) => {
+  const toolFrame = await launchTokamakFromCanvas(page, launchLinkName);
+
+  await toolFrame.getByRole('link', { name: 'Assignments' }).click();
+  await toolFrame.getByRole('link', { name: gradedPageName }).click();
+  await expect(toolFrame.getByText(gradedPageName).first()).toBeVisible();
+
+  return toolFrame;
+};
+
+const completeStudentAttempt = async (
+  page: Page,
+  launchLinkName: string,
+  answers: StudentAnswers,
+) => {
+  // Open the Canvas course, launch Tokamak, and navigate to the graded page.
+  const toolFrame = await openGradedPage(page, launchLinkName);
+
+  const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
+  await expect(beginAttemptButton).toBeVisible();
+  await beginAttemptButton.click();
+
+  // Complete the graded page with the selected responses.
+  await expect(toolFrame.getByText(answers.selectedChoice)).toBeVisible();
+  await toolFrame.getByText(answers.selectedChoice).click();
+
+  const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
+  await expect(answerTextbox).toBeVisible();
+  await answerTextbox.fill(answers.textAnswer);
+
+  // Submit the attempt and verify the redirected review page is displayed.
+  const submitAnswersButton = toolFrame.locator('#submit_answers');
+  await expect(submitAnswersButton).toBeVisible();
+  await submitAnswersButton.evaluate((button) => {
+    button.scrollIntoView({ block: 'center', inline: 'center' });
+  });
+  await page.mouse.move(20, 20);
+  await submitAnswersButton.click();
+
+  await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
+};
+
+const getGradebookScore = async (page: Page) =>
+  page.evaluate(
+    ({ assignmentName, learnerName }) => {
+      const normalize = (value: string | null | undefined) =>
+        value?.replace(/\s+/g, ' ').trim() ?? '';
+      const assignmentLabel = normalize(assignmentName);
+
+      const isVisible = (element: Element) => {
+        const rect = element.getBoundingClientRect();
+
+        return rect.width > 0 && rect.height > 0;
+      };
+
+      const studentLink = Array.from(document.querySelectorAll('.student-grades-link')).find(
+        (element) => normalize(element.textContent) === learnerName && isVisible(element),
+      );
+
+      const studentRow = studentLink?.closest('.slick-row');
+
+      if (!studentRow) {
+        return null;
+      }
+
+      const assignmentHeader = Array.from(document.querySelectorAll('.slick-header-column')).find(
+        (element) => {
+          const label = normalize(
+            `${element.textContent ?? ''} ${element.getAttribute('title') ?? ''} ${
+              element.getAttribute('aria-label') ?? ''
+            }`,
+          );
+
+          return (
+            isVisible(element) &&
+            (label.includes(assignmentLabel) ||
+              (label.length > 10 && assignmentLabel.startsWith(label.split(' Out of ')[0])))
+          );
+        },
+      );
+
+      if (!assignmentHeader) {
+        return null;
+      }
+
+      const headerRect = assignmentHeader.getBoundingClientRect();
+      const rowRect = studentRow.getBoundingClientRect();
+      const x = headerRect.left + headerRect.width / 2;
+      const y = rowRect.top + rowRect.height / 2;
+      const scoreCell = [...document.elementsFromPoint(x, y)]
+        .map((element) => element.closest('.slick-cell'))
+        .find(Boolean);
+
+      return normalize(scoreCell?.textContent);
+    },
+    { assignmentName: gradedPageName, learnerName: studentName },
+  );
+
+const verifyInstructorGrade = async (page: Page, expectedScore: string) => {
+  await openCanvasCourse(page);
+  await page.getByRole('link', { name: 'Grades', exact: true }).click();
+
+  await expect
+    .poll(
+      async () => {
+        const studentResult = page
+          .locator('.student-grades-link', { hasText: studentName })
+          .first();
+
+        if (!(await studentResult.isVisible({ timeout: 5_000 }).catch(() => false))) {
+          await page.reload();
+          return '';
+        }
+
+        const score = await getGradebookScore(page);
+
+        if (score === expectedScore) {
+          return expectedScore;
+        }
+
+        await page.reload();
+
+        return '';
+      },
+      { timeout: gradePassbackTimeout, intervals: [5_000, 10_000, 15_000] },
+    )
+    .toBe(expectedScore);
+};
+
+test('passes Tokamak graded page score back to Canvas gradebook', async ({ browser }) => {
+  test.setTimeout(testTimeout);
 
   const studentEmail = requireEnv('CANVAS_STUDENT_EMAIL');
   const studentPassword = requireEnv('CANVAS_STUDENT_PASSWORD');
   const instructorEmail = requireAnyEnv(['CANVAS_ADMIN_EMAIL', 'CANVAS_INSTRUCTOR_EMAIL']);
   const instructorPassword = requireAnyEnv(['CANVAS_ADMIN_PASSWORD', 'CANVAS_INSTRUCTOR_PASSWORD']);
   const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
+  const answers = buildRandomAnswers();
 
   const studentContext = await browser.newContext();
   const instructorContext = await browser.newContext();
@@ -63,46 +222,11 @@ test('student completes Tokamak graded page launched from Canvas', async ({ brow
 
     // Log in to Canvas as the student who will complete the graded page.
     await loginToCanvas(studentPage, studentEmail, studentPassword);
-
-    // Open the Canvas course, launch Tokamak, and navigate to the graded page.
-    await openCanvasCourse(studentPage);
-    await studentPage.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
-
-    const toolFrame = studentPage.frameLocator('iframe[name="tool_content"]');
-    await expect(toolFrame.locator('body')).toBeVisible();
-
-    await toolFrame.getByRole('link', { name: 'Assignments' }).click();
-    await toolFrame.getByRole('link', { name: gradedPageName }).click();
-    await expect(toolFrame.getByText(gradedPageName).first()).toBeVisible();
-
-    const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
-    await expect(beginAttemptButton).toBeVisible();
-    await beginAttemptButton.click();
-
-    // Complete the graded page with the known correct responses.
-    const submitAnswersButton = toolFrame.locator('#submit_answers');
-    await expect(submitAnswersButton).toBeVisible();
-
-    await expect(toolFrame.getByText('Choice A')).toBeVisible();
-    await toolFrame.getByText('Choice A').click();
-
-    const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
-    await expect(answerTextbox).toBeVisible();
-    await answerTextbox.fill('answer');
-
-    // Submit the attempt and verify the redirected review page is displayed.
-    await submitAnswersButton.evaluate((button) => {
-      button.scrollIntoView({ block: 'center', inline: 'center' });
-    });
-    await studentPage.mouse.move(20, 20);
-    await submitAnswersButton.click();
-
-    await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
+    await completeStudentAttempt(studentPage, launchLinkName, answers);
 
     // Continue in the already logged-in instructor context after the student attempt is complete.
     await instructorLogin;
-    await openCanvasCourse(instructorPage);
-    await instructorPage.getByRole('link', { name: 'Grades', exact: true }).click();
+    await verifyInstructorGrade(instructorPage, answers.expectedScore);
   } finally {
     await Promise.all([studentContext.close(), instructorContext.close()]);
   }

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 const requireEnv = (name: string) => {
   const value = process.env[name];
@@ -10,58 +10,100 @@ const requireEnv = (name: string) => {
   return value;
 };
 
+const requireAnyEnv = (names: string[]) => {
+  const foundName = names.find((name) => process.env[name]);
+
+  if (!foundName) {
+    throw new Error(`Missing required environment variable. Expected one of: ${names.join(', ')}`);
+  }
+
+  return process.env[foundName] as string;
+};
+
 const gradedPageName = 'Graded page for graded passback';
 const courseName = 'Playwright Test Course';
 
-test('student completes Tokamak graded page launched from Canvas', async ({ page }) => {
-  const canvasEmail = requireEnv('CANVAS_STUDENT_EMAIL');
-  const canvasPassword = requireEnv('CANVAS_STUDENT_PASSWORD');
-  const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
-
-  // Log in to Canvas as the student who will complete the graded page.
+const loginToCanvas = async (page: Page, email: string, password: string) => {
   await page.goto('https://canvas.oli.cmu.edu/login/canvas');
-  await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
-  await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
+  await page.getByRole('textbox', { name: 'Email' }).fill(email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
   await Promise.all([
     page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
     page.getByRole('button', { name: 'Log In' }).click(),
   ]);
+};
 
-  // Open the Canvas course, launch Tokamak, and navigate to the graded page.
-  await page
-    .locator('a.ic-DashboardCard__link', { has: page.locator(`h3[title="${courseName}"]`) })
-    .first()
-    .click();
-  await page.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
+const openCanvasCourse = async (page: Page) => {
+  const courseLink = page
+    .locator('a.ic-DashboardCard__link', {
+      has: page.locator('.ic-DashboardCard__header-title', { hasText: courseName }),
+    })
+    .first();
 
-  const toolFrame = page.frameLocator('iframe[name="tool_content"]');
-  await expect(toolFrame.locator('body')).toBeVisible();
+  await expect(courseLink).toBeVisible();
+  await courseLink.click();
+};
 
-  await toolFrame.getByRole('link', { name: 'Assignments' }).click();
-  await toolFrame.getByRole('link', { name: gradedPageName }).click();
-  await expect(toolFrame.getByText(gradedPageName).first()).toBeVisible();
+test('student completes Tokamak graded page launched from Canvas', async ({ browser }) => {
+  test.setTimeout(120_000);
 
-  const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
-  await expect(beginAttemptButton).toBeVisible();
-  await beginAttemptButton.click();
+  const studentEmail = requireEnv('CANVAS_STUDENT_EMAIL');
+  const studentPassword = requireEnv('CANVAS_STUDENT_PASSWORD');
+  const instructorEmail = requireAnyEnv(['CANVAS_ADMIN_EMAIL', 'CANVAS_INSTRUCTOR_EMAIL']);
+  const instructorPassword = requireAnyEnv(['CANVAS_ADMIN_PASSWORD', 'CANVAS_INSTRUCTOR_PASSWORD']);
+  const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
 
-  // Complete the graded page with the known correct responses.
-  const submitAnswersButton = toolFrame.locator('#submit_answers');
-  await expect(submitAnswersButton).toBeVisible();
+  const studentContext = await browser.newContext();
+  const instructorContext = await browser.newContext();
 
-  await expect(toolFrame.getByText('Choice A')).toBeVisible();
-  await toolFrame.getByText('Choice A').click();
+  try {
+    const studentPage = await studentContext.newPage();
+    const instructorPage = await instructorContext.newPage();
+    const instructorLogin = loginToCanvas(instructorPage, instructorEmail, instructorPassword);
 
-  const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
-  await expect(answerTextbox).toBeVisible();
-  await answerTextbox.fill('answer');
+    // Log in to Canvas as the student who will complete the graded page.
+    await loginToCanvas(studentPage, studentEmail, studentPassword);
 
-  // Submit the attempt and verify the redirected review page is displayed.
-  await submitAnswersButton.evaluate((button) => {
-    button.scrollIntoView({ block: 'center', inline: 'center' });
-  });
-  await page.mouse.move(20, 20);
-  await submitAnswersButton.click();
+    // Open the Canvas course, launch Tokamak, and navigate to the graded page.
+    await openCanvasCourse(studentPage);
+    await studentPage.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
 
-  await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
+    const toolFrame = studentPage.frameLocator('iframe[name="tool_content"]');
+    await expect(toolFrame.locator('body')).toBeVisible();
+
+    await toolFrame.getByRole('link', { name: 'Assignments' }).click();
+    await toolFrame.getByRole('link', { name: gradedPageName }).click();
+    await expect(toolFrame.getByText(gradedPageName).first()).toBeVisible();
+
+    const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
+    await expect(beginAttemptButton).toBeVisible();
+    await beginAttemptButton.click();
+
+    // Complete the graded page with the known correct responses.
+    const submitAnswersButton = toolFrame.locator('#submit_answers');
+    await expect(submitAnswersButton).toBeVisible();
+
+    await expect(toolFrame.getByText('Choice A')).toBeVisible();
+    await toolFrame.getByText('Choice A').click();
+
+    const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
+    await expect(answerTextbox).toBeVisible();
+    await answerTextbox.fill('answer');
+
+    // Submit the attempt and verify the redirected review page is displayed.
+    await submitAnswersButton.evaluate((button) => {
+      button.scrollIntoView({ block: 'center', inline: 'center' });
+    });
+    await studentPage.mouse.move(20, 20);
+    await submitAnswersButton.click();
+
+    await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
+
+    // Continue in the already logged-in instructor context after the student attempt is complete.
+    await instructorLogin;
+    await openCanvasCourse(instructorPage);
+    await instructorPage.getByRole('link', { name: 'Grades', exact: true }).click();
+  } finally {
+    await Promise.all([studentContext.close(), instructorContext.close()]);
+  }
 });

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -1,26 +1,7 @@
 import { type Page, expect, test } from '@playwright/test';
 
-// Reads a required environment variable and fails fast when it is missing.
-const requireEnv = (name: string) => {
-  const value = process.env[name];
-
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-
-  return value;
-};
-
-// Reads the first available environment variable from a list of supported names.
-const requireAnyEnv = (names: string[]) => {
-  const foundName = names.find((name) => process.env[name]);
-
-  if (!foundName) {
-    throw new Error(`Missing required environment variable. Expected one of: ${names.join(', ')}`);
-  }
-
-  return process.env[foundName] as string;
-};
+import { requireAnyEnv, requireEnv } from '../../support/testConfig';
+import { loginToCanvas } from './support/canvas';
 
 const gradedPageName = 'Graded page for graded passback';
 const courseName = 'Playwright Test Course';
@@ -46,17 +27,6 @@ const buildRandomAnswers = (): StudentAnswers => {
   );
 
   return { selectedChoice, textAnswer, expectedScore };
-};
-
-// Logs into Canvas with the given credentials and waits for the successful-login redirect.
-const loginToCanvas = async (page: Page, email: string, password: string) => {
-  await page.goto('https://canvas.oli.cmu.edu/login/canvas');
-  await page.getByRole('textbox', { name: 'Email' }).fill(email);
-  await page.getByRole('textbox', { name: 'Password' }).fill(password);
-  await Promise.all([
-    page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
-    page.getByRole('button', { name: 'Log In' }).click(),
-  ]);
 };
 
 // Opens the Canvas course card used by this LTI grade passback test.

--- a/assets/automation/tests/torus/lti/grade-passback.spec.ts
+++ b/assets/automation/tests/torus/lti/grade-passback.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+
+const requireEnv = (name: string) => {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+};
+
+const gradedPageName = 'Graded page for graded passback';
+const courseName = 'Playwright Test Course';
+
+test('student completes Tokamak graded page launched from Canvas', async ({ page }) => {
+  const canvasEmail = requireEnv('CANVAS_STUDENT_EMAIL');
+  const canvasPassword = requireEnv('CANVAS_STUDENT_PASSWORD');
+  const launchLinkName = process.env.CANVAS_LTI_LAUNCH_LINK_NAME ?? 'OLI Torus (tokamak)';
+
+  // Log in to Canvas as the student who will complete the graded page.
+  await page.goto('https://canvas.oli.cmu.edu/login/canvas');
+  await page.getByRole('textbox', { name: 'Email' }).fill(canvasEmail);
+  await page.getByRole('textbox', { name: 'Password' }).fill(canvasPassword);
+  await Promise.all([
+    page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
+    page.getByRole('button', { name: 'Log In' }).click(),
+  ]);
+
+  // Open the Canvas course, launch Tokamak, and navigate to the graded page.
+  await page
+    .locator('a.ic-DashboardCard__link', { has: page.locator(`h3[title="${courseName}"]`) })
+    .first()
+    .click();
+  await page.locator('#section-tabs a').filter({ hasText: launchLinkName }).click();
+
+  const toolFrame = page.frameLocator('iframe[name="tool_content"]');
+  await expect(toolFrame.locator('body')).toBeVisible();
+
+  await toolFrame.getByRole('link', { name: 'Assignments' }).click();
+  await toolFrame.getByRole('link', { name: gradedPageName }).click();
+  await expect(toolFrame.getByText(gradedPageName).first()).toBeVisible();
+
+  const beginAttemptButton = toolFrame.locator('#begin_attempt_button');
+  await expect(beginAttemptButton).toBeVisible();
+  await beginAttemptButton.click();
+
+  // Complete the graded page with the known correct responses.
+  const submitAnswersButton = toolFrame.locator('#submit_answers');
+  await expect(submitAnswersButton).toBeVisible();
+
+  await expect(toolFrame.getByText('Choice A')).toBeVisible();
+  await toolFrame.getByText('Choice A').click();
+
+  const answerTextbox = toolFrame.getByRole('textbox', { name: 'answer submission textbox' });
+  await expect(answerTextbox).toBeVisible();
+  await answerTextbox.fill('answer');
+
+  // Submit the attempt and verify the redirected review page is displayed.
+  await submitAnswersButton.evaluate((button) => {
+    button.scrollIntoView({ block: 'center', inline: 'center' });
+  });
+  await page.mouse.move(20, 20);
+  await submitAnswersButton.click();
+
+  await expect(toolFrame.getByText('Review', { exact: true })).toBeVisible();
+});

--- a/assets/automation/tests/torus/lti/support/canvas.ts
+++ b/assets/automation/tests/torus/lti/support/canvas.ts
@@ -1,4 +1,10 @@
 import { type Page } from '@playwright/test';
+import { requireAnyEnv, requireEnv } from '../../../support/testConfig';
+
+type CanvasCredentials = {
+  email: string;
+  password: string;
+};
 
 // Logs into Canvas with the given credentials and waits for the successful-login redirect.
 export const loginToCanvas = async (page: Page, email: string, password: string) => {
@@ -9,4 +15,40 @@ export const loginToCanvas = async (page: Page, email: string, password: string)
     page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
     page.getByRole('button', { name: 'Log In' }).click(),
   ]);
+};
+
+// Reads the student credentials used by the grade passback test.
+export const getCanvasStudentCredentials = (): CanvasCredentials => ({
+  email: requireEnv('CANVAS_STUDENT_EMAIL'),
+  password: requireEnv('CANVAS_STUDENT_PASSWORD'),
+});
+
+// Reads the instructor credentials used by the grade passback test.
+export const getCanvasInstructorCredentials = (): CanvasCredentials => ({
+  email: requireAnyEnv(['CANVAS_ADMIN_EMAIL', 'CANVAS_INSTRUCTOR_EMAIL']),
+  password: requireAnyEnv(['CANVAS_ADMIN_PASSWORD', 'CANVAS_INSTRUCTOR_PASSWORD']),
+});
+
+// Resolves the authenticated user's display name from Canvas.
+export const getCanvasUserName = async (page: Page) => {
+  const user = await page.evaluate(async () => {
+    const response = await fetch('/api/v1/users/self', {
+      headers: { Accept: 'application/json' },
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load Canvas user profile: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    return (await response.json()) as { name?: string };
+  });
+
+  if (!user.name) {
+    throw new Error('Canvas user profile did not include a name');
+  }
+
+  return user.name;
 };

--- a/assets/automation/tests/torus/lti/support/canvas.ts
+++ b/assets/automation/tests/torus/lti/support/canvas.ts
@@ -1,0 +1,12 @@
+import { type Page } from '@playwright/test';
+
+// Logs into Canvas with the given credentials and waits for the successful-login redirect.
+export const loginToCanvas = async (page: Page, email: string, password: string) => {
+  await page.goto('https://canvas.oli.cmu.edu/login/canvas');
+  await page.getByRole('textbox', { name: 'Email' }).fill(email);
+  await page.getByRole('textbox', { name: 'Password' }).fill(password);
+  await Promise.all([
+    page.waitForURL('https://canvas.oli.cmu.edu/?login_success=1'),
+    page.getByRole('button', { name: 'Log In' }).click(),
+  ]);
+};

--- a/oli.example.env
+++ b/oli.example.env
@@ -225,3 +225,10 @@ KNOWLEDGEBASE_URL="#"
 
 # Local development only. Do not set this in production.
 # PROJECT_EXPORT_LOCAL_OUTPUT_DIR=/path/to/export_directory
+
+## Canvas automation with Playwright
+# CANVAS_STUDENT_EMAIL=student@email.com
+# CANVAS_STUDENT_PASSWORD=student_password
+# CANVAS_INSTRUCTOR_EMAIL=instructor@email.com
+# CANVAS_INSTRUCTOR_PASSWORD=instructor_password
+# CANVAS_LTI_LAUNCH_LINK_NAME=OLI Torus (tokamak)


### PR DESCRIPTION
[MER-5396](https://eliterate.atlassian.net/browse/MER-5396)

## Summary

This PR adds and hardens the end-to-end Canvas grade passback smoke test for Tokamak. The flow validates student and instructor login, the LTI launch, the graded page attempt, submission, and verification that the score returns correctly to the Canvas gradebook.

### Details

- Adds Playwright coverage for the Canvas-to-Torus grade passback flow.
- Makes the test tolerate an already-started attempt instead of failing.
- Resolves the student display name from Canvas at runtime.
- Improves gradebook reading so it works across different Canvas renderings.
- Extracts reusable Canvas and test credential helpers.
- Adds dedicated documentation for running and debugging the spec.

### Requirements

To run the test, the Playwright execution environment must have these environment variables set:

- `CANVAS_STUDENT_EMAIL`
- `CANVAS_STUDENT_PASSWORD`
- `CANVAS_INSTRUCTOR_EMAIL`
- `CANVAS_INSTRUCTOR_PASSWORD`

The correct values for those variables can be provided by @simonchoxx 

Canvas must already have:

- the `Playwright Test Course` course
- the `Graded page for graded passback` graded page

Optional:

- `CANVAS_LTI_LAUNCH_LINK_NAME`

If it is not set, the test uses `OLI Torus (tokamak)`.

### Notes

- No API key is required.
- The test uses isolated Playwright contexts for the student and instructor flows.
- If Canvas is still loading the gradebook, the test waits and retries until it finds the expected score.

[MER-5396]: https://eliterate.atlassian.net/browse/MER-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ