### PR TITLE
[FEATURE] [MER-5622] Add preview customization wiring part 1

### DIFF
--- a/assets/css/bs/nav-tabs.css
+++ b/assets/css/bs/nav-tabs.css
@@ -82,3 +82,30 @@ html.dark .nav-tabs .nav-item.show .nav-link {
 .tab-content > .active {
   display: block;
 }
+
+/*
+  Some activity types still do not have a dedicated instructor-preview component, so preview mode
+  falls back to rendering their authoring element inside the same preview card chrome used by
+  fully supported preview activities. When one of those fallback cards is marked removed in dark
+  mode, align the legacy authoring tabs/panes with the card's dark removed canvas so the fallback
+  still looks like the rest of instructor preview instead of showing white authoring surfaces.
+*/
+html.dark .instructor-preview-authoring-fallback.instructor-preview-removed .nav-tabs .nav-link.active,
+html.dark
+  .instructor-preview-authoring-fallback.instructor-preview-removed
+  .nav-tabs
+  .nav-item.show
+  .nav-link {
+  background-color: #1b191f;
+  border-color: var(--color-gray-600) var(--color-gray-600) #1b191f;
+}
+
+html.dark .instructor-preview-authoring-fallback.instructor-preview-removed {
+  background-color: #1b191f;
+}
+
+html.dark .instructor-preview-authoring-fallback.instructor-preview-removed .tab-content,
+html.dark .instructor-preview-authoring-fallback.instructor-preview-removed .tab-content > .tab-pane,
+html.dark .instructor-preview-authoring-fallback.instructor-preview-removed .tab-content .bg-white {
+  background-color: #1b191f;
+}

--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -14,6 +14,81 @@ interface Props {
   defaultExpanded?: boolean;
 }
 
+const TrashActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3 6H5H21"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M10 11V17"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M14 11V17"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const RestoreActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const actionButtonClasses = (kind: 'remove' | 'restore') => {
+  const shared =
+    'inline-flex items-center gap-2 rounded-[6px] border bg-Surface-surface-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-70';
+
+  if (kind === 'remove') {
+    return `${shared} border-Border-border-danger text-Specially-Tokens-Text-text-button-pill-muted hover:bg-[rgba(255,64,64,0.08)] dark:border-Border-border-danger dark:text-[#FFB5B7] dark:hover:bg-[rgba(255,64,64,0.18)] focus-visible:outline-Border-border-danger`;
+  }
+
+  return `${shared} bg-transparent border-[#8AB8E5] text-Text-text-button hover:bg-[#EEF6FF] hover:text-Text-text-button-hover dark:bg-transparent dark:border-[#4C82B8] dark:text-[#9FD0FF] dark:hover:bg-[#16395C] dark:hover:text-[#D7ECFF] focus-visible:outline-[#8AB8E5]`;
+};
+
 export const ActivityPreviewCard: React.FC<Props> = ({
   previewContext,
   children,
@@ -23,10 +98,29 @@ export const ActivityPreviewCard: React.FC<Props> = ({
 }) => {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [activeTabId, setActiveTabId] = React.useState(detailTabs[0]?.id ?? '');
+  const [actions, setActions] = React.useState(previewContext.actions ?? []);
+  const [visualState, setVisualState] = React.useState(previewContext.visualState ?? 'default');
+  const [statusPill, setStatusPill] = React.useState(previewContext.statusPill);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const detailsRegionId = React.useMemo(
     () => `${previewContext.activityHtmlId}-preview-details`,
     [previewContext.activityHtmlId],
   );
+  const cardClasses =
+    visualState === 'removed'
+      ? 'relative h-full bg-Surface-surface-secondary-muted before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger'
+      : '';
+
+  React.useEffect(() => {
+    setActions(previewContext.actions ?? []);
+    setVisualState(previewContext.visualState ?? 'default');
+    setStatusPill(previewContext.statusPill);
+  }, [
+    previewContext.activityResourceId,
+    previewContext.actions,
+    previewContext.visualState,
+    previewContext.statusPill,
+  ]);
 
   React.useEffect(() => {
     if (detailTabs.length === 0) {
@@ -40,13 +134,80 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     }
   }, [activeTabId, detailTabs]);
 
+  React.useEffect(() => {
+    const handleCustomizationReply = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+
+      if (
+        detail?.target?.activityResourceId !== previewContext.activityResourceId &&
+        detail?.activityResourceId !== previewContext.activityResourceId
+      ) {
+        return;
+      }
+
+      setIsSubmitting(false);
+
+      if (detail.ok && Array.isArray(detail.actions)) {
+        setActions(detail.actions);
+      }
+
+      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'visualState')) {
+        setVisualState(detail.visualState ?? 'default');
+      }
+
+      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'statusPill')) {
+        setStatusPill(detail.statusPill ?? undefined);
+      }
+    };
+
+    window.addEventListener('oli:preview-customization:reply', handleCustomizationReply);
+
+    return () => {
+      window.removeEventListener('oli:preview-customization:reply', handleCustomizationReply);
+    };
+  }, [previewContext.activityResourceId]);
+
+  const headerActions =
+    previewContext.canCustomize && actions.length > 0 ? (
+      <div className="flex flex-wrap items-center gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.kind}
+            type="button"
+            disabled={isSubmitting}
+            className={actionButtonClasses(action.kind)}
+            onClick={() => {
+              // Keep preview components presentational: emit a typed intent and let the enclosing
+              // LiveView decide how "remove" or "restore" maps to section/page mutations. The
+              // reply updates only local customization state, avoiding a remount so existing
+              // component UI state remains intact.
+              setIsSubmitting(true);
+              window.dispatchEvent(
+                new CustomEvent('oli:preview-customization', {
+                  detail: {
+                    action: action.kind,
+                    target: previewContext.customizationTarget,
+                  },
+                }),
+              );
+            }}
+          >
+            {action.kind === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+            {isSubmitting ? 'Updating...' : action.label}
+          </button>
+        ))}
+      </div>
+    ) : null;
+
   return (
-    <article className="p-6">
+    <article className={`p-6 ${cardClasses}`}>
       <div className="flex flex-col gap-4">
         <PreviewHeader
           activityTypeLabel={previewContext.activityTypeLabel}
           title={previewContext.title}
           points={previewContext.points}
+          actions={headerActions}
+          statusPill={statusPill}
         />
 
         <div>{children}</div>

--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -14,6 +14,35 @@ interface Props {
   defaultExpanded?: boolean;
 }
 
+const matchesCustomizationTarget = (
+  expectedTarget: PreviewContext['customizationTarget'],
+  replyTarget?: Partial<PreviewContext['customizationTarget']>,
+) => {
+  if (!replyTarget || replyTarget.kind !== expectedTarget.kind) {
+    return false;
+  }
+
+  if (replyTarget.pageResourceId !== expectedTarget.pageResourceId) {
+    return false;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(expectedTarget, 'selectionId') &&
+    expectedTarget.selectionId !== replyTarget.selectionId
+  ) {
+    return false;
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(expectedTarget, 'activityResourceId') &&
+    expectedTarget.activityResourceId !== replyTarget.activityResourceId
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 const TrashActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
   <svg
     aria-hidden="true"
@@ -138,10 +167,19 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     const handleCustomizationReply = (event: Event) => {
       const detail = (event as CustomEvent).detail;
 
-      if (
-        detail?.target?.activityResourceId !== previewContext.activityResourceId &&
-        detail?.activityResourceId !== previewContext.activityResourceId
-      ) {
+      const replyTarget =
+        detail?.target ??
+        (detail
+          ? {
+              kind: previewContext.customizationTarget.kind,
+              pageResourceId:
+                detail.pageResourceId ?? previewContext.customizationTarget.pageResourceId,
+              activityResourceId: detail.activityResourceId,
+              selectionId: detail.selectionId,
+            }
+          : undefined);
+
+      if (!matchesCustomizationTarget(previewContext.customizationTarget, replyTarget)) {
         return;
       }
 
@@ -165,7 +203,7 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     return () => {
       window.removeEventListener('oli:preview-customization:reply', handleCustomizationReply);
     };
-  }, [previewContext.activityResourceId]);
+  }, [previewContext.customizationTarget]);
 
   const headerActions =
     previewContext.canCustomize && actions.length > 0 ? (

--- a/assets/src/components/activities/common/preview/PreviewHeader.tsx
+++ b/assets/src/components/activities/common/preview/PreviewHeader.tsx
@@ -4,6 +4,11 @@ interface Props {
   activityTypeLabel: string;
   title?: string;
   points?: number | null;
+  actions?: React.ReactNode;
+  statusPill?: {
+    kind: 'removed';
+    label: string;
+  };
 }
 
 const formatPoints = (points?: number | null) => {
@@ -14,23 +19,43 @@ const formatPoints = (points?: number | null) => {
   return `${points} ${points === 1 ? 'point' : 'points'}`;
 };
 
-export const PreviewHeader: React.FC<Props> = ({ activityTypeLabel, title, points }) => {
+export const PreviewHeader: React.FC<Props> = ({
+  activityTypeLabel,
+  title,
+  points,
+  actions,
+  statusPill,
+}) => {
   const pointsLabel = formatPoints(points);
 
   return (
-    <header className="flex flex-col gap-2">
-      <div className="flex flex-wrap items-center gap-3 text-sm font-normal leading-[21px] text-Text-text-low-alpha">
-        <span>{activityTypeLabel}</span>
-        {pointsLabel && (
-          <>
-            <span aria-hidden="true">&bull;</span>
-            <span>{pointsLabel}</span>
-          </>
-        )}
+    <header className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-3 text-sm font-normal leading-[21px] text-Text-text-low-alpha">
+            <span>{activityTypeLabel}</span>
+            {pointsLabel && (
+              <>
+                <span aria-hidden="true">&bull;</span>
+                <span>{pointsLabel}</span>
+              </>
+            )}
+          </div>
+          {title && (
+            <div className="flex flex-wrap items-center gap-3">
+              <h3 className="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">
+                {title}
+              </h3>
+              {statusPill?.kind === 'removed' ? (
+                <span className="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">
+                  {statusPill.label}
+                </span>
+              ) : null}
+            </div>
+          )}
+        </div>
+        {actions ? <div className="shrink-0">{actions}</div> : null}
       </div>
-      {title && (
-        <h3 className="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">{title}</h3>
-      )}
     </header>
   );
 };

--- a/assets/src/components/activities/common/preview/PreviewHeader.tsx
+++ b/assets/src/components/activities/common/preview/PreviewHeader.tsx
@@ -30,7 +30,7 @@ export const PreviewHeader: React.FC<Props> = ({
 
   return (
     <header className="flex flex-col gap-3">
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
         <div className="flex min-w-0 flex-col gap-2">
           <div className="flex flex-wrap items-center gap-3 text-sm font-normal leading-[21px] text-Text-text-low-alpha">
             <span>{activityTypeLabel}</span>
@@ -41,11 +41,13 @@ export const PreviewHeader: React.FC<Props> = ({
               </>
             )}
           </div>
-          {title && (
+          {(title || statusPill?.kind === 'removed') && (
             <div className="flex flex-wrap items-center gap-3">
-              <h3 className="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">
-                {title}
-              </h3>
+              {title ? (
+                <h3 className="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">
+                  {title}
+                </h3>
+              ) : null}
               {statusPill?.kind === 'removed' ? (
                 <span className="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">
                   {statusPill.label}
@@ -54,7 +56,7 @@ export const PreviewHeader: React.FC<Props> = ({
             </div>
           )}
         </div>
-        {actions ? <div className="shrink-0">{actions}</div> : null}
+        {actions ? <div className="w-full sm:w-auto sm:shrink-0">{actions}</div> : null}
       </div>
     </header>
   );

--- a/assets/src/components/activities/types.ts
+++ b/assets/src/components/activities/types.ts
@@ -156,10 +156,28 @@ export type ModeSpecification = {
   entry: string;
 };
 
+export type PreviewCustomizationTargetKind =
+  | 'embedded_activity'
+  | 'bank_selection'
+  | 'bank_candidate';
+
 export interface PreviewCustomizationTarget {
-  kind: string;
+  kind: PreviewCustomizationTargetKind;
   pageResourceId: number;
-  activityResourceId: number;
+  activityResourceId?: number;
+  selectionId?: string;
+}
+
+export interface PreviewAction {
+  kind: 'remove' | 'restore';
+  label: string;
+}
+
+export type PreviewVisualState = 'default' | 'removed';
+
+export interface PreviewStatusPill {
+  kind: 'removed';
+  label: string;
 }
 
 export interface PreviewBibParams {
@@ -179,6 +197,9 @@ export interface PreviewContext {
   points?: number | null;
   learningObjectives: string[];
   canCustomize: boolean;
+  actions?: PreviewAction[];
+  visualState?: PreviewVisualState;
+  statusPill?: PreviewStatusPill;
   customizationTarget: PreviewCustomizationTarget;
   bibParams?: PreviewBibParams;
   variables?: any;

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -37,6 +37,7 @@ import { HighlightCode } from './highlight_code';
 import { HomeMobileTabs } from './home_mobile_tabs';
 import { IframeLoadState } from './iframe_load_state';
 import { InputAutoSelect } from './input_auto_select';
+import { InstructorPreviewCustomization } from './instructor_preview_customization';
 import { KeepScrollAtBottom } from './keep_scroll_at_bottom';
 import { ListNavigatorDropdown } from './list_navigator_dropdown';
 import { LiveModal } from './live_modal';
@@ -104,6 +105,7 @@ export const Hooks = {
   DropTarget,
   DragSource,
   HomeMobileTabs,
+  InstructorPreviewCustomization,
   ModalLaunch,
   InputAutoSelect,
   IframeLoadState,

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -7,6 +7,64 @@ type InstructorPreviewCustomizationHook = {
   handlePreviewCustomization?: (event: Event) => void;
 };
 
+const validTargetKinds = new Set(['embedded_activity', 'bank_selection', 'bank_candidate']);
+const validActions = new Set(['remove', 'restore']);
+
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isString = (value: unknown): value is string => typeof value === 'string';
+
+const isValidCustomizationDetail = (
+  detail: unknown,
+): detail is {
+  action: 'remove' | 'restore';
+  target: {
+    kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+    pageResourceId: number;
+    activityResourceId?: number;
+    selectionId?: string;
+  };
+} => {
+  if (!detail || typeof detail !== 'object') {
+    return false;
+  }
+
+  const candidate = detail as Record<string, unknown>;
+  const target =
+    candidate.target && typeof candidate.target === 'object'
+      ? (candidate.target as Record<string, unknown>)
+      : null;
+
+  if (!target) {
+    return false;
+  }
+
+  if (!isString(candidate.action) || !validActions.has(candidate.action)) {
+    return false;
+  }
+
+  if (!isString(target.kind) || !validTargetKinds.has(target.kind)) {
+    return false;
+  }
+
+  if (!isNumber(target.pageResourceId)) {
+    return false;
+  }
+
+  switch (target.kind) {
+    case 'embedded_activity':
+      return isNumber(target.activityResourceId);
+
+    case 'bank_selection':
+      return isString(target.selectionId);
+
+    case 'bank_candidate':
+      return isString(target.selectionId) && isNumber(target.activityResourceId);
+
+    default:
+      return false;
+  }
+};
+
 export const InstructorPreviewCustomization = {
   mounted(this: InstructorPreviewCustomizationHook) {
     // Preview activities are custom elements hydrated by React, but the mutation authority stays
@@ -14,7 +72,7 @@ export const InstructorPreviewCustomization = {
     this.handlePreviewCustomization = (event: Event) => {
       const detail = (event as CustomEvent).detail;
 
-      if (!detail) {
+      if (!isValidCustomizationDetail(detail)) {
         return;
       }
 

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -1,0 +1,43 @@
+type InstructorPreviewCustomizationHook = {
+  pushEvent: (
+    event: string,
+    payload: Record<string, unknown>,
+    callback?: (reply: Record<string, unknown>) => void,
+  ) => void;
+  handlePreviewCustomization?: (event: Event) => void;
+};
+
+export const InstructorPreviewCustomization = {
+  mounted(this: InstructorPreviewCustomizationHook) {
+    // Preview activities are custom elements hydrated by React, but the mutation authority stays
+    // in LiveView. This hook is the bridge from browser-side preview actions back to the socket.
+    this.handlePreviewCustomization = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+
+      if (!detail) {
+        return;
+      }
+
+      // The pushEvent callback carries the per-component reply while the same handle_event can
+      // still update normal LiveView assigns for the rest of the page.
+      this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
+        window.dispatchEvent(
+          new CustomEvent('oli:preview-customization:reply', {
+            detail: {
+              ...detail,
+              ...reply,
+            },
+          }),
+        );
+      });
+    };
+
+    window.addEventListener('oli:preview-customization', this.handlePreviewCustomization);
+  },
+
+  destroyed(this: InstructorPreviewCustomizationHook) {
+    if (this.handlePreviewCustomization) {
+      window.removeEventListener('oli:preview-customization', this.handlePreviewCustomization);
+    }
+  },
+};

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -5,6 +5,7 @@ type InstructorPreviewCustomizationHook = {
     callback?: (reply: Record<string, unknown>) => void,
   ) => void;
   handlePreviewCustomization?: (event: Event) => void;
+  handleFallbackPreviewCustomizationClick?: (event: Event) => void;
 };
 
 const validTargetKinds = new Set(['embedded_activity', 'bank_selection', 'bank_candidate']);
@@ -67,6 +68,112 @@ const isValidCustomizationDetail = (
 
 export const InstructorPreviewCustomization = {
   mounted(this: InstructorPreviewCustomizationHook) {
+    // Some activity types still fall back to the authoring element during instructor preview.
+    // Those cards are rendered fully on the server, so they cannot rely on the React preview
+    // component's local state. This helper applies the LiveView reply directly to the fallback
+    // wrapper so Remove/Restore stays aligned with the preview-component path. (The activity types
+    // considered preview-capable by the server are listed in Oli.Activities.preview_supported_activity_slugs/0.)
+    const updateFallbackPreviewCard = (
+      target: {
+        kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+        pageResourceId: number;
+        activityResourceId?: number;
+        selectionId?: string;
+      },
+      reply: Record<string, unknown>,
+    ) => {
+      if (!reply.ok) {
+        return;
+      }
+
+      const wrappers = document.querySelectorAll<HTMLElement>('.instructor-preview-activity-wrapper');
+
+      wrappers.forEach((wrapper) => {
+        const button = wrapper.querySelector<HTMLButtonElement>('[data-preview-customization-button]');
+
+        if (!button) {
+          return;
+        }
+
+        const encodedTarget = button.dataset.previewCustomizationTarget;
+
+        if (!encodedTarget) {
+          return;
+        }
+
+        try {
+          const buttonTarget = JSON.parse(encodedTarget) as {
+            kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+            pageResourceId: number;
+            activityResourceId?: number;
+            selectionId?: string;
+          };
+
+          if (
+            buttonTarget.kind !== target.kind ||
+            buttonTarget.pageResourceId !== target.pageResourceId ||
+            buttonTarget.activityResourceId !== target.activityResourceId ||
+            buttonTarget.selectionId !== target.selectionId
+          ) {
+            return;
+          }
+        } catch {
+          return;
+        }
+
+        const visualState = reply.visualState === 'removed' ? 'removed' : 'default';
+        const isAuthoringFallback = wrapper.classList.contains('instructor-preview-authoring-fallback');
+
+        wrapper.className =
+          visualState === 'removed'
+            ? `instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default overflow-hidden p-6 relative instructor-preview-removed bg-Surface-surface-secondary-muted dark:bg-Background-bg-primary before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger${
+                isAuthoringFallback ? ' instructor-preview-authoring-fallback' : ''
+              }`
+            : `instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default overflow-hidden p-6 instructor-preview-default bg-Surface-surface-primary${
+                isAuthoringFallback ? ' instructor-preview-authoring-fallback' : ''
+              }`;
+
+        if (Array.isArray(reply.actions) && reply.actions.length > 0) {
+          const action = reply.actions[0] as { kind?: string; label?: string };
+
+          if (action.kind === 'remove' || action.kind === 'restore') {
+            button.dataset.previewCustomizationAction = action.kind;
+            button.className =
+              action.kind === 'remove'
+                ? 'inline-flex items-center gap-2 rounded-[6px] border bg-Surface-surface-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 border-Border-border-danger text-Specially-Tokens-Text-text-button-pill-muted hover:bg-[rgba(255,64,64,0.08)] dark:border-Border-border-danger dark:text-[#FFB5B7] dark:hover:bg-[rgba(255,64,64,0.18)] focus-visible:outline-Border-border-danger disabled:cursor-wait disabled:opacity-70'
+                : 'inline-flex items-center gap-2 rounded-[6px] border bg-transparent px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 border-[#8AB8E5] text-Text-text-button hover:bg-[#EEF6FF] hover:text-Text-text-button-hover dark:bg-transparent dark:border-[#4C82B8] dark:text-[#9FD0FF] dark:hover:bg-[#16395C] dark:hover:text-[#D7ECFF] focus-visible:outline-[#8AB8E5] disabled:cursor-wait disabled:opacity-70';
+
+            const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
+            if (label) {
+              label.textContent = action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore');
+            }
+
+            button.innerHTML =
+              `${action.kind === 'remove'
+                ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+                : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+              }<span data-preview-customization-label>${action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore')}</span>`;
+          }
+        }
+
+        const titleRow = wrapper.querySelector<HTMLElement>('[data-preview-title-row]');
+        const existingPill = wrapper.querySelector<HTMLElement>('[data-preview-status-pill]');
+        const statusPill = reply.statusPill as { kind?: string; label?: string } | null | undefined;
+
+        if (statusPill?.kind === 'removed') {
+          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">${statusPill.label ?? 'Removed'}</span>`;
+
+          if (existingPill) {
+            existingPill.outerHTML = pillMarkup;
+          } else if (titleRow) {
+            titleRow.insertAdjacentHTML('beforeend', pillMarkup);
+          }
+        } else if (existingPill) {
+          existingPill.remove();
+        }
+      });
+    };
+
     // Preview activities are custom elements hydrated by React, but the mutation authority stays
     // in LiveView. This hook is the bridge from browser-side preview actions back to the socket.
     this.handlePreviewCustomization = (event: Event) => {
@@ -87,15 +194,94 @@ export const InstructorPreviewCustomization = {
             },
           }),
         );
+
+        updateFallbackPreviewCard(detail.target, reply);
+      });
+    };
+
+    // Authoring-element fallbacks render their header actions directly in server HTML, so they
+    // do not emit the custom browser event that React preview cards use. Delegate their clicks
+    // here and forward the same payload shape into LiveView.
+    this.handleFallbackPreviewCustomizationClick = (event: Event) => {
+      const button = (event.target as HTMLElement | null)?.closest?.<HTMLButtonElement>(
+        '[data-preview-customization-button]',
+      );
+
+      if (!button) {
+        return;
+      }
+
+      const action = button.dataset.previewCustomizationAction;
+      const encodedTarget = button.dataset.previewCustomizationTarget;
+
+      if (!action || !encodedTarget) {
+        return;
+      }
+
+      let target: {
+        kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+        pageResourceId: number;
+        activityResourceId?: number;
+        selectionId?: string;
+      };
+
+      try {
+        target = JSON.parse(encodedTarget);
+      } catch {
+        return;
+      }
+
+      const detail = { action, target };
+
+      if (!isValidCustomizationDetail(detail)) {
+        return;
+      }
+
+      button.disabled = true;
+      const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
+      const previousLabel = label?.textContent ?? '';
+
+      if (label) {
+        label.textContent = 'Updating...';
+      }
+
+      this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
+        button.disabled = false;
+
+        if (!reply.ok && label) {
+          label.textContent = previousLabel;
+        }
+
+        window.dispatchEvent(
+          new CustomEvent('oli:preview-customization:reply', {
+            detail: {
+              ...detail,
+              ...reply,
+            },
+          }),
+        );
+
+        updateFallbackPreviewCard(detail.target, reply);
       });
     };
 
     window.addEventListener('oli:preview-customization', this.handlePreviewCustomization);
+    window.addEventListener(
+      'click',
+      this.handleFallbackPreviewCustomizationClick as EventListener,
+    );
   },
 
   destroyed(this: InstructorPreviewCustomizationHook) {
     if (this.handlePreviewCustomization) {
       window.removeEventListener('oli:preview-customization', this.handlePreviewCustomization);
+    }
+
+    if (this.handleFallbackPreviewCustomizationClick) {
+      window.removeEventListener(
+        'click',
+        this.handleFallbackPreviewCustomizationClick as EventListener,
+      );
     }
   },
 };

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -86,10 +86,14 @@ export const InstructorPreviewCustomization = {
         return;
       }
 
-      const wrappers = document.querySelectorAll<HTMLElement>('.instructor-preview-activity-wrapper');
+      const wrappers = document.querySelectorAll<HTMLElement>(
+        '.instructor-preview-activity-wrapper',
+      );
 
       wrappers.forEach((wrapper) => {
-        const button = wrapper.querySelector<HTMLButtonElement>('[data-preview-customization-button]');
+        const button = wrapper.querySelector<HTMLButtonElement>(
+          '[data-preview-customization-button]',
+        );
 
         if (!button) {
           return;
@@ -122,7 +126,9 @@ export const InstructorPreviewCustomization = {
         }
 
         const visualState = reply.visualState === 'removed' ? 'removed' : 'default';
-        const isAuthoringFallback = wrapper.classList.contains('instructor-preview-authoring-fallback');
+        const isAuthoringFallback = wrapper.classList.contains(
+          'instructor-preview-authoring-fallback',
+        );
 
         wrapper.className =
           visualState === 'removed'
@@ -148,11 +154,13 @@ export const InstructorPreviewCustomization = {
               label.textContent = action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore');
             }
 
-            button.innerHTML =
-              `${action.kind === 'remove'
+            button.innerHTML = `${
+              action.kind === 'remove'
                 ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
                 : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
-              }<span data-preview-customization-label>${action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore')}</span>`;
+            }<span data-preview-customization-label>${
+              action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore')
+            }</span>`;
           }
         }
 
@@ -161,7 +169,9 @@ export const InstructorPreviewCustomization = {
         const statusPill = reply.statusPill as { kind?: string; label?: string } | null | undefined;
 
         if (statusPill?.kind === 'removed') {
-          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">${statusPill.label ?? 'Removed'}</span>`;
+          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">${
+            statusPill.label ?? 'Removed'
+          }</span>`;
 
           if (existingPill) {
             existingPill.outerHTML = pillMarkup;
@@ -266,10 +276,7 @@ export const InstructorPreviewCustomization = {
     };
 
     window.addEventListener('oli:preview-customization', this.handlePreviewCustomization);
-    window.addEventListener(
-      'click',
-      this.handleFallbackPreviewCustomizationClick as EventListener,
-    );
+    window.addEventListener('click', this.handleFallbackPreviewCustomizationClick as EventListener);
   },
 
   destroyed(this: InstructorPreviewCustomizationHook) {

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -121,6 +121,11 @@ describe('ActivityPreviewCard', () => {
         new CustomEvent('oli:preview-customization:reply', {
           detail: {
             ok: true,
+            target: {
+              kind: 'embedded_activity',
+              pageResourceId: 10,
+              activityResourceId: 100,
+            },
             activityResourceId: 100,
             visualState: 'removed',
             statusPill: { kind: 'removed', label: 'Removed' },
@@ -132,6 +137,44 @@ describe('ActivityPreviewCard', () => {
 
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
     expect(screen.getByText('Removed')).toBeInTheDocument();
+  });
+
+  test('matches replies for selection-based targets using the full customization target', () => {
+    const selectionContext = {
+      ...previewContext,
+      actions: [{ kind: 'remove' as const, label: 'Remove bank' }],
+      customizationTarget: {
+        kind: 'bank_selection' as const,
+        pageResourceId: 10,
+        selectionId: 'selection-1',
+      },
+    };
+
+    render(
+      <ActivityPreviewCard previewContext={selectionContext}>
+        <div>Question body</div>
+      </ActivityPreviewCard>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove bank' }));
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: {
+            ok: true,
+            target: {
+              kind: 'bank_selection',
+              pageResourceId: 10,
+              selectionId: 'selection-1',
+            },
+            actions: [{ kind: 'restore', label: 'Restore' }],
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
   });
 
   test('renders removed visual treatment only when the preview context asks for it', () => {

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { PreviewElementProps } from 'components/activities/PreviewElement';
 import {
   PreviewElementProvider,
@@ -98,6 +98,76 @@ describe('ActivityPreviewCard', () => {
     expect(screen.queryByText('LO')).not.toBeInTheDocument();
     expect(screen.queryByText('Explain entropy')).not.toBeInTheDocument();
     expect(screen.queryByText('Interpret Gibbs free energy')).not.toBeInTheDocument();
+  });
+
+  test('updates action label from remove to restore after LiveView reply without remounting', () => {
+    const actionableContext = {
+      ...previewContext,
+      actions: [{ kind: 'remove' as const, label: 'Remove' }],
+    };
+
+    render(
+      <ActivityPreviewCard previewContext={actionableContext}>
+        <div>Question body</div>
+      </ActivityPreviewCard>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(screen.getByRole('button', { name: 'Updating...' })).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: {
+            ok: true,
+            activityResourceId: 100,
+            visualState: 'removed',
+            statusPill: { kind: 'removed', label: 'Removed' },
+            actions: [{ kind: 'restore', label: 'Restore' }],
+          },
+        }),
+      );
+    });
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+  });
+
+  test('renders removed visual treatment only when the preview context asks for it', () => {
+    const removedContext = {
+      ...previewContext,
+      actions: [{ kind: 'restore' as const, label: 'Restore' }],
+      visualState: 'removed' as const,
+      statusPill: { kind: 'removed' as const, label: 'Removed' },
+    };
+
+    const { rerender } = render(
+      <ActivityPreviewCard previewContext={removedContext}>
+        <div>Question body</div>
+      </ActivityPreviewCard>,
+    );
+
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('Question body').closest('article')).toHaveClass(
+      'relative',
+      'before:w-[6px]',
+      'before:bg-Border-border-danger',
+    );
+
+    const restoreOnlyContext = {
+      ...previewContext,
+      actions: [{ kind: 'restore' as const, label: 'Restore' }],
+    };
+
+    rerender(
+      <ActivityPreviewCard previewContext={restoreOnlyContext}>
+        <div>Question body</div>
+      </ActivityPreviewCard>,
+    );
+
+    expect(screen.queryByText('Removed')).not.toBeInTheDocument();
+    expect(screen.getByText('Question body').closest('article')).not.toHaveClass('border-l-4');
   });
 });
 

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -8,6 +8,7 @@ import {
 import { ActivityPreviewCard } from 'components/activities/common/preview/ActivityPreviewCard';
 import { ReadonlyPanel } from 'components/activities/common/preview/ReadonlyPanel';
 import { ActivityModelSchema, PreviewContext } from 'components/activities/types';
+import { InstructorPreviewCustomization } from 'hooks/instructor_preview_customization';
 
 const previewContext: PreviewContext = {
   sectionSlug: 'section-1',
@@ -243,5 +244,96 @@ describe('PreviewElementProvider', () => {
     expect(screen.getByText('section-1')).toBeInTheDocument();
     expect(screen.getByText('10')).toBeInTheDocument();
     expect(screen.getByText('Identify the best answer')).toBeInTheDocument();
+  });
+});
+
+describe('InstructorPreviewCustomization fallback preview wiring', () => {
+  test('updates a server-rendered authoring fallback card after a successful reply', () => {
+    document.body.innerHTML = `
+      <div class="instructor-preview-activity-wrapper instructor-preview-authoring-fallback instructor-preview-default mb-6 rounded-lg border border-Border-border-default overflow-hidden p-6 bg-Surface-surface-primary">
+        <header class="mb-4 flex flex-col gap-3">
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+            <div class="flex min-w-0 flex-col gap-2">
+              <div class="flex flex-wrap items-center gap-3 text-sm font-normal leading-[21px] text-Text-text-low-alpha">
+                <span>Short Answer</span>
+              </div>
+              <div data-preview-title-row="200" class="flex flex-wrap items-center gap-3">
+                <h3 class="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">Fallback Activity</h3>
+              </div>
+            </div>
+            <div class="w-full sm:w-auto sm:shrink-0">
+              <div data-preview-action-container="200" class="flex flex-wrap items-center gap-2">
+                <button
+                  type="button"
+                  data-preview-customization-action="remove"
+                  data-preview-customization-target='{"kind":"embedded_activity","pageResourceId":10,"activityResourceId":200}'
+                  data-preview-customization-button
+                  class="initial-button-class"
+                >
+                  <span data-preview-customization-label>Remove</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+      </div>
+    `;
+
+    const pushEvent = jest.fn(
+      (
+        _event: string,
+        _payload: Record<string, unknown>,
+        callback?: (reply: Record<string, unknown>) => void,
+      ) => {
+        callback?.({
+          ok: true,
+          actions: [{ kind: 'restore', label: 'Restore' }],
+          visualState: 'removed',
+          statusPill: { kind: 'removed', label: 'Removed' },
+        });
+      },
+    );
+
+    const hook: {
+      pushEvent: (
+        event: string,
+        payload: Record<string, unknown>,
+        callback?: (reply: Record<string, unknown>) => void,
+      ) => void;
+      handlePreviewCustomization?: (event: Event) => void;
+      handleFallbackPreviewCustomizationClick?: (event: Event) => void;
+    } = {
+      pushEvent,
+    };
+
+    InstructorPreviewCustomization.mounted.call(hook);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(pushEvent).toHaveBeenCalledWith(
+      'toggle_preview_activity_customization',
+      {
+        action: 'remove',
+        target: {
+          kind: 'embedded_activity',
+          pageResourceId: 10,
+          activityResourceId: 200,
+        },
+      },
+      expect.any(Function),
+    );
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(document.querySelector('.instructor-preview-activity-wrapper')).toHaveClass(
+      'instructor-preview-authoring-fallback',
+      'instructor-preview-removed',
+      'bg-Surface-surface-secondary-muted',
+      'before:w-[6px]',
+      'before:bg-Border-border-danger',
+    );
+
+    InstructorPreviewCustomization.destroyed.call(hook);
+    document.body.innerHTML = '';
   });
 });

--- a/docs/exec-plans/current/epics/instructor_customizations/overview.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/overview.md
@@ -50,6 +50,7 @@ This epic initially targets basic pages for the LiveView shell migration. Adapti
 
 - `docs/exec-plans/current/epics/instructor_customizations/core/informal.md`
 - `docs/exec-plans/current/epics/instructor_customizations/preview_components/informal.md`
+- `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md`
 - `docs/exec-plans/current/epics/instructor_customizations/instructor_view_shell/prd.md`
 - `docs/exec-plans/current/epics/instructor_customizations/plan.md`
 

--- a/docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md
@@ -1,0 +1,269 @@
+# Instructor Preview Customization Wiring Contract
+
+This document captures the shared React-to-LiveView customization contract used by instructor-facing preview activities in the `MER-5613` epic.
+
+It is intentionally implementation-oriented rather than ticket-oriented. Later stories can reuse this contract without re-explaining how preview cards communicate with LiveView or how LiveView returns per-card state updates without forcing a remount.
+
+## Purpose
+
+Instructor preview cards need to support section-specific customization actions such as `Remove` and `Restore`, while remaining reusable across multiple LiveViews and multiple target types:
+
+- embedded activities rendered directly on a page preview
+- activity bank selections rendered at page level
+- candidate activities rendered inside an activity bank selection manager
+
+The contract in this document separates:
+
+- local component UI state owned by React
+- business mutations owned by the containing LiveView
+- optional visual treatment owned by the containing surface
+
+## Ownership Model
+
+### React Preview Components
+
+React preview cards own local UI state that should survive customization actions, such as:
+
+- expanded or collapsed sections
+- active tabs
+- local loading state
+- local action state derived from the latest server reply
+
+React preview cards do not decide which database mutation to execute.
+
+### Containing LiveView
+
+The LiveView that renders the preview surface owns:
+
+- the meaning of each customization action in that surface
+- dispatch to the correct `Oli.Delivery.InstructorCustomizations` context function
+- page-level or manager-level aggregates that depend on customization state
+- flash messages and any other screen-owned feedback
+
+This keeps the preview cards reusable across multiple surfaces while allowing each LiveView to react differently to the same `Remove` or `Restore` intent.
+
+## Event Flow
+
+The wiring uses a bidirectional flow between React and LiveView:
+
+1. A preview card button is clicked in React.
+2. React dispatches a browser event that carries:
+   - the requested action
+   - the typed customization target for that preview
+3. The `InstructorPreviewCustomization` hook listens for that browser event and calls `pushEvent(...)` into the owning LiveView.
+4. The LiveView `handle_event/3` pattern matches on the target kind and action, then performs the appropriate domain mutation.
+5. The LiveView returns:
+   - a `{:reply, reply, socket}` payload for the specific preview card that initiated the action
+   - normal socket assigns updates for any other LiveView-owned UI that depends on the mutation
+6. The hook callback emits a reply event back to the browser.
+7. The originating React card consumes that reply and updates only its local customization-related state.
+
+The key property of this design is that the preview card does not need to remount to reflect `Remove` or `Restore`. Existing local UI state remains intact.
+
+## Why `{:reply, reply, socket}` Is The Right Boundary
+
+This contract deliberately avoids a `React -> controller/API -> LiveView sync` design.
+
+The owning LiveView is already the screen authority and already holds the websocket connection needed to:
+
+- perform the mutation
+- update screen-level aggregates
+- return a targeted reply to the initiating preview card
+
+Using `{:reply, reply, socket}` keeps the flow single-owner:
+
+- React sends intent
+- LiveView performs the mutation
+- LiveView replies with the new per-card state
+- LiveView diffs the rest of the screen as needed
+
+## Browser Event Contract
+
+The event emitted by React should be treated as a customization intent, not a direct mutation command.
+
+Current payload shape:
+
+```json
+{
+  "action": "remove",
+  "target": {
+    "kind": "embedded_activity",
+    "pageResourceId": 123,
+    "activityResourceId": 456
+  }
+}
+```
+
+The hook forwards that payload unchanged into the LiveView event.
+
+## Target Kinds
+
+The shared `PreviewCustomizationTarget.kind` contract is defined in `assets/src/components/activities/types.ts`.
+
+Supported kinds are:
+
+- `embedded_activity`
+- `bank_selection`
+- `bank_candidate`
+
+Expected meaning:
+
+- `embedded_activity`
+  - an authored activity embedded directly in the page preview
+- `bank_selection`
+  - an activity bank selection treated as a page-level customizable item
+- `bank_candidate`
+  - a specific candidate activity inside a selection manager surface
+
+The point of `kind` is to make each containing LiveView dispatch explicitly rather than inferring behavior from button labels.
+
+## TypeScript Contract
+
+The shared preview typing lives in `assets/src/components/activities/types.ts`.
+
+Relevant structures:
+
+```ts
+export type PreviewCustomizationTargetKind =
+  | 'embedded_activity'
+  | 'bank_selection'
+  | 'bank_candidate';
+
+export interface PreviewCustomizationTarget {
+  kind: PreviewCustomizationTargetKind;
+  pageResourceId: number;
+  activityResourceId?: number;
+  selectionId?: string;
+}
+
+export interface PreviewAction {
+  kind: 'remove' | 'restore';
+  label: string;
+}
+
+export type PreviewVisualState = 'default' | 'removed';
+
+export interface PreviewStatusPill {
+  kind: 'removed';
+  label: string;
+}
+```
+
+`PreviewContext` carries:
+
+- `actions`
+- `customizationTarget`
+- `visualState`
+- `statusPill`
+
+alongside the existing preview content metadata.
+
+## Why Visual State Is Separate From Remove/Restore State
+
+The same business state does not always require the same visual treatment.
+
+Examples:
+
+- In page preview, an excluded embedded activity may need:
+  - `Restore`
+  - gray removed background
+  - red left accent
+  - `Removed` pill beside the title
+- In a bank-selection management screen, an excluded candidate may need:
+  - `Restore`
+  - no removed card treatment because removal state is communicated elsewhere in the layout
+
+For that reason, the contract does not infer removed styling from the presence of a `Restore` action.
+
+Instead:
+
+- `actions` control what the user can do
+- `visualState` controls the card-level visual treatment
+- `statusPill` controls optional header status chips such as `Removed`
+
+This allows the same preview component to be reused across multiple LiveViews without hardcoding surface-specific styling rules inside React.
+
+## LiveView Dispatch Expectations
+
+Each LiveView that consumes preview customization events should pattern match on `target.kind` and then choose the correct side effect for that screen.
+
+Illustrative shape:
+
+```elixir
+def handle_event("toggle_preview_activity_customization", %{"action" => action, "target" => %{"kind" => "embedded_activity"} = target}, socket) do
+  ...
+end
+
+def handle_event("toggle_preview_activity_customization", %{"action" => action, "target" => %{"kind" => "bank_selection"} = target}, socket) do
+  ...
+end
+
+def handle_event("toggle_preview_activity_customization", %{"action" => action, "target" => %{"kind" => "bank_candidate"} = target}, socket) do
+  ...
+end
+```
+
+The handler is free to perform whatever screen-appropriate side effects are needed before replying to React.
+
+Typical side effects include:
+
+- calling an `InstructorCustomizations` remove or restore function
+- recalculating page or manager aggregates
+- updating flashes
+- updating any LiveView-owned UI outside the preview card itself
+
+## Reply Contract
+
+The reply sent back to React should be limited to the state the preview card itself needs to update locally.
+
+Typical reply shape:
+
+```json
+{
+  "ok": true,
+  "activityResourceId": 456,
+  "actions": [{ "kind": "restore", "label": "Restore" }],
+  "visualState": "removed",
+  "statusPill": { "kind": "removed", "label": "Removed" }
+}
+```
+
+On error, the LiveView should still reply so the initiating component can leave its submitting state:
+
+```json
+{
+  "ok": false
+}
+```
+
+The LiveView can still update its socket at the same time so aggregates and flashes continue to use normal LiveView diffs.
+
+## Current Reference Implementation
+
+The first concrete implementation of this wiring lives in the instructor page preview flow:
+
+- React preview card:
+  - `assets/src/components/activities/common/preview/ActivityPreviewCard.tsx`
+- shared preview types:
+  - `assets/src/components/activities/types.ts`
+- hook bridge:
+  - `assets/src/hooks/instructor_preview_customization.ts`
+- current LiveView consumer:
+  - `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`
+- current preview-context builder:
+  - `lib/oli_web/delivery/instructor/preview_page_context.ex`
+
+That implementation currently dispatches only `embedded_activity` mutations, but the event and type contract are intentionally shaped so later LiveViews can add `bank_selection` and `bank_candidate` handling without redesigning the preview card.
+
+## Guidance For Future Tickets
+
+When a new LiveView wants to reuse preview customization:
+
+1. Reuse the existing preview card and hook contract.
+2. Provide a `customizationTarget` with the correct `kind`.
+3. Provide `actions` that reflect the current server-owned customization state.
+4. Provide `visualState` and `statusPill` only if that surface wants removed-card treatment.
+5. Pattern match on `target.kind` in the LiveView event handler.
+6. Return `{:reply, reply, socket}` so the initiating card updates in place while the rest of the screen continues to update through normal LiveView diffs.
+
+This keeps the customization flow consistent across page preview, activity-bank selection management, and later instructor customization surfaces.

--- a/docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md
@@ -94,7 +94,18 @@ Current payload shape:
 }
 ```
 
-The hook forwards that payload unchanged into the LiveView event.
+The hook forwards that payload into the LiveView event only after runtime validation.
+
+Current hook-side validation responsibilities:
+
+- `action` must be `remove` or `restore`
+- `target.kind` must be one of the supported preview customization kinds
+- `pageResourceId` must be present
+- `embedded_activity` requires `activityResourceId`
+- `bank_selection` requires `selectionId`
+- `bank_candidate` requires both `selectionId` and `activityResourceId`
+
+Invalid browser events are dropped client-side and never reach `pushEvent(...)`.
 
 ## Target Kinds
 
@@ -116,6 +127,31 @@ Expected meaning:
   - a specific candidate activity inside a selection manager surface
 
 The point of `kind` is to make each containing LiveView dispatch explicitly rather than inferring behavior from button labels.
+
+## Validation Boundaries
+
+The wiring intentionally validates the customization request at more than one layer.
+
+### Hook-side Validation
+
+The browser event boundary is untyped at runtime, even though the preview card is authored in TypeScript.
+
+The `InstructorPreviewCustomization` hook therefore validates the event payload shape before forwarding it into LiveView. This prevents malformed or incomplete browser events from becoming LiveView mutation requests.
+
+### LiveView-side Validation
+
+The containing LiveView must still revalidate the target against its own current state before executing a write.
+
+For example, page preview should reject requests where:
+
+- `pageResourceId` does not match the page currently being previewed
+- `activityResourceId` does not belong to the set of activities rendered on that page
+
+This prevents stale or mismatched browser payloads from mutating unrelated preview state and keeps any derived LiveView aggregates aligned with the current screen.
+
+### Domain-side Validation
+
+After the LiveView-level target checks pass, the LiveView still delegates the actual mutation to `Oli.Delivery.InstructorCustomizations`, which remains responsible for authorization and domain-level validity.
 
 ## TypeScript Contract
 
@@ -208,6 +244,7 @@ The handler is free to perform whatever screen-appropriate side effects are need
 Typical side effects include:
 
 - calling an `InstructorCustomizations` remove or restore function
+- validating that the requested target belongs to the current preview surface
 - recalculating page or manager aggregates
 - updating flashes
 - updating any LiveView-owned UI outside the preview card itself

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -746,6 +746,12 @@ defmodule Oli.Rendering.Activity.Html do
       nil ->
         warn_supported_preview_fallback(summary)
 
+        # Activities without a dedicated preview component still render inside the
+        # instructor-preview card chrome. In that case we wrap the authoring element with the
+        # same header/actions shell so Remove/Restore and removed styling behave like preview
+        # components, while the inner activity body continues to use authoring-mode rendering.
+        # (Activities whose types are treated as preview-capable on the Elixir side are listed by
+        # Oli.Activities.preview_supported_activity_slugs/0.)
         activity_context =
           %{
             variables: variables,
@@ -760,9 +766,12 @@ defmodule Oli.Rendering.Activity.Html do
           |> Poison.encode!()
           |> HtmlEntities.encode()
 
+        wrapper_class =
+          preview_wrapper_class(preview_context, padded?: true, authoring_fallback?: true)
+
         [
-          ~s|<div class="instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden p-6">|,
-          render_preview_header(preview_context),
+          ~s|<div class="#{wrapper_class}">|,
+          render_preview_header(preview_context, activity_id),
           ~s|<#{tag} authoringcontext="#{activity_context}" student_responses=\"#{student_responses}\" section_slug=\"#{section_slug}\" activity_id=\"#{activity_html_id}\" model="#{model_json}" activityId="#{activity_id}" editmode="false" mode="instructor_preview" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|,
           render_learning_objectives(preview_context),
           ~s|</div>|
@@ -801,15 +810,28 @@ defmodule Oli.Rendering.Activity.Html do
     end
   end
 
-  defp render_preview_header(nil), do: []
+  defp render_preview_header(nil, _activity_id), do: []
 
-  defp render_preview_header(preview_context) do
+  # Shared header renderer for instructor preview cards. It now serves both true preview
+  # components and authoring-element fallbacks, so the action button/pill contract must remain
+  # server-renderable and not depend on React-only state. (Preview-capable activity types are the
+  # ones surfaced in Elixir through Oli.Activities.preview_supported_activity_slugs/0.)
+  defp render_preview_header(preview_context, activity_id) do
     activity_type_label =
       Map.get(preview_context, :activityTypeLabel) ||
         Map.get(preview_context, "activityTypeLabel")
 
     title = Map.get(preview_context, :title) || Map.get(preview_context, "title")
     points = Map.get(preview_context, :points) || Map.get(preview_context, "points")
+    status_pill = Map.get(preview_context, :statusPill) || Map.get(preview_context, "statusPill")
+    actions = Map.get(preview_context, :actions) || Map.get(preview_context, "actions") || []
+
+    can_customize =
+      Map.get(preview_context, :canCustomize) || Map.get(preview_context, "canCustomize")
+
+    target =
+      Map.get(preview_context, :customizationTarget) ||
+        Map.get(preview_context, "customizationTarget")
 
     points_label =
       case points do
@@ -841,12 +863,118 @@ defmodule Oli.Rendering.Activity.Html do
           ~s|<h3 class="!m-0 text-xl font-semibold leading-[26px] text-Text-text-high">#{HtmlEntities.encode(value)}</h3>|
       end
 
+    status_pill_html =
+      render_preview_status_pill(status_pill)
+
+    title_row_html =
+      if title_html == "" and status_pill_html == "" do
+        ""
+      else
+        ~s|<div data-preview-title-row="#{activity_id}" class="flex flex-wrap items-center gap-3">#{title_html}#{status_pill_html}</div>|
+      end
+
+    actions_html =
+      render_preview_header_actions(can_customize, actions, target, activity_id)
+
     [
-      ~s|<header class="mb-4 flex flex-col gap-2">|,
+      ~s|<header class="mb-4 flex flex-col gap-3">|,
+      ~s|<div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">|,
+      ~s|<div class="flex min-w-0 flex-col gap-2">|,
       ~s|<div class="flex flex-wrap items-center gap-3 text-sm font-normal leading-[21px] text-Text-text-low-alpha">#{metadata}</div>|,
-      title_html,
+      title_row_html,
+      ~s|</div>|,
+      actions_html,
+      ~s|</div>|,
       ~s|</header>|
     ]
+  end
+
+  defp render_preview_status_pill(nil), do: ""
+
+  defp render_preview_status_pill(%{kind: kind, label: label}),
+    do: render_preview_status_pill(%{"kind" => kind, "label" => label})
+
+  defp render_preview_status_pill(%{"kind" => "removed", "label" => label}) do
+    ~s|<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">#{HtmlEntities.encode(label)}</span>|
+  end
+
+  defp render_preview_status_pill(_), do: ""
+
+  defp render_preview_header_actions(false, _actions, _target, _activity_id), do: ""
+  defp render_preview_header_actions(_can_customize, [], _target, _activity_id), do: ""
+  defp render_preview_header_actions(_can_customize, _actions, nil, _activity_id), do: ""
+
+  defp render_preview_header_actions(_can_customize, actions, target, activity_id) do
+    buttons =
+      Enum.map_join(actions, "", fn action ->
+        render_preview_action_button(action, target)
+      end)
+
+    ~s|<div class="w-full sm:w-auto sm:shrink-0"><div data-preview-action-container="#{activity_id}" class="flex flex-wrap items-center gap-2">#{buttons}</div></div>|
+  end
+
+  defp render_preview_action_button(%{kind: kind, label: label}, target),
+    do: render_preview_action_button(%{"kind" => kind, "label" => label}, target)
+
+  defp render_preview_action_button(%{"kind" => kind, "label" => label}, target)
+       when kind in ["remove", "restore"] do
+    encoded_target =
+      target
+      |> Poison.encode!()
+      |> HtmlEntities.encode()
+
+    classes = preview_action_button_classes(kind)
+    icon = if kind == "remove", do: trash_action_icon(), else: restore_action_icon()
+
+    ~s|<button type="button" data-preview-customization-action="#{kind}" data-preview-customization-target="#{encoded_target}" data-preview-customization-button class="#{classes}">#{icon}<span data-preview-customization-label>#{HtmlEntities.encode(label)}</span></button>|
+  end
+
+  defp render_preview_action_button(_, _), do: ""
+
+  defp preview_action_button_classes("remove") do
+    "inline-flex items-center gap-2 rounded-[6px] border bg-Surface-surface-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 border-Border-border-danger text-Specially-Tokens-Text-text-button-pill-muted hover:bg-[rgba(255,64,64,0.08)] dark:border-Border-border-danger dark:text-[#FFB5B7] dark:hover:bg-[rgba(255,64,64,0.18)] focus-visible:outline-Border-border-danger disabled:cursor-wait disabled:opacity-70"
+  end
+
+  defp preview_action_button_classes("restore") do
+    "inline-flex items-center gap-2 rounded-[6px] border bg-transparent px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 border-[#8AB8E5] text-Text-text-button hover:bg-[#EEF6FF] hover:text-Text-text-button-hover dark:bg-transparent dark:border-[#4C82B8] dark:text-[#9FD0FF] dark:hover:bg-[#16395C] dark:hover:text-[#D7ECFF] focus-visible:outline-[#8AB8E5] disabled:cursor-wait disabled:opacity-70"
+  end
+
+  # The authoring fallback and the preview-component path both use the same outer wrapper
+  # contract so the client hook can toggle removed/default styling from a LiveView reply.
+  defp preview_wrapper_class(preview_context, opts) do
+    padded? = Keyword.get(opts, :padded?, false)
+    authoring_fallback? = Keyword.get(opts, :authoring_fallback?, false)
+
+    visual_state =
+      Map.get(preview_context || %{}, :visualState) ||
+        Map.get(preview_context || %{}, "visualState")
+
+    classes = [
+      "instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default overflow-hidden",
+      if(authoring_fallback?, do: "instructor-preview-authoring-fallback", else: nil),
+      if(visual_state == "removed",
+        do: "instructor-preview-removed",
+        else: "instructor-preview-default"
+      ),
+      if(padded?, do: "p-6", else: nil),
+      if(visual_state == "removed",
+        do:
+          "relative bg-Surface-surface-secondary-muted dark:bg-Background-bg-primary before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger",
+        else: "bg-Surface-surface-primary"
+      )
+    ]
+
+    classes
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+  end
+
+  defp trash_action_icon do
+    ~s|<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>|
+  end
+
+  defp restore_action_icon do
+    ~s|<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>|
   end
 
   defp format_preview_points(points) when is_float(points) do

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Components.Common do
   use Gettext, backend: OliWeb.Gettext
 
   alias OliWeb.Common.{FormatDateTime, React}
+  alias OliWeb.Icons
   alias Phoenix.LiveView.JS
 
   def not_found(assigns) do
@@ -867,6 +868,83 @@ defmodule OliWeb.Components.Common do
       Hang in there while we get back on track
       <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
     </.flash>
+    """
+  end
+
+  attr(:flash, :map, required: true, doc: "the map of flash messages")
+
+  def preview_flash_group(assigns) do
+    ~H"""
+    <.preview_flash kind={:info} flash={@flash} />
+    <.preview_flash kind={:error} flash={@flash} />
+    <.preview_flash
+      id="client-error"
+      kind={:error}
+      phx-disconnected={show(".phx-client-error #client-error")}
+      phx-connected={hide("#client-error")}
+      hidden
+    >
+      Attempting to reconnect
+    </.preview_flash>
+
+    <.preview_flash
+      id="server-error"
+      kind={:error}
+      phx-disconnected={show(".phx-server-error #server-error")}
+      phx-connected={hide("#server-error")}
+      hidden
+    >
+      Hang in there while we get back on track
+    </.preview_flash>
+    """
+  end
+
+  attr(:id, :string, default: "preview-flash", doc: "the optional id of flash container")
+  attr(:flash, :map, default: %{}, doc: "the map of flash messages to display")
+  attr(:kind, :atom, values: [:info, :error], doc: "used for styling and flash lookup")
+  attr(:rest, :global, doc: "the arbitrary HTML attributes to add to the flash container")
+
+  slot(:inner_block, doc: "the optional inner block that renders the flash message")
+
+  def preview_flash(assigns) do
+    ~H"""
+    <div
+      :if={msg = render_slot(@inner_block) || Phoenix.Flash.get(@flash, @kind)}
+      id={@id}
+      class={[
+        "mb-4 rounded-2xl px-8 py-6 shadow-none",
+        @kind == :info && "bg-[#DDF5EE] text-Text-text-high dark:bg-[#13342B] dark:text-[#E7F7F1]",
+        @kind == :error && "bg-[#FCEBEC] text-Text-text-high dark:bg-[#3B1F21] dark:text-[#FCEBEC]"
+      ]}
+      role="alert"
+      {@rest}
+    >
+      <div class="flex items-center gap-4">
+        <div
+          :if={@kind == :info}
+          class="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-Text-text-high text-white dark:bg-[#E7F7F1] dark:text-[#13342B]"
+        >
+          <Icons.checkmark class="h-4 w-4" />
+        </div>
+        <div
+          :if={@kind == :error}
+          class="flex h-7 w-7 shrink-0 items-center justify-center text-Border-border-danger dark:text-[#FFB5B7]"
+        >
+          <Icons.alert />
+        </div>
+        <p class="m-0 flex-1 font-open-sans text-[16px] font-semibold leading-6 tracking-normal">
+          {msg}
+        </p>
+        <button
+          type="button"
+          class="group -m-1 shrink-0 rounded p-1 text-Text-text-high/80 transition hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus dark:text-[#E7F7F1]/80 dark:hover:text-[#E7F7F1]"
+          aria-label={gettext("close")}
+          phx-click={JS.push("lv:clear-flash", value: %{key: @kind}) |> hide("##{@id}")}
+        >
+          <Icons.close_sm class="h-4 w-4 stroke-current" />
+        </button>
+      </div>
+    </div>
     """
   end
 

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -875,8 +875,8 @@ defmodule OliWeb.Components.Common do
 
   def preview_flash_group(assigns) do
     ~H"""
-    <.preview_flash kind={:info} flash={@flash} />
-    <.preview_flash kind={:error} flash={@flash} />
+    <.preview_flash id="preview-flash-info" kind={:info} flash={@flash} />
+    <.preview_flash id="preview-flash-error" kind={:error} flash={@flash} />
     <.preview_flash
       id="client-error"
       kind={:error}

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -70,6 +70,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       next_page: next,
       numbered_revisions: numbered_revisions,
       current_page: current,
+      current_page_resource_id: revision.resource_id,
       page_number: section_resource.numbering_index,
       question_count: map_size(activity_map),
       title: revision.title,
@@ -135,7 +136,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     # This summary is intentionally data-only. It lets header-level aggregates change
     # independently from the client-owned preview body as customization features expand.
     build_page_summary(
-      Map.values(preview_metadata.activity_revisions_by_id),
+      preview_metadata.activity_ids,
+      preview_metadata.activity_points_by_id,
       exclusion_view,
       preview_metadata.objective_titles_by_activity_id
     )
@@ -243,9 +245,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     render_context =
       build_render_context(section, revision, user, activity_map, bib_entries, all_activities)
 
-    html =
-      Page.render(render_context, revision.content, Page.Html)
-      |> IO.iodata_to_binary()
+    html = Page.render(render_context, revision.content, Page.Html)
 
     %{
       activity_map: activity_map,
@@ -254,13 +254,22 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       # Metadata cached on the LiveView so remove/restore can recompute aggregate page data
       # without repeating DB lookups for page activities and their objective labels.
       preview_metadata: %{
-        activity_revisions_by_id: Map.new(activity_revisions, &{&1.resource_id, &1}),
-        objective_titles_by_activity_id: objective_titles_by_activity_id,
-        activity_type_by_id: type_by_id,
-        activity_types: all_activities
+        activity_ids: Enum.map(activity_revisions, & &1.resource_id),
+        activity_points_by_id:
+          Map.new(activity_revisions, fn activity_revision ->
+            {activity_revision.resource_id, Grading.determine_activity_out_of(activity_revision)}
+          end),
+        objective_titles_by_activity_id: objective_titles_by_activity_id
       },
       page_summary:
-        build_page_summary(activity_revisions, exclusion_view, objective_titles_by_activity_id)
+        build_page_summary(
+          Enum.map(activity_revisions, & &1.resource_id),
+          Map.new(activity_revisions, fn activity_revision ->
+            {activity_revision.resource_id, Grading.determine_activity_out_of(activity_revision)}
+          end),
+          exclusion_view,
+          objective_titles_by_activity_id
+        )
     }
   end
 
@@ -326,25 +335,30 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     }
   end
 
-  defp build_page_summary(activity_revisions, exclusion_view, objective_titles_by_activity_id) do
-    enabled_activity_revisions =
-      Enum.filter(activity_revisions, fn activity_revision ->
-        InstructorCustomizations.activity_enabled?(exclusion_view, activity_revision.resource_id)
+  defp build_page_summary(
+         activity_ids,
+         activity_points_by_id,
+         exclusion_view,
+         objective_titles_by_activity_id
+       ) do
+    enabled_activity_ids =
+      Enum.filter(activity_ids, fn activity_id ->
+        InstructorCustomizations.activity_enabled?(exclusion_view, activity_id)
       end)
 
     learning_objectives =
-      enabled_activity_revisions
-      |> Enum.flat_map(fn activity_revision ->
-        Map.get(objective_titles_by_activity_id, activity_revision.resource_id, [])
+      enabled_activity_ids
+      |> Enum.flat_map(fn activity_id ->
+        Map.get(objective_titles_by_activity_id, activity_id, [])
       end)
       |> Enum.uniq()
       |> Enum.sort()
 
     %{
-      enabled_activity_count: length(enabled_activity_revisions),
+      enabled_activity_count: length(enabled_activity_ids),
       available_points:
-        Enum.reduce(enabled_activity_revisions, 0, fn activity_revision, acc ->
-          acc + Grading.determine_activity_out_of(activity_revision)
+        Enum.reduce(enabled_activity_ids, 0, fn activity_id, acc ->
+          acc + Map.get(activity_points_by_id, activity_id, 0)
         end),
       learning_objectives: learning_objectives,
       learning_objective_count: length(learning_objectives)

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -10,6 +10,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
   alias Oli.Activities
   alias Oli.Delivery.Hierarchy
+  alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.{PreviousNextIndex, Sections, Settings}
   alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Resources.Collaboration.CollabSpaceConfig
@@ -26,53 +27,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     {:ok, {previous, next, current}, _} =
       PreviousNextIndex.retrieve(section, revision.resource_id)
 
-    all_activities = Activities.list_activity_registrations()
-    type_by_id = Map.new(all_activities, fn activity -> {activity.id, activity} end)
+    preview_data = build_preview_data(section, revision, user)
 
-    activity_revisions =
-      revision.content
-      |> activity_ids()
-      |> then(&Resolver.from_resource_id(section_slug, &1))
-
-    objective_titles_by_activity_id =
-      preview_objective_titles_by_activity_id(section.id, activity_revisions)
-
-    activity_map =
-      activity_revisions
-      |> Enum.map(fn activity_revision ->
-        type = Map.fetch!(type_by_id, activity_revision.activity_type_id)
-
-        %ActivitySummary{
-          id: activity_revision.resource_id,
-          script: preview_script_for(type),
-          attempt_guid: nil,
-          state: nil,
-          lifecycle_state: :active,
-          model:
-            activity_revision.content
-            |> Jason.encode!()
-            |> Oli.Delivery.Page.ActivityContext.encode(),
-          delivery_element: type.delivery_element,
-          authoring_element: type.authoring_element,
-          preview_element: type.preview_element,
-          preview_script: type.preview_script,
-          graded: revision.graded,
-          activity_type_slug: type.slug,
-          preview_context:
-            build_preview_context(
-              section_slug,
-              revision,
-              activity_revision,
-              type,
-              preview_supported?(type),
-              Map.get(objective_titles_by_activity_id, activity_revision.resource_id, [])
-            ),
-          bib_refs: Map.get(activity_revision.content, "bibrefs", [])
-        }
-      end)
-      |> Map.new(fn summary -> {summary.id, summary} end)
-
-    summaries = Map.values(activity_map)
+    activity_map = preview_data.activity_map
+    summaries = preview_data.summaries
+    page_summary = preview_data.page_summary
+    html = preview_data.html
 
     bib_entries =
       revision.content
@@ -84,25 +44,6 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       )
       |> Enum.with_index(1)
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
-
-    base_project_attributes = Sections.get_section_attributes(section)
-
-    render_context = %Context{
-      user: user,
-      section_slug: section_slug,
-      revision_slug: revision.slug,
-      mode: :instructor_preview,
-      activity_map: activity_map,
-      resource_summary_fn: &Resources.resource_summary(&1, section_slug, Resolver),
-      alternatives_selector_fn: &Resources.Alternatives.select/2,
-      extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,
-      activity_types_map: Map.new(all_activities, fn activity -> {activity.id, activity} end),
-      bib_app_params: bib_entries,
-      learning_language: base_project_attributes.learning_language,
-      submitted_surveys: %{}
-    }
-
-    html = Page.render(render_context, revision.content, Page.Html)
 
     effective_settings =
       case user do
@@ -134,6 +75,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       title: revision.title,
       graded: revision.graded,
       review_mode: false,
+      # Keep aggregate page-level state separate from the preview HTML so future work can update
+      # totals like enabled points / objective coverage without rebuilding the page body.
+      page_summary: page_summary,
+      # Cache the immutable page/activity metadata needed to recompute page-level aggregates after
+      # a remove/restore action. The page body itself remains a client-owned raw HTML island.
+      preview_metadata: preview_data.preview_metadata,
       page_context: %{
         page: %{
           graded: revision.graded,
@@ -182,6 +129,16 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       is_student: false,
       has_scheduled_resources?: SectionResourceDepot.has_scheduled_resources?(section.id)
     }
+  end
+
+  def build_page_summary(preview_metadata, exclusion_view) do
+    # This summary is intentionally data-only. It lets header-level aggregates change
+    # independently from the client-owned preview body as customization features expand.
+    build_page_summary(
+      Map.values(preview_metadata.activity_revisions_by_id),
+      exclusion_view,
+      preview_metadata.objective_titles_by_activity_id
+    )
   end
 
   defp activity_ids(content) do
@@ -235,6 +192,173 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   defp preview_supported?(%{slug: slug}),
     do: Activities.preview_supported_activity_slug?(slug)
 
+  defp build_preview_data(section, revision, user) do
+    section_slug = section.slug
+    all_activities = Activities.list_activity_registrations()
+    type_by_id = Map.new(all_activities, fn activity -> {activity.id, activity} end)
+
+    activity_revisions =
+      revision.content
+      |> activity_ids()
+      |> then(&Resolver.from_resource_id(section_slug, &1))
+
+    objective_titles_by_activity_id =
+      preview_objective_titles_by_activity_id(section.id, activity_revisions)
+
+    exclusion_view =
+      InstructorCustomizations.get_page_exclusion_view(section.id, revision.resource_id)
+
+    activity_map =
+      activity_revisions
+      |> Enum.map(fn activity_revision ->
+        type = Map.fetch!(type_by_id, activity_revision.activity_type_id)
+
+        summary =
+          activity_summary(
+            section_slug,
+            revision,
+            activity_revision,
+            type,
+            exclusion_view,
+            Map.get(objective_titles_by_activity_id, activity_revision.resource_id, [])
+          )
+
+        {summary.id, summary}
+      end)
+      |> Map.new()
+
+    summaries = Map.values(activity_map)
+
+    bib_entries =
+      revision.content
+      |> BibUtils.assemble_bib_entries(
+        summaries,
+        fn summary -> Map.get(summary, :bib_refs, []) end,
+        section_slug,
+        Resolver
+      )
+      |> Enum.with_index(1)
+      |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
+
+    render_context =
+      build_render_context(section, revision, user, activity_map, bib_entries, all_activities)
+
+    html =
+      Page.render(render_context, revision.content, Page.Html)
+      |> IO.iodata_to_binary()
+
+    %{
+      activity_map: activity_map,
+      summaries: summaries,
+      html: html,
+      # Metadata cached on the LiveView so remove/restore can recompute aggregate page data
+      # without repeating DB lookups for page activities and their objective labels.
+      preview_metadata: %{
+        activity_revisions_by_id: Map.new(activity_revisions, &{&1.resource_id, &1}),
+        objective_titles_by_activity_id: objective_titles_by_activity_id,
+        activity_type_by_id: type_by_id,
+        activity_types: all_activities
+      },
+      page_summary:
+        build_page_summary(activity_revisions, exclusion_view, objective_titles_by_activity_id)
+    }
+  end
+
+  defp build_render_context(section, revision, user, activity_map, bib_entries, all_activities) do
+    section_slug = section.slug
+    base_project_attributes = Sections.get_section_attributes(section)
+
+    %Context{
+      user: user,
+      section_slug: section_slug,
+      revision_slug: revision.slug,
+      mode: :instructor_preview,
+      activity_map: activity_map,
+      resource_summary_fn: &Resources.resource_summary(&1, section_slug, Resolver),
+      alternatives_selector_fn: &Resources.Alternatives.select/2,
+      extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,
+      activity_types_map: Map.new(all_activities, fn activity -> {activity.id, activity} end),
+      bib_app_params: bib_entries,
+      learning_language: base_project_attributes.learning_language,
+      submitted_surveys: %{}
+    }
+  end
+
+  defp activity_summary(
+         section_slug,
+         page_revision,
+         activity_revision,
+         type,
+         exclusion_view,
+         learning_objectives
+       ) do
+    %ActivitySummary{
+      id: activity_revision.resource_id,
+      script: preview_script_for(type),
+      attempt_guid: nil,
+      state: nil,
+      lifecycle_state: :active,
+      model:
+        activity_revision.content
+        |> Jason.encode!()
+        |> Oli.Delivery.Page.ActivityContext.encode(),
+      delivery_element: type.delivery_element,
+      authoring_element: type.authoring_element,
+      preview_element: type.preview_element,
+      preview_script: type.preview_script,
+      graded: page_revision.graded,
+      activity_type_slug: type.slug,
+      preview_context:
+        build_preview_context(
+          section_slug,
+          page_revision,
+          activity_revision,
+          type,
+          preview_supported?(type),
+          InstructorCustomizations.activity_enabled?(
+            exclusion_view,
+            activity_revision.resource_id
+          ),
+          preview_actions(exclusion_view, activity_revision.resource_id),
+          learning_objectives
+        ),
+      bib_refs: Map.get(activity_revision.content, "bibrefs", [])
+    }
+  end
+
+  defp build_page_summary(activity_revisions, exclusion_view, objective_titles_by_activity_id) do
+    enabled_activity_revisions =
+      Enum.filter(activity_revisions, fn activity_revision ->
+        InstructorCustomizations.activity_enabled?(exclusion_view, activity_revision.resource_id)
+      end)
+
+    learning_objectives =
+      enabled_activity_revisions
+      |> Enum.flat_map(fn activity_revision ->
+        Map.get(objective_titles_by_activity_id, activity_revision.resource_id, [])
+      end)
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    %{
+      enabled_activity_count: length(enabled_activity_revisions),
+      available_points:
+        Enum.reduce(enabled_activity_revisions, 0, fn activity_revision, acc ->
+          acc + Grading.determine_activity_out_of(activity_revision)
+        end),
+      learning_objectives: learning_objectives,
+      learning_objective_count: length(learning_objectives)
+    }
+  end
+
+  defp preview_actions(exclusion_view, activity_resource_id) do
+    if InstructorCustomizations.activity_enabled?(exclusion_view, activity_resource_id) do
+      [%{kind: "remove", label: "Remove"}]
+    else
+      [%{kind: "restore", label: "Restore"}]
+    end
+  end
+
   defp preview_script_for(%{
          slug: slug,
          preview_element: preview_element,
@@ -265,6 +389,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
          activity_revision,
          activity_type,
          can_customize?,
+         activity_enabled?,
+         actions,
          learning_objectives
        ) do
     %{
@@ -280,6 +406,16 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       points: Grading.determine_activity_out_of(activity_revision),
       learningObjectives: learning_objectives,
       canCustomize: can_customize?,
+      actions: actions,
+      # Visual removed treatment is context-specific. Preview page cards use it so excluded
+      # embedded activities are obvious in-place, while other surfaces can omit it and still
+      # reuse the same Remove/Restore action contract.
+      visualState: if(activity_enabled?, do: "default", else: "removed"),
+      statusPill: if(activity_enabled?, do: nil, else: %{kind: "removed", label: "Removed"}),
+      # Preview page components emit a generic customization target back to whatever LiveView owns
+      # them. On this surface we only expect page-level targets such as embedded activities and,
+      # in future activity-bank rendering, whole bank selections. Candidate-level targets belong
+      # to the separate bank selection manager LiveView, not to the page preview.
       customizationTarget: %{
         kind: "embedded_activity",
         pageResourceId: page_revision.resource_id,

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   import OliWeb.Delivery.Student.Utils, only: [scripts: 1, references: 1]
 
   alias Oli.Accounts
+  alias Oli.Delivery.InstructorCustomizations
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.CollabSpaceConfig
@@ -66,7 +67,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
   def render(%{graded: true} = assigns) do
     ~H"""
-    <div id="instructor-preview-lesson" data-preview-mode={@preview_mode}>
+    <div
+      id="instructor-preview-lesson"
+      data-preview-mode={@preview_mode}
+      phx-hook="InstructorPreviewCustomization"
+    >
       <.scripts scripts={@scripts} user_token={assigns[:user_token]} />
 
       <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
@@ -79,6 +84,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
+      <div id="flash_container" class="container mx-auto sticky top-[8.5rem] z-[55] px-4">
+        <.preview_flash_group flash={@flash} />
+      </div>
 
       <.preview_back_nav request_path={@request_path} />
 
@@ -120,7 +128,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
   def render(assigns) do
     ~H"""
-    <div id="instructor-preview-lesson" data-preview-mode={@preview_mode}>
+    <div
+      id="instructor-preview-lesson"
+      data-preview-mode={@preview_mode}
+      phx-hook="InstructorPreviewCustomization"
+    >
       <.scripts scripts={@scripts} user_token={assigns[:user_token]} />
 
       <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
@@ -133,6 +145,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
+      <div id="flash_container" class="container mx-auto sticky top-[8.5rem] z-[55] px-4">
+        <.preview_flash_group flash={@flash} />
+      </div>
 
       <.preview_back_nav request_path={@request_path} />
       <.page_content_with_sidebar_layout active_sidebar_panel={@active_sidebar_panel}>
@@ -301,10 +316,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     <div
       id="page_content"
       class="content"
-      phx-update="ignore"
       role="region"
       aria-label="Page content"
+      phx-update="ignore"
     >
+      <%!-- Keep the preview body as one client-owned HTML island. React updates button state via
+      hook replies, while LiveView diffs only shell-level data like aggregates and flashes. --%>
       {raw(@html)}
       <div :if={@graded && @question_count == 0} class="flex w-full justify-center py-8">
         <p>There are no questions available for this page.</p>
@@ -375,6 +392,97 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     end
 
     {:noreply, assign(socket, active_sidebar_panel: active_sidebar_panel)}
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
+        %{
+          "action" => action,
+          "target" => %{
+            "kind" => "embedded_activity",
+            "pageResourceId" => page_resource_id,
+            "activityResourceId" => activity_resource_id
+          }
+        },
+        socket
+      ) do
+    # Pattern match on target kind so other preview surfaces can reuse the same browser contract
+    # while dispatching to different customization writes for selections or bank candidates.
+    section = socket.assigns.section
+    actor = socket.assigns.current_user
+
+    result =
+      case action do
+        "remove" ->
+          InstructorCustomizations.exclude_activity(
+            section,
+            page_resource_id,
+            activity_resource_id,
+            actor: actor
+          )
+
+        "restore" ->
+          InstructorCustomizations.restore_activity(
+            section,
+            page_resource_id,
+            activity_resource_id,
+            actor: actor
+          )
+
+        _ ->
+          {:error, {:invalid_action, action}}
+      end
+
+    case result do
+      {:ok, exclusion_view} ->
+        page_summary =
+          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
+
+        # Reply directly to the preview component so it can update local button state without a
+        # remount, while the socket diff updates any LiveView-owned aggregates on the page shell.
+        reply = %{
+          ok: true,
+          activityResourceId: activity_resource_id,
+          visualState: if(action == "remove", do: "removed", else: "default"),
+          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
+          actions:
+            if(action == "remove",
+              do: [%{kind: "restore", label: "Restore"}],
+              else: [%{kind: "remove", label: "Remove"}]
+            )
+        }
+
+        {:reply, reply,
+         socket
+         |> assign(:page_summary, page_summary)
+         |> put_flash(
+           :info,
+           if(action == "remove",
+             do: "Question removed from this page.",
+             else: "Question restored to this page."
+           )
+         )}
+
+      {:error, {:unauthorized, :customize_section}} ->
+        {:reply, %{ok: false},
+         put_flash(socket, :error, "You are not allowed to customize this page.")}
+
+      {:error, _reason} ->
+        {:reply, %{ok: false}, put_flash(socket, :error, "Unable to update this question.")}
+    end
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
+        %{"action" => _action, "target" => %{"kind" => unsupported_kind}},
+        socket
+      ) do
+    {:reply, %{ok: false},
+     put_flash(
+       socket,
+       :error,
+       "Unsupported customization target #{unsupported_kind} for this preview surface."
+     )}
   end
 
   def handle_event("toggle_notes_sidebar", _params, socket) do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -84,7 +84,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
-      <div id="flash_container" class="container mx-auto sticky top-[8.5rem] z-[55] px-4">
+      <div
+        :if={preview_flash_visible?(@flash)}
+        id="flash_container"
+        class="container mx-auto sticky top-[8.5rem] z-[55] px-4"
+      >
         <.preview_flash_group flash={@flash} />
       </div>
 
@@ -145,7 +149,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
-      <div id="flash_container" class="container mx-auto sticky top-[8.5rem] z-[55] px-4">
+      <div
+        :if={preview_flash_visible?(@flash)}
+        id="flash_container"
+        class="container mx-auto sticky top-[8.5rem] z-[55] px-4"
+      >
         <.preview_flash_group flash={@flash} />
       </div>
 
@@ -263,7 +271,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
   defp preview_back_nav(assigns) do
     ~H"""
-    <div class="sticky top-40 z-50 md:h-20 2xl:h-28">
+    <div class="sticky top-[135px] sm:top-40 z-50 md:h-20 2xl:h-28">
       <div class="hidden md:block">
         <Layouts.back_arrow to={@request_path} show_sidebar={false} view={:practice_page} />
       </div>
@@ -305,7 +313,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     """
   end
 
-  attr :html, :string, required: true
+  attr :html, :any, required: true
   attr :ctx, :map, required: true
   attr :bib_app_params, :any, required: true
   attr :graded, :boolean, required: true
@@ -411,26 +419,38 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     section = socket.assigns.section
     actor = socket.assigns.current_user
 
+    current_page_resource_id = socket.assigns.current_page_resource_id
+    valid_activity_ids = MapSet.new(socket.assigns.preview_metadata.activity_ids)
+
     result =
-      case action do
-        "remove" ->
-          InstructorCustomizations.exclude_activity(
-            section,
-            page_resource_id,
-            activity_resource_id,
-            actor: actor
-          )
+      cond do
+        page_resource_id != current_page_resource_id ->
+          {:error, :invalid_page_target}
 
-        "restore" ->
-          InstructorCustomizations.restore_activity(
-            section,
-            page_resource_id,
-            activity_resource_id,
-            actor: actor
-          )
+        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
+          {:error, :invalid_activity_target}
 
-        _ ->
-          {:error, {:invalid_action, action}}
+        true ->
+          case action do
+            "remove" ->
+              InstructorCustomizations.exclude_activity(
+                section,
+                page_resource_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            "restore" ->
+              InstructorCustomizations.restore_activity(
+                section,
+                page_resource_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            _ ->
+              {:error, {:invalid_action, action}}
+          end
       end
 
     case result do
@@ -442,6 +462,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         # remount, while the socket diff updates any LiveView-owned aggregates on the page shell.
         reply = %{
           ok: true,
+          target: %{
+            kind: "embedded_activity",
+            pageResourceId: page_resource_id,
+            activityResourceId: activity_resource_id
+          },
           activityResourceId: activity_resource_id,
           visualState: if(action == "remove", do: "removed", else: "default"),
           statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
@@ -466,6 +491,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       {:error, {:unauthorized, :customize_section}} ->
         {:reply, %{ok: false},
          put_flash(socket, :error, "You are not allowed to customize this page.")}
+
+      {:error, :invalid_page_target} ->
+        {:reply, %{ok: false},
+         put_flash(socket, :error, "Unable to update a question outside this page preview.")}
+
+      {:error, :invalid_activity_target} ->
+        {:reply, %{ok: false},
+         put_flash(socket, :error, "Unable to update a question that is not part of this page.")}
 
       {:error, _reason} ->
         {:reply, %{ok: false}, put_flash(socket, :error, "Unable to update this question.")}
@@ -571,6 +604,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
        search_results: nil,
        search_term: ""
      )}
+  end
+
+  defp preview_flash_visible?(flash) do
+    not is_nil(Phoenix.Flash.get(flash, :info)) or not is_nil(Phoenix.Flash.get(flash, :error))
   end
 
   defp navigation_params(params, section_slug) do

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
   alias Oli.Activities
   alias Oli.Analytics.Summary.ResourceSummary
+  alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections
   alias Oli.Resources.Collaboration.CollabSpaceConfig
 
@@ -242,6 +243,101 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert side_effect_counts(section, user, page_revision) == before_counts
     end
+
+    test "remove hook event stores an exclusion and shows a success flash", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      activity_resource_id = first_activity_resource_id(page_revision)
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "embedded_activity",
+            "pageResourceId" => page_revision.resource_id,
+            "activityResourceId" => activity_resource_id
+          }
+        })
+
+      assert html =~ "Question removed from this page."
+
+      exclusions =
+        InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id)
+
+      assert Enum.any?(exclusions, fn exclusion ->
+               exclusion.kind == :embedded_activity and
+                 exclusion.excluded_resource_id == activity_resource_id
+             end)
+    end
+
+    test "restore hook event removes an exclusion and shows a success flash", %{
+      conn: conn,
+      section: section,
+      user: user,
+      page_revision: page_revision
+    } do
+      activity_resource_id = first_activity_resource_id(page_revision)
+
+      {:ok, _view} =
+        InstructorCustomizations.exclude_activity(
+          section,
+          page_revision.resource_id,
+          activity_resource_id,
+          actor: user
+        )
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "restore",
+          "target" => %{
+            "kind" => "embedded_activity",
+            "pageResourceId" => page_revision.resource_id,
+            "activityResourceId" => activity_resource_id
+          }
+        })
+
+      assert html =~ "Question restored to this page."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
+
+    test "invalid hook target is rejected and does not write exclusions", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      activity_resource_id = first_activity_resource_id(page_revision)
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "embedded_activity",
+            "pageResourceId" => page_revision.resource_id + 999_999,
+            "activityResourceId" => activity_resource_id
+          }
+        })
+
+      assert html =~ "Unable to update a question outside this page preview."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
   end
 
   describe "mixed activity preview script selection" do
@@ -455,6 +551,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
   defp enroll_as_instructor(%{section: section, user: user}) do
     enroll_user_to_section(user, section, :context_instructor)
     :ok
+  end
+
+  defp first_activity_resource_id(page_revision) do
+    page_revision.content["model"]
+    |> Enum.find_value(fn
+      %{"type" => "activity-reference", "activity_id" => activity_id} -> activity_id
+      _ -> nil
+    end)
   end
 
   defp cache_lti_context(section, user) do


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5622

## Summary

This PR is part 1 of `MER-5622` and establishes the shared React-to-LiveView wiring contract that instructor preview activities use to send customization intents such as `Remove` and `Restore`, receive targeted replies, and update local component state without remounting.

Although the ticket scope ultimately includes a dedicated LiveView for customizing activities inside an activity bank, this PR focuses on the foundational communication model that both `MER-5622` and `MER-5620` need. To validate the approach end to end, this PR also applies that wiring to embedded activity remove/restore in `PreviewLessonLive`.

This PR also extends the authoring fallback path used in instructor preview for activity types that do not yet have a dedicated preview component, so they render as close as possible to the preview-card experience and also support the same Remove/Restore customization flow.

## What Was Added

- Added the shared preview customization event flow between React preview cards, the `InstructorPreviewCustomization` LiveView hook, and `handle_event/3` replies via `{:reply, reply, socket}`.
- Generalized the preview customization target contract so LiveViews can dispatch by `target.kind`, covering `embedded_activity`, `bank_selection`, and `bank_candidate`.
- Extended preview card state handling so action state and optional visual removed treatment are separate concerns.
- Implemented the first concrete consumer in `PreviewLessonLive` for embedded activity remove/restore, including socket-side aggregate updates and targeted reply payloads for the initiating preview card.
- Added preview-specific flash styling and updated preview card button styling to match the current Figma direction for remove, restore, and removed-card states.
- Added epic-level reference documentation for the shared wiring contract in `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md`.

## Validation

- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
- `yarn test assets/test/activities/preview/preview_foundation_test.tsx --runInBand`

## Part 2

A follow-up PR will implement the standalone LiveView required by `MER-5622` for customizing the activities that belong to a specific activity bank selection, reusing the wiring contract established here and dispatching with the `bank_candidate` target kind.

## Demo

### Remove/restore activities that support preview mode
https://github.com/user-attachments/assets/65bcf5d3-77c0-446f-851e-724bcdf87a15

### Remove/restore activities that still do not support review mode (fallback to authoring mode)

https://github.com/user-attachments/assets/e48904b4-93f4-4060-8754-f3dcf6850b66


