### PR TITLE
[BUG FIX] [MER-5706] Fix nil input handling in math-backed evaluation

### DIFF
--- a/lib/oli/delivery/evaluation/legacy_input.ex
+++ b/lib/oli/delivery/evaluation/legacy_input.ex
@@ -4,9 +4,11 @@ defmodule Oli.Delivery.Evaluation.LegacyInput do
   alias Oli.Delivery.Evaluation.EvaluationContext
 
   @spec submitted_value(:input | {:input, String.t()}, EvaluationContext.t()) :: String.t()
-  def submitted_value(:input, %EvaluationContext{input: input}) do
+  def submitted_value(:input, %EvaluationContext{input: input}) when is_binary(input) do
     Oli.Utils.normalize_whitespace(input)
   end
+
+  def submitted_value(:input, %EvaluationContext{}), do: ""
 
   def submitted_value({:input, ref}, %EvaluationContext{input: input}) do
     try do

--- a/lib/oli/delivery/evaluation/math_expression_matcher.ex
+++ b/lib/oli/delivery/evaluation/math_expression_matcher.ex
@@ -15,7 +15,9 @@ defmodule Oli.Delivery.Evaluation.MathExpressionMatcher do
     |> evaluate(submitted)
   end
 
-  @spec evaluate(map() | String.t(), String.t()) :: {:ok, boolean()} | {:error, term()}
+  @spec evaluate(map() | String.t(), String.t() | nil) :: {:ok, boolean()} | {:error, term()}
+  def evaluate(_match_config, nil), do: {:ok, false}
+
   def evaluate(match_config, submitted) when is_binary(submitted) do
     case Match.evaluate_json(match_config, submitted) do
       {:ok, result} -> normalize_result(result)

--- a/test/oli/delivery/evaluation/legacy_rule_adapter_test.exs
+++ b/test/oli/delivery/evaluation/legacy_rule_adapter_test.exs
@@ -78,6 +78,10 @@ defmodule Oli.Delivery.Evaluation.LegacyRuleAdapterTest do
     assert LegacyNumericRuleAdapter.match?("(!(input = {3}))", context("4", 1)) == {:ok, true}
   end
 
+  test "legacy numeric adapter treats missing input as no match" do
+    assert LegacyNumericRuleAdapter.match?("input = {3}", context(nil, 1)) == {:ok, false}
+  end
+
   test "legacy numeric adapter preserves range and significant-figure behavior" do
     cases = [
       {"input = {[1,3]}", "2"},
@@ -148,6 +152,10 @@ defmodule Oli.Delivery.Evaluation.LegacyRuleAdapterTest do
     Enum.each(cases, fn {rule, input} ->
       assert_parity(rule, input, math_part())
     end)
+  end
+
+  test "legacy math adapter treats missing input as no match" do
+    assert LegacyMathRuleAdapter.match?("input equals {x}", context(nil, 1)) == {:ok, false}
   end
 
   test "legacy math adapter preserves parser unescaping for braces and backslashes" do

--- a/test/oli/delivery/math_expression_full_model_test.exs
+++ b/test/oli/delivery/math_expression_full_model_test.exs
@@ -138,6 +138,20 @@ defmodule Oli.Delivery.MathExpressionFullModelTest do
     assert MathExpressionMatcher.evaluate(exact_config, "2x + 2") == {:ok, false}
   end
 
+  test "math expression matcher treats missing submissions as no match" do
+    config = %{
+      "version" => 1,
+      "type" => "math_expression",
+      "math" => %{
+        "mode" => "numeric",
+        "expected" => "2",
+        "operator" => "equal"
+      }
+    }
+
+    assert MathExpressionMatcher.evaluate(config, nil) == {:ok, false}
+  end
+
   test "invalid math submissions return authored fallback feedback without math diagnostics" do
     model = short_answer_model()
 


### PR DESCRIPTION
 ## Summary

  Fixes [MER-5706](https://eliterate.atlassian.net/browse/MER-5706), a regression where scored assessment submission could crash when finalization evaluated an unanswered  numeric/math-expression part.

  Root cause: #6619 for MER-5691 routed supported legacy numeric/math rules through the new math-backed matcher. Server-side page finalization can evaluate untouched parts whose persisted response is missing, producing `input: nil`. The old rule evaluator surfaced that as a contained non-match/error path, but the new matcher had no nil-input clause and raised a FunctionClauseError.

  This change restores the intended behavior: missing input represented by nil is treated as no match/zero credit, not a finalization crash.

  ## Testing

  - mix test test/oli/delivery/evaluation/legacy_rule_adapter_test.exs test/oli/delivery/
    math_expression_full_model_test.exs

[MER-5706]: https://eliterate.atlassian.net/browse/MER-5706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ