### PR TITLE
[FEATURE] [MER-5632] Navigating away from SAYG assignment

### DIFF
--- a/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.scenario.yaml
+++ b/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.scenario.yaml
@@ -1,0 +1,129 @@
+- project:
+    name: 'sayg_saved_work_notice_project'
+    title: 'SAYG Saved Work Notice Course ${RUN_ID}'
+    root:
+      children:
+        - container: 'Module 1'
+          children:
+            - page: 'Intro Page'
+            - page: 'San Lorenzo'
+            - page: 'Rosario Central'
+
+- edit_page:
+    project: 'sayg_saved_work_notice_project'
+    page: 'Intro Page'
+    content: |
+      title: "Intro Page"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Intro content"
+
+- edit_page:
+    project: 'sayg_saved_work_notice_project'
+    page: 'San Lorenzo'
+    content: |
+      title: "San Lorenzo"
+      graded: true
+      blocks:
+        - type: activity
+          virtual_id: "sayg_question"
+          activity:
+            type: oli_multiple_choice
+            stem_md: "Question 1"
+            choices:
+              - id: "a"
+                body_md: "Choice A"
+                score: 1
+              - id: "b"
+                body_md: "Choice B"
+                score: 0
+
+- edit_page:
+    project: 'sayg_saved_work_notice_project'
+    page: 'Rosario Central'
+    content: |
+      title: "Rosario Central"
+      graded: true
+      blocks:
+        - type: activity
+          virtual_id: "standard_question"
+          activity:
+            type: oli_multiple_choice
+            stem_md: "Question 1"
+            choices:
+              - id: "a"
+                body_md: "Choice A"
+                score: 1
+              - id: "b"
+                body_md: "Choice B"
+                score: 0
+
+- publish:
+    to: 'sayg_saved_work_notice_project'
+    description: 'Initial SAYG saved work notice course'
+
+- section:
+    name: 'sayg_saved_work_notice_section'
+    title: 'SAYG Saved Work Notice Section ${RUN_ID}'
+    from: 'sayg_saved_work_notice_project'
+    type: 'enrollable'
+    registration_open: true
+    start_date: '2026-04-16T00:00:00Z'
+
+- user:
+    name: 'sayg_notice_student'
+    type: 'student'
+    email: 'sayg-notice-student${RUN_ID}@example.com'
+    given_name: 'SAYG'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
+    name: 'sayg_notice_instructor'
+    type: 'instructor'
+    email: 'sayg-notice-instructor${RUN_ID}@example.com'
+    given_name: 'SAYG'
+    family_name: 'Instructor'
+    password: 'changeme123456'
+
+- enroll:
+    user: 'sayg_notice_student'
+    section: 'sayg_saved_work_notice_section'
+    role: 'student'
+
+- enroll:
+    user: 'sayg_notice_instructor'
+    section: 'sayg_saved_work_notice_section'
+    role: 'instructor'
+
+- manipulate:
+    to: 'sayg_saved_work_notice_section'
+    ops:
+      - revise:
+          target: 'Intro Page'
+          set:
+            scheduling_type: '@atom(read_by)'
+            end_date: '2026-05-27T23:59:59Z'
+      - revise:
+          target: 'San Lorenzo'
+          set:
+            batch_scoring: false
+            max_attempts: 0
+            scheduling_type: '@atom(due_by)'
+            end_date: '2026-11-11T23:59:59Z'
+      - revise:
+          target: 'Rosario Central'
+          set:
+            batch_scoring: true
+            max_attempts: 0
+            scheduling_type: '@atom(due_by)'
+            end_date: '2026-06-13T23:59:59Z'
+
+- visit_page:
+    student: 'sayg_notice_student'
+    section: 'sayg_saved_work_notice_section'
+    page: 'San Lorenzo'
+
+- hook:
+    function: 'Oli.Scenarios.Hooks.mark_sections_visited/1'

--- a/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.spec.ts
@@ -1,0 +1,331 @@
+import { expect, type Page } from '@playwright/test';
+import { setRuntimeConfig } from '@core/runtimeConfig';
+import { test } from '@fixture/my-fixture';
+import { MenuDropdownCO } from '@pom/home/MenuDropdownCO';
+import { TYPE_USER, type TypeUser } from '@pom/types/type-user';
+import path from 'node:path';
+
+const runId = `-${Date.now()}`;
+const baseUrl = 'http://localhost';
+const defaultPassword = 'changeme123456';
+const scenarioPath = path.resolve(__dirname, './sayg-saved-work-notice.scenario.yaml');
+const savedWorkStorageKey = 'torus.saygSavedWorkNotice';
+const saygNoticeSourceSelector = '#sayg_navigation_notice_source';
+const saygLessonTitle = 'San Lorenzo';
+const saygLessonTitlePattern = new RegExp(saygLessonTitle, 'i');
+const standardLessonTitle = 'Rosario Central';
+const savedWorkMessage =
+  'Your work has been saved. You can resume the assignment anytime before the due date.';
+
+type UserMenuLink = 'Account Settings' | 'My Courses' | 'Research Consent';
+
+const loginRecord = (
+  userType: TypeUser,
+  role: string,
+  emailPrefix: string,
+  welcomeTitle: string,
+  header?: string,
+) => ({
+  type: TYPE_USER[userType],
+  pageTitle: 'OLI Torus',
+  role,
+  welcomeText: 'Welcome to OLI Torus',
+  welcomeTitle,
+  email: `${emailPrefix}${runId}@example.com`,
+  pass: defaultPassword,
+  ...(header ? { header } : {}),
+});
+
+setRuntimeConfig({
+  baseUrl,
+  scenarioToken: 'my-token',
+  loginData: {
+    student: {
+      ...loginRecord('student', 'Student', 'sayg-notice-student', 'Hi, SAYG'),
+      name: 'SAYG',
+      last_name: 'Student',
+    },
+    instructor: loginRecord(
+      'instructor',
+      'Instructor',
+      'sayg-notice-instructor',
+      'Instructor Dashboard',
+      'Instructor Dashboard',
+    ),
+    author: loginRecord(
+      'author',
+      'Course Author',
+      'sayg-notice-author',
+      'Course Author',
+      'Course Author',
+    ),
+    administrator: loginRecord(
+      'administrator',
+      'Course Author',
+      'sayg-notice-admin',
+      'Course Author',
+      'Course Author',
+    ),
+  },
+});
+
+type ScenarioOutputs = {
+  sections?: Record<string, string>;
+};
+
+let sectionSlug: string;
+
+test.beforeAll(async ({ seedScenario }) => {
+  const response = await seedScenario(scenarioPath, { RUN_ID: runId });
+  const outputs = response.outputs as ScenarioOutputs;
+
+  sectionSlug = outputs.sections?.sayg_saved_work_notice_section ?? '';
+
+  expect(sectionSlug).toBeTruthy();
+});
+
+test.describe('SAYG saved work notice', () => {
+  test.beforeEach(async ({ homeTask, page }) => {
+    await homeTask.login('student');
+    await page.evaluate((key) => sessionStorage.removeItem(key), savedWorkStorageKey);
+    await gotoPath(page, learnPath());
+    await enterCourseIfNeeded(page);
+  });
+
+  test('lesson back to home shows saved work notice', async ({
+    page,
+  }) => {
+    await gotoPath(page, sectionHomePath());
+    await expectHomePage(page);
+
+    await openSaygLessonFromHome(page);
+    await page.getByRole('link', { name: /Back/i }).first().click();
+
+    await expectHomePage(page);
+    await expectSavedWorkNotice(page);
+  });
+
+  test('lesson back to learn shows saved work notice', async ({
+    page,
+  }) => {
+    await expectNoticeAfterLessonBack(page, learnPath(), expectLearnPage);
+  });
+
+  test('lesson back to schedule shows saved work notice', async ({
+    page,
+  }) => {
+    await expectNoticeAfterLessonBack(page, schedulePath(), expectSchedulePage);
+  });
+
+  test('lesson back to assignments shows saved work notice', async ({
+    page,
+  }) => {
+    await expectNoticeAfterLessonBack(page, assignmentsPath(), expectAssignmentsPage);
+  });
+
+  test('lesson bottom navigation shows saved work notice', async ({
+    page,
+  }) => {
+    await gotoPath(page, learnPath());
+    await expectLearnPage(page);
+    await openSaygLessonFromCurrentPage(page);
+
+    await revealBottomNavigation(page);
+    const nextLessonLink = page.getByRole('link', { name: 'next' });
+    await expect(nextLessonLink).toBeVisible();
+    await nextLessonLink.click();
+
+    await expectLessonTitle(page, standardLessonTitle);
+    await expectSavedWorkNotice(page);
+  });
+
+  test('user menu to account settings shows saved work notice', async ({ page }) => {
+    await openSaygLessonFromAssignments(page);
+    await navigateFromUserMenu(page, 'Account Settings');
+
+    await expect(page).toHaveURL(/\/users\/settings/);
+    await expect(page.getByRole('heading', { name: 'Account Settings' })).toBeVisible();
+    await expectSavedWorkNotice(page);
+  });
+
+  test('user menu to my courses shows saved work notice', async ({ page }) => {
+    await openSaygLessonFromAssignments(page);
+    await navigateFromUserMenu(page, 'My Courses');
+
+    await expect(page).toHaveURL(/\/workspaces\/student/);
+    await expect(page.getByText('Courses available').first()).toBeVisible();
+    await expectSavedWorkNotice(page);
+  });
+
+  test('user menu to research consent shows saved work notice', async ({ page }) => {
+    await openSaygLessonFromAssignments(page);
+    await navigateFromUserMenu(page, 'Research Consent');
+
+    await expect(page).toHaveURL(/\/research_consent/);
+    await expect(page.getByText('Online Consent Form')).toBeVisible();
+    await expectSavedWorkNotice(page);
+  });
+});
+
+async function expectNoticeAfterLessonBack(
+  page: Page,
+  destinationPath: string,
+  expectDestinationPage: (page: Page) => Promise<void>,
+) {
+  await gotoPath(page, destinationPath);
+  await expectDestinationPage(page);
+
+  await openSaygLessonFromCurrentPage(page);
+  await page.getByRole('link', { name: /Back/i }).first().click();
+
+  await expectDestinationPage(page);
+  await expectSavedWorkNotice(page);
+}
+
+async function openSaygLessonFromHome(page: Page) {
+  const resumeLessonLink = page
+    .getByRole('link', { name: /Resume lesson/i })
+    .or(page.getByRole('button', { name: /Resume lesson/i }))
+    .first();
+
+  if (await resumeLessonLink.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await resumeLessonLink.click();
+    await waitForMainLiveView(page);
+    await expectSaygLessonOpened(page);
+    return;
+  }
+
+  const latestTab = page.locator('#latest_tab');
+
+  await expect(latestTab).toBeVisible();
+
+  if (await latestTab.isEnabled()) {
+    await latestTab.click();
+    await waitForMainLiveView(page);
+  }
+
+  await page.getByRole('link', { name: saygLessonTitlePattern }).first().click();
+  await waitForMainLiveView(page);
+  await expectSaygLessonOpened(page);
+}
+
+async function openSaygLessonFromCurrentPage(page: Page) {
+  const sanLorenzoLink = page
+    .getByRole('link', { name: saygLessonTitlePattern })
+    .or(page.getByRole('button', { name: saygLessonTitlePattern }))
+    .first();
+
+  await expect(sanLorenzoLink).toBeVisible();
+  await sanLorenzoLink.click();
+  await waitForMainLiveView(page);
+  await expectSaygLessonOpened(page);
+}
+
+async function openSaygLessonFromAssignments(page: Page) {
+  await gotoPath(page, assignmentsPath());
+  await expectAssignmentsPage(page);
+  await openSaygLessonFromCurrentPage(page);
+}
+
+async function navigateFromUserMenu(page: Page, linkName: UserMenuLink) {
+  const menu = new MenuDropdownCO(page);
+
+  await menu.open();
+  await clickVisibleUserMenuLink(page, linkName);
+}
+
+async function clickVisibleUserMenuLink(page: Page, name: UserMenuLink) {
+  const menuLinks = page
+    .locator('#workspace-user-menu-dropdown, #user-account-menu-dropdown')
+    .getByRole('link', { name });
+  const count = await menuLinks.count();
+
+  for (let i = 0; i < count; i++) {
+    const link = menuLinks.nth(i);
+
+    if (await link.isVisible().catch(() => false)) {
+      await link.click();
+      return;
+    }
+  }
+
+  throw new Error(`User menu link '${name}' was not visible`);
+}
+
+async function revealBottomNavigation(page: Page) {
+  const bottomBarWrapper = page.locator('#bottom-bar-wrapper');
+
+  await expect(bottomBarWrapper).toBeAttached();
+  await bottomBarWrapper.hover();
+}
+
+async function waitForMainLiveView(page: Page) {
+  await page.waitForFunction(
+    () => document.querySelector('[data-phx-main]')?.classList.contains('phx-connected'),
+    undefined,
+    { timeout: 15_000 },
+  );
+}
+
+async function enterCourseIfNeeded(page: Page) {
+  const goToCourseButton = page.getByRole('button', { name: 'Go to course' });
+
+  if (await goToCourseButton.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await goToCourseButton.click();
+    await expect(goToCourseButton).toBeHidden({ timeout: 10_000 });
+  }
+}
+
+async function expectSavedWorkNotice(page: Page) {
+  const notice = page.locator('#sayg_saved_work_notice');
+
+  await expect(notice).toBeVisible();
+  await expect(notice).toContainText(savedWorkMessage);
+}
+
+async function expectSaygLessonOpened(page: Page) {
+  await expectLessonTitle(page, saygLessonTitle);
+  await expect(page.locator(saygNoticeSourceSelector)).toBeAttached();
+}
+
+async function expectLessonTitle(page: Page, title: string) {
+  await expect(page.getByText(title).first()).toBeVisible();
+}
+
+async function expectAssignmentsPage(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Assignments' })).toBeVisible();
+}
+
+async function expectSchedulePage(page: Page) {
+  await expect(page.getByRole('heading', { name: 'Course Schedule' })).toBeVisible();
+}
+
+async function expectHomePage(page: Page) {
+  await expect(page.locator('#home-assignments')).toBeVisible();
+}
+
+async function expectLearnPage(page: Page) {
+  await expect(page.locator('#student_learn')).toBeVisible();
+}
+
+function sectionHomePath() {
+  return `/sections/${sectionSlug}?sidebar_expanded=true`;
+}
+
+function assignmentsPath() {
+  return `/sections/${sectionSlug}/assignments?sidebar_expanded=true`;
+}
+
+function schedulePath() {
+  return `/sections/${sectionSlug}/student_schedule?sidebar_expanded=true`;
+}
+
+function learnPath() {
+  const searchTerm = encodeURIComponent(saygLessonTitle);
+
+  return `/sections/${sectionSlug}/learn?sidebar_expanded=true&selected_view=outline&search_term=${searchTerm}`;
+}
+
+async function gotoPath(page: Page, path: string) {
+  await page.goto(path, { waitUntil: 'load' });
+}

--- a/assets/src/hooks/index.ts
+++ b/assets/src/hooks/index.ts
@@ -65,6 +65,10 @@ import { RenderedActivityIframeState } from './rendered_activity_iframe_state';
 import { ResizeListener } from './resize_listener';
 import { ReviewActivity } from './review_activity';
 import { SaveCookiePreferences } from './save_cookie_preferences';
+import {
+  ScoreAsYouGoNavigationNotice,
+  ScoreAsYouGoSavedWorkNotice,
+} from './score_as_you_go_saved_work_notice';
 import { ScrollToTheTop } from './scroll_to_the_top';
 import { Scroller } from './scroller';
 import { SelectListener } from './select_listener';
@@ -183,4 +187,6 @@ export const Hooks = {
   SaveCookiePreferences,
   ScrollToTheTop,
   ContainerToggleAriaLabel,
+  ScoreAsYouGoNavigationNotice,
+  ScoreAsYouGoSavedWorkNotice,
 };

--- a/assets/src/hooks/score_as_you_go_saved_work_notice.ts
+++ b/assets/src/hooks/score_as_you_go_saved_work_notice.ts
@@ -1,0 +1,209 @@
+const storageKey = 'torus.saygSavedWorkNotice';
+
+/**
+ * Coordinates the "your work has been saved" notice shown after leaving a
+ * Score as You Go assignment.
+ *
+ * The source SAYG page writes a short-lived notice before internal navigation.
+ * The destination page consumes that notice once and renders a dismissible
+ * banner. sessionStorage is intentionally used so the notice is scoped to the
+ * current tab and is not shown again in a future browser session.
+ */
+type SavedWorkNotice = {
+  message: string;
+  sourceUrl: string;
+  targetUrl: string;
+};
+
+type ScoreAsYouGoNavigationNoticeHook = {
+  el: HTMLElement;
+  clickListener?: (event: MouseEvent) => void;
+  pageLoadingStartListener?: (event: Event) => void;
+};
+
+type ScoreAsYouGoSavedWorkNoticeHook = {
+  el: HTMLElement;
+  consumeNotice?: () => void;
+  cleanupSavedWorkNotice?: () => void;
+};
+
+const readNotice = (): SavedWorkNotice | null => {
+  try {
+    const value = window.sessionStorage.getItem(storageKey);
+    if (!value) return null;
+
+    const notice = JSON.parse(value) as SavedWorkNotice;
+    return notice.message && notice.sourceUrl && notice.targetUrl ? notice : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeNotice = (message: string, targetUrl: string) => {
+  try {
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify({ message, sourceUrl: window.location.href, targetUrl }),
+    );
+  } catch {
+    // Ignore storage failures. Navigation should continue normally.
+  }
+};
+
+const clearNotice = () => {
+  try {
+    window.sessionStorage.removeItem(storageKey);
+  } catch {
+    // Ignore storage failures.
+  }
+};
+
+// SAYG lesson pages render this hidden marker. It lets destination pages know
+// whether the current page is also a SAYG page without coupling this hook to
+// LiveView assigns or route names.
+const isScoreAsYouGoPage = (): boolean =>
+  document.getElementById('sayg_navigation_notice_source') !== null;
+
+const internalUrlFor = (href: string): URL | null => {
+  try {
+    const url = new URL(href, window.location.href);
+    if (url.origin !== window.location.origin) return null;
+
+    return url;
+  } catch {
+    return null;
+  }
+};
+
+const isCurrentUrl = (href: string): boolean => internalUrlFor(href)?.href === window.location.href;
+
+const shouldShowNotice = (notice: SavedWorkNotice): boolean => {
+  // Do not show the banner when returning to the same SAYG page that created it.
+  if (isCurrentUrl(notice.sourceUrl)) return false;
+
+  // Prefer the exact intended target. The non-SAYG fallback handles redirects
+  // and controller-rendered pages reached from the original internal navigation.
+  return isCurrentUrl(notice.targetUrl) || !isScoreAsYouGoPage();
+};
+
+const internalNavigationUrl = (event: MouseEvent, link: HTMLAnchorElement): URL | null => {
+  // Only plain left-click same-tab navigation is treated as an internal exit.
+  // Modified clicks, downloads, anchors, javascript URLs, and external links
+  // should behave normally and should not create the saved-work banner.
+  if (event.defaultPrevented) return null;
+  if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return null;
+  }
+
+  if (link.target === '_blank' || link.hasAttribute('download')) return null;
+
+  const href = link.getAttribute('href');
+  if (!href || href.startsWith('#') || href.startsWith('javascript:')) return null;
+
+  return internalUrlFor(href);
+};
+
+const mountSavedWorkNotice = (noticeElement: HTMLElement): (() => void) | undefined => {
+  const messageTarget = noticeElement.querySelector<HTMLElement>('[data-sayg-saved-work-message]');
+  const dismissButton = noticeElement.querySelector<HTMLButtonElement>(
+    '[data-sayg-saved-work-dismiss]',
+  );
+  const notice = readNotice();
+
+  if (!notice || !shouldShowNotice(notice) || !messageTarget) return;
+
+  const dismissListener = () => {
+    noticeElement.classList.add('hidden');
+  };
+
+  messageTarget.textContent = notice.message;
+  noticeElement.classList.remove('hidden');
+  noticeElement.dataset.initialized = 'true';
+  clearNotice();
+
+  dismissButton?.addEventListener('click', dismissListener);
+
+  return () => {
+    dismissButton?.removeEventListener('click', dismissListener);
+  };
+};
+
+export const ScoreAsYouGoNavigationNotice = {
+  mounted(this: ScoreAsYouGoNavigationNoticeHook) {
+    const message = this.el.dataset.message;
+    if (!message) return;
+
+    // Capture regular link clicks from a SAYG page before navigation starts.
+    this.clickListener = (event: MouseEvent) => {
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+
+      const link = target.closest('a[href]') as HTMLAnchorElement | null;
+      if (!link) return;
+
+      const url = internalNavigationUrl(event, link);
+      if (!url) return;
+
+      writeNotice(message, url.href);
+    };
+
+    // Capture LiveView patch/navigate events that may not originate from a
+    // normal anchor click but still represent internal navigation.
+    this.pageLoadingStartListener = (event: Event) => {
+      const to = (event as CustomEvent<{ to?: string }>).detail?.to;
+      if (!to) return;
+
+      const url = internalUrlFor(to);
+      if (!url) return;
+
+      writeNotice(message, url.href);
+    };
+
+    document.addEventListener('click', this.clickListener, true);
+    window.addEventListener('phx:page-loading-start', this.pageLoadingStartListener);
+  },
+
+  destroyed(this: ScoreAsYouGoNavigationNoticeHook) {
+    if (this.clickListener) {
+      document.removeEventListener('click', this.clickListener, true);
+    }
+
+    if (this.pageLoadingStartListener) {
+      window.removeEventListener('phx:page-loading-start', this.pageLoadingStartListener);
+    }
+  },
+};
+
+export const ScoreAsYouGoSavedWorkNotice = {
+  mounted(this: ScoreAsYouGoSavedWorkNoticeHook) {
+    // LiveView destinations can mount before navigation has fully settled, so
+    // consume immediately and again after LiveView reports page loading stop.
+    this.consumeNotice = () => {
+      const cleanup = mountSavedWorkNotice(this.el);
+      if (cleanup) {
+        this.cleanupSavedWorkNotice = cleanup;
+      }
+    };
+
+    window.addEventListener('phx:page-loading-stop', this.consumeNotice);
+
+    this.consumeNotice();
+  },
+
+  destroyed(this: ScoreAsYouGoSavedWorkNoticeHook) {
+    this.cleanupSavedWorkNotice?.();
+
+    if (this.consumeNotice) {
+      window.removeEventListener('phx:page-loading-stop', this.consumeNotice);
+    }
+  },
+};
+
+export const initializeStaticScoreAsYouGoSavedWorkNotice = () => {
+  // Controller-rendered pages do not mount Phoenix hooks, but they still load
+  // app.ts. This initializer lets those pages consume the same notice payload.
+  const noticeElement = document.querySelector<HTMLElement>('[data-sayg-saved-work-static="true"]');
+  if (!noticeElement || noticeElement.dataset.initialized === 'true') return;
+
+  mountSavedWorkNotice(noticeElement);
+};

--- a/assets/src/hooks/score_as_you_go_saved_work_notice.ts
+++ b/assets/src/hooks/score_as_you_go_saved_work_notice.ts
@@ -108,7 +108,8 @@ const internalNavigationUrl = (event: MouseEvent, link: HTMLAnchorElement): URL 
     return null;
   }
 
-  if (link.target === '_blank' || link.hasAttribute('download')) return null;
+  const target = link.getAttribute('target')?.toLowerCase();
+  if ((target && target !== '_self') || link.hasAttribute('download')) return null;
 
   const href = link.getAttribute('href');
   if (!href || href.startsWith('#') || href.startsWith('javascript:')) return null;
@@ -180,13 +181,13 @@ export const ScoreAsYouGoNavigationNotice = {
       writeNotice(message, url.href);
     };
 
-    document.addEventListener('click', this.clickListener, true);
+    document.addEventListener('click', this.clickListener);
     window.addEventListener('phx:page-loading-start', this.pageLoadingStartListener);
   },
 
   destroyed(this: ScoreAsYouGoNavigationNoticeHook) {
     if (this.clickListener) {
-      document.removeEventListener('click', this.clickListener, true);
+      document.removeEventListener('click', this.clickListener);
     }
 
     if (this.pageLoadingStartListener) {

--- a/assets/src/hooks/score_as_you_go_saved_work_notice.ts
+++ b/assets/src/hooks/score_as_you_go_saved_work_notice.ts
@@ -75,7 +75,20 @@ const internalUrlFor = (href: string): URL | null => {
   }
 };
 
-const isCurrentUrl = (href: string): boolean => internalUrlFor(href)?.href === window.location.href;
+// Compare the current document location without the hash. Fragment-only changes
+// keep the student on the same lesson page and should not trigger the notice.
+const isCurrentPageUrl = (url: URL): boolean =>
+  url.origin === window.location.origin &&
+  url.pathname === window.location.pathname &&
+  url.search === window.location.search;
+
+// Accept the stored string form used in sessionStorage, but compare it using the
+// same hash-agnostic current-page check.
+const isCurrentUrl = (href: string): boolean => {
+  const url = internalUrlFor(href);
+
+  return url ? isCurrentPageUrl(url) : false;
+};
 
 const shouldShowNotice = (notice: SavedWorkNotice): boolean => {
   // Do not show the banner when returning to the same SAYG page that created it.
@@ -100,7 +113,10 @@ const internalNavigationUrl = (event: MouseEvent, link: HTMLAnchorElement): URL 
   const href = link.getAttribute('href');
   if (!href || href.startsWith('#') || href.startsWith('javascript:')) return null;
 
-  return internalUrlFor(href);
+  const url = internalUrlFor(href);
+  if (!url || isCurrentPageUrl(url)) return null;
+
+  return url;
 };
 
 const mountSavedWorkNotice = (noticeElement: HTMLElement): (() => void) | undefined => {
@@ -110,7 +126,12 @@ const mountSavedWorkNotice = (noticeElement: HTMLElement): (() => void) | undefi
   );
   const notice = readNotice();
 
-  if (!notice || !shouldShowNotice(notice) || !messageTarget) return;
+  if (!notice || !messageTarget) return;
+
+  if (!shouldShowNotice(notice)) {
+    clearNotice();
+    return;
+  }
 
   const dismissListener = () => {
     noticeElement.classList.add('hidden');
@@ -154,7 +175,7 @@ export const ScoreAsYouGoNavigationNotice = {
       if (!to) return;
 
       const url = internalUrlFor(to);
-      if (!url) return;
+      if (!url || isCurrentPageUrl(url)) return;
 
       writeNotice(message, url.href);
     };

--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -24,6 +24,7 @@ import { selectCookieConsent } from 'components/cookies/CookieConsent';
 import { selectCookiePreferences } from 'components/cookies/CookiePreferences';
 import { retrieveCookies } from 'components/cookies/utils';
 import { CreateAccountPopup } from 'components/messages/CreateAccountPopup';
+import { initializeStaticScoreAsYouGoSavedWorkNotice } from 'hooks/score_as_you_go_saved_work_notice';
 import { commandButtonClicked } from '../components/editing/elements/command_button/commandButtonClicked';
 import { initActivityBridge, initPreviewActivityBridge } from './activity_bridge';
 import { finalize } from './finalize';
@@ -184,6 +185,8 @@ liveSocket.connect();
 window.liveSocket = liveSocket;
 
 document.addEventListener('DOMContentLoaded', () => {
+  initializeStaticScoreAsYouGoSavedWorkNotice();
+
   // initialize popover elements
   [].slice
     .call(document.querySelectorAll('[data-bs-toggle="popover"]'))

--- a/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
+++ b/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
@@ -107,7 +107,7 @@ describe('score as you go saved work notice hooks', () => {
     ScoreAsYouGoSavedWorkNotice.destroyed.call(hook as any);
   });
 
-  test('does not show a stored notice on the source SAYG page', () => {
+  test('clears a stored notice on the source SAYG page without showing it', () => {
     window.sessionStorage.setItem(
       storageKey,
       JSON.stringify({
@@ -123,7 +123,7 @@ describe('score as you go saved work notice hooks', () => {
     ScoreAsYouGoSavedWorkNotice.mounted.call(hook as any);
 
     expect(el).toHaveClass('hidden');
-    expect(window.sessionStorage.getItem(storageKey)).not.toBeNull();
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
 
     ScoreAsYouGoSavedWorkNotice.destroyed.call(hook as any);
   });

--- a/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
+++ b/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
@@ -1,0 +1,152 @@
+import {
+  ScoreAsYouGoNavigationNotice,
+  ScoreAsYouGoSavedWorkNotice,
+  initializeStaticScoreAsYouGoSavedWorkNotice,
+} from 'hooks/score_as_you_go_saved_work_notice';
+
+const storageKey = 'torus.saygSavedWorkNotice';
+
+const setLocation = (path: string) => {
+  window.history.pushState({}, '', path);
+};
+
+const storedNotice = () => JSON.parse(window.sessionStorage.getItem(storageKey) || '{}');
+
+const noticeElement = (staticNotice = false) => {
+  const el = document.createElement('div');
+  el.id = 'sayg_saved_work_notice';
+  el.className = 'hidden';
+  if (staticNotice) {
+    el.dataset.saygSavedWorkStatic = 'true';
+  }
+  el.innerHTML = `
+    <p data-sayg-saved-work-message></p>
+    <button type="button" data-sayg-saved-work-dismiss>Close</button>
+  `;
+  document.body.appendChild(el);
+
+  return el;
+};
+
+describe('score as you go saved work notice hooks', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.sessionStorage.clear();
+    setLocation('/sections/example/lesson/sayg-page');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('stores a notice before internal link navigation from a SAYG page', () => {
+    const source = document.createElement('div');
+    source.dataset.message = 'Your work has been saved.';
+
+    const hook = { el: source };
+    ScoreAsYouGoNavigationNotice.mounted.call(hook as any);
+
+    const link = document.createElement('a');
+    link.href = '/sections/example/assignments';
+    document.body.appendChild(link);
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+
+    expect(storedNotice()).toEqual({
+      message: 'Your work has been saved.',
+      sourceUrl: 'http://localhost/sections/example/lesson/sayg-page',
+      targetUrl: 'http://localhost/sections/example/assignments',
+    });
+
+    ScoreAsYouGoNavigationNotice.destroyed.call(hook as any);
+  });
+
+  test('does not store a notice for external link navigation', () => {
+    const source = document.createElement('div');
+    source.dataset.message = 'Your work has been saved.';
+
+    const hook = { el: source };
+    ScoreAsYouGoNavigationNotice.mounted.call(hook as any);
+
+    const link = document.createElement('a');
+    link.href = 'https://example.com';
+    document.body.appendChild(link);
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+
+    ScoreAsYouGoNavigationNotice.destroyed.call(hook as any);
+  });
+
+  test('shows and consumes a stored notice on LiveView destinations', () => {
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        message: 'Your work has been saved.',
+        sourceUrl: 'http://localhost/sections/example/lesson/sayg-page',
+        targetUrl: 'http://localhost/sections/example/assignments',
+      }),
+    );
+    setLocation('/sections/example/assignments');
+
+    const el = noticeElement();
+    const hook = { el };
+
+    ScoreAsYouGoSavedWorkNotice.mounted.call(hook as any);
+
+    expect(el).not.toHaveClass('hidden');
+    expect(el.querySelector('[data-sayg-saved-work-message]')).toHaveTextContent(
+      'Your work has been saved.',
+    );
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+
+    el.querySelector<HTMLButtonElement>('[data-sayg-saved-work-dismiss]')?.click();
+    expect(el).toHaveClass('hidden');
+
+    ScoreAsYouGoSavedWorkNotice.destroyed.call(hook as any);
+  });
+
+  test('does not show a stored notice on the source SAYG page', () => {
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        message: 'Your work has been saved.',
+        sourceUrl: 'http://localhost/sections/example/lesson/sayg-page',
+        targetUrl: 'http://localhost/sections/example/assignments',
+      }),
+    );
+
+    const el = noticeElement();
+    const hook = { el };
+
+    ScoreAsYouGoSavedWorkNotice.mounted.call(hook as any);
+
+    expect(el).toHaveClass('hidden');
+    expect(window.sessionStorage.getItem(storageKey)).not.toBeNull();
+
+    ScoreAsYouGoSavedWorkNotice.destroyed.call(hook as any);
+  });
+
+  test('shows and consumes a stored notice on static controller-rendered destinations', () => {
+    window.sessionStorage.setItem(
+      storageKey,
+      JSON.stringify({
+        message: 'Your work has been saved.',
+        sourceUrl: 'http://localhost/sections/example/lesson/sayg-page',
+        targetUrl: 'http://localhost/research_consent',
+      }),
+    );
+    setLocation('/research_consent');
+
+    const el = noticeElement(true);
+
+    initializeStaticScoreAsYouGoSavedWorkNotice();
+
+    expect(el).not.toHaveClass('hidden');
+    expect(el.querySelector('[data-sayg-saved-work-message]')).toHaveTextContent(
+      'Your work has been saved.',
+    );
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+  });
+});

--- a/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
+++ b/assets/test/phoenix/score_as_you_go_saved_work_notice_test.ts
@@ -79,6 +79,44 @@ describe('score as you go saved work notice hooks', () => {
     ScoreAsYouGoNavigationNotice.destroyed.call(hook as any);
   });
 
+  test('does not store a notice for cancelled internal link navigation', () => {
+    const source = document.createElement('div');
+    source.dataset.message = 'Your work has been saved.';
+
+    const hook = { el: source };
+    ScoreAsYouGoNavigationNotice.mounted.call(hook as any);
+
+    const link = document.createElement('a');
+    link.href = '/sections/example/assignments';
+    link.addEventListener('click', (event) => event.preventDefault());
+    document.body.appendChild(link);
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }));
+
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+
+    ScoreAsYouGoNavigationNotice.destroyed.call(hook as any);
+  });
+
+  test('does not store a notice for non-self link targets', () => {
+    const source = document.createElement('div');
+    source.dataset.message = 'Your work has been saved.';
+
+    const hook = { el: source };
+    ScoreAsYouGoNavigationNotice.mounted.call(hook as any);
+
+    const link = document.createElement('a');
+    link.href = '/sections/example/assignments';
+    link.target = '_blank';
+    document.body.appendChild(link);
+
+    link.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+
+    expect(window.sessionStorage.getItem(storageKey)).toBeNull();
+
+    ScoreAsYouGoNavigationNotice.destroyed.call(hook as any);
+  });
+
   test('shows and consumes a stored notice on LiveView destinations', () => {
     window.sessionStorage.setItem(
       storageKey,

--- a/lib/oli/scenarios/hooks.ex
+++ b/lib/oli/scenarios/hooks.ex
@@ -11,8 +11,9 @@ defmodule Oli.Scenarios.Hooks do
   - Return an updated ExecutionState
   """
 
-  alias Oli.Scenarios.DirectiveTypes.ExecutionState
+  alias Oli.Delivery.Sections
   alias Oli.Resources
+  alias Oli.Scenarios.DirectiveTypes.ExecutionState
   require Logger
 
   @doc """
@@ -134,6 +135,30 @@ defmodule Oli.Scenarios.Hooks do
 
     updated_users = Map.merge(state.users, Map.new(users))
     %{state | users: updated_users}
+  end
+
+  @doc """
+  Marks all scenario sections as visited for all student users.
+
+  This is useful for UI automation scenarios that need to start inside delivery
+  views without being redirected through the student onboarding wizard.
+
+  Example usage in YAML:
+    - hook:
+        function: "Oli.Scenarios.Hooks.mark_sections_visited/1"
+  """
+  def mark_sections_visited(%ExecutionState{} = state) do
+    state.sections
+    |> Map.values()
+    |> Enum.each(fn section ->
+      section.slug
+      |> Sections.enrolled_students([:context_learner])
+      |> Enum.each(fn student ->
+        {:ok, _} = Sections.mark_section_visited_for_student(section, student)
+      end)
+    end)
+
+    state
   end
 
   @doc """

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -187,6 +187,45 @@ defmodule OliWeb.Components.Delivery.Layouts do
     """
   end
 
+  attr :container_class, :string, default: "absolute left-4 right-4 z-[45] md:left-6 md:right-6"
+
+  attr :class, :string, default: nil
+  attr :static, :boolean, default: false
+
+  def sayg_saved_work_notice(assigns) do
+    ~H"""
+    <div
+      id="sayg_saved_work_notice"
+      phx-hook="ScoreAsYouGoSavedWorkNotice"
+      data-sayg-saved-work-static={@static}
+      class={[
+        "hidden rounded-lg border border-Specially-Tokens-Border-border-input bg-Surface-surface-background px-5 py-3 shadow-md backdrop-blur-sm md:px-8",
+        @container_class,
+        @class
+      ]}
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <div class="flex items-center justify-between gap-4">
+        <p
+          data-sayg-saved-work-message
+          class="font-['Open_Sans'] text-base font-normal leading-[30px] text-Text-text-high"
+        >
+        </p>
+        <button
+          type="button"
+          data-sayg-saved-work-dismiss
+          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-Icon-icon-low hover:bg-Fill-fill-hover focus:outline-none focus:ring-2 focus:ring-Border-border-active"
+          aria-label="Close"
+        >
+          <Icons.close_sm class="h-5 w-5 stroke-current" />
+        </button>
+      </div>
+    </div>
+    """
+  end
+
   attr :return_context, :map, required: true
   attr :preview_active, :boolean, default: true
 

--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -199,7 +199,7 @@ defmodule OliWeb.Components.Delivery.Layouts do
       phx-hook="ScoreAsYouGoSavedWorkNotice"
       data-sayg-saved-work-static={@static}
       class={[
-        "hidden rounded-lg border border-Specially-Tokens-Border-border-input bg-Surface-surface-background px-5 py-3 shadow-md backdrop-blur-sm md:px-8",
+        "hidden rounded-lg border border-Specially-Tokens-Border-border-input bg-Background-bg-primary px-5 py-4 shadow-md backdrop-blur-sm md:px-8",
         @container_class,
         @class
       ]}
@@ -210,13 +210,13 @@ defmodule OliWeb.Components.Delivery.Layouts do
       <div class="flex items-center justify-between gap-4">
         <p
           data-sayg-saved-work-message
-          class="font-['Open_Sans'] text-base font-normal leading-[30px] text-Text-text-high"
+          class="text-base font-normal leading-[30px] text-Text-text-high"
         >
         </p>
         <button
           type="button"
           data-sayg-saved-work-dismiss
-          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-Icon-icon-low hover:bg-Fill-fill-hover focus:outline-none focus:ring-2 focus:ring-Border-border-active"
+          class="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-Icon-icon-default hover:bg-Fill-fill-hover focus:outline-none focus:ring-2 focus:ring-Border-border-active"
           aria-label="Close"
         >
           <Icons.close_sm class="h-5 w-5 stroke-current" />

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -56,12 +56,12 @@
       <.flash_group flash={@flash} />
     </div>
     <Components.Delivery.Layouts.sayg_saved_work_notice
-      :if={assigns[:active_tab] == :learn}
-      container_class="relative z-[45] mx-4 mt-4 mb-6 md:mx-6"
-    />
-    <Components.Delivery.Layouts.sayg_saved_work_notice
-      :if={assigns[:active_tab] != :learn}
-      class="top-2"
+      container_class={
+        if assigns[:active_tab] == :learn,
+          do: "relative z-[45] mx-4 mt-4 mb-6 md:mx-6",
+          else: "absolute left-4 right-4 z-[45] md:left-6 md:right-6"
+      }
+      class={if(assigns[:active_tab] != :learn, do: "top-2", else: nil)}
     />
     <div
       :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -61,7 +61,7 @@
     />
     <Components.Delivery.Layouts.sayg_saved_work_notice
       :if={assigns[:active_tab] != :learn}
-      class="top-4"
+      class="top-2"
     />
     <div
       :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}

--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -36,7 +36,7 @@
     </div>
   </div>
   <div class={[
-    "flex-1 flex flex-col bg-Background-bg-primary",
+    "relative flex-1 flex flex-col bg-Background-bg-primary",
     if(@preview_mode,
       do: "min-h-[calc(100vh-136px)]",
       else: "min-h-[calc(100vh-56px)]"
@@ -55,6 +55,14 @@
     >
       <.flash_group flash={@flash} />
     </div>
+    <Components.Delivery.Layouts.sayg_saved_work_notice
+      :if={assigns[:active_tab] == :learn}
+      container_class="relative z-[45] mx-4 mt-4 mb-6 md:mx-6"
+    />
+    <Components.Delivery.Layouts.sayg_saved_work_notice
+      :if={assigns[:active_tab] != :learn}
+      class="top-4"
+    />
     <div
       :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
       id="pay_early_message"

--- a/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery_lesson.html.heex
@@ -59,6 +59,7 @@
             </div>
           <% end %>
         </div>
+        <Components.Delivery.Layouts.sayg_saved_work_notice container_class="relative z-[45] mx-4 mt-4 md:mx-6" />
         <div
           :if={assigns[:paywall_summary] && OliWeb.LayoutView.show_pay_early(@paywall_summary)}
           id="pay_early_message"

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -313,6 +313,18 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   defp sayg_saved_work_notice(_effective_settings), do: nil
 
+  defp sayg_navigation_notice_source(assigns) do
+    ~H"""
+    <div
+      :if={@message}
+      id="sayg_navigation_notice_source"
+      phx-hook="ScoreAsYouGoNavigationNotice"
+      data-message={@message}
+    >
+    </div>
+    """
+  end
+
   def handle_event("survey_scripts_loaded", %{"error" => _}, socket) do
     {:noreply, assign(socket, error: true)}
   end
@@ -1115,13 +1127,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       ) do
     ~H"""
     <.countdown {assigns} />
-    <div
-      :if={@sayg_saved_work_notice}
-      id="sayg_navigation_notice_source"
-      phx-hook="ScoreAsYouGoNavigationNotice"
-      data-message={@sayg_saved_work_notice}
-    >
-    </div>
+    <.sayg_navigation_notice_source message={@sayg_saved_work_notice} />
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner {assigns} />
@@ -1180,13 +1186,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     # For graded page with attempt in progress the activity scripts and activity_bridge script are needed as soon as the page loads.
     ~H"""
     <.countdown {assigns} />
-    <div
-      :if={@sayg_saved_work_notice}
-      id="sayg_navigation_notice_source"
-      phx-hook="ScoreAsYouGoNavigationNotice"
-      data-message={@sayg_saved_work_notice}
-    >
-    </div>
+    <.sayg_navigation_notice_source message={@sayg_saved_work_notice} />
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner {assigns} />

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -181,7 +181,8 @@ defmodule OliWeb.Delivery.Student.LessonLive do
           review_mode: page_context.review_mode,
           current_score: resource_attempt.score,
           current_out_of: current_out_of,
-          effective_settings: page_context.effective_settings
+          effective_settings: page_context.effective_settings,
+          sayg_saved_work_notice: sayg_saved_work_notice(page_context.effective_settings)
         )
         |> slim_assigns()
         |> assign(attempt_expired_auto_submit: attempt_expired_auto_submit)
@@ -292,6 +293,25 @@ defmodule OliWeb.Delivery.Student.LessonLive do
 
   defp format_score(nil), do: "--"
   defp format_score(v), do: Utils.parse_score(v)
+
+  defp sayg_saved_work_notice(%{batch_scoring: false, end_date: end_date})
+       when is_nil(end_date) do
+    "Your work has been saved. You can resume the assignment anytime."
+  end
+
+  defp sayg_saved_work_notice(%{
+         batch_scoring: false,
+         scheduling_type: :read_by,
+         end_date: _end_date
+       }) do
+    "Your work has been saved. You can resume the assignment anytime before the read by date."
+  end
+
+  defp sayg_saved_work_notice(%{batch_scoring: false}) do
+    "Your work has been saved. You can resume the assignment anytime before the due date."
+  end
+
+  defp sayg_saved_work_notice(_effective_settings), do: nil
 
   def handle_event("survey_scripts_loaded", %{"error" => _}, socket) do
     {:noreply, assign(socket, error: true)}
@@ -1095,6 +1115,12 @@ defmodule OliWeb.Delivery.Student.LessonLive do
       ) do
     ~H"""
     <.countdown {assigns} />
+    <div
+      id="sayg_navigation_notice_source"
+      phx-hook="ScoreAsYouGoNavigationNotice"
+      data-message={@sayg_saved_work_notice}
+    >
+    </div>
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner {assigns} />
@@ -1153,6 +1179,12 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     # For graded page with attempt in progress the activity scripts and activity_bridge script are needed as soon as the page loads.
     ~H"""
     <.countdown {assigns} />
+    <div
+      id="sayg_navigation_notice_source"
+      phx-hook="ScoreAsYouGoNavigationNotice"
+      data-message={@sayg_saved_work_notice}
+    >
+    </div>
     <div class="flex pb-20 flex-col w-full items-center gap-15 flex-1">
       <div class="flex flex-col items-center w-full">
         <.scored_page_banner {assigns} />

--- a/lib/oli_web/live/delivery/student/lesson_live.ex
+++ b/lib/oli_web/live/delivery/student/lesson_live.ex
@@ -1116,6 +1116,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     ~H"""
     <.countdown {assigns} />
     <div
+      :if={@sayg_saved_work_notice}
       id="sayg_navigation_notice_source"
       phx-hook="ScoreAsYouGoNavigationNotice"
       data-message={@sayg_saved_work_notice}
@@ -1180,6 +1181,7 @@ defmodule OliWeb.Delivery.Student.LessonLive do
     ~H"""
     <.countdown {assigns} />
     <div
+      :if={@sayg_saved_work_notice}
       id="sayg_navigation_notice_source"
       phx-hook="ScoreAsYouGoNavigationNotice"
       data-message={@sayg_saved_work_notice}

--- a/lib/oli_web/live/user_settings_live.ex
+++ b/lib/oli_web/live/user_settings_live.ex
@@ -11,10 +11,11 @@ defmodule OliWeb.UserSettingsLive do
   def render(assigns) do
     ~H"""
     <div class="bg-Background-bg-primary flex flex-col gap-4 items-center py-2 w-full">
+      <OliWeb.Components.Delivery.Layouts.sayg_saved_work_notice container_class="relative z-[45] mx-4 mt-6 w-[calc(100%-2rem)] md:mx-8 md:mt-10 md:w-[calc(100%-4rem)]" />
       <!-- Back Button -->
       <.link
         navigate={@back_path}
-        class="flex gap-2 items-center px-4 md:px-8 py-4 w-full cursor-pointer"
+        class="flex gap-2 items-center px-4 md:px-8 py-2 mt-6 w-full cursor-pointer"
       >
         <div class="size-5">
           <Icons.back_arrow class="w-5 h-5 fill-Icon-icon-active stroke-Icon-icon-active" />

--- a/lib/oli_web/live/user_settings_live.ex
+++ b/lib/oli_web/live/user_settings_live.ex
@@ -15,7 +15,7 @@ defmodule OliWeb.UserSettingsLive do
       <!-- Back Button -->
       <.link
         navigate={@back_path}
-        class="flex gap-2 items-center px-4 md:px-8 py-2 mt-6 w-full cursor-pointer"
+        class="flex gap-2 items-center px-4 md:px-8 py-4 min-h-[44px] mt-6 w-full cursor-pointer"
       >
         <div class="size-5">
           <Icons.back_arrow class="w-5 h-5 fill-Icon-icon-active stroke-Icon-icon-active" />

--- a/lib/oli_web/live/workspaces/student.ex
+++ b/lib/oli_web/live/workspaces/student.ex
@@ -172,6 +172,7 @@ defmodule OliWeb.Workspaces.Student do
         Hi, <span class="font-bold">{user_given_name(@ctx)}</span>
       </h1>
     </div>
+    <OliWeb.Components.Delivery.Layouts.sayg_saved_work_notice container_class="relative z-[45] mx-4 mt-4 md:mx-6" />
     <div class="flex flex-col items-start py-6 md:py-[60px] px-4 md:px-[100px]">
       <div class="flex flex-col md:flex-row mb-9 w-full">
         <h2 class="w-full py-2 md:py-0 text-xl md:text-[26px] md:leading-[32px] tracking-[0.02px] font-semibold dark:text-white">

--- a/lib/oli_web/templates/delivery/research_consent.html.heex
+++ b/lib/oli_web/templates/delivery/research_consent.html.heex
@@ -1,3 +1,8 @@
+<OliWeb.Components.Delivery.Layouts.sayg_saved_work_notice
+  static
+  container_class="relative z-[45] mx-4 mt-6 mb-6 md:mx-8"
+/>
+
 <div class="container my-5 mx-auto">
   <h1 class="h5 text-center">Carnegie Mellon University Open Learning Initiative</h1>
   <h2 class="h5 text-center">Online Consent Form</h2>

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -73,6 +73,21 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "delivery_controller research_consent" do
+    test "renders SAYG saved work notice static mount point", %{conn: conn} do
+      student = user_fixture(%{independent_learner: true, research_opt_out: nil})
+
+      conn =
+        conn
+        |> log_in_user(student)
+        |> get(Routes.delivery_path(conn, :show_research_consent))
+
+      html = html_response(conn, 200)
+
+      assert html =~ ~s(id="sayg_saved_work_notice")
+    end
+  end
+
   describe "delivery_controller deleted_project" do
     setup [:setup_lti_session]
 

--- a/test/oli_web/live/delivery/student/lesson_live_test.exs
+++ b/test/oli_web/live/delivery/student/lesson_live_test.exs
@@ -2640,6 +2640,115 @@ defmodule OliWeb.Delivery.Student.LessonLiveTest do
     end
   end
 
+  describe "SAYG saved work notice source" do
+    setup [:user_conn, :create_elixir_project]
+
+    test "is rendered with due date messaging on score as you go graded pages", %{
+      conn: conn,
+      section: section,
+      user: user,
+      page_3: graded_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{
+        batch_scoring: false,
+        scheduling_type: :due_by,
+        end_date: ~U[2026-06-13 20:00:00Z]
+      })
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      assert has_element?(
+               view,
+               "#sayg_navigation_notice_source[phx-hook='ScoreAsYouGoNavigationNotice']"
+             )
+
+      html = render(view)
+
+      assert html =~
+               "Your work has been saved. You can resume the assignment anytime before the due date."
+    end
+
+    test "is rendered without due date messaging when score as you go graded page has no end date",
+         %{
+           conn: conn,
+           section: section,
+           user: user,
+           page_3: graded_page
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{
+        batch_scoring: false,
+        end_date: nil
+      })
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      assert has_element?(view, "#sayg_navigation_notice_source")
+      assert render(view) =~ "Your work has been saved. You can resume the assignment anytime."
+    end
+
+    test "is rendered with read by messaging on score as you go graded pages with read by scheduling",
+         %{
+           conn: conn,
+           section: section,
+           user: user,
+           page_3: graded_page
+         } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{
+        batch_scoring: false,
+        scheduling_type: :read_by,
+        end_date: ~U[2026-06-13 20:00:00Z]
+      })
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      assert has_element?(view, "#sayg_navigation_notice_source")
+
+      assert render(view) =~
+               "Your work has been saved. You can resume the assignment anytime before the read by date."
+    end
+
+    test "is not rendered on score at the end graded pages", %{
+      conn: conn,
+      section: section,
+      user: user,
+      page_3: graded_page
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+      Sections.mark_section_visited_for_student(section, user)
+
+      Sections.get_section_resource(section.id, graded_page.resource_id)
+      |> Sections.update_section_resource(%{batch_scoring: true})
+
+      create_attempt(user, section, graded_page, %{lifecycle_state: :active})
+
+      {:ok, view, _html} = live(conn, Utils.lesson_live_path(section.slug, graded_page.slug))
+      ensure_content_is_visible(view)
+
+      refute has_element?(view, "#sayg_navigation_notice_source")
+    end
+  end
+
   describe "outline panel" do
     setup [:user_conn, :create_elixir_project]
 


### PR DESCRIPTION
[MER-5632](https://eliterate.atlassian.net/browse/MER-5632)

## Summary

This PR adds a saved-work notice for students when they leave a score-as-you-go assignment. The notice is shown on the next page they navigate to so students know their work was saved and that they can resume the assignment before the due date.

### Changes

- Adds a client-side hook to track when a student is leaving a score-as-you-go lesson and show the saved-work notice after navigation.
- Renders the notice mount point across student delivery layouts and supporting pages where students can land after leaving a lesson.
- Adds the notice source marker to score-as-you-go lesson pages so navigation can be detected reliably.
- Keeps the notice dismissible and avoids showing it repeatedly once consumed.
- Adjusts layout placement for delivery pages, settings, research consent, and student workspace pages so the notice does not block key content or navigation.

### Tests

- Adds hook coverage for the saved-work notice behavior.
- Adds LiveView/controller coverage for the notice mount points and SAYG lesson marker behavior.
- Adds Playwright coverage for leaving a SAYG lesson through lesson back navigation, bottom lesson navigation, and user menu destinations.

### Visual Changes


https://github.com/user-attachments/assets/17a90447-c3c5-4fe8-9ee5-2959c9083015

---


https://github.com/user-attachments/assets/02662b7d-c814-489a-8e57-7213db653b6a





[MER-5632]: https://eliterate.atlassian.net/browse/MER-5632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ