### PR TITLE
[BUG FIX] [MER-5698] fix template/section remix drag to reorder

### DIFF
--- a/assets/src/hooks/dragdrop.ts
+++ b/assets/src/hooks/dragdrop.ts
@@ -31,8 +31,13 @@ export const DragSource = {
       dt.setData('text/plain', this.el.getAttribute('data-drag-index'));
       dt.effectAllowed = 'move';
 
-      const dragSlug = this.el.getAttribute('data-drag-slug');
-      this.pushEvent('dragstart', dragSlug);
+      // Remix entries identify dragged nodes by UUID, while curriculum authoring entries still use slugs.
+      const dragId =
+        this.el.getAttribute('data-drag-uuid') || this.el.getAttribute('data-drag-slug');
+
+      if (dragId) {
+        this.pushEvent('dragstart', dragId);
+      }
     });
 
     this.el.addEventListener('dragend', (e: any) => {


### PR DESCRIPTION
## Summary

  Fixes drag to reorder used in template and section remix (customize content).

  ## Details

  Remix entries now identify dragged nodes with data-drag-uuid, while curriculum authoring entries still use data-drag-slug. The hook was modified so it now:

  - Reads data-drag-uuid first
  - Falls back to data-drag-slug
  - Skips the dragstart event if neither identity is present

  This preserves existing curriculum authoring behavior while restoring remix section/template drag state handling.

