### PR TITLE
[BUG FIX] [MER-5618] Update instructor view question UI - rework

### DIFF
--- a/assets/src/components/activities/common/preview/PreviewAnswerKeyPanel.tsx
+++ b/assets/src/components/activities/common/preview/PreviewAnswerKeyPanel.tsx
@@ -11,6 +11,11 @@ interface Props {
   targetedResponseMappings?: ResponseMapping[];
   answerKeyChoices?: Choice[];
   answerKeyMultiSelect?: boolean;
+  targetedResponseChoicesRenderer?: (
+    mapping: ResponseMapping,
+    choices: Choice[],
+    multiSelect: boolean,
+  ) => React.ReactNode;
 }
 
 export const PreviewAnswerKeyPanel: React.FC<Props> = ({
@@ -21,6 +26,7 @@ export const PreviewAnswerKeyPanel: React.FC<Props> = ({
   targetedResponseMappings = [],
   answerKeyChoices = [],
   answerKeyMultiSelect = false,
+  targetedResponseChoicesRenderer,
 }) => {
   return (
     <div className="flex flex-col gap-4">
@@ -33,6 +39,7 @@ export const PreviewAnswerKeyPanel: React.FC<Props> = ({
         responseMappings={targetedResponseMappings}
         choices={answerKeyChoices}
         multiSelect={answerKeyMultiSelect}
+        renderChoices={targetedResponseChoicesRenderer}
       />
     </div>
   );

--- a/assets/src/components/activities/common/preview/PreviewResponsePanels.tsx
+++ b/assets/src/components/activities/common/preview/PreviewResponsePanels.tsx
@@ -33,6 +33,11 @@ interface TargetedResponsesProps {
   responseMappings?: ResponseMapping[];
   choices?: Choice[];
   multiSelect?: boolean;
+  renderChoices?: (
+    mapping: ResponseMapping,
+    choices: Choice[],
+    multiSelect: boolean,
+  ) => React.ReactNode;
 }
 
 export const PreviewTargetedResponses: React.FC<TargetedResponsesProps> = ({
@@ -40,6 +45,7 @@ export const PreviewTargetedResponses: React.FC<TargetedResponsesProps> = ({
   responseMappings = [],
   choices = [],
   multiSelect = false,
+  renderChoices,
 }) => {
   if (responses.length === 0) {
     return null;
@@ -60,17 +66,27 @@ export const PreviewTargetedResponses: React.FC<TargetedResponsesProps> = ({
               className="text-base leading-6 text-Text-text-high [&_.content_p]:my-0"
             />
           </div>
-          {responseMappings.length > 0 && choices.length > 0 ? (
-            <PreviewChoiceList
-              choices={choices}
-              selectedChoiceIds={
-                responseMappings.find((mapping) => mapping.response.id === response.id)
-                  ?.choiceIds || []
-              }
-              multiSelect={multiSelect}
-              surface="plain"
-            />
-          ) : null}
+          {responseMappings.length > 0 && choices.length > 0
+            ? (() => {
+                const mapping = responseMappings.find(
+                  (candidate) => candidate.response.id === response.id,
+                );
+                if (!mapping) {
+                  return null;
+                }
+
+                return renderChoices ? (
+                  renderChoices(mapping, choices, multiSelect)
+                ) : (
+                  <PreviewChoiceList
+                    choices={choices}
+                    selectedChoiceIds={mapping.choiceIds}
+                    multiSelect={multiSelect}
+                    surface="plain"
+                  />
+                );
+              })()
+            : null}
         </div>
       ))}
     </div>

--- a/assets/src/components/activities/common/preview/StandardDetailTabs.tsx
+++ b/assets/src/components/activities/common/preview/StandardDetailTabs.tsx
@@ -13,6 +13,11 @@ interface Props {
   answerKeySummary: React.ReactNode;
   answerKeyChoices?: Choice[];
   answerKeyMultiSelect?: boolean;
+  targetedResponseChoicesRenderer?: (
+    mapping: ReturnType<typeof getTargetedResponseMappings>[number],
+    choices: Choice[],
+    multiSelect: boolean,
+  ) => React.ReactNode;
 }
 
 export const standardDetailTabs = ({
@@ -21,11 +26,8 @@ export const standardDetailTabs = ({
   answerKeySummary,
   answerKeyChoices = [],
   answerKeyMultiSelect = false,
+  targetedResponseChoicesRenderer,
 }: Props): PreviewTab[] => {
-  const { correctResponse, incorrectResponse, targetedResponses } = standardFeedbackData(
-    model,
-    partId,
-  );
   const part = model.authoring.parts.find((candidate) => candidate.id === partId);
   const targeted = (model.authoring as { targeted?: ChoiceIdsToResponseId[] } | undefined)
     ?.targeted;
@@ -44,12 +46,11 @@ export const standardDetailTabs = ({
       content: (
         <PreviewAnswerKeyPanel
           summary={answerKeySummary}
-          correctResponse={correctResponse}
-          incorrectResponse={incorrectResponse}
-          targetedResponses={targetedResponses}
+          {...standardFeedbackData(model, partId, targetedResponseMappings)}
           targetedResponseMappings={targetedResponseMappings}
           answerKeyChoices={answerKeyChoices}
           answerKeyMultiSelect={answerKeyMultiSelect}
+          targetedResponseChoicesRenderer={targetedResponseChoicesRenderer}
         />
       ),
     },

--- a/assets/src/components/activities/common/preview/previewUtils.ts
+++ b/assets/src/components/activities/common/preview/previewUtils.ts
@@ -1,5 +1,6 @@
 import { Choice, ChoiceId, HasParts, Part, Response } from 'components/activities/types';
 import {
+  ResponseMapping,
   findTargetedResponses,
   getCorrectChoiceIds,
   getCorrectResponse,
@@ -37,6 +38,7 @@ export const choicesInIdOrder = (choices: Choice[], choiceIds: ChoiceId[]): Choi
 export const standardFeedbackData = (
   model: HasParts,
   partId: string,
+  targetedResponseMappings: ResponseMapping[] = [],
 ): {
   correctResponse: Response;
   incorrectResponse: Response;
@@ -44,7 +46,10 @@ export const standardFeedbackData = (
 } => ({
   correctResponse: getCorrectResponse(model, partId),
   incorrectResponse: getIncorrectResponse(model, partId),
-  targetedResponses: findTargetedResponses(model, partId),
+  targetedResponses:
+    targetedResponseMappings.length > 0
+      ? targetedResponseMappings.map((mapping) => mapping.response)
+      : findTargetedResponses(model, partId),
 });
 
 export const correctChoiceIdsForModel = (model: ModelWithCorrectChoiceIds) =>

--- a/assets/src/components/activities/multi_input/MultiInputPreview.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputPreview.tsx
@@ -8,14 +8,22 @@ import { PreviewRichText } from 'components/activities/common/preview/PreviewRic
 import { PreviewTab } from 'components/activities/common/preview/types';
 import { MultiInputDelivery } from 'components/activities/multi_input/schema';
 import { getCorrectChoice } from 'components/activities/multiple_choice/utils';
-import { getTargetedResponses } from 'components/activities/short_answer/utils';
+import {
+  expectedAnswerFromResponse,
+  getTargetedResponses,
+  mathExpressionQuestionTypeFromMatchConfig,
+} from 'components/activities/short_answer/utils';
 import { GradingApproach, Response } from 'components/activities/types';
+import { MatchConfig } from 'data/activities/model/match';
+import { numericInputFromMatchConfig } from 'data/activities/model/match_conversion';
 import {
   getCorrectResponse,
   getIncorrectResponse,
   getOutOfPoints,
+  getTargetedResponseMappings,
 } from 'data/activities/model/responses';
 import {
+  Input,
   InputKind,
   NumericOperator,
   RangeOperator,
@@ -120,58 +128,82 @@ const FeedbackSection: React.FC<{
   );
 };
 
-const RuleRow: React.FC<{ rule: string }> = ({ rule }) =>
-  parseInputFromRule(rule).caseOf({
-    just: (input) => {
-      if (input.kind === InputKind.Text) {
-        return (
-          <div className="flex flex-wrap items-center gap-[9px]">
-            <div className={readonlyLabelClasses}>{textOperatorLabels[input.operator]}</div>
-            <div className={`${readonlyControlClasses} min-w-[220px] flex-1`}>{input.value}</div>
-          </div>
-        );
-      }
+const InputRow: React.FC<{ input: Input }> = ({ input }) => {
+  if (input.kind === InputKind.Text) {
+    return (
+      <div className="flex flex-wrap items-center gap-[9px]">
+        <div className={readonlyLabelClasses}>{textOperatorLabels[input.operator]}</div>
+        <div className={`${readonlyControlClasses} min-w-[220px] flex-1`}>{input.value}</div>
+      </div>
+    );
+  }
 
-      if (input.kind === InputKind.Numeric) {
-        return (
-          <div className="flex flex-wrap items-center gap-[9px]">
-            <div className={readonlyLabelClasses}>{numericOperatorLabels[input.operator]}</div>
-            <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.value}</div>
-            {input.precision !== undefined ? (
-              <>
-                <PreviewCheckboxLabel label="Significant figures" />
-                <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.precision}</div>
-              </>
-            ) : null}
-          </div>
-        );
-      }
+  if (input.kind === InputKind.Numeric) {
+    return (
+      <div className="flex flex-wrap items-center gap-[9px]">
+        <div className={readonlyLabelClasses}>{numericOperatorLabels[input.operator]}</div>
+        <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.value}</div>
+        {input.precision !== undefined ? (
+          <>
+            <PreviewCheckboxLabel label="Significant figures" />
+            <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.precision}</div>
+          </>
+        ) : null}
+      </div>
+    );
+  }
 
-      return (
-        <div className="flex flex-wrap items-start gap-[9px]">
-          <div className={readonlyLabelClasses}>{rangeOperatorLabels[input.operator]}</div>
-          <div className={`${readonlyControlClasses} min-w-[60px]`}>{input.lowerBound}</div>
-          <div className="font-open-sans text-[16px] font-normal leading-[24px] tracking-normal text-Text-text-high">
-            and
-          </div>
-          <div className={`${readonlyControlClasses} min-w-[60px]`}>{input.upperBound}</div>
-          <div className={readonlyLabelClasses}>{input.inclusive ? 'Inclusive' : 'Exclusive'}</div>
-          {input.precision !== undefined ? (
-            <>
-              <PreviewCheckboxLabel label="Significant figures" />
-              <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.precision}</div>
-            </>
-          ) : null}
-        </div>
-      );
-    },
-    nothing: () => <div className="text-sm text-Text-text-high">{rule}</div>,
+  return (
+    <div className="flex flex-wrap items-start gap-[9px]">
+      <div className={readonlyLabelClasses}>{rangeOperatorLabels[input.operator]}</div>
+      <div className={`${readonlyControlClasses} min-w-[60px]`}>{input.lowerBound}</div>
+      <div className="font-open-sans text-[16px] font-normal leading-[24px] tracking-normal text-Text-text-high">
+        and
+      </div>
+      <div className={`${readonlyControlClasses} min-w-[60px]`}>{input.upperBound}</div>
+      <div className={readonlyLabelClasses}>{input.inclusive ? 'Inclusive' : 'Exclusive'}</div>
+      {input.precision !== undefined ? (
+        <>
+          <PreviewCheckboxLabel label="Significant figures" />
+          <div className={`${readonlyControlClasses} min-w-[40px]`}>{input.precision}</div>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+const MatchConfigRow: React.FC<{ matchConfig?: MatchConfig; response: Response }> = ({
+  matchConfig,
+  response,
+}) => {
+  const numericInput = numericInputFromMatchConfig(matchConfig);
+  if (numericInput) {
+    return <InputRow input={numericInput} />;
+  }
+
+  const expected = expectedAnswerFromResponse(response);
+  if (expected.length > 0) {
+    return <div className={`${readonlyControlClasses} min-w-[220px] flex-1`}>{expected}</div>;
+  }
+
+  return null;
+};
+
+const ResponseConditionRow: React.FC<{ response: Response }> = ({ response }) => {
+  if (response.matchConfig) {
+    return <MatchConfigRow matchConfig={response.matchConfig} response={response} />;
+  }
+
+  return parseInputFromRule(response.rule).caseOf({
+    just: (input) => <InputRow input={input} />,
+    nothing: () => <div className="text-sm text-Text-text-high">{response.rule}</div>,
   });
+};
 
 const MainAnswerKeyFields: React.FC<{
   gradingApproach?: GradingApproach;
-  rule: string;
-}> = ({ gradingApproach, rule }) => (
+  response: Response;
+}> = ({ gradingApproach, response }) => (
   <div className="flex flex-col gap-[9px]">
     <div className="flex flex-wrap items-center gap-[9px]">
       <div className={sectionTitleClasses}>Grading Approach:</div>
@@ -179,7 +211,7 @@ const MainAnswerKeyFields: React.FC<{
         {gradingApproach === GradingApproach.manual ? 'Instructor manual grading' : 'Automatic'}
       </div>
     </div>
-    <RuleRow rule={rule} />
+    <ResponseConditionRow response={response} />
   </div>
 );
 
@@ -189,7 +221,7 @@ const NumericTargetedFeedback: React.FC<{ response: Response }> = ({ response })
       <div className={sectionTitleClasses}>Targeted Feedback</div>
       <div className={supportingTextClasses}>{pointsLabel(response.score ?? 0)}</div>
     </div>
-    <RuleRow rule={response.rule} />
+    <ResponseConditionRow response={response} />
     <FeedbackBox response={response} />
   </div>
 );
@@ -201,7 +233,30 @@ const TextTargetedFeedback: React.FC<{ response: Response }> = ({ response }) =>
       {response.correct ? <PreviewCheckboxLabel label="Correct" /> : null}
     </div>
     <FeedbackBox response={response} />
-    <RuleRow rule={response.rule} />
+    <ResponseConditionRow response={response} />
+  </div>
+);
+
+const RuleBasedTargetedFeedback: React.FC<{ response: Response }> = ({ response }) => (
+  <div className="flex flex-col gap-[9px]">
+    <div className="flex flex-wrap items-center gap-[9px]">
+      <div className={sectionTitleClasses}>Targeted Feedback</div>
+      <div className={supportingTextClasses}>{pointsLabel(response.score ?? 0)}</div>
+    </div>
+    <ResponseConditionRow response={response} />
+    <FeedbackBox response={response} />
+  </div>
+);
+
+const DropdownTargetedFeedback: React.FC<{
+  response: Response;
+  selectedChoiceIds: string[];
+  choices: MultiInputSchema['choices'];
+}> = ({ response, selectedChoiceIds, choices }) => (
+  <div className="flex flex-col gap-[9px]">
+    <div className={sectionTitleClasses}>Targeted Feedback</div>
+    <FeedbackBox response={response} />
+    <PreviewChoiceList choices={choices} selectedChoiceIds={selectedChoiceIds} surface="plain" />
   </div>
 );
 
@@ -217,6 +272,19 @@ export const MultiInputPreview: React.FC = () => {
   const correctResponse = getCorrectResponse(model, part.id);
   const incorrectResponse = getIncorrectResponse(model, part.id);
   const targetedResponses = getTargetedResponses(model, part.id);
+  const selectedQuestionType =
+    selectedInput?.inputType === 'math_expression'
+      ? mathExpressionQuestionTypeFromMatchConfig(correctResponse.matchConfig)
+      : selectedInput?.inputType;
+  const targetedResponseMappings = React.useMemo(
+    () =>
+      model.authoring.targeted
+        ? getTargetedResponseMappings(model).filter((mapping) =>
+            targetedResponses.some((response) => response.id === mapping.response.id),
+          )
+        : [],
+    [model, targetedResponses],
+  );
   const orderedPartIds = React.useMemo(() => getOrderedPartIds(model), [model]);
   const selectedPartIndex = Math.max(orderedPartIds.indexOf(part.id), 0);
   const showPartHeader = model.inputs.length > 1;
@@ -288,7 +356,7 @@ export const MultiInputPreview: React.FC = () => {
         })}
       />
     ) : (
-      <MainAnswerKeyFields gradingApproach={part.gradingApproach} rule={correctResponse.rule} />
+      <MainAnswerKeyFields gradingApproach={part.gradingApproach} response={correctResponse} />
     );
 
   const detailsHeader = showPartHeader ? (
@@ -313,9 +381,28 @@ export const MultiInputPreview: React.FC = () => {
             ? targetedResponses.map((response) => (
                 <NumericTargetedFeedback key={response.id} response={response} />
               ))
+            : selectedQuestionType === 'numeric'
+            ? targetedResponses.map((response) => (
+                <NumericTargetedFeedback key={response.id} response={response} />
+              ))
             : selectedInput?.inputType === 'text'
             ? targetedResponses.map((response) => (
                 <TextTargetedFeedback key={response.id} response={response} />
+              ))
+            : selectedInput?.inputType === 'math' || selectedInput?.inputType === 'math_expression'
+            ? targetedResponses.map((response) => (
+                <RuleBasedTargetedFeedback key={response.id} response={response} />
+              ))
+            : selectedInput?.inputType === 'dropdown'
+            ? targetedResponseMappings.map((mapping) => (
+                <DropdownTargetedFeedback
+                  key={mapping.response.id}
+                  response={mapping.response}
+                  selectedChoiceIds={mapping.choiceIds}
+                  choices={model.choices.filter((choice) =>
+                    (selectedInput as Dropdown).choiceIds.includes(choice.id),
+                  )}
+                />
               ))
             : null}
         </div>

--- a/assets/src/components/activities/multi_input/MultiInputPreview.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputPreview.tsx
@@ -254,7 +254,10 @@ const DropdownTargetedFeedback: React.FC<{
   choices: MultiInputSchema['choices'];
 }> = ({ response, selectedChoiceIds, choices }) => (
   <div className="flex flex-col gap-[9px]">
-    <div className={sectionTitleClasses}>Targeted Feedback</div>
+    <div className="flex flex-wrap items-center gap-[9px]">
+      <div className={sectionTitleClasses}>Targeted Feedback</div>
+      <div className={supportingTextClasses}>{pointsLabel(response.score ?? 0)}</div>
+    </div>
     <FeedbackBox response={response} />
     <PreviewChoiceList choices={choices} selectedChoiceIds={selectedChoiceIds} surface="plain" />
   </div>

--- a/assets/src/components/activities/ordering/OrderingPreview.tsx
+++ b/assets/src/components/activities/ordering/OrderingPreview.tsx
@@ -8,6 +8,7 @@ import {
   choicesInIdOrder,
   correctChoiceIdsForModel,
 } from 'components/activities/common/preview/previewUtils';
+import { ResponseMapping } from 'data/activities/model/responses';
 import { OrderingSchema } from './schema';
 
 export const OrderingPreview: React.FC = () => {
@@ -20,6 +21,9 @@ export const OrderingPreview: React.FC = () => {
     partId,
     answerKeyChoices: model.choices,
     answerKeySummary: <PreviewOrderedChoiceList choices={correctChoices} />,
+    targetedResponseChoicesRenderer: (mapping: ResponseMapping, choices) => (
+      <PreviewOrderedChoiceList choices={choicesInIdOrder(choices, mapping.choiceIds)} />
+    ),
   });
 
   return (

--- a/assets/test/activities/preview/activity_previews_test.tsx
+++ b/assets/test/activities/preview/activity_previews_test.tsx
@@ -20,6 +20,8 @@ import {
   makeResponse,
   makeStem,
 } from 'components/activities/types';
+import { MatchConfigs } from 'data/activities/model/match';
+import { makeMatchConfigResponse } from 'data/activities/model/responses';
 import { containsRule, eqRule, gteRule, iequalsRule } from 'data/activities/model/rules';
 
 const previewContext: PreviewContext = {
@@ -259,6 +261,120 @@ describe('activity previews', () => {
     expect(screen.getByText('Very close, you can still get the points.')).toBeInTheDocument();
   });
 
+  test('multi input preview renders dropdown and math targeted feedback details', () => {
+    const model = defaultMultiInputModel();
+    const dropdownChoiceA = makeChoice('Mercury');
+    const dropdownChoiceB = makeChoice('Venus');
+
+    model.choices = [dropdownChoiceA, dropdownChoiceB];
+    model.inputs = [
+      {
+        id: 'input-1',
+        inputType: 'dropdown',
+        partId: 'part-1',
+        choiceIds: [dropdownChoiceA.id, dropdownChoiceB.id],
+      },
+      { id: 'input-2', inputType: 'math', partId: 'part-2' },
+    ];
+    model.stem = {
+      id: 'stem-1',
+      content: [
+        {
+          type: 'p',
+          id: 'p-1',
+          children: [
+            { text: 'Select ' },
+            { type: 'input_ref', id: 'input-1' },
+            { text: ' and solve ' },
+            { type: 'input_ref', id: 'input-2' },
+            { text: '.' },
+          ],
+        } as any,
+      ],
+    } as any;
+    model.authoring.parts = [
+      makePart(
+        [
+          makeResponse(`input like {${dropdownChoiceA.id}}`, 1, 'Correct', true),
+          makeResponse(`input like {${dropdownChoiceB.id}}`, 0, 'Planet targeted feedback'),
+          makeResponse('input like {.*}', 0, 'Incorrect'),
+        ],
+        [],
+        'part-1',
+      ),
+      makePart(
+        [
+          makeResponse(eqRule(1), 1, 'Correct', true),
+          makeResponse('input like {x^2+2x+1}', 0, 'Math targeted feedback'),
+          makeResponse('input like {.*}', 0, 'Incorrect'),
+        ],
+        [],
+        'part-2',
+      ),
+    ];
+    model.authoring.targeted = [[[dropdownChoiceB.id], model.authoring.parts[0].responses[1].id]];
+
+    renderPreview(MultiInputPreview, model, {
+      activityTypeSlug: 'oli_multi_input',
+      activityTypeLabel: 'Multi Input',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+    expect(screen.getByText('Planet targeted feedback')).toBeInTheDocument();
+    expect(screen.getAllByText('Venus').length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /select math input/i }));
+    expect(screen.getByText('Math targeted feedback')).toBeInTheDocument();
+    expect(screen.getByText((content) => content.includes('x^2+2x+1'))).toBeInTheDocument();
+  });
+
+  test('multi input preview renders numeric math-expression targeted feedback conditions', () => {
+    const model = defaultMultiInputModel();
+    model.inputs = [{ id: 'input-1', inputType: 'math_expression', partId: 'part-1' } as any];
+    model.authoring.parts = [
+      makePart(
+        [
+          makeMatchConfigResponse(
+            MatchConfigs.numeric({
+              operator: 'equal',
+              expected: '3',
+            }),
+            1,
+            'Correct',
+            true,
+          ),
+          makeMatchConfigResponse(
+            MatchConfigs.numeric({
+              operator: 'greater_than_or_equal',
+              threshold: '1',
+              precision: { type: 'significant_figures', count: 5 },
+            }),
+            0,
+            'Numeric math targeted feedback',
+          ),
+          makeResponse('input like {.*}', 0, 'Incorrect'),
+        ],
+        [],
+        'part-1',
+      ),
+    ];
+
+    renderPreview(MultiInputPreview, model, {
+      activityTypeSlug: 'oli_multi_input',
+      activityTypeLabel: 'Multi Input',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+
+    expect(screen.getByText('Equal to')).toBeInTheDocument();
+    expect(screen.getAllByText('3').length).toBeGreaterThan(0);
+    expect(screen.getByText('Greater than or equal to')).toBeInTheDocument();
+    expect(screen.getAllByText('1').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Significant figures').length).toBeGreaterThan(0);
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('Numeric math targeted feedback')).toBeInTheDocument();
+  });
+
   test('directed discussion preview renders participation and hints details', () => {
     const model = {
       stem: makeStem('What do you think of the article above?'),
@@ -375,6 +491,53 @@ describe('activity previews', () => {
     expect(answerKeyText.indexOf('3.Second')).toBeGreaterThan(-1);
     expect(answerKeyText.indexOf('1.Third')).toBeLessThan(answerKeyText.indexOf('2.First'));
     expect(answerKeyText.indexOf('2.First')).toBeLessThan(answerKeyText.indexOf('3.Second'));
+  });
+
+  test('ordering preview shows targeted feedback in the authored mapped order', () => {
+    const first = makeChoice('First');
+    const second = makeChoice('Second');
+    const third = makeChoice('Third');
+
+    const model = {
+      stem: makeStem('Put these in order.'),
+      choices: [first, second, third],
+      authoring: {
+        version: 2,
+        correct: [[first.id, second.id, third.id], 'response-order'],
+        targeted: [],
+        parts: [makePart([], [], 'part-1')],
+        transformations: [],
+        previewText: '',
+      },
+    } as any;
+
+    model.authoring.parts[0].responses = [
+      makeResponse(`input like {${first.id} ${second.id} ${third.id}}`, 1, 'Correct', true),
+      makeResponse(`input like {${second.id} ${third.id} ${first.id}}`, 0, 'Second mapping'),
+      makeResponse(`input like {${third.id} ${first.id} ${second.id}}`, 0, 'First mapping'),
+      makeResponse('input like {.*}', 0, 'Incorrect'),
+    ];
+    model.authoring.targeted = [
+      [[third.id, first.id, second.id], model.authoring.parts[0].responses[2].id],
+      [[second.id, third.id, first.id], model.authoring.parts[0].responses[1].id],
+    ];
+
+    renderPreview(OrderingPreview, model, {
+      activityTypeSlug: 'oli_ordering',
+      activityTypeLabel: 'Ordering',
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /view details/i }));
+
+    const answerKeyPanel = screen.getByRole('tabpanel', { name: 'Answer Key' });
+    const answerKeyText = answerKeyPanel.textContent || '';
+
+    expect(answerKeyText.indexOf('First mapping')).toBeLessThan(
+      answerKeyText.indexOf('Second mapping'),
+    );
+    expect(answerKeyText.indexOf('1.Third')).toBeGreaterThan(-1);
+    expect(answerKeyText.indexOf('2.First')).toBeGreaterThan(-1);
+    expect(answerKeyText.indexOf('3.Second')).toBeGreaterThan(-1);
   });
 
   test('other scoped previews render without crashing', () => {


### PR DESCRIPTION
## Jira

- [MER-5618](https://eliterate.atlassian.net/browse/MER-5618)
- [Link to comment in the ticket](https://eliterate.atlassian.net/browse/MER-5618?focusedCommentId=52484&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-52484)

## Summary

This rework fixes targeted feedback rendering issues in instructor preview for Ordering and Multi Input activities.

## Bug Origin

QA reported that:
- Ordering targeted feedback was rendered incorrectly in instructor preview
- Multi Input dropdown and math parts were missing targeted feedback in instructor preview
- Numeric math-expression targeted feedback conditions were not fully rendered in instructor preview

## Fix

- preserve targeted feedback mapping order from authoring in preview
- render Ordering targeted feedback with the ordered drag-style layout instead of the generic choice list
- render Multi Input targeted feedback for dropdown, math, and math_expression parts
- reconstruct numeric math-expression conditions from `matchConfig` so operator, value, and significant figures appear in preview
- add preview coverage for Ordering and Multi Input targeted feedback scenarios

## Validation

- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- `yarn test assets/test/activities/preview/activity_previews_test.tsx --runInBand`

## Evidence

### Ordering Before

https://github.com/user-attachments/assets/f35b69d1-0ff4-4934-a0ff-1264230251d6




### Ordering After

https://github.com/user-attachments/assets/b85bdad5-ac5d-4373-9f4a-e5cb368b2985




### MultiInput Before

https://github.com/user-attachments/assets/f0eefdfb-0ec3-4431-978a-342dcd93466a




### MultiInput After

https://github.com/user-attachments/assets/5c80c0cb-72cc-4038-8614-afa09642c262





[MER-5618]: https://eliterate.atlassian.net/browse/MER-5618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ