### PR TITLE
[ENHANCEMENT] [MER-5666] Duplicates all activity exclusions from one section to another

### DIFF
--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -22,7 +22,47 @@ defmodule Oli.Delivery.InstructorCustomizations do
 
   @default_candidate_limit 25
 
+  @doc """
+  Duplicates all activity exclusions from one section to another.
+
+  This is used when a template/blueprint is duplicated into a new section so
+  template-owned exclusions are inherited without changing authored content.
+  """
+  def duplicate_section_exclusions(source_section_or_id, destination_section_or_id) do
+    source_section_id = section_id(source_section_or_id)
+    destination_section_id = section_id(destination_section_or_id)
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    exclusions =
+      source_section_id
+      |> get_section_exclusions()
+      |> Enum.map(fn exclusion ->
+        %{
+          section_id: destination_section_id,
+          page_resource_id: exclusion.page_resource_id,
+          selection_id: exclusion.selection_id,
+          kind: exclusion.kind,
+          excluded_resource_id: exclusion.excluded_resource_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    {count, _} = Repo.insert_all(ActivityExclusion, exclusions, on_conflict: :nothing)
+
+    {:ok, count}
+  end
+
   # Reads
+
+  defp get_section_exclusions(section_id) do
+    from(exclusion in ActivityExclusion,
+      where: exclusion.section_id == ^section_id,
+      order_by: exclusion.id,
+      select: struct(exclusion, [:page_resource_id, :selection_id, :kind, :excluded_resource_id])
+    )
+    |> Repo.all()
+  end
 
   @doc """
   Returns raw exclusions for trusted internal callers.

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -33,36 +33,26 @@ defmodule Oli.Delivery.InstructorCustomizations do
     destination_section_id = section_id(destination_section_or_id)
     now = DateTime.utc_now() |> DateTime.truncate(:second)
 
-    exclusions =
-      source_section_id
-      |> get_section_exclusions()
-      |> Enum.map(fn exclusion ->
-        %{
-          section_id: destination_section_id,
+    query =
+      from(exclusion in ActivityExclusion,
+        where: exclusion.section_id == ^source_section_id,
+        select: %{
+          section_id: ^destination_section_id,
           page_resource_id: exclusion.page_resource_id,
           selection_id: exclusion.selection_id,
           kind: exclusion.kind,
           excluded_resource_id: exclusion.excluded_resource_id,
-          inserted_at: now,
-          updated_at: now
+          inserted_at: ^now,
+          updated_at: ^now
         }
-      end)
+      )
 
-    {count, _} = Repo.insert_all(ActivityExclusion, exclusions, on_conflict: :nothing)
+    {count, _} = Repo.insert_all(ActivityExclusion, query, on_conflict: :nothing)
 
     {:ok, count}
   end
 
   # Reads
-
-  defp get_section_exclusions(section_id) do
-    from(exclusion in ActivityExclusion,
-      where: exclusion.section_id == ^section_id,
-      order_by: exclusion.id,
-      select: struct(exclusion, [:page_resource_id, :selection_id, :kind, :excluded_resource_id])
-    )
-    |> Repo.all()
-  end
 
   @doc """
   Returns raw exclusions for trusted internal callers.

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -9,6 +9,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
   alias Oli.Delivery.Sections.PostProcessing
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.BlueprintBrowseOptions
+  alias Oli.Delivery.InstructorCustomizations
   alias Oli.Groups.CommunityVisibility
   alias Oli.Institutions.Institution
   alias Oli.Repo
@@ -265,7 +266,9 @@ defmodule Oli.Delivery.Sections.Blueprint do
            {:ok, blueprint} <-
              Sections.update_section(blueprint, %{
                root_section_resource_id: duplicated_root_resource.id
-             }) do
+             }),
+           {:ok, _count} <-
+             InstructorCustomizations.duplicate_section_exclusions(section, blueprint) do
         Oli.Delivery.Gating.duplicate_gates(section, blueprint)
 
         blueprint

--- a/test/oli/delivery/instructor_customizations/context_test.exs
+++ b/test/oli/delivery/instructor_customizations/context_test.exs
@@ -106,6 +106,82 @@ defmodule Oli.Delivery.InstructorCustomizationsTest do
     end
   end
 
+  describe "duplicate_section_exclusions/2" do
+    test "copies all exclusion kinds from one section to another", context do
+      destination_section = insert(:section)
+
+      insert_exclusion(context, :embedded_activity)
+      insert_exclusion(context, :bank_selection)
+      insert_exclusion(context, :bank_candidate)
+
+      assert {:ok, 3} =
+               InstructorCustomizations.duplicate_section_exclusions(
+                 context.section,
+                 destination_section
+               )
+
+      assert %PageExclusions{
+               section_id: section_id,
+               page_resource_id: page_resource_id,
+               excluded_activity_ids: excluded_activity_ids,
+               excluded_selection_ids: excluded_selection_ids,
+               excluded_bank_candidate_ids_by_selection: candidates
+             } =
+               InstructorCustomizations.get_page_exclusion_view(
+                 destination_section,
+                 context.page_resource.id
+               )
+
+      assert section_id == destination_section.id
+      assert page_resource_id == context.page_resource.id
+      assert excluded_activity_ids == MapSet.new([context.activity_resource.id])
+      assert excluded_selection_ids == MapSet.new(["selection-1"])
+      assert candidates == %{"selection-1" => MapSet.new([context.candidate_resource.id])}
+
+      assert length(
+               InstructorCustomizations.get_page_exclusions(
+                 context.section,
+                 context.page_resource.id
+               )
+             ) == 3
+    end
+
+    test "is idempotent for the same destination section", context do
+      destination_section = insert(:section)
+
+      insert_exclusion(context, :embedded_activity)
+
+      assert {:ok, 1} =
+               InstructorCustomizations.duplicate_section_exclusions(
+                 context.section.id,
+                 destination_section.id
+               )
+
+      assert {:ok, 0} =
+               InstructorCustomizations.duplicate_section_exclusions(
+                 context.section.id,
+                 destination_section.id
+               )
+
+      assert [
+               %ActivityExclusion{
+                 section_id: section_id,
+                 page_resource_id: page_resource_id,
+                 kind: :embedded_activity,
+                 excluded_resource_id: excluded_resource_id
+               }
+             ] =
+               InstructorCustomizations.get_page_exclusions(
+                 destination_section.id,
+                 context.page_resource.id
+               )
+
+      assert section_id == destination_section.id
+      assert page_resource_id == context.page_resource.id
+      assert excluded_resource_id == context.activity_resource.id
+    end
+  end
+
   describe "predicate helpers" do
     test "answers enabled state from the page view", context do
       view =

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -5,6 +5,8 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
   import Ecto.Query, warn: false
 
   alias Oli.Authoring.Course
+  alias Oli.Delivery.InstructorCustomizations
+  alias Oli.Delivery.InstructorCustomizations.ActivityExclusion
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Publishing
@@ -194,6 +196,65 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
         |> MapSet.new()
 
       assert MapSet.size(duped) == MapSet.size(original)
+    end
+
+    test "duplicate/2 copies template activity exclusions into the created section" do
+      %{authors: [author]} = project = create_project_with_assocs()
+
+      %{resource: container_resource, revision: container_revision, publication: publication} =
+        create_bundle_for(@container_type_id, project, author, nil, nil, title: "Root container")
+
+      %{resource: page_resource} =
+        create_bundle_for(@page_type_id, project, author, publication, nil, graded: true)
+
+      assoc_resources([page_resource], container_revision, container_resource, publication)
+
+      {:ok, blueprint} =
+        insert(:section, base_project: project, open_and_free: true, type: :blueprint)
+        |> Sections.create_section_resources(publication)
+
+      page_resource_id = page_resource.id
+
+      excluded_activity_resource = insert(:resource)
+      excluded_candidate_resource = insert(:resource)
+
+      insert_activity_exclusion!(blueprint.id, page_resource_id, %{
+        kind: :embedded_activity,
+        excluded_resource_id: excluded_activity_resource.id
+      })
+
+      insert_activity_exclusion!(blueprint.id, page_resource_id, %{
+        kind: :bank_selection,
+        selection_id: "selection-1"
+      })
+
+      insert_activity_exclusion!(blueprint.id, page_resource_id, %{
+        kind: :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: excluded_candidate_resource.id
+      })
+
+      section_params = %{
+        type: :enrollable,
+        title: "Section from Template",
+        open_and_free: true,
+        blueprint_id: blueprint.id
+      }
+
+      assert {:ok, duplicate} = Blueprint.duplicate(blueprint, section_params)
+
+      assert %InstructorCustomizations.PageExclusions{
+               section_id: section_id,
+               page_resource_id: ^page_resource_id,
+               excluded_activity_ids: excluded_activity_ids,
+               excluded_selection_ids: excluded_selection_ids,
+               excluded_bank_candidate_ids_by_selection: candidates
+             } = InstructorCustomizations.get_page_exclusion_view(duplicate, page_resource_id)
+
+      assert section_id == duplicate.id
+      assert excluded_activity_ids == MapSet.new([excluded_activity_resource.id])
+      assert excluded_selection_ids == MapSet.new(["selection-1"])
+      assert candidates == %{"selection-1" => MapSet.new([excluded_candidate_resource.id])}
     end
 
     test "list/0 lists all the active products" do
@@ -452,6 +513,12 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       assert product1.id in product_ids
       refute product2.id in product_ids
       refute product3.id in product_ids
+    end
+
+    def insert_activity_exclusion!(section_id, page_resource_id, attrs) do
+      %ActivityExclusion{}
+      |> ActivityExclusion.changeset(section_id, page_resource_id, attrs)
+      |> Repo.insert!()
     end
 
     def get_resources(id) do


### PR DESCRIPTION
## Summary

  - Add duplication support for instructor activity exclusions between sections.
  - Copy template/blueprint activity exclusions when `Blueprint.duplicate/3` creates a section from a template.
  - Add context and blueprint duplication tests for embedded activity, bank selection, and bank candidate exclusions.
