### PR TITLE
[BUG FIX] [MER-5698] Fix remix move modal crash

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -753,11 +753,10 @@ defmodule OliWeb.Delivery.RemixSection do
 
     active = Hierarchy.find_in_hierarchy(hierarchy, uuid)
 
-    modal_assigns = %{
+    modal_assigns =
       modal_assigns
-      | active: active,
-        error_message: nil
-    }
+      |> Map.put(:active, active)
+      |> Map.put(:error_message, nil)
 
     {:noreply, assign(socket, modal_assigns: modal_assigns)}
   end

--- a/test/oli_web/live/remix_section_create_container_live_test.exs
+++ b/test/oli_web/live/remix_section_create_container_live_test.exs
@@ -103,6 +103,51 @@ defmodule OliWeb.RemixSectionCreateContainerTest do
 
       assert sr_count_after == sr_count_before
     end
+
+    test "move modal moves an item into the selected container", ctx do
+      {:ok, view, _html} = live(ctx.conn, ~p"/authoring/products/#{ctx.section.slug}/remix")
+
+      view
+      |> element(~s{button[phx-click="set_active"]}, "Unit 1")
+      |> render_click()
+
+      page_uuid =
+        view
+        |> render()
+        |> Floki.parse_document!()
+        |> Floki.find(~s{button[phx-click="show_move_modal"]})
+        |> Floki.attribute("phx-value-uuid")
+        |> List.first()
+
+      view
+      |> element(~s{button[phx-click="show_move_modal"][phx-value-uuid="#{page_uuid}"]})
+      |> render_click()
+
+      view
+      |> element(
+        ~s{.hierarchy-picker button[phx-click="HierarchyPicker.update_active"]},
+        "Module 1"
+      )
+      |> render_click()
+
+      view
+      |> element(~s{button[phx-click="MoveModal.move_item"]})
+      |> render_click()
+
+      refute view
+             |> element(~s{button[phx-click="show_move_modal"][phx-value-uuid="#{page_uuid}"]})
+             |> has_element?()
+
+      view
+      |> element(~s{button[phx-click="set_active"]}, "Module 1")
+      |> render_click()
+
+      assert view
+             |> element(~s{button[phx-click="show_move_modal"][phx-value-uuid="#{page_uuid}"]})
+             |> has_element?()
+
+      assert render_click(view, "save") =~ "Your work has been saved."
+    end
   end
 
   describe "scope isolation through LiveView" do

--- a/test/oli_web/live/remix_section_create_container_live_test.exs
+++ b/test/oli_web/live/remix_section_create_container_live_test.exs
@@ -111,6 +111,10 @@ defmodule OliWeb.RemixSectionCreateContainerTest do
       |> element(~s{button[phx-click="set_active"]}, "Unit 1")
       |> render_click()
 
+      view
+      |> element(~s{button[phx-click="set_active"]}, "Module 1")
+      |> render_click()
+
       page_uuid =
         view
         |> render()
@@ -126,7 +130,7 @@ defmodule OliWeb.RemixSectionCreateContainerTest do
       view
       |> element(
         ~s{.hierarchy-picker button[phx-click="HierarchyPicker.update_active"]},
-        "Module 1"
+        "Unit 1"
       )
       |> render_click()
 
@@ -139,7 +143,7 @@ defmodule OliWeb.RemixSectionCreateContainerTest do
              |> has_element?()
 
       view
-      |> element(~s{button[phx-click="set_active"]}, "Module 1")
+      |> element(~s{button[phx-click="set_active"]}, "Unit 1")
       |> render_click()
 
       assert view

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -40,6 +40,37 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert html =~ "Your work has been saved."
     end
 
+    test "move modal moves an item into the selected container", %{
+      conn: conn,
+      section: section,
+      page_5: page_5
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/remix")
+
+      view
+      |> element(~s{#entry-#{page_5.resource_id} button[phx-click="show_move_modal"]})
+      |> render_click()
+
+      view
+      |> element(
+        ~s{.hierarchy-picker button[phx-click="HierarchyPicker.update_active"]},
+        "Unit 1"
+      )
+      |> render_click()
+
+      view
+      |> element(~s{button[phx-click="MoveModal.move_item"]})
+      |> render_click()
+
+      refute view |> element("#entry-#{page_5.resource_id}") |> has_element?()
+
+      view
+      |> element(~s{button[phx-click="set_active"]}, "Unit 1")
+      |> render_click()
+
+      assert view |> element("#entry-#{page_5.resource_id}") |> has_element?()
+    end
+
     test "breadcrumbs render correctly", %{
       conn: conn,
       section: section


### PR DESCRIPTION
## Summary

  Fixes a crash when moving remix items with the Move button/modal in section and template customize-content pages.

  ## Details

  Selecting a destination container in the Move modal reused the shared HierarchyPicker.update_active handler. That handler attempted to clear :error_message with map update syntax, but Move modal assigns do not include :error_message, causing a KeyError.

  The fix uses Map.put/3 so the handler works for both Add Materials and Move modal state.

  ## Regression Source

  This was introduced by 47754de102 ([BUG FIX] [MER-5615] Prevent remixing projects with shared resources (#6577)), which added error_message: nil handling for Add Materials modal errors. That commit is included in both v0.33.0 and v0.33.1.

  ## Testing

  Added regression coverage for:

  - Section remix Move modal moving an item into a selected container
  - Template/product remix Move modal moving an item into a nested selected container and saving

  Ran:

  mix test test/oli_web/live/remix_section_test.exs:37 test/oli_web/live/remix_section_create_container_live_test.exs:103

[MER-5615]: https://eliterate.atlassian.net/browse/MER-5615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ