### PR TITLE
[BUG FIX] [MER-5699] Fix adaptive page full screen elements showing blank area in delivery

### DIFF
--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -479,6 +479,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
         ) : null}
         <PartsLayoutRenderer
           parts={partsLayout}
+          mode={mode}
           sectionSlug={sectionSlug}
           resourceId={props.context.resourceId ?? props.model.resourceId}
           onPartInit={handlePartInit}

--- a/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
+++ b/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
@@ -324,7 +324,7 @@ const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
   if (!(props as AuthorProps).editMode) {
     webComponentProps.style =
       props.type === 'janus-capi-iframe'
-        ? getIframePartDeliveryStyle(componentStyle)
+        ? getIframePartDeliveryStyle(componentStyle, props.mode === 'review')
         : componentStyle;
     // console.log('DELIVERY RENDER:', wcTagName, props);
   }

--- a/assets/src/components/activities/adaptive/components/delivery/PartsLayoutRenderer.tsx
+++ b/assets/src/components/activities/adaptive/components/delivery/PartsLayoutRenderer.tsx
@@ -5,6 +5,7 @@ import PartComponent from '../common/PartComponent';
 interface PartsLayoutRendererProps {
   parts: PartComponentDefinition[];
   state?: ActivityState;
+  mode?: string;
   sectionSlug?: string;
   resourceId?: number;
   onPartInit?: any;
@@ -27,6 +28,7 @@ const defaultHandler = async () => {
 const PartsLayoutRenderer: React.FC<PartsLayoutRendererProps> = ({
   parts,
   state = {},
+  mode,
   sectionSlug,
   resourceId,
   onPartInit = defaultHandler,
@@ -62,6 +64,7 @@ const PartsLayoutRenderer: React.FC<PartsLayoutRendererProps> = ({
           }
         : partDefinition.custom, // Use original model in non-responsive mode
       state,
+      mode,
       sectionSlug,
       resourceId,
       onInit: onPartInit,

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -12,7 +12,11 @@ import { contexts } from '../../../types/applicationContext';
 import { clone, parseBool, parseBoolean, parseNumString } from '../../../utils/common';
 import { PartComponentProps } from '../types/parts';
 import { JanusCAPIRequestTypes, getJanusCAPIRequestTypeString } from './JanusCAPIRequestTypes';
-import { getExternalIframeStyles, shouldAllowIframeScrolling } from './iframeBehavior';
+import {
+  getExternalActivityContainerStyles,
+  getExternalIframeStyles,
+  shouldAllowIframeScrolling,
+} from './iframeBehavior';
 import { CapiIframeModel } from './schema';
 import { resolveAdaptiveIframeSource, sanitizeAdaptiveIframeFallbackHref } from './sourceResolver';
 
@@ -387,6 +391,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
 
   const messageListener = useRef<any>(null);
   const [simIsInitStatePassedOnce, setSimIsInitStatePassedOnce] = useState(false);
+  const isReviewContext = () => contextRef.current === contexts.REVIEW || props.mode === 'review';
 
   const externalActivityStyles: CSSProperties = {
     /* position: 'absolute',
@@ -399,12 +404,11 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
     // any (legacy) override css attempt at hiding it
     visibility: frameVisible ? undefined : 'hidden',
   };
-  const externalActivityContainerStyles: CSSProperties = {
-    position: 'relative',
-    width: frameWidth || '100%',
-    height: frameHeight || '100%',
-    overflow: 'auto',
-  };
+  const externalActivityContainerStyles = getExternalActivityContainerStyles(
+    frameWidth,
+    frameHeight,
+    isReviewContext(),
+  );
   const fallbackOverlayStyles: CSSProperties = {
     position: 'absolute',
     inset: 0,
@@ -480,8 +484,6 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       console.log(`%c Capi(${id}) - ${msg}`, colorStyle, ...args);
     }
   };
-
-  const isReviewContext = () => contextRef.current === contexts.REVIEW;
 
   const reviewReadonlyVariable = () =>
     new CapiVariable({

--- a/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
+++ b/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
@@ -44,6 +44,27 @@ export const getIframePartDeliveryStyle = (
         overflow: 'hidden',
       };
 
+export const getExternalActivityContainerStyles = (
+  frameWidth: number,
+  frameHeight: number,
+  isReviewMode = false,
+): CSSProperties =>
+  isReviewMode
+    ? {
+        position: 'relative',
+        width: frameWidth || '100%',
+        height: frameHeight || '100%',
+        overflow: 'auto',
+      }
+    : {
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        maxWidth: '100%',
+        maxHeight: '100%',
+        overflow: 'hidden',
+      };
+
 export const getExternalIframeStyles = (
   style: CSSProperties,
   scrollingEnabled: boolean,

--- a/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
+++ b/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
@@ -26,11 +26,23 @@ export const shouldAllowIframeScrolling = (
   );
 };
 
-export const getIframePartDeliveryStyle = (style: CSSProperties): CSSProperties => ({
-  ...style,
-  boxSizing: 'border-box',
-  overflow: 'visible',
-});
+export const getIframePartDeliveryStyle = (
+  style: CSSProperties,
+  isReviewMode = false,
+): CSSProperties =>
+  isReviewMode
+    ? {
+        ...style,
+        boxSizing: 'border-box',
+        overflow: 'visible',
+      }
+    : {
+        ...style,
+        boxSizing: 'border-box',
+        maxWidth: '100%',
+        maxHeight: '100%',
+        overflow: 'hidden',
+      };
 
 export const getExternalIframeStyles = (
   style: CSSProperties,

--- a/assets/src/components/parts/types/parts.ts
+++ b/assets/src/components/parts/types/parts.ts
@@ -36,6 +36,7 @@ export interface PartComponentProps<T extends CustomProperties> {
   type: string;
   model: T;
   state: any;
+  mode?: string;
   sectionSlug?: string;
   resourceId?: number;
   notify?: any;

--- a/assets/test/delivery/janus_capi_iframe_test.ts
+++ b/assets/test/delivery/janus_capi_iframe_test.ts
@@ -1,4 +1,5 @@
 import {
+  getExternalActivityContainerStyles,
   getExternalIframeStyles,
   getIframePartDeliveryStyle,
   shouldAllowIframeScrolling,
@@ -48,6 +49,12 @@ describe('janus_capi_iframe delivery behavior', () => {
       overflow: 'visible',
     });
 
+    expect(getExternalActivityContainerStyles(1200, 700, true)).toMatchObject({
+      width: 1200,
+      height: 700,
+      overflow: 'auto',
+    });
+
     expect(getExternalIframeStyles({ width: '100%', height: '100%' }, true)).toMatchObject({
       width: '100%',
       height: '100%',
@@ -55,6 +62,16 @@ describe('janus_capi_iframe delivery behavior', () => {
       maxWidth: '100%',
       maxHeight: '100%',
       overflow: 'auto',
+    });
+  });
+
+  it('fills and clips the iframe container in normal delivery', () => {
+    expect(getExternalActivityContainerStyles(1200, 700)).toMatchObject({
+      width: '100%',
+      height: '100%',
+      maxWidth: '100%',
+      maxHeight: '100%',
+      overflow: 'hidden',
     });
   });
 });

--- a/assets/test/delivery/janus_capi_iframe_test.ts
+++ b/assets/test/delivery/janus_capi_iframe_test.ts
@@ -29,8 +29,19 @@ describe('janus_capi_iframe delivery behavior', () => {
     ).toBe(true);
   });
 
-  it('preserves the authored iframe host dimensions and bounds the iframe element', () => {
+  it('clamps the iframe part to the adaptive slot in normal delivery', () => {
     expect(getIframePartDeliveryStyle({ width: 1200, height: 700 })).toMatchObject({
+      width: 1200,
+      height: 700,
+      boxSizing: 'border-box',
+      maxWidth: '100%',
+      maxHeight: '100%',
+      overflow: 'hidden',
+    });
+  });
+
+  it('preserves the authored iframe host dimensions in review mode', () => {
+    expect(getIframePartDeliveryStyle({ width: 1200, height: 700 }, true)).toMatchObject({
       width: 1200,
       height: 700,
       boxSizing: 'border-box',


### PR DESCRIPTION
## Summary

  Fixes MER-5699 by making janus-capi-iframe sizing mode-aware.

  Normal delivery now keeps the embedded iframe filling the authored adaptive part area. Review/manual-grading mode continues to preserve the legacy report/runtime iframe dimensions and allow scrolling.

  ## Cause

  The v33.2 manual-grading hotfix changed CAPI iframe sizing so legacy adaptive reports could preserve their runtime dimensions and scroll in review/manual-grading. However, that change  was implemented so the behavior also applied incorrectly in normal delivery.

  For affected Real Chem pages, the adaptive part area could be taller than the CAPI iframe runtime frameHeight. In normal delivery, the iframe’s immediate container then used that smaller frameHeight instead of filling the authored adaptive part slot. The embedded simulation received a reduced viewport, causing its internal layout to shrink upward and leave a large blank area below.

  ## Changes

  - Restore normal delivery behavior so the CAPI iframe part and inner iframe container fill and clip to the authored adaptive part area.
  - Preserve review/manual-grading behavior so legacy adaptive reports can keep runtime dimensions and scroll.
  - Pass delivery mode through adaptive part rendering so CAPI iframe sizing can distinguish delivery from review.
  - Add focused tests for delivery vs review CAPI iframe sizing.

  ## Testing

  yarn test assets/test/delivery/janus_capi_iframe_test.ts --runInBand
  
  ## Screenshots
  Bug Report:
  
<img width="1919" height="1001" alt="adaptive-bug" src="https://github.com/user-attachments/assets/3156ea2e-901e-4e00-95a0-b873d3fcbaa4" />

  After Fix:
  
<img width="1327" height="704" alt="Screenshot 2026-06-04 at 1 40 34 PM" src="https://github.com/user-attachments/assets/bd3f6a5e-8e9c-405e-96bc-244149af3ca5" />


