### PR TITLE
[ENHANCEMENT] [MER-5633] One at a time mode updates

### DIFF
--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -1,23 +1,37 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { ActivityContext } from 'components/activities/DeliveryElement';
 import { useDeliveryElementContext } from 'components/activities/DeliveryElementProvider';
 import { Evaluation } from 'components/activities/common/delivery/evaluation/Evaluation';
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
+import { DeliveryMode } from 'components/activities/types';
 import { ActivityDeliveryState, isEvaluated } from 'data/activities/DeliveryState';
 
+export const isOneAtATimeScoreAtTheEndDelivery = (context: ActivityContext, mode: DeliveryMode) =>
+  context.graded && mode !== 'review' && context.oneAtATime && context.batchScoring;
+
+export const shouldShowActivityFeedback = (
+  context: ActivityContext,
+  mode: DeliveryMode,
+  evaluated: boolean,
+) =>
+  context.showFeedback == true &&
+  evaluated &&
+  context.surveyId === null &&
+  !isOneAtATimeScoreAtTheEndDelivery(context, mode);
+
 export const EvaluationConnected: React.FC = () => {
-  const { context, writerContext } = useDeliveryElementContext();
-  const { surveyId } = context;
+  const { context, mode, writerContext } = useDeliveryElementContext();
   const uiState = useSelector((state: ActivityDeliveryState) => state);
 
   return (
     <>
       <Evaluation
-        shouldShow={context.showFeedback == true && isEvaluated(uiState) && surveyId === null}
+        shouldShow={shouldShowActivityFeedback(context, mode, isEvaluated(uiState))}
         attemptState={uiState.attemptState}
         context={writerContext}
       />
-      <Submission attemptState={uiState.attemptState} surveyId={surveyId} />
+      <Submission attemptState={uiState.attemptState} surveyId={context.surveyId} />
     </>
   );
 };

--- a/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
+++ b/assets/src/components/activities/common/delivery/evaluation/EvaluationConnected.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { ActivityContext } from 'components/activities/DeliveryElement';
+import type { ActivityContext } from 'components/activities/DeliveryElement';
 import { useDeliveryElementContext } from 'components/activities/DeliveryElementProvider';
 import { Evaluation } from 'components/activities/common/delivery/evaluation/Evaluation';
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
-import { DeliveryMode } from 'components/activities/types';
+import type { DeliveryMode } from 'components/activities/types';
 import { ActivityDeliveryState, isEvaluated } from 'data/activities/DeliveryState';
 
 export const isOneAtATimeScoreAtTheEndDelivery = (context: ActivityContext, mode: DeliveryMode) =>

--- a/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
+++ b/assets/src/components/activities/common/delivery/graded_points/GradedPointsConnected.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { useDeliveryElementContext } from 'components/activities/DeliveryElementProvider';
+import { isOneAtATimeScoreAtTheEndDelivery } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { GradedPoints } from 'components/activities/common/delivery/graded_points/GradedPoints';
 import { Checkmark } from 'components/misc/icons/Checkmark';
 import { Cross } from 'components/misc/icons/Cross';
@@ -8,7 +9,8 @@ import { ActivityDeliveryState } from 'data/activities/DeliveryState';
 import { isCorrect } from 'data/activities/utils';
 
 export const GradedPointsConnected: React.FC = () => {
-  const { graded, surveyId, showFeedback } = useDeliveryElementContext().context;
+  const { context, mode } = useDeliveryElementContext();
+  const { graded, surveyId, showFeedback } = context;
   const uiState = useSelector((state: ActivityDeliveryState) => state);
   return (
     <GradedPoints
@@ -17,7 +19,8 @@ export const GradedPointsConnected: React.FC = () => {
         uiState.attemptState.score !== null &&
         graded &&
         surveyId === null &&
-        uiState.activityContext.batchScoring
+        uiState.activityContext.batchScoring &&
+        !isOneAtATimeScoreAtTheEndDelivery(context, mode)
       }
       icon={isCorrect(uiState.attemptState) ? <Checkmark /> : <Cross />}
       attemptState={uiState.attemptState}

--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { DeliveryElement, DeliveryElementProps } from 'components/activities/DeliveryElement';
 import { Evaluation } from 'components/activities/common/delivery/evaluation/Evaluation';
+import { shouldShowActivityFeedback } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
@@ -372,12 +373,7 @@ export const MultiInputComponent: React.FC = () => {
           />
         ))}
         <Evaluation
-          shouldShow={
-            context.showFeedback == true &&
-            anyEvaluated(uiState) &&
-            surveyId === null &&
-            (!context.graded || mode === 'review' || context.oneAtATime || !context.batchScoring)
-          }
+          shouldShow={shouldShowActivityFeedback(context, mode, anyEvaluated(uiState))}
           attemptState={uiState.attemptState}
           context={writerContext}
           partOrder={orderedPartIds}

--- a/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
+++ b/assets/src/components/activities/response_multi/ResponseMultiInputDelivery.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Provider, useDispatch, useSelector } from 'react-redux';
 import { DeliveryElement, DeliveryElementProps } from 'components/activities/DeliveryElement';
 import { Evaluation } from 'components/activities/common/delivery/evaluation/Evaluation';
+import { shouldShowActivityFeedback } from 'components/activities/common/delivery/evaluation/EvaluationConnected';
 import { Submission } from 'components/activities/common/delivery/evaluation/Submission';
 import { GradedPointsConnected } from 'components/activities/common/delivery/graded_points/GradedPointsConnected';
 import { ResetButtonConnected } from 'components/activities/common/delivery/reset_button/ResetButtonConnected';
@@ -404,12 +405,7 @@ export const ResponseMultiInputComponent: React.FC = () => {
           />
         ))}
         <Evaluation
-          shouldShow={
-            context.showFeedback == true &&
-            anyEvaluated(uiState) &&
-            surveyId === null &&
-            (!context.graded || mode === 'review')
-          }
+          shouldShow={shouldShowActivityFeedback(context, mode, anyEvaluated(uiState))}
           attemptState={uiState.attemptState}
           context={writerContext}
         />

--- a/assets/test/delivery/activity_feedback_visibility_test.ts
+++ b/assets/test/delivery/activity_feedback_visibility_test.ts
@@ -1,0 +1,62 @@
+import { ActivityContext } from 'components/activities/DeliveryElement';
+import {
+  isOneAtATimeScoreAtTheEndDelivery,
+  shouldShowActivityFeedback,
+} from 'components/activities/common/delivery/evaluation/EvaluationConnected';
+import { DeliveryMode } from 'components/activities/types';
+
+const context = (overrides: Partial<ActivityContext> = {}): ActivityContext =>
+  ({
+    allowHints: false,
+    batchScoring: true,
+    bibParams: [],
+    graded: true,
+    groupId: null,
+    isAnnotationLevel: false,
+    learningLanguage: undefined,
+    maxAttempts: 3,
+    oneAtATime: false,
+    ordinal: 1,
+    pageAttemptGuid: 'page-attempt-guid',
+    pageLinkParams: {},
+    pageState: {},
+    projectSlug: 'project',
+    renderPointMarkers: false,
+    resourceId: 1,
+    scoringStrategyId: 1,
+    sectionSlug: 'section',
+    showFeedback: true,
+    surveyId: null,
+    userId: 1,
+    variables: {},
+    ...overrides,
+  } as ActivityContext);
+
+describe('activity feedback visibility', () => {
+  const mode: DeliveryMode = 'delivery';
+
+  it('suppresses activity-owned feedback for one-at-a-time score-at-the-end delivery', () => {
+    const deliveryContext = context({ oneAtATime: true, batchScoring: true });
+
+    expect(isOneAtATimeScoreAtTheEndDelivery(deliveryContext, mode)).toBe(true);
+    expect(shouldShowActivityFeedback(deliveryContext, mode, true)).toBe(false);
+  });
+
+  it('allows activity-owned feedback for one-at-a-time score-as-you-go delivery', () => {
+    expect(
+      shouldShowActivityFeedback(context({ oneAtATime: true, batchScoring: false }), mode, true),
+    ).toBe(true);
+  });
+
+  it('allows activity-owned feedback in review mode', () => {
+    expect(
+      shouldShowActivityFeedback(context({ oneAtATime: true, batchScoring: true }), 'review', true),
+    ).toBe(true);
+  });
+
+  it('still requires evaluated state and feedback permission', () => {
+    expect(shouldShowActivityFeedback(context(), mode, false)).toBe(false);
+    expect(shouldShowActivityFeedback(context({ showFeedback: false }), mode, true)).toBe(false);
+    expect(shouldShowActivityFeedback(context({ surveyId: 'survey' }), mode, true)).toBe(false);
+  });
+});

--- a/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
+++ b/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
@@ -36,7 +36,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
       <% total_questions = Enum.count(@questions) %>
       <% selected_question_points =
         Map.get(selected_question, :out_of, Map.get(selected_question, "outOf")) %>
-      <% selected_question_parts_count = map_size(selected_question.part_points) %>
       <% submitted_questions = Enum.count(@questions, & &1.submitted) %>
       <% unattempted_questions = total_questions - submitted_questions %>
       <Modal.modal id="finish_quiz_confirmation_modal" class="w-auto min-w-[50%]" body_class="px-6">
@@ -121,12 +120,12 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
           />
           <div
             role="questions content"
-            class="content min-h-[484px] w-[981px] rounded-md border border-[#c8c8c8]"
+            class="content min-h-[484px] w-[981px]"
           >
             <div
               id="react_to_liveview"
               phx-hook="ReactToLiveView"
-              class="flex h-[400px] border-b border-[#c8c8c8]"
+              class="flex w-full"
             >
               <div id="eventIntercept_one_at_a_time_question" phx-update="ignore">
                 <div
@@ -134,36 +133,13 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
                   id={"question_#{question.number}"}
                   role="one at a time question"
                   class={[
-                    "overflow-scroll p-10 h-[400px] oveflow-hidden",
-                    if(map_size(question.part_points) == 1, do: "w-[981px]", else: "w-[808px]"),
+                    "w-[981px] overflow-visible px-10 py-8",
                     if(!question.selected, do: "hidden")
                   ]}
                   phx-hook="DisableSubmitted"
                   data-submitted={"#{question.submitted and @effective_settings.batch_scoring}"}
                 >
                   {raw(question.raw_content)}
-                </div>
-              </div>
-              <div
-                :if={selected_question_parts_count > 1}
-                role="parts score summary"
-                class="w-[173px] px-3 py-6 gap-2 text-sm font-normal leading-none whitespace-nowrap border-l border-[#c8c8c8]"
-              >
-                <div
-                  :for={{{id, points}, index} <- Enum.with_index(selected_question.part_points, 1)}
-                  class="flex items-center h-6"
-                >
-                  <span class="w-4">
-                    <.part_result_icon part={
-                      Enum.find(selected_question.state["parts"], &(&1["partId"] == id))
-                    } />
-                  </span>
-                  <span class="text-[#757682] ml-4 dark:text-white/80">
-                    Part {index}:
-                  </span>
-                  <span class="text-[#353740] ml-1 dark:text-white">
-                    {parse_points(points)}
-                  </span>
                 </div>
               </div>
             </div>
@@ -281,7 +257,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
         ]}>
         </div>
         <span class={[
-          "text-[#353740] text-base font-normal leading-normal dark:text-white",
+          "whitespace-nowrap text-[#353740] text-base font-normal leading-normal dark:text-white",
           if(question.selected, do: "!text-[#0f6bf5] !font-bold")
         ]}>
           Question {question.number}
@@ -454,26 +430,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
     # string keys are expected...
     |> Jason.encode!()
     |> Jason.decode!()
-  end
-
-  attr :part, :map, required: true
-
-  def part_result_icon(%{part: %{"dateEvaluated" => nil}} = assigns) do
-    ~H"""
-    """
-  end
-
-  def part_result_icon(%{part: %{"score" => score, "outOf" => out_of}} = assigns)
-      when score == out_of and score != 0 do
-    ~H"""
-    <Icons.check />
-    """
-  end
-
-  def part_result_icon(assigns) do
-    ~H"""
-    <Icons.close class="stroke-red-500 dark:stroke-white" />
-    """
   end
 
   defp get_progress([] = _questions), do: 0.5

--- a/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
+++ b/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
@@ -120,7 +120,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
           />
           <div
             role="questions content"
-            class="content min-h-[484px] w-[981px]"
+            class="content min-h-[484px] w-full max-w-[981px]"
           >
             <div
               id="react_to_liveview"
@@ -133,7 +133,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
                   id={"question_#{question.number}"}
                   role="one at a time question"
                   class={[
-                    "w-[981px] overflow-visible px-10 py-8",
+                    "w-full overflow-visible px-10 py-8",
                     if(!question.selected, do: "hidden")
                   ]}
                   phx-hook="DisableSubmitted"

--- a/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
+++ b/lib/oli_web/live/delivery/student/lesson/components/one_at_a_time_question.ex
@@ -4,17 +4,10 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
   import OliWeb.Delivery.Student.Utils,
     only: [references: 1]
 
-  require Logger
-
   alias Oli.Delivery.Attempts.Core
   alias Oli.Delivery.Attempts.ActivityLifecycle.Evaluate
-  alias Oli.Delivery.Attempts.PageLifecycle
-  alias Oli.Delivery.Attempts.PageLifecycle.FinalizationSummary
-  alias Oli.Delivery.Sections
-
   alias OliWeb.Components.Common
   alias OliWeb.Components.Modal
-  alias OliWeb.Delivery.Student.Utils
   alias OliWeb.Icons
 
   attr :questions, :list
@@ -23,9 +16,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
   attr :datashop_session_id, :string
   attr :ctx, :map
   attr :bib_app_params, :map
-  attr :request_path, :string
-  attr :revision_slug, :string
-  attr :attempt_guid, :string
   attr :section_slug, :string
   attr :effective_settings, :map
 
@@ -62,7 +52,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
             </button>
             <button
               phx-click="finalize_attempt"
-              phx-target={@myself}
               class="w-[187.52px] h-[30px] px-5 py-2.5 bg-[#0062f2] rounded-md shadow justify-center items-center gap-2.5 inline-flex"
             >
               <div class="justify-end items-center gap-2 flex">
@@ -276,55 +265,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestion do
 
   def handle_event("activity_saved", params, socket) do
     {:noreply, update_activity(socket, params)}
-  end
-
-  def handle_event(
-        "finalize_attempt",
-        _params,
-        %{
-          assigns: %{
-            section_slug: section_slug,
-            datashop_session_id: datashop_session_id,
-            request_path: request_path,
-            revision_slug: revision_slug,
-            attempt_guid: attempt_guid
-          }
-        } = socket
-      ) do
-    case PageLifecycle.finalize(section_slug, attempt_guid, datashop_session_id) do
-      {:ok,
-       %FinalizationSummary{
-         graded: true,
-         resource_access: %Oli.Delivery.Attempts.Core.ResourceAccess{id: id}
-       }} ->
-        # graded resource finalization success
-        section = Sections.get_section_by(slug: section_slug)
-
-        if section.grade_passback_enabled,
-          do: PageLifecycle.GradeUpdateWorker.create(section.id, id, :inline)
-
-        {:noreply,
-         redirect(socket,
-           to: Utils.lesson_live_path(section_slug, revision_slug, request_path: request_path)
-         )}
-
-      {:ok, %FinalizationSummary{graded: false}} ->
-        {:noreply,
-         redirect(socket,
-           to: Utils.lesson_live_path(section_slug, revision_slug, request_path: request_path)
-         )}
-
-      {:error, {reason}}
-      when reason in [:already_submitted, :active_attempt_present, :no_more_attempts] ->
-        {:noreply, put_flash(socket, :error, "Unable to finalize page")}
-
-      e ->
-        error_msg = Kernel.inspect(e)
-        Logger.error("Page finalization error encountered: #{error_msg}")
-        Oli.Utils.Appsignal.capture_error(error_msg)
-
-        {:noreply, put_flash(socket, :error, "Unable to finalize page")}
-    end
   end
 
   def handle_event("select_question", %{"question_number" => question_number}, socket) do

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1130,9 +1130,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
               datashop_session_id={@datashop_session_id}
               ctx={@ctx}
               bib_app_params={@bib_app_params}
-              request_path={@request_path}
-              revision_slug={@revision_slug}
-              attempt_guid={@attempt_guid}
               section_slug={@section.slug}
               effective_settings={@page_context.effective_settings}
             />

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1119,6 +1119,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             }
             display_curriculum_item_numbering={@section.display_curriculum_item_numbering}
           />
+          <.score_as_you_go_explanation batch_scoring={@page_context.effective_settings.batch_scoring} />
 
           <div :if={@questions != []} class="relative min-h-[500px] justify-center">
             <.live_component
@@ -1177,6 +1178,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             }
             display_curriculum_item_numbering={@section.display_curriculum_item_numbering}
           />
+          <.score_as_you_go_explanation batch_scoring={@page_context.effective_settings.batch_scoring} />
 
           <div
             id="page_content"
@@ -1432,6 +1434,21 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   def score_header(assigns) do
+    ~H"""
+    """
+  end
+
+  attr :batch_scoring, :boolean, default: false
+
+  def score_as_you_go_explanation(%{batch_scoring: false} = assigns) do
+    ~H"""
+    <p class="w-full font-open-sans text-[16px] font-normal leading-[24px] text-Text-text-high">
+      Your score will be updated as you complete questions on this page.
+    </p>
+    """
+  end
+
+  def score_as_you_go_explanation(assigns) do
     ~H"""
     """
   end

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1119,7 +1119,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             }
             display_curriculum_item_numbering={@section.display_curriculum_item_numbering}
           />
-          <.score_as_you_go_explanation batch_scoring={@page_context.effective_settings.batch_scoring} />
 
           <div :if={@questions != []} class="relative min-h-[500px] justify-center">
             <.live_component
@@ -1178,7 +1177,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
             }
             display_curriculum_item_numbering={@section.display_curriculum_item_numbering}
           />
-          <.score_as_you_go_explanation batch_scoring={@page_context.effective_settings.batch_scoring} />
 
           <div
             id="page_content"
@@ -1434,21 +1432,6 @@ defmodule OliWeb.Delivery.Student.LessonLive do
   end
 
   def score_header(assigns) do
-    ~H"""
-    """
-  end
-
-  attr :batch_scoring, :boolean, default: false
-
-  def score_as_you_go_explanation(%{batch_scoring: false} = assigns) do
-    ~H"""
-    <p class="w-full font-open-sans text-[16px] font-normal leading-[24px] text-Text-text-high">
-      Your score will be updated as you complete questions on this page.
-    </p>
-    """
-  end
-
-  def score_as_you_go_explanation(assigns) do
     ~H"""
     """
   end

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -26,6 +26,7 @@ defmodule OliWeb.Delivery.Student.Utils do
   attr :container_label, :string
   attr :has_assignments?, :boolean
   attr :display_curriculum_item_numbering, :boolean, default: true
+  attr :show_divider, :boolean, default: true
 
   def page_header(assigns) do
     ~H"""
@@ -182,7 +183,7 @@ defmodule OliWeb.Delivery.Student.Utils do
           </div>
         </div>
       </div>
-      <span class="mb-6 border-b border-Border-border-default w-full"></span>
+      <span :if={@show_divider} class="mb-6 border-b border-Border-border-default w-full"></span>
     </div>
     """
   end

--- a/test/oli_web/live/delivery/student/lesson/components/one_at_a_time_question_test.exs
+++ b/test/oli_web/live/delivery/student/lesson/components/one_at_a_time_question_test.exs
@@ -421,7 +421,7 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestionTest do
              |> render() =~ "Question 3 / 3 • 6.0 points"
     end
 
-    test "shows the parts score summary for activities with more than 1 part", %{
+    test "does not show the parts score summary for activities with more than 1 part", %{
       conn: conn,
       component_params: component_params
     } do
@@ -439,18 +439,10 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestionTest do
       |> element("#question_3_button")
       |> render_click()
 
-      assert has_element?(lcd, "div[role='parts score summary']")
-
-      lcd
-      |> element("div[role='parts score summary']")
-      |> render() =~ "Part 1: 2.5 points"
-
-      lcd
-      |> element("div[role='parts score summary']")
-      |> render() =~ "Part 2: 3.5 points"
+      refute has_element?(lcd, "div[role='parts score summary']")
     end
 
-    test "the total points matches the sum of the part points", %{
+    test "the question-wide total points remain visible for multipart questions", %{
       conn: conn,
       component_params: component_params
     } do
@@ -461,14 +453,6 @@ defmodule OliWeb.Delivery.Student.Lesson.Components.OneAtATimeQuestionTest do
       |> render_click()
 
       # 2.5 + 3.5 = 6.0
-
-      lcd
-      |> element("div[role='parts score summary']")
-      |> render() =~ "Part 1: 2.5 points"
-
-      lcd
-      |> element("div[role='parts score summary']")
-      |> render() =~ "Part 2: 3.5 points"
 
       assert lcd
              |> element("div[role='questions header']")

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -2909,6 +2909,72 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert has_element?(view, "div[id='one_at_a_time_questions']")
     end
 
+    test "finish attempt routes through parent finalizer and redirects to review when allowed", %{
+      conn: conn,
+      section: section,
+      mcq_activity_1: mcq_activity_1,
+      user: user,
+      one_at_a_time_question_page: one_at_a_time_question_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      resource_access =
+        Oli.Delivery.Attempts.Core.track_access(
+          one_at_a_time_question_page.resource_id,
+          section.id,
+          user.id
+        )
+
+      resource_attempt =
+        insert(:resource_attempt, %{
+          resource_access_id: resource_access.id,
+          resource_access: resource_access,
+          revision_id: one_at_a_time_question_page.id,
+          revision: one_at_a_time_question_page,
+          attempt_guid: UUID.uuid4(),
+          content: one_at_a_time_question_page.content,
+          lifecycle_state: :active
+        })
+
+      activity_attempt =
+        insert(:activity_attempt, %{
+          resource_attempt_id: resource_attempt.id,
+          resource_attempt: resource_attempt,
+          revision_id: mcq_activity_1.id,
+          revision: mcq_activity_1,
+          resource_id: mcq_activity_1.resource_id,
+          resource: mcq_activity_1.resource,
+          attempt_guid: UUID.uuid4()
+        })
+
+      insert(:part_attempt, %{
+        activity_attempt_id: activity_attempt.id,
+        activity_attempt: activity_attempt,
+        attempt_guid: UUID.uuid4(),
+        part_id: "1"
+      })
+
+      {:ok, view, _html} =
+        live(conn, Utils.lesson_live_path(section.slug, one_at_a_time_question_page.slug))
+
+      ensure_content_is_visible(view)
+
+      view
+      |> element("#finish_quiz_confirmation_modal button", "Yes, Finish The Attempt")
+      |> render_click()
+
+      assert_redirected(
+        view,
+        Utils.review_live_path(
+          section.slug,
+          one_at_a_time_question_page.slug,
+          resource_attempt.attempt_guid,
+          request_path: Utils.learn_live_path(section.slug, selected_view: @default_selected_view)
+        )
+      )
+    end
+
     test "are rendered correctly even if the page has no questions in it's content",
          %{
            conn: conn,

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -16,6 +16,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   alias OliWeb.Delivery.Student.Utils
 
   @default_selected_view :gallery
+  @sayg_explanation "Your score will be updated as you complete questions on this page."
 
   defp pay_early_message_classes(html) do
     html
@@ -1244,6 +1245,43 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert html =~ "dark:text-[#EEEBF5]"
     end
 
+    test "renders score-as-you-go explanatory text on score-as-you-go graded pages", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: graded_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{batch_scoring: false})
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      assert render(view) =~ @sayg_explanation
+    end
+
+    test "does not render score-as-you-go explanatory text on score-at-the-end graded pages", %{
+      conn: conn,
+      user: user,
+      section: section,
+      page_3: graded_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      refute render(view) =~ @sayg_explanation
+    end
+
     test "can not see `reset answers` button on practice pages without activities", %{
       conn: conn,
       user: user,
@@ -2205,6 +2243,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert html =~ "text-Text-text-white"
       assert html =~ "Overall Page Score"
       assert html =~ "3 / 5"
+      assert html =~ @sayg_explanation
     end
   end
 

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -16,7 +16,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
   alias OliWeb.Delivery.Student.Utils
 
   @default_selected_view :gallery
-  @sayg_explanation "Your score will be updated as you complete questions on this page."
+  @sayg_banner_title "Score as you go Activity"
+  @sayg_banner_explanation "Your score is updated as you complete questions on this page."
 
   defp pay_early_message_classes(html) do
     html
@@ -1245,7 +1246,7 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert html =~ "dark:text-[#EEEBF5]"
     end
 
-    test "renders score-as-you-go explanatory text on score-as-you-go graded pages", %{
+    test "renders score-as-you-go banner copy on score-as-you-go graded pages", %{
       conn: conn,
       user: user,
       section: section,
@@ -1262,10 +1263,13 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
       ensure_content_is_visible(view)
 
-      assert render(view) =~ @sayg_explanation
+      html = render(view)
+
+      assert html =~ @sayg_banner_title
+      assert html =~ @sayg_banner_explanation
     end
 
-    test "does not render score-as-you-go explanatory text on score-at-the-end graded pages", %{
+    test "does not render score-as-you-go banner copy on score-at-the-end graded pages", %{
       conn: conn,
       user: user,
       section: section,
@@ -1279,7 +1283,10 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
       ensure_content_is_visible(view)
 
-      refute render(view) =~ @sayg_explanation
+      html = render(view)
+
+      refute html =~ @sayg_banner_title
+      refute html =~ @sayg_banner_explanation
     end
 
     test "can not see `reset answers` button on practice pages without activities", %{
@@ -2243,7 +2250,8 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
       assert html =~ "text-Text-text-white"
       assert html =~ "Overall Page Score"
       assert html =~ "3 / 5"
-      assert html =~ @sayg_explanation
+      assert html =~ @sayg_banner_title
+      assert html =~ @sayg_banner_explanation
     end
   end
 


### PR DESCRIPTION
## Summary
Updates one-at-a-time assessment layout to match the revised Figma direction. [MER-5633](url)

  - Removes the inner scrollable question box so question content can use the page layout normally.
  - Removes the right-side per-part point rail while preserving the question-wide points display.
  - Aligns question-list rail in margin left of question content area.
  
  This also fixes two other pre-existing issues discovered in the course of testing One-at-a-Time mode:
 
  ## One-at-a-Time Feedback Rendering fix

  While validating the layout change, we found that in the case of one-at-a-time presentation with score-at-the-end (SATE),  multi-input questions could render duplicate feedback after evaluation/reload. This was a pre-existing bug. This does not arise with one-at-a-time/Score-as-You-Go (SAYG).

  This happened because although activities are generally responsible for rendering their own feedback, in the case of one-at-a-time/SATE, question submission is initiated by LiveView event handler which evaluates server-side and renders feedback from LiveView state. Activities using common components like `EvaluationConnected` avoided rendering feedback in this case. But the feedback-controlling logic in the custom multi-input activity feedback components resulted in that activity _also_ rendering its own feedback after remounting with evaluated state in this state.
  
   To avoid duplicate feedback, a common predicate was defined to ensure activity-owned feedback and graded points are consistently suppressed for the case of graded one-at-a-time/score-at-the-end delivery. SAYG and review behavior are unchanged.
  
 ## One-at-a-Time Finish Attempt Routing fix

  While validating the one-at-a-time/SATE flow, we found that the one-at-a-time component had its own `finalize_attempt` handler that had drifted from the parent `LessonLive` finalization behavior. In particular, it always redirected back to lesson delivery and did not honor the usual review-submission redirect.

  This appears to be a pre-existing one-at-a-time bug rather than a regression due to the layout changes, but fix is included here because this PR updates the same specialized presentation mode. The component now routes Finish Attempt through the parent `LessonLive` finalizer, so it shares the same finalization and review routing behavior as the normal scored page submit flow.

  ## Testing

  - `mix test test/oli_web/live/delivery/student/lesson/components/one_at_a_time_question_test.exs`
  - `mix test test/oli_web/live/delivery/student/lesson_live_test.exs`
  - `yarn test test/delivery/activity_feedback_visibility_test.ts --runInBand`
  - `yarn test test/multi_input/multi_input_delivery_test.tsx --runInBand`
  
  Browser MCP verified that a non-SAYG one-at-a-time multi-input question renders LiveView feedback/points without duplicate activity feedback/points after reload.
  
  ## One-at-a-Time + Score-As-You-Go ##
  
<img width="1357" height="1024" alt="Screenshot 2026-06-11 at 10 23 20 AM" src="https://github.com/user-attachments/assets/19362ad2-df8b-4f4c-bfa4-d032024209f2" />

  ## One-at-a-Time + Score-at-the-End ##
  
<img width="1403" height="1056" alt="Screenshot 2026-06-11 at 10 30 38 AM" src="https://github.com/user-attachments/assets/b4e09c66-9ff2-48dc-a116-03ffe0ded5e6" />


[MER-5633]: https://eliterate.atlassian.net/browse/MER-5633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ