### PR TITLE
[FEATURE] [MER-5631] Student interface SAYG icons

### DIFF
--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -16,7 +16,7 @@ defmodule OliWeb.Components.Delivery.Student do
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
         <path
           d="M3.88301 14.0007L4.96634 9.31732L1.33301 6.16732L6.13301 5.75065L7.99967 1.33398L9.86634 5.75065L14.6663 6.16732L11.033 9.31732L12.1163 14.0007L7.99967 11.5173L3.88301 14.0007Z"
-          class="fill-Icon-icon-accent-green-bold"
+          class="fill-Text-text-accent-green"
         />
       </svg>
       <span class="text-[12px] leading-[16px] tracking-[0.02px] text-Text-text-accent-green font-semibold whitespace-nowrap">
@@ -31,7 +31,7 @@ defmodule OliWeb.Components.Delivery.Student do
   def score_as_you_go_summary(assigns) do
     ~H"""
     <div role="score summary" class="flex gap-[6px] ml-auto">
-      <Icons.score_as_you_go />
+      <Icons.score_as_you_go color="text-Text-text-accent-green" />
       <span class="text-[12px] leading-[16px] tracking-[0.02px] text-Text-text-accent-green font-semibold whitespace-nowrap">
         {Utils.format_score(@raw_avg_score[:score])} / {Utils.format_score(@raw_avg_score[:out_of])}
       </span>
@@ -88,7 +88,7 @@ defmodule OliWeb.Components.Delivery.Student do
     <div class="self-stretch justify-start items-start gap-6 inline-flex relative mb-1">
       <button
         id={"#{@id}-dropdown-button"}
-        class="text-Text-text-high text-sm font-bold font-['Open Sans'] uppercase whitespace-nowrap tracking-wider"
+        class="text-Text-text-low text-sm font-bold font-['Open Sans'] uppercase whitespace-nowrap tracking-wider"
         phx-click={show_attempts_dropdown("##{@id}-dropdown", @page_revision_slug)}
         phx-value-hide-target={"##{@id}-dropdown"}
       >
@@ -183,11 +183,13 @@ defmodule OliWeb.Components.Delivery.Student do
           <i class="fa-solid fa-xmark"></i>
         </button>
       </div>
-      <div class="flex flex-row p-2 justify-start vertical-align">
-        <div class="mr-2"><strong>SCORE AS YOU GO</strong></div>
-        <div>
-          <Icons.score_as_you_go />
-          <span class="text-[12px] leading-[16px] tracking-[0.02px] text-Text-text-accent-green font-semibold whitespace-nowrap">
+      <div class="flex flex-row items-center p-2 justify-start">
+        <div class="mr-2 leading-none text-Text-text-low"><strong>SCORE AS YOU GO:</strong></div>
+        <div class="flex items-center gap-1.5">
+          <span class="[&>svg]:h-[18px] [&>svg]:w-[18px]">
+            <Icons.score_as_you_go color="text-Text-text-accent-green" />
+          </span>
+          <span class="text-[18px] leading-[18px] tracking-[0.02px] text-Text-text-accent-green font-bold whitespace-nowrap">
             {Utils.format_score(@raw_avg_score[:score])} / {Utils.format_score(
               @raw_avg_score[:out_of]
             )}

--- a/lib/oli_web/live/delivery/student/assignments_live.ex
+++ b/lib/oli_web/live/delivery/student/assignments_live.ex
@@ -318,24 +318,30 @@ defmodule OliWeb.Delivery.Student.AssignmentsLive do
       </div>
       <div :if={@assignment.raw_avg_score} class="ml-auto h-12 flex flex-col justify-between">
         <%= if @assignment.score_as_you_go do %>
-          <span class="h-6 ml-auto text-Text-text-low dark:text-[#eeebf5]/75 text-xs font-semibold leading-3 whitespace-nowrap">
+          <span class="h-6 ml-auto text-Text-text-low-alpha text-xs font-semibold leading-3 whitespace-nowrap">
             Score as you go
           </span>
         <% else %>
-          <span class="h-6 ml-auto text-Text-text-low dark:text-[#eeebf5]/75 text-xs font-semibold leading-3 whitespace-nowrap">
+          <span class="h-6 ml-auto text-Text-text-low-alpha text-xs font-semibold leading-3 whitespace-nowrap">
             Attempt {@assignment.attempts} of {max_attempts(@assignment.max_attempts)}
           </span>
         <% end %>
-        <div class="flex ml-auto gap-1.5 text-[#218358] dark:text-[#39e581]">
-          <div class="w-4 h-4">
+        <div class="flex ml-auto items-center gap-1.5">
+          <div class={[
+            "inline-flex w-4 h-4 shrink-0 items-center justify-center text-Icon-icon-accent-green-bold",
+            if(@assignment.score_as_you_go and @assignment.can_start, do: "-translate-y-px")
+          ]}>
             <%= if @assignment.score_as_you_go and @assignment.can_start do %>
-              <Icons.score_as_you_go />
+              <Icons.score_as_you_go color="text-Icon-icon-accent-green-bold" />
             <% else %>
               <Icons.star />
             <% end %>
           </div>
 
-          <span class="flex gap-1 text-base font-bold leading-none whitespace-nowrap">
+          <span class={[
+            "flex gap-1 text-base font-bold leading-none whitespace-nowrap text-Text-text-accent-green",
+            if(@assignment.score_as_you_go and @assignment.can_start, do: "-translate-y-px")
+          ]}>
             {Utils.parse_score(@assignment.raw_avg_score.score)} / {Utils.parse_score(
               @assignment.raw_avg_score.out_of
             )}

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -1261,11 +1261,13 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   # Non-completed graded page (assignment)
   defp lesson_details(%{lesson: %{graded: true, batch_scoring: false}} = assigns) do
     ~H"""
-    <div role="details" class="pt-2 pb-1 px-1 flex self-stretch justify-between gap-5">
-      <div class="flex justify-between gap-2.5 w-full">
-        <div>Score as you go</div>
-        <div class="text-green-700 dark:text-green-500 flex justify-end items-center gap-1">
-          <div class="relative"><Icons.score_as_you_go /></div>
+    <div role="details" class="pt-2 pb-1 px-2 flex self-stretch justify-between gap-5">
+      <div class="flex items-center justify-between gap-2.5 w-full">
+        <div class="text-sm font-semibold leading-4 text-Text-text-low-alpha">Score as you go</div>
+        <div class="flex justify-end items-center gap-1 text-Icon-icon-accent-green-bold">
+          <div class="inline-flex h-4 w-4 shrink-0 items-center justify-center">
+            <Icons.score_as_you_go color="text-Icon-icon-accent-green-bold" />
+          </div>
           <div role="score" class="text-sm font-semibold tracking-tight">
             {Utils.format_score(@lesson.score)}
           </div>
@@ -1339,8 +1341,8 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         :if={nil not in [@lesson.score, @lesson.out_of]}
         class="justify-end items-end gap-2.5 flex ml-auto"
       >
-        <div class="text-green-700 dark:text-green-500 flex justify-end items-center gap-1">
-          <div class="w-4 h-4 relative"><Icons.star /></div>
+        <div class="flex justify-end items-center gap-1 text-Icon-icon-accent-green-bold">
+          <div class="inline-flex h-4 w-4 shrink-0 items-center justify-center"><Icons.star /></div>
           <div role="score" class="text-sm font-semibold tracking-tight">
             {Utils.format_score(@lesson.score)}
           </div>


### PR DESCRIPTION
[MER-5631](https://eliterate.atlassian.net/browse/MER-5631)

## Summary

This PR updates the student-facing Score as You Go indicators so they are consistent across the Assignments tab, course Home page, and Schedule view. It keeps the existing SAYG behavior intact and only adjusts how the label, score, and icon are presented.

### Changes

- Updates SAYG score display in the Assignments tab to use the SAYG icon, label, and design tokens for label, icon, and score colors.
- Updates the Home page assignment score details so SAYG assignments show the `Score as you go` label and SAYG icon, while non-SAYG assignments continue to use the standard score icon.
- Updates Schedule score summaries and the score information dropdown to use the SAYG icon, SAYG label, and supporting score message.

### Visual Changes

### Home 
<img width="630" height="189" alt="Captura de pantalla 2026-06-09 a la(s) 8 12 41 p  m" src="https://github.com/user-attachments/assets/4b93b16b-03de-4b96-abb0-0d3a75fead91" />

---

<img width="627" height="181" alt="Captura de pantalla 2026-06-09 a la(s) 8 12 57 p  m" src="https://github.com/user-attachments/assets/2f65a3ab-d0c3-4ba8-b545-6ea5b59f2d5c" />

### Assignments 

<img width="1105" height="92" alt="Captura de pantalla 2026-06-09 a la(s) 8 13 36 p  m" src="https://github.com/user-attachments/assets/4d2acd62-114a-41f7-ae83-1a50c8a44339" />
<img width="1128" height="251" alt="Captura de pantalla 2026-06-09 a la(s) 8 13 45 p  m" src="https://github.com/user-attachments/assets/6c4c1fd1-774e-4a05-8455-31543cf595c1" />

---

<img width="1122" height="101" alt="Captura de pantalla 2026-06-09 a la(s) 8 13 08 p  m" src="https://github.com/user-attachments/assets/95c73757-4ce1-42b6-8123-86b4e33c1dc3" />
<img width="1112" height="254" alt="Captura de pantalla 2026-06-09 a la(s) 8 13 22 p  m" src="https://github.com/user-attachments/assets/a50ac097-9183-4648-9538-f7fc97c5229f" />

### Schedule
<img width="1534" height="87" alt="Captura de pantalla 2026-06-09 a la(s) 8 13 56 p  m" src="https://github.com/user-attachments/assets/b69f6825-9920-47cc-bed5-ce1c26680159" />

---


<img width="1523" height="72" alt="Captura de pantalla 2026-06-09 a la(s) 8 14 04 p  m" src="https://github.com/user-attachments/assets/7171ff91-c1cb-46c2-acda-078d2ddb6fa8" />


[MER-5631]: https://eliterate.atlassian.net/browse/MER-5631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ