### PR TITLE
[ENHANCEMENT] [MER-5629] SAYG reset modal updates

### DIFF
--- a/assets/src/components/activities/DeliveryElement.ts
+++ b/assets/src/components/activities/DeliveryElement.ts
@@ -54,6 +54,10 @@ export interface ActivityContext {
   oneAtATime: boolean;
   maxAttempts: number;
   scoringStrategyId: number;
+  replacementStrategy?: 'none' | 'dynamic';
+  aggregateScore?: number | null;
+  aggregateOutOf?: number | null;
+  aggregateIncludesCurrentAttempt?: boolean;
   ordinal: number;
   sectionSlug: string;
   projectSlug: string;

--- a/assets/src/components/activities/common/ScoreAsYouGoSubmitReset.tsx
+++ b/assets/src/components/activities/common/ScoreAsYouGoSubmitReset.tsx
@@ -8,14 +8,14 @@ import { ScoreAsYouGoIcon } from './utils';
 
 interface Props {
   onSubmit: () => void;
-  onReset: () => void;
+  onReset: () => unknown;
   mode: DeliveryMode;
 }
 
 interface ModalProps {
-  onDone: () => void;
+  onDone: () => unknown;
   onCancel: () => void;
-  message: any;
+  message: React.ReactNode;
 }
 export const ResetModal = ({ onDone, onCancel, message }: ModalProps) => {
   const [busy, setBusy] = React.useState(false);
@@ -28,10 +28,17 @@ export const ResetModal = ({ onDone, onCancel, message }: ModalProps) => {
 
   return (
     <Modal
-      title="Reset Question"
+      title="Reset this question?"
       size={ModalSize.MEDIUM}
-      okLabel={busy ? 'Working…' : 'Ok'}
+      contentClassName="!bg-Background-bg-primary !text-Text-text-high"
+      headerClassName="!border-0 !px-6 sm:!px-8 !pt-6 sm:!pt-8 !pb-4"
+      titleClassName="font-open-sans !text-[18px] !font-semibold !leading-[24px] text-Text-text-high"
+      bodyClassName="!px-6 sm:!px-8 !py-0"
+      footerClassName="!border-0 !px-6 sm:!px-8 !pt-6 !pb-6 sm:!pb-8 !gap-4"
+      okLabel={busy ? 'Resetting…' : 'Reset'}
+      okClassName="m-0 inline-flex min-w-[64px] items-center justify-center rounded-md bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-[16px] text-white hover:bg-Fill-Buttons-fill-primary-hover disabled:cursor-not-allowed disabled:opacity-60"
       cancelLabel="Cancel"
+      cancelClassName="m-0 inline-flex min-w-[64px] items-center justify-center rounded-md border border-Border-border-bold bg-Background-bg-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-[16px] text-Specially-Tokens-Text-text-button-secondary hover:no-underline"
       onCancel={() => onCancel()}
       onOk={handleOk}
       disableOk={busy}
@@ -41,33 +48,117 @@ export const ResetModal = ({ onDone, onCancel, message }: ModalProps) => {
   );
 };
 
-function buildConfirmMessage(uiState: ActivityDeliveryState): any {
-  const { activityContext } = uiState;
+interface Score {
+  score: number;
+  outOf: number;
+}
 
-  let scoringDesc = 'average';
-  switch (activityContext.scoringStrategyId) {
-    case 1:
-      scoringDesc = 'average';
-      break;
-    case 2:
-      scoringDesc = 'best';
-      break;
-    case 3:
-      scoringDesc = 'most recent';
-      break;
+const numberFormat = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return '';
   }
 
+  return Number.isInteger(value) ? value.toString() : value.toFixed(2);
+};
+
+const percentage = ({ score, outOf }: Score) => (outOf === 0 ? 0 : score / outOf);
+
+export function getDisplayedScore(uiState: ActivityDeliveryState): Score {
+  const { activityContext, attemptState } = uiState;
+  const current = {
+    score: attemptState.score || 0,
+    outOf: attemptState.outOf || 0,
+  };
+  const aggregate =
+    activityContext.aggregateScore === null ||
+    activityContext.aggregateScore === undefined ||
+    activityContext.aggregateOutOf === null ||
+    activityContext.aggregateOutOf === undefined
+      ? null
+      : {
+          score: activityContext.aggregateScore,
+          outOf: activityContext.aggregateOutOf,
+        };
+
+  if (activityContext.aggregateIncludesCurrentAttempt && aggregate) {
+    return aggregate;
+  }
+
+  if (!aggregate || attemptState.attemptNumber <= 1) {
+    return current;
+  }
+
+  switch (activityContext.scoringStrategyId) {
+    case 2:
+      return percentage(current) >= percentage(aggregate) ? current : aggregate;
+    case 3:
+      return current;
+    default: {
+      const previousAttempts = attemptState.attemptNumber - 1;
+      const outOf = Math.max(aggregate.outOf, current.outOf);
+      const averagePercentage =
+        (percentage(aggregate) * previousAttempts + percentage(current)) /
+        attemptState.attemptNumber;
+
+      return { score: averagePercentage * outOf, outOf };
+    }
+  }
+}
+
+export function buildConfirmMessage(uiState: ActivityDeliveryState): React.ReactNode {
+  const { activityContext, attemptState } = uiState;
+  const displayedScore = getDisplayedScore(uiState);
+  const score = `${numberFormat(displayedScore.score)}/${numberFormat(displayedScore.outOf)}`;
+  const multipleAttempts = attemptState.attemptNumber > 1;
+  const attemptsRemaining =
+    activityContext.maxAttempts > 0
+      ? Math.max(activityContext.maxAttempts - attemptState.attemptNumber, 0)
+      : null;
+  const hasReplacement = activityContext.replacementStrategy === 'dynamic';
+
+  const scoreLabel =
+    activityContext.scoringStrategyId === 2 ? 'Your best score' : 'Your current score';
+  const attemptsDescription = multipleAttempts
+    ? activityContext.scoringStrategyId === 1
+      ? ` (average of ${attemptState.attemptNumber} attempts)`
+      : ` (${attemptState.attemptNumber} attempts)`
+    : '';
+
+  const scoreImpact =
+    activityContext.scoringStrategyId === 2 ? (
+      <>
+        Your best score will be kept. You can try again to improve your score; a lower score will
+        not reduce your current best.
+      </>
+    ) : activityContext.scoringStrategyId === 3 ? (
+      <>
+        Your next attempt will replace your current score. Scoring below {score} will lower your
+        score.
+      </>
+    ) : (
+      <>Your score is the average of all attempts. Scoring below {score} will lower your score.</>
+    );
+
   return (
-    <div>
-      <p>
-        Are you sure you want to reset <strong>Question #{activityContext.ordinal}</strong>? If you
-        choose to reset this question, <strong>a new question may be generated</strong>. Your
-        overall score on this question will be the <strong>{scoringDesc} of all attempts</strong> of
-        all your attempts.
+    <div className="font-open-sans text-[14px] font-normal leading-[21px] text-Text-text-high">
+      <p className="mb-1">
+        <strong>{scoreLabel}: </strong>
+        <strong>{score} points</strong>
+        {attemptsDescription}
       </p>
-      <p className="mt-3">
-        If you do not answer the question after resetting, your score could be affected
+      {attemptsRemaining !== null && (
+        <p className="mb-1">
+          <strong>Attempts Remaining: {attemptsRemaining}</strong>
+          {attemptsRemaining === 1 && ' (last attempt)'}
+        </p>
+      )}
+      <p className="mb-1">
+        Resetting {hasReplacement ? 'may give you a ' : 'will clear your answer and '}
+        {hasReplacement && <strong>new version of this question</strong>}
+        {hasReplacement && ' and '}
+        count as another attempt.
       </p>
+      <p className="mb-0">{scoreImpact}</p>
     </div>
   );
 }
@@ -90,18 +181,13 @@ export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset, mo
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   const { attemptState } = uiState;
   const didConfirmRef = React.useRef(false);
+  const resetButtonRef = React.useRef<HTMLButtonElement>(null);
   const [modalOpen, setModalOpen] = React.useState(false);
 
-  const numberFormat = (value: number | null) => {
-    if (value === null) {
-      return '';
-    }
-    // If the number is an integer, return it as is
-    if (Number.isInteger(value)) {
-      return value.toString();
-    }
-    // Otherwise, return it with two decimal places
-    return value.toFixed(2);
+  const closeModal = () => {
+    setModalOpen(false);
+    window.oliDispatch(modalActions.dismiss());
+    window.setTimeout(() => resetButtonRef.current?.focus(), 0);
   };
 
   if (uiState.activityContext.graded) {
@@ -117,6 +203,7 @@ export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset, mo
         return (
           <div className="mt-3 flex w-full items-center justify-between gap-4">
             <button
+              ref={resetButtonRef}
               type="button"
               className="inline-flex items-center p-0 bg-transparent border-0"
               disabled={isResetDisabled(uiState, mode)}
@@ -126,17 +213,19 @@ export const ScoreAsYouGoSubmitReset: React.FC<Props> = ({ onSubmit, onReset, mo
                 window.oliDispatch(
                   modalActions.display(
                     <ResetModal
-                      onDone={() => {
+                      onDone={async () => {
                         if (didConfirmRef.current) return; // one-shot protection
                         didConfirmRef.current = true;
-                        setModalOpen(false);
-                        window.oliDispatch(modalActions.dismiss());
-                        onReset();
+                        closeModal();
+                        try {
+                          await onReset();
+                        } finally {
+                          didConfirmRef.current = false;
+                        }
                       }}
                       onCancel={() => {
                         didConfirmRef.current = false;
-                        setModalOpen(false);
-                        window.oliDispatch(modalActions.dismiss());
+                        closeModal();
                       }}
                       message={buildConfirmMessage(uiState)}
                     />,

--- a/assets/test/components/activities/common/score_as_you_go_submit_reset_test.tsx
+++ b/assets/test/components/activities/common/score_as_you_go_submit_reset_test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { Provider } from 'react-redux';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createStore } from 'redux';
+import {
+  ResetModal,
+  ScoreAsYouGoSubmitReset,
+  buildConfirmMessage,
+  getDisplayedScore,
+} from 'components/activities/common/ScoreAsYouGoSubmitReset';
+import { ActivityDeliveryState } from 'data/activities/DeliveryState';
+
+const buildState = (
+  scoringStrategyId: number,
+  overrides: Partial<ActivityDeliveryState['activityContext']> = {},
+): ActivityDeliveryState =>
+  ({
+    model: {},
+    activityContext: {
+      graded: true,
+      batchScoring: false,
+      oneAtATime: false,
+      maxAttempts: 4,
+      scoringStrategyId,
+      replacementStrategy: 'none',
+      aggregateScore: 7,
+      aggregateOutOf: 8,
+      aggregateIncludesCurrentAttempt: true,
+      ordinal: 1,
+      sectionSlug: '',
+      projectSlug: '',
+      userId: 1,
+      groupId: null,
+      surveyId: null,
+      bibParams: [],
+      pageAttemptGuid: '',
+      showFeedback: true,
+      renderPointMarkers: false,
+      isAnnotationLevel: true,
+      variables: {},
+      pageLinkParams: {},
+      allowHints: false,
+      ...overrides,
+    },
+    attemptState: {
+      attemptGuid: 'attempt-guid',
+      attemptNumber: 2,
+      dateEvaluated: new Date(),
+      dateSubmitted: new Date(),
+      score: 6,
+      outOf: 8,
+      parts: [],
+      hasMoreAttempts: true,
+      hasMoreHints: false,
+      groupId: null,
+    },
+    partState: {},
+  } as ActivityDeliveryState);
+
+describe('ScoreAsYouGoSubmitReset', () => {
+  it('renders average strategy score impact and remaining attempts', () => {
+    render(<>{buildConfirmMessage(buildState(1))}</>);
+
+    expect(screen.getByText(/Your current score:/).closest('p')).toHaveTextContent(
+      'Your current score: 7/8 points (average of 2 attempts)',
+    );
+    expect(screen.getByText(/Attempts Remaining:/)).toHaveTextContent('Attempts Remaining: 2');
+    expect(screen.getByText(/Your score is the average/)).toHaveTextContent(
+      'Your score is the average of all attempts. Scoring below 7/8 will lower your score.',
+    );
+  });
+
+  it('renders best strategy score protection and last-attempt language', () => {
+    render(<>{buildConfirmMessage(buildState(2, { maxAttempts: 3 }))}</>);
+
+    expect(screen.getByText(/Your best score:/).closest('p')).toHaveTextContent(
+      'Your best score: 7/8 points (2 attempts)',
+    );
+    expect(screen.getByText(/Attempts Remaining:/).closest('p')).toHaveTextContent(
+      'Attempts Remaining: 1 (last attempt)',
+    );
+    expect(screen.getByText(/Your best score will be kept/)).toHaveTextContent(
+      'a lower score will not reduce your current best.',
+    );
+  });
+
+  it('renders most-recent replacement language and omits unlimited attempts remaining', () => {
+    render(
+      <>
+        {buildConfirmMessage(
+          buildState(3, {
+            maxAttempts: 0,
+            replacementStrategy: 'dynamic',
+          }),
+        )}
+      </>,
+    );
+
+    expect(screen.queryByText(/Attempts Remaining:/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Resetting may give you/)).toHaveTextContent(
+      'Resetting may give you a new version of this question and count as another attempt.',
+    );
+    expect(screen.getByText(/Your next attempt will replace/)).toHaveTextContent(
+      'Your next attempt will replace your current score. Scoring below 7/8 will lower your score.',
+    );
+  });
+
+  it('derives the new average immediately after a client-side submission', () => {
+    const state = buildState(1, {
+      aggregateScore: 8,
+      aggregateOutOf: 8,
+      aggregateIncludesCurrentAttempt: false,
+    });
+    state.attemptState.score = 6;
+
+    expect(getDisplayedScore(state)).toEqual({ score: 7, outOf: 8 });
+  });
+
+  it('does not reset until the confirmation callback is invoked', async () => {
+    const state = buildState(1);
+    const store = createStore(() => state);
+    const onReset = jest.fn().mockResolvedValue(undefined);
+    const dispatch = jest.fn();
+    window.oliDispatch = dispatch;
+
+    render(
+      <Provider store={store}>
+        <ScoreAsYouGoSubmitReset mode="delivery" onSubmit={jest.fn()} onReset={onReset} />
+      </Provider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset Question/ }));
+
+    expect(onReset).not.toHaveBeenCalled();
+    const firstModal = dispatch.mock.calls[0][0].component as React.ReactElement;
+    expect(firstModal.type).toBe(ResetModal);
+
+    act(() => firstModal.props.onCancel());
+    expect(onReset).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset Question/ }));
+    const secondModal = dispatch.mock.calls[2][0].component as React.ReactElement;
+
+    await act(async () => secondModal.props.onDone());
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/oli/delivery/page/activity_context.ex
+++ b/lib/oli/delivery/page/activity_context.ex
@@ -67,6 +67,9 @@ defmodule Oli.Delivery.Page.ActivityContext do
          script: type.delivery_script,
          graded: graded,
          has_more_attempts: state.hasMoreAttempts,
+         aggregate_score: activity_attempt.aggregate_score,
+         aggregate_out_of: activity_attempt.aggregate_out_of,
+         aggregate_includes_current_attempt: !is_nil(activity_attempt.date_evaluated),
          bib_refs: Map.get(model, "bibrefs", []),
          ordinal: ordinal_assign_fn.(id),
          variables: build_variables_map(type.variables, type.petite_label)

--- a/lib/oli/rendering/activity/activity_summary.ex
+++ b/lib/oli/rendering/activity/activity_summary.ex
@@ -47,6 +47,11 @@ defmodule Oli.Rendering.Activity.ActivitySummary do
     :bib_refs,
     :has_more_attempts,
 
+    # score-as-you-go aggregate state for the latest activity attempt
+    :aggregate_score,
+    :aggregate_out_of,
+    :aggregate_includes_current_attempt,
+
     # The ordinal position of this activity within the page
     :ordinal,
 

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -184,6 +184,9 @@ defmodule Oli.Rendering.Activity.Html do
          %ActivitySummary{
            state: state,
            graded: graded,
+           aggregate_score: aggregate_score,
+           aggregate_out_of: aggregate_out_of,
+           aggregate_includes_current_attempt: aggregate_includes_current_attempt,
            variables: variables,
            ordinal: ordinal
          },
@@ -205,6 +208,10 @@ defmodule Oli.Rendering.Activity.Html do
         oneAtATime: effective_settings && effective_settings.assessment_mode == :one_at_a_time,
         maxAttempts: effective_settings && effective_settings.max_attempts,
         scoringStrategyId: effective_settings && effective_settings.scoring_strategy_id,
+        replacementStrategy: effective_settings && effective_settings.replacement_strategy,
+        aggregateScore: aggregate_score,
+        aggregateOutOf: aggregate_out_of,
+        aggregateIncludesCurrentAttempt: aggregate_includes_current_attempt,
         ordinal: ordinal,
         userId: user.id,
         sectionSlug: context.section_slug,

--- a/test/oli/delivery/page/activity_context_test.exs
+++ b/test/oli/delivery/page/activity_context_test.exs
@@ -51,8 +51,17 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
 
     test "create_context_map/2 returns the activities mapped correctly", %{
       attempt1: attempt1,
-      a1: a1
+      a1: a1,
+      activity_attempt1: activity_attempt1
     } do
+      activity_attempt1
+      |> Ecto.Changeset.change(%{
+        aggregate_score: 0.75,
+        aggregate_out_of: 1.0,
+        date_evaluated: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+      |> Oli.Repo.update!()
+
       latest_attempts = Hierarchy.get_latest_attempts(attempt1.id)
 
       m =
@@ -68,6 +77,9 @@ defmodule Oli.Delivery.Page.ActivityContextTest do
       assert Map.get(m, a1.resource.id).model == "{&quot;stem&quot;:&quot;1&quot;}"
       assert Map.get(m, a1.resource.id).delivery_element == "oli-multiple-choice-delivery"
       assert Map.get(m, a1.resource.id).script == "oli_multiple_choice_delivery.js"
+      assert Map.get(m, a1.resource.id).aggregate_score == 0.75
+      assert Map.get(m, a1.resource.id).aggregate_out_of == 1.0
+      assert Map.get(m, a1.resource.id).aggregate_includes_current_attempt
     end
 
     test "build_variables_map/2 returns correct vars", %{} do

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -5,6 +5,7 @@ defmodule Oli.Content.Activity.HtmlTest do
   alias Oli.Rendering.Activity
   alias Oli.Rendering.Activity.ActivitySummary
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
+  alias Oli.Delivery.Settings.Combined
   alias Oli.Accounts
 
   import ExUnit.CaptureLog
@@ -298,6 +299,47 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~ "&quot;showMathPreviews&quot;:false"
+    end
+
+    test "includes score-as-you-go reset messaging state in delivery context", %{author: author} do
+      activity_map = %{
+        1 => %ActivitySummary{
+          id: 1,
+          graded: true,
+          state: "{ \"active\": true }",
+          model: "{ \"stem\": \"test\" }",
+          delivery_element: "oli-multiple-choice-delivery",
+          authoring_element: "oli-multiple-choice-authoring",
+          script: "./authoring-entry.ts",
+          attempt_guid: "activity-guid-456",
+          lifecycle_state: :evaluated,
+          aggregate_score: 0.75,
+          aggregate_out_of: 1.0,
+          aggregate_includes_current_attempt: true
+        }
+      }
+
+      rendered_html =
+        Activity.render(
+          %Context{
+            user: author,
+            activity_map: activity_map,
+            effective_settings: %Combined{
+              replacement_strategy: :dynamic,
+              scoring_strategy_id: 1,
+              max_attempts: 4
+            }
+          },
+          %{"activity_id" => 1, "purpose" => "none"},
+          Activity.Html
+        )
+
+      rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
+
+      assert rendered_html_string =~ "&quot;aggregateScore&quot;:0.75"
+      assert rendered_html_string =~ "&quot;aggregateOutOf&quot;:1.0"
+      assert rendered_html_string =~ "&quot;aggregateIncludesCurrentAttempt&quot;:true"
+      assert rendered_html_string =~ "&quot;replacementStrategy&quot;:&quot;dynamic&quot;"
     end
 
     test "uses empty map for pageState when extrinsic_state is nil", %{author: author} do


### PR DESCRIPTION
Updates the Score as You Go question reset flow so students understand the potential score impact before confirming a reset.

Changes
- Adds the approved “Reset this question?” confirmation modal.
- Displays strategy-specific messaging for Average, Best, and Most Recent scoring.
- Shows the current or best score, attempts taken, and attempts remaining.
- Communicates when dynamic replacement may provide a new question version.

Best score, Dynamic replacement:

https://github.com/user-attachments/assets/968e1b2e-d3e2-4b69-b03f-8ea9450755af

Average, no replacement:

https://github.com/user-attachments/assets/d479d7a2-3e0b-4fb0-8a67-1f229cb916d6


Most Recent, no replacement:

https://github.com/user-attachments/assets/1457c564-3c50-4b9c-8cdb-72924b7d990c



See: https://eliterate.atlassian.net/browse/MER-5629