### PR TITLE
[ENHANCEMENT] [MER-5701] Comprehensive automated CAPI component tests

### DIFF
--- a/assets/automation/tests/torus/capi/capi.md
+++ b/assets/automation/tests/torus/capi/capi.md
@@ -18,30 +18,31 @@ The host (`ExternalActivity`) is the ground truth for the wire format — there 
 
 ## Test layers
 
-| Layer | File | Run |
-|---|---|---|
-| Protocol E2E (Playwright) | `capi.spec.ts` | `npx playwright test tests/torus/capi/capi.spec.ts` |
-| Value coercion (Jest) | `assets/test/adaptivity/capi_variable_test.ts` | `cd assets && npx jest test/adaptivity/capi_variable_test.ts` |
-| Seeding directive (ExUnit) | `test/oli/scenarios/edit_adaptive_page_test.exs` | `mix test test/oli/scenarios/edit_adaptive_page_test.exs` |
+| Layer                      | File                                             | Run                                                           |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------------------------- |
+| Protocol E2E (Playwright)  | `capi.spec.ts`                                   | `npx playwright test tests/torus/capi/capi.spec.ts`           |
+| Value coercion (Jest)      | `assets/test/adaptivity/capi_variable_test.ts`   | `cd assets && npx jest test/adaptivity/capi_variable_test.ts` |
+| Seeding directive (ExUnit) | `test/oli/scenarios/edit_adaptive_page_test.exs` | `mix test test/oli/scenarios/edit_adaptive_page_test.exs`     |
 
 ## Playwright coverage
 
-| # | Test | Asserts |
-|---|---|---|
-| 1 | handshake | HANDSHAKE_REQUEST → HANDSHAKE_RESPONSE, requestToken echoed, config has context/sectionSlug/userId/questionId |
-| 2 | init sequence | ON_READY → page→sim VALUE_CHANGE (carries seeded var) → INITIAL_SETUP_COMPLETE |
-| 5 | state restore | sim sets a var, revisit lesson, value pushed back on re-init |
-| 6 | SET_DATA | SET_DATA_REQUEST → SET_DATA_RESPONSE success, value echoed |
-| 7 | GET_DATA | stored value returns `exists:true`; unknown key returns `exists:false`, value `'[]'` |
-| 8 | RESIZE | RESIZE_PARENT_CONTAINER_REQUEST (absolute + relative) → RESPONSE echoes messageId |
-| 9 | robustness | malformed / non-JSON / pre-handshake traffic does not break the listener; handshake still works after |
-| 10 | source check | a CAPI message posted from the top window (not the iframe) is ignored |
-| 11 | token gap (characterization) | a same-iframe post-handshake message with a *mismatched* `requestToken` is still processed — documents the current boundary (source enforced, token not), see finding #2 |
-| 3 | check lifecycle | CHECK_REQUEST → deck check → CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE (seed carries a non-navigating trapstate rule) |
+| #   | Test                         | Asserts                                                                                                                                                                  |
+| --- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | handshake                    | HANDSHAKE_REQUEST → HANDSHAKE_RESPONSE, requestToken echoed, config has context/sectionSlug/userId/questionId                                                            |
+| 2   | init sequence                | ON_READY → page→sim VALUE_CHANGE (carries seeded var) → INITIAL_SETUP_COMPLETE                                                                                           |
+| 5   | state restore                | sim sets a var, revisit lesson, value pushed back on re-init                                                                                                             |
+| 6   | SET_DATA                     | SET_DATA_REQUEST → SET_DATA_RESPONSE success, value echoed                                                                                                               |
+| 7   | GET_DATA                     | stored value returns `exists:true`; unknown key returns `exists:false`, value `'[]'`                                                                                     |
+| 8   | RESIZE                       | RESIZE_PARENT_CONTAINER_REQUEST (absolute + relative) → RESPONSE echoes messageId; iframe bounding box follows (800×600 → 500×400 → 550×400)                             |
+| 9   | robustness                   | malformed / non-JSON / pre-handshake traffic does not break the listener; handshake still works after                                                                    |
+| 10  | source check                 | a CAPI message posted from the top window (not the iframe) is ignored                                                                                                    |
+| 11  | token gap (characterization) | a same-iframe post-handshake message with a _mismatched_ `requestToken` is still processed — documents the current boundary (source enforced, token not), see finding #2 |
+| 3   | check lifecycle              | CHECK_REQUEST → deck check → CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE (seed carries a non-navigating trapstate rule)                                               |
 
 Out of this Playwright suite's scope (deliberately): outbound `CONFIG_CHANGE` and review-mode
 behavior (VALUE_CHANGE suppressed / `readonly` pushed) — these need a context-change/review flow
-beyond the protocol round-trip this suite covers, and aren't asserted here.
+beyond the protocol round-trip this suite covers, and aren't asserted here. `CONFIG_CHANGE`
+coverage is tracked as TRIAGE-2412.
 
 ## How it works
 

--- a/assets/automation/tests/torus/capi/capi.md
+++ b/assets/automation/tests/torus/capi/capi.md
@@ -39,6 +39,10 @@ The host (`ExternalActivity`) is the ground truth for the wire format — there 
 | 11 | token gap (characterization) | a same-iframe post-handshake message with a *mismatched* `requestToken` is still processed — documents the current boundary (source enforced, token not), see finding #2 |
 | 3 | check lifecycle | CHECK_REQUEST → deck check → CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE (seed carries a non-navigating trapstate rule) |
 
+Out of this Playwright suite's scope (deliberately): outbound `CONFIG_CHANGE` and review-mode
+behavior (VALUE_CHANGE suppressed / `readonly` pushed) — these need a context-change/review flow
+beyond the protocol round-trip this suite covers, and aren't asserted here.
+
 ## How it works
 
 - **Stub sim** (`support/stub-sim.html`): a static page speaking the CAPI envelope, loaded into the
@@ -81,9 +85,8 @@ seedScenario tests, not just CAPI.
    Surfaced while building test 3; the test now seeds a non-navigating trapstate rule to avoid it.
    The crash itself is latent delivery hardening — see
    `docs/exec-plans/current/epics/automated_testing/capi/F2-no-rules-check-crash.md`. (The earlier
-   "part not registered / 403" framing was wrong; the 403 is a benign deferred-save race. Full trail
-   in `reviews/mer-5701-check-lifecycle-*.md` and
-   `docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md`.)
+   "part not registered / 403" framing was wrong; the 403 is a benign deferred-save race. Full
+   write-up in `docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md`.)
 2. **`requestToken` is not validated after handshake** (`ExternalActivity.tsx:1076` TODO). The host
    filters by `evnt.source` (confirmed enforced — test 10) but accepts any post-handshake message
    regardless of requestToken (characterized by test 11). Low risk given the source check, but

--- a/assets/automation/tests/torus/capi/capi.md
+++ b/assets/automation/tests/torus/capi/capi.md
@@ -36,6 +36,7 @@ The host (`ExternalActivity`) is the ground truth for the wire format — there 
 | 8 | RESIZE | RESIZE_PARENT_CONTAINER_REQUEST (absolute + relative) → RESPONSE echoes messageId |
 | 9 | robustness | malformed / non-JSON / pre-handshake traffic does not break the listener; handshake still works after |
 | 10 | source check | a CAPI message posted from the top window (not the iframe) is ignored |
+| 11 | token gap (characterization) | a same-iframe post-handshake message with a *mismatched* `requestToken` is still processed — documents the current boundary (source enforced, token not), see finding #2 |
 | 3 | check lifecycle | CHECK_REQUEST → deck check → CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE (seed carries a non-navigating trapstate rule) |
 
 ## How it works
@@ -58,7 +59,7 @@ The host (`ExternalActivity`) is the ground truth for the wire format — there 
 2. Ensure the dev DB is migrated (`mix ecto.migrate`).
 3. `cd assets/automation && npx playwright test tests/torus/capi/capi.spec.ts`
 
-No external services (no Canvas, no real sim host). Runtime ≈ 4 min for the 9 active tests
+No external services (no Canvas, no real sim host). Runtime ≈ 5 min for the 10 active tests
 (single worker, per `playwright.config.ts`).
 
 If you hit `Playwright Test did not expect test.describe()` / "two versions of @playwright/test"
@@ -85,7 +86,9 @@ seedScenario tests, not just CAPI.
    `docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md`.)
 2. **`requestToken` is not validated after handshake** (`ExternalActivity.tsx:1076` TODO). The host
    filters by `evnt.source` (confirmed enforced — test 10) but accepts any post-handshake message
-   regardless of requestToken. Low risk given the source check, but worth a decision.
+   regardless of requestToken (characterized by test 11). Low risk given the source check, but
+   worth a decision — hardening would be a separate ticket; flip test 11 to a negative assertion if
+   added.
 3. **Pre-existing duplicate `id="app"`** in `lib/oli_web/templates/layout/chromeless.html.heex:33-34`
    — two `<link>` stylesheet tags share `id="app"`, producing a `Multiple IDs detected: app`
    console warning on every adaptive (chromeless) page load. Harmless but a real duplicate-id

--- a/assets/automation/tests/torus/capi/capi.md
+++ b/assets/automation/tests/torus/capi/capi.md
@@ -1,0 +1,92 @@
+# CAPI component automated tests (MER-5701)
+
+Automated coverage for the CAPI interface — the postMessage protocol between an embedded
+simulation and the host adaptive page, implemented in
+`assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx`.
+
+## What CAPI is
+
+Adaptive pages embed simulations in an `<iframe>`. The sim and the host page talk over
+`window.postMessage` using a fixed envelope:
+
+```
+{ handshake: { requestToken, authToken, config }, options, type: <numeric>, values }
+```
+
+The host (`ExternalActivity`) is the ground truth for the wire format — there is no vendored
+`simcapi.js` in the repo.
+
+## Test layers
+
+| Layer | File | Run |
+|---|---|---|
+| Protocol E2E (Playwright) | `capi.spec.ts` | `npx playwright test tests/torus/capi/capi.spec.ts` |
+| Value coercion (Jest) | `assets/test/adaptivity/capi_variable_test.ts` | `cd assets && npx jest test/adaptivity/capi_variable_test.ts` |
+| Seeding directive (ExUnit) | `test/oli/scenarios/edit_adaptive_page_test.exs` | `mix test test/oli/scenarios/edit_adaptive_page_test.exs` |
+
+## Playwright coverage
+
+| # | Test | Asserts |
+|---|---|---|
+| 1 | handshake | HANDSHAKE_REQUEST → HANDSHAKE_RESPONSE, requestToken echoed, config has context/sectionSlug/userId/questionId |
+| 2 | init sequence | ON_READY → page→sim VALUE_CHANGE (carries seeded var) → INITIAL_SETUP_COMPLETE |
+| 5 | state restore | sim sets a var, revisit lesson, value pushed back on re-init |
+| 6 | SET_DATA | SET_DATA_REQUEST → SET_DATA_RESPONSE success, value echoed |
+| 7 | GET_DATA | stored value returns `exists:true`; unknown key returns `exists:false`, value `'[]'` |
+| 8 | RESIZE | RESIZE_PARENT_CONTAINER_REQUEST (absolute + relative) → RESPONSE echoes messageId |
+| 9 | robustness | malformed / non-JSON / pre-handshake traffic does not break the listener; handshake still works after |
+| 10 | source check | a CAPI message posted from the top window (not the iframe) is ignored |
+| 3 | check lifecycle | CHECK_REQUEST → deck check → CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE (seed carries a non-navigating trapstate rule) |
+
+## How it works
+
+- **Stub sim** (`support/stub-sim.html`): a static page speaking the CAPI envelope, loaded into the
+  iframe by intercepting an absolute URL via Playwright `page.route()`. It records every message
+  received from the host in `window.__capiLog` and is driven from tests via `frame.evaluate()`
+  (see `support/capiStub.ts`). Deterministic and offline — no real simulation needed.
+- **Seeding** (`capi_page.scenario.yaml`): builds a project with an `oli_adaptive` activity holding a
+  `janus-capi-iframe` part pointed at the stub URL, then converts the page to an adaptive page via
+  the `edit_adaptive_page` scenario directive (added for this work), publishes, creates a section,
+  and enrolls a student. Delivered through the `seedScenario` fixture →
+  `POST /test/scenario-yaml`.
+
+## Running locally
+
+1. Dev server with scenario seeding enabled and a token:
+   `PLAYWRIGHT_SCENARIO_TOKEN=my-token mix phx.server`
+   (`enable_playwright_scenarios` is already true in dev/test, false in prod.)
+2. Ensure the dev DB is migrated (`mix ecto.migrate`).
+3. `cd assets/automation && npx playwright test tests/torus/capi/capi.spec.ts`
+
+No external services (no Canvas, no real sim host). Runtime ≈ 4 min for the 9 active tests
+(single worker, per `playwright.config.ts`).
+
+If you hit `Playwright Test did not expect test.describe()` / "two versions of @playwright/test"
+on a full-file run, it's a stale transform cache — `rm -rf node_modules/.cache` and re-run.
+
+## CI placement
+
+Only a nightly Playwright workflow exists today (`--grep @nightly`). These tests, like the other
+`seedScenario`-based specs (`curriculum.spec.ts`), are **untagged** and run in the standard local
+suite. Wiring scenario-seeding tests into nightly CI needs `PLAYWRIGHT_SCENARIO_TOKEN` +
+`enable_playwright_scenarios` in that environment — a shared infra follow-up affecting all
+seedScenario tests, not just CAPI.
+
+## Findings (for the team)
+
+1. **No-rules check crash (F2 — product bug candidate).** An adaptive activity reaching check with
+   no evaluable rules crashes `triggerCheck` (`processResults(undefined).forEach`,
+   `DeckLayoutFooter.tsx:210`) — CHECK_START_RESPONSE fires but CHECK_COMPLETE_RESPONSE never does.
+   Surfaced while building test 3; the test now seeds a non-navigating trapstate rule to avoid it.
+   The crash itself is latent delivery hardening — see
+   `docs/exec-plans/current/epics/automated_testing/capi/F2-no-rules-check-crash.md`. (The earlier
+   "part not registered / 403" framing was wrong; the 403 is a benign deferred-save race. Full trail
+   in `reviews/mer-5701-check-lifecycle-*.md` and
+   `docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md`.)
+2. **`requestToken` is not validated after handshake** (`ExternalActivity.tsx:1076` TODO). The host
+   filters by `evnt.source` (confirmed enforced — test 10) but accepts any post-handshake message
+   regardless of requestToken. Low risk given the source check, but worth a decision.
+3. **Pre-existing duplicate `id="app"`** in `lib/oli_web/templates/layout/chromeless.html.heex:33-34`
+   — two `<link>` stylesheet tags share `id="app"`, producing a `Multiple IDs detected: app`
+   console warning on every adaptive (chromeless) page load. Harmless but a real duplicate-id
+   defect, unrelated to CAPI. Trivial fix (drop/rename the id on one link).

--- a/assets/automation/tests/torus/capi/capi.spec.ts
+++ b/assets/automation/tests/torus/capi/capi.spec.ts
@@ -161,10 +161,13 @@ test.describe('CAPI delivery protocol', () => {
     // which the host pushes back to the sim — proving the CAPI variable reached and
     // satisfied evaluation (Kevin TC2 intent), not just that the check completed.
     await expect
-      .poll(async () => {
-        const changes = await receivedMessages(frame, CapiType.VALUE_CHANGE);
-        return changes.some((m) => `${m.values?.acknowledged?.value}` === '1');
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const changes = await receivedMessages(frame, CapiType.VALUE_CHANGE);
+          return changes.some((m) => `${m.values?.acknowledged?.value}` === '1');
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
   });
 
@@ -247,24 +250,34 @@ test.describe('CAPI delivery protocol', () => {
     await waitForCount(frame, CapiType.GET_DATA_RESPONSE);
 
     await expect
-      .poll(async () => {
-        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
-        return hits.some(
-          (m) => m.values?.key === 'progress' && m.values?.exists === true && `${m.values?.value}`.includes('step-2'),
-        );
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+          return hits.some(
+            (m) =>
+              m.values?.key === 'progress' &&
+              m.values?.exists === true &&
+              `${m.values?.value}`.includes('step-2'),
+          );
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
 
     await sendFromStub(frame, CapiType.GET_DATA_REQUEST, { simId: 'miniFeeder', key: 'never-set' });
     await expect
-      .poll(async () => {
-        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
-        return hits.some((m) => m.values?.key === 'never-set' && m.values?.exists === false);
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+          return hits.some((m) => m.values?.key === 'never-set' && m.values?.exists === false);
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
   });
 
-  // Test 8 — RESIZE round-trip (absolute then relative), response echoes messageId
+  // Test 8 — RESIZE round-trip (absolute then relative): response echoes messageId, and the
+  // rendered iframe viewport actually changes, not just the ACK. Seeded part starts 800x600.
   test('responds to RESIZE_PARENT_CONTAINER_REQUEST (absolute and relative)', async ({
     page,
     seedScenario,
@@ -272,28 +285,46 @@ test.describe('CAPI delivery protocol', () => {
     const { frame } = await setup(page, seedScenario);
     await handshakeAndReady(frame);
 
+    const simIframe = page.locator(`iframe[src="${STUB_SIM_URL}"]`);
+    const iframeBoxMatches = async (width: number, height: number) => {
+      const box = await simIframe.boundingBox();
+      return !!box && Math.abs(box.width - width) <= 1 && Math.abs(box.height - height) <= 1;
+    };
+
     await sendFromStub(frame, CapiType.RESIZE_PARENT_CONTAINER_REQUEST, {
       messageId: 'resize-abs',
       width: { type: 'absolute', value: '500' },
       height: { type: 'absolute', value: '400' },
     });
     await expect
-      .poll(async () => {
-        const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
-        return r.some((m) => m.values?.messageId === 'resize-abs' && m.values?.responseType === 'success');
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
+          return r.some(
+            (m) => m.values?.messageId === 'resize-abs' && m.values?.responseType === 'success',
+          );
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
+    await expect.poll(() => iframeBoxMatches(500, 400), { timeout: 15_000 }).toBe(true);
 
     await sendFromStub(frame, CapiType.RESIZE_PARENT_CONTAINER_REQUEST, {
       messageId: 'resize-rel',
       width: { type: 'relative', value: '50' },
     });
     await expect
-      .poll(async () => {
-        const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
-        return r.some((m) => m.values?.messageId === 'resize-rel' && m.values?.responseType === 'success');
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
+          return r.some(
+            (m) => m.values?.messageId === 'resize-rel' && m.values?.responseType === 'success',
+          );
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
+    await expect.poll(() => iframeBoxMatches(550, 400), { timeout: 15_000 }).toBe(true);
   });
 
   // Test 9 — robustness: malformed and pre-handshake traffic must not break the listener
@@ -368,15 +399,18 @@ test.describe('CAPI delivery protocol', () => {
     // Host still dispatches and responds despite the mismatched token, and the response is tied to
     // this request (echoed simId/key, miss shape) — not a coincidental unrelated response.
     await expect
-      .poll(async () => {
-        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
-        return hits.some(
-          (m) =>
-            m.values?.simId === 'miniFeeder' &&
-            m.values?.key === 'progress' &&
-            m.values?.exists === false,
-        );
-      }, { timeout: 15_000 })
+      .poll(
+        async () => {
+          const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+          return hits.some(
+            (m) =>
+              m.values?.simId === 'miniFeeder' &&
+              m.values?.key === 'progress' &&
+              m.values?.exists === false,
+          );
+        },
+        { timeout: 15_000 },
+      )
       .toBe(true);
   });
 });

--- a/assets/automation/tests/torus/capi/capi.spec.ts
+++ b/assets/automation/tests/torus/capi/capi.spec.ts
@@ -1,0 +1,336 @@
+import { expect, FrameLocator, Page } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import {
+  CapiType,
+  countOf,
+  receivedMessages,
+  sendFromStub,
+  sendRawFromStub,
+  sendValueChange,
+  serveStubSim,
+  startHandshake,
+  stubFrame,
+  STUB_SIM_URL,
+} from './support/capiStub';
+
+const SCENARIO = './capi_page.scenario.yaml';
+const STUDENT_PASSWORD = 'changeme123456';
+
+interface CapiContext {
+  frame: FrameLocator;
+  sectionSlug: string;
+  pageSlug: string;
+}
+
+const attachConsole = (page: Page) => {
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') console.log(`[browser:error] ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => console.log(`[browser:pageerror] ${err.message}`));
+};
+
+const loginAsStudent = async (page: Page, email: string) => {
+  await page.goto('/users/log_in');
+  const acceptCookies = page.locator('#cookie_consent_display button:has-text("Accept")');
+  if (await acceptCookies.isVisible({ timeout: 2000 }).catch(() => false)) {
+    await acceptCookies.click();
+  }
+  await page.locator('#login_form_email').fill(email);
+  await page.locator('#login_form_password').fill(STUDENT_PASSWORD);
+  await page.locator('#login_form button:has-text("Sign in")').click();
+  await page.waitForLoadState('networkidle');
+};
+
+const dismissOnboardingWizard = async (page: Page) => {
+  const automationBypass = page.locator('#automation-go-to-course');
+  for (let i = 0; i < 5; i++) {
+    const onWizard =
+      (await automationBypass.isVisible({ timeout: 3000 }).catch(() => false)) ||
+      (await automationBypass.count()) > 0;
+    if (!onWizard) break;
+    await automationBypass.dispatchEvent('click');
+    await page.waitForTimeout(1000);
+  }
+};
+
+/** Returns the seeded lesson's revision slug (discovered from the Learn outline). */
+const resolvePageSlug = async (page: Page, sectionSlug: string): Promise<string> => {
+  await page.goto(`/sections/${sectionSlug}/learn`);
+  const slug = await page.locator('[phx-value-slug]').first().getAttribute('phx-value-slug');
+  expect(slug).toBeTruthy();
+  return slug as string;
+};
+
+const visitLesson = async (page: Page, sectionSlug: string, pageSlug: string) => {
+  await page.goto(`/sections/${sectionSlug}/lesson/${pageSlug}`);
+  await expect(page.locator(`iframe[src="${STUB_SIM_URL}"]`)).toBeVisible({ timeout: 30_000 });
+};
+
+/** Seed a fresh section, log in as the student, and open the CAPI lesson. */
+const setup = async (
+  page: Page,
+  seedScenario: (path: string, params: Record<string, unknown>) => Promise<any>,
+): Promise<CapiContext> => {
+  const runId = `capi${Date.now()}`;
+  const seeded = await seedScenario(SCENARIO, { run_id: runId, stub_url: STUB_SIM_URL });
+  const sectionSlug = seeded.outputs?.sections?.[`capi_section_${runId}`] as string;
+  const studentEmail = seeded.outputs?.users?.[`capi_student_${runId}`] as string;
+  expect(sectionSlug, 'seeded section slug').toBeTruthy();
+  expect(studentEmail, 'seeded student email').toBeTruthy();
+
+  attachConsole(page);
+  await serveStubSim(page);
+  await loginAsStudent(page, studentEmail);
+  // First visit to the section surfaces the onboarding wizard; dismiss it, then
+  // the outline (with the lesson's phx-value-slug) is reachable.
+  await page.goto(`/sections/${sectionSlug}/learn`);
+  await dismissOnboardingWizard(page);
+  const pageSlug = await resolvePageSlug(page, sectionSlug);
+  await visitLesson(page, sectionSlug, pageSlug);
+
+  const frame = stubFrame(page);
+  await expect(frame.locator('#status')).toContainText('stub-sim loaded');
+  return { frame, sectionSlug, pageSlug };
+};
+
+const waitForCount = (frame: FrameLocator, type: CapiType, atLeast = 1) =>
+  expect.poll(() => countOf(frame, type), { timeout: 15_000 }).toBeGreaterThanOrEqual(atLeast);
+
+/** Drive the sim through handshake + ON_READY to a fully initialized state. */
+const handshakeAndReady = async (frame: FrameLocator) => {
+  await startHandshake(frame);
+  await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+  await sendFromStub(frame, CapiType.ON_READY);
+  await waitForCount(frame, CapiType.INITIAL_SETUP_COMPLETE);
+};
+
+test.describe('CAPI delivery protocol', () => {
+  // Test 1 — handshake
+  test('completes handshake with the sim', async ({ page, seedScenario }) => {
+    const { frame, sectionSlug } = await setup(page, seedScenario);
+
+    await startHandshake(frame);
+    await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+
+    const [response] = await receivedMessages(frame, CapiType.HANDSHAKE_RESPONSE);
+    expect(response.handshake.requestToken).toBe('stub-request-token');
+    expect(response.handshake.config).toMatchObject({ context: 'VIEWER', sectionSlug });
+    expect(response.handshake.config.userId).toBeTruthy();
+    expect(response.handshake.config.questionId).toBeTruthy();
+  });
+
+  // Test 2 — init sequence (also exercises page -> sim VALUE_CHANGE for configData)
+  test('pushes initial state then INITIAL_SETUP_COMPLETE after ON_READY', async ({
+    page,
+    seedScenario,
+  }) => {
+    const { frame } = await setup(page, seedScenario);
+
+    await startHandshake(frame);
+    await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+    await sendFromStub(frame, CapiType.ON_READY);
+
+    // Host pushes configData variables to the sim, then signals setup complete.
+    await waitForCount(frame, CapiType.VALUE_CHANGE);
+    await waitForCount(frame, CapiType.INITIAL_SETUP_COMPLETE);
+
+    const valueChanges = await receivedMessages(frame, CapiType.VALUE_CHANGE);
+    const carriesSeededVar = valueChanges.some(
+      (m) => m.values && Object.prototype.hasOwnProperty.call(m.values, 'x'),
+    );
+    expect(carriesSeededVar, 'a VALUE_CHANGE carries the seeded "x" variable').toBe(true);
+  });
+
+  // Test 3 — check round-trip. The sim sets a variable then sends CHECK_REQUEST;
+  // the host runs the deck check (CHECK_REQUEST -> part submit -> triggerCheck ->
+  // lastCheckTriggered -> CHECK_STARTED/COMPLETE notifications) and replies to the
+  // sim with CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE. The seed includes a
+  // non-navigating trapstate rule so evaluation returns rule-shaped results and the
+  // completion half is not suppressed (navigation away would suppress CHECK_COMPLETE).
+  test('runs the check lifecycle on CHECK_REQUEST', async ({ page, seedScenario }) => {
+    const { frame } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    await sendValueChange(frame, { x: { type: 1, value: '5' } });
+    await sendFromStub(frame, CapiType.CHECK_REQUEST);
+
+    await waitForCount(frame, CapiType.CHECK_START_RESPONSE);
+    await waitForCount(frame, CapiType.CHECK_COMPLETE_RESPONSE);
+
+    // The rule (stage.capi_iframe_part.x == 5) fires a mutateState on `acknowledged`,
+    // which the host pushes back to the sim — proving the CAPI variable reached and
+    // satisfied evaluation (Kevin TC2 intent), not just that the check completed.
+    await expect
+      .poll(async () => {
+        const changes = await receivedMessages(frame, CapiType.VALUE_CHANGE);
+        return changes.some((m) => `${m.values?.acknowledged?.value}` === '1');
+      }, { timeout: 15_000 })
+      .toBe(true);
+  });
+
+  // Test 5 — state restore across a page revisit
+  test('restores saved sim state on revisit', async ({ page, seedScenario }) => {
+    const { frame, sectionSlug, pageSlug } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    await sendValueChange(frame, { x: { type: 1, value: '42' } });
+    // Allow the debounced save (100ms) + server persistence to settle before revisit.
+    await page.waitForTimeout(3000);
+
+    await visitLesson(page, sectionSlug, pageSlug);
+    const frame2 = stubFrame(page);
+    await expect(frame2.locator('#status')).toContainText('stub-sim loaded');
+
+    await startHandshake(frame2);
+    await waitForCount(frame2, CapiType.HANDSHAKE_RESPONSE);
+    await sendFromStub(frame2, CapiType.ON_READY);
+    await waitForCount(frame2, CapiType.VALUE_CHANGE);
+
+    await expect
+      .poll(
+        async () => {
+          const vcs = await receivedMessages(frame2, CapiType.VALUE_CHANGE);
+          return vcs.some((m) => `${m.values?.x?.value}` === '42');
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(true);
+  });
+
+  // Test 6 — SET_DATA round-trip (sim user storage)
+  test('acknowledges SET_DATA_REQUEST with a success response', async ({ page, seedScenario }) => {
+    const { frame } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    await sendFromStub(frame, CapiType.SET_DATA_REQUEST, {
+      simId: 'miniFeeder',
+      key: 'progress',
+      value: 'step-1',
+    });
+
+    await waitForCount(frame, CapiType.SET_DATA_RESPONSE);
+    const [resp] = await receivedMessages(frame, CapiType.SET_DATA_RESPONSE);
+    expect(resp.values).toMatchObject({
+      simId: 'miniFeeder',
+      key: 'progress',
+      responseType: 'success',
+      value: 'step-1',
+    });
+  });
+
+  // Test 7 — GET_DATA round-trip: stored value comes back; unknown key reports a miss
+  test('returns stored data on GET_DATA_REQUEST and a miss for unknown keys', async ({
+    page,
+    seedScenario,
+  }) => {
+    const { frame } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    await sendFromStub(frame, CapiType.SET_DATA_REQUEST, {
+      simId: 'miniFeeder',
+      key: 'progress',
+      value: 'step-2',
+    });
+    await waitForCount(frame, CapiType.SET_DATA_RESPONSE);
+
+    await sendFromStub(frame, CapiType.GET_DATA_REQUEST, { simId: 'miniFeeder', key: 'progress' });
+    await waitForCount(frame, CapiType.GET_DATA_RESPONSE);
+
+    await expect
+      .poll(async () => {
+        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+        return hits.some(
+          (m) => m.values?.key === 'progress' && m.values?.exists === true && `${m.values?.value}`.includes('step-2'),
+        );
+      }, { timeout: 15_000 })
+      .toBe(true);
+
+    await sendFromStub(frame, CapiType.GET_DATA_REQUEST, { simId: 'miniFeeder', key: 'never-set' });
+    await expect
+      .poll(async () => {
+        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+        return hits.some((m) => m.values?.key === 'never-set' && m.values?.exists === false);
+      }, { timeout: 15_000 })
+      .toBe(true);
+  });
+
+  // Test 8 — RESIZE round-trip (absolute then relative), response echoes messageId
+  test('responds to RESIZE_PARENT_CONTAINER_REQUEST (absolute and relative)', async ({
+    page,
+    seedScenario,
+  }) => {
+    const { frame } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    await sendFromStub(frame, CapiType.RESIZE_PARENT_CONTAINER_REQUEST, {
+      messageId: 'resize-abs',
+      width: { type: 'absolute', value: '500' },
+      height: { type: 'absolute', value: '400' },
+    });
+    await expect
+      .poll(async () => {
+        const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
+        return r.some((m) => m.values?.messageId === 'resize-abs' && m.values?.responseType === 'success');
+      }, { timeout: 15_000 })
+      .toBe(true);
+
+    await sendFromStub(frame, CapiType.RESIZE_PARENT_CONTAINER_REQUEST, {
+      messageId: 'resize-rel',
+      width: { type: 'relative', value: '50' },
+    });
+    await expect
+      .poll(async () => {
+        const r = await receivedMessages(frame, CapiType.RESIZE_PARENT_CONTAINER_RESPONSE);
+        return r.some((m) => m.values?.messageId === 'resize-rel' && m.values?.responseType === 'success');
+      }, { timeout: 15_000 })
+      .toBe(true);
+  });
+
+  // Test 9 — robustness: malformed and pre-handshake traffic must not break the listener
+  test('survives malformed and pre-handshake messages, then handshakes normally', async ({
+    page,
+    seedScenario,
+  }) => {
+    const { frame } = await setup(page, seedScenario);
+
+    // Garbage and out-of-order traffic before any handshake.
+    await sendRawFromStub(frame, 'this is not json');
+    await sendRawFromStub(frame, JSON.stringify({ foo: 'bar', no: 'type field' }));
+    await sendValueChange(frame, { x: { type: 1, value: '9' } });
+
+    // The listener must still be alive: a real handshake afterwards succeeds.
+    await startHandshake(frame);
+    await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+    const [resp] = await receivedMessages(frame, CapiType.HANDSHAKE_RESPONSE);
+    expect(resp.handshake.requestToken).toBe('stub-request-token');
+  });
+
+  // Test 10 — source check: a CAPI message from the main window (not the iframe) is ignored
+  test('ignores a CAPI message posted from a foreign source', async ({ page, seedScenario }) => {
+    const { frame } = await setup(page, seedScenario);
+
+    // Post a well-formed HANDSHAKE_REQUEST from the top window. The host listener
+    // filters on evnt.source === iframe.contentWindow, so this must be ignored.
+    await page.evaluate(() => {
+      window.postMessage(
+        JSON.stringify({
+          handshake: { requestToken: 'foreign-token', authToken: 'x', config: {} },
+          options: {},
+          type: 1,
+          values: {},
+        }),
+        '*',
+      );
+    });
+
+    // Wait past the 500ms handshake delay; the stub must NOT receive a response.
+    await page.waitForTimeout(2000);
+    expect(await countOf(frame, CapiType.HANDSHAKE_RESPONSE)).toBe(0);
+
+    // A genuine handshake from the iframe still works -> only the foreign one was dropped.
+    await startHandshake(frame);
+    await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+    const [resp] = await receivedMessages(frame, CapiType.HANDSHAKE_RESPONSE);
+    expect(resp.handshake.requestToken).toBe('stub-request-token');
+  });
+});

--- a/assets/automation/tests/torus/capi/capi.spec.ts
+++ b/assets/automation/tests/torus/capi/capi.spec.ts
@@ -173,9 +173,19 @@ test.describe('CAPI delivery protocol', () => {
     const { frame, sectionSlug, pageSlug } = await setup(page, seedScenario);
     await handshakeAndReady(frame);
 
+    // The save is observable only as the PATCH to the activity-attempt `/active` endpoint. Wait for
+    // that response (started before the change) so we never navigate away before persistence —
+    // deterministic, vs betting on a fixed sleep. No other save is in flight after handshakeAndReady.
+    const saved = page.waitForResponse(
+      (r) =>
+        r.request().method() === 'PATCH' &&
+        r.url().includes('/state/course/') &&
+        r.url().includes('/active') &&
+        r.ok(),
+      { timeout: 30_000 },
+    );
     await sendValueChange(frame, { x: { type: 1, value: '42' } });
-    // Allow the debounced save (100ms) + server persistence to settle before revisit.
-    await page.waitForTimeout(3000);
+    await saved;
 
     await visitLesson(page, sectionSlug, pageSlug);
     const frame2 = stubFrame(page);
@@ -332,5 +342,41 @@ test.describe('CAPI delivery protocol', () => {
     await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
     const [resp] = await receivedMessages(frame, CapiType.HANDSHAKE_RESPONSE);
     expect(resp.handshake.requestToken).toBe('stub-request-token');
+  });
+
+  // Test 11 — characterization of the current listener boundary, NOT a desired security contract:
+  // ExternalActivity filters by evnt.source but does not validate requestToken after handshake
+  // (see the TODO in ExternalActivity.tsx and the MER-5701 CAPI findings). Pairs with test 10:
+  // source is enforced; requestToken is not. If token validation is added later, replace this with
+  // a negative assertion.
+  test('documents current gap: same-iframe messages with a mismatched requestToken are still processed', async ({
+    page,
+    seedScenario,
+  }) => {
+    const { frame } = await setup(page, seedScenario);
+    await handshakeAndReady(frame);
+
+    // Side-effect-light request from the iframe, but with the WRONG token. `progress` was never
+    // set for this fresh student, so the response should echo the request and report a miss.
+    await sendFromStub(
+      frame,
+      CapiType.GET_DATA_REQUEST,
+      { simId: 'miniFeeder', key: 'progress' },
+      { requestToken: 'wrong-token' },
+    );
+
+    // Host still dispatches and responds despite the mismatched token, and the response is tied to
+    // this request (echoed simId/key, miss shape) — not a coincidental unrelated response.
+    await expect
+      .poll(async () => {
+        const hits = await receivedMessages(frame, CapiType.GET_DATA_RESPONSE);
+        return hits.some(
+          (m) =>
+            m.values?.simId === 'miniFeeder' &&
+            m.values?.key === 'progress' &&
+            m.values?.exists === false,
+        );
+      }, { timeout: 15_000 })
+      .toBe(true);
   });
 });

--- a/assets/automation/tests/torus/capi/capi_page.scenario.yaml
+++ b/assets/automation/tests/torus/capi/capi_page.scenario.yaml
@@ -1,0 +1,104 @@
+# Seeds an adaptive lesson whose CAPI iframe points at the Playwright stub sim.
+# ${stub_url} and ${run_id} are interpolated by the /test/scenario-yaml endpoint.
+
+- project:
+    name: "capi_project_${run_id}"
+    title: "CAPI Test Project ${run_id}"
+    root:
+      children:
+        - page: "CAPI Sim Page"
+
+- create_activity:
+    project: "capi_project_${run_id}"
+    title: "CAPI Stub Activity"
+    virtual_id: "capi_stub_activity"
+    scope: "embedded"
+    type: "oli_adaptive"
+    content_format: "json"
+    content:
+      authoring:
+        parts:
+          - id: "capi_iframe_part"
+            type: "janus-capi-iframe"
+            src: "${stub_url}"
+            sourceType: "url"
+            configData:
+              - key: "x"
+                type: 1
+                value: "0"
+        rules:
+          # Non-navigating trapstate rule on the CAPI variable. Its presence makes the
+          # server take the rule-evaluation path, so the check returns rule-shaped results
+          # and the CHECK_COMPLETE round-trip completes (see deferred-check-lifecycle.md).
+          # mutateState (not navigation) so CHECK_COMPLETE is not suppressed.
+          - id: "r:capi.x_set.correct"
+            name: "x_set"
+            disabled: false
+            additionalScore: 0.0
+            forceProgress: false
+            default: false
+            correct: true
+            conditions:
+              all:
+                - id: "c:capi.x"
+                  fact: "stage.capi_iframe_part.x"
+                  operator: "equal"
+                  value: 5
+            event:
+              type: "r:capi.x_set.correct"
+              params:
+                actions:
+                  - type: "mutateState"
+                    params:
+                      target: "stage.capi_iframe_part.acknowledged"
+                      operator: "="
+                      type: 1
+                      value: 1
+      custom:
+        x: 0
+        y: 0
+        z: 0
+        width: 800
+        height: 600
+      partsLayout:
+        - id: "capi_iframe_part"
+          type: "janus-capi-iframe"
+          custom:
+            x: 0
+            y: 0
+            z: 0
+            width: 800
+            height: 600
+            src: "${stub_url}"
+            sourceType: "url"
+            allowScrolling: false
+            configData:
+              - key: "x"
+                type: 1
+                value: "0"
+
+- edit_adaptive_page:
+    project: "capi_project_${run_id}"
+    page: "CAPI Sim Page"
+    activity_virtual_id: "capi_stub_activity"
+
+- publish:
+    to: "capi_project_${run_id}"
+    description: "Initial publish"
+
+- section:
+    name: "capi_section_${run_id}"
+    title: "CAPI Test Section ${run_id}"
+    from: "capi_project_${run_id}"
+
+- user:
+    name: "capi_student_${run_id}"
+    type: "student"
+    email: "capi_student_${run_id}@example.com"
+    password: "changeme123456"
+    email_verified: true
+
+- enroll:
+    user: "capi_student_${run_id}"
+    section: "capi_section_${run_id}"
+    role: "student"

--- a/assets/automation/tests/torus/capi/support/capiStub.ts
+++ b/assets/automation/tests/torus/capi/support/capiStub.ts
@@ -42,10 +42,15 @@ export const serveStubSim = async (page: Page) => {
 export const stubFrame = (page: Page): FrameLocator =>
   page.frameLocator(`iframe[src="${STUB_SIM_URL}"]`);
 
-export const sendFromStub = (frame: FrameLocator, type: CapiType, values?: unknown) =>
+export const sendFromStub = (
+  frame: FrameLocator,
+  type: CapiType,
+  values?: unknown,
+  handshakeOverrides?: Record<string, unknown>,
+) =>
   frame.locator('body').evaluate(
-    (_el, args) => (window as any).__capiSend(args.type, args.values),
-    { type, values },
+    (_el, args) => (window as any).__capiSend(args.type, args.values, args.handshakeOverrides),
+    { type, values, handshakeOverrides },
   );
 
 export const sendRawFromStub = (frame: FrameLocator, raw: string) =>

--- a/assets/automation/tests/torus/capi/support/capiStub.ts
+++ b/assets/automation/tests/torus/capi/support/capiStub.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { FrameLocator, Page } from '@playwright/test';
+
+export const STUB_SIM_URL = 'https://capi-stub.test/sim.html';
+
+export enum CapiType {
+  HANDSHAKE_REQUEST = 1,
+  HANDSHAKE_RESPONSE = 2,
+  ON_READY = 3,
+  VALUE_CHANGE = 4,
+  CONFIG_CHANGE = 5,
+  CHECK_REQUEST = 7,
+  CHECK_COMPLETE_RESPONSE = 8,
+  GET_DATA_REQUEST = 9,
+  GET_DATA_RESPONSE = 10,
+  SET_DATA_REQUEST = 11,
+  SET_DATA_RESPONSE = 12,
+  INITIAL_SETUP_COMPLETE = 14,
+  CHECK_START_RESPONSE = 15,
+  RESIZE_PARENT_CONTAINER_REQUEST = 18,
+  RESIZE_PARENT_CONTAINER_RESPONSE = 19,
+}
+
+export interface CapiMessage {
+  handshake: { requestToken: string; authToken: string; config: Record<string, unknown> };
+  options?: unknown;
+  type: CapiType;
+  values: any;
+}
+
+const stubHtml = fs.readFileSync(path.resolve(__dirname, 'stub-sim.html'), 'utf8');
+
+/** Intercept the stub URL so the seeded iframe loads our stub sim. */
+export const serveStubSim = async (page: Page) => {
+  await page.route(STUB_SIM_URL, (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: stubHtml }),
+  );
+};
+
+/** The CAPI iframe inside the adaptive delivery page. */
+export const stubFrame = (page: Page): FrameLocator =>
+  page.frameLocator(`iframe[src="${STUB_SIM_URL}"]`);
+
+export const sendFromStub = (frame: FrameLocator, type: CapiType, values?: unknown) =>
+  frame.locator('body').evaluate(
+    (_el, args) => (window as any).__capiSend(args.type, args.values),
+    { type, values },
+  );
+
+export const sendRawFromStub = (frame: FrameLocator, raw: string) =>
+  frame.locator('body').evaluate((_el, value) => (window as any).__capiSendRaw(value), raw);
+
+export const startHandshake = (frame: FrameLocator) =>
+  frame.locator('body').evaluate(() => (window as any).__capiHandshake());
+
+export const receivedMessages = (
+  frame: FrameLocator,
+  type: CapiType,
+): Promise<CapiMessage[]> =>
+  frame
+    .locator('body')
+    .evaluate((_el, t) => (window as any).__capiReceived(t), type) as Promise<CapiMessage[]>;
+
+export const allMessages = (frame: FrameLocator): Promise<CapiMessage[]> =>
+  frame.locator('body').evaluate(() => (window as any).__capiLog) as Promise<CapiMessage[]>;
+
+export const countOf = async (frame: FrameLocator, type: CapiType): Promise<number> =>
+  (await receivedMessages(frame, type)).length;
+
+/** Send a VALUE_CHANGE from the stub. vars: { key: { type, value, allowedValues? } } */
+export const sendValueChange = (frame: FrameLocator, vars: Record<string, unknown>) =>
+  sendFromStub(frame, CapiType.VALUE_CHANGE, vars);

--- a/assets/automation/tests/torus/capi/support/stub-sim.html
+++ b/assets/automation/tests/torus/capi/support/stub-sim.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>CAPI Stub Sim</title>
+  </head>
+  <body>
+    <div id="status">stub-sim loaded</div>
+    <script>
+      // Test stub speaking the CAPI postMessage protocol implemented by
+      // assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx.
+      // Driven from Playwright via window.__capiSend / window.__capiHandshake;
+      // every message received from the host is appended to window.__capiLog.
+
+      const REQUEST_TOKEN = 'stub-request-token';
+      const AUTH_TOKEN = 'stub-auth-token';
+
+      const TYPES = {
+        HANDSHAKE_REQUEST: 1,
+        HANDSHAKE_RESPONSE: 2,
+        ON_READY: 3,
+        VALUE_CHANGE: 4,
+        CONFIG_CHANGE: 5,
+        CHECK_REQUEST: 7,
+        CHECK_COMPLETE_RESPONSE: 8,
+        GET_DATA_REQUEST: 9,
+        GET_DATA_RESPONSE: 10,
+        SET_DATA_REQUEST: 11,
+        SET_DATA_RESPONSE: 12,
+        INITIAL_SETUP_COMPLETE: 14,
+        CHECK_START_RESPONSE: 15,
+        RESIZE_PARENT_CONTAINER_REQUEST: 18,
+        RESIZE_PARENT_CONTAINER_RESPONSE: 19,
+      };
+
+      window.__capiLog = [];
+      window.__capiTypes = TYPES;
+
+      window.addEventListener('message', (evnt) => {
+        let data;
+        try {
+          data = JSON.parse(evnt.data);
+        } catch (e) {
+          return;
+        }
+        window.__capiLog.push(data);
+        document.getElementById('status').textContent =
+          'last received type ' + data.type + ' (total ' + window.__capiLog.length + ')';
+      });
+
+      const envelope = (type, values, handshakeOverrides) =>
+        JSON.stringify({
+          handshake: Object.assign(
+            { requestToken: REQUEST_TOKEN, authToken: AUTH_TOKEN, config: {} },
+            handshakeOverrides || {},
+          ),
+          options: {},
+          type,
+          values: values === undefined ? {} : values,
+        });
+
+      // Send a CAPI message to the host. values/handshakeOverrides optional.
+      window.__capiSend = (type, values, handshakeOverrides) => {
+        window.parent.postMessage(envelope(type, values, handshakeOverrides), '*');
+      };
+
+      // Send a raw (possibly malformed) string to the host.
+      window.__capiSendRaw = (raw) => {
+        window.parent.postMessage(raw, '*');
+      };
+
+      // Convenience: full handshake start.
+      window.__capiHandshake = () => {
+        window.__capiSend(TYPES.HANDSHAKE_REQUEST);
+      };
+
+      // Convenience: variable value helper. vars = { key: {type, value, allowedValues?} }
+      window.__capiValueChange = (vars) => {
+        window.__capiSend(TYPES.VALUE_CHANGE, vars);
+      };
+
+      window.__capiReceived = (type) =>
+        window.__capiLog.filter((m) => m.type === type);
+    </script>
+  </body>
+</html>

--- a/assets/test/adaptivity/capi_variable_test.ts
+++ b/assets/test/adaptivity/capi_variable_test.ts
@@ -1,0 +1,114 @@
+import {
+  CapiVariable,
+  CapiVariableTypes,
+  coerceCapiValue,
+  getCapiType,
+  isSpecialArrayString,
+  parseCapiValue,
+} from 'adaptivity/capi';
+
+describe('getCapiType', () => {
+  it('detects ENUM when allowedValues are all strings', () => {
+    expect(getCapiType('a', ['a', 'b'])).toBe(CapiVariableTypes.ENUM);
+  });
+
+  it('detects BOOLEAN for booleans and "true"/"false" strings', () => {
+    expect(getCapiType(true)).toBe(CapiVariableTypes.BOOLEAN);
+    expect(getCapiType('true')).toBe(CapiVariableTypes.BOOLEAN);
+    expect(getCapiType('false')).toBe(CapiVariableTypes.BOOLEAN);
+  });
+
+  it('detects NUMBER for numeric values', () => {
+    expect(getCapiType(42)).toBe(CapiVariableTypes.NUMBER);
+  });
+
+  it('detects ARRAY for real arrays and ordinary array strings', () => {
+    expect(getCapiType([1, 2, 3])).toBe(CapiVariableTypes.ARRAY);
+    expect(getCapiType('["0.12"]')).toBe(CapiVariableTypes.ARRAY);
+  });
+
+  it('treats leading-zero decimal array strings as STRING (sim-sensitive)', () => {
+    // ["00.12"] must stay STRING so the sim does not choke (see isSpecialArrayString)
+    expect(getCapiType('["00.12"]')).toBe(CapiVariableTypes.STRING);
+  });
+
+  it('detects STRING for plain text and UNKNOWN for unhandled types', () => {
+    expect(getCapiType('hello')).toBe(CapiVariableTypes.STRING);
+    expect(getCapiType(undefined)).toBe(CapiVariableTypes.UNKNOWN);
+  });
+});
+
+describe('isSpecialArrayString', () => {
+  it('flags leading-zero decimals but not normal decimals', () => {
+    expect(isSpecialArrayString('["00.12"]')).toBe(true);
+    expect(isSpecialArrayString('["0.12"]')).toBe(false);
+    expect(isSpecialArrayString('not an array')).toBe(false);
+  });
+});
+
+describe('coerceCapiValue', () => {
+  it('stringifies numbers via parseFloat', () => {
+    expect(coerceCapiValue('42', CapiVariableTypes.NUMBER)).toBe('42');
+    expect(coerceCapiValue(3.5, CapiVariableTypes.NUMBER)).toBe('3.5');
+  });
+
+  it('passes strings and math expressions through as strings', () => {
+    expect(coerceCapiValue('hello', CapiVariableTypes.STRING)).toBe('hello');
+    expect(coerceCapiValue('x^2', CapiVariableTypes.MATH_EXPR)).toBe('x^2');
+  });
+
+  it('normalizes booleans to "true"/"false" strings', () => {
+    expect(coerceCapiValue(true, CapiVariableTypes.BOOLEAN)).toBe('true');
+    expect(coerceCapiValue('false', CapiVariableTypes.BOOLEAN)).toBe('false');
+  });
+
+  it('validates ENUM membership and throws on invalid values', () => {
+    expect(coerceCapiValue('a', CapiVariableTypes.ENUM, ['a', 'b'])).toBe('a');
+    expect(() => coerceCapiValue('z', CapiVariableTypes.ENUM, ['a', 'b'])).toThrow();
+  });
+
+  it('returns an array for ARRAY values', () => {
+    expect(Array.isArray(coerceCapiValue('[1,2]', CapiVariableTypes.ARRAY, null, true))).toBe(true);
+  });
+});
+
+describe('parseCapiValue', () => {
+  it('parses booleans back to real booleans', () => {
+    const v = new CapiVariable({ key: 'flag', type: CapiVariableTypes.BOOLEAN, value: 'true' });
+    expect(parseCapiValue(v)).toBe(true);
+  });
+
+  it('parses numbers back to real numbers', () => {
+    const v = new CapiVariable({ key: 'n', type: CapiVariableTypes.NUMBER, value: '7' });
+    expect(parseCapiValue(v)).toBe(7);
+  });
+});
+
+describe('CapiVariable', () => {
+  it('infers type from value when none is given and coerces the value', () => {
+    expect(new CapiVariable({ key: 'n', value: 5 })).toMatchObject({
+      type: CapiVariableTypes.NUMBER,
+      value: '5',
+    });
+    expect(new CapiVariable({ key: 'b', value: 'true' })).toMatchObject({
+      type: CapiVariableTypes.BOOLEAN,
+      value: 'true',
+    });
+    expect(new CapiVariable({ key: 's', value: 'hello' })).toMatchObject({
+      type: CapiVariableTypes.STRING,
+      value: 'hello',
+    });
+  });
+
+  it('honors an explicit type over inference', () => {
+    const v = new CapiVariable({ key: 's', type: CapiVariableTypes.STRING, value: '42' });
+    expect(v.type).toBe(CapiVariableTypes.STRING);
+    expect(v.value).toBe('42');
+  });
+
+  it('defaults allowedValues to null and bindTo to null', () => {
+    const v = new CapiVariable({ key: 'k', value: 1 });
+    expect(v.allowedValues).toBeNull();
+    expect(v.bindTo).toBeNull();
+  });
+});

--- a/docs/exec-plans/current/epics/automated_testing/capi/F2-no-rules-check-crash.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/F2-no-rules-check-crash.md
@@ -1,0 +1,56 @@
+# F2 (product bug candidate): Adaptive delivery CHECK crashes when evaluation has no rule results
+
+Surfaced during MER-5701. **Not fixed here** — adjacent product hardening, needs a separate ticket
+and a product severity call. Confirmed by both Claude (runtime) and Codex (source).
+
+## Summary
+
+In adaptive **delivery** (not preview), when a check runs against an activity whose evaluation
+returns no rule-shaped results, the frontend throws and the check never completes.
+
+- Backend: `lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex:134-142` has an explicit
+  `{:ok, %Model{rules: []}}` branch → `evaluate_from_input`, which does not produce rule result
+  events. So `rules: []` is a real model shape at the server boundary.
+- Frontend: `triggerCheck.ts:339-370` reads `(evalResult).result.actions` → `checkResult =
+  resultData.results` and passes it straight to `processResults(checkResult)`
+  (`DeckLayoutFooter.tsx:203-210`), which does `events.forEach(...)` with no array guard.
+- Result: `checkResult` undefined → `processResults` throws `Cannot read properties of undefined
+  (reading 'forEach')` → caught in `triggerCheck` *after* `setLastCheckTriggered` already fired →
+  `CHECK_STARTED` was notified but `CHECK_COMPLETE` never is. The learner hits the generic
+  "We could not load feedback" path.
+
+## Repro
+
+Seed the MER-5701 single-screen CAPI activity with `authoring.rules: []`, start the lesson as a
+student, drive the CAPI sim to send `CHECK_REQUEST` (or click the deck check). Observe the thrown
+`forEach` and missing completion.
+
+- Expected: delivery handles empty/no-rule evaluation gracefully — return a completed check with
+  empty results, or treat as no-op/incorrect, without throwing.
+- Actual: `CHECK_START_RESPONSE` sent, `processResults(undefined)` throws, `CHECK_COMPLETE_RESPONSE`
+  never sent.
+
+## Reachability (the product question)
+
+Codex could not prove that normal authoring/publish prevents a checkable zero-rule adaptive screen.
+Supporting evidence it's reachable:
+- `createActivityTemplate` initializes `authoring.rules: []` (`activity.ts:11-15`).
+- Rule deletion has no guard preserving ≥1 rule (`AdaptiveRulesList.tsx:191-205`,
+  `BottomPanel.tsx:140-152`).
+- Validators iterate `(authoring?.rules || [])` but none reject zero rules (`validate.ts:275,358`).
+- `flowchart` mode skips default rule insertion (`createNew.ts:69-83`) — repopulation path not
+  fully traced.
+
+→ Likely **medium severity**; confirm with product whether a no-rule checkable activity is
+publishable/reachable.
+
+## Suggested fix direction
+
+Guard `processResults` (and/or the `checkResult` assignment in `triggerCheck`) against
+non-array/undefined results; decide product semantics for a no-rule check (empty completion vs
+incorrect).
+
+## For triage
+Attach the exact network response body from the eval call (`PUT /activity_attempt/:guid` /
+evaluations endpoint) for the no-rules seed — re-run the deferred-state seed with response logging
+to capture it.

--- a/docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md
@@ -35,4 +35,5 @@ for the protocol round-trip (it remains a good basis for a future adaptivity/nav
   root-caused, and is not implicated in the check lifecycle or its fix. Not chased further.
 
 ## Cross-review trail
-`reviews/mer-5701-check-lifecycle-01..04.md` (Claude diagnosis ↔ Codex review, 4 rounds).
+Diagnosed over several rounds of Claude↔Codex cross-review (an internal review dialogue, not
+committed to the repo).

--- a/docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/deferred-check-lifecycle.md
@@ -1,0 +1,38 @@
+# RESOLVED: CAPI CHECK lifecycle (former items 1+2)
+
+**Status: resolved 2026-06-16.** Test 3 (`runs the check lifecycle on CHECK_REQUEST`) now passes;
+no longer `test.fixme`. This doc records how the deferral was resolved. The original "minimal seed
+doesn't register the part / 403" framing was **wrong** — see the corrected root cause below.
+
+## What it actually was (after instrumented pass + Codex cross-review)
+
+The part *was* registered (DB + frontend confirmed). The CHECK_REQUEST path *does* reach the deck
+check: `handleCheckRequest → onSubmit → AdaptiveDelivery.handlePartSubmit →
+DeckLayoutView.handleActivitySubmitPart → triggerCheck → setLastCheckTriggered → CHECK_STARTED →
+CHECK_START_RESPONSE`. All of that fired.
+
+The break was only the **completion half**: our seed had `authoring.rules: []`, so the server took
+the no-rules evaluation branch (`evaluate.ex:134-142`) and returned a response without rule-shaped
+results. `triggerCheck` passed that `undefined` to `processResults` (`DeckLayoutFooter.tsx:210`,
+`events.forEach`) → threw → caught after CHECK_START already fired → `CHECK_COMPLETE` never notified
+→ no `CHECK_COMPLETE_RESPONSE`.
+
+## The fix (F1)
+
+Added one **non-navigating** trapstate rule (mutateState action) on `stage.capi_iframe_part.x` to
+`capi_page.scenario.yaml`. With a rule present, the server takes the rule-evaluation path and returns
+rule-shaped results, so the check completes and both `CHECK_START_RESPONSE` + `CHECK_COMPLETE_RESPONSE`
+reach the sim. Non-navigating is deliberate: a navigating (correct→advance) rule would hit
+`ActivityRenderer`'s CHECK_COMPLETE nav-suppression and the test could not assert the completion
+message. Single screen suffices — Kevin's full layer/subscreen navigating structure is not needed
+for the protocol round-trip (it remains a good basis for a future adaptivity/navigation test).
+
+## Spun off
+- **F2** (`F2-no-rules-check-crash.md`): the underlying `processResults(undefined)` crash is a latent
+  delivery robustness bug, tracked separately for a product severity call. Not fixed in MER-5701.
+- Benign anomaly: a spurious empty `handlePartSubmit({id: undefined})` was observed in instrumented
+  runs (logs "part attempt guid for undefined not found"). It's a harmless early-return, was not
+  root-caused, and is not implicated in the check lifecycle or its fix. Not chased further.
+
+## Cross-review trail
+`reviews/mer-5701-check-lifecycle-01..04.md` (Claude diagnosis ↔ Codex review, 4 rounds).

--- a/docs/exec-plans/current/epics/automated_testing/capi/kevin-test-cases.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/kevin-test-cases.md
@@ -1,0 +1,51 @@
+# Kevin Segovia's manual CAPI test cases (verbatim)
+
+Source: MER-5701 Jira comment (Kevin Segovia, 2026-06-15), comment id 53355. Reproduced verbatim as
+the acceptance reference for the automated tests. Do not paraphrase — judge automation fidelity
+against this text.
+
+---
+
+# Test Cases for CAPI Component
+
+## Test Case 1: Ensure External Site Loads Correctly
+
+As an Author
+
+1. Create a new authoring Project
+2. On the left side, click on **Create**
+3. Click on **Curriculum**
+4. On the row with **Advanced Author,** click on **Scored**
+5. Toggle **Read-only** mode **Off**
+6. On the component panel at the top of the page, click on the **Box Icon** (should say Iframe)
+7. This should bring up a new component on the Canvas. Select the new component
+8. On the right side should be a component panel that should have opened up. Here you will paste an external site URL.
+    1. For example, paste: https://en.wikipedia.org/wiki/FIFA_World_Cup
+9. Finally, to test correct behavior for live view, click on **Preview**
+
+Expected Behavior: The Wikipedia page has loaded correctly, and you can scroll the page within the iframe.
+
+## Test Case 2: Ensure that CAPI exposes correct variables to the rules engine (trapstate configuration)
+
+As an Author
+
+1. Create a new authoring Project
+2. On the left side, click on **Create**
+3. Click on **Curriculum**
+4. On the row with **Advanced Author,** click on **Scored**
+5. Toggle **Read-only** mode **Off**
+6. Create a new layer by clicking on the plus sign next to the sequence editor, then clicking on **Layer**
+7. In a new layer, click the CAPI Simulation Component icon (Box icon) in the toolbar above the canvas
+8. On the canvas, select the newly created CAPI iframe and stretch the width and height so the iframe takes up the whole screen
+9. In the Component panel, under Custom --> Source, input a link to a simulation, such as the Sea Turtle "mini feeder" from Nitrogen Tales: A Sea Turtle's Quest: https://etx-nec.s3.us-west-2.amazonaws.com/css/torus/etx/styles/infini-dev/sites/nc/feed-mini/index.html
+10. In the Component panel, overwrite the system-generated Id* which begins with "janus_capi_iframe-..." with a new Id*: "miniFeeder".
+11. Add a new subscreen below the layer, by clicking on the three dots next to new layer and then clicking on add Subscreen
+12. On the layer on which the CAPI component was created, select the component "miniFeeder", click its edit button (pen and paper icon), and click Save to close the dialog box. (This step initalizes the CAPI.)
+13. Navigate to the subscreen below the layer with the CAPI component to be validated, in this case the Sea Turtle "mini feeder" from Nitrogen Tales: A Sea Turtle's Quest
+14. In the Adaptivity panel (bottom left side of screen), select "correct" to set a correct trap state
+15. In the Rule Editor panel, click the plus (+) sign next to Conditions and choose "+ Single Condition"
+16. In the input box to the right of the target icon, overwrite "stage." with the text "stage.miniFeeder.selected" (input is case sensitive and should not include quotation marks)
+17. In the new condition, enter "food" in the input field at right containing the prompt "Value"
+18. Now click on **Preview**
+
+Expected Behavior: In Preview mode, clicking on the Food button, then Next, allows the user to move to the next screen. If the user tries to click Next before clicking the Food button, it triggers an incorrect state.

--- a/docs/exec-plans/current/epics/automated_testing/capi/plan.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/plan.md
@@ -190,24 +190,22 @@ lib/oli/scenarios/...        # only if seeding-gap extension approved (§2)
   `#automation-go-to-course`; navigate to lesson directly via `phx-value-slug` from the Learn
   outline; configData keys are sent verbatim as CAPI variable keys (use plain names like `x`).
 
-### Step 2 — core protocol ✅/deferred (2026-06-16)
-Passing (3): handshake (1), init sequence + page→sim VALUE_CHANGE for configData (2), state
-restore across revisit (5).
+### Final state ✅ (shipped — PR #6663)
+All planned coverage landed and is green:
+- **Playwright (10)** in `capi.spec.ts`: handshake, init + page→sim VALUE_CHANGE, check lifecycle,
+  state restore, SET_DATA, GET_DATA, RESIZE, malformed/pre-handshake robustness, foreign-source
+  ignored, requestToken characterization.
+- **Jest (17)** `capi_variable_test.ts`; **ExUnit (4)** `edit_adaptive_page_test.exs`.
 
-**Deferred — Test 3 (check lifecycle), `test.fixme`. FINDING:**
-CHECK_REQUEST → `onSubmit` reaches `AdaptiveDelivery.handlePartSubmit/handlePartSave`, which look up
-the part in `currentAttemptState.parts` by `partId` and abort with
-`part attempt guid for undefined not found` plus a **403** on the server part-save. The minimal
-single-screen seeded adaptive activity does not register the CAPI part in the activity attempt the
-way the check lifecycle needs. So CHECK_START_RESPONSE / CHECK_COMPLETE_RESPONSE are never emitted.
-Note: the *save* path (used by state restore, test 5) works — only the check/submit path fails.
-Resolution requires deeper attempt/part seeding (server-side); tracked as its own task, not a
-CAPI-component bug.
+The check-lifecycle test (test 3) was briefly deferred mid-build while the cause was diagnosed; it
+is now **passing**. Root cause was a no-rules evaluation crash (`processResults` on undefined), not
+part-registration — fixed in the test by seeding a non-navigating trapstate rule, with the
+underlying delivery crash tracked as a separate finding. See `deferred-check-lifecycle.md`.
 
-**Test 4 (rule-driven page→sim mutate):** not implemented. Page→sim VALUE_CHANGE is already
-exercised by test 2 (init). A rule-driven mutate needs hand-authored adaptivity-rule JSON + a
-working check/evaluation cycle — same subsystem as the test-3 finding. Folded into that deferral.
+Test 4 (rule-driven page→sim mutate) was folded into test 3, which now asserts the observable
+`mutateState` effect (the variable reaching and satisfying the rule).
 
-### Remaining
-Step 3 (tests 6–8: GET/SET data, resize), Step 4 (tests 9–10: robustness/malformed/foreign-source),
-Step 5 (Jest capi.ts suite), Step 6 (capi.md doc + CI placement).
+### Follow-up findings (separate tickets, out of scope per Eli's "tests only" ruling)
+F2 (no-rules check crash), `requestToken` not validated post-handshake, duplicate `id="app"` in
+`chromeless.html.heex`, and the sibling `edit_page_handler` swallowed-upsert. See `capi.md` findings
+and `F2-no-rules-check-crash.md`.

--- a/docs/exec-plans/current/epics/automated_testing/capi/plan.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/plan.md
@@ -1,0 +1,213 @@
+# MER-5701 Plan: Automated CAPI Component Tests
+
+Companion to `research.md`. Scope per research §8: Playwright-primary, no CAPI production
+refactoring, programmable in-repo stub sim, Jest only for already-pure code.
+
+Revised 2026-06-12 after full-file reads of `ExternalActivity.tsx`, `capi.ts`, `schema.ts`,
+`sourceResolver.ts`, the seeding endpoint, scenario ops, and three deep-trace agent passes.
+Everything below cites verified behavior.
+
+## 1. Verified protocol surface (delivery, `ExternalActivity.tsx`)
+
+Host listener (lines 1065–1112) accepts only messages where `evnt.source === iframe.contentWindow`;
+non-JSON silently dropped; **no requestToken validation** on incoming messages (TODO at line 1076).
+Envelope: `{ handshake: {requestToken, authToken, config}, options, type: <numeric enum>, values }`,
+JSON-stringified.
+
+| Flow | Behavior (file:line) |
+|---|---|
+| HANDSHAKE_REQUEST (1) → HANDSHAKE_RESPONSE (2) | Token stored and echoed **after a 500ms setTimeout** (740–742); config carries `context/lessonId/questionId/sectionSlug/userId` (731–737) |
+| ON_READY (3) | Pushes configData/current state as per-variable VALUE_CHANGE; values templatized via janus-script env (757–792); INITIAL_SETUP_COMPLETE (14) sent from the init-state effect (1207) |
+| VALUE_CHANGE (4) sim→page | Ignored in review context (1095); vars stored under `stage.<partId>.<key>`; saved via **100ms debounced** (maxWait 30s, leading) `props.onSave` (849–885) |
+| VALUE_CHANGE page→sim | On init-state apply (1203), on STATE_CHANGED notification → `processMutateStateVariable` (563–591, 278), on review readonly (508) |
+| CONFIG_CHANGE (5) page→sim | On CONTEXT_CHANGED notification (606–613) |
+| CHECK_REQUEST (7) | 150ms delay → `props.onSubmit` (919–926); page later emits CHECK_START_RESPONSE (15) / CHECK_COMPLETE_RESPONSE (8) on CHECK_STARTED/CHECK_COMPLETE notifications (534–561) |
+| GET_DATA_REQUEST (9) → GET_DATA_RESPONSE (10) | Per-sim user storage via `props.onGetData`; `{simId, key, responseType, exists, value}`; missing → `value: '[]'`, `exists: false` (807–847) |
+| SET_DATA_REQUEST (11) → SET_DATA_RESPONSE (12) | Via `props.onSetData`; success echoes value; error → `responseType: 'error'` (887–917) |
+| RESIZE_PARENT_CONTAINER_REQUEST (18) → RESPONSE (19) | Absolute or relative width/height; echoes `messageId` (928–981) |
+| Re-init pass | Host regenerates requestToken and sends unsolicited HANDSHAKE_RESPONSE (1212–1214) |
+
+Component quirks that constrain tests:
+- Message listener attaches only when `simFrame && scriptEnv` — `scriptEnv` comes from the adaptive
+  runtime's `onInit` result (177–179, 1020). **Component is functional only inside the adaptive
+  delivery runtime.**
+- `model.configData` must be an array or line 1031 (`configData.map`) throws. Seeded part model
+  MUST include `configData: []` minimum.
+- `resolveAdaptiveIframeSource` passes any src not starting with `/course/link/` through verbatim
+  (sourceResolver.ts:34–36) — an absolute stub URL reaches the iframe untouched, interceptable by
+  `page.route()`. Iframe has no `sandbox` attr.
+- Sim-specific hacks exist (KIP `CurrentEclipse` ordering 1161–1168, SmallWorld
+  `AllowNextOnCacheCase` inversion 1192–1198) — out of test scope, noted to avoid confusion.
+
+## 2. Critical architecture facts (change earlier assumptions)
+
+1. **Adaptive runtime only mounts on adaptive pages.** `InitPage` routes by
+   `content["advancedDelivery"]` (init_page.ex:157): regular practice pages get server-rendered
+   HTML — an `oli_adaptive` activity referenced there does NOT boot the adaptive React app. Page
+   revision content must carry `advancedDelivery: true` (+ `advancedAuthoring: true`,
+   `model: [{type: group, layout: deck, children: [activity-reference]}]` per db_seeder shape).
+2. **Rules don't fire on VALUE_CHANGE.** Adaptive rules evaluate on check/submit
+   (NodeEvaluator → client rules engine). VALUE_CHANGE only updates state; CHECK triggers
+   evaluation. Tests pair them.
+3. **Scenario hooks are unusable via the Playwright endpoint.** Hook functions resolve at runtime,
+   but dev compiles only `lib/` (mix.exs:131) — hook modules in `test/` (e.g. IframeLinksHooks)
+   don't exist on the dev server.
+4. **Seeding endpoint supports `${param}` interpolation** (playwright_scenario_controller.ex:107)
+   and returns outputs: project/section slugs + user emails (114–124). It does NOT return resource
+   ids.
+5. **`manipulate → revise → set` passes arbitrary maps verbatim** into revision params
+   (ops.ex:351–366, 456) — page `content` is settable from pure YAML. But it REPLACES the whole
+   content map, and the adaptive `model` needs the activity's `resource_id`, which YAML/params
+   cannot know. **This is the one unresolved seeding gap.**
+
+### Seeding gap resolution (decision needed at build start)
+
+Preferred: **small scenario-framework extension** in `lib/oli/scenarios/` — teach `edit_page` (or a
+new op) to produce adaptive page content with virtual_id → resource_id resolution. Precedent: epic
+sibling tickets are literally titled "…including any directive expansion needed for scenario-driven
+coverage" — directive expansion is the epic's blessed pattern and is test infrastructure, distinct
+from the CAPI refactoring the team declined. Estimated ~50–100 lines + schema entry + unit test.
+Fallback if even that is unwanted: drive authoring UI with Playwright to build the adaptive page
+(slow, brittle — not recommended).
+
+## 3. Test inventory
+
+### Playwright — `assets/automation/tests/torus/capi/capi.spec.ts` (10 + 1 optional)
+
+Core:
+1. **Handshake** — stub sends HANDSHAKE_REQUEST; within ~1s receives HANDSHAKE_RESPONSE echoing
+   requestToken, config has `context: "VIEWER"` + sectionSlug/userId/questionId/lessonId.
+2. **Init sequence** — stub sends ON_READY; receives configData vars as VALUE_CHANGEs then
+   INITIAL_SETUP_COMPLETE.
+3. **Variable change + check fires rule** — stub sends VALUE_CHANGE (`stage.x`), then
+   CHECK_REQUEST; submission occurs, rule on `stage.x` fires → visible feedback; stub receives
+   CHECK_START_RESPONSE and CHECK_COMPLETE_RESPONSE.
+4. **Page→sim mutate** — rule action `mutateState` targets a stub variable; stub receives
+   VALUE_CHANGE with the mutated value.
+5. **State restore** — after test-3-style save (mind the 100ms debounce), reload page; stub
+   receives saved variables as init VALUE_CHANGEs.
+6. **Sim data write** — SET_DATA_REQUEST → SET_DATA_RESPONSE `responseType: success`, value echoed.
+7. **Sim data read-back** — GET_DATA_REQUEST returns stored value with `exists: true`; unknown key
+   returns `exists: false, value: '[]'`.
+8. **Resize** — absolute then relative RESIZE_PARENT_CONTAINER_REQUEST; container dimensions
+   change; RESPONSE echoes messageId.
+9. **Malformed + pre-handshake traffic** — non-JSON, wrong-shape JSON, VALUE_CHANGE before
+   handshake: no crash, handshake afterwards still succeeds. (Documents actual behavior — host
+   currently accepts post-handshake messages with any token; if that surprises reviewers it's a
+   finding, not a test failure.)
+10. **Foreign-source message** — postMessage from main window with valid CAPI shape; ignored
+    (source check 1066).
+
+Optional (decide at build): **Review context** — in review mode stub's VALUE_CHANGE ignored and
+`readonly: true` pushed (494–511, 1095). Needs review-mode navigation; include if cheap.
+
+### Jest — `assets/test/adaptivity/capi_variable_test.ts`
+
+11. **capi.ts suite** (file read in full; pure, exported): `getCapiType` (incl. allowedValues→ENUM,
+    special array strings → STRING), `coerceCapiValue` (number/string/math/bool/array paths, ENUM
+    invalid-value throw), `parseCapiValue` round-trips, `CapiVariable` constructor inference +
+    `shouldConvertNumbers` flag, `isSpecialArrayString` edge cases (`["00.12"]` vs `["0.12"]`).
+
+## 4. Stub sim design
+
+`assets/automation/tests/torus/capi/support/stub-sim.html` — static, no build step. Served by
+`page.route()` fulfilling an absolute URL (e.g. `https://capi-stub.test/sim.html`) injected into
+the seeded part model via `${stub_url}` param interpolation.
+
+- Speaks the verified envelope; uses one fixed requestToken; sends to `window.parent`.
+- **Programmable**: test drives it via `frame.evaluate()` calls that enqueue actions
+  (send message X, wait for type Y) — avoids needing the stub itself to be clever.
+- **Recording**: every received message appended to `window.__capiLog` (parsed objects);
+  assertions read it via `frameLocator().evaluate()` with `expect.poll()` (handshake has a 500ms
+  server-side... component-side delay; saves debounce 100ms).
+
+## 5. Seeding
+
+`capi_page.scenario.yaml`, derived from `adaptive_iframe_internal_link_resolution.scenario.yaml`
+(verified template) with:
+- part model: `sourceType: "url"`, `src: "${stub_url}"`, `configData: []` (mandatory, §1),
+  plus 1–2 seed variables in configData for init-sequence assertions
+- `authoring.rules`: one rule on `stage.x` with feedback + one `mutateState` action (rules pass
+  through verbatim — activity content stored as-is when `content_format: "json"`,
+  activity_handler.ex:148)
+- adaptive page content via the §2 seeding-gap resolution
+- student (scenario default password `temporarypassword123`, user_handler.ex:12), section, enroll
+- Playwright logs in via UI, navigates to `/sections/<slug>/lesson/<page>` — fullscreen adaptive
+  route renders via `page_fullscreen` for chrome pages or direct React mount chromeless
+  (page_delivery_controller.ex:334–348)
+
+All local: dev server + Postgres, `PLAYWRIGHT_SCENARIO_TOKEN`, no external services.
+
+## 6. File layout
+
+```
+assets/automation/tests/torus/capi/
+├── capi.spec.ts
+├── capi.md                  # spec-adjacent doc (epic convention)
+├── capi_page.scenario.yaml
+└── support/
+    ├── stub-sim.html
+    └── capiStub.ts          # route fulfillment, action driving, log reading
+assets/test/adaptivity/
+└── capi_variable_test.ts
+lib/oli/scenarios/...        # only if seeding-gap extension approved (§2)
+```
+
+## 7. Build order (sequential, present after each step)
+
+0. **Decision gate**: seeding-gap approach (§2) — directive extension vs alternatives.
+1. **Walking skeleton** — stub sim + seeding + test 1 (handshake). Proves: adaptive page renders
+   for student, iframe mounts with stub URL, route interception works, round-trip completes.
+2. Tests 2–5 (core: init, check/rules, mutate, restore).
+3. Tests 6–8 (data + resize).
+4. Tests 9–10 (robustness) + optional review-context test.
+5. Jest capi.ts suite.
+6. `capi.md` + CI placement (PR suite vs `@nightly` by observed runtime).
+
+## 8. Constraints & risks
+
+- **No CAPI production changes** (research §8). The §2 scenario extension is test infrastructure
+  in `lib/` — flagged explicitly for approval because it technically touches `lib/`.
+- **Residual unknowns** (only discoverable by running — step 1 exists for these): whether the
+  db_seeder-shaped adaptive content renders correctly when seeded this way; deck-layout navigation
+  needs (`session.currentQuestionScreen` etc.); whether CHECK flow in practice (ungraded) adaptive
+  pages surfaces feedback visibly enough to assert.
+- **Timing discipline**: 500ms handshake delay, 100ms save debounce, 150ms submit delay — all
+  assertions via `expect.poll()`/`waitFor`, no fixed sleeps.
+- **Findings rule**: robustness tests document actual behavior; weak validation (no token check —
+  TODO line 1076) reported as finding, not encoded as aspiration.
+
+## 9. Build progress
+
+### Step 1 — walking skeleton ✅ (2026-06-12)
+- New scenario directive `edit_adaptive_page` (directive_types, parser, engine, handler, schema)
+  builds advancedDelivery/advancedAuthoring page content: page `custom` block (defaultScreenWidth
+  etc.), deck `model`, activity-reference with `custom.sequenceId`/`sequenceName`. Unit test:
+  4 passing (`test/oli/scenarios/edit_adaptive_page_test.exs`).
+- Stub sim (`support/stub-sim.html` + `support/capiStub.ts`), seeding YAML
+  (`capi_page.scenario.yaml`), handshake Playwright test — green.
+- Setup learnings baked into the spec: DB migrate first; dismiss onboarding wizard via hidden
+  `#automation-go-to-course`; navigate to lesson directly via `phx-value-slug` from the Learn
+  outline; configData keys are sent verbatim as CAPI variable keys (use plain names like `x`).
+
+### Step 2 — core protocol ✅/deferred (2026-06-16)
+Passing (3): handshake (1), init sequence + page→sim VALUE_CHANGE for configData (2), state
+restore across revisit (5).
+
+**Deferred — Test 3 (check lifecycle), `test.fixme`. FINDING:**
+CHECK_REQUEST → `onSubmit` reaches `AdaptiveDelivery.handlePartSubmit/handlePartSave`, which look up
+the part in `currentAttemptState.parts` by `partId` and abort with
+`part attempt guid for undefined not found` plus a **403** on the server part-save. The minimal
+single-screen seeded adaptive activity does not register the CAPI part in the activity attempt the
+way the check lifecycle needs. So CHECK_START_RESPONSE / CHECK_COMPLETE_RESPONSE are never emitted.
+Note: the *save* path (used by state restore, test 5) works — only the check/submit path fails.
+Resolution requires deeper attempt/part seeding (server-side); tracked as its own task, not a
+CAPI-component bug.
+
+**Test 4 (rule-driven page→sim mutate):** not implemented. Page→sim VALUE_CHANGE is already
+exercised by test 2 (init). A rule-driven mutate needs hand-authored adaptivity-rule JSON + a
+working check/evaluation cycle — same subsystem as the test-3 finding. Folded into that deferral.
+
+### Remaining
+Step 3 (tests 6–8: GET/SET data, resize), Step 4 (tests 9–10: robustness/malformed/foreign-source),
+Step 5 (Jest capi.ts suite), Step 6 (capi.md doc + CI placement).

--- a/docs/exec-plans/current/epics/automated_testing/capi/research.md
+++ b/docs/exec-plans/current/epics/automated_testing/capi/research.md
@@ -1,0 +1,195 @@
+# MER-5701 Research: Automated Testing Epic (MER-5367) Patterns
+
+Research synthesized on 2026-06-12 from Jira (epic MER-5367 + 44 children) and repo analysis
+(commits, PRs, test code) to inform MER-5701: "Create comprehensive, automated test of CAPI
+component / interface".
+
+## 1. The ticket
+
+- **MER-5701** — In Progress, assigned Francisco Castro. Parent epic: MER-5367 "Automated Testing"
+  (epic has no description/comments — all context comes from siblings).
+- Description: "If one does not exist already, this task is to create a fully comprehensive set of
+  automated tests for the CAPI component (which allows simulations to communicate with a host
+  adaptive page)".
+- Verified: no comprehensive CAPI test exists. Only `assets/test/delivery/janus_capi_iframe_test.ts`
+  (96 lines, styling/scrolling helpers only). Core protocol untested.
+
+## 2. CAPI surface on master (verified by direct read)
+
+| File | Lines | Tested? |
+|---|---|---|
+| `assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx` | 1256 | No — handshake, VALUE_CHANGE, CONFIG_CHANGE, postMessage lifecycle all here |
+| `assets/src/adaptivity/capi.ts` (CapiVariable, type coercion) | 169 | Indirect only (via `scripting_test.ts`) |
+| `assets/src/components/parts/janus-capi-iframe/iframeBehavior.ts` | 78 | Yes — the one existing test |
+| `JanusCAPIRequestTypes.ts` | 70 | No |
+| `schema.ts` | 292 | No |
+| `sourceResolver.ts` | 95 | No |
+| `CapiIframeAuthor.tsx` / `CapiVariablePicker.tsx` | 458 / 167 | No (authoring side) |
+
+`iframeBehavior.ts` is itself the precedent for the testability pattern: logic extracted out of the
+big component into pure functions, then unit-tested with Jest.
+
+## 3. Epic sibling inventory (Jira, 2026-06-12)
+
+44 children. Status distribution: 6 Done, 8 QA, 2 In Progress, rest To Do/Analyzing.
+Worked tickets group into three families:
+
+| Family | Tickets | Test type | State |
+|---|---|---|---|
+| LTI smoke tests | MER-5394, 5396, 5397, (+5669 outside epic) | Playwright | 5396/5669 merged; 5397 done on unmerged branch `origin/MER-5397-instructor-first-launch-and-course-creation`; 5394 has **no commits in this repo** |
+| Authoring coverage | MER-5415 (objectives), 5653 (activity bank), 5418 (Google Docs import, in progress) | Scenario framework | 5415 merged PR #6608; 5653 merged PR #6596 |
+| Delivery coverage w/ service extraction | MER-5465, 5469, 5471, 5475, 5477, 5479, 5481, 5482, 5502 | Scenario framework | All shipped in two big PRs: #6362 (gating + certificates, ~6.8k lines) and #6455 (assessment settings + attempts, ~6.2k lines) |
+
+Note: tickets map many-to-one onto PRs. One PR routinely closes 2–7 tickets in this epic.
+
+## 4. The three test layers (and how this epic uses them)
+
+### 4.1 Jest (frontend unit/integration) — `assets/test/`
+- `yarn test` (jest + ts-jest). Simulated DOM, no browser.
+- Existing CAPI-adjacent tests: `adaptivity/scripting_test.ts` (uses CapiVariable),
+  `delivery/janus_capi_iframe_test.ts`.
+- Epic siblings barely used this layer — their targets were backend workflows. CAPI is the first
+  frontend-protocol target in the epic.
+
+### 4.2 Scenario framework (backend integration) — `test/scenarios/`, `lib/oli/scenarios/`
+- YAML directives → parser (`directive_parser.ex`) → engine (`engine.ex`) → handlers
+  (`directives/*_handler.ex`) calling **real** Oli modules, real DB (DataCase transaction). No UI,
+  no mocks.
+- JSON Schema source of truth: `priv/schemas/v0-1-0/scenario.schema.json`.
+- Test runners auto-discover `*.scenario.yaml` per directory; metadata supports `nightly`/`slow`
+  tags and timeout overrides.
+- Docs live in `test/support/scenarios/docs/` (e.g. `gating.md` 346 lines,
+  `student_simulation.md` 278 lines) — every scenario-family ticket shipped docs alongside.
+- **Elixir-only.** Cannot exercise client-side postMessage protocol.
+
+### 4.3 Playwright (browser E2E) — `assets/automation/`
+- Config: `assets/automation/playwright.config.ts` (Chrome, 1920x1080, single worker).
+- Layout: `src/systems/torus/pom/` (page objects), `src/systems/canvas/api/` (API clients),
+  `tests/torus/<area>/<name>.spec.ts` + adjacent `.md` doc + `support/` helpers.
+- `@nightly` tag → scheduled CI run (`.github/workflows/nightly-playwright.yml`, daily 5:17 UTC,
+  `npx playwright test --grep @nightly`).
+- Established iframe pattern (grade-passback test): `page.frameLocator('iframe[name="tool_content"]')`,
+  `expect.poll()` for async state, isolated browser contexts per user, cleanup in `finally`.
+
+### 4.4 The bridge: `seedScenario` fixture (verified in code)
+`assets/automation/src/core/fixture/my-fixture.ts` exposes `seedScenario(relativePath, params)` —
+Playwright sends a scenario YAML to a backend HTTP endpoint, which executes it via the Scenario
+engine. So Playwright tests get declarative backend seeding (project + pages + activities) and then
+drive the real browser. This is how a CAPI E2E test can stand up an adaptive page containing a
+`janus-capi-iframe` part without manual authoring clicks.
+
+## 5. Recurring patterns across worked siblings
+
+1. **Service extraction / "below the UI boundary"** — when logic was trapped in LiveViews, tickets
+   extracted it into plain modules first (e.g. `lib/oli/delivery/page/prologue_state.ex`,
+   `lib/oli/delivery/settings/student_exceptions.ex`, `lib/oli/datetime.ex` time override), then
+   tested the extracted module. Several ticket titles say this explicitly ("…service extraction
+   needed to move X below the UI boundary"). Frontend equivalent already in repo: `iframeBehavior.ts`.
+2. **Shared setup via `use: file: setup.yaml`** — scenario families share one setup file; each test
+   case is its own small YAML.
+3. **Docs are part of the deliverable** — every family shipped a markdown doc next to the tests
+   (scenario directive docs, or spec-adjacent `.md` for Playwright like `grade-passback.md`,
+   `canvas_playwright.md`).
+4. **Deterministic time** — `time` directive / `Oli.DateTime` override instead of real waits;
+   real-wait tests are tagged `nightly`/`slow` and excluded from PR CI.
+5. **Big PRs are normal here** — 6–7k lines, 60–73 files, closing several tickets at once.
+6. **Resilience idioms (Playwright)** — `expect.poll()`, selector fallbacks, retry helpers
+   (`clickUntilVisible`), `waitForLiveView()` (`[data-phx-main].phx-connected`).
+
+## 6. What this means for MER-5701
+
+> **Superseded 2026-06-12 — see section 8.** This section was the original recommendation
+> (Jest-primary + extraction refactor). Team feedback redirected to Playwright-primary with no
+> production refactoring. Kept for context.
+
+CAPI is a client-side TypeScript postMessage protocol, so the epic's dominant tool (Scenario
+framework) cannot test the protocol itself. The fit:
+
+| Layer | Role for CAPI | Effort center |
+|---|---|---|
+| **Jest** (primary) | Protocol correctness: handshake (HANDSHAKE_REQUEST/RESPONSE, requestToken), VALUE_CHANGE in/out, CONFIG_CHANGE, state restore, CapiVariable type coercion both directions, bad-message/wrong-token/pre-handshake edge cases | Likely needs light refactor of `ExternalActivity.tsx` first — extract message handlers into pure functions (the `iframeBehavior.ts` precedent) |
+| **Playwright** (secondary) | One real-browser proof: adaptive page + real iframe + real postMessage round-trip, seeded via `seedScenario` | New `assets/automation/tests/torus/capi/` (or `adaptive/`) spec + adjacent `.md`; a sim stub page to load in the iframe |
+| **Scenario** (supporting only) | Backend seeding YAML consumed by the Playwright spec; possibly assert authored adaptive-activity structure | Reuse existing directives; new CAPI-specific directives almost certainly unnecessary |
+
+### Open questions (resolve with team before/at spec time)
+1. **Definition of "comprehensive"** — ticket body is one sentence; epic has no description. Test
+   inventory needs team sign-off (protocol messages × directions × edge cases?).
+2. **Refactor scope** — how much of `ExternalActivity.tsx` (1256 lines) may move into pure modules?
+   Pure test ticket vs test+refactor ticket changes review surface significantly.
+3. **Sim stub for E2E** — is there an existing CAPI test simulation to load in the iframe, or do we
+   build a minimal stub page? (None found in repo.)
+4. **Authoring side in scope?** — `CapiIframeAuthor.tsx`/`CapiVariablePicker.tsx` are untested too;
+   ticket says "component / interface", ambiguous.
+
+## 7. Additional code findings (2026-06-12, direct reads)
+
+- **Authoring side duplicates the protocol.** `CapiIframeAuthor.tsx` (read in full) contains its own
+  postMessage listener and handlers: `HANDSHAKE_REQUEST` → `HANDSHAKE_RESPONSE` with
+  `config: { context: 'AUTHOR' }` (lines 134–146), `ON_READY` → pushes saved configData as
+  `VALUE_CHANGE` + `INITIAL_SETUP_COMPLETE` (166–189), incoming `VALUE_CHANGE` → captures sim
+  variables into state, which is how the variable picker discovers them (148–164). It is not just
+  form UI.
+- **Known tech debt, 2021.** Comment at `CapiIframeAuthor.tsx:113`: protocol methods "will move to a
+  common place where authoring and delivery both can share the same JS file". Author per git blame:
+  Devesh Tiwari, September 2021 (not Darren — earlier attribution in conversation was wrong).
+- **`CapiVariablePicker.tsx` (read in full, 167 lines) is thin UI**: accordion markup delegating to
+  existing shared inspector components (`AutoDetectInput`, `NestedStateDisplay`, `unflatten` from
+  delivery preview-tools). Own logic ≈ 15 lines. Authoring-only remainder beyond the protocol ≈
+  350–400 lines of UI glue (picker, configure-mode notifications, save/cancel persistence, render
+  states).
+
+## 8. Scope decisions (2026-06-12)
+
+Questions were sent to the team (Darren on PTO ~2 weeks; colleague answered):
+
+1. **"Comprehensive" proposal** (handshake, VALUE_CHANGE both directions, CONFIG_CHANGE, state
+   save/restore, coercion, edge cases + one E2E): *"sounds reasonable"*.
+2. **Refactor/extraction**: declined. *"I believe by automated tests, we are talking about
+   playwright… we shouldn't have to refactor anything… I would prefer we don't change or refactor
+   anything unless we uncover a bug as a result of the testing or we absolutely must to facilitate
+   automated tests (e.g. DOM test handles, etc.)"*
+3. **Existing sim/CAPI harness as reference**: unknown ("I don't know the answer to this").
+
+### Resulting direction
+
+| Decision | Consequence |
+|---|---|
+| **Playwright-primary, no production refactor** | Protocol tested through real browser: seed adaptive page (`seedScenario`), load stub sim in iframe, assert observable behavior. No `ExternalActivity.tsx` extraction. |
+| **Programmable stub sim** (in-repo) | The test instrument. Per-test scripting of what the stub sends (normal handshake, wrong token, malformed JSON, pre-handshake messages); records all page→sim traffic for assertions. Covers the edge-case list without touching production code. |
+| **Jest only where zero-refactor** | `capi.ts` (CapiVariable/coercion) is already exported pure code — Jest-testable today. Included. Component-internal handlers: not Jest-tested (would require extraction). |
+| **Authoring coverage: open again** | The "extraction covers both sides" path is dead with the refactor. Authoring (editor + variable picker) coverage would need its own Playwright flows — in/out decision deferred to the plan. |
+| **Trade-off accepted** | Coarser, slower tests than the Jest plan; assertions on effects rather than individual handlers. Extraction idea (2021 TODO) can be revisited with Darren later as a separate ticket. |
+
+Next artifact: `plan.md` in this directory — test inventory, stub sim design, seeding approach,
+file layout, CI placement.
+
+## 9. Deep verification pass (2026-06-12, second session)
+
+Full-file reads: `ExternalActivity.tsx` (all 1256 lines), `capi.ts`, `schema.ts`,
+`sourceResolver.ts`, `CapiIframeAuthor.tsx`, `CapiVariablePicker.tsx`, seeding endpoint controller,
+scenario `ops.ex` revise path, hook handler. Three agent traces: adaptive delivery mount path,
+scenario rules support, CAPI wire format. Results folded into `plan.md` §1–§2. Headlines:
+
+- Adaptive runtime only boots on pages with `content.advancedDelivery == true`
+  (init_page.ex:157) — adaptive activity on a regular page does NOT mount `ExternalActivity`.
+- Rules evaluate on check/submit, not on VALUE_CHANGE — test design adjusted.
+- Scenario hooks can't run via the dev-server seeding endpoint (test/ not compiled in dev,
+  mix.exs:131). `manipulate→revise` CAN set arbitrary page content from YAML (ops.ex:456) but
+  can't know activity resource_ids → one seeding gap remains; preferred fix = small scenario
+  directive extension (epic-blessed pattern), pending approval.
+- Wire format fully documented (envelope, per-type payloads, 500ms handshake delay, 100ms save
+  debounce, no token validation TODO at ExternalActivity.tsx:1076, source check at 1066).
+- Seeding endpoint does `${param}` interpolation and returns slugs/emails but no resource ids
+  (playwright_scenario_controller.ex:107–124).
+- No simcapi.js vendored anywhere; Torus host code is the protocol ground truth for this system.
+
+## 10. Confidence notes
+
+- Directly verified this session: CAPI file inventory and line counts, existing test files,
+  `seedScenario` fixture, scenario directory layout, MER-5394 absence of commits, MER-5397 unmerged
+  branch, nightly workflow existence, Jira statuses.
+- Agent-reported (spot-checked but not line-by-line verified): per-PR line counts and file lists for
+  #6362/#6455/#6596/#6608, internal structure details of handlers/assertions. Treat exact numbers as
+  approximate.
+- MER-5394 (Canvas LTI launch smoke): marked Done in Jira but no commits found in this repo —
+  possibly done elsewhere or superseded by MER-5669 (PR #6618), which implements that flow.

--- a/lib/oli/scenarios/directive_parser.ex
+++ b/lib/oli/scenarios/directive_parser.ex
@@ -24,6 +24,7 @@ defmodule Oli.Scenarios.DirectiveParser do
     ActivityBankDirective,
     InstructorCustomizationDirective,
     EditPageDirective,
+    EditAdaptivePageDirective,
     ViewPracticePageDirective,
     VisitPageDirective,
     StartAttemptDirective,
@@ -580,6 +581,23 @@ defmodule Oli.Scenarios.DirectiveParser do
     end
   end
 
+  defp parse_directive(%{"edit_adaptive_page" => edit_data}) do
+    allowed_attrs = ["project", "page", "activity_virtual_id", "graded"]
+
+    case DirectiveValidator.validate_attributes(allowed_attrs, edit_data, "edit_adaptive_page") do
+      :ok ->
+        %EditAdaptivePageDirective{
+          project: edit_data["project"],
+          page: edit_data["page"],
+          activity_virtual_id: edit_data["activity_virtual_id"],
+          graded: edit_data["graded"] == true
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
   defp parse_directive(%{"view_practice_page" => view_data}) do
     # Validate attributes
     allowed_attrs = ["student", "section", "page"]
@@ -940,6 +958,7 @@ defmodule Oli.Scenarios.DirectiveParser do
          "activity_bank",
          "instructor_customization",
          "edit_page",
+         "edit_adaptive_page",
          "view_practice_page",
          "visit_page",
          "start_attempt",
@@ -984,6 +1003,7 @@ defmodule Oli.Scenarios.DirectiveParser do
              "activity_bank",
              "instructor_customization",
              "edit_page",
+             "edit_adaptive_page",
              "view_practice_page",
              "visit_page",
              "start_attempt",

--- a/lib/oli/scenarios/directive_types.ex
+++ b/lib/oli/scenarios/directive_types.ex
@@ -176,6 +176,18 @@ defmodule Oli.Scenarios.DirectiveTypes do
     defstruct [:project, :page, :objectives, :content]
   end
 
+  defmodule EditAdaptivePageDirective do
+    @moduledoc """
+    Converts an existing page into an adaptive (advancedDelivery) page whose
+    deck references a previously created adaptive activity by virtual_id.
+    project: target project name
+    page: title of the page to edit
+    activity_virtual_id: virtual_id of the oli_adaptive activity to reference
+    graded: optional boolean, defaults to false
+    """
+    defstruct [:project, :page, :activity_virtual_id, graded: false]
+  end
+
   defmodule ViewPracticePageDirective do
     @moduledoc """
     Simulates a student viewing a practice page in a section.

--- a/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
+++ b/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
@@ -59,7 +59,13 @@ defmodule Oli.Scenarios.Directives.EditAdaptivePageHandler do
          "Activity with virtual_id '#{directive.activity_virtual_id}' not found in project '#{directive.project}'"}
 
       revision ->
-        {:ok, revision}
+        if Oli.Activities.AdaptiveParts.adaptive_activity?(revision) do
+          {:ok, revision}
+        else
+          {:error,
+           "Activity '#{directive.activity_virtual_id}' is not an oli_adaptive activity; " <>
+             "edit_adaptive_page requires an adaptive activity"}
+        end
     end
   end
 

--- a/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
+++ b/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
@@ -113,8 +113,10 @@ defmodule Oli.Scenarios.Directives.EditAdaptivePageHandler do
             {:ok, updated_revision}
 
           publication ->
-            Oli.Publishing.upsert_published_resource(publication, updated_revision)
-            {:ok, updated_revision}
+            with {:ok, _} <-
+                   Oli.Publishing.upsert_published_resource(publication, updated_revision) do
+              {:ok, updated_revision}
+            end
         end
 
       error ->

--- a/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
+++ b/lib/oli/scenarios/directives/edit_adaptive_page_handler.ex
@@ -1,0 +1,124 @@
+defmodule Oli.Scenarios.Directives.EditAdaptivePageHandler do
+  @moduledoc """
+  Handles edit_adaptive_page directives, converting an existing page into an
+  adaptive (advancedDelivery) page whose deck references an adaptive activity
+  created earlier in the scenario via create_activity with a virtual_id.
+  """
+
+  alias Oli.Scenarios.DirectiveTypes.{ExecutionState, EditAdaptivePageDirective}
+
+  def handle(%EditAdaptivePageDirective{} = directive, %ExecutionState{} = state) do
+    with {:ok, author} <- validate_author(state.current_author),
+         {:ok, built_project} <- get_project(directive.project, state),
+         {:ok, page_revision} <- get_page_revision(built_project, directive.page),
+         {:ok, activity_revision} <- get_activity_revision(directive, state),
+         content <- adaptive_page_content(activity_revision.resource_id, directive),
+         {:ok, new_revision} <-
+           update_page(built_project, page_revision, author, content, directive.graded) do
+      updated_built_project = %{
+        built_project
+        | rev_by_title: Map.put(built_project.rev_by_title, directive.page, new_revision)
+      }
+
+      updated_projects = Map.put(state.projects, directive.project, updated_built_project)
+      {:ok, %{state | projects: updated_projects}}
+    else
+      {:error, reason} ->
+        {:error, "Failed to edit adaptive page '#{directive.page}': #{inspect(reason)}"}
+    end
+  end
+
+  defp validate_author(nil),
+    do: {:error, "No author available. The Engine should provide a default author"}
+
+  defp validate_author(author), do: {:ok, author}
+
+  defp get_project(nil, _state), do: {:error, "Project name is required"}
+
+  defp get_project(project_name, state) do
+    case Map.get(state.projects, project_name) do
+      nil -> {:error, "Project '#{project_name}' not found"}
+      built_project -> {:ok, built_project}
+    end
+  end
+
+  defp get_page_revision(built_project, page_title) do
+    case Map.get(built_project.rev_by_title, page_title) do
+      nil -> {:error, "Page '#{page_title}' not found in project"}
+      revision -> {:ok, revision}
+    end
+  end
+
+  defp get_activity_revision(%{activity_virtual_id: nil}, _state),
+    do: {:error, "activity_virtual_id is required"}
+
+  defp get_activity_revision(directive, state) do
+    case Map.get(state.activity_virtual_ids, {directive.project, directive.activity_virtual_id}) do
+      nil ->
+        {:error,
+         "Activity with virtual_id '#{directive.activity_virtual_id}' not found in project '#{directive.project}'"}
+
+      revision ->
+        {:ok, revision}
+    end
+  end
+
+  defp adaptive_page_content(activity_resource_id, directive) do
+    %{
+      "advancedDelivery" => true,
+      "advancedAuthoring" => true,
+      "displayApplicationChrome" => false,
+      "custom" => %{
+        "contentMode" => "standard",
+        "defaultScreenHeight" => 540,
+        "defaultScreenWidth" => 1000,
+        "enableHistory" => true,
+        "maxScore" => 0,
+        "responsiveLayout" => false,
+        "themeId" => "torus-default-light",
+        "totalScore" => 0
+      },
+      "additionalStylesheets" => ["/css/delivery_adaptive_themes_default_light.css"],
+      "model" => [
+        %{
+          "id" => "adaptive_group_1",
+          "type" => "group",
+          "layout" => "deck",
+          "children" => [
+            %{
+              "type" => "activity-reference",
+              "activity_id" => activity_resource_id,
+              "custom" => %{
+                "sequenceId" => "screen_#{directive.activity_virtual_id}",
+                "sequenceName" => directive.page
+              }
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  defp update_page(built_project, page_revision, author, content, graded) do
+    attrs = %{
+      content: content,
+      graded: graded == true,
+      author_id: author.id
+    }
+
+    case Oli.Resources.update_revision(page_revision, attrs) do
+      {:ok, updated_revision} ->
+        case Oli.Publishing.project_working_publication(built_project.project.slug) do
+          nil ->
+            {:ok, updated_revision}
+
+          publication ->
+            Oli.Publishing.upsert_published_resource(publication, updated_revision)
+            {:ok, updated_revision}
+        end
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/oli/scenarios/engine.ex
+++ b/lib/oli/scenarios/engine.ex
@@ -25,6 +25,7 @@ defmodule Oli.Scenarios.Engine do
     ActivityBankDirective,
     InstructorCustomizationDirective,
     EditPageDirective,
+    EditAdaptivePageDirective,
     ViewPracticePageDirective,
     VisitPageDirective,
     StartAttemptDirective,
@@ -65,6 +66,7 @@ defmodule Oli.Scenarios.Engine do
     ActivityBankHandler,
     InstructorCustomizationHandler,
     EditPageHandler,
+    EditAdaptivePageHandler,
     ViewPracticePageHandler,
     VisitPageHandler,
     StartAttemptHandler,
@@ -290,6 +292,10 @@ defmodule Oli.Scenarios.Engine do
 
   def execute_directive(%EditPageDirective{} = directive, state) do
     EditPageHandler.handle(directive, state)
+  end
+
+  def execute_directive(%EditAdaptivePageDirective{} = directive, state) do
+    EditAdaptivePageHandler.handle(directive, state)
   end
 
   def execute_directive(%ViewPracticePageDirective{} = directive, state) do

--- a/priv/schemas/v0-1-0/scenario.schema.json
+++ b/priv/schemas/v0-1-0/scenario.schema.json
@@ -1394,6 +1394,24 @@
         },
         {
           "type": "object",
+          "required": ["edit_adaptive_page"],
+          "additionalProperties": false,
+          "properties": {
+            "edit_adaptive_page": {
+              "type": "object",
+              "required": ["project", "page", "activity_virtual_id"],
+              "additionalProperties": false,
+              "properties": {
+                "project": { "type": "string" },
+                "page": { "type": "string" },
+                "activity_virtual_id": { "type": "string" },
+                "graded": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
           "required": ["view_practice_page"],
           "additionalProperties": false,
           "properties": {

--- a/test/oli/scenarios/edit_adaptive_page_test.exs
+++ b/test/oli/scenarios/edit_adaptive_page_test.exs
@@ -138,5 +138,42 @@ defmodule Oli.Scenarios.EditAdaptivePageTest do
       assert [{_directive, message}] = result.errors
       assert message =~ "No Such Page"
     end
+
+    test "errors when the referenced activity is not adaptive" do
+      yaml = """
+      - project:
+          name: adaptive_project
+          title: "Adaptive Project"
+          root:
+            container: "Root"
+            children:
+              - page: "Sim Page"
+
+      - create_activity:
+          project: adaptive_project
+          title: "Plain MC"
+          virtual_id: "plain_mc"
+          type: "oli_multiple_choice"
+          content: |
+            stem_md: "What is 2 + 2?"
+            choices:
+              - id: "a"
+                body_md: "4"
+                score: 1
+              - id: "b"
+                body_md: "5"
+                score: 0
+
+      - edit_adaptive_page:
+          project: adaptive_project
+          page: "Sim Page"
+          activity_virtual_id: "plain_mc"
+      """
+
+      result = Scenarios.execute_yaml(yaml)
+
+      assert [{_directive, message}] = result.errors
+      assert message =~ "not an oli_adaptive activity"
+    end
   end
 end

--- a/test/oli/scenarios/edit_adaptive_page_test.exs
+++ b/test/oli/scenarios/edit_adaptive_page_test.exs
@@ -1,0 +1,142 @@
+defmodule Oli.Scenarios.EditAdaptivePageTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios
+
+  @adaptive_activity_content """
+  {
+    "authoring": {
+      "parts": [
+        {
+          "id": "capi_iframe_part",
+          "type": "janus-capi-iframe",
+          "src": "https://example.com/sim.html",
+          "sourceType": "url",
+          "configData": []
+        }
+      ],
+      "rules": []
+    },
+    "partsLayout": [
+      {
+        "id": "capi_iframe_part",
+        "type": "janus-capi-iframe",
+        "src": "https://example.com/sim.html",
+        "sourceType": "url",
+        "configData": []
+      }
+    ]
+  }
+  """
+
+  defp base_yaml(extra) do
+    """
+    - project:
+        name: adaptive_project
+        title: "Adaptive Project"
+        root:
+          container: "Root"
+          children:
+            - page: "Sim Page"
+
+    - create_activity:
+        project: adaptive_project
+        title: "CAPI Activity"
+        virtual_id: "capi_activity"
+        scope: "embedded"
+        type: "oli_adaptive"
+        content_format: "json"
+        content: |
+    #{indent(@adaptive_activity_content, 6)}
+    #{extra}
+    """
+  end
+
+  defp indent(text, n) do
+    pad = String.duplicate(" ", n)
+
+    text
+    |> String.split("\n")
+    |> Enum.map_join("\n", &(pad <> &1))
+  end
+
+  describe "edit_adaptive_page directive" do
+    test "converts page into adaptive page referencing the activity" do
+      yaml =
+        base_yaml("""
+        - edit_adaptive_page:
+            project: adaptive_project
+            page: "Sim Page"
+            activity_virtual_id: "capi_activity"
+        """)
+
+      result = Scenarios.execute_yaml(yaml)
+      assert result.errors == []
+
+      project = result.state.projects["adaptive_project"]
+      revision = project.rev_by_title["Sim Page"]
+
+      assert revision.content["advancedDelivery"] == true
+      assert revision.content["advancedAuthoring"] == true
+      assert revision.content["displayApplicationChrome"] == false
+      assert revision.graded == false
+
+      activity_revision =
+        result.state.activity_virtual_ids[{"adaptive_project", "capi_activity"}]
+
+      assert [%{"type" => "group", "layout" => "deck", "children" => children}] =
+               revision.content["model"]
+
+      assert [%{"type" => "activity-reference", "activity_id" => activity_id}] = children
+      assert activity_id == activity_revision.resource_id
+    end
+
+    test "supports graded flag" do
+      yaml =
+        base_yaml("""
+        - edit_adaptive_page:
+            project: adaptive_project
+            page: "Sim Page"
+            activity_virtual_id: "capi_activity"
+            graded: true
+        """)
+
+      result = Scenarios.execute_yaml(yaml)
+      assert result.errors == []
+
+      revision = result.state.projects["adaptive_project"].rev_by_title["Sim Page"]
+      assert revision.graded == true
+      assert revision.content["advancedDelivery"] == true
+    end
+
+    test "errors when activity virtual_id is unknown" do
+      yaml =
+        base_yaml("""
+        - edit_adaptive_page:
+            project: adaptive_project
+            page: "Sim Page"
+            activity_virtual_id: "missing_activity"
+        """)
+
+      result = Scenarios.execute_yaml(yaml)
+
+      assert [{_directive, message}] = result.errors
+      assert message =~ "missing_activity"
+    end
+
+    test "errors when page is unknown" do
+      yaml =
+        base_yaml("""
+        - edit_adaptive_page:
+            project: adaptive_project
+            page: "No Such Page"
+            activity_virtual_id: "capi_activity"
+        """)
+
+      result = Scenarios.execute_yaml(yaml)
+
+      assert [{_directive, message}] = result.errors
+      assert message =~ "No Such Page"
+    end
+  end
+end

--- a/test/support/scenarios/docs/content_authoring.md
+++ b/test/support/scenarios/docs/content_authoring.md
@@ -7,6 +7,7 @@ This document covers directives for creating and editing content using the Torus
 - [create_activity](#create_activity) - Create standalone activities
 - [activity_bank](#activity_bank) - Execute Activity Bank workflows
 - [edit_page](#edit_page) - Edit page content
+- [edit_adaptive_page](#edit_adaptive_page) - Convert a page to an adaptive page referencing an activity
 - [TorusDoc Format](#torusdoc-format)
 - [Virtual IDs](#virtual-ids)
 - [Activity Types](#activity-types)
@@ -1161,6 +1162,54 @@ choices:
               - id: "var_value"
                 type: "numeric"
             rule: "var_name == 'age' && var_value == 25"
+```
+
+## edit_adaptive_page
+
+Converts an existing page into an **adaptive** (advanced delivery) page whose deck references an
+`oli_adaptive` activity created earlier in the scenario by its `virtual_id`. Use this when a test
+needs the adaptive delivery runtime to mount (e.g. to exercise `janus-capi-iframe` parts), which a
+regular page does not provide.
+
+The directive builds the adaptive page content for you — `advancedDelivery`/`advancedAuthoring`
+flags, the page `custom` block (screen dimensions, theme), and a deck `model` with an
+`activity-reference` (including the `custom.sequenceId`/`sequenceName` the runtime requires). You
+only supply the page and the activity's `virtual_id`.
+
+### Parameters
+
+- `project` (required) — project name
+- `page` (required) — title of the page to convert
+- `activity_virtual_id` (required) — `virtual_id` of an `oli_adaptive` activity created earlier
+- `graded` (optional, default `false`) — whether the page is graded
+
+### Example
+
+```yaml
+- create_activity:
+    project: "adaptive_project"
+    title: "CAPI Activity"
+    virtual_id: "capi_activity"
+    scope: "embedded"
+    type: "oli_adaptive"
+    content_format: "json"
+    content:
+      authoring:
+        parts:
+          - id: "capi_iframe_part"
+            type: "janus-capi-iframe"
+            src: "https://example.com/sim.html"
+            sourceType: "url"
+            configData: []
+        rules: []
+      partsLayout:
+        - id: "capi_iframe_part"
+          type: "janus-capi-iframe"
+
+- edit_adaptive_page:
+    project: "adaptive_project"
+    page: "Sim Page"
+    activity_virtual_id: "capi_activity"
 ```
 
 ## Notes


### PR DESCRIPTION
---

## Ticket

- **MER-5701** — https://eliterate.atlassian.net/browse/MER-5701  (epic **MER-5367** — Automated Testing)
- Requirement (verbatim): "If one does not exist already, this task is to create a fully comprehensive set of automated tests for the CAPI component (which allows simulations to communicate with a host adaptive page)."
- **Scope guidance (Eli, covering for Darren):** automated tests = Playwright driving the headless browser and asserting; **do not change or refactor production code** unless the testing uncovers a bug or a change is strictly required to enable a test (e.g. DOM test handles). This PR honors that — no CAPI/delivery runtime code changed; the only Elixir app change is the prod-gated `edit_adaptive_page` scenario-seeding directive.
- **Acceptance test cases (Kevin Segovia, in-ticket):** TC1 (external iframe loads + scrolls) and TC2 (CAPI variable reaches the rules engine via a trapstate condition). Captured verbatim at `docs/exec-plans/current/epics/automated_testing/capi/kevin-test-cases.md`. TC2 is reflected by Playwright test 3; TC1's iframe-load portion is covered by the stub iframe load exercised across the Playwright suite (scroll-specific behavior is not separately asserted here — it is unit-tested in `assets/test/delivery/janus_capi_iframe_test.ts`).

## What

Comprehensive automated test coverage for the CAPI component / interface — the `postMessage` protocol between an embedded simulation and the host adaptive page (`assets/src/components/parts/janus-capi-iframe/`). No prior coverage existed for the protocol itself; this adds it across three layers.

## Coverage

### Playwright (10) — `assets/automation/tests/torus/capi/capi.spec.ts`
1. Complete the CAPI handshake and assert the host echoes the requestToken + config (context/section/user/question). See `completes handshake with the sim`.
2. Drive ON_READY and assert the host pushes initial configData to the sim (page→sim VALUE_CHANGE) then INITIAL_SETUP_COMPLETE. See `pushes initial state then INITIAL_SETUP_COMPLETE after ON_READY`.
3. Set a variable, send CHECK_REQUEST, and assert the full check round-trip (CHECK_START_RESPONSE + CHECK_COMPLETE_RESPONSE) plus the observable trapstate effect (`acknowledged`), proving the variable reached the rules engine. See `runs the check lifecycle on CHECK_REQUEST`.
4. Set sim state, revisit the lesson, and assert the saved value is pushed back on re-init. See `restores saved sim state on revisit`.
5. Exercise SET_DATA_REQUEST and assert a success SET_DATA_RESPONSE echoing the value. See `acknowledges SET_DATA_REQUEST with a success response`.
6. Exercise GET_DATA_REQUEST for a stored key (hit) and an unknown key (miss → `exists:false`). See `returns stored data on GET_DATA_REQUEST and a miss for unknown keys`.
7. Exercise RESIZE_PARENT_CONTAINER_REQUEST (absolute + relative) and assert the response echoes messageId. See `responds to RESIZE_PARENT_CONTAINER_REQUEST (absolute and relative)`.
8. Send malformed / non-JSON / pre-handshake traffic and assert the listener survives and still handshakes. See `survives malformed and pre-handshake messages, then handshakes normally`.
9. Post a well-formed CAPI message from the top window and assert it is ignored (source check). See `ignores a CAPI message posted from a foreign source`.
10. Send a post-handshake message with a mismatched requestToken and assert it is still processed — characterizing the current boundary (source enforced, token not). See `documents current gap: same-iframe messages with a mismatched requestToken are still processed`.

### Jest (17) — `assets/test/adaptivity/capi_variable_test.ts`
1. Verify `capi.ts` type coercion and inference: `getCapiType`, `coerceCapiValue` (incl. ENUM-invalid throw), `parseCapiValue`, `isSpecialArrayString`, and the `CapiVariable` constructor.

### ExUnit (4) — `test/oli/scenarios/edit_adaptive_page_test.exs`
1. Verify the new `edit_adaptive_page` directive builds adaptive page content referencing the activity (happy path, `graded`, unknown activity, unknown page).

## How it's built

- Deterministic in-repo **stub sim** (`support/stub-sim.html` + `capiStub.ts`) loaded via `page.route()` — no live simulation, fully offline/CI-safe.
- Seeded through the scenario framework via a new **`edit_adaptive_page`** directive (`lib/oli/scenarios/`) that builds an adaptive page referencing a created activity. Test infrastructure only; the scenario endpoint is gated off in prod.

## Notable

- **No CAPI/delivery runtime code changed** — `git diff` on `assets/src`, `lib/oli_web`, and `lib/oli/delivery` is empty (per Eli's scope guidance above). The only Elixir app changes are scenario-seeding infrastructure (`lib/oli/scenarios/` + schema) used through the prod-disabled `/test/scenario-yaml` endpoint.
- Docs: `assets/automation/tests/torus/capi/capi.md` (run + coverage) and `docs/exec-plans/current/epics/automated_testing/capi/` (research, plan, findings).

## Findings surfaced (separate follow-up tickets, not addressed here)

- **F2 — no-rules check crash** (`triggerCheck` → `processResults` on undefined; medium): **TRIAGE-2359**.
- **`requestToken` not validated after handshake** (`ExternalActivity.tsx:1076` TODO; characterized by the requestToken test): **TRIAGE-2360**.
- **Duplicate `id="app"`** in `chromeless.html.heex`: **TRIAGE-2361**.
- **Sibling `edit_page_handler` swallows the same upsert error** fixed in the new `edit_adaptive_page` handler: **TRIAGE-2362**.
- **Scenario page-edit handlers mutate revisions in place** (theoretical post-publish concern; not triggered by the pre-publish seed): **TRIAGE-2365**.

## Test plan

```
PLAYWRIGHT_SCENARIO_TOKEN=my-token mix phx.server
cd assets/automation && npx playwright test tests/torus/capi/capi.spec.ts   # 10 pass, ~5 min
cd assets && npx jest test/adaptivity/capi_variable_test.ts                 # 17 pass
mix test test/oli/scenarios/edit_adaptive_page_test.exs                      # 4 pass
```

