### PR TITLE
[ENHANCEMENT] [MER-5703] Adjust math preview implementation

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -71,6 +71,7 @@ export interface ActivityContext {
   variables: any;
   pageLinkParams: any;
   allowHints: boolean;
+  showMathPreviews?: boolean;
   responsiveLayout?: boolean;
 }
 

--- a/assets/src/components/activities/common/math_expression/MathExpressionInput.tsx
+++ b/assets/src/components/activities/common/math_expression/MathExpressionInput.tsx
@@ -208,7 +208,7 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
     validateNowSignal,
     onValidationChange,
   });
-  const [showDeliveryPreview, setShowDeliveryPreview] = useState(true);
+  const [isFocused, setIsFocused] = useState(false);
   const statusText = visibleStatusText(state);
   const isInline = layout === 'inline_multi_input';
   const RootTag = isInline ? 'span' : 'div';
@@ -217,11 +217,16 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
     .join(' ');
 
   const previewLatex =
-    previewMode !== 'none' && state.status === 'valid' && value.trim() !== ''
+    previewMode !== 'none' && isFocused && state.status === 'valid' && value.trim() !== ''
       ? state.latex
       : undefined;
   const showRightPreview = previewMode === 'right_of_input' && !isInline;
   const useFloatingDeliveryPreview = showRightPreview && layout === 'delivery_single';
+  const handleBlur = () => {
+    setIsFocused(false);
+    validate();
+    onBlur?.();
+  };
 
   return (
     <RootTag
@@ -245,26 +250,15 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
               value={value}
               disabled={typeof disabled === 'boolean' ? disabled : false}
               onChange={(e) => onChange(e.target.value)}
-              onBlur={() => {
-                validate();
-                onBlur?.();
-              }}
+              onFocus={() => setIsFocused(true)}
+              onBlur={handleBlur}
               onKeyUp={onKeyUp}
             />
             <MathExpressionHelpPopover describedById={helpId} inline={isInline} />
-            {showDeliveryPreview && previewLatex && (
+            {previewLatex && (
               <MathExpressionPreview latex={previewLatex} placement="right_of_input" floating />
             )}
           </span>
-          <label className="inline-flex min-h-[2.5rem] items-center gap-2 text-sm text-gray-700 dark:text-gray-200">
-            <input
-              type="checkbox"
-              className="h-4 w-4 rounded border-gray-300 text-blue-700 focus:ring-blue-600"
-              checked={showDeliveryPreview}
-              onChange={(event) => setShowDeliveryPreview(event.target.checked)}
-            />
-            <span>Show Preview</span>
-          </label>
         </span>
       ) : showRightPreview ? (
         <span
@@ -283,10 +277,8 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
               value={value}
               disabled={typeof disabled === 'boolean' ? disabled : false}
               onChange={(e) => onChange(e.target.value)}
-              onBlur={() => {
-                validate();
-                onBlur?.();
-              }}
+              onFocus={() => setIsFocused(true)}
+              onBlur={handleBlur}
               onKeyUp={onKeyUp}
             />
             <MathExpressionHelpPopover describedById={helpId} inline={isInline} />
@@ -306,10 +298,8 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
             value={value}
             disabled={typeof disabled === 'boolean' ? disabled : false}
             onChange={(e) => onChange(e.target.value)}
-            onBlur={() => {
-              validate();
-              onBlur?.();
-            }}
+            onFocus={() => setIsFocused(true)}
+            onBlur={handleBlur}
             onKeyUp={onKeyUp}
           />
           <MathExpressionHelpPopover describedById={helpId} inline={isInline} />

--- a/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerDelivery.tsx
@@ -47,6 +47,7 @@ type InputProps = {
   inputType: InputType;
   isEvaluated: boolean;
   isSubmitted: boolean;
+  showMathPreviews?: boolean;
   mathExpressionQuestionType?: MathExpressionQuestionType;
   onChange: (value: string) => void;
   onBlur?: () => void;
@@ -87,7 +88,7 @@ const Input = (props: InputProps) => {
             {...shared}
             validationKind={validationKind}
             layout="delivery_single"
-            previewMode="right_of_input"
+            previewMode={props.showMathPreviews === false ? 'none' : 'right_of_input'}
             ariaLabel="answer submission textbox"
           />
         );
@@ -198,6 +199,7 @@ export const ShortAnswerComponent: React.FC = () => {
         <Input
           inputType={activeModel.inputType}
           mathExpressionQuestionType={mathExpressionQuestionType}
+          showMathPreviews={context.showMathPreviews}
           // Short answers only have one selection, but are modeled as an array.
           // Select the first element.
           input={

--- a/assets/test/components/activities/common/math_expression/MathExpressionInput_test.tsx
+++ b/assets/test/components/activities/common/math_expression/MathExpressionInput_test.tsx
@@ -57,8 +57,8 @@ const renderControlledInput = (props: Partial<MathExpressionInputProps> = {}) =>
   return render(<Harness />);
 };
 
-// @ac "AC-005" Valid examples produce valid feedback through parser-backed preview results.
-// @ac "AC-006" Invalid examples produce accessible invalid feedback and no preview.
+// @ac "AC-005" Valid examples produce valid feedback through parser-backed results.
+// @ac "AC-006" Invalid examples produce accessible invalid feedback.
 // @ac "AC-007" Empty fields stay neutral.
 // @ac "AC-008" Invalid state is exposed through aria-invalid and status text.
 // @ac "AC-009" Validation is debounced during editing and immediate on blur/save signals.
@@ -67,10 +67,6 @@ const renderControlledInput = (props: Partial<MathExpressionInputProps> = {}) =>
 // @ac "AC-012" Syntax help opens by click and keyboard activation.
 // @ac "AC-013" Syntax help closes by Escape and outside click.
 // @ac "AC-014" Syntax help links to /help/math-syntax.
-// @ac "AC-019" Authoring layout renders parser-derived previews.
-// @ac "AC-021" Inline Multi-Input layout suppresses rendered previews.
-// @ac "AC-022" Stale previews are suppressed while changed values await validation.
-// @ac "AC-023" Previews are driven by parser-derived LaTeX from the adapter mock.
 // @ac "AC-029" Inline layout avoids visible validation blocks that shift prose.
 // @ac "AC-033" Component tests cover valid, invalid, empty, authoring, delivery, and inline modes.
 // @ac "AC-034" Component tests cover keyboard help flow and accessible invalid state.
@@ -102,7 +98,7 @@ describe('MathExpressionInput', () => {
     expect(screen.queryByText('Preview')).not.toBeInTheDocument();
   });
 
-  it('debounces valid syntax feedback and renders parser-derived preview', () => {
+  it('debounces valid syntax feedback', () => {
     previewMock.mockReturnValue(validResult);
     renderControlledInput();
 
@@ -116,8 +112,6 @@ describe('MathExpressionInput', () => {
 
     expect(previewMock).toHaveBeenCalledWith('2x + 6', 'expression');
     expect(screen.getByText('Expression syntax looks valid.')).toBeInTheDocument();
-    expect(screen.getByText('Preview')).toBeInTheDocument();
-    expect(screen.getByText('\\[2x + 6\\]')).toBeInTheDocument();
   });
 
   it('validates immediately on blur without waiting for the debounce', () => {
@@ -153,20 +147,6 @@ describe('MathExpressionInput', () => {
 
     expect(screen.getByLabelText('answer expression')).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByRole('alert')).toHaveTextContent('Check the math syntax');
-    expect(screen.queryByText('Preview')).not.toBeInTheDocument();
-  });
-
-  it('suppresses stale preview while a changed value is waiting for validation', () => {
-    previewMock.mockReturnValue(validResult);
-    renderControlledInput({ value: '2x + 6' });
-
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
-    expect(screen.getByText('Preview')).toBeInTheDocument();
-
-    fireEvent.change(screen.getByLabelText('answer expression'), { target: { value: '2^^3' } });
-
     expect(screen.queryByText('Preview')).not.toBeInTheDocument();
   });
 
@@ -268,28 +248,5 @@ describe('MathExpressionInput', () => {
     expect(inputRow).toContainElement(
       screen.getByRole('button', { name: 'Math expression syntax help' }),
     );
-  });
-
-  it('can render the single-response delivery preview to the right of the input', () => {
-    previewMock.mockReturnValue(validResult);
-    renderControlledInput({
-      layout: 'delivery_single',
-      previewMode: 'right_of_input',
-      value: '2x + 6',
-    });
-
-    act(() => {
-      jest.advanceTimersByTime(200);
-    });
-
-    expect(screen.getByText('Preview').closest('[data-math-expression-preview]')).toHaveAttribute(
-      'data-math-expression-preview',
-      'right_of_input',
-    );
-    expect(
-      screen
-        .getByLabelText('answer expression')
-        .closest('[data-math-expression-preview-placement]'),
-    ).toHaveAttribute('data-math-expression-preview-placement', 'right_of_input');
   });
 });

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -292,51 +291,31 @@ describe('multi input question - default (with text input)', () => {
     expect(model.inputs[1]).toHaveProperty('inputType', 'text');
   });
 
-  it('uses shared math expression help and preview in answer key and targeted feedback editors', () => {
-    jest.useFakeTimers();
+  it('uses shared math expression help in answer key and targeted feedback editors', () => {
+    const freshModel = defaultModel();
+    const originalInput = freshModel.inputs[0] as FillInTheBlank;
+    let mathModel = dispatch(
+      freshModel,
+      MultiInputActions.setQuestionType(originalInput.id, 'algebraic'),
+    );
+    const mathInput = mathModel.inputs[0] as FillInTheBlank;
+    mathModel = dispatch(mathModel, addTargetedFeedbackFillInTheBlank(mathInput));
+    const authoringModel = JSON.parse(JSON.stringify(mathModel)) as MultiInputSchema;
+    const authoringInput = authoringModel.inputs[0] as FillInTheBlank;
 
-    try {
-      const freshModel = defaultModel();
-      const originalInput = freshModel.inputs[0] as FillInTheBlank;
-      let mathModel = dispatch(
-        freshModel,
-        MultiInputActions.setQuestionType(originalInput.id, 'algebraic'),
-      );
-      const mathInput = mathModel.inputs[0] as FillInTheBlank;
-      mathModel = dispatch(mathModel, addTargetedFeedbackFillInTheBlank(mathInput));
-      const authoringModel = JSON.parse(JSON.stringify(mathModel)) as MultiInputSchema;
-      const authoringInput = authoringModel.inputs[0] as FillInTheBlank;
+    render(
+      <Provider store={configureStore()}>
+        <AuthoringElementProvider
+          {...defaultAuthoringElementProps<MultiInputSchema>(authoringModel)}
+        >
+          <AnswerKeyTab input={authoringInput} />
+        </AuthoringElementProvider>
+      </Provider>,
+    );
 
-      render(
-        <Provider store={configureStore()}>
-          <AuthoringElementProvider
-            {...defaultAuthoringElementProps<MultiInputSchema>(authoringModel)}
-          >
-            <AnswerKeyTab input={authoringInput} />
-          </AuthoringElementProvider>
-        </Provider>,
-      );
+    expect(screen.getAllByRole('button', { name: 'Math expression syntax help' })).toHaveLength(2);
 
-      expect(screen.getAllByRole('button', { name: 'Math expression syntax help' })).toHaveLength(
-        2,
-      );
-
-      const answerEditors = screen.getAllByLabelText('Correct answer');
-      expect(answerEditors).toHaveLength(2);
-
-      fireEvent.change(answerEditors[0], { target: { value: '2x + 6' } });
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
-      expect(screen.getByText('\\[2x + 6\\]')).toBeInTheDocument();
-
-      fireEvent.change(answerEditors[1], { target: { value: 'x^2' } });
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
-      expect(screen.getByText('\\[x^2\\]')).toBeInTheDocument();
-    } finally {
-      jest.useRealTimers();
-    }
+    const answerEditors = screen.getAllByLabelText('Correct answer');
+    expect(answerEditors).toHaveLength(2);
   });
 });

--- a/assets/test/short_answer/short_answer_delivery_test.tsx
+++ b/assets/test/short_answer/short_answer_delivery_test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ActivityContext } from 'components/activities/DeliveryElement';
 import { DeliveryElementProvider } from 'components/activities/DeliveryElementProvider';
 import { ShortAnswerComponent } from 'components/activities/short_answer/ShortAnswerDelivery';
 import { ShortAnswerActions } from 'components/activities/short_answer/actions';
@@ -45,7 +46,10 @@ describe('multiple choice delivery', () => {
     window.MathJax = restoreMathJax;
   });
 
-  const renderShortAnswer = (model: ShortAnswerModelSchema) => {
+  const renderShortAnswer = (
+    model: ShortAnswerModelSchema,
+    contextOverrides: Partial<ActivityContext> = {},
+  ) => {
     const props = {
       model,
       activitySlug: 'activity-slug',
@@ -70,6 +74,7 @@ describe('multiple choice delivery', () => {
         variables: {},
         pageLinkParams: {},
         allowHints: false,
+        ...contextOverrides,
       },
       preview: false,
     };
@@ -214,6 +219,53 @@ describe('multiple choice delivery', () => {
       }
     },
   );
+
+  it('shows math expression previews only while the valid math input is focused', async () => {
+    jest.useFakeTimers();
+    const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('algebraic', '1'));
+
+    try {
+      renderShortAnswer(model);
+
+      const input = screen.getByLabelText('answer submission textbox');
+      fireEvent.change(input, { target: { value: '2x + 6' } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      await waitFor(() => expect(input).toHaveClass('input-success'));
+      expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+
+      fireEvent.focus(input);
+      expect(screen.getByText('Preview')).toBeInTheDocument();
+
+      fireEvent.blur(input);
+      expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('suppresses math expression previews when the user preference is disabled', async () => {
+    jest.useFakeTimers();
+    const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('algebraic', '1'));
+
+    try {
+      renderShortAnswer(model, { showMathPreviews: false });
+
+      const input = screen.getByLabelText('answer submission textbox');
+      fireEvent.focus(input);
+      fireEvent.change(input, { target: { value: '2x + 6' } });
+      act(() => {
+        jest.advanceTimersByTime(200);
+      });
+
+      await waitFor(() => expect(input).toHaveClass('input-success'));
+      expect(screen.queryByText('Preview')).not.toBeInTheDocument();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
 
   it('renders LaTeX direct math expressions with the math input', () => {
     const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('latex_direct', '1'));

--- a/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
+++ b/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
@@ -28,8 +28,8 @@ jest.mock('gleam/torusExpression', () => ({
   ),
 }));
 
-// @ac "AC-024" Answer-key expected-answer editors expose validation, help, and preview.
-// @ac "AC-025" Targeted feedback editors expose validation, help, and preview.
+// @ac "AC-024" Answer-key expected-answer editors expose validation and help.
+// @ac "AC-025" Targeted feedback editors expose validation and help.
 // @ac "AC-026" Candidate/test expression coverage is satisfied by the shared editor path when present.
 // @ac "AC-027" Required author fields keep existing persistence and grading semantics unchanged.
 describe('short answer math expression authoring', () => {
@@ -49,7 +49,7 @@ describe('short answer math expression authoring', () => {
     jest.useRealTimers();
   });
 
-  it('uses shared math expression help and preview for the answer key editor', () => {
+  it('uses shared math expression help for the answer key editor', () => {
     const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('algebraic', '1'));
     const response = model.authoring.parts[0].responses[0];
     const onEditResponseMatchConfig = jest.fn();
@@ -78,8 +78,6 @@ describe('short answer math expression authoring', () => {
       jest.advanceTimersByTime(200);
     });
 
-    expect(screen.getByText('Preview')).toBeInTheDocument();
-    expect(screen.getByText('\\[2x + 6\\]')).toBeInTheDocument();
     expect(onEditResponseMatchConfig).toHaveBeenCalledWith(
       response.id,
       expect.objectContaining({
@@ -247,7 +245,7 @@ describe('short answer math expression authoring', () => {
     expect(screen.getByRole('button', { name: 'x' })).toBeInTheDocument();
   });
 
-  it('uses quantity validation and preview for algebraic-with-units targeted feedback editors', () => {
+  it('uses quantity validation for algebraic-with-units targeted feedback editors', () => {
     const model = dispatch(
       defaultModel(),
       ShortAnswerActions.setQuestionType('expression_with_units', '1'),
@@ -275,7 +273,6 @@ describe('short answer math expression authoring', () => {
       jest.advanceTimersByTime(200);
     });
 
-    expect(screen.getByText('Preview')).toBeInTheDocument();
     expect(screen.getByLabelText('Correct answer')).toHaveAttribute('aria-invalid', 'false');
     expect(screen.getByLabelText('Unit feedback match type')).toHaveValue('none');
     expect(screen.getByRole('option', { name: 'Wrong unit' })).toBeInTheDocument();
@@ -336,7 +333,7 @@ describe('short answer math expression authoring', () => {
   });
 
   it.each(['number_with_units', 'fraction'] as const)(
-    'uses shared math expression help and preview for %s answer editors',
+    'uses shared math expression help for %s answer editors',
     (questionType) => {
       const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType(questionType, '1'));
       const response =
@@ -369,7 +366,6 @@ describe('short answer math expression authoring', () => {
       expect(
         screen.getByRole('button', { name: 'Math expression syntax help' }),
       ).toBeInTheDocument();
-      expect(screen.getByText('Preview')).toBeInTheDocument();
       expect(onEditResponseMatchConfig).toHaveBeenCalled();
     },
   );

--- a/lib/oli/accounts/schemas/user_preferences.ex
+++ b/lib/oli/accounts/schemas/user_preferences.ex
@@ -7,10 +7,11 @@ defmodule Oli.Accounts.UserPreferences do
   embedded_schema do
     field :timezone, :string
     field :page_outline_panel_active?, :boolean, default: false
+    field :show_math_previews?, :boolean, default: true
   end
 
   def changeset(preferences, attrs \\ %{}) do
     preferences
-    |> cast(attrs, [:timezone, :page_outline_panel_active?])
+    |> cast(attrs, [:timezone, :page_outline_panel_active?, :show_math_previews?])
   end
 end

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -4,6 +4,7 @@ defmodule Oli.Rendering.Activity.Html do
   """
   import Oli.Utils
 
+  alias Oli.Accounts
   alias Oli.Delivery.Settings
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Activities
@@ -226,6 +227,7 @@ defmodule Oli.Rendering.Activity.Html do
         pageLinkParams: page_link_params,
         allowHints: effective_settings && effective_settings.allow_hints
       }
+      |> maybe_put_show_math_previews(tag, user)
       |> Poison.encode!()
       |> HtmlEntities.encode()
 
@@ -238,6 +240,19 @@ defmodule Oli.Rendering.Activity.Html do
       ~s|<#{tag} id="#{activity_resource_id}" phx-update="ignore" class="activity-container" state="#{state}" model="#{model_json}" mode="#{mode}" context="#{activity_context}"></#{tag}>\n|
     ]
   end
+
+  defp maybe_put_show_math_previews(activity_context, "oli-adaptive-delivery", _user),
+    do: activity_context
+
+  defp maybe_put_show_math_previews(activity_context, _tag, user) do
+    Map.put(activity_context, :showMathPreviews, show_math_previews?(user))
+  end
+
+  defp show_math_previews?(%Oli.Accounts.User{} = user) do
+    Accounts.get_user_preference(user, :show_math_previews?, true)
+  end
+
+  defp show_math_previews?(_), do: true
 
   defp resolve_adaptive_dynamic_links(model_json, tag, %Context{} = context) do
     if is_adaptive?(tag) and dynamic_link_markers_present?(model_json) do

--- a/lib/oli_web/components/delivery/user_account.ex
+++ b/lib/oli_web/components/delivery/user_account.ex
@@ -317,6 +317,7 @@ defmodule OliWeb.Components.Delivery.UserAccount do
       label="Cookies"
       onclick={"OLI.handleCookiePreferences(#{Jason.encode!(privacy_policies_url())})"}
     />
+    <.menu_item_profile_math_previews :if={@ctx.user} ctx={@ctx} />
     <.menu_item_profile_timezone id={"#{@id}-tz-selector"} ctx={@ctx} />
     <.menu_item_guest_actions section={@section} />
     """
@@ -628,6 +629,37 @@ defmodule OliWeb.Components.Delivery.UserAccount do
           select_class="bg-delivery-hints-bg dark:bg-delivery-hints-bg-dark text-delivery-body-color dark:text-delivery-body-color-dark border-gray-300 dark:border-gray-700 h-9"
         />
       </div>
+    </li>
+    """
+  end
+
+  attr(:ctx, SessionContext, required: true)
+
+  def menu_item_profile_math_previews(assigns) do
+    ~H"""
+    <li class="px-4 py-3 border-b border-gray-200 dark:border-gray-800 sm:px-2">
+      <form action={~p"/update_user_preference"} method="post">
+        <input type="hidden" name="_csrf_token" value={Plug.CSRFProtection.get_csrf_token()} />
+        <input type="hidden" name="user_preference[key]" value="show_math_previews?" />
+        <input type="hidden" name="user_preference[value]" value="false" />
+        <input
+          type="hidden"
+          name="user_preference[redirect_to]"
+          value="/"
+        />
+        <label class="flex items-center gap-4 text-base font-medium text-delivery-body-color dark:text-delivery-body-color-dark">
+          <i class="fa-solid fa-square-root-variable text-gray-500 dark:text-gray-400 text-lg"></i>
+          <span class="flex-1">Show Math Previews</span>
+          <input
+            type="checkbox"
+            name="user_preference[value]"
+            value="true"
+            checked={Accounts.get_user_preference(@ctx.user, :show_math_previews?, true)}
+            class="h-4 w-4 rounded border-gray-300 text-blue-700 focus:ring-blue-600"
+            onchange="this.form.elements['user_preference[redirect_to]'].value = window.location.pathname + window.location.search; this.form.submit()"
+          />
+        </label>
+      </form>
     </li>
     """
   end

--- a/lib/oli_web/controllers/static_page_controller.ex
+++ b/lib/oli_web/controllers/static_page_controller.ex
@@ -109,6 +109,25 @@ defmodule OliWeb.StaticPageController do
     redirect(conn, to: redirect_to)
   end
 
+  def update_user_preference(conn, %{
+        "user_preference" => %{
+          "key" => "show_math_previews?",
+          "value" => value,
+          "redirect_to" => redirect_to
+        }
+      }) do
+    redirect_to = validate_path(conn, redirect_to)
+    value = value == "true"
+
+    conn =
+      case maybe_update_user_preference(conn, :show_math_previews?, value) do
+        {:ok, conn} -> put_flash(conn, :info, "Preference updated successfully.")
+        {:error, _} -> put_flash(conn, :error, "There was an error updating the preference.")
+      end
+
+    redirect(conn, to: redirect_to)
+  end
+
   defp validate_path(_, "/" <> _ = path), do: path
   defp validate_path(conn, _), do: Routes.static_page_path(conn, :index)
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -458,6 +458,7 @@ defmodule OliWeb.Router do
     # update session timezone information
     get("/timezones", StaticPageController, :list_timezones)
     post("/update_timezone", StaticPageController, :update_timezone)
+    post("/update_user_preference", StaticPageController, :update_user_preference)
   end
 
   scope "/", OliWeb do

--- a/test/oli/accounts_test.exs
+++ b/test/oli/accounts_test.exs
@@ -432,6 +432,12 @@ defmodule Oli.AccountsTest do
       assert Accounts.get_user_preference(user, :timezone, "default") == "default"
     end
 
+    test "get_user_preference/3 returns the math preview default" do
+      user = insert(:user, preferences: %UserPreferences{})
+
+      assert Accounts.get_user_preference(user, :show_math_previews?, false)
+    end
+
     test "set_user_preference/3 sets an user preference" do
       user = insert(:user)
 

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -5,6 +5,7 @@ defmodule Oli.Content.Activity.HtmlTest do
   alias Oli.Rendering.Activity
   alias Oli.Rendering.Activity.ActivitySummary
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
+  alias Oli.Accounts
 
   import ExUnit.CaptureLog
 
@@ -267,6 +268,36 @@ defmodule Oli.Content.Activity.HtmlTest do
       assert rendered_html_string =~ "app.explorations.bpr"
       assert rendered_html_string =~ "test-value"
       assert rendered_html_string =~ "session.currentQuestionScore"
+    end
+
+    test "includes user math preview preference in delivery context" do
+      user = user_fixture()
+      {:ok, user} = Accounts.set_user_preference(user, :show_math_previews?, false)
+
+      activity_map = %{
+        1 => %ActivitySummary{
+          id: 1,
+          graded: false,
+          state: "{ \"active\": true }",
+          model: "{ \"stem\": \"test\" }",
+          delivery_element: "oli-multiple-choice-delivery",
+          authoring_element: "oli-multiple-choice-authoring",
+          script: "./authoring-entry.ts",
+          attempt_guid: "activity-guid-456",
+          lifecycle_state: :active
+        }
+      }
+
+      rendered_html =
+        Activity.render(
+          %Context{user: user, activity_map: activity_map},
+          %{"activity_id" => 1, "purpose" => "none"},
+          Activity.Html
+        )
+
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      assert rendered_html_string =~ "&quot;showMathPreviews&quot;:false"
     end
 
     test "uses empty map for pageState when extrinsic_state is nil", %{author: author} do

--- a/test/oli_web/components/delivery/user_account_test.exs
+++ b/test/oli_web/components/delivery/user_account_test.exs
@@ -29,6 +29,7 @@ defmodule OliWeb.Components.Delivery.UserAccountTest do
       assert html =~ "Preferences"
       assert html =~ "Cookies"
       assert html =~ "Timezone"
+      assert html =~ "Show Math Previews"
       assert html =~ "Create an Account"
       assert html =~ "Sign In"
       assert html =~ "/users/register"

--- a/test/oli_web/controllers/static_page_controller_test.exs
+++ b/test/oli_web/controllers/static_page_controller_test.exs
@@ -178,6 +178,47 @@ defmodule OliWeb.StaticPageControllerTest do
     end
   end
 
+  describe "update_user_preference" do
+    test "updates the user math preview preference and redirects correctly", context do
+      {:ok, conn: conn, user: user} = user_conn(context)
+      redirect_to = ~p"/workspaces/student"
+
+      conn =
+        post(conn, Routes.static_page_path(conn, :update_user_preference), %{
+          user_preference: %{
+            key: "show_math_previews?",
+            value: "false",
+            redirect_to: redirect_to
+          }
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Preference updated successfully."
+
+      refute Accounts.get_user_preference(user.id, :show_math_previews?)
+      assert redirected_to(conn, 302) == redirect_to
+    end
+
+    test "redirects to the index page when the preference redirect path is invalid", context do
+      {:ok, conn: conn, user: user} = user_conn(context)
+
+      conn =
+        post(conn, Routes.static_page_path(conn, :update_user_preference), %{
+          user_preference: %{
+            key: "show_math_previews?",
+            value: "true",
+            redirect_to: "https://example.com"
+          }
+        })
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) ==
+               "Preference updated successfully."
+
+      assert Accounts.get_user_preference(user.id, :show_math_previews?)
+      assert redirected_to(conn, 302) == Routes.static_page_path(conn, :index)
+    end
+  end
+
   describe "student login" do
     test "shows student login view", %{conn: conn} do
       conn = get(conn, Routes.static_page_path(conn, :index))


### PR DESCRIPTION
Adds a global user preference for math previews and uses it to control student-facing math preview display.

Math previews now only appear when the preference is enabled, the math field has focus, and the entered math is valid. The old per-question “Show Preview” checkbox was removed.