### PR TITLE
[ENHANCEMENT] [MER-5704] Expand number with units support

### DIFF
--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -663,7 +663,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
     const executeAction = (message: any, action: any) => action.execute(message);
 
     return (
-      <React.StrictMode>
+      <>
         <AppsignalContext.Provider value={this.state.appsignal}>
           <ErrorBoundary>
             <div className="resource-editor row">
@@ -736,7 +736,7 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
             </div>
           </ErrorBoundary>
         </AppsignalContext.Provider>
-      </React.StrictMode>
+      </>
     );
   }
 }

--- a/assets/src/components/activities/common/math_expression/MathExpressionInput.tsx
+++ b/assets/src/components/activities/common/math_expression/MathExpressionInput.tsx
@@ -35,6 +35,7 @@ export interface MathExpressionInputProps {
 const helpUrl = '/help/math-syntax';
 const defaultDebounceMs = 200;
 let nextInputId = 0;
+const inputIdPrefix = Math.random().toString(36).slice(2);
 
 const safePreview = (
   expression: string,
@@ -197,7 +198,7 @@ export const MathExpressionInput: React.FC<MathExpressionInputProps> = ({
   onKeyUp,
   onValidationChange,
 }) => {
-  const [generatedId] = useState(() => `math-expression-${nextInputId++}`);
+  const [generatedId] = useState(() => `math-expression-${inputIdPrefix}-${nextInputId++}`);
   const inputId = id ?? generatedId;
   const statusId = `${inputId}-status`;
   const helpId = `${inputId}-help`;
@@ -436,7 +437,7 @@ export const MathExpressionPreview: React.FC<PreviewProps> = ({
   collapsible = false,
   floating = false,
 }) => {
-  const [previewId] = useState(() => `math-expression-preview-${nextInputId++}`);
+  const [previewId] = useState(() => `math-expression-preview-${inputIdPrefix}-${nextInputId++}`);
   const [collapsed, setCollapsed] = useState(false);
   const previewContentId = `${previewId}-content`;
 

--- a/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
+++ b/assets/src/components/activities/short_answer/ShortAnswerAuthoring.tsx
@@ -136,11 +136,7 @@ const ControlledTabs: React.FC<{ isInstructorPreview: boolean; children: React.R
             </button>
           </li>
         ))}
-        {activitySettings && (
-          <li className="nav-item ml-auto" role="presentation">
-            {activitySettings}
-          </li>
-        )}
+        {activitySettings}
       </ul>
       <div className="tab-content">
         {validChildren.map((child, index) => (

--- a/assets/src/components/activities/short_answer/sections/InputEntry.tsx
+++ b/assets/src/components/activities/short_answer/sections/InputEntry.tsx
@@ -26,6 +26,7 @@ import {
 import {
   numericInputFromMatchConfig,
   numericInputToMatchConfig,
+  numericInputToUnitAwareMatchConfig,
 } from 'data/activities/model/match_conversion';
 import {
   Input,
@@ -144,7 +145,8 @@ const stateFromKind = (kind: NumericAnswerKind, previous: NumericState): Numeric
 };
 
 const toleranceFromMatchConfig = (matchConfig: MatchConfig | undefined): NumericTolerance =>
-  matchConfig?.type === 'math_expression' && matchConfig.math.mode === 'numeric'
+  matchConfig?.type === 'math_expression' &&
+  (matchConfig.math.mode === 'numeric' || matchConfig.math.mode === 'unit_aware')
     ? matchConfig.math.tolerance ?? { type: 'none' }
     : { type: 'none' };
 
@@ -197,6 +199,9 @@ const textStateFromResponse = (response: Response) =>
 
 const isNumericQuestion = (inputType: InputType, questionType: ShortAnswerQuestionType) =>
   inputType === 'numeric' || questionType === 'numeric';
+
+const usesNumericAnswerControls = (inputType: InputType, questionType: ShortAnswerQuestionType) =>
+  isNumericQuestion(inputType, questionType) || questionType === 'number_with_units';
 
 const isLatexQuestion = (inputType: InputType, questionType: ShortAnswerQuestionType) =>
   inputType === 'math' || questionType === 'latex_direct';
@@ -445,12 +450,15 @@ export const InputEntry: React.FC<InputProps> = ({
   );
 
   useEffect(() => {
-    if (isNumericQuestion(inputType, activeQuestionType)) {
+    const usesNumericControls = usesNumericAnswerControls(inputType, activeQuestionType);
+    const usesMathExpressionControls =
+      isMathExpressionQuestionType(activeQuestionType) || inputType === 'math';
+
+    if (usesNumericControls) {
       setNumericState(numericStateFromResponse(response));
-      return;
     }
 
-    if (isMathExpressionQuestionType(activeQuestionType) || inputType === 'math') {
+    if (usesMathExpressionControls) {
       setMathTextState(textInput(expectedAnswerFromResponse(response)));
       setUnitTargetMode(unitTargetModeFromMatchConfig(response.matchConfig));
       setFractionMatchMode(fractionMatchModeFromMatchConfig(response.matchConfig));
@@ -458,14 +466,27 @@ export const InputEntry: React.FC<InputProps> = ({
       return;
     }
 
-    setTextInputState(textStateFromResponse(response));
+    if (!usesNumericControls) {
+      setTextInputState(textStateFromResponse(response));
+    }
   }, [responseShape, inputType, activeQuestionType, response]);
 
-  const persistNumericState = (nextState: NumericState) => {
-    const matchConfig = numericInputToMatchConfig(nextState.input, undefined, {
+  const persistNumericState = (nextState: NumericState, nextUnitTargetMode = unitTargetMode) => {
+    const tolerance: NumericTolerance =
+      nextState.kind === 'tol' ? nextState.tolerance : { type: 'none' };
+    const numericOptions = {
       representation: numericRepresentationForConfig(mathExpressionConfig),
-      tolerance: nextState.kind === 'tol' ? nextState.tolerance : { type: 'none' },
-    });
+      tolerance,
+    };
+    const matchConfig =
+      activeQuestionType === 'number_with_units'
+        ? numericInputToUnitAwareMatchConfig(nextState.input, undefined, {
+            ...numericOptions,
+            unitPolicy: mathExpressionConfig.unitPolicy,
+            matchWrongUnits: nextUnitTargetMode === 'wrong_units',
+            matchMissingUnit: nextUnitTargetMode === 'missing_unit',
+          })
+        : numericInputToMatchConfig(nextState.input, undefined, numericOptions);
 
     if (onEditResponseMatchConfig) {
       onEditResponseMatchConfig(response.id, matchConfig);
@@ -543,6 +564,12 @@ export const InputEntry: React.FC<InputProps> = ({
   }) => {
     const nextMode = value as UnitTargetMode;
     setUnitTargetMode(nextMode);
+
+    if (activeQuestionType === 'number_with_units') {
+      persistNumericState(numericState, nextMode);
+      return;
+    }
+
     persistMathExpressionMatchConfig(
       mathTextState.value,
       nextMode,
@@ -577,14 +604,29 @@ export const InputEntry: React.FC<InputProps> = ({
     );
   };
 
-  if (
-    !isNumericQuestion(inputType, activeQuestionType) &&
-    !isMathExpressionQuestionType(activeQuestionType)
-  ) {
+  const showsNumericAnswerControls = usesNumericAnswerControls(inputType, activeQuestionType);
+  const unitMismatchTargetControl =
+    allowUnitMismatchTarget && isUnitQuestionType(activeQuestionType) ? (
+      <div className="mt-2 rounded border border-gray-200 bg-gray-50 p-3 text-body-color dark:border-gray-700 dark:bg-gray-800 dark:text-body-color-dark">
+        <select
+          disabled={!editMode}
+          className={controlClassName}
+          value={unitTargetMode}
+          onChange={onSelectUnitTargetMode}
+          aria-label="Unit feedback match type"
+        >
+          <option value="none">Match answer normally</option>
+          <option value="wrong_units">Wrong unit</option>
+          <option value="missing_unit">Missing unit</option>
+        </select>
+      </div>
+    ) : null;
+
+  if (!showsNumericAnswerControls && !isMathExpressionQuestionType(activeQuestionType)) {
     return <TextInput input={textInputState as InputText} onEditInput={onEditTextInput} />;
   }
 
-  if (isNumericQuestion(inputType, activeQuestionType)) {
+  if (showsNumericAnswerControls) {
     return (
       <div className="mb-2">
         <div className="d-flex flex-column">
@@ -615,6 +657,7 @@ export const InputEntry: React.FC<InputProps> = ({
             />
           )}
           <PrecisionInput input={numericState.input} onEditInput={onEditNumericInput} />
+          {activeQuestionType === 'number_with_units' && unitMismatchTargetControl}
         </div>
       </div>
     );
@@ -623,23 +666,6 @@ export const InputEntry: React.FC<InputProps> = ({
   if (isLatexQuestion(inputType, activeQuestionType)) {
     return <MathInput input={mathTextState} onEditInput={onEditMathTextInput} />;
   }
-
-  const unitMismatchTargetControl =
-    allowUnitMismatchTarget && isUnitQuestionType(activeQuestionType) ? (
-      <div className="mt-2 rounded border border-gray-200 bg-gray-50 p-3 text-body-color dark:border-gray-700 dark:bg-gray-800 dark:text-body-color-dark">
-        <select
-          disabled={!editMode}
-          className={controlClassName}
-          value={unitTargetMode}
-          onChange={onSelectUnitTargetMode}
-          aria-label="Unit feedback match type"
-        >
-          <option value="none">Match answer normally</option>
-          <option value="wrong_units">Wrong unit</option>
-          <option value="missing_unit">Missing unit</option>
-        </select>
-      </div>
-    ) : null;
 
   const fractionMatchControl =
     activeQuestionType === 'fraction' ? (

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -74,6 +74,7 @@ export const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ input, o
     <div>
       <input
         ref={numericInputRef}
+        aria-label="Correct answer"
         disabled={!editMode}
         type="text"
         className={classNames('form-control', editableNumberInvalid && 'is-invalid')}
@@ -128,6 +129,7 @@ export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onE
       <div className="d-md-flex flex-md-row align-items-center">
         <input
           ref={lowerBoundInputRef}
+          aria-label="Lower bound"
           placeholder="Lower bound"
           disabled={!editMode}
           type="text"
@@ -147,6 +149,7 @@ export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onE
         <div className="mx-1">and</div>
         <input
           ref={upperBoundInputRef}
+          aria-label="Upper bound"
           placeholder="Upper bound"
           disabled={!editMode}
           type="text"

--- a/assets/src/components/activities/short_answer/utils.ts
+++ b/assets/src/components/activities/short_answer/utils.ts
@@ -7,8 +7,10 @@ import {
   MathExpressionItemConfig,
   MathExpressionQuestionConfig,
   MathExpressionQuestionType,
+  NumericComparisonSpec,
   NumericRepresentation,
   SamplingConfig,
+  UnitAwareSpec,
   VariableDomain,
 } from 'data/activities/model/match';
 import {
@@ -260,6 +262,7 @@ export const mathExpressionMatchConfigForQuestionType = (
     matchMissingUnit?: boolean;
     fractionMatch?: 'exact' | 'equivalent';
     expressionMatch?: 'equivalent' | 'exact';
+    numericMatch?: Partial<NumericComparisonSpec>;
   } = {},
 ): MatchConfig => {
   switch (type) {
@@ -274,6 +277,7 @@ export const mathExpressionMatchConfigForQuestionType = (
     case 'number_with_units':
     case 'expression_with_units':
       return MatchConfigs.unitAware(expected, undefined, {
+        ...(type === 'number_with_units' ? options.numericMatch : {}),
         ...(options.matchWrongUnits ? { matchWrongUnits: true } : {}),
         ...(options.matchMissingUnit ? { matchMissingUnit: true } : {}),
         ...(type === 'expression_with_units' && config.sampling
@@ -329,11 +333,35 @@ export const applyMathExpressionConfigToMatchConfig = (
     (matchConfig.math.mode === 'algebraic_equivalence' || matchConfig.math.mode === 'unit_aware')
       ? matchConfig.math.expressionMatch
       : undefined;
+  const numericMatch =
+    questionType === 'number_with_units' &&
+    matchConfig?.type === 'math_expression' &&
+    matchConfig.math.mode === 'unit_aware'
+      ? unitAwareNumericFields(matchConfig.math)
+      : undefined;
 
   return mathExpressionMatchConfigForQuestionType(questionType, fallbackExpected, config, {
     ...options,
     expressionMatch,
+    numericMatch,
   });
+};
+
+const unitAwareNumericFields = (
+  math: UnitAwareSpec,
+): Partial<NumericComparisonSpec> | undefined => {
+  const fields: Partial<NumericComparisonSpec> = {
+    ...(math.operator ? { operator: math.operator } : {}),
+    ...(math.threshold ? { threshold: math.threshold } : {}),
+    ...(math.lower ? { lower: math.lower } : {}),
+    ...(math.upper ? { upper: math.upper } : {}),
+    ...(math.bounds ? { bounds: math.bounds } : {}),
+    ...(math.tolerance ? { tolerance: math.tolerance } : {}),
+    ...(math.representation ? { representation: math.representation } : {}),
+    ...(math.precision ? { precision: math.precision } : {}),
+  };
+
+  return Object.keys(fields).length > 0 ? fields : undefined;
 };
 
 export const expectedAnswerFromResponse = (response: Response): string => {

--- a/assets/src/components/resource/editors/ContentOutline.tsx
+++ b/assets/src/components/resource/editors/ContentOutline.tsx
@@ -103,60 +103,61 @@ export const ContentOutline = ({
     editMode,
   );
 
-  const items = [
-    ...content.model
-      .filter((contentItem: ResourceContent) => contentItem.id !== activeDragId)
-      .map((contentItem: ResourceContent, index: number) => {
-        const onFocus = focusHandler(setAssistive, content, editorMap, activityContexts);
-        const onMove = moveHandler(
-          content,
-          onEditContent,
-          editorMap,
-          activityContexts,
-          setAssistive,
-        );
+  const items = content.model
+    .filter((contentItem: ResourceContent) => contentItem.id !== activeDragId)
+    .map((contentItem: ResourceContent, index: number) => {
+      const onFocus = focusHandler(setAssistive, content, editorMap, activityContexts);
+      const onMove = moveHandler(content, onEditContent, editorMap, activityContexts, setAssistive);
 
-        const onKeyDown = (id: string) => (e: React.KeyboardEvent<HTMLDivElement>) => {
-          if (isShiftArrowDown(e.nativeEvent)) {
-            onMove(id, false);
-            setTimeout(() => document.getElementById(`content-item-${id}`)?.focus());
-          } else if (isShiftArrowUp(e.nativeEvent)) {
-            onMove(id, true);
-            setTimeout(() => document.getElementById(`content-item-${id}`)?.focus());
-          }
-        };
+      const onKeyDown = (id: string) => (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (isShiftArrowDown(e.nativeEvent)) {
+          onMove(id, false);
+          setTimeout(() => document.getElementById(`content-item-${id}`)?.focus());
+        } else if (isShiftArrowUp(e.nativeEvent)) {
+          onMove(id, true);
+          setTimeout(() => document.getElementById(`content-item-${id}`)?.focus());
+        }
+      };
 
-        return (
-          <OutlineItem
-            key={contentItem.id}
-            id={contentItem.id}
-            index={index}
-            parents={[]}
-            className={className}
-            level={0}
-            editMode={editMode}
-            projectSlug={projectSlug}
-            activeDragId={activeDragId}
-            setActiveDragId={setActiveDragId}
-            assistive={assistive}
-            contentItem={contentItem}
-            activityContexts={activityContexts}
-            isReorderMode={isReorderMode}
-            activeDragIndex={activeDragIndex}
-            parentDropIndex={[]}
-            content={content}
-            collapsedGroupMap={collapsedGroupMap}
-            setCollapsedGroupMap={setCollapsedGroupMap}
-            onEditContent={onEditContent}
-            onFocus={onFocus}
-            onKeyDown={onKeyDown}
-          />
-        );
-      }),
-    isReorderMode && (
-      <DropTarget key="last" id="last" index={[content.model.size + 1]} onDrop={onDropLast} />
-    ),
-  ];
+      return (
+        <OutlineItem
+          key={contentItem.id}
+          id={contentItem.id}
+          index={index}
+          parents={[]}
+          className={className}
+          level={0}
+          editMode={editMode}
+          projectSlug={projectSlug}
+          activeDragId={activeDragId}
+          setActiveDragId={setActiveDragId}
+          assistive={assistive}
+          contentItem={contentItem}
+          activityContexts={activityContexts}
+          isReorderMode={isReorderMode}
+          activeDragIndex={activeDragIndex}
+          parentDropIndex={[]}
+          content={content}
+          collapsedGroupMap={collapsedGroupMap}
+          setCollapsedGroupMap={setCollapsedGroupMap}
+          onEditContent={onEditContent}
+          onFocus={onFocus}
+          onKeyDown={onKeyDown}
+        />
+      );
+    })
+    .toArray();
+
+  if (isReorderMode) {
+    items.push(
+      <DropTarget
+        key="last-drop-target"
+        id="last"
+        index={[content.model.size + 1]}
+        onDrop={onDropLast}
+      />,
+    );
+  }
 
   return (
     <div

--- a/assets/src/data/activities/model/match.ts
+++ b/assets/src/data/activities/model/match.ts
@@ -34,6 +34,8 @@ export type NumericMatchSpec = {
   precision?: NumericPrecision;
 };
 
+export type NumericComparisonSpec = Omit<NumericMatchSpec, 'mode'>;
+
 export type ExactFormConfig =
   | { type: 'none' | 'integer' | 'fraction' | 'simplified_fraction' }
   | {
@@ -120,7 +122,14 @@ export type UnitAwareSpec = {
   unitPolicy?: UnitPolicy;
   validation?: AlgebraicValidationConfig;
   sampling?: SamplingConfig;
-  tolerance?: { type: 'absolute_or_relative'; absolute: number; relative: number };
+  operator?: NumericOperator;
+  threshold?: string;
+  lower?: string;
+  upper?: string;
+  bounds?: 'inclusive' | 'exclusive';
+  tolerance?: NumericTolerance;
+  representation?: NumericRepresentation;
+  precision?: NumericPrecision;
   matchWrongUnits?: boolean;
   matchMissingUnit?: boolean;
   expressionMatch?: 'equivalent' | 'exact';
@@ -185,15 +194,7 @@ export const MatchConfigs = {
   unitAware: (
     expected: string,
     unitPolicy?: UnitPolicy,
-    options: Pick<
-      UnitAwareSpec,
-      | 'tolerance'
-      | 'validation'
-      | 'sampling'
-      | 'matchWrongUnits'
-      | 'matchMissingUnit'
-      | 'expressionMatch'
-    > = {},
+    options: Omit<UnitAwareSpec, 'mode' | 'expected' | 'unitPolicy'> = {},
   ): MathExpressionMatchConfig => ({
     version: 1,
     type: 'math_expression',

--- a/assets/src/data/activities/model/match_conversion.ts
+++ b/assets/src/data/activities/model/match_conversion.ts
@@ -5,10 +5,12 @@ import {
   ItemConfigs,
   MatchConfig,
   MatchConfigs,
+  NumericComparisonSpec,
   NumericMatchSpec,
   NumericOperator,
   NumericRepresentation,
   NumericTolerance,
+  UnitPolicy,
 } from 'data/activities/model/match';
 import {
   Input,
@@ -122,26 +124,64 @@ export const numericInputToMatchConfig = (
   });
 };
 
+export const numericInputToUnitAwareMatchConfig = (
+  input: InputNumeric | InputRange,
+  rawRule?: string,
+  options: {
+    unitPolicy?: UnitPolicy;
+    representation?: NumericRepresentation;
+    tolerance?: NumericTolerance;
+    matchWrongUnits?: boolean;
+    matchMissingUnit?: boolean;
+  } = {},
+): MatchConfig => {
+  const numericMatchConfig = numericInputToMatchConfig(input, rawRule, {
+    representation: options.representation,
+    tolerance: options.tolerance,
+  }) as { math: NumericMatchSpec };
+  const { mode: _mode, ...numericSpec } = numericMatchConfig.math as NumericMatchSpec;
+  const { expected, ...numericOptions } = numericSpec;
+
+  return MatchConfigs.unitAware(
+    expected ?? numericExpectedFromSpec(numericSpec),
+    options.unitPolicy,
+    {
+      ...numericOptions,
+      ...(options.matchWrongUnits ? { matchWrongUnits: true } : {}),
+      ...(options.matchMissingUnit ? { matchMissingUnit: true } : {}),
+    },
+  );
+};
+
 export const numericInputFromMatchConfig = (
   matchConfig: MatchConfig | undefined,
 ): InputNumeric | InputRange | undefined => {
-  if (matchConfig?.type !== 'math_expression' || matchConfig.math.mode !== 'numeric') {
+  if (
+    matchConfig?.type !== 'math_expression' ||
+    (matchConfig.math.mode !== 'numeric' && matchConfig.math.mode !== 'unit_aware')
+  ) {
     return undefined;
   }
 
+  const math = matchConfig.math;
+  if (math.mode === 'unit_aware' && math.operator === undefined && math.expected.trim() === '') {
+    return undefined;
+  }
+
+  const matchOperator = math.mode === 'unit_aware' ? math.operator ?? 'equal' : math.operator;
   const precision =
-    matchConfig.math.precision?.type === 'significant_figures' ||
-    matchConfig.math.precision?.type === 'legacy_significant_figures'
-      ? matchConfig.math.precision.count
+    math.precision?.type === 'significant_figures' ||
+    math.precision?.type === 'legacy_significant_figures'
+      ? math.precision.count
       : undefined;
 
-  switch (matchConfig.math.operator) {
+  switch (matchOperator) {
     case 'equal':
     case 'not_equal':
       return {
         kind: InputKind.Numeric,
-        operator: matchConfig.math.operator === 'equal' ? 'eq' : 'neq',
-        value: matchConfig.math.expected ?? '',
+        operator: matchOperator === 'equal' ? 'eq' : 'neq',
+        value: numericExpectedValue(math.expected),
         precision,
       };
     case 'greater_than':
@@ -153,12 +193,12 @@ export const numericInputFromMatchConfig = (
         greater_than_or_equal: 'gte',
         less_than: 'lt',
         less_than_or_equal: 'lte',
-      }[matchConfig.math.operator] as InputNumeric['operator'];
+      }[matchOperator] as InputNumeric['operator'];
 
       return {
         kind: InputKind.Numeric,
         operator,
-        value: matchConfig.math.threshold ?? '',
+        value: math.threshold ?? numericExpectedValue(math.expected),
         precision,
       };
     }
@@ -166,13 +206,27 @@ export const numericInputFromMatchConfig = (
     case 'not_between':
       return {
         kind: InputKind.Range,
-        operator: matchConfig.math.operator === 'between' ? 'btw' : 'nbtw',
-        lowerBound: matchConfig.math.lower ?? '',
-        upperBound: matchConfig.math.upper ?? '',
-        inclusive: matchConfig.math.bounds !== 'exclusive',
+        operator: matchOperator === 'between' ? 'btw' : 'nbtw',
+        lowerBound: math.lower ?? numericExpectedValue(math.expected),
+        upperBound: math.upper ?? numericExpectedValue(math.expected),
+        inclusive: math.bounds !== 'exclusive',
         precision,
       };
   }
+};
+
+const numericExpectedFromSpec = (spec: NumericComparisonSpec): string => {
+  if (spec.expected !== undefined) return spec.expected;
+  if (spec.threshold !== undefined) return spec.threshold;
+  if (spec.lower !== undefined) return spec.lower;
+  return '';
+};
+
+const numericExpectedValue = (expected: string | undefined): string => {
+  const value = expected ?? '';
+  const match = value.trim().match(new RegExp(`^(${numberPattern})(?=\\s|[A-Za-z*/^]|$)`));
+
+  return match?.[1] ?? value;
 };
 
 const responseWithMatchConfig = (response: Response, matchConfig: MatchConfig): Response => {

--- a/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
+++ b/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
@@ -332,41 +332,77 @@ describe('short answer math expression authoring', () => {
     );
   });
 
-  it.each(['number_with_units', 'fraction'] as const)(
-    'uses shared math expression help for %s answer editors',
-    (questionType) => {
-      const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType(questionType, '1'));
-      const response =
-        questionType === 'fraction'
-          ? makeMatchConfigResponse(MatchConfigs.algebraicEquivalence('1/2'), 0)
-          : makeMatchConfigResponse(MatchConfigs.unitAware('9.8 m/s^2'), 0);
-      const onEditResponseMatchConfig = jest.fn();
+  it('uses shared math expression help for fraction answer editors', () => {
+    const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('fraction', '1'));
+    const response = makeMatchConfigResponse(MatchConfigs.algebraicEquivalence('1/2'), 0);
+    const onEditResponseMatchConfig = jest.fn();
 
-      render(
-        <AuthoringElementProvider {...defaultAuthoringElementProps(model)}>
-          <InputEntry
-            inputType={model.inputType}
-            questionType={shortAnswerQuestionType(model)}
-            mathExpressionConfig={shortAnswerMathExpressionConfig(model)}
-            response={response}
-            onEditResponseRule={jest.fn()}
-            onEditResponseMatchConfig={onEditResponseMatchConfig}
-            allowUnitMismatchTarget
-          />
-        </AuthoringElementProvider>,
-      );
+    render(
+      <AuthoringElementProvider {...defaultAuthoringElementProps(model)}>
+        <InputEntry
+          inputType={model.inputType}
+          questionType={shortAnswerQuestionType(model)}
+          mathExpressionConfig={shortAnswerMathExpressionConfig(model)}
+          response={response}
+          onEditResponseRule={jest.fn()}
+          onEditResponseMatchConfig={onEditResponseMatchConfig}
+          allowUnitMismatchTarget
+        />
+      </AuthoringElementProvider>,
+    );
 
-      fireEvent.change(screen.getByLabelText('Correct answer'), {
-        target: { value: questionType === 'fraction' ? '2/4' : '10 m/s^2' },
-      });
-      act(() => {
-        jest.advanceTimersByTime(200);
-      });
+    fireEvent.change(screen.getByLabelText('Correct answer'), {
+      target: { value: '2/4' },
+    });
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
-      expect(
-        screen.getByRole('button', { name: 'Math expression syntax help' }),
-      ).toBeInTheDocument();
-      expect(onEditResponseMatchConfig).toHaveBeenCalled();
-    },
-  );
+    expect(screen.getByRole('button', { name: 'Math expression syntax help' })).toBeInTheDocument();
+    expect(onEditResponseMatchConfig).toHaveBeenCalled();
+  });
+
+  it('uses numeric answer controls for number_with_units answer editors', () => {
+    const model = dispatch(
+      defaultModel(),
+      ShortAnswerActions.setQuestionType('number_with_units', '1'),
+    );
+    const response = makeMatchConfigResponse(MatchConfigs.unitAware('9.8 m/s^2'), 0);
+    const onEditResponseMatchConfig = jest.fn();
+
+    render(
+      <AuthoringElementProvider {...defaultAuthoringElementProps(model)}>
+        <InputEntry
+          inputType={model.inputType}
+          questionType={shortAnswerQuestionType(model)}
+          mathExpressionConfig={shortAnswerMathExpressionConfig(model)}
+          response={response}
+          onEditResponseRule={jest.fn()}
+          onEditResponseMatchConfig={onEditResponseMatchConfig}
+          allowUnitMismatchTarget
+        />
+      </AuthoringElementProvider>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Math expression syntax help' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Unit feedback match type')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Correct answer'), {
+      target: { value: '10' },
+    });
+
+    expect(onEditResponseMatchConfig).toHaveBeenCalledWith(
+      response.id,
+      expect.objectContaining({
+        type: 'math_expression',
+        math: expect.objectContaining({
+          mode: 'unit_aware',
+          expected: '10',
+          operator: 'equal',
+        }),
+      }),
+    );
+  });
 });

--- a/gleam/src/math/equality/numeric.gleam
+++ b/gleam/src/math/equality/numeric.gleam
@@ -26,6 +26,45 @@ pub fn evaluate(
   }
 }
 
+/// Evaluate an already-parsed numeric value while still applying submitted-text
+/// representation and precision constraints. Unit-aware Number matching uses
+/// this after converting the submitted quantity into the reference unit.
+pub fn evaluate_submitted_value(
+  spec: types.NumericSpec,
+  submitted: String,
+  submitted_value: Float,
+) -> types.EqualityResult {
+  case validate_numeric_options(spec) {
+    Error(error) -> types.InvalidConfig(error: error)
+    Ok(Nil) -> evaluate_supported_spec(spec, submitted, submitted_value)
+  }
+}
+
+/// Parse one scalar Number-input value. This intentionally excludes expression
+/// syntax so Number with Units keeps the same scalar value contract as Number.
+pub fn parse_scalar(raw: String) -> Result(Float, Nil) {
+  parse_number(raw)
+}
+
+/// Scale all authored numeric comparison values by a unit conversion factor.
+/// This lets unit-aware matching compare canonical values while keeping the
+/// operator, tolerance, representation, and precision semantics in this module.
+pub fn scale_comparison_values(
+  spec: types.NumericSpec,
+  scale: Float,
+) -> Result(types.NumericSpec, types.EqualityConfigError) {
+  case scale_comparison(spec.comparison, scale) {
+    Error(error) -> Error(error)
+    Ok(comparison) ->
+      Ok(types.NumericSpec(
+        comparison: comparison,
+        tolerance: spec.tolerance,
+        representation: spec.representation,
+        precision: spec.precision,
+      ))
+  }
+}
+
 /// Validate option parameters before reading the submitted answer so malformed
 /// author configuration always reports as config failure, not learner failure.
 /// JSON decoding catches shape errors; this protects hand-built Gleam specs too.
@@ -168,6 +207,66 @@ fn comparison_diagnostics(
 
     types.NotBetween(lower, upper, bounds) ->
       evaluate_range(submitted_value, lower, upper, bounds, inverted: True)
+  }
+}
+
+fn scale_comparison(
+  comparison: types.NumericComparison,
+  scale: Float,
+) -> Result(types.NumericComparison, types.EqualityConfigError) {
+  case comparison {
+    types.Equal(expected) ->
+      scale_input(expected, "comparison.expected", scale)
+      |> result_map(types.Equal)
+    types.NotEqual(expected) ->
+      scale_input(expected, "comparison.expected", scale)
+      |> result_map(types.NotEqual)
+    types.GreaterThan(threshold) ->
+      scale_input(threshold, "comparison.threshold", scale)
+      |> result_map(types.GreaterThan)
+    types.GreaterThanOrEqual(threshold) ->
+      scale_input(threshold, "comparison.threshold", scale)
+      |> result_map(types.GreaterThanOrEqual)
+    types.LessThan(threshold) ->
+      scale_input(threshold, "comparison.threshold", scale)
+      |> result_map(types.LessThan)
+    types.LessThanOrEqual(threshold) ->
+      scale_input(threshold, "comparison.threshold", scale)
+      |> result_map(types.LessThanOrEqual)
+    types.Between(lower, upper, bounds) ->
+      case
+        scale_input(lower, "comparison.lower", scale),
+        scale_input(upper, "comparison.upper", scale)
+      {
+        Ok(lower), Ok(upper) -> Ok(types.Between(lower, upper, bounds))
+        Error(error), _ | _, Error(error) -> Error(error)
+      }
+    types.NotBetween(lower, upper, bounds) ->
+      case
+        scale_input(lower, "comparison.lower", scale),
+        scale_input(upper, "comparison.upper", scale)
+      {
+        Ok(lower), Ok(upper) -> Ok(types.NotBetween(lower, upper, bounds))
+        Error(error), _ | _, Error(error) -> Error(error)
+      }
+  }
+}
+
+fn scale_input(
+  input: types.NumericInput,
+  field: String,
+  scale: Float,
+) -> Result(types.NumericInput, types.EqualityConfigError) {
+  case parse_config_number(input, field) {
+    Error(error) -> Error(error)
+    Ok(value) -> Ok(types.NumericInput(raw: float.to_string(value *. scale)))
+  }
+}
+
+fn result_map(result: Result(a, e), transform: fn(a) -> b) -> Result(b, e) {
+  case result {
+    Ok(value) -> Ok(transform(value))
+    Error(error) -> Error(error)
   }
 }
 

--- a/gleam/src/math/match/evaluate.gleam
+++ b/gleam/src/math/match/evaluate.gleam
@@ -1,6 +1,8 @@
+import gleam/float
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/result
+import gleam/string
 import math/ast
 import math/equality/algebraic
 import math/equality/algebraic_types
@@ -13,10 +15,19 @@ import math/normalization/format as normalization_format
 import math/normalization/normalize as normalization
 import math/parser
 import math/units/compare as unit_compare
+import math/units/config as unit_config
 import math/units/format as unit_format
 import math/units/normalize as unit_normalize
 import math/units/quantity
 import math/units/types as unit_types
+
+const scale_epsilon = 0.000000000001
+
+type SubmittedUnitStatus {
+  SubmittedAccepted(scale: Float)
+  SubmittedWrongUnit
+  SubmittedMissingUnit
+}
 
 /// Validate only the root contract invariant owned by the match-config layer.
 pub fn validate_config(
@@ -78,21 +89,17 @@ fn evaluate_math(
     types.UnitAware(
       expected,
       config,
-      tolerance,
-      equivalence,
+      value_matcher,
       match_wrong_units,
       match_missing_unit,
-      expression_match,
     ) ->
       evaluate_unit_aware(
         expected,
         submitted,
         config,
-        tolerance,
-        equivalence,
+        value_matcher,
         match_wrong_units,
         match_missing_unit,
-        expression_match,
       )
   }
 }
@@ -369,6 +376,38 @@ fn evaluate_unit_aware(
   expected: String,
   submitted: String,
   config: unit_types.UnitConfig,
+  value_matcher: types.UnitAwareValueMatcher,
+  match_wrong_units: Bool,
+  match_missing_unit: Bool,
+) -> types.MatchResult {
+  case value_matcher {
+    types.UnitExpressionEquality(tolerance, equivalence, expression_match) ->
+      evaluate_unit_expression_aware(
+        expected,
+        submitted,
+        config,
+        tolerance,
+        equivalence,
+        match_wrong_units,
+        match_missing_unit,
+        expression_match,
+      )
+
+    types.UnitNumericComparison(spec) ->
+      evaluate_unit_numeric_aware(
+        spec,
+        submitted,
+        config,
+        match_wrong_units,
+        match_missing_unit,
+      )
+  }
+}
+
+fn evaluate_unit_expression_aware(
+  expected: String,
+  submitted: String,
+  config: unit_types.UnitConfig,
   tolerance,
   equivalence,
   match_wrong_units: Bool,
@@ -413,6 +452,148 @@ fn evaluate_unit_aware(
         submitted,
         expression_match,
       )
+  }
+}
+
+fn evaluate_unit_numeric_aware(
+  spec: equality_types.NumericSpec,
+  submitted: String,
+  config: unit_types.UnitConfig,
+  match_wrong_units: Bool,
+  match_missing_unit: Bool,
+) -> types.MatchResult {
+  case reference_unit(config) {
+    Error(error) -> types.MatchInvalidConfig(error: error)
+    Ok(reference_unit) -> {
+      case
+        numeric.scale_comparison_values(spec, reference_unit.scale_to_canonical)
+      {
+        Error(error) -> types.MatchInvalidConfig(error: equality_error(error))
+        Ok(canonical_spec) ->
+          evaluate_unit_numeric_submission(
+            canonical_spec,
+            submitted,
+            config,
+            reference_unit,
+            match_wrong_units,
+            match_missing_unit,
+          )
+      }
+    }
+  }
+}
+
+fn evaluate_unit_numeric_submission(
+  canonical_spec: equality_types.NumericSpec,
+  submitted: String,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+  match_wrong_units: Bool,
+  match_missing_unit: Bool,
+) -> types.MatchResult {
+  case parse_numeric_unit_submission(submitted, config, reference_unit) {
+    Error(error) -> error
+    Ok(#(raw_value, value, status)) ->
+      case match_missing_unit, match_wrong_units, status {
+        True, _, SubmittedMissingUnit ->
+          evaluate_unit_numeric_value_target(
+            canonical_spec,
+            raw_value,
+            value *. reference_unit.scale_to_canonical,
+            types.UnitMissingMatched,
+            types.UnitMissingNotMatched,
+          )
+
+        True, _, _ ->
+          types.MatchNotMatched(diagnostics: [
+            types.ConfigAccepted,
+            types.UnitMissingNotMatched,
+          ])
+
+        False, True, SubmittedWrongUnit ->
+          evaluate_unit_numeric_value_target(
+            canonical_spec,
+            raw_value,
+            value *. reference_unit.scale_to_canonical,
+            types.UnitWrongMatched,
+            types.UnitWrongNotMatched,
+          )
+
+        False, True, _ ->
+          types.MatchNotMatched(diagnostics: [
+            types.ConfigAccepted,
+            types.UnitWrongNotMatched,
+          ])
+
+        False, False, SubmittedAccepted(scale) ->
+          evaluate_unit_numeric_value(
+            canonical_spec,
+            raw_value,
+            value *. scale,
+            types.UnitMatched,
+            types.UnitNotMatched,
+          )
+
+        False, False, SubmittedMissingUnit | False, False, SubmittedWrongUnit ->
+          types.MatchNotMatched(diagnostics: [
+            types.ConfigAccepted,
+            types.UnitNotMatched,
+          ])
+      }
+  }
+}
+
+fn evaluate_unit_numeric_value_target(
+  canonical_spec: equality_types.NumericSpec,
+  raw_value: String,
+  canonical_value: Float,
+  matched_diagnostic: types.MatchDiagnostic,
+  not_matched_diagnostic: types.MatchDiagnostic,
+) -> types.MatchResult {
+  evaluate_unit_numeric_value(
+    canonical_spec,
+    raw_value,
+    canonical_value,
+    matched_diagnostic,
+    not_matched_diagnostic,
+  )
+}
+
+fn evaluate_unit_numeric_value(
+  canonical_spec: equality_types.NumericSpec,
+  raw_value: String,
+  canonical_value: Float,
+  matched_diagnostic: types.MatchDiagnostic,
+  not_matched_diagnostic: types.MatchDiagnostic,
+) -> types.MatchResult {
+  case
+    numeric.evaluate_submitted_value(canonical_spec, raw_value, canonical_value)
+  {
+    equality_types.EqualityMatched(_) ->
+      types.MatchMatched(diagnostics: [
+        types.ConfigAccepted,
+        matched_diagnostic,
+      ])
+
+    equality_types.EqualityNotMatched(_) ->
+      types.MatchNotMatched(diagnostics: [
+        types.ConfigAccepted,
+        not_matched_diagnostic,
+      ])
+
+    equality_types.InvalidConfig(error) ->
+      types.MatchInvalidConfig(error: equality_error(error))
+
+    equality_types.InvalidSubmittedAnswer(_) ->
+      types.MatchInvalidSubmission(diagnostics: [
+        types.InvalidSubmittedAnswer,
+      ])
+
+    equality_types.UnsupportedMode(_) ->
+      types.MatchInvalidConfig(error: types.InvalidField(
+        field: "math.mode",
+        reason: "unsupported numeric unit-aware equality mode",
+      ))
   }
 }
 
@@ -461,6 +642,179 @@ fn exact_unit_expression_match(
       types.MatchInvalidSubmission(diagnostics: [
         types.InvalidSubmittedAnswer,
       ])
+  }
+}
+
+fn reference_unit(
+  config: unit_types.UnitConfig,
+) -> Result(unit_types.NormalUnit, types.MatchConfigError) {
+  case config.mode {
+    unit_types.IgnoreUnits ->
+      Ok(unit_types.NormalUnit(
+        dimensions: [],
+        scale_to_canonical: 1.0,
+        canonical_debug: "1",
+        original: unit_types.UnitAtom(symbol: "1"),
+        catalog_version: "ignored",
+        semantic: unit_types.PlainUnit,
+      ))
+    unit_types.RequireUnits ->
+      case unit_config.validate_unit_config(config) {
+        Error(_) ->
+          Error(types.InvalidField(
+            field: "math.unitPolicy",
+            reason: "invalid unit policy",
+          ))
+        Ok(validated) ->
+          case validated.accepted_units {
+            [first, ..] -> Ok(first.normalized)
+            [] ->
+              Error(types.InvalidField(
+                field: "math.unitPolicy",
+                reason: "number-with-units requires a reference unit",
+              ))
+          }
+      }
+  }
+}
+
+fn parse_numeric_unit_submission(
+  submitted: String,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(#(String, Float, SubmittedUnitStatus), types.MatchResult) {
+  let raw_value = submitted_numeric_value_source(submitted)
+
+  case numeric.parse_scalar(raw_value) {
+    Error(Nil) ->
+      Error(
+        types.MatchInvalidSubmission(diagnostics: [
+          types.InvalidSubmittedAnswer,
+        ]),
+      )
+
+    Ok(value) ->
+      case unit_config.validate_unit_config(config) {
+        Error(_) ->
+          Error(
+            types.MatchInvalidConfig(error: types.InvalidField(
+              field: "math.unitPolicy",
+              reason: "invalid unit policy",
+            )),
+          )
+
+        Ok(validated) ->
+          case quantity.parse_quantity_or_expression(submitted) {
+            Error(_) ->
+              Error(
+                types.MatchInvalidSubmission(diagnostics: [
+                  types.InvalidSubmittedAnswer,
+                ]),
+              )
+
+            Ok(unit_types.ParsedExpression(_)) ->
+              Ok(#(
+                raw_value,
+                value,
+                unitless_submission_status(
+                  validated.mode,
+                  reference_unit.scale_to_canonical,
+                ),
+              ))
+
+            Ok(unit_types.ParsedQuantity(unit: submitted_unit, ..)) ->
+              case unit_normalize.normalize_unit(submitted_unit) {
+                Error(_) ->
+                  Error(
+                    types.MatchInvalidSubmission(diagnostics: [
+                      types.InvalidSubmittedAnswer,
+                    ]),
+                  )
+
+                Ok(normal_unit) ->
+                  Ok(#(
+                    raw_value,
+                    value,
+                    submitted_unit_status(
+                      normal_unit,
+                      validated,
+                      reference_unit,
+                    ),
+                  ))
+              }
+          }
+      }
+  }
+}
+
+fn unitless_submission_status(
+  mode: unit_types.UnitMode,
+  reference_scale: Float,
+) -> SubmittedUnitStatus {
+  case mode {
+    unit_types.IgnoreUnits -> SubmittedAccepted(scale: reference_scale)
+    unit_types.RequireUnits -> SubmittedMissingUnit
+  }
+}
+
+fn submitted_unit_status(
+  submitted: unit_types.NormalUnit,
+  validated: unit_types.ValidatedUnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> SubmittedUnitStatus {
+  case validated.mode {
+    unit_types.IgnoreUnits ->
+      SubmittedAccepted(scale: reference_unit.scale_to_canonical)
+    unit_types.RequireUnits ->
+      case same_dimensions(submitted, reference_unit) {
+        False -> SubmittedWrongUnit
+        True ->
+          case
+            list.any(validated.accepted_units, fn(accepted) {
+              same_normal_unit(submitted, accepted.normalized)
+            })
+          {
+            True ->
+              case
+                validated.conversion,
+                same_normal_unit(submitted, reference_unit)
+              {
+                unit_types.DisallowConversion, False -> SubmittedWrongUnit
+                _, _ -> SubmittedAccepted(scale: submitted.scale_to_canonical)
+              }
+
+            False -> SubmittedWrongUnit
+          }
+      }
+  }
+}
+
+fn same_normal_unit(
+  left: unit_types.NormalUnit,
+  right: unit_types.NormalUnit,
+) -> Bool {
+  same_dimensions(left, right)
+  && same_scale(left.scale_to_canonical, right.scale_to_canonical)
+}
+
+fn same_dimensions(
+  left: unit_types.NormalUnit,
+  right: unit_types.NormalUnit,
+) -> Bool {
+  left.dimensions == right.dimensions
+}
+
+fn same_scale(left: Float, right: Float) -> Bool {
+  let difference = float.absolute_value(left -. right)
+  difference <=. scale_epsilon *. float.max(float.absolute_value(left), 1.0)
+}
+
+fn submitted_numeric_value_source(submitted: String) -> String {
+  let trimmed = string.trim(submitted)
+
+  case string.split_once(trimmed, on: " ") {
+    Ok(#(value, _unit)) -> value
+    Error(Nil) -> trimmed
   }
 }
 

--- a/gleam/src/math/match/json.gleam
+++ b/gleam/src/math/match/json.gleam
@@ -57,18 +57,13 @@ fn math_to_json(spec: types.MathExpressionSpec) -> gleam_json.Json {
     types.UnitAware(
       expected,
       config,
-      tolerance,
-      equivalence,
+      value_matcher,
       match_wrong_units,
       match_missing_unit,
-      expression_match,
     ) -> {
-      let fields = [
-        #("mode", gleam_json.string("unit_aware")),
-        #("expected", gleam_json.string(expected)),
-        #("unitPolicy", unit_policy_to_json(config)),
-        #("tolerance", tolerance_to_json(tolerance)),
-      ]
+      let fields = unit_value_matcher_to_json_fields(expected, value_matcher)
+      let fields =
+        list.append(fields, [#("unitPolicy", unit_policy_to_json(config))])
 
       let fields = case match_wrong_units {
         False -> fields
@@ -86,6 +81,25 @@ fn math_to_json(spec: types.MathExpressionSpec) -> gleam_json.Json {
           ])
       }
 
+      gleam_json.object(fields)
+    }
+  }
+}
+
+fn unit_value_matcher_to_json_fields(
+  expected: String,
+  value_matcher: types.UnitAwareValueMatcher,
+) -> List(#(String, gleam_json.Json)) {
+  let fields = [
+    #("mode", gleam_json.string("unit_aware")),
+    #("expected", gleam_json.string(expected)),
+  ]
+
+  case value_matcher {
+    types.UnitExpressionEquality(tolerance, equivalence, expression_match) -> {
+      let fields =
+        list.append(fields, [#("tolerance", tolerance_to_json(tolerance))])
+
       let fields = case equivalence {
         None -> fields
         Some(equivalence) ->
@@ -94,10 +108,28 @@ fn math_to_json(spec: types.MathExpressionSpec) -> gleam_json.Json {
           |> append_sampling_if_needed(equivalence)
       }
 
-      let fields = encode_expression_match_policy(fields, expression_match)
-
-      gleam_json.object(fields)
+      encode_expression_match_policy(fields, expression_match)
     }
+
+    types.UnitNumericComparison(spec) ->
+      spec.comparison
+      |> unit_numeric_comparison_fields
+      |> list.append([
+        #("operator", gleam_json.string(numeric_operator(spec.comparison))),
+        #("tolerance", numeric_tolerance_to_json(spec.tolerance)),
+        #("representation", representation_to_json(spec.representation)),
+        #("precision", numeric_precision_to_json(spec.precision)),
+      ])
+      |> list.append(fields)
+  }
+}
+
+fn unit_numeric_comparison_fields(
+  comparison: equality_types.NumericComparison,
+) -> List(#(String, gleam_json.Json)) {
+  case comparison {
+    equality_types.Equal(_) | equality_types.NotEqual(_) -> []
+    _ -> comparison_fields(comparison)
   }
 }
 
@@ -1079,47 +1111,74 @@ fn decode_unit_aware(
     Error(error) -> Error(error)
     Ok(expected) -> {
       let config = decode_unit_config(dynamic)
-      let tolerance = decode_optional_sampling_tolerance(dynamic)
-      let equivalence = decode_optional_unit_algebraic_config(dynamic)
+      let value_matcher = decode_unit_aware_value_matcher(dynamic)
       let match_wrong_units =
         read_optional_bool(dynamic, "matchWrongUnits", False)
       let match_missing_unit =
         read_optional_bool(dynamic, "matchMissingUnit", False)
-      let expression_match = decode_optional_expression_match_policy(dynamic)
 
-      case
-        config,
-        tolerance,
-        equivalence,
-        match_wrong_units,
-        match_missing_unit,
-        expression_match
-      {
+      case config, value_matcher, match_wrong_units, match_missing_unit {
         Ok(config),
-          Ok(tolerance),
-          Ok(equivalence),
+          Ok(value_matcher),
           Ok(match_wrong_units),
-          Ok(match_missing_unit),
-          Ok(expression_match)
+          Ok(match_missing_unit)
         ->
           Ok(types.UnitAware(
             expected: expected,
             config: config,
-            tolerance: tolerance,
-            equivalence: equivalence,
+            value_matcher: value_matcher,
             match_wrong_units: match_wrong_units,
             match_missing_unit: match_missing_unit,
-            expression_match: expression_match,
           ))
-        Error(error), _, _, _, _, _
-        | _, Error(error), _, _, _, _
-        | _, _, Error(error), _, _, _
-        | _, _, _, Error(error), _, _
-        | _, _, _, _, Error(error), _
-        | _, _, _, _, _, Error(error)
+        Error(error), _, _, _
+        | _, Error(error), _, _
+        | _, _, Error(error), _
+        | _, _, _, Error(error)
         -> Error(error)
       }
     }
+  }
+}
+
+fn decode_unit_aware_value_matcher(
+  dynamic: Dynamic,
+) -> Result(types.UnitAwareValueMatcher, types.MatchConfigError) {
+  case read_optional_string(dynamic, "operator") {
+    Error(error) -> Error(error)
+    Ok(Some(_)) -> decode_unit_numeric_value_matcher(dynamic)
+    Ok(None) -> decode_unit_expression_value_matcher(dynamic)
+  }
+}
+
+fn decode_unit_numeric_value_matcher(
+  dynamic: Dynamic,
+) -> Result(types.UnitAwareValueMatcher, types.MatchConfigError) {
+  case decode_numeric_spec(dynamic) {
+    Ok(types.Numeric(spec)) -> Ok(types.UnitNumericComparison(spec: spec))
+    Ok(_) ->
+      Error(types.InvalidField(
+        field: "math",
+        reason: "expected numeric unit-aware matcher",
+      ))
+    Error(error) -> Error(error)
+  }
+}
+
+fn decode_unit_expression_value_matcher(
+  dynamic: Dynamic,
+) -> Result(types.UnitAwareValueMatcher, types.MatchConfigError) {
+  let tolerance = decode_optional_sampling_tolerance(dynamic)
+  let equivalence = decode_optional_unit_algebraic_config(dynamic)
+  let expression_match = decode_optional_expression_match_policy(dynamic)
+
+  case tolerance, equivalence, expression_match {
+    Ok(tolerance), Ok(equivalence), Ok(expression_match) ->
+      Ok(types.UnitExpressionEquality(
+        tolerance: tolerance,
+        equivalence: equivalence,
+        expression_match: expression_match,
+      ))
+    Error(error), _, _ | _, Error(error), _ | _, _, Error(error) -> Error(error)
   }
 }
 

--- a/gleam/src/math/match/types.gleam
+++ b/gleam/src/math/match/types.gleam
@@ -63,12 +63,19 @@ pub type MathExpressionSpec {
   UnitAware(
     expected: String,
     config: unit_types.UnitConfig,
-    tolerance: sampling_types.Tolerance,
-    equivalence: Option(algebraic_types.AlgebraicEquivalenceConfig),
+    value_matcher: UnitAwareValueMatcher,
     match_wrong_units: Bool,
     match_missing_unit: Bool,
+  )
+}
+
+pub type UnitAwareValueMatcher {
+  UnitExpressionEquality(
+    tolerance: sampling_types.Tolerance,
+    equivalence: Option(algebraic_types.AlgebraicEquivalenceConfig),
     expression_match: ExpressionMatchPolicy,
   )
+  UnitNumericComparison(spec: equality_types.NumericSpec)
 }
 
 pub type ExpressionMatchPolicy {

--- a/gleam/test/math_match_test.gleam
+++ b/gleam/test/math_match_test.gleam
@@ -163,6 +163,97 @@ pub fn unit_aware_match_config_evaluates_convertible_units_test() {
     ])
 }
 
+pub fn unit_aware_numeric_config_evaluates_equal_with_number_tolerance_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"equal\",\"tolerance\":{\"type\":\"absolute\",\"value\":0.25},\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "36.72 km/hr")
+    == types.MatchMatched(diagnostics: [types.ConfigAccepted, types.UnitMatched])
+  assert torus_math.evaluate_match(config, "37.08 km/hr")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitNotMatched,
+    ])
+}
+
+pub fn unit_aware_numeric_config_evaluates_ordered_comparisons_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"greater_than\",\"threshold\":\"10\",\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "40 km/hr")
+    == types.MatchMatched(diagnostics: [types.ConfigAccepted, types.UnitMatched])
+  assert torus_math.evaluate_match(config, "35 km/hr")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitNotMatched,
+    ])
+}
+
+pub fn unit_aware_numeric_config_evaluates_ranges_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"between\",\"lower\":\"9\",\"upper\":\"11\",\"bounds\":\"inclusive\",\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "36 km/hr")
+    == types.MatchMatched(diagnostics: [types.ConfigAccepted, types.UnitMatched])
+  assert torus_math.evaluate_match(config, "43.2 km/hr")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitNotMatched,
+    ])
+}
+
+pub fn unit_aware_numeric_config_targets_wrong_units_by_raw_value_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"greater_than\",\"threshold\":\"10\",\"matchWrongUnits\":true,\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "11 cm/s")
+    == types.MatchMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitWrongMatched,
+    ])
+  assert torus_math.evaluate_match(config, "9 cm/s")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitWrongNotMatched,
+    ])
+  assert torus_math.evaluate_match(config, "11 m/s")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitWrongNotMatched,
+    ])
+}
+
+pub fn unit_aware_numeric_config_targets_missing_units_by_raw_value_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"greater_than\",\"threshold\":\"10\",\"matchMissingUnit\":true,\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "11")
+    == types.MatchMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitMissingMatched,
+    ])
+  assert torus_math.evaluate_match(config, "9")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitMissingNotMatched,
+    ])
+  assert torus_math.evaluate_match(config, "11 m/s")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitMissingNotMatched,
+    ])
+}
+
 pub fn unit_aware_match_config_can_target_correct_value_with_wrong_units_test() {
   let source =
     "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10 m/s\",\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"cm/s\"]},\"matchWrongUnits\":true}}"
@@ -372,7 +463,10 @@ pub fn unit_aware_sampling_config_enables_algebraic_value_comparison_test() {
   let assert Ok(config) = torus_math.decode_match_config(source)
   let assert types.MatchConfig(
     matcher: types.MathExpression(types.UnitAware(
-      equivalence: Some(equivalence),
+      value_matcher: types.UnitExpressionEquality(
+        equivalence: Some(equivalence),
+        ..,
+      ),
       ..,
     )),
     ..,

--- a/lib/oli/torus_doc/activities/math_expression_support.ex
+++ b/lib/oli/torus_doc/activities/math_expression_support.ex
@@ -203,6 +203,18 @@ defmodule Oli.TorusDoc.Activities.MathExpressionSupport do
 
   defp numeric_value_field(_operator), do: "expected"
 
+  defp numeric_value_fields(operator, expected, config)
+       when operator in ["between", "not_between"] do
+    %{
+      "lower" => config["lower"] || expected,
+      "upper" => config["upper"] || expected,
+      "bounds" => config["bounds"] || "inclusive"
+    }
+  end
+
+  defp numeric_value_fields(operator, expected, _config),
+    do: %{numeric_value_field(operator) => expected}
+
   defp match_config(subtype, expected, config, response_data) do
     %{
       "version" => 1,
@@ -224,6 +236,19 @@ defmodule Oli.TorusDoc.Activities.MathExpressionSupport do
 
   defp math_spec("latex_direct", expected, _config, _response_data) do
     %{"mode" => "latex_direct", "expected" => expected}
+  end
+
+  defp math_spec("number_with_units", expected, %{"operator" => operator} = config, response_data) do
+    %{
+      "mode" => "unit_aware",
+      "expected" => expected,
+      "operator" => operator
+    }
+    |> Map.merge(numeric_value_fields(operator, expected, config))
+    |> put_if_not_empty("unitPolicy", maybe_unit_policy(config))
+    |> put_if_not_empty("tolerance", tolerance(config))
+    |> maybe_put_match_wrong_units(config, response_data)
+    |> maybe_put_match_missing_unit(config, response_data)
   end
 
   defp math_spec(subtype, expected, config, response_data)
@@ -273,6 +298,9 @@ defmodule Oli.TorusDoc.Activities.MathExpressionSupport do
       "mode",
       "operator",
       "tolerance",
+      "lower",
+      "upper",
+      "bounds",
       "sampling",
       "expression_match",
       "expressionMatch"

--- a/lib/oli_web/endpoint.ex
+++ b/lib/oli_web/endpoint.ex
@@ -25,7 +25,7 @@ defmodule OliWeb.Endpoint do
   plug(Plug.Static,
     at: "/",
     from: :oli,
-    gzip: true,
+    gzip: Mix.env() == :prod,
     only:
       ~w(assets css fonts images js custom branding vlab favicon.ico robots.txt flame_graphs ebsco superactivity)
   )

--- a/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
+++ b/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
@@ -62,6 +62,61 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
           misses("9 cm/s", out_of: 2)
         ]
       ),
+      single("single number with units numeric tolerance",
+        subtype: "number_with_units",
+        unit_policy: convertible_units(["m/s", "km/hr"]),
+        responses: [
+          correct("10", 2,
+            subtype: "number_with_units",
+            tolerance: absolute_tolerance(0.25),
+            operator: "equal",
+            feedback: "unit-tolerance-absolute"
+          ),
+          incorrect()
+        ],
+        cases: [
+          solves("36.72 km/hr", score: 2, out_of: 2, feedback: "unit-tolerance-absolute"),
+          misses("37.08 km/hr", out_of: 2)
+        ]
+      ),
+      single("single number with units numeric greater-than and unit targets",
+        subtype: "number_with_units",
+        unit_policy: convertible_units(["m/s"]),
+        responses: [
+          correct("10", 2,
+            subtype: "number_with_units",
+            operator: "greater_than",
+            feedback: "unit-greater-than"
+          ),
+          targeted("10", 1.5,
+            subtype: "number_with_units",
+            operator: "greater_than",
+            wrong_units: true,
+            feedback: "unit-greater-than-wrong-units"
+          ),
+          targeted("10", 1,
+            subtype: "number_with_units",
+            operator: "greater_than",
+            missing_unit: true,
+            feedback: "unit-greater-than-missing-unit"
+          ),
+          incorrect()
+        ],
+        cases: [
+          solves("11 m/s", score: 2, out_of: 2, feedback: "unit-greater-than"),
+          solves("11 cm/s",
+            score: 1.5,
+            out_of: 2,
+            feedback: "unit-greater-than-wrong-units"
+          ),
+          solves("11",
+            score: 1,
+            out_of: 2,
+            feedback: "unit-greater-than-missing-unit"
+          ),
+          misses("9 cm/s", out_of: 2)
+        ]
+      ),
       single("single algebraic expression with units and unit-targeted custom scoring",
         subtype: "expression_with_units",
         answer: "x m/s",
@@ -480,6 +535,10 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
     |> maybe_put("validation", Keyword.get(opts, :validation))
     |> maybe_put("unit_policy", Keyword.get(opts, :unit_policy))
     |> maybe_put("tolerance", Keyword.get(opts, :tolerance))
+    |> maybe_put("operator", Keyword.get(opts, :operator))
+    |> maybe_put("lower", Keyword.get(opts, :lower))
+    |> maybe_put("upper", Keyword.get(opts, :upper))
+    |> maybe_put("bounds", Keyword.get(opts, :bounds))
   end
 
   defp variables(names, domains) do

--- a/test/oli/torus_doc/activities/math_expression_converter_test.exs
+++ b/test/oli/torus_doc/activities/math_expression_converter_test.exs
@@ -208,6 +208,44 @@ defmodule Oli.TorusDoc.Activities.MathExpressionConverterTest do
                "threshold" => "3"
              }
     end
+
+    test "converts number with units numeric operators and tolerance" do
+      yaml = """
+      type: oli_short_answer
+      stem_md: "Enter ten meters per second."
+      input_type: math_expression
+      math_expression:
+        subtype: number_with_units
+        unit_policy:
+          type: convertible_units
+          units: ["m/s", "km/hr"]
+      responses:
+        - answer: "10"
+          score: 1
+          correct: true
+          math_expression:
+            operator: equal
+            tolerance:
+              type: absolute
+              value: 0.25
+      """
+
+      assert {:ok, json} = ActivityConverter.from_yaml(yaml)
+
+      math =
+        json["authoring"]["parts"]
+        |> hd()
+        |> Map.fetch!("responses")
+        |> hd()
+        |> get_in(["matchConfig", "math"])
+
+      assert math == %{
+               "mode" => "unit_aware",
+               "expected" => "10",
+               "operator" => "equal",
+               "tolerance" => %{"type" => "absolute", "value" => 0.25}
+             }
+    end
   end
 
   describe "multi input math_expression YAML" do


### PR DESCRIPTION
Adds support to the "Number with Units" model to allow exact equality, greater than, less than, between, tolerance, etc. Now an author can build a question where the correct answer can be "1.5 m/s" exactly, or "1.5 m/s" with a 0.1 tolerance, etc. 

Also fixes some client-side React warnings.  