### PR TITLE
[BUG FIX] [MER-5695] [MER-5694] Fix manual grading rendering of legacy adaptive reports

### DIFF
--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -76,6 +76,106 @@ const AllAttemptStateList: {
   attemptGuid: string;
   attempt: unknown;
 }[] = [];
+
+const normalizeReviewDataKey = (key: string) => key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+
+const valueForKey = (snapshot: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(snapshot, key) ? snapshot[key] : undefined;
+
+const valueFromAggregateData = (
+  snapshot: Record<string, unknown>,
+  simId: string,
+  key: string,
+): { found: boolean; value?: unknown } => {
+  const data = valueForKey(snapshot, `app.${simId}.data`);
+
+  if (data === undefined) {
+    return { found: false };
+  }
+
+  const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+
+  if (!parsedData || typeof parsedData !== 'object' || Array.isArray(parsedData)) {
+    return { found: false };
+  }
+
+  const exactValue = valueForKey(parsedData as Record<string, unknown>, key);
+
+  if (exactValue !== undefined) {
+    return { found: true, value: exactValue };
+  }
+
+  const normalizedKey = normalizeReviewDataKey(key);
+  const matchingKey = Object.keys(parsedData).find(
+    (dataKey) => normalizeReviewDataKey(dataKey) === normalizedKey,
+  );
+
+  if (matchingKey) {
+    return { found: true, value: (parsedData as Record<string, unknown>)[matchingKey] };
+  }
+
+  return { found: false };
+};
+
+const findReviewDataValue = (
+  snapshot: Record<string, unknown>,
+  simId: string,
+  key: string,
+  partId?: string,
+) => {
+  const exactAppKey = `app.${simId}.${key}`;
+  const exactAppValue = valueForKey(snapshot, exactAppKey);
+
+  if (exactAppValue !== undefined) {
+    return exactAppValue;
+  }
+
+  try {
+    const aggregateValue = valueFromAggregateData(snapshot, simId, key);
+
+    if (aggregateValue.found) {
+      return aggregateValue.value;
+    }
+  } catch (_e) {
+    // Ignore malformed legacy aggregate data and fall back to keyed state.
+  }
+
+  const normalizedKey = normalizeReviewDataKey(key);
+  const appPrefix = `app.${simId}.`;
+  const appKey = Object.keys(snapshot).find(
+    (snapshotKey) =>
+      snapshotKey.startsWith(appPrefix) &&
+      normalizeReviewDataKey(snapshotKey.slice(appPrefix.length)) === normalizedKey,
+  );
+
+  if (appKey) {
+    return snapshot[appKey];
+  }
+
+  if (!partId) {
+    return undefined;
+  }
+
+  const stagePrefix = `stage.${partId}.`;
+  const scopedStagePrefix = `|${stagePrefix}`;
+  const stageKey = Object.keys(snapshot).find((snapshotKey) => {
+    if (snapshotKey.startsWith(stagePrefix)) {
+      return normalizeReviewDataKey(snapshotKey.slice(stagePrefix.length)) === normalizedKey;
+    }
+
+    const scopedIndex = snapshotKey.indexOf(scopedStagePrefix);
+    if (scopedIndex === -1) {
+      return false;
+    }
+
+    return (
+      normalizeReviewDataKey(snapshotKey.slice(scopedIndex + scopedStagePrefix.length)) ===
+      normalizedKey
+    );
+  });
+
+  return stageKey ? snapshot[stageKey] : undefined;
+};
 // the activity renderer should be capable of handling *any* activity type, not just adaptive
 // most events should be simply bubbled up to the layout renderer for handling
 const ActivityRenderer: React.FC<ActivityRendererProps> = ({
@@ -123,14 +223,10 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
   };
 
   const readUserData = async (attemptGuid: string, partAttemptGuid: string, payload: any) => {
-    const { simId, key } = payload;
+    const { simId, key, id } = payload;
     if (isReviewMode) {
       const { snapshot } = await onRequestLatestState();
-      const keyData = snapshot[`app.${simId}.${key}`];
-      if (keyData) {
-        return keyData;
-      }
-      return undefined;
+      return findReviewDataValue(snapshot, simId, key, id);
     }
     const data = await Extrinsic.readGlobalUserState(blobStorageProvider, [simId], isPreviewMode);
     if (data) {

--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -77,8 +77,6 @@ const AllAttemptStateList: {
   attempt: unknown;
 }[] = [];
 
-const normalizeReviewDataKey = (key: string) => key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-
 const valueForKey = (snapshot: Record<string, unknown>, key: string) =>
   Object.prototype.hasOwnProperty.call(snapshot, key) ? snapshot[key] : undefined;
 
@@ -105,24 +103,10 @@ const valueFromAggregateData = (
     return { found: true, value: exactValue };
   }
 
-  const normalizedKey = normalizeReviewDataKey(key);
-  const matchingKey = Object.keys(parsedData).find(
-    (dataKey) => normalizeReviewDataKey(dataKey) === normalizedKey,
-  );
-
-  if (matchingKey) {
-    return { found: true, value: (parsedData as Record<string, unknown>)[matchingKey] };
-  }
-
   return { found: false };
 };
 
-const findReviewDataValue = (
-  snapshot: Record<string, unknown>,
-  simId: string,
-  key: string,
-  partId?: string,
-) => {
+const findReviewDataValue = (snapshot: Record<string, unknown>, simId: string, key: string) => {
   const exactAppKey = `app.${simId}.${key}`;
   const exactAppValue = valueForKey(snapshot, exactAppKey);
 
@@ -140,41 +124,7 @@ const findReviewDataValue = (
     // Ignore malformed legacy aggregate data and fall back to keyed state.
   }
 
-  const normalizedKey = normalizeReviewDataKey(key);
-  const appPrefix = `app.${simId}.`;
-  const appKey = Object.keys(snapshot).find(
-    (snapshotKey) =>
-      snapshotKey.startsWith(appPrefix) &&
-      normalizeReviewDataKey(snapshotKey.slice(appPrefix.length)) === normalizedKey,
-  );
-
-  if (appKey) {
-    return snapshot[appKey];
-  }
-
-  if (!partId) {
-    return undefined;
-  }
-
-  const stagePrefix = `stage.${partId}.`;
-  const scopedStagePrefix = `|${stagePrefix}`;
-  const stageKey = Object.keys(snapshot).find((snapshotKey) => {
-    if (snapshotKey.startsWith(stagePrefix)) {
-      return normalizeReviewDataKey(snapshotKey.slice(stagePrefix.length)) === normalizedKey;
-    }
-
-    const scopedIndex = snapshotKey.indexOf(scopedStagePrefix);
-    if (scopedIndex === -1) {
-      return false;
-    }
-
-    return (
-      normalizeReviewDataKey(snapshotKey.slice(scopedIndex + scopedStagePrefix.length)) ===
-      normalizedKey
-    );
-  });
-
-  return stageKey ? snapshot[stageKey] : undefined;
+  return undefined;
 };
 // the activity renderer should be capable of handling *any* activity type, not just adaptive
 // most events should be simply bubbled up to the layout renderer for handling
@@ -223,10 +173,10 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
   };
 
   const readUserData = async (attemptGuid: string, partAttemptGuid: string, payload: any) => {
-    const { simId, key, id } = payload;
+    const { simId, key } = payload;
     if (isReviewMode) {
       const { snapshot } = await onRequestLatestState();
-      return findReviewDataValue(snapshot, simId, key, id);
+      return findReviewDataValue(snapshot, simId, key);
     }
     const data = await Extrinsic.readGlobalUserState(blobStorageProvider, [simId], isPreviewMode);
     if (data) {

--- a/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
@@ -34,6 +34,14 @@ export interface IEverappRendererProps {
   open: boolean;
 }
 
+const isSnapshotPayload = (snapshot: unknown): snapshot is Record<string, unknown> =>
+  Boolean(snapshot) && typeof snapshot === 'object' && !Array.isArray(snapshot);
+
+const getSnapshotPayload = (result: unknown): Record<string, unknown> => {
+  const snapshot = (result as { payload?: { snapshot?: unknown } })?.payload?.snapshot;
+  return isSnapshotPayload(snapshot) ? snapshot : {};
+};
+
 const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
   const everApp = props.app;
   const index = props.index;
@@ -70,7 +78,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
 
   const getCurrentSnapshot = async () => {
     const sResult = await dispatch(getLocalizedCurrentStateSnapshot());
-    return (sResult as any)?.payload?.snapshot || {};
+    return getSnapshotPayload(sResult);
   };
 
   const handleActivitySavePart = async (

--- a/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
@@ -14,8 +14,10 @@ import { toggleEverapp } from 'apps/delivery/store/features/page/actions/toggleE
 import {
   selectBlobStorageProvider,
   selectPreviewMode,
+  selectReviewMode,
 } from 'apps/delivery/store/features/page/slice';
 import { updateGlobalUserState } from 'data/persistence/extrinsic';
+import { contexts } from '../../../../../types/applicationContext';
 import { getEverAppActivity, updateAttemptGuid } from '../EverApps';
 
 export interface Everapp {
@@ -38,6 +40,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
 
   const dispatch = useDispatch();
   const isPreviewMode = useSelector(selectPreviewMode);
+  const isReviewMode = useSelector(selectReviewMode);
   const [isOpen, setIsOpen] = useState<boolean>(props.open);
   const blobStorageProvider = useSelector(selectBlobStorageProvider);
   const currentActivityTree = useSelector(selectCurrentActivityTree);
@@ -54,14 +57,24 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
 
     const [currentActivity] = currentActivityTree.slice(-1);
     const currentActivityIds = currentActivityTree.map((a) => String(a.id));
+    const mode = isReviewMode ? contexts.REVIEW : contexts.VIEWER;
+
     return {
       snapshot: getLocalizedStateSnapshot(currentActivityIds),
       context: {
         currentActivity: currentActivity.id,
-        mode: 'VIEWER', // TODO ENUM
+        mode,
       },
     };
-  }, [currentActivityTree]);
+  }, [currentActivityTree, isReviewMode]);
+
+  const getCurrentSnapshot = async () => {
+    const sResult = await dispatch(getLocalizedCurrentStateSnapshot());
+    const {
+      payload: { snapshot },
+    } = sResult as any;
+    return snapshot;
+  };
 
   const handleActivitySavePart = async (
     activityId: string | number,
@@ -69,6 +82,11 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
     partAttemptGuid: string,
     response: StudentResponse,
   ) => {
+    if (isReviewMode) {
+      const snapshot = await getCurrentSnapshot();
+      return { result: { type: 'success' }, snapshot };
+    }
+
     /*
       id: "app.ispk-bio-observer.external.env"
       key: "external.env"
@@ -103,10 +121,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
       result,
     }); */
 
-    const sResult = await dispatch(getLocalizedCurrentStateSnapshot());
-    const {
-      payload: { snapshot },
-    } = sResult as any;
+    const snapshot = await getCurrentSnapshot();
     return { result, snapshot };
   };
 
@@ -116,6 +131,11 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
     partAttemptGuid: string,
     response: StudentResponse,
   ) => {
+    if (isReviewMode) {
+      const snapshot = await getCurrentSnapshot();
+      return { result: { type: 'success', actions: [] }, snapshot };
+    }
+
     const { result, snapshot } = await handleActivitySavePart(
       activityId,
       attemptGuid,
@@ -129,10 +149,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
   };
 
   const handleRequestLatestState = async () => {
-    const sResult = await dispatch(getLocalizedCurrentStateSnapshot());
-    const {
-      payload: { snapshot },
-    } = sResult as any;
+    const snapshot = await getCurrentSnapshot();
     return {
       snapshot,
     };

--- a/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
+++ b/assets/src/apps/delivery/layouts/deck/components/EverappRenderer.tsx
@@ -70,10 +70,7 @@ const EverappRenderer: React.FC<IEverappRendererProps> = (props) => {
 
   const getCurrentSnapshot = async () => {
     const sResult = await dispatch(getLocalizedCurrentStateSnapshot());
-    const {
-      payload: { snapshot },
-    } = sResult as any;
-    return snapshot;
+    return (sResult as any)?.payload?.snapshot || {};
   };
 
   const handleActivitySavePart = async (

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -377,8 +377,8 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
     if (!props.onReadUserState || isReviewMode) {
       const { simId, key } = payload;
       const allState = {
-        ...reviewSnapshotRef.current,
         ...getEnvState(scriptEnv),
+        ...reviewSnapshotRef.current,
       };
       // keys will be like app.simId.key
       if (isReviewMode) {

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -376,10 +376,8 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
     // if we are in standalone review mode for manual grading, then we should use the state from the attempt
     if (!props.onReadUserState || isReviewMode) {
       const { simId, key } = payload;
-      const allState = {
-        ...getEnvState(scriptEnv),
-        ...reviewSnapshotRef.current,
-      };
+      const envState = getEnvState(scriptEnv);
+      const allState = isReviewMode ? { ...envState, ...reviewSnapshotRef.current } : envState;
       // keys will be like app.simId.key
       if (isReviewMode) {
         return findReviewDataValue(allState, simId, key);

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -21,8 +21,6 @@ const partInitResponseMap = new Map();
 const sharedPromiseMap = new Map();
 const sharedAttemptStateMap = new Map();
 
-const normalizeReviewDataKey = (key: string) => key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
-
 const valueForKey = (snapshot: Record<string, unknown>, key: string) =>
   Object.prototype.hasOwnProperty.call(snapshot, key) ? snapshot[key] : undefined;
 
@@ -49,77 +47,27 @@ const valueFromAggregateData = (
     return { found: true, value: exactValue };
   }
 
-  const normalizedKey = normalizeReviewDataKey(key);
-  const matchingKey = Object.keys(parsedData).find(
-    (dataKey) => normalizeReviewDataKey(dataKey) === normalizedKey,
-  );
-
-  if (matchingKey) {
-    return { found: true, value: (parsedData as Record<string, unknown>)[matchingKey] };
-  }
-
   return { found: false };
 };
 
-const findReviewDataValue = (
-  snapshot: Record<string, unknown>,
-  simId: string,
-  key: string,
-  partId?: string,
-) => {
+const findReviewDataValue = (snapshot: Record<string, unknown>, simId: string, key: string) => {
   const exactAppValue = valueForKey(snapshot, `app.${simId}.${key}`);
 
   if (exactAppValue !== undefined) {
-    return { source: 'exact-app-key', value: exactAppValue };
+    return exactAppValue;
   }
 
   try {
     const aggregateValue = valueFromAggregateData(snapshot, simId, key);
 
     if (aggregateValue.found) {
-      return { source: 'aggregate-data', value: aggregateValue.value };
+      return aggregateValue.value;
     }
   } catch (_e) {
     // Ignore malformed legacy aggregate data and fall back to keyed state.
   }
 
-  const normalizedKey = normalizeReviewDataKey(key);
-  const appPrefix = `app.${simId}.`;
-  const appKey = Object.keys(snapshot).find(
-    (snapshotKey) =>
-      snapshotKey.startsWith(appPrefix) &&
-      normalizeReviewDataKey(snapshotKey.slice(appPrefix.length)) === normalizedKey,
-  );
-
-  if (appKey) {
-    return { source: 'normalized-app-key', value: snapshot[appKey] };
-  }
-
-  if (!partId) {
-    return { source: 'missing', value: undefined };
-  }
-
-  const stagePrefix = `stage.${partId}.`;
-  const scopedStagePrefix = `|${stagePrefix}`;
-  const stageKey = Object.keys(snapshot).find((snapshotKey) => {
-    if (snapshotKey.startsWith(stagePrefix)) {
-      return normalizeReviewDataKey(snapshotKey.slice(stagePrefix.length)) === normalizedKey;
-    }
-
-    const scopedIndex = snapshotKey.indexOf(scopedStagePrefix);
-    if (scopedIndex === -1) {
-      return false;
-    }
-
-    return (
-      normalizeReviewDataKey(snapshotKey.slice(scopedIndex + scopedStagePrefix.length)) ===
-      normalizedKey
-    );
-  });
-
-  return stageKey
-    ? { source: 'stage-key', value: snapshot[stageKey] }
-    : { source: 'missing', value: undefined };
+  return undefined;
 };
 
 export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
@@ -434,9 +382,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
       };
       // keys will be like app.simId.key
       if (isReviewMode) {
-        const result = findReviewDataValue(allState, simId, key, payload.id);
-
-        return result.value;
+        return findReviewDataValue(allState, simId, key);
       }
 
       return allState[`app.${simId}.${key}`];

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { EventEmitter } from 'events';
 import { Environment } from 'janus-script';
@@ -21,6 +21,107 @@ const partInitResponseMap = new Map();
 const sharedPromiseMap = new Map();
 const sharedAttemptStateMap = new Map();
 
+const normalizeReviewDataKey = (key: string) => key.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+
+const valueForKey = (snapshot: Record<string, unknown>, key: string) =>
+  Object.prototype.hasOwnProperty.call(snapshot, key) ? snapshot[key] : undefined;
+
+const valueFromAggregateData = (
+  snapshot: Record<string, unknown>,
+  simId: string,
+  key: string,
+): { found: boolean; value?: unknown } => {
+  const data = valueForKey(snapshot, `app.${simId}.data`);
+
+  if (data === undefined) {
+    return { found: false };
+  }
+
+  const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+
+  if (!parsedData || typeof parsedData !== 'object' || Array.isArray(parsedData)) {
+    return { found: false };
+  }
+
+  const exactValue = valueForKey(parsedData as Record<string, unknown>, key);
+
+  if (exactValue !== undefined) {
+    return { found: true, value: exactValue };
+  }
+
+  const normalizedKey = normalizeReviewDataKey(key);
+  const matchingKey = Object.keys(parsedData).find(
+    (dataKey) => normalizeReviewDataKey(dataKey) === normalizedKey,
+  );
+
+  if (matchingKey) {
+    return { found: true, value: (parsedData as Record<string, unknown>)[matchingKey] };
+  }
+
+  return { found: false };
+};
+
+const findReviewDataValue = (
+  snapshot: Record<string, unknown>,
+  simId: string,
+  key: string,
+  partId?: string,
+) => {
+  const exactAppValue = valueForKey(snapshot, `app.${simId}.${key}`);
+
+  if (exactAppValue !== undefined) {
+    return { source: 'exact-app-key', value: exactAppValue };
+  }
+
+  try {
+    const aggregateValue = valueFromAggregateData(snapshot, simId, key);
+
+    if (aggregateValue.found) {
+      return { source: 'aggregate-data', value: aggregateValue.value };
+    }
+  } catch (_e) {
+    // Ignore malformed legacy aggregate data and fall back to keyed state.
+  }
+
+  const normalizedKey = normalizeReviewDataKey(key);
+  const appPrefix = `app.${simId}.`;
+  const appKey = Object.keys(snapshot).find(
+    (snapshotKey) =>
+      snapshotKey.startsWith(appPrefix) &&
+      normalizeReviewDataKey(snapshotKey.slice(appPrefix.length)) === normalizedKey,
+  );
+
+  if (appKey) {
+    return { source: 'normalized-app-key', value: snapshot[appKey] };
+  }
+
+  if (!partId) {
+    return { source: 'missing', value: undefined };
+  }
+
+  const stagePrefix = `stage.${partId}.`;
+  const scopedStagePrefix = `|${stagePrefix}`;
+  const stageKey = Object.keys(snapshot).find((snapshotKey) => {
+    if (snapshotKey.startsWith(stagePrefix)) {
+      return normalizeReviewDataKey(snapshotKey.slice(stagePrefix.length)) === normalizedKey;
+    }
+
+    const scopedIndex = snapshotKey.indexOf(scopedStagePrefix);
+    if (scopedIndex === -1) {
+      return false;
+    }
+
+    return (
+      normalizeReviewDataKey(snapshotKey.slice(scopedIndex + scopedStagePrefix.length)) ===
+      normalizedKey
+    );
+  });
+
+  return stageKey
+    ? { source: 'stage-key', value: snapshot[stageKey] }
+    : { source: 'missing', value: undefined };
+};
+
 export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
   const [activityId, _setActivityId] = useState<string>(
     props.model?.id || props.model?.activity_id || `unknown_activity`,
@@ -40,6 +141,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
   // TODO: this type should be Environment | undefined; this is a local script env for each activity
   // should be provided by the parent as a child env, possibly default to having its own instead
   const [scriptEnv, setScriptEnv] = useState<any>(new Environment());
+  const reviewSnapshotRef = useRef<Record<string, unknown>>({});
 
   const [adaptivityDomain, setAdaptivityDomain] = useState<string>('stage');
 
@@ -176,6 +278,8 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
           const response: any = Array.from(partInitResponseMap);
           const readyResults: any = await props.onReady(currentAttemptState.attemptGuid, response);
           const { env, domain } = readyResults;
+          const snapshot = readyResults.snapshot || {};
+          reviewSnapshotRef.current = snapshot;
           if (env) {
             setScriptEnv(env);
           }
@@ -184,7 +288,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
           }
           /* console.log('ACTIVITY READY RESULTS', readyResults); */
           partsInitDeferred.resolve({
-            snapshot: readyResults.snapshot || {},
+            snapshot,
             context: {
               sectionSlug,
               currentUserId,
@@ -229,6 +333,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
               : null;
           /* console.log('ACTIVITY READY RESULTS', { testRes, attemptStateMap }); */
           const snapshot = getLocalizedStateSnapshot([activityId], scriptEnv);
+          reviewSnapshotRef.current = snapshot;
           // if for some reason this isn't defined, don't leave it hanging
           const context = {
             snapshot,
@@ -323,9 +428,17 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
     // if we are in standalone review mode for manual grading, then we should use the state from the attempt
     if (!props.onReadUserState || isReviewMode) {
       const { simId, key } = payload;
-      const allState = getEnvState(scriptEnv);
+      const allState = {
+        ...reviewSnapshotRef.current,
+        ...getEnvState(scriptEnv),
+      };
       // keys will be like app.simId.key
-      /* console.log('GET DATA', { simId, key, allState }); */
+      if (isReviewMode) {
+        const result = findReviewDataValue(allState, simId, key, payload.id);
+
+        return result.value;
+      }
+
       return allState[`app.${simId}.${key}`];
     }
   };

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -17,7 +17,6 @@ import { CapiIframeModel } from './schema';
 import { resolveAdaptiveIframeSource, sanitizeAdaptiveIframeFallbackHref } from './sourceResolver';
 
 const externalActivityMap: Map<string, any> = new Map();
-let context = 'VIEWER';
 
 const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) => {
   const [state, setState] = useState<any[]>(Array.isArray(props.state) ? props.state : []);
@@ -28,6 +27,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [initStateBindToFacts, setInitStateBindToFacts] = useState<any>({});
   const [screenContext, setScreenContext] = useState('');
   const id: string = props.id;
+  const contextRef = useRef('VIEWER');
 
   const [scriptEnv, setScriptEnv] = useState<any>();
   // model items, note that we use default values now because
@@ -167,7 +167,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       simLife.ownerActivityId = initResult.context.currentActivity;
     }
     if (initResult.context.mode) {
-      context = initResult.context.mode;
+      contextRef.current = initResult.context.mode;
     }
     if (initResult.env) {
       const env = new Environment(initResult.env);
@@ -480,7 +480,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     }
   };
 
-  const isReviewContext = () => context === contexts.REVIEW;
+  const isReviewContext = () => contextRef.current === contexts.REVIEW;
 
   const reviewReadonlyVariable = () =>
     new CapiVariable({
@@ -589,7 +589,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
             break;
           case NotificationType.CONTEXT_CHANGED:
             {
-              context = payload.mode;
+              contextRef.current = payload.mode;
               writeCapiLog('CONTEXT CHANGED!!!!', 3, {
                 simLife,
                 payload,
@@ -724,7 +724,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
 
     // taken from simcapi.js TODO move somewhere, use from settings
     simLife.handshake.config = {
-      context: context,
+      context: contextRef.current,
       lessonId: uniqueLessonId ? `${lessonId}_${guid()}` : lessonId,
       questionId,
       sectionSlug,
@@ -753,7 +753,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         const simKey = `${simLife.domain}.${simLife.simId}.${variable}`;
         const formatted: Record<string, any> = {};
         formatted[variable] = filterVars[variable];
-        if (context !== contexts.REVIEW) {
+        if (!isReviewContext()) {
           const value = formatted[variable].value;
           const isMathExpr = formatted[variable].type === CapiVariableTypes.MATH_EXPR;
           if (typeof value === 'string' && !isMathExpr) {
@@ -1087,15 +1087,15 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
           break;
 
         case JanusCAPIRequestTypes.VALUE_CHANGE:
-          if (context !== contexts.REVIEW) handleValueChange(data, simLife.domain);
+          if (!isReviewContext()) handleValueChange(data, simLife.domain);
           break;
 
         case JanusCAPIRequestTypes.SET_DATA_REQUEST:
-          if (context !== contexts.REVIEW) handleSetData(data);
+          if (!isReviewContext()) handleSetData(data);
           break;
 
         case JanusCAPIRequestTypes.CHECK_REQUEST:
-          if (context !== contexts.REVIEW) handleCheckRequest(data);
+          if (!isReviewContext()) handleCheckRequest(data);
           break;
 
         case JanusCAPIRequestTypes.RESIZE_PARENT_CONTAINER_REQUEST:

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -589,7 +589,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
             break;
           case NotificationType.CONTEXT_CHANGED:
             {
-              contextRef.current = payload.mode;
+              const nextContext =
+                contextRef.current === contexts.REVIEW ? contexts.REVIEW : payload.mode;
+              contextRef.current = nextContext;
               writeCapiLog('CONTEXT CHANGED!!!!', 3, {
                 simLife,
                 payload,
@@ -599,7 +601,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
                 simLife.domain = payload.domain;
               }
               simLife.handshake.config = {
-                context: payload.mode,
+                context: nextContext,
                 questionId: payload.currentActivityId,
                 sectionSlug: payload.sectionSlug,
                 lessonId: payload.currentLessonId,

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -18,6 +18,7 @@ import { resolveAdaptiveIframeSource, sanitizeAdaptiveIframeFallbackHref } from 
 
 const externalActivityMap: Map<string, any> = new Map();
 let context = 'VIEWER';
+
 const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) => {
   const [state, setState] = useState<any[]>(Array.isArray(props.state) ? props.state : []);
   const [model, setModel] = useState<any>(Array.isArray(props.model) ? props.model : {});
@@ -268,7 +269,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
           cVar.value = val;
         }
       }
-      formatted[baseKey] = cVar;
+      formatted[baseKey] = coerceReadonlyForReview(baseKey, cVar);
       sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.VALUE_CHANGE, formatted);
     });
   };
@@ -399,11 +400,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   };
   const externalActivityContainerStyles: CSSProperties = {
     position: 'relative',
-    width: '100%',
-    height: '100%',
-    maxWidth: '100%',
-    maxHeight: '100%',
-    overflow: 'hidden',
+    width: frameWidth || '100%',
+    height: frameHeight || '100%',
+    overflow: 'auto',
   };
   const fallbackOverlayStyles: CSSProperties = {
     position: 'absolute',
@@ -479,6 +478,33 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       // eslint-disable-next-line
       console.log(`%c Capi(${id}) - ${msg}`, colorStyle, ...args);
     }
+  };
+
+  const isReviewContext = () => context === contexts.REVIEW;
+
+  const reviewReadonlyVariable = () =>
+    new CapiVariable({
+      key: 'readonly',
+      type: CapiVariableTypes.BOOLEAN,
+      value: true,
+    });
+
+  const coerceReadonlyForReview = (key: string, variable: CapiVariable) => {
+    if (isReviewContext() && key === 'readonly') {
+      return reviewReadonlyVariable();
+    }
+
+    return variable;
+  };
+
+  const sendReadonlyValueChangeInReview = () => {
+    if (!isReviewContext()) {
+      return;
+    }
+
+    sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.VALUE_CHANGE, {
+      readonly: reviewReadonlyVariable(),
+    });
   };
 
   /*
@@ -660,12 +686,15 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     return vars
       .filter((v) => v.id.indexOf(`${domain}.${id}.`) === 0)
       .reduce((capiFormatted, item) => {
-        capiFormatted[item.key] = new CapiVariable({
-          key: item.key,
-          type: item.type,
-          value: item.value,
-          allowedValues: item.allowedValues,
-        });
+        capiFormatted[item.key] = coerceReadonlyForReview(
+          item.key,
+          new CapiVariable({
+            key: item.key,
+            type: item.type,
+            value: item.value,
+            allowedValues: item.allowedValues,
+          }),
+        );
         return capiFormatted;
       }, {});
   };
@@ -757,6 +786,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.VALUE_CHANGE, formatted);
       });
     }
+    sendReadonlyValueChangeInReview();
     //if there are no more facts/init state data then send INITIAL_SETUP_COMPLETE response to SIM
     if (!initState && !Object.keys(initState)?.length) {
       simLife.init = true;
@@ -794,8 +824,8 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         value = JSON.stringify(val);
       }
       response.values.responseType = 'success';
-      response.values.value = value?.length ? value : '[]';
       response.values.exists = exists;
+      response.values.value = exists ? value : '[]';
     } catch (err) {
       response.values.responseType = 'error';
       response.values.error = err;
@@ -995,7 +1025,13 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     // so here we want to apply configData FIRST, then overwrite it with anything already set in the state
     const configDataState: any = [
       ...configData.map((cdVar: { key: any }) => {
-        return { ...cdVar, id: `${newLife.domain}.${id}.${cdVar.key}` };
+        return {
+          ...cdVar,
+          id: `${newLife.domain}.${id}.${cdVar.key}`,
+          ...(isReviewContext() && cdVar.key === 'readonly'
+            ? { type: CapiVariableTypes.BOOLEAN, value: true }
+            : {}),
+        };
       }),
     ];
     // override configData values from init trap state data.
@@ -1104,7 +1140,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
           cVar.value = JSON.stringify(cVar.value);
         }
       }
-      formatted[baseKey] = cVar;
+      formatted[baseKey] = coerceReadonlyForReview(baseKey, cVar);
       sendFormedResponse(simLife.handshake, {}, JanusCAPIRequestTypes.VALUE_CHANGE, formatted);
     });
   };
@@ -1146,7 +1182,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
           cVar.value = val;
         }
       }
-      formatted[baseKey] = cVar;
+      formatted[baseKey] = coerceReadonlyForReview(baseKey, cVar);
       //hack for Small world type SIMs
       if (baseKey.indexOf('System.AllowNextOnCacheCase') !== -1) {
         const mFormatted: Record<string, unknown> = {};

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -167,7 +167,8 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       simLife.ownerActivityId = initResult.context.currentActivity;
     }
     if (initResult.context.mode) {
-      contextRef.current = initResult.context.mode;
+      contextRef.current =
+        contextRef.current === contexts.REVIEW ? contexts.REVIEW : initResult.context.mode;
     }
     if (initResult.env) {
       const env = new Environment(initResult.env);

--- a/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
+++ b/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
@@ -29,9 +29,7 @@ export const shouldAllowIframeScrolling = (
 export const getIframePartDeliveryStyle = (style: CSSProperties): CSSProperties => ({
   ...style,
   boxSizing: 'border-box',
-  maxWidth: '100%',
-  maxHeight: '100%',
-  overflow: 'hidden',
+  overflow: 'visible',
 });
 
 export const getExternalIframeStyles = (

--- a/assets/test/delivery/janus_capi_iframe_test.ts
+++ b/assets/test/delivery/janus_capi_iframe_test.ts
@@ -29,13 +29,12 @@ describe('janus_capi_iframe delivery behavior', () => {
     ).toBe(true);
   });
 
-  it('clamps the iframe part and iframe element to the adaptive slot', () => {
+  it('preserves the authored iframe host dimensions and bounds the iframe element', () => {
     expect(getIframePartDeliveryStyle({ width: 1200, height: 700 })).toMatchObject({
       width: 1200,
       height: 700,
-      maxWidth: '100%',
-      maxHeight: '100%',
-      overflow: 'hidden',
+      boxSizing: 'border-box',
+      overflow: 'visible',
     });
 
     expect(getExternalIframeStyles({ width: '100%', height: '100%' }, true)).toMatchObject({

--- a/lib/oli_web/components/delivery/adaptive_iframe.ex
+++ b/lib/oli_web/components/delivery/adaptive_iframe.ex
@@ -71,8 +71,21 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
         _ -> base_url <> "?" <> URI.encode_query(query_params)
       end
 
+    hook_id =
+      [
+        "adaptive-screen-preview",
+        section_slug,
+        page_revision.slug,
+        revision.slug,
+        Keyword.get(opts, :attempt_guid),
+        Keyword.get(opts, :page_revision_id),
+        Keyword.get(opts, :screen_revision_id)
+      ]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join("-")
+
     """
-    <div class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">
+    <div id="#{hook_id}" class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">
       <div
         class="flex items-center justify-center text-sm text-gray-500 min-h-[24px] mb-3"
         data-iframe-loading

--- a/lib/oli_web/components/delivery/adaptive_iframe.ex
+++ b/lib/oli_web/components/delivery/adaptive_iframe.ex
@@ -82,6 +82,7 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
         Keyword.get(opts, :screen_revision_id)
       ]
       |> Enum.reject(&is_nil/1)
+      |> Enum.map(&sanitize_id_segment/1)
       |> Enum.join("-")
 
     container_open =
@@ -109,6 +110,12 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
   defp maybe_put_query_param(params, _key, nil), do: params
   defp maybe_put_query_param(params, _key, ""), do: params
   defp maybe_put_query_param(params, key, value), do: Map.put(params, key, value)
+
+  defp sanitize_id_segment(segment) do
+    segment
+    |> to_string()
+    |> String.replace(~r/[^A-Za-z0-9_-]/, "-")
+  end
 
   def delivery(section_slug, revision_slug, content) do
     size = get_size(content)

--- a/lib/oli_web/components/delivery/adaptive_iframe.ex
+++ b/lib/oli_web/components/delivery/adaptive_iframe.ex
@@ -84,8 +84,11 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
       |> Enum.reject(&is_nil/1)
       |> Enum.join("-")
 
+    container_open =
+      ~s(<div id="#{hook_id}" class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">)
+
     """
-    <div id="#{hook_id}" class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">
+    #{container_open}
       <div
         class="flex items-center justify-center text-sm text-gray-500 min-h-[24px] mb-3"
         data-iframe-loading

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1318,12 +1318,8 @@ defmodule OliWeb.PageDeliveryController do
 
     resource_attempt = hd(page_context.resource_attempts)
 
-    screen_lineage =
-      adaptive_screen_lineage(resource_attempt.content, screen_revision)
-
     activity_guid_mapping =
-      page_context.activities
-      |> Map.take(Enum.map(screen_lineage, & &1["activity_id"]))
+      Map.take(page_context.activities, [screen_revision.resource_id])
 
     resource_attempt_state = Core.fetch_extrinsic_state(resource_attempt)
 
@@ -1335,7 +1331,11 @@ defmodule OliWeb.PageDeliveryController do
       build_adaptive_single_screen_preview_content(
         page_revision,
         screen_revision,
-        screen_lineage: screen_lineage
+        sequence_id:
+          extract_sequence_id_for_screen(
+            Map.get(resource_attempt, :content, %{}),
+            screen_revision.resource_id
+          )
       ),
       page_revision.graded,
       activity_types,
@@ -1348,20 +1348,6 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp build_adaptive_single_screen_preview_content(page_revision, screen_revision, opts \\ []) do
-    screen_lineage =
-      Keyword.get_lazy(opts, :screen_lineage, fn ->
-        [
-          %{
-            "type" => "activity-reference",
-            "activity_id" => screen_revision.resource_id,
-            "custom" => %{
-              "sequenceId" => "insights-screen-#{screen_revision.resource_id}",
-              "sequenceName" => screen_revision.title
-            }
-          }
-        ]
-      end)
-
     page_revision.content
     |> Map.update("custom", %{"insightsStageOnlyPreview" => true}, fn custom ->
       Map.put(custom, "insightsStageOnlyPreview", true)
@@ -1370,60 +1356,34 @@ defmodule OliWeb.PageDeliveryController do
       %{
         "type" => "group",
         "layout" => "deck",
-        "children" => screen_lineage
+        "children" => [
+          %{
+            "type" => "activity-reference",
+            "activity_id" => screen_revision.resource_id,
+            "custom" => %{
+              "sequenceId" =>
+                Keyword.get(opts, :sequence_id, "insights-screen-#{screen_revision.resource_id}"),
+              "sequenceName" => screen_revision.title
+            }
+          }
+        ]
       }
     ])
   end
 
-  defp adaptive_screen_lineage(%{"model" => _} = content, screen_revision) do
-    activity_references =
-      Oli.Resources.PageContent.flat_filter(content, fn item ->
-        item["type"] == "activity-reference"
-      end)
-
-    screen_entry =
-      Enum.find(activity_references, fn item ->
-        item["activity_id"] == screen_revision.resource_id
-      end)
-
-    case screen_entry do
-      %{"custom" => %{"sequenceId" => sequence_id}} when is_binary(sequence_id) ->
-        build_adaptive_screen_lineage(activity_references, sequence_id)
-
-      _ ->
-        default_adaptive_screen_lineage(screen_revision)
+  defp extract_sequence_id_for_screen(%{"model" => _} = content, resource_id) do
+    content
+    |> Oli.Resources.PageContent.flat_filter(fn item ->
+      item["type"] == "activity-reference" and item["activity_id"] == resource_id
+    end)
+    |> List.first()
+    |> case do
+      %{"custom" => %{"sequenceId" => sequence_id}} when is_binary(sequence_id) -> sequence_id
+      _ -> nil
     end
   end
 
-  defp adaptive_screen_lineage(_, screen_revision),
-    do: default_adaptive_screen_lineage(screen_revision)
-
-  defp build_adaptive_screen_lineage(activity_references, sequence_id) do
-    case Enum.find(activity_references, &(get_in(&1, ["custom", "sequenceId"]) == sequence_id)) do
-      nil ->
-        []
-
-      %{"custom" => %{"layerRef" => parent_sequence_id}} = entry
-      when is_binary(parent_sequence_id) ->
-        build_adaptive_screen_lineage(activity_references, parent_sequence_id) ++ [entry]
-
-      entry ->
-        [entry]
-    end
-  end
-
-  defp default_adaptive_screen_lineage(screen_revision) do
-    [
-      %{
-        "type" => "activity-reference",
-        "activity_id" => screen_revision.resource_id,
-        "custom" => %{
-          "sequenceId" => "insights-screen-#{screen_revision.resource_id}",
-          "sequenceName" => screen_revision.title
-        }
-      }
-    ]
-  end
+  defp extract_sequence_id_for_screen(_, _), do: nil
 
   defp current_preview_user(conn),
     do: conn.assigns[:current_user] || conn.assigns[:current_author]

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -3,8 +3,6 @@ defmodule OliWeb.PageDeliveryController do
 
   import OliWeb.Common.FormatDateTime
 
-  require Logger
-
   alias Oli.Accounts
   alias Oli.Activities
   alias Oli.Delivery.Attempts.{Core, PageLifecycle}
@@ -1320,8 +1318,14 @@ defmodule OliWeb.PageDeliveryController do
 
     resource_attempt = hd(page_context.resource_attempts)
 
+    screen_lineage =
+      adaptive_screen_lineage(resource_attempt.content, screen_revision)
+
     activity_guid_mapping =
-      Map.take(page_context.activities, [screen_revision.resource_id])
+      page_context.activities
+      |> Map.take(Enum.map(screen_lineage, & &1["activity_id"]))
+
+    resource_attempt_state = Core.fetch_extrinsic_state(resource_attempt)
 
     render_advanced_page_preview(
       conn,
@@ -1331,23 +1335,33 @@ defmodule OliWeb.PageDeliveryController do
       build_adaptive_single_screen_preview_content(
         page_revision,
         screen_revision,
-        sequence_id:
-          extract_sequence_id_for_screen(
-            Map.get(resource_attempt, :content, %{}),
-            screen_revision.resource_id
-          )
+        screen_lineage: screen_lineage
       ),
       page_revision.graded,
       activity_types,
       preview_mode: false,
       review_mode: true,
-      resource_attempt_state: Core.fetch_extrinsic_state(resource_attempt),
+      resource_attempt_state: resource_attempt_state,
       resource_attempt_guid: resource_attempt.attempt_guid,
       activity_guid_mapping: activity_guid_mapping
     )
   end
 
   defp build_adaptive_single_screen_preview_content(page_revision, screen_revision, opts \\ []) do
+    screen_lineage =
+      Keyword.get_lazy(opts, :screen_lineage, fn ->
+        [
+          %{
+            "type" => "activity-reference",
+            "activity_id" => screen_revision.resource_id,
+            "custom" => %{
+              "sequenceId" => "insights-screen-#{screen_revision.resource_id}",
+              "sequenceName" => screen_revision.title
+            }
+          }
+        ]
+      end)
+
     page_revision.content
     |> Map.update("custom", %{"insightsStageOnlyPreview" => true}, fn custom ->
       Map.put(custom, "insightsStageOnlyPreview", true)
@@ -1356,34 +1370,60 @@ defmodule OliWeb.PageDeliveryController do
       %{
         "type" => "group",
         "layout" => "deck",
-        "children" => [
-          %{
-            "type" => "activity-reference",
-            "activity_id" => screen_revision.resource_id,
-            "custom" => %{
-              "sequenceId" =>
-                Keyword.get(opts, :sequence_id, "insights-screen-#{screen_revision.resource_id}"),
-              "sequenceName" => screen_revision.title
-            }
-          }
-        ]
+        "children" => screen_lineage
       }
     ])
   end
 
-  defp extract_sequence_id_for_screen(%{"model" => _} = content, resource_id) do
-    content
-    |> Oli.Resources.PageContent.flat_filter(fn item ->
-      item["type"] == "activity-reference" and item["activity_id"] == resource_id
-    end)
-    |> List.first()
-    |> case do
-      %{"custom" => %{"sequenceId" => sequence_id}} when is_binary(sequence_id) -> sequence_id
-      _ -> nil
+  defp adaptive_screen_lineage(%{"model" => _} = content, screen_revision) do
+    activity_references =
+      Oli.Resources.PageContent.flat_filter(content, fn item ->
+        item["type"] == "activity-reference"
+      end)
+
+    screen_entry =
+      Enum.find(activity_references, fn item ->
+        item["activity_id"] == screen_revision.resource_id
+      end)
+
+    case screen_entry do
+      %{"custom" => %{"sequenceId" => sequence_id}} when is_binary(sequence_id) ->
+        build_adaptive_screen_lineage(activity_references, sequence_id)
+
+      _ ->
+        default_adaptive_screen_lineage(screen_revision)
     end
   end
 
-  defp extract_sequence_id_for_screen(_, _), do: nil
+  defp adaptive_screen_lineage(_, screen_revision),
+    do: default_adaptive_screen_lineage(screen_revision)
+
+  defp build_adaptive_screen_lineage(activity_references, sequence_id) do
+    case Enum.find(activity_references, &(get_in(&1, ["custom", "sequenceId"]) == sequence_id)) do
+      nil ->
+        []
+
+      %{"custom" => %{"layerRef" => parent_sequence_id}} = entry
+      when is_binary(parent_sequence_id) ->
+        build_adaptive_screen_lineage(activity_references, parent_sequence_id) ++ [entry]
+
+      entry ->
+        [entry]
+    end
+  end
+
+  defp default_adaptive_screen_lineage(screen_revision) do
+    [
+      %{
+        "type" => "activity-reference",
+        "activity_id" => screen_revision.resource_id,
+        "custom" => %{
+          "sequenceId" => "insights-screen-#{screen_revision.resource_id}",
+          "sequenceName" => screen_revision.title
+        }
+      }
+    ]
+  end
 
   defp current_preview_user(conn),
     do: conn.assigns[:current_user] || conn.assigns[:current_author]

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -11,10 +11,28 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
   end
 
   def render(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :rendered_activity,
+        namespace_inner_ids(assigns.rendered_activity, assigns.id)
+      )
+
     ~H"""
     <div class="mt-5 rendered-activity" id={@id} phx-hook="RenderedActivityIframeState">
       {raw(@rendered_activity)}
     </div>
     """
   end
+
+  defp namespace_inner_ids(rendered_activity, id)
+       when is_binary(rendered_activity) and is_binary(id) do
+    String.replace(
+      rendered_activity,
+      ~s(id="adaptive-screen-preview-),
+      ~s(id="#{id}-adaptive-screen-preview-)
+    )
+  end
+
+  defp namespace_inner_ids(rendered_activity, _id), do: rendered_activity
 end

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -27,13 +27,19 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
 
   defp namespace_inner_ids(rendered_activity, id)
        when is_binary(rendered_activity) and is_binary(id) do
-    id = String.replace(id, ~r/[^A-Za-z0-9_-]/, "-")
+    marker = ~s(id="adaptive-screen-preview-)
 
-    String.replace(
-      rendered_activity,
-      ~s(id="adaptive-screen-preview-),
-      ~s(id="#{id}-adaptive-screen-preview-)
-    )
+    if String.contains?(rendered_activity, marker) do
+      id = String.replace(id, ~r/[^A-Za-z0-9_-]/, "-")
+
+      String.replace(
+        rendered_activity,
+        marker,
+        ~s(id="#{id}-adaptive-screen-preview-)
+      )
+    else
+      rendered_activity
+    end
   end
 
   defp namespace_inner_ids(rendered_activity, _id), do: rendered_activity

--- a/lib/oli_web/live/manual_grading/rendered_activity.ex
+++ b/lib/oli_web/live/manual_grading/rendered_activity.ex
@@ -27,6 +27,8 @@ defmodule OliWeb.ManualGrading.RenderedActivity do
 
   defp namespace_inner_ids(rendered_activity, id)
        when is_binary(rendered_activity) and is_binary(id) do
+    id = String.replace(id, ~r/[^A-Za-z0-9_-]/, "-")
+
     String.replace(
       rendered_activity,
       ~s(id="adaptive-screen-preview-),

--- a/test/oli_web/components/delivery/adaptive_iframe_test.exs
+++ b/test/oli_web/components/delivery/adaptive_iframe_test.exs
@@ -19,6 +19,7 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrameTest do
     assert iframe =~
              ~s(<div id="adaptive-screen-preview-adaptive_section-adaptive-page-second-screen" class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">)
 
+    refute iframe =~ "\#{hook_id}"
     assert iframe =~ ~s(data-iframe-loading)
     assert iframe =~ "Loading screen preview..."
     assert iframe =~ "<iframe"

--- a/test/oli_web/components/delivery/adaptive_iframe_test.exs
+++ b/test/oli_web/components/delivery/adaptive_iframe_test.exs
@@ -16,7 +16,9 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrameTest do
 
     iframe = AdaptiveIFrame.insights_preview("adaptive_section", page_revision, revision)
 
-    assert iframe =~ ~s(<div class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">)
+    assert iframe =~
+             ~s(<div id="adaptive-screen-preview-adaptive_section-adaptive-page-second-screen" class="w-full overflow-x-auto p-4" phx-hook="IframeLoadState">)
+
     assert iframe =~ ~s(data-iframe-loading)
     assert iframe =~ "Loading screen preview..."
     assert iframe =~ "<iframe"

--- a/test/oli_web/components/delivery/adaptive_iframe_test.exs
+++ b/test/oli_web/components/delivery/adaptive_iframe_test.exs
@@ -56,6 +56,28 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrameTest do
     assert iframe =~ "screen_revision_id=202"
   end
 
+  test "screen_preview/4 sanitizes the hook id segments before rendering raw html" do
+    page_revision = %Revision{
+      slug: "adaptive-page",
+      content: %{
+        "custom" => %{"defaultScreenHeight" => 640, "defaultScreenWidth" => 960}
+      }
+    }
+
+    revision = %Revision{slug: "second-screen", content: %{}}
+
+    iframe =
+      AdaptiveIFrame.screen_preview(~S|section" onmouseover="alert(1)|, page_revision, revision,
+        attempt_guid: ~S|attempt" autofocus="true|
+      )
+
+    assert iframe =~
+             ~s(id="adaptive-screen-preview-section--onmouseover--alert-1--adaptive-page-second-screen-attempt--autofocus--true")
+
+    refute iframe =~ ~s(onmouseover="alert)
+    refute iframe =~ ~s(autofocus="true)
+  end
+
   test "preview/3 carries preview_sequence_id for author preview iframe routes" do
     revision = %Revision{
       slug: "adaptive-page",

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -2205,6 +2205,83 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "Instructor preview of adaptive activities by admin accounts is not supported"
     end
 
+    test "adaptive screen review preview preserves screen lineage for inherited parts", %{
+      conn: conn,
+      user: user
+    } do
+      %{
+        section: section,
+        page_revision: page_revision,
+        revision: revision,
+        parent_revision: parent_revision
+      } = section_with_adaptive_screen_revision(with_layer: true)
+
+      enroll_as_instructor(%{section: section, user: user})
+
+      student = insert(:user)
+      {:ok, _enrollment} = enroll_user_to_section(student, section, :context_learner)
+
+      resource_attempt =
+        create_attempt(student, section, page_revision,
+          content: page_revision.content,
+          lifecycle_state: :submitted,
+          date_evaluated: nil
+        )
+
+      parent_activity_attempt =
+        insert(:activity_attempt,
+          resource_attempt: resource_attempt,
+          resource: parent_revision.resource,
+          resource_id: parent_revision.resource_id,
+          revision: parent_revision,
+          revision_id: parent_revision.id,
+          lifecycle_state: :evaluated,
+          date_evaluated: ~U[2023-11-14 20:10:00Z]
+        )
+
+      child_activity_attempt =
+        insert(:activity_attempt,
+          resource_attempt: resource_attempt,
+          resource: revision.resource,
+          resource_id: revision.resource_id,
+          revision: revision,
+          revision_id: revision.id,
+          lifecycle_state: :submitted,
+          date_submitted: ~U[2023-11-14 20:20:00Z]
+        )
+
+      conn =
+        conn
+        |> log_in_user(user)
+        |> get(
+          Routes.page_delivery_path(
+            conn,
+            :adaptive_screen_preview,
+            section.slug,
+            page_revision.slug,
+            revision.slug,
+            attempt_guid: resource_attempt.attempt_guid,
+            page_revision_id: page_revision.id,
+            screen_revision_id: revision.id
+          )
+        )
+
+      props = delivery_component_props(conn)
+      [group] = props["content"]["model"]
+      children = group["children"]
+
+      assert Enum.map(children, &get_in(&1, ["custom", "sequenceId"])) == [
+               "parent-screen",
+               "child-screen"
+             ]
+
+      assert props["activityGuidMapping"]["#{parent_revision.resource_id}"]["attemptGuid"] ==
+               parent_activity_attempt.attempt_guid
+
+      assert props["activityGuidMapping"]["#{revision.resource_id}"]["attemptGuid"] ==
+               child_activity_attempt.attempt_guid
+    end
+
     test "page preview - do not show the prologue when is graded", %{
       conn: conn,
       section: section,
@@ -2989,17 +3066,35 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
   defp section_with_adaptive_screen_revision(opts \\ []) do
     display_application_chrome = Keyword.get(opts, :display_application_chrome, false)
+    with_layer = Keyword.get(opts, :with_layer, false)
 
     author = insert(:author)
     project = create_project_with_assocs(authors: [author])
     publication = insert(:publication, %{project: project})
 
     adaptive_registration = Oli.Activities.get_registration_by_slug("oli_adaptive")
+    parent_adaptive_resource = insert(:resource)
     adaptive_resource = insert(:resource)
     page_resource = insert(:resource)
 
+    insert(:project_resource, project_id: project.id, resource_id: parent_adaptive_resource.id)
     insert(:project_resource, project_id: project.id, resource_id: adaptive_resource.id)
     insert(:project_resource, project_id: project.id, resource_id: page_resource.id)
+
+    parent_revision =
+      insert(:revision,
+        resource: parent_adaptive_resource,
+        author: author,
+        resource_type_id: Oli.Resources.ResourceType.id_for_activity(),
+        activity_type_id: adaptive_registration.id,
+        title: "Parent Screen",
+        slug: "parent-screen",
+        content: %{
+          "custom" => %{"defaultScreenHeight" => 640, "defaultScreenWidth" => 960},
+          "authoring" => %{"parts" => []},
+          "partsLayout" => []
+        }
+      )
 
     revision =
       insert(:revision,
@@ -3016,11 +3111,51 @@ defmodule OliWeb.PageDeliveryControllerTest do
         }
       )
 
-    insert(:published_resource,
-      publication: publication,
-      resource: adaptive_resource,
-      revision: revision
-    )
+    for {resource, revision} <- [
+          {parent_adaptive_resource, parent_revision},
+          {adaptive_resource, revision}
+        ] do
+      insert(:published_resource,
+        publication: publication,
+        resource: resource,
+        revision: revision
+      )
+    end
+
+    screen_children =
+      if with_layer do
+        [
+          %{
+            "type" => "activity-reference",
+            "activity_id" => parent_adaptive_resource.id,
+            "custom" => %{
+              "sequenceId" => "parent-screen",
+              "sequenceName" => "Parent Screen",
+              "isLayer" => true
+            }
+          },
+          %{
+            "type" => "activity-reference",
+            "activity_id" => adaptive_resource.id,
+            "custom" => %{
+              "sequenceId" => "child-screen",
+              "sequenceName" => "Second Screen",
+              "layerRef" => "parent-screen"
+            }
+          }
+        ]
+      else
+        [
+          %{
+            "type" => "activity-reference",
+            "activity_id" => adaptive_resource.id,
+            "custom" => %{
+              "sequenceId" => "screen-1",
+              "sequenceName" => "Second Screen"
+            }
+          }
+        ]
+      end
 
     page_revision =
       insert(:revision,
@@ -3047,16 +3182,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
             %{
               "type" => "group",
               "layout" => "deck",
-              "children" => [
-                %{
-                  "type" => "activity-reference",
-                  "activity_id" => adaptive_resource.id,
-                  "custom" => %{
-                    "sequenceId" => "screen-1",
-                    "sequenceName" => "Second Screen"
-                  }
-                }
-              ]
+              "children" => screen_children
             }
           ]
         }
@@ -3122,7 +3248,22 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
     {:ok, section} = Sections.create_section_resources(section, publication)
 
-    %{section: section, page_revision: page_revision, revision: revision}
+    %{
+      section: section,
+      page_revision: page_revision,
+      revision: revision,
+      parent_revision: parent_revision
+    }
+  end
+
+  defp delivery_component_props(conn) do
+    {:ok, document} = Floki.parse_document(html_response(conn, 200))
+
+    document
+    |> Floki.find(~s|[data-react-class="Components.Delivery"]|)
+    |> Floki.attribute("data-react-props")
+    |> List.first()
+    |> Jason.decode!()
   end
 
   defp setup_lti_session(%{conn: conn}) do

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -2205,83 +2205,6 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "Instructor preview of adaptive activities by admin accounts is not supported"
     end
 
-    test "adaptive screen review preview preserves screen lineage for inherited parts", %{
-      conn: conn,
-      user: user
-    } do
-      %{
-        section: section,
-        page_revision: page_revision,
-        revision: revision,
-        parent_revision: parent_revision
-      } = section_with_adaptive_screen_revision(with_layer: true)
-
-      enroll_as_instructor(%{section: section, user: user})
-
-      student = insert(:user)
-      {:ok, _enrollment} = enroll_user_to_section(student, section, :context_learner)
-
-      resource_attempt =
-        create_attempt(student, section, page_revision,
-          content: page_revision.content,
-          lifecycle_state: :submitted,
-          date_evaluated: nil
-        )
-
-      parent_activity_attempt =
-        insert(:activity_attempt,
-          resource_attempt: resource_attempt,
-          resource: parent_revision.resource,
-          resource_id: parent_revision.resource_id,
-          revision: parent_revision,
-          revision_id: parent_revision.id,
-          lifecycle_state: :evaluated,
-          date_evaluated: ~U[2023-11-14 20:10:00Z]
-        )
-
-      child_activity_attempt =
-        insert(:activity_attempt,
-          resource_attempt: resource_attempt,
-          resource: revision.resource,
-          resource_id: revision.resource_id,
-          revision: revision,
-          revision_id: revision.id,
-          lifecycle_state: :submitted,
-          date_submitted: ~U[2023-11-14 20:20:00Z]
-        )
-
-      conn =
-        conn
-        |> log_in_user(user)
-        |> get(
-          Routes.page_delivery_path(
-            conn,
-            :adaptive_screen_preview,
-            section.slug,
-            page_revision.slug,
-            revision.slug,
-            attempt_guid: resource_attempt.attempt_guid,
-            page_revision_id: page_revision.id,
-            screen_revision_id: revision.id
-          )
-        )
-
-      props = delivery_component_props(conn)
-      [group] = props["content"]["model"]
-      children = group["children"]
-
-      assert Enum.map(children, &get_in(&1, ["custom", "sequenceId"])) == [
-               "parent-screen",
-               "child-screen"
-             ]
-
-      assert props["activityGuidMapping"]["#{parent_revision.resource_id}"]["attemptGuid"] ==
-               parent_activity_attempt.attempt_guid
-
-      assert props["activityGuidMapping"]["#{revision.resource_id}"]["attemptGuid"] ==
-               child_activity_attempt.attempt_guid
-    end
-
     test "page preview - do not show the prologue when is graded", %{
       conn: conn,
       section: section,
@@ -3066,35 +2989,17 @@ defmodule OliWeb.PageDeliveryControllerTest do
 
   defp section_with_adaptive_screen_revision(opts \\ []) do
     display_application_chrome = Keyword.get(opts, :display_application_chrome, false)
-    with_layer = Keyword.get(opts, :with_layer, false)
 
     author = insert(:author)
     project = create_project_with_assocs(authors: [author])
     publication = insert(:publication, %{project: project})
 
     adaptive_registration = Oli.Activities.get_registration_by_slug("oli_adaptive")
-    parent_adaptive_resource = insert(:resource)
     adaptive_resource = insert(:resource)
     page_resource = insert(:resource)
 
-    insert(:project_resource, project_id: project.id, resource_id: parent_adaptive_resource.id)
     insert(:project_resource, project_id: project.id, resource_id: adaptive_resource.id)
     insert(:project_resource, project_id: project.id, resource_id: page_resource.id)
-
-    parent_revision =
-      insert(:revision,
-        resource: parent_adaptive_resource,
-        author: author,
-        resource_type_id: Oli.Resources.ResourceType.id_for_activity(),
-        activity_type_id: adaptive_registration.id,
-        title: "Parent Screen",
-        slug: "parent-screen",
-        content: %{
-          "custom" => %{"defaultScreenHeight" => 640, "defaultScreenWidth" => 960},
-          "authoring" => %{"parts" => []},
-          "partsLayout" => []
-        }
-      )
 
     revision =
       insert(:revision,
@@ -3111,51 +3016,11 @@ defmodule OliWeb.PageDeliveryControllerTest do
         }
       )
 
-    for {resource, revision} <- [
-          {parent_adaptive_resource, parent_revision},
-          {adaptive_resource, revision}
-        ] do
-      insert(:published_resource,
-        publication: publication,
-        resource: resource,
-        revision: revision
-      )
-    end
-
-    screen_children =
-      if with_layer do
-        [
-          %{
-            "type" => "activity-reference",
-            "activity_id" => parent_adaptive_resource.id,
-            "custom" => %{
-              "sequenceId" => "parent-screen",
-              "sequenceName" => "Parent Screen",
-              "isLayer" => true
-            }
-          },
-          %{
-            "type" => "activity-reference",
-            "activity_id" => adaptive_resource.id,
-            "custom" => %{
-              "sequenceId" => "child-screen",
-              "sequenceName" => "Second Screen",
-              "layerRef" => "parent-screen"
-            }
-          }
-        ]
-      else
-        [
-          %{
-            "type" => "activity-reference",
-            "activity_id" => adaptive_resource.id,
-            "custom" => %{
-              "sequenceId" => "screen-1",
-              "sequenceName" => "Second Screen"
-            }
-          }
-        ]
-      end
+    insert(:published_resource,
+      publication: publication,
+      resource: adaptive_resource,
+      revision: revision
+    )
 
     page_revision =
       insert(:revision,
@@ -3182,7 +3047,16 @@ defmodule OliWeb.PageDeliveryControllerTest do
             %{
               "type" => "group",
               "layout" => "deck",
-              "children" => screen_children
+              "children" => [
+                %{
+                  "type" => "activity-reference",
+                  "activity_id" => adaptive_resource.id,
+                  "custom" => %{
+                    "sequenceId" => "screen-1",
+                    "sequenceName" => "Second Screen"
+                  }
+                }
+              ]
             }
           ]
         }
@@ -3251,19 +3125,8 @@ defmodule OliWeb.PageDeliveryControllerTest do
     %{
       section: section,
       page_revision: page_revision,
-      revision: revision,
-      parent_revision: parent_revision
+      revision: revision
     }
-  end
-
-  defp delivery_component_props(conn) do
-    {:ok, document} = Floki.parse_document(html_response(conn, 200))
-
-    document
-    |> Floki.find(~s|[data-react-class="Components.Delivery"]|)
-    |> Floki.attribute("data-react-props")
-    |> List.first()
-    |> Jason.decode!()
   end
 
   defp setup_lti_session(%{conn: conn}) do


### PR DESCRIPTION
Fixes issues in manual grading review rendering for legacy adaptive/EverApp CAPI reports, as seen in the old BioBeyond Blue Planet report which, unlike newer version, stores data in EverApp.

## Root Causes ##
- Blank report: the legacy CAPI iframe content was loaded, but Torus constrained the nested iframe/host sizing so the rendered content collapsed or was clipped.
- Editable report in instructor review: EverApp initialized in VIEWER mode even during manual grading review, and the legacy report hydrated its persisted readonly:false value unless Torus explicitly forced read-only review behavior.
- Potential instructor data mutation: EverApp save/submit handlers were not guarded for review mode, so instructor interaction could flow through the normal student persistence path.
  
## Direct Fixes ##
 - Fix nested CAPI iframe sizing so legacy report content is visible instead of collapsing/clipping in manual grading.
  - Make EverApp initialize activities with REVIEW mode during instructor review/manual grading.
  - Suppress EverApp save/submit handlers in review mode so instructor interaction cannot persist as student work.
  - Force CAPI readonly: true in review mode so legacy reports render read-only even when the stored student attempt has readonly: false.
  
 ## Defensive Hardening ##
  - Resolve legacy report data from review snapshots, including aggregate app.<simId>.data values.
  - Add stable IDs/namespacing for manual grading adaptive preview iframes to avoid LiveView hook and duplicate ID issues.

  ## Testing
  - Manually verified the legacy Blue Planet report renders in manual grading review.
  - Manually verified the rendered report is read-only in instructor review.

<img width="1008" height="708" alt="Screenshot 2026-06-02 at 9 12 24 PM" src="https://github.com/user-attachments/assets/341a81ec-d588-43de-8e34-3fc934289c78" />
