### PR TITLE
[BUG FIX] [MER-5700] Scope CAPI iframe size preservation to manual grading

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -48,6 +48,7 @@ export interface DeliveryProps {
   blobStorageProvider: 'new' | 'deprecated';
   screenIdleTimeOutInSeconds?: number;
   reviewMode?: boolean;
+  preserveCapiIframeSize?: boolean;
   signoutUrl?: string;
   currentServerTime?: number;
   effectiveEndTime?: number;
@@ -210,6 +211,7 @@ const Delivery: React.FC<DeliveryProps> = ({
   blobStorageProvider = 'deprecated',
   screenIdleTimeOutInSeconds = 1800,
   reviewMode = false,
+  preserveCapiIframeSize = false,
   currentServerTime = 0,
   effectiveEndTime = 0,
   lateSubmit = 'allow',
@@ -334,6 +336,7 @@ const Delivery: React.FC<DeliveryProps> = ({
         blobStorageProvider,
         screenIdleTimeOutInSeconds,
         reviewMode,
+        preserveCapiIframeSize,
         debuggerURL,
       }),
     );

--- a/assets/src/apps/delivery/components/ActivityRenderer.tsx
+++ b/assets/src/apps/delivery/components/ActivityRenderer.tsx
@@ -36,6 +36,7 @@ import {
 import { selectCurrentActivityTree } from '../store/features/groups/selectors/deck';
 import {
   selectPageSlug,
+  selectPreserveCapiIframeSize,
   selectPreviewMode,
   selectReviewMode,
   selectSectionSlug,
@@ -149,6 +150,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
   const isPreviewMode = useSelector(selectPreviewMode);
   const isReviewMode = useSelector(selectReviewMode);
   const currentUserId = useSelector(selectUserId);
+  const preserveCapiIframeSize = useSelector(selectPreserveCapiIframeSize);
   const currentLessonId = useSelector(selectPageSlug);
   const sectionSlug = useSelector(selectSectionSlug);
   const saveUserData = async (attemptGuid: string, partAttemptGuid: string, payload: any) => {
@@ -701,6 +703,7 @@ const ActivityRenderer: React.FC<ActivityRendererProps> = ({
       bibParams: null,
       pageAttemptGuid: '', // TODO: don't think we use this currently, but might be good to have
       responsiveLayout,
+      preserveCapiIframeSize,
     }),
     mode: isPreviewMode ? 'preview' : isReviewMode ? 'review' : 'delivery',
     model,

--- a/assets/src/apps/delivery/store/features/page/slice.ts
+++ b/assets/src/apps/delivery/store/features/page/slice.ts
@@ -31,6 +31,7 @@ export interface PageState {
   screenIdleExpireTime?: number;
   reviewMode?: boolean;
   responsiveLayout?: boolean;
+  preserveCapiIframeSize?: boolean;
   debuggerURL?: string;
 }
 
@@ -61,6 +62,7 @@ const initialState: PageState = {
   screenIdleTimeOutInSeconds: 1800,
   reviewMode: false,
   responsiveLayout: false,
+  preserveCapiIframeSize: false,
   debuggerURL: undefined,
 };
 
@@ -95,6 +97,7 @@ const pageSlice = createSlice({
       state.blobStorageProvider = action.payload.blobStorageProvider || 'deprecated';
       state.screenIdleTimeOutInSeconds = action.payload.screenIdleTimeOutInSeconds;
       state.reviewMode = action.payload.reviewMode;
+      state.preserveCapiIframeSize = !!action.payload.preserveCapiIframeSize;
       state.debuggerURL = action.payload.debuggerURL;
       if (state.previewMode && !state.resourceAttemptGuid) {
         state.resourceAttemptGuid = `preview_${guid()}`;
@@ -145,6 +148,11 @@ export const selectEnableHistory = createSelector(selectState, (state) => state.
 export const selectResponsiveLayout = createSelector(
   selectState,
   (state) => state.responsiveLayout,
+);
+
+export const selectPreserveCapiIframeSize = createSelector(
+  selectState,
+  (state) => state.preserveCapiIframeSize,
 );
 
 export const selectShowHistory = createSelector(selectState, (state) => state.showHistory);

--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -72,6 +72,7 @@ export interface ActivityContext {
   pageLinkParams: any;
   allowHints: boolean;
   responsiveLayout?: boolean;
+  preserveCapiIframeSize?: boolean;
 }
 
 /**

--- a/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
+++ b/assets/src/components/activities/adaptive/AdaptiveDelivery.tsx
@@ -490,6 +490,7 @@ export const Adaptive = (props: DeliveryElementProps<AdaptiveModelSchema>) => {
           onPartSetData={handleSetData}
           onPartGetData={handleGetData}
           responsiveLayout={props?.context?.responsiveLayout || false}
+          preserveCapiIframeSize={props?.context?.preserveCapiIframeSize || false}
         />
       </>
     </NotificationContext.Provider>

--- a/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
+++ b/assets/src/components/activities/adaptive/components/common/PartComponent.tsx
@@ -324,7 +324,7 @@ const PartComponent: React.FC<AuthorProps | DeliveryProps> = (props) => {
   if (!(props as AuthorProps).editMode) {
     webComponentProps.style =
       props.type === 'janus-capi-iframe'
-        ? getIframePartDeliveryStyle(componentStyle, props.mode === 'review')
+        ? getIframePartDeliveryStyle(componentStyle, props.preserveCapiIframeSize === true)
         : componentStyle;
     // console.log('DELIVERY RENDER:', wcTagName, props);
   }

--- a/assets/src/components/activities/adaptive/components/delivery/PartsLayoutRenderer.tsx
+++ b/assets/src/components/activities/adaptive/components/delivery/PartsLayoutRenderer.tsx
@@ -16,6 +16,7 @@ interface PartsLayoutRendererProps {
   onPartSetData?: (payload: any) => Promise<any>;
   onPartGetData?: (payload: any) => Promise<any>;
   responsiveLayout?: boolean;
+  preserveCapiIframeSize?: boolean;
 }
 
 const defaultHandler = async () => {
@@ -39,6 +40,7 @@ const PartsLayoutRenderer: React.FC<PartsLayoutRendererProps> = ({
   onPartSetData,
   onPartGetData,
   responsiveLayout = true,
+  preserveCapiIframeSize = false,
 }) => {
   // Helper function to create part props
   const createPartProps = (partDefinition: PartComponentDefinition) => {
@@ -65,6 +67,7 @@ const PartsLayoutRenderer: React.FC<PartsLayoutRendererProps> = ({
         : partDefinition.custom, // Use original model in non-responsive mode
       state,
       mode,
+      preserveCapiIframeSize,
       sectionSlug,
       resourceId,
       onInit: onPartInit,

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -407,7 +407,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const externalActivityContainerStyles = getExternalActivityContainerStyles(
     frameWidth,
     frameHeight,
-    isReviewContext(),
+    props.preserveCapiIframeSize === true,
   );
   const fallbackOverlayStyles: CSSProperties = {
     position: 'absolute',

--- a/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
+++ b/assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts
@@ -28,9 +28,9 @@ export const shouldAllowIframeScrolling = (
 
 export const getIframePartDeliveryStyle = (
   style: CSSProperties,
-  isReviewMode = false,
+  preserveCapiIframeSize = false,
 ): CSSProperties =>
-  isReviewMode
+  preserveCapiIframeSize
     ? {
         ...style,
         boxSizing: 'border-box',
@@ -47,9 +47,9 @@ export const getIframePartDeliveryStyle = (
 export const getExternalActivityContainerStyles = (
   frameWidth: number,
   frameHeight: number,
-  isReviewMode = false,
+  preserveCapiIframeSize = false,
 ): CSSProperties =>
-  isReviewMode
+  preserveCapiIframeSize
     ? {
         position: 'relative',
         width: frameWidth || '100%',

--- a/assets/src/components/parts/types/parts.ts
+++ b/assets/src/components/parts/types/parts.ts
@@ -37,6 +37,7 @@ export interface PartComponentProps<T extends CustomProperties> {
   model: T;
   state: any;
   mode?: string;
+  preserveCapiIframeSize?: boolean;
   sectionSlug?: string;
   resourceId?: number;
   notify?: any;

--- a/assets/test/delivery/janus_capi_iframe_test.ts
+++ b/assets/test/delivery/janus_capi_iframe_test.ts
@@ -41,7 +41,26 @@ describe('janus_capi_iframe delivery behavior', () => {
     });
   });
 
-  it('preserves the authored iframe host dimensions in review mode', () => {
+  it('clamps the iframe part to the adaptive slot in ordinary review mode', () => {
+    expect(getIframePartDeliveryStyle({ width: 1200, height: 700 }, false)).toMatchObject({
+      width: 1200,
+      height: 700,
+      boxSizing: 'border-box',
+      maxWidth: '100%',
+      maxHeight: '100%',
+      overflow: 'hidden',
+    });
+
+    expect(getExternalActivityContainerStyles(1200, 700, false)).toMatchObject({
+      width: '100%',
+      height: '100%',
+      maxWidth: '100%',
+      maxHeight: '100%',
+      overflow: 'hidden',
+    });
+  });
+
+  it('preserves the CAPI-reported iframe size when explicitly requested', () => {
     expect(getIframePartDeliveryStyle({ width: 1200, height: 700 }, true)).toMatchObject({
       width: 1200,
       height: 700,

--- a/lib/oli_web/components/delivery/adaptive_iframe.ex
+++ b/lib/oli_web/components/delivery/adaptive_iframe.ex
@@ -64,6 +64,10 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrame do
       |> maybe_put_query_param("attempt_guid", Keyword.get(opts, :attempt_guid))
       |> maybe_put_query_param("page_revision_id", Keyword.get(opts, :page_revision_id))
       |> maybe_put_query_param("screen_revision_id", Keyword.get(opts, :screen_revision_id))
+      |> maybe_put_query_param(
+        "preserve_capi_iframe_size",
+        Keyword.get(opts, :preserve_capi_iframe_size)
+      )
 
     url =
       case map_size(query_params) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1299,6 +1299,7 @@ defmodule OliWeb.PageDeliveryController do
         nextPageURL: nil,
         previewMode: Keyword.get(opts, :preview_mode, true),
         reviewMode: Keyword.get(opts, :review_mode, false),
+        preserveCapiIframeSize: Keyword.get(opts, :preserve_capi_iframe_size, false),
         isInstructor: true
       }
     )
@@ -1341,6 +1342,7 @@ defmodule OliWeb.PageDeliveryController do
       activity_types,
       preview_mode: false,
       review_mode: true,
+      preserve_capi_iframe_size: conn.params["preserve_capi_iframe_size"] == "true",
       resource_attempt_state: resource_attempt_state,
       resource_attempt_guid: resource_attempt.attempt_guid,
       activity_guid_mapping: activity_guid_mapping

--- a/lib/oli_web/live/manual_grading/rendering.ex
+++ b/lib/oli_web/live/manual_grading/rendering.ex
@@ -66,7 +66,8 @@ defmodule OliWeb.ManualGrading.Rendering do
         screen_revision,
         attempt_guid: context.resource_attempt.attempt_guid,
         page_revision_id: context.resource_attempt.revision_id,
-        screen_revision_id: context.activity_revision_id
+        screen_revision_id: context.activity_revision_id,
+        preserve_capi_iframe_size: true
       )
     else
       _ ->

--- a/test/oli_web/components/delivery/adaptive_iframe_test.exs
+++ b/test/oli_web/components/delivery/adaptive_iframe_test.exs
@@ -54,6 +54,26 @@ defmodule OliWeb.Components.Delivery.AdaptiveIFrameTest do
     assert iframe =~ "attempt_guid=attempt-1"
     assert iframe =~ "page_revision_id=101"
     assert iframe =~ "screen_revision_id=202"
+    refute iframe =~ "preserve_capi_iframe_size"
+  end
+
+  test "screen_preview/4 carries the CAPI size preservation marker only when requested" do
+    page_revision = %Revision{
+      slug: "adaptive-page",
+      content: %{
+        "custom" => %{"defaultScreenHeight" => 640, "defaultScreenWidth" => 960}
+      }
+    }
+
+    revision = %Revision{slug: "second-screen", content: %{}}
+
+    iframe =
+      AdaptiveIFrame.screen_preview("adaptive_section", page_revision, revision,
+        attempt_guid: "attempt-1",
+        preserve_capi_iframe_size: true
+      )
+
+    assert iframe =~ "preserve_capi_iframe_size=true"
   end
 
   test "screen_preview/4 sanitizes the hook id segments before rendering raw html" do


### PR DESCRIPTION
The v33.2 manual-grading hotfix fixed legacy adaptive report rendering by changing CAPI iframe sizing in review mode: instead of filling the adaptive layout slot, the iframe preserved its CAPI-reported frameWidth / frameHeight and allowed scrolling. This was done because the manual grading container does not include the machinery needed to properly handle responsive layout and iframes could become invisible in this context. Using a fixed-size within scrollable view sufficed to make the content accessible in this context and worked for the problematic cases prompting the issue.

  But that fix was too broad. since review mode is also used for normal student attempt review and instructor attempt review, not just manual grading. For responsive adaptive pages, the CAPI-reported size is not the authoritative layout size; the iframe should fill the resolved adaptive page slot. When ordinary review used the CAPI-reported dimensions instead, responsive iframe content could render with the wrong viewport, causing clipped, shrunken, or blank-area layouts.

  This fix scopes the CAPI size-preservation behavior to manual grading only via an explicit flag. Ordinary review mode now uses the same responsive/clipped CAPI iframe sizing as delivery. 
 
 Changes:

  - Added a `preserveCapiIframeSize` flag that is set only from OliWeb.ManualGrading.Rendering via `AdaptiveIFrame.screen_preview(...)`.

  - The adaptive screen preview route carries that flag into the React delivery app only when the manual grading URL includes `preserve_capi_iframe_size=true`.

  - Changed CAPI iframe sizing so ordinary review mode no longer uses CAPI-reported frameWidth/frameHeight.
  - Manual grading can still preserve CAPI-reported size and scroll.
  - Added tests that ordinary review clamps/fills like delivery, and that the manual-grading marker is only emitted when
    requested.
