### PR TITLE
[BUG FIX] [MER-5312] Fix adaptive page iframe height calculation when displayed within Torus navigation

### DIFF
--- a/assets/src/apps/delivery/Delivery.tsx
+++ b/assets/src/apps/delivery/Delivery.tsx
@@ -72,6 +72,7 @@ const adaptiveIframeFallbackContentSelectors = ['[data-adaptive-delivery-root]',
   ',',
 );
 const adaptivePartTagPrefix = 'janus-';
+const capiIframePartTagName = 'janus-capi-iframe';
 const adaptiveRootSelector = '[data-adaptive-delivery-root]';
 
 const isHTMLElement = (element?: Element | null): element is HTMLElement => {
@@ -103,6 +104,14 @@ const getElementHeight = (element?: Element | null) => {
     element.getBoundingClientRect().height || 0,
     element.getBoundingClientRect().bottom + window.scrollY,
   );
+};
+
+const getElementLayoutHeight = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  return Math.max(element.offsetHeight || 0, element.getBoundingClientRect().height || 0);
 };
 
 const getElementVisualBottom = (element?: Element | null) => {
@@ -159,6 +168,9 @@ const getIntrinsicAdaptiveElementHeight = (element?: Element | null) => {
 const getMaxElementHeight = (elements: Element[]) =>
   Math.max(...elements.map(getElementHeight), minimumAdaptiveIframeHeight);
 
+const getMaxElementLayoutHeight = (elements: Element[]) =>
+  Math.max(...elements.map(getElementLayoutHeight), minimumAdaptiveIframeHeight);
+
 const getMaxIntrinsicAdaptiveElementHeight = (elements: Element[]) =>
   Math.max(...elements.map(getIntrinsicAdaptiveElementHeight), minimumAdaptiveIframeHeight);
 
@@ -169,7 +181,30 @@ export const getAdaptiveContentHeight = (contentElement?: HTMLElement | null) =>
   const contentElements = Array.from(document.querySelectorAll(adaptiveIframeContentSelectors));
 
   if (contentElements.length > 0) {
-    return getMaxIntrinsicAdaptiveElementHeight(contentElements);
+    const intrinsicHeight = getMaxIntrinsicAdaptiveElementHeight(contentElements);
+
+    if (intrinsicHeight === minimumAdaptiveIframeHeight) {
+      return minimumAdaptiveIframeHeight;
+    }
+
+    const adaptiveContainerHeight = getMaxElementLayoutHeight(contentElements);
+    const hasCapiIframe = contentElements.some((element) =>
+      element.querySelector(capiIframePartTagName),
+    );
+    const adaptiveOverflowHeight = hasCapiIframe
+      ? 0
+      : Math.max(
+          ...contentElements.map(
+            (element) => getElementHeight(element) - getElementLayoutHeight(element),
+          ),
+          0,
+        );
+    const surroundingDocumentHeight = Math.max(
+      getDocumentHeight() - Math.max(adaptiveContainerHeight, intrinsicHeight),
+      0,
+    );
+
+    return intrinsicHeight + Math.max(adaptiveOverflowHeight, surroundingDocumentHeight);
   }
 
   const fallbackContentElements = Array.from(

--- a/assets/src/hooks/adaptive_iframe_resize.ts
+++ b/assets/src/hooks/adaptive_iframe_resize.ts
@@ -16,6 +16,7 @@ const stableHeightLimit = 3;
 const contentSelectors = ['#stage-stage', '.stage-content-wrapper > .content'].join(',');
 const fallbackContentSelectors = ['[data-adaptive-delivery-root]', '.mainView'].join(',');
 const adaptivePartTagPrefix = 'janus-';
+const capiIframePartTagName = 'janus-capi-iframe';
 const adaptiveRootSelector = '[data-adaptive-delivery-root]';
 
 const findIframe = (root: HTMLElement) =>
@@ -67,6 +68,14 @@ const elementHeight = (element?: Element | null) => {
     element.getBoundingClientRect().height || 0,
     element.getBoundingClientRect().bottom + scrollY,
   );
+};
+
+const elementLayoutHeight = (element?: Element | null) => {
+  if (!isHTMLElement(element)) {
+    return 0;
+  }
+
+  return Math.max(element.offsetHeight || 0, element.getBoundingClientRect().height || 0);
 };
 
 const elementVisualBottom = (element?: Element | null) => {
@@ -127,6 +136,9 @@ const intrinsicAdaptiveElementHeight = (
 const maxElementHeight = (elements: Element[]) =>
   Math.max(...elements.map(elementHeight), minIframeHeight);
 
+const maxElementLayoutHeight = (elements: Element[]) =>
+  Math.max(...elements.map(elementLayoutHeight), minIframeHeight);
+
 const maxIntrinsicAdaptiveElementHeight = (elements: Element[], useAuthoredPartBounds = false) =>
   Math.max(
     ...elements.map((element) => intrinsicAdaptiveElementHeight(element, useAuthoredPartBounds)),
@@ -147,7 +159,33 @@ export const measureIframeContentHeight = (iframe: HTMLIFrameElement) => {
     const contentElements = Array.from(doc.querySelectorAll(contentSelectors));
 
     if (contentElements.length > 0) {
-      return maxIntrinsicAdaptiveElementHeight(contentElements, !usesResponsiveAdaptiveLayout(doc));
+      const intrinsicHeight = maxIntrinsicAdaptiveElementHeight(
+        contentElements,
+        !usesResponsiveAdaptiveLayout(doc),
+      );
+
+      if (intrinsicHeight === minIframeHeight) {
+        return minIframeHeight;
+      }
+
+      const adaptiveContainerHeight = maxElementLayoutHeight(contentElements);
+      const hasCapiIframe = contentElements.some((element) =>
+        element.querySelector(capiIframePartTagName),
+      );
+      const adaptiveOverflowHeight = hasCapiIframe
+        ? 0
+        : Math.max(
+            ...contentElements.map(
+              (element) => elementHeight(element) - elementLayoutHeight(element),
+            ),
+            0,
+          );
+      const surroundingDocumentHeight = Math.max(
+        documentHeight(doc) - Math.max(adaptiveContainerHeight, intrinsicHeight),
+        0,
+      );
+
+      return intrinsicHeight + Math.max(adaptiveOverflowHeight, surroundingDocumentHeight);
     }
 
     const fallbackContentElements = Array.from(doc.querySelectorAll(fallbackContentSelectors));

--- a/assets/test/delivery/adaptive_iframe_resize_test.ts
+++ b/assets/test/delivery/adaptive_iframe_resize_test.ts
@@ -6,6 +6,11 @@ const setElementHeight = (element: Element, height: number) => {
   setElementVisualBottom(element, height);
 };
 
+const setElementOverflowHeight = (element: Element, layoutHeight: number, scrollHeight: number) => {
+  setElementHeight(element, layoutHeight);
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: scrollHeight });
+};
+
 const setElementVisualBottom = (element: Element, bottom: number) => {
   element.getBoundingClientRect = jest.fn(
     () =>
@@ -92,6 +97,81 @@ describe('AdaptiveIframeResize', () => {
     setElementHeight(iframeDocument.documentElement, 3000);
 
     expect(measureIframeContentHeight(iframe)).toBe(740);
+
+    iframe.remove();
+  });
+
+  it('includes document content surrounding the adaptive stage', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-text-flow></janus-text-flow>
+      </div>
+    `;
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    const textFlow = iframeDocument.querySelector('janus-text-flow') as HTMLElement;
+    textFlow.setAttribute('model', JSON.stringify({ height: 770 }));
+    setElementOverflowHeight(stage, 770, 879);
+    setElementHeight(textFlow, 770);
+    setElementHeight(iframeDocument.body, 879);
+    setElementHeight(iframeDocument.documentElement, 879);
+
+    expect(measureIframeContentHeight(iframe)).toBe(879);
+
+    iframe.remove();
+  });
+
+  it('includes stage overflow around regular adaptive parts', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-text-flow></janus-text-flow>
+      </div>
+    `;
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    const textFlow = iframeDocument.querySelector('janus-text-flow') as HTMLElement;
+    textFlow.setAttribute('model', JSON.stringify({ height: 696 }));
+    setElementOverflowHeight(stage, 696, 879);
+    setElementHeight(textFlow, 696);
+    setElementHeight(iframeDocument.body, 696);
+    setElementHeight(iframeDocument.documentElement, 696);
+
+    expect(measureIframeContentHeight(iframe)).toBe(879);
+
+    iframe.remove();
+  });
+
+  it('ignores stage overflow caused by a CAPI iframe', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+
+    const iframeDocument = iframe.contentDocument as Document;
+    iframeDocument.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-capi-iframe></janus-capi-iframe>
+      </div>
+    `;
+
+    const stage = iframeDocument.querySelector('#stage-stage') as HTMLElement;
+    const capiIframe = iframeDocument.querySelector('janus-capi-iframe') as HTMLElement;
+    capiIframe.setAttribute('model', JSON.stringify({ height: 650 }));
+    setElementOverflowHeight(stage, 650, 900);
+    setElementHeight(capiIframe, 650);
+    setElementHeight(iframeDocument.body, 650);
+    setElementHeight(iframeDocument.documentElement, 650);
+
+    expect(measureIframeContentHeight(iframe)).toBe(650);
 
     iframe.remove();
   });

--- a/assets/test/delivery/delivery_height_test.ts
+++ b/assets/test/delivery/delivery_height_test.ts
@@ -6,6 +6,11 @@ const setElementHeight = (element: Element, height: number) => {
   setElementVisualBottom(element, height);
 };
 
+const setElementOverflowHeight = (element: Element, layoutHeight: number, scrollHeight: number) => {
+  setElementHeight(element, layoutHeight);
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: scrollHeight });
+};
+
 const setElementVisualBottom = (element: Element, bottom: number) => {
   element.getBoundingClientRect = jest.fn(
     () =>
@@ -80,5 +85,62 @@ describe('Delivery adaptive iframe height reporting', () => {
     setElementHeight(document.documentElement, 3000);
 
     expect(getAdaptiveContentHeight()).toBe(740);
+  });
+
+  it('includes document content surrounding the adaptive stage', () => {
+    document.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-text-flow></janus-text-flow>
+      </div>
+    `;
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    const textFlow = document.querySelector('janus-text-flow') as HTMLElement;
+    textFlow.setAttribute('model', JSON.stringify({ height: 770 }));
+    setElementOverflowHeight(stage, 770, 879);
+    setElementHeight(textFlow, 770);
+    setElementHeight(document.body, 879);
+    setElementHeight(document.documentElement, 879);
+
+    expect(getAdaptiveContentHeight()).toBe(879);
+  });
+
+  it('includes stage overflow around regular adaptive parts', () => {
+    document.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-text-flow></janus-text-flow>
+      </div>
+    `;
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    const textFlow = document.querySelector('janus-text-flow') as HTMLElement;
+    textFlow.setAttribute('model', JSON.stringify({ height: 696 }));
+    setElementOverflowHeight(stage, 696, 879);
+    setElementHeight(textFlow, 696);
+    setElementHeight(document.body, 696);
+    setElementHeight(document.documentElement, 696);
+
+    expect(getAdaptiveContentHeight()).toBe(879);
+  });
+
+  it('ignores stage overflow caused by a CAPI iframe', () => {
+    document.body.innerHTML = `
+      <div data-adaptive-delivery-root data-adaptive-responsive-layout="false"></div>
+      <div id="stage-stage">
+        <janus-capi-iframe></janus-capi-iframe>
+      </div>
+    `;
+
+    const stage = document.querySelector('#stage-stage') as HTMLElement;
+    const capiIframe = document.querySelector('janus-capi-iframe') as HTMLElement;
+    capiIframe.setAttribute('model', JSON.stringify({ height: 650 }));
+    setElementOverflowHeight(stage, 650, 900);
+    setElementHeight(capiIframe, 650);
+    setElementHeight(document.body, 650);
+    setElementHeight(document.documentElement, 650);
+
+    expect(getAdaptiveContentHeight()).toBe(650);
   });
 });


### PR DESCRIPTION
## Changes

- Expands the iframe to include adaptive stage overflow.
- Includes content surrounding the adaptive stage.
- Preserves the 650px minimum loading height.
- Ignores CAPI iframe-driven overflow to prevent infinite height growth.
- Keeps parent and child iframe measurements consistent.


https://github.com/user-attachments/assets/42e43065-52b6-4e8c-9439-d7c0e4208c1c



See: https://eliterate.atlassian.net/browse/MER-5312