### PR TITLE
[ENHANCEMENT] [MER-5626] Jump to activity dropdown

### DIFF
--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -9,6 +9,7 @@ defmodule Oli.Rendering.Activity.Html do
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Activities
   alias Oli.Rendering.Context
+  alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.Content.ResourceSummary
   alias Oli.Rendering.Error
   alias Oli.Rendering.Activity.ActivitySummary
@@ -777,7 +778,7 @@ defmodule Oli.Rendering.Activity.Html do
           preview_wrapper_class(preview_context, padded?: true, authoring_fallback?: true)
 
         [
-          ~s|<div class="#{wrapper_class}">|,
+          ~s|<div id="#{JumpNavigation.activity_target_id(activity_id)}" class="#{wrapper_class}">|,
           render_preview_header(preview_context, activity_id),
           ~s|<#{tag} authoringcontext="#{activity_context}" student_responses=\"#{student_responses}\" section_slug=\"#{section_slug}\" activity_id=\"#{activity_html_id}\" model="#{model_json}" activityId="#{activity_id}" editmode="false" mode="instructor_preview" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|,
           render_learning_objectives(preview_context),
@@ -799,7 +800,7 @@ defmodule Oli.Rendering.Activity.Html do
           |> HtmlEntities.encode()
 
         [
-          ~s|<div class="instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden">|,
+          ~s|<div id="#{JumpNavigation.activity_target_id(activity_id)}" class="instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden #{JumpNavigation.target_classes()}">|,
           ~s|<#{tag} previewcontext="#{preview_context}" section_slug="#{section_slug}" activity_id="#{activity_html_id}" model="#{model_json}" activityId="#{activity_id}" mode="preview" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|,
           ~s|</div>|
         ]
@@ -957,7 +958,7 @@ defmodule Oli.Rendering.Activity.Html do
         Map.get(preview_context || %{}, "visualState")
 
     classes = [
-      "instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default overflow-hidden",
+      "instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default overflow-hidden #{JumpNavigation.target_classes()}",
       if(authoring_fallback?, do: "instructor-preview-authoring-fallback", else: nil),
       if(visual_state == "removed",
         do: "instructor-preview-removed",

--- a/lib/oli/rendering/activity/html.ex
+++ b/lib/oli/rendering/activity/html.ex
@@ -66,7 +66,7 @@ defmodule Oli.Rendering.Activity.Html do
            model: model,
            variables: variables
          } = summary,
-         %{"activity_id" => activity_id}
+         %{"activity_id" => activity_id} = element
        ) do
     tag =
       case mode do
@@ -95,6 +95,7 @@ defmodule Oli.Rendering.Activity.Html do
           section_slug,
           model_json,
           activity_id,
+          Map.get(element, "jump_target_id", JumpNavigation.activity_target_id(activity_id)),
           variables,
           bib_params_json
         )
@@ -745,6 +746,7 @@ defmodule Oli.Rendering.Activity.Html do
          section_slug,
          model_json,
          activity_id,
+         jump_target_id,
          variables,
          bib_params_json
        ) do
@@ -778,7 +780,7 @@ defmodule Oli.Rendering.Activity.Html do
           preview_wrapper_class(preview_context, padded?: true, authoring_fallback?: true)
 
         [
-          ~s|<div id="#{JumpNavigation.activity_target_id(activity_id)}" class="#{wrapper_class}">|,
+          ~s|<div id="#{jump_target_id}" class="#{wrapper_class}">|,
           render_preview_header(preview_context, activity_id),
           ~s|<#{tag} authoringcontext="#{activity_context}" student_responses=\"#{student_responses}\" section_slug=\"#{section_slug}\" activity_id=\"#{activity_html_id}\" model="#{model_json}" activityId="#{activity_id}" editmode="false" mode="instructor_preview" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|,
           render_learning_objectives(preview_context),
@@ -800,7 +802,7 @@ defmodule Oli.Rendering.Activity.Html do
           |> HtmlEntities.encode()
 
         [
-          ~s|<div id="#{JumpNavigation.activity_target_id(activity_id)}" class="instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden #{JumpNavigation.target_classes()}">|,
+          ~s|<div id="#{jump_target_id}" class="instructor-preview-activity-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden #{JumpNavigation.target_classes()}">|,
           ~s|<#{tag} previewcontext="#{preview_context}" section_slug="#{section_slug}" activity_id="#{activity_html_id}" model="#{model_json}" activityId="#{activity_id}" mode="preview" projectSlug="#{section_slug}" bib_params="#{Base.encode64(bib_params_json)}"></#{tag}>\n|,
           ~s|</div>|
         ]

--- a/lib/oli/rendering/content/jump_navigation.ex
+++ b/lib/oli/rendering/content/jump_navigation.ex
@@ -3,6 +3,9 @@ defmodule Oli.Rendering.Content.JumpNavigation do
 
   def activity_target_id(activity_id), do: "jump-question-#{safe_id(activity_id)}"
 
+  def activity_target_id(activity_id, occurrence_id),
+    do: "jump-question-#{safe_id(activity_id)}-#{safe_id(occurrence_id)}"
+
   def selection_target_id(selection_id), do: "jump-selection-#{safe_id(selection_id)}"
 
   def target_classes do

--- a/lib/oli/rendering/content/jump_navigation.ex
+++ b/lib/oli/rendering/content/jump_navigation.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Rendering.Content.JumpNavigation do
+  @moduledoc false
+
+  def activity_target_id(activity_id), do: "jump-question-#{safe_id(activity_id)}"
+
+  def selection_target_id(selection_id), do: "jump-selection-#{safe_id(selection_id)}"
+
+  def target_classes do
+    "scroll-mt-[280px] target:outline target:outline-2 target:outline-offset-4 target:outline-Border-border-focus"
+  end
+
+  defp safe_id(value) do
+    value
+    |> to_string()
+    |> String.replace(~r/[^A-Za-z0-9_-]/, "-")
+    |> String.trim("-")
+    |> case do
+      "" -> "target"
+      id -> id
+    end
+  end
+end

--- a/lib/oli/rendering/content/selection.ex
+++ b/lib/oli/rendering/content/selection.ex
@@ -1,4 +1,6 @@
 defmodule Oli.Rendering.Content.Selection do
+  alias Oli.Rendering.Content.JumpNavigation
+
   def render(
         %Oli.Rendering.Context{
           section_slug: section_slug,
@@ -18,7 +20,7 @@ defmodule Oli.Rendering.Content.Selection do
       end
 
     [
-      "<div class=\"jumbotron selection\">",
+      "<div id=\"#{JumpNavigation.selection_target_id(id)}\" class=\"jumbotron selection #{JumpNavigation.target_classes()}\">",
       "<h2 class=\"display-6\">Activity Bank Selection</h2>",
       "<p class=\"lead\">The following activity bank selection will select ",
       "<span class=\"badge badge-pill badge-primary\">#{count_desc}</span> randomly according to the following constraints:",

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -75,7 +75,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       current_page_resource_id: revision.resource_id,
       page_number: section_resource.numbering_index,
       question_count: map_size(activity_map),
-      jump_targets: jump_targets(revision.content),
+      jump_targets: preview_data.jump_targets,
       title: revision.title,
       graded: revision.graded,
       review_mode: false,
@@ -169,22 +169,40 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
           target_id: JumpNavigation.selection_target_id(id)
         }
 
-        {items ++ [item], selection_count, question_count}
+        {[item | items], selection_count, question_count}
 
-      %{"type" => "activity-reference", "activity_id" => id},
+      %{"type" => "activity-reference", "activity_id" => id} = element,
       {items, selection_count, question_count} ->
         question_count = question_count + 1
 
         item = %{
           kind: :question,
           label: "Question #{question_count}",
-          target_id: JumpNavigation.activity_target_id(id)
+          target_id: Map.get(element, "jump_target_id", JumpNavigation.activity_target_id(id))
         }
 
-        {items ++ [item], selection_count, question_count}
+        {[item | items], selection_count, question_count}
 
       _other, acc ->
         acc
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
+  defp add_jump_target_ids(content) do
+    content
+    |> PageContent.map_reduce(0, fn
+      %{"type" => "activity-reference", "activity_id" => activity_id} = element,
+      question_count,
+      _tr_context ->
+        question_count = question_count + 1
+        target_id = JumpNavigation.activity_target_id(activity_id, question_count)
+
+        {Map.put(element, "jump_target_id", target_id), question_count}
+
+      element, question_count, _tr_context ->
+        {element, question_count}
     end)
     |> elem(0)
   end
@@ -238,9 +256,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     section_slug = section.slug
     all_activities = Activities.list_activity_registrations()
     type_by_id = Map.new(all_activities, fn activity -> {activity.id, activity} end)
+    content = add_jump_target_ids(revision.content)
 
     activity_revisions =
-      revision.content
+      content
       |> activity_ids()
       |> then(&Resolver.from_resource_id(section_slug, &1))
 
@@ -272,7 +291,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     summaries = Map.values(activity_map)
 
     bib_entries =
-      revision.content
+      content
       |> BibUtils.assemble_bib_entries(
         summaries,
         fn summary -> Map.get(summary, :bib_refs, []) end,
@@ -285,12 +304,13 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     render_context =
       build_render_context(section, revision, user, activity_map, bib_entries, all_activities)
 
-    html = Page.render(render_context, revision.content, Page.Html)
+    html = Page.render(render_context, content, Page.Html)
 
     %{
       activity_map: activity_map,
       summaries: summaries,
       html: html,
+      jump_targets: jump_targets(content),
       # Metadata cached on the LiveView so remove/restore can recompute aggregate page data
       # without repeating DB lookups for page activities and their objective labels.
       preview_metadata: %{

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -17,8 +17,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Rendering.Activity.ActivitySummary
+  alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.{Context, Page}
   alias Oli.Resources
+  alias Oli.Resources.PageContent
   alias Oli.Utils.BibUtils
 
   def build(section, revision, user, navigation_params \\ %{}) do
@@ -73,6 +75,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       current_page_resource_id: revision.resource_id,
       page_number: section_resource.numbering_index,
       question_count: map_size(activity_map),
+      jump_targets: jump_targets(revision.content),
       title: revision.title,
       graded: revision.graded,
       review_mode: false,
@@ -145,8 +148,45 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
   defp activity_ids(content) do
     content
-    |> Oli.Resources.PageContent.flat_filter(fn item -> item["type"] == "activity-reference" end)
+    |> PageContent.flat_filter(fn item -> item["type"] == "activity-reference" end)
     |> Enum.map(fn %{"activity_id" => id} -> id end)
+  end
+
+  defp jump_targets(content) do
+    content
+    |> PageContent.flat_filter(fn
+      %{"type" => "activity-reference"} -> true
+      %{"type" => "selection"} -> true
+      _ -> false
+    end)
+    |> Enum.reduce({[], 0, 0}, fn
+      %{"type" => "selection", "id" => id}, {items, selection_count, question_count} ->
+        selection_count = selection_count + 1
+
+        item = %{
+          kind: :selection,
+          label: "Selection #{selection_count}",
+          target_id: JumpNavigation.selection_target_id(id)
+        }
+
+        {items ++ [item], selection_count, question_count}
+
+      %{"type" => "activity-reference", "activity_id" => id},
+      {items, selection_count, question_count} ->
+        question_count = question_count + 1
+
+        item = %{
+          kind: :question,
+          label: "Question #{question_count}",
+          target_id: JumpNavigation.activity_target_id(id)
+        }
+
+        {items ++ [item], selection_count, question_count}
+
+      _other, acc ->
+        acc
+    end)
+    |> elem(0)
   end
 
   defp preview_objectives(revision, section_slug) do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -104,6 +104,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
             section={@section}
           />
 
+          <.preview_jump_to_section jump_targets={@jump_targets} />
+
           <.preview_page_content
             html={@html}
             ctx={@ctx}
@@ -167,6 +169,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
             objectives={@objectives}
             section={@section}
           />
+
+          <.preview_jump_to_section jump_targets={@jump_targets} />
 
           <.preview_page_content
             html={@html}
@@ -312,6 +316,70 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     />
     """
   end
+
+  attr :jump_targets, :list, required: true
+
+  defp preview_jump_to_section(assigns) do
+    assigns =
+      assigns
+      |> assign(:selection_count, jump_target_count(assigns.jump_targets, :selection))
+      |> assign(:question_count, jump_target_count(assigns.jump_targets, :question))
+
+    ~H"""
+    <div
+      :if={Enum.any?(@jump_targets)}
+      id="jump-to-section-nav"
+      class="sticky top-[148px] z-[60] -mt-3 w-full pointer-events-none"
+    >
+      <details
+        id="jump-to-section-details"
+        class="group pointer-events-auto w-full rounded-lg border border-[#D0D5DD] bg-Surface-surface-primary shadow-[0px_1px_4px_rgba(16,24,40,0.12)] [&[open]_.jump-to-section-chevron]:rotate-180"
+      >
+        <summary
+          aria-label="Jump to Section"
+          class="flex min-h-14 cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 transition hover:bg-Surface-surface-secondary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden"
+        >
+          <span class="font-open-sans text-sm font-bold uppercase leading-4 text-[#353741]">
+            Jump to Section
+          </span>
+          <span class="flex min-w-0 items-center gap-3">
+            <span class="truncate text-right font-open-sans text-sm font-normal leading-5 text-[#353741]">
+              {jump_target_count_label(
+                @selection_count,
+                "Activity Bank Selection",
+                "Activity Bank Selections"
+              )}
+              <span aria-hidden="true"> &bull; </span>
+              {jump_target_count_label(@question_count, "Embedded Question", "Embedded Questions")}
+            </span>
+            <OliWeb.Icons.chevron_down class="jump-to-section-chevron h-4 w-4 shrink-0 fill-[#353741] transition-transform" />
+          </span>
+        </summary>
+
+        <nav
+          aria-label="Jump to page section"
+          class="flex max-h-[min(18rem,calc(100vh-18rem))] flex-wrap gap-4 overflow-y-auto border-t border-[#D0D5DD] px-4 pb-4 pt-4"
+        >
+          <a
+            :for={target <- @jump_targets}
+            href={"##{target.target_id}"}
+            phx-click={JS.remove_attribute("open", to: "#jump-to-section-details")}
+            class="inline-flex min-h-10 items-center justify-center rounded-full border border-[#D0D5DD] bg-Surface-surface-primary px-5 py-2 font-open-sans text-sm font-normal leading-5 text-[#353741] no-underline transition hover:border-[#B8C0CC] hover:bg-Surface-surface-secondary-hover hover:text-[#353741] hover:no-underline focus-visible:border-[#006CD9] focus-visible:text-[#006CD9] focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-0 focus-visible:outline-[#006CD9]"
+          >
+            <span>{target.label}</span>
+          </a>
+        </nav>
+      </details>
+    </div>
+    """
+  end
+
+  defp jump_target_count(jump_targets, kind) do
+    Enum.count(jump_targets, &(&1.kind == kind))
+  end
+
+  defp jump_target_count_label(1, singular, _plural), do: "1 #{singular}"
+  defp jump_target_count_label(count, _singular, plural), do: "#{count} #{plural}"
 
   attr :html, :any, required: true
   attr :ctx, :map, required: true
@@ -706,7 +774,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     ~H"""
     <div class="flex-1 flex flex-col w-full">
       <div class={[
-        "flex-1 flex flex-col overflow-auto",
+        "flex-1 flex flex-col overflow-visible",
         if(@active_sidebar_panel == :notes, do: "xl:mr-[550px]"),
         if(@active_sidebar_panel == :outline, do: "xl:mr-[360px]")
       ]}>

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -333,17 +333,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     >
       <details
         id="jump-to-section-details"
-        class="group pointer-events-auto w-full rounded-lg border border-[#D0D5DD] bg-Surface-surface-primary shadow-[0px_1px_4px_rgba(16,24,40,0.12)] [&[open]_.jump-to-section-chevron]:rotate-180"
+        class="group pointer-events-auto w-full rounded-[6px] border border-Specially-Tokens-Border-border-input bg-Specially-Tokens-Fill-fill-input shadow-[0px_1px_4px_rgba(16,24,40,0.12)] [&[open]_.jump-to-section-chevron]:rotate-180"
       >
         <summary
           aria-label="Jump to Section"
           class="flex min-h-14 cursor-pointer list-none items-center justify-between gap-4 px-4 py-3 transition hover:bg-Surface-surface-secondary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-Border-border-focus [&::-webkit-details-marker]:hidden"
         >
-          <span class="font-open-sans text-sm font-bold uppercase leading-4 text-[#353741]">
+          <span class="font-open-sans text-sm font-bold uppercase leading-4 text-Text-text-high">
             Jump to Section
           </span>
           <span class="flex min-w-0 items-center gap-3">
-            <span class="truncate text-right font-open-sans text-sm font-normal leading-5 text-[#353741]">
+            <span class="truncate text-right font-open-sans text-sm font-normal leading-4 text-Text-text-high">
               {jump_target_count_label(
                 @selection_count,
                 "Activity Bank Selection",
@@ -352,19 +352,19 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
               <span aria-hidden="true"> &bull; </span>
               {jump_target_count_label(@question_count, "Embedded Question", "Embedded Questions")}
             </span>
-            <OliWeb.Icons.chevron_down class="jump-to-section-chevron h-4 w-4 shrink-0 fill-[#353741] transition-transform" />
+            <OliWeb.Icons.chevron_down class="jump-to-section-chevron h-4 w-4 shrink-0 fill-Icon-icon-active transition-transform" />
           </span>
         </summary>
 
         <nav
           aria-label="Jump to page section"
-          class="flex max-h-[min(18rem,calc(100vh-18rem))] flex-wrap gap-4 overflow-y-auto border-t border-[#D0D5DD] px-4 pb-4 pt-4"
+          class="flex max-h-[min(18rem,calc(100vh-18rem))] flex-wrap gap-4 overflow-y-auto border-t border-Specially-Tokens-Border-border-input px-4 pb-4 pt-4"
         >
           <a
             :for={target <- @jump_targets}
             href={"##{target.target_id}"}
             phx-click={JS.remove_attribute("open", to: "#jump-to-section-details")}
-            class="inline-flex min-h-10 items-center justify-center rounded-full border border-[#D0D5DD] bg-Surface-surface-primary px-5 py-2 font-open-sans text-sm font-normal leading-5 text-[#353741] no-underline transition hover:border-[#B8C0CC] hover:bg-Surface-surface-secondary-hover hover:text-[#353741] hover:no-underline focus-visible:border-[#006CD9] focus-visible:text-[#006CD9] focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-0 focus-visible:outline-[#006CD9]"
+            class="inline-flex min-h-10 items-center justify-center rounded-[12px] border border-Border-border-default bg-Specially-Tokens-Fill-fill-detail-pill px-5 py-2 font-open-sans text-sm font-medium leading-4 text-Text-text-high no-underline transition hover:border-Border-border-default hover:bg-Surface-surface-secondary-hover hover:text-Text-text-high hover:no-underline focus-visible:border-Specially-Tokens-Text-text-button-secondary focus-visible:bg-Surface-surface-secondary-hover focus-visible:text-Text-text-button focus-visible:outline focus-visible:outline-[3px] focus-visible:outline-offset-0 focus-visible:outline-Specially-Tokens-Text-text-button-secondary"
           >
             <span>{target.label}</span>
           </a>

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -329,7 +329,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     <div
       :if={Enum.any?(@jump_targets)}
       id="jump-to-section-nav"
-      class="sticky top-[148px] z-[60] -mt-3 w-full pointer-events-none"
+      class="sticky top-[148px] z-[55] -mt-3 w-full pointer-events-none"
     >
       <details
         id="jump-to-section-details"

--- a/test/oli/rendering/activity/html_test.exs
+++ b/test/oli/rendering/activity/html_test.exs
@@ -164,6 +164,7 @@ defmodule Oli.Content.Activity.HtmlTest do
       rendered_html_string = Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
       assert rendered_html_string =~ "instructor-preview-activity-wrapper"
+      assert rendered_html_string =~ ~s|id="jump-question-1"|
       assert rendered_html_string =~ "<oli-multiple-choice-preview"
       assert rendered_html_string =~ "mode=\"preview\""
       assert rendered_html_string =~ "previewcontext="
@@ -206,6 +207,7 @@ defmodule Oli.Content.Activity.HtmlTest do
                  Phoenix.HTML.raw(rendered_html) |> Phoenix.HTML.safe_to_string()
 
                assert rendered_html_string =~ "instructor-preview-activity-wrapper"
+               assert rendered_html_string =~ ~s|id="jump-question-1"|
                assert rendered_html_string =~ "p-6"
                assert rendered_html_string =~ "border-Border-border-default"
                assert rendered_html_string =~ "bg-Surface-surface-primary"

--- a/test/oli_web/controllers/activity_bank_controller_test.exs
+++ b/test/oli_web/controllers/activity_bank_controller_test.exs
@@ -3,6 +3,8 @@ defmodule OliWeb.ActivityBankControllerTest do
 
   import Oli.Factory
 
+  alias Oli.Rendering.Content.JumpNavigation
+
   setup [:project_seed]
 
   describe "index" do
@@ -137,6 +139,9 @@ defmodule OliWeb.ActivityBankControllerTest do
 
       assert html_response(conn, 200) =~ "Activity Bank Selection"
       assert html_response(conn, 200) =~ "2 activities"
+
+      assert html_response(conn, 200) =~
+               ~s|id="#{JumpNavigation.selection_target_id("test_selection")}"|
     end
 
     test "returns error when not authorized", %{conn: conn, project: project} do

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -353,13 +353,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     } do
       {:ok, view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
 
-      first_question_target = JumpNavigation.activity_target_id(first_activity_id)
+      first_question_target = JumpNavigation.activity_target_id(first_activity_id, 1)
       selection_target = JumpNavigation.selection_target_id("selection_a")
-      second_question_target = JumpNavigation.activity_target_id(second_activity_id)
+      reused_question_target = JumpNavigation.activity_target_id(first_activity_id, 2)
+      second_question_target = JumpNavigation.activity_target_id(second_activity_id, 3)
 
       assert has_element?(view, "#jump-to-section-nav summary", "Jump to Section")
       assert html =~ "1 Activity Bank Selection"
-      assert html =~ "2 Embedded Questions"
+      assert html =~ "3 Embedded Questions"
       assert html =~ ~s|id="jump-to-section-nav"|
       assert html =~ "sticky top-[148px]"
       assert html =~ "-mt-3"
@@ -368,16 +369,19 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert html =~ ~s|href="##{first_question_target}"|
       assert html =~ ~s|href="##{selection_target}"|
+      assert html =~ ~s|href="##{reused_question_target}"|
       assert html =~ ~s|href="##{second_question_target}"|
 
       assert_in_order(html, [
         ~s|href="##{first_question_target}"|,
         ~s|href="##{selection_target}"|,
+        ~s|href="##{reused_question_target}"|,
         ~s|href="##{second_question_target}"|
       ])
 
       assert html =~ ~s|id="#{first_question_target}"|
       assert html =~ ~s|id="#{selection_target}"|
+      assert html =~ ~s|id="#{reused_question_target}"|
       assert html =~ ~s|id="#{second_question_target}"|
       assert html =~ "scroll-mt-[280px]"
     end
@@ -646,6 +650,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
             "id" => "selection_a",
             "logic" => %{"conditions" => nil},
             "count" => 2
+          },
+          %{
+            "type" => "activity-reference",
+            "purpose" => "None",
+            "activity_id" => first_activity_id
           },
           %{
             "type" => "activity-reference",

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -9,6 +9,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
   alias Oli.Analytics.Summary.ResourceSummary
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections
+  alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Resources.Collaboration.CollabSpaceConfig
 
   alias Oli.Delivery.Attempts.Core.{
@@ -340,6 +341,48 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     end
   end
 
+  describe "jump to section navigation" do
+    setup [:setup_jump_preview_section]
+
+    test "renders ordered jump links for activity bank selections and embedded questions", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      first_activity_id: first_activity_id,
+      second_activity_id: second_activity_id
+    } do
+      {:ok, view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      first_question_target = JumpNavigation.activity_target_id(first_activity_id)
+      selection_target = JumpNavigation.selection_target_id("selection_a")
+      second_question_target = JumpNavigation.activity_target_id(second_activity_id)
+
+      assert has_element?(view, "#jump-to-section-nav summary", "Jump to Section")
+      assert html =~ "1 Activity Bank Selection"
+      assert html =~ "2 Embedded Questions"
+      assert html =~ ~s|id="jump-to-section-nav"|
+      assert html =~ "sticky top-[148px]"
+      assert html =~ "-mt-3"
+      assert html =~ "flex-1 flex flex-col overflow-visible"
+      refute html =~ "fixed left-1/2"
+
+      assert html =~ ~s|href="##{first_question_target}"|
+      assert html =~ ~s|href="##{selection_target}"|
+      assert html =~ ~s|href="##{second_question_target}"|
+
+      assert_in_order(html, [
+        ~s|href="##{first_question_target}"|,
+        ~s|href="##{selection_target}"|,
+        ~s|href="##{second_question_target}"|
+      ])
+
+      assert html =~ ~s|id="#{first_question_target}"|
+      assert html =~ ~s|id="#{selection_target}"|
+      assert html =~ ~s|id="#{second_question_target}"|
+      assert html =~ "scroll-mt-[280px]"
+    end
+  end
+
   describe "mixed activity preview script selection" do
     setup [:setup_mixed_preview_section]
 
@@ -548,6 +591,93 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     {:ok, conn: log_in_user(conn, user), section: map.section, page_revision: map.page.revision}
   end
 
+  defp setup_jump_preview_section(%{conn: conn}) do
+    user = user_fixture(%{independent_learner: false})
+
+    content = %{
+      "stem" => "jump preview activity",
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "part_1",
+            "responses" => [
+              %{"rule" => "input like {a}", "score" => 1, "id" => "r1"},
+              %{"rule" => "input like {b}", "score" => 0, "id" => "r2"}
+            ],
+            "scoringStrategy" => "best",
+            "evaluationStrategy" => "regex"
+          }
+        ]
+      }
+    }
+
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_activity(
+        %{title: "first question", content: content},
+        :publication,
+        :project,
+        :author,
+        :first_activity
+      )
+      |> Seeder.add_activity(
+        %{title: "second question", content: content},
+        :publication,
+        :project,
+        :author,
+        :second_activity
+      )
+
+    first_activity_id = Map.get(map, :first_activity).resource.id
+    second_activity_id = Map.get(map, :second_activity).resource.id
+
+    page_attrs = %{
+      graded: true,
+      title: "jump preview page",
+      content: %{
+        "model" => [
+          %{
+            "type" => "activity-reference",
+            "purpose" => "None",
+            "activity_id" => first_activity_id
+          },
+          %{
+            "type" => "selection",
+            "id" => "selection_a",
+            "logic" => %{"conditions" => nil},
+            "count" => 2
+          },
+          %{
+            "type" => "activity-reference",
+            "purpose" => "None",
+            "activity_id" => second_activity_id
+          }
+        ]
+      }
+    }
+
+    map = Seeder.add_page(map, page_attrs, :container, :page)
+
+    {:ok, publication} =
+      Oli.Publishing.publish_project(map.project, "jump preview page", map.author.id)
+
+    map =
+      map
+      |> Map.merge(%{publication: publication})
+      |> Seeder.create_section()
+      |> Seeder.create_section_resources()
+
+    enroll_as_instructor(%{section: map.section, user: user})
+    cache_lti_context(map.section, user)
+
+    {:ok,
+     conn: log_in_user(conn, user),
+     section: map.section,
+     page_revision: map.page.revision,
+     first_activity_id: first_activity_id,
+     second_activity_id: second_activity_id}
+  end
+
   defp enroll_as_instructor(%{section: section, user: user}) do
     enroll_user_to_section(user, section, :context_instructor)
     :ok
@@ -617,5 +747,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       part_attempts: Repo.aggregate(part_attempt_query, :count),
       resource_summaries: Repo.aggregate(resource_summary_query, :count)
     }
+  end
+
+  defp assert_in_order(html, snippets) do
+    snippets
+    |> Enum.reduce(0, fn snippet, min_index ->
+      index = :binary.match(html, snippet) |> elem(0)
+      assert index >= min_index
+      index + byte_size(snippet)
+    end)
   end
 end

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -363,6 +363,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "3 Embedded Questions"
       assert html =~ ~s|id="jump-to-section-nav"|
       assert html =~ "sticky top-[148px]"
+      assert html =~ "z-[55]"
       assert html =~ "-mt-3"
       assert html =~ "flex-1 flex flex-col overflow-visible"
       refute html =~ "fixed left-1/2"


### PR DESCRIPTION
## Summary

Add a “Jump to Section” control to instructor lesson preview pages. The control lists Activity Bank Selections and embedded questions in page order, displays summary counts, and lets instructors jump directly to each rendered section.

## Changes

- Adds ordered jump targets for `selection` and `activity-reference` content in instructor preview context.
- Adds stable anchor IDs to rendered activity previews and activity bank selections.
- Adds a sticky, in-page “Jump to Section” dropdown below the Learning Objectives & Proficiency area.
- Keeps the dropdown sticky while scrolling, with tightened spacing below the preview header.
- Styles the closed and expanded states to match the provided design: compact sizing, updated border/color treatment, pill links, and accessible focus styling.
- Collapses the dropdown after selecting a jump link so the destination content remains visible.

See: https://eliterate.atlassian.net/browse/MER-5626


https://github.com/user-attachments/assets/8b685848-96f7-43d2-9047-2eba78bdf29b

