### PR TITLE
[BUG FIX] [MER-5681] Typeset formulas in instructor scored page details

### DIFF
--- a/assets/src/hooks/activity_detail_hooks.ts
+++ b/assets/src/hooks/activity_detail_hooks.ts
@@ -1,9 +1,22 @@
 import { EvaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
 import { LoadSurveyScripts } from './load_survey_scripts';
 
+type HookWithUpdated = {
+  updated?: () => void;
+};
+
+const forwardUpdated = (hook: unknown, context: unknown) => {
+  (hook as HookWithUpdated).updated?.call(context);
+};
+
 export const ActivityDetailHooks = {
   mounted() {
     LoadSurveyScripts.mounted.call(this);
     EvaluateMathJaxExpressions.mounted.call(this);
+  },
+
+  updated() {
+    forwardUpdated(LoadSurveyScripts, this);
+    forwardUpdated(EvaluateMathJaxExpressions, this);
   },
 };

--- a/assets/src/hooks/activity_detail_hooks.ts
+++ b/assets/src/hooks/activity_detail_hooks.ts
@@ -1,0 +1,9 @@
+import { EvaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
+import { LoadSurveyScripts } from './load_survey_scripts';
+
+export const ActivityDetailHooks = {
+  mounted() {
+    LoadSurveyScripts.mounted.call(this);
+    EvaluateMathJaxExpressions.mounted.call(this);
+  },
+};

--- a/assets/src/hooks/activity_detail_hooks.ts
+++ b/assets/src/hooks/activity_detail_hooks.ts
@@ -1,4 +1,4 @@
-import { EvaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
+import { evaluateMathJaxExpressions } from './evaluate_mathjax_expressions';
 import { LoadSurveyScripts } from './load_survey_scripts';
 
 type HookWithUpdated = {
@@ -12,11 +12,11 @@ const forwardUpdated = (hook: unknown, context: unknown) => {
 export const ActivityDetailHooks = {
   mounted() {
     LoadSurveyScripts.mounted.call(this);
-    EvaluateMathJaxExpressions.mounted.call(this);
+    evaluateMathJaxExpressions(this.el);
   },
 
   updated() {
     forwardUpdated(LoadSurveyScripts, this);
-    forwardUpdated(EvaluateMathJaxExpressions, this);
+    evaluateMathJaxExpressions(this.el);
   },
 };

--- a/assets/src/hooks/activity_detail_hooks.ts
+++ b/assets/src/hooks/activity_detail_hooks.ts
@@ -5,17 +5,21 @@ type HookWithUpdated = {
   updated?: () => void;
 };
 
+type ActivityDetailHook = {
+  el: HTMLElement;
+};
+
 const forwardUpdated = (hook: unknown, context: unknown) => {
   (hook as HookWithUpdated).updated?.call(context);
 };
 
 export const ActivityDetailHooks = {
-  mounted() {
+  mounted(this: ActivityDetailHook) {
     LoadSurveyScripts.mounted.call(this);
     evaluateMathJaxExpressions(this.el);
   },
 
-  updated() {
+  updated(this: ActivityDetailHook) {
     forwardUpdated(LoadSurveyScripts, this);
     evaluateMathJaxExpressions(this.el);
   },

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -1,32 +1,40 @@
 // this hook is used to evaluate MathJax expressions in the page
 // just after the page is mounted and the websocket connection is established.
 
+const evaluateMathJaxExpressions = () => {
+  const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
+
+  const getGlobalLastPromise = () => {
+    /* istanbul ignore next */
+    let lastPromise = window?.MathJax?.startup?.promise;
+    /* istanbul ignore next */
+    if (!lastPromise) {
+      typeof jest === 'undefined' &&
+        console.warn(
+          'Load the MathJax script before this one or unpredictable rendering might occur.',
+        );
+      lastPromise = Promise.resolve();
+    }
+    return lastPromise;
+  };
+
+  const setGlobalLastPromise = (promise: Promise<any>) => {
+    window.MathJax.startup.promise = promise;
+  };
+
+  let lastPromise = getGlobalLastPromise();
+  lastPromise = lastPromise.then(() =>
+    window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]),
+  );
+  setGlobalLastPromise(lastPromise);
+};
+
 export const EvaluateMathJaxExpressions = {
   mounted() {
-    const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
+    evaluateMathJaxExpressions();
+  },
 
-    const getGlobalLastPromise = () => {
-      /* istanbul ignore next */
-      let lastPromise = window?.MathJax?.startup?.promise;
-      /* istanbul ignore next */
-      if (!lastPromise) {
-        typeof jest === 'undefined' &&
-          console.warn(
-            'Load the MathJax script before this one or unpredictable rendering might occur.',
-          );
-        lastPromise = Promise.resolve();
-      }
-      return lastPromise;
-    };
-
-    const setGlobalLastPromise = (promise: Promise<any>) => {
-      window.MathJax.startup.promise = promise;
-    };
-
-    let lastPromise = getGlobalLastPromise();
-    lastPromise = lastPromise.then(() =>
-      window.MathJax.typesetPromise(Array.from(elements) as HTMLElement[]),
-    );
-    setGlobalLastPromise(lastPromise);
+  updated() {
+    evaluateMathJaxExpressions();
   },
 };

--- a/assets/src/hooks/evaluate_mathjax_expressions.ts
+++ b/assets/src/hooks/evaluate_mathjax_expressions.ts
@@ -1,8 +1,15 @@
 // this hook is used to evaluate MathJax expressions in the page
 // just after the page is mounted and the websocket connection is established.
 
-const evaluateMathJaxExpressions = () => {
-  const elements = document.querySelectorAll('.formula, .formula-inline, .chat-message');
+type MathJaxHook = {
+  el: HTMLElement;
+};
+
+const mathJaxSelector = '.formula, .formula-inline, .chat-message';
+
+export const evaluateMathJaxExpressions = (root: ParentNode = document) => {
+  const rootElement = root instanceof Element && root.matches(mathJaxSelector) ? [root] : [];
+  const elements = [...rootElement, ...Array.from(root.querySelectorAll(mathJaxSelector))];
 
   const getGlobalLastPromise = () => {
     /* istanbul ignore next */
@@ -30,11 +37,7 @@ const evaluateMathJaxExpressions = () => {
 };
 
 export const EvaluateMathJaxExpressions = {
-  mounted() {
-    evaluateMathJaxExpressions();
-  },
-
-  updated() {
+  mounted(this: MathJaxHook) {
     evaluateMathJaxExpressions();
   },
 };

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -1,4 +1,5 @@
 import LiveReact from 'phoenix_live_react';
+import { ActivityDetailHooks } from './activity_detail_hooks';
 import { AdaptiveDialogueSync } from './adaptive_dialogue_sync';
 import { AdaptiveIframeResize } from './adaptive_iframe_resize';
 import { AdaptivePreviewPanel } from './adaptive_preview_panel';
@@ -86,6 +87,7 @@ import { WakeUpDot } from './wakeup_dot';
 
 export const Hooks = {
   AdaptiveIframeResize,
+  ActivityDetailHooks,
   AdaptivePreviewPanel,
   AdaptiveDialogueSync,
   AnnotationBubbles,

--- a/assets/test/phoenix/activity_detail_hooks_test.ts
+++ b/assets/test/phoenix/activity_detail_hooks_test.ts
@@ -51,6 +51,7 @@ describe('ActivityDetailHooks', () => {
     } as any;
 
     document.body.innerHTML = `
+      <span class="formula">\\(outside\\)</span>
       <div id="activity_detail_1">
         <span class="formula">\\(x^2\\)</span>
       </div>

--- a/assets/test/phoenix/activity_detail_hooks_test.ts
+++ b/assets/test/phoenix/activity_detail_hooks_test.ts
@@ -42,4 +42,30 @@ describe('ActivityDetailHooks', () => {
     expect(window.OLI.initPreviewActivityBridge).toHaveBeenCalledWith('activity_detail_1');
     expect(typesetPromise).toHaveBeenCalledWith([el.querySelector('.formula')]);
   });
+
+  test('typesets MathJax content after LiveView updates the activity detail pane', async () => {
+    const typesetPromise = jest.fn().mockResolvedValue(undefined);
+    window.MathJax = {
+      startup: { promise: Promise.resolve() },
+      typesetPromise,
+    } as any;
+
+    document.body.innerHTML = `
+      <div id="activity_detail_1">
+        <span class="formula">\\(x^2\\)</span>
+      </div>
+    `;
+
+    const el = document.getElementById('activity_detail_1') as HTMLElement;
+    const hook = {
+      el,
+      pushEventTo: jest.fn(),
+      handleEvent: jest.fn(),
+    };
+
+    ActivityDetailHooks.updated.call(hook as any);
+    await window.MathJax.startup.promise;
+
+    expect(typesetPromise).toHaveBeenCalledWith([el.querySelector('.formula')]);
+  });
 });

--- a/assets/test/phoenix/activity_detail_hooks_test.ts
+++ b/assets/test/phoenix/activity_detail_hooks_test.ts
@@ -1,0 +1,45 @@
+import { ActivityDetailHooks } from 'hooks/activity_detail_hooks';
+
+describe('ActivityDetailHooks', () => {
+  const originalMathJax = window.MathJax;
+  const originalOLI = window.OLI;
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.restoreAllMocks();
+    window.MathJax = originalMathJax;
+    window.OLI = originalOLI;
+  });
+
+  test('initializes activity scripts and typesets MathJax content', async () => {
+    const typesetPromise = jest.fn().mockResolvedValue(undefined);
+    window.MathJax = {
+      startup: { promise: Promise.resolve() },
+      typesetPromise,
+    } as any;
+    window.OLI = {
+      initActivityBridge: jest.fn(),
+      initPreviewActivityBridge: jest.fn(),
+    } as any;
+
+    document.body.innerHTML = `
+      <div id="activity_detail_1" data-preview-activity-bridge="true" data-script-sources="[]">
+        <span class="formula">\\(x^2\\)</span>
+      </div>
+    `;
+
+    const el = document.getElementById('activity_detail_1') as HTMLElement;
+    const hook = {
+      el,
+      pushEventTo: jest.fn(),
+      handleEvent: jest.fn(),
+    };
+
+    ActivityDetailHooks.mounted.call(hook as any);
+    await Promise.resolve();
+    await window.MathJax.startup.promise;
+
+    expect(window.OLI.initPreviewActivityBridge).toHaveBeenCalledWith('activity_detail_1');
+    expect(typesetPromise).toHaveBeenCalledWith([el.querySelector('.formula')]);
+  });
+});

--- a/lib/oli_web/components/delivery/pages/activities_table_model.ex
+++ b/lib/oli_web/components/delivery/pages/activities_table_model.ex
@@ -157,7 +157,7 @@ defmodule OliWeb.Delivery.Pages.ActivitiesTableModel do
         <div
           class="bg-white dark:bg-gray-800 dark:text-white shadow-sm px-6 -mt-5"
           id={"activity_detail_#{@id}"}
-          phx-hook="LoadSurveyScripts"
+          phx-hook="ActivityDetailHooks"
           data-preview-activity-bridge="true"
           data-script-sources={Jason.encode!(@scripts || [])}
         >

--- a/test/oli_web/components/delivery/pages/activities_table_model_test.exs
+++ b/test/oli_web/components/delivery/pages/activities_table_model_test.exs
@@ -22,7 +22,7 @@ defmodule OliWeb.Delivery.Pages.ActivitiesTableModelTest do
     refute html =~ "[Empty]"
   end
 
-  test "render_assessment_details marks instructor preview panes to use the preview activity bridge" do
+  test "render_assessment_details uses activity detail hooks and marks instructor preview panes to use the preview activity bridge" do
     assessment = %{
       title: "Second Screen",
       resource_id: 2,
@@ -52,7 +52,7 @@ defmodule OliWeb.Delivery.Pages.ActivitiesTableModelTest do
         ActivitiesTableModel.render_assessment_details(assigns, assessment)
       end)
 
-    assert html =~ ~s(phx-hook="LoadSurveyScripts")
+    assert html =~ ~s(phx-hook="ActivityDetailHooks")
     assert html =~ ~s(data-preview-activity-bridge="true")
     assert html =~ ~s(data-script-sources="[&quot;/js/janus_mcq_delivery.js&quot;]")
   end


### PR DESCRIPTION
 ## Summary

  Fixes raw LaTeX display in the activity detail pane on Instructor Dashboard > Insights > Scored Pages.

  Adds a scored/practice page detail-specific LiveView hook composition that initializes the rendered activity preview and runs the MathJax typesetting pass, matching the behavior users expect from normal learning pages.

  ## Changes

  - Added ActivityDetailHooks as a composite hook:
      - runs LoadSurveyScripts
      - runs EvaluateMathJaxExpressions

  - Updated the scored/practice page expanded activity detail pane to use ActivityDetailHooks.
  - Added frontend coverage for the composite hook.
  - Updated the existing component test to assert the new hook is installed.

  ## Verification

  - yarn test assets/test/phoenix/activity_detail_hooks_test.ts --runInBand
  - mix test test/oli_web/components/delivery/pages/activities_table_model_test.exs
  
  ## Screenshot
<img width="1249" height="578" alt="Screenshot 2026-06-04 at 7 00 40 AM" src="https://github.com/user-attachments/assets/e02303d3-4e28-4022-841a-e68f22abe239" />
