### PR TITLE
[BUG FIX] [MER-5717] Honor section institution research consent setting

### DIFF
--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -258,26 +258,55 @@ defmodule Oli.Delivery do
       when not is_nil(institution_id) do
     case research_consent_for_institution(institution_id) do
       nil -> user_research_consent_required?(user, nil)
-      research_consent -> research_consent == :oli_form
+      research_consent -> research_consent_required?(research_consent)
     end
   end
 
   def user_research_consent_required?(%User{independent_learner: true}, _section) do
     # Direct delivery users with no section institution fall back to the platform setting
-    get_system_research_consent_form_setting() == :oli_form
+    research_consent_required?(get_system_research_consent_form_setting())
   end
 
   def user_research_consent_required?(user, _section) do
     # LTI users
     case Institutions.get_institution_by_lti_user(user) do
-      %Institution{research_consent: :oli_form} -> true
-      _ -> false
+      %Institution{research_consent: research_consent} ->
+        research_consent_required?(research_consent)
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
+  Returns true if research consent is required for the section identified by the
+  given return-to slug, resolving the section's institution setting in a single
+  query.
+
+  Falls back to the user-level policy when the slug is nil, unknown, or the
+  section has no associated institution.
+  """
+  def user_research_consent_required_for_slug?(nil, _slug), do: false
+
+  def user_research_consent_required_for_slug?(user, nil),
+    do: user_research_consent_required?(user, nil)
+
+  def user_research_consent_required_for_slug?(user, slug) do
+    case Sections.get_section_research_consent_by_slug(slug) do
+      {institution_id, research_consent} when not is_nil(institution_id) ->
+        research_consent_required?(research_consent)
+
+      _ ->
+        user_research_consent_required?(user, nil)
     end
   end
 
   defp research_consent_for_institution(institution_id) do
     Repo.one(from(i in Institution, where: i.id == ^institution_id, select: i.research_consent))
   end
+
+  defp research_consent_required?(:oli_form), do: true
+  defp research_consent_required?(_), do: false
 
   # ------------------------------------------------------------
   # Delivery Settings

--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -243,24 +243,40 @@ defmodule Oli.Delivery do
   end
 
   @doc """
-  Returns true if the user is required to provide research consent
-  """
-  def user_research_consent_required?(nil), do: false
+  Returns true if the user is required to provide research consent.
 
-  def user_research_consent_required?(%User{independent_learner: true}) do
-    # Direct delivery users
-    case get_system_research_consent_form_setting() do
-      :oli_form -> true
-      _ -> false
+  When a section is provided and it is associated with an institution, that
+  institution's research consent setting is authoritative. Otherwise the
+  decision falls back to the user-level behavior: the global platform setting
+  for direct delivery users, and the user's institution for LTI users.
+  """
+  def user_research_consent_required?(user, section \\ nil)
+
+  def user_research_consent_required?(nil, _section), do: false
+
+  def user_research_consent_required?(user, %Section{institution_id: institution_id})
+      when not is_nil(institution_id) do
+    case research_consent_for_institution(institution_id) do
+      nil -> user_research_consent_required?(user, nil)
+      research_consent -> research_consent == :oli_form
     end
   end
 
-  def user_research_consent_required?(user) do
+  def user_research_consent_required?(%User{independent_learner: true}, _section) do
+    # Direct delivery users with no section institution fall back to the platform setting
+    get_system_research_consent_form_setting() == :oli_form
+  end
+
+  def user_research_consent_required?(user, _section) do
     # LTI users
     case Institutions.get_institution_by_lti_user(user) do
       %Institution{research_consent: :oli_form} -> true
       _ -> false
     end
+  end
+
+  defp research_consent_for_institution(institution_id) do
+    Repo.one(from(i in Institution, where: i.id == ^institution_id, select: i.research_consent))
   end
 
   # ------------------------------------------------------------

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1194,15 +1194,19 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
-  Returns a minimal section (`id` and `institution_id` only) for a slug, or nil.
+  Returns `{institution_id, research_consent}` for a section slug in a single
+  query (joining its institution), or nil when the slug is unknown.
 
-  Used where only the section's institution is needed (e.g. research consent
-  routing) to avoid loading the full section and its associations.
+  `institution_id` is nil when the section has no associated institution. Used
+  by research consent routing to resolve the authoritative setting without
+  loading the full section.
   """
-  def get_section_institution_by_slug(slug) do
+  def get_section_research_consent_by_slug(slug) do
     from(s in Section,
+      left_join: i in Oli.Institutions.Institution,
+      on: i.id == s.institution_id,
       where: s.slug == ^slug,
-      select: %Section{id: s.id, institution_id: s.institution_id}
+      select: {s.institution_id, i.research_consent}
     )
     |> Repo.one()
   end

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -1194,6 +1194,20 @@ defmodule Oli.Delivery.Sections do
   end
 
   @doc """
+  Returns a minimal section (`id` and `institution_id` only) for a slug, or nil.
+
+  Used where only the section's institution is needed (e.g. research consent
+  routing) to avoid loading the full section and its associations.
+  """
+  def get_section_institution_by_slug(slug) do
+    from(s in Section,
+      where: s.slug == ^slug,
+      select: %Section{id: s.id, institution_id: s.institution_id}
+    )
+    |> Repo.one()
+  end
+
+  @doc """
   Gets a single section by slug with base_project preloaded.
   ## Examples
       iex> get_section_by_slug_with_base_project("123")

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -55,7 +55,7 @@ defmodule OliWeb.DeliveryController do
   def show_research_consent(conn, params) do
     user = conn.assigns.current_user
     user_return_to = params["user_return_to"]
-    section = section_from_return_to(user_return_to)
+    section_slug = section_slug_from_return_to(user_return_to)
 
     cond do
       is_nil(user) ->
@@ -63,7 +63,7 @@ defmodule OliWeb.DeliveryController do
         |> put_flash(:error, "User not found")
         |> redirect(to: Routes.delivery_path(conn, :index))
 
-      Delivery.user_research_consent_required?(user, section) ->
+      Delivery.user_research_consent_required_for_slug?(user, section_slug) ->
         conn
         |> assign(:research_opt_out, user_research_opt_out?(user))
         |> assign(:user_return_to, user_return_to)
@@ -76,14 +76,14 @@ defmodule OliWeb.DeliveryController do
     end
   end
 
-  defp section_from_return_to("/sections/" <> rest) do
+  defp section_slug_from_return_to("/sections/" <> rest) do
     case String.split(rest, "/", parts: 2) do
-      [slug | _] when slug != "" -> Sections.get_section_institution_by_slug(slug)
+      [slug | _] when slug != "" -> slug
       _ -> nil
     end
   end
 
-  defp section_from_return_to(_), do: nil
+  defp section_slug_from_return_to(_), do: nil
 
   defp user_research_opt_out?(%User{research_opt_out: true}), do: true
   defp user_research_opt_out?(_), do: false

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -16,8 +16,6 @@ defmodule OliWeb.DeliveryController do
   alias Oli.Delivery.Sections.EnrollmentBrowseOptions
   alias Oli.InstructorDashboard.DataSnapshot.CsvExport
   alias Oli.InstructorDashboard.OracleRegistry
-  alias Oli.Institutions
-  alias Oli.Institutions.Institution
   alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
   alias OliWeb.LtiRedirect
@@ -57,46 +55,35 @@ defmodule OliWeb.DeliveryController do
   def show_research_consent(conn, params) do
     user = conn.assigns.current_user
     user_return_to = params["user_return_to"]
+    section = section_from_return_to(user_return_to)
 
-    institution = Institutions.get_institution_by_lti_user(user)
-
-    case conn.assigns.current_user do
-      nil ->
+    cond do
+      is_nil(user) ->
         conn
         |> put_flash(:error, "User not found")
         |> redirect(to: Routes.delivery_path(conn, :index))
 
-      # Direct delivery users
-      %User{independent_learner: true} = user ->
-        case Delivery.get_system_research_consent_form_setting() do
-          :oli_form ->
-            conn
-            |> assign(:research_opt_out, user_research_opt_out?(user))
-            |> assign(:user_return_to, user_return_to)
-            |> render("research_consent.html")
+      Delivery.user_research_consent_required?(user, section) ->
+        conn
+        |> assign(:research_opt_out, user_research_opt_out?(user))
+        |> assign(:user_return_to, user_return_to)
+        |> render("research_consent.html")
 
-          _ ->
-            conn
-            |> put_flash(:error, "Research consent is not enabled for this platform")
-            |> redirect(to: Routes.delivery_path(conn, :index))
-        end
-
-      # LTI users
-      user ->
-        case institution do
-          %Institution{research_consent: :oli_form} ->
-            conn
-            |> assign(:research_opt_out, user_research_opt_out?(user))
-            |> assign(:user_return_to, user_return_to)
-            |> render("research_consent.html")
-
-          _ ->
-            conn
-            |> put_flash(:error, "Research consent is not enabled for your institution")
-            |> redirect(to: Routes.delivery_path(conn, :index))
-        end
+      true ->
+        conn
+        |> put_flash(:error, "Research consent is not enabled")
+        |> redirect(to: Routes.delivery_path(conn, :index))
     end
   end
+
+  defp section_from_return_to("/sections/" <> rest) do
+    case String.split(rest, "/", parts: 2) do
+      [slug | _] when slug != "" -> Sections.get_section_by_slug(slug)
+      _ -> nil
+    end
+  end
+
+  defp section_from_return_to(_), do: nil
 
   defp user_research_opt_out?(%User{research_opt_out: true}), do: true
   defp user_research_opt_out?(_), do: false

--- a/lib/oli_web/controllers/delivery_controller.ex
+++ b/lib/oli_web/controllers/delivery_controller.ex
@@ -78,7 +78,7 @@ defmodule OliWeb.DeliveryController do
 
   defp section_from_return_to("/sections/" <> rest) do
     case String.split(rest, "/", parts: 2) do
-      [slug | _] when slug != "" -> Sections.get_section_by_slug(slug)
+      [slug | _] when slug != "" -> Sections.get_section_institution_by_slug(slug)
       _ -> nil
     end
   end

--- a/lib/oli_web/plugs/ensure_research_consent.ex
+++ b/lib/oli_web/plugs/ensure_research_consent.ex
@@ -17,7 +17,7 @@ defmodule Oli.Plugs.EnsureResearchConsent do
 
     with false <- is_admin,
          nil <- user.research_opt_out,
-         true <- Delivery.user_research_consent_required?(user) do
+         true <- Delivery.user_research_consent_required?(user, conn.assigns[:section]) do
       # User is required to provide research consent before accessing the system
       conn
       |> redirect(to: ~p"/research_consent?user_return_to=#{conn.request_path}")

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -78,6 +78,66 @@ defmodule Oli.DeliveryTest do
       refute Delivery.user_research_consent_required?(user)
     end
 
+    test "for_slug?: section institution setting is authoritative" do
+      for {setting, required?} <- [{:oli_form, true}, {:no_form, false}] do
+        institution = insert(:institution, research_consent: setting)
+
+        section =
+          insert(:section,
+            open_and_free: true,
+            institution: institution,
+            lti_1p3_deployment: nil,
+            lti_1p3_deployment_id: nil
+          )
+
+        user = insert(:user, independent_learner: true)
+
+        assert Delivery.user_research_consent_required_for_slug?(user, section.slug) == required?
+      end
+    end
+
+    test "for_slug?: section with no institution falls back to the global setting" do
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: nil,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      user = insert(:user, independent_learner: true)
+
+      assert Delivery.user_research_consent_required_for_slug?(user, section.slug)
+
+      Delivery.update_system_research_consent_form_setting(:no_form)
+      refute Delivery.user_research_consent_required_for_slug?(user, section.slug)
+    end
+
+    test "for_slug?: returns false for a nil user" do
+      institution = insert(:institution, research_consent: :oli_form)
+
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: institution,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      refute Delivery.user_research_consent_required_for_slug?(nil, section.slug)
+    end
+
+    test "for_slug?: unknown or nil slug falls back to the user-level policy" do
+      user = insert(:user, independent_learner: true)
+
+      assert Delivery.user_research_consent_required_for_slug?(user, "does-not-exist")
+      assert Delivery.user_research_consent_required_for_slug?(user, nil)
+
+      Delivery.update_system_research_consent_form_setting(:no_form)
+      refute Delivery.user_research_consent_required_for_slug?(user, "does-not-exist")
+      refute Delivery.user_research_consent_required_for_slug?(user, nil)
+    end
+
     test "LTI section honors its institution setting" do
       for {setting, required?} <- [{:oli_form, true}, {:no_form, false}] do
         institution = insert(:institution, research_consent: setting)

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -4,9 +4,95 @@ defmodule Oli.DeliveryTest do
   import Oli.Factory
   import Oli.TestHelpers
 
+  alias Lti_1p3.Roles.ContextRoles
   alias Oli.Delivery
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.{Section, SectionSpecification}
+
+  describe "user_research_consent_required?/2" do
+    setup do
+      Delivery.update_system_research_consent_form_setting(:oli_form)
+      :ok
+    end
+
+    test "returns false for a nil user" do
+      refute Delivery.user_research_consent_required?(nil)
+    end
+
+    test "direct delivery section with a :no_form institution does not require consent (MER-5717)" do
+      institution = insert(:institution, research_consent: :no_form)
+
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: institution,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      user = insert(:user, independent_learner: true)
+
+      refute Delivery.user_research_consent_required?(user, section)
+    end
+
+    test "section institution is authoritative over the global setting" do
+      Delivery.update_system_research_consent_form_setting(:no_form)
+      institution = insert(:institution, research_consent: :oli_form)
+
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: institution,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      user = insert(:user, independent_learner: true)
+
+      assert Delivery.user_research_consent_required?(user, section)
+    end
+
+    test "direct delivery section with no institution falls back to the global setting" do
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: nil,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      user = insert(:user, independent_learner: true)
+
+      assert Delivery.user_research_consent_required?(user, section)
+
+      Delivery.update_system_research_consent_form_setting(:no_form)
+      refute Delivery.user_research_consent_required?(user, section)
+    end
+
+    test "without a section, a direct delivery user follows the global setting" do
+      user = insert(:user, independent_learner: true)
+
+      assert Delivery.user_research_consent_required?(user)
+
+      Delivery.update_system_research_consent_form_setting(:no_form)
+      refute Delivery.user_research_consent_required?(user)
+    end
+
+    test "LTI section honors its institution setting" do
+      for {setting, required?} <- [{:oli_form, true}, {:no_form, false}] do
+        institution = insert(:institution, research_consent: setting)
+        deployment = insert(:lti_deployment, institution: institution)
+
+        section =
+          insert(:section, institution: institution, lti_1p3_deployment: deployment)
+
+        user = insert(:user, independent_learner: false)
+        Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+        assert Delivery.user_research_consent_required?(user, section) == required?
+      end
+    end
+  end
 
   describe "delivery settings" do
     test "maybe_update_section_contains_explorations/1 update contains_explorations field" do

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -192,6 +192,49 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "show_research_consent" do
+    setup %{conn: conn} do
+      Oli.Delivery.update_system_research_consent_form_setting(:oli_form)
+      user = insert(:user, independent_learner: true, research_opt_out: nil)
+      {:ok, conn: log_in_user(conn, user), user: user}
+    end
+
+    defp direct_section(institution) do
+      insert(:section,
+        open_and_free: true,
+        institution: institution,
+        lti_1p3_deployment: nil,
+        lti_1p3_deployment_id: nil
+      )
+    end
+
+    test "renders the form when the return-to section requires consent", %{conn: conn} do
+      section = direct_section(insert(:institution, research_consent: :oli_form))
+
+      conn =
+        get(conn, ~p"/research_consent?user_return_to=/sections/#{section.slug}")
+
+      assert html_response(conn, 200) =~ "Consent"
+    end
+
+    test "redirects away when the return-to section institution disables consent (MER-5717)", %{
+      conn: conn
+    } do
+      section = direct_section(insert(:institution, research_consent: :no_form))
+
+      conn =
+        get(conn, ~p"/research_consent?user_return_to=/sections/#{section.slug}")
+
+      assert redirected_to(conn) == Routes.delivery_path(conn, :index)
+    end
+
+    test "falls back to the global setting for a non-section return path", %{conn: conn} do
+      conn = get(conn, ~p"/research_consent?user_return_to=/not/a/section")
+
+      assert html_response(conn, 200) =~ "Consent"
+    end
+  end
+
   describe "download_course_content_info" do
     setup [:setup_lti_session, :create_project_with_units_and_modules]
 

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -773,6 +773,80 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                "/research_consent?user_return_to=%2Fsections%2F#{section.slug}"
     end
 
+    test "not redirected to research consent form when section institution has consent disabled (MER-5717)",
+         context do
+      {:ok, conn: conn, user: student} = user_conn(context)
+
+      {:ok, _user} = Accounts.update_user(student, %{research_opt_out: nil})
+
+      institution = insert(:institution, research_consent: :no_form)
+
+      section =
+        insert(:section,
+          open_and_free: true,
+          institution: institution,
+          lti_1p3_deployment: nil,
+          lti_1p3_deployment_id: nil
+        )
+
+      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:error, {:redirect, %{to: redirect_path}}} =
+        live(conn, ~p"/sections/#{section.slug}")
+
+      assert redirect_path == "/sections/#{section.slug}/welcome"
+      refute redirect_path =~ "research_consent"
+    end
+
+    test "LTI section redirects to research consent when its institution requires it (MER-5717)",
+         context do
+      {:ok, conn: conn, user: student} = user_conn(context, %{independent_learner: false})
+
+      {:ok, _user} = Accounts.update_user(student, %{research_opt_out: nil})
+
+      institution = insert(:institution, research_consent: :oli_form)
+      deployment = insert(:lti_deployment, institution: institution)
+
+      section =
+        insert(:section,
+          type: :enrollable,
+          open_and_free: false,
+          institution: institution,
+          lti_1p3_deployment: deployment
+        )
+
+      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:error, {:redirect, %{to: redirect_path}}} =
+        live(conn, ~p"/sections/#{section.slug}")
+
+      assert redirect_path =~ "/research_consent"
+    end
+
+    test "LTI section does not redirect to research consent when its institution disables it",
+         context do
+      {:ok, conn: conn, user: student} = user_conn(context, %{independent_learner: false})
+
+      {:ok, _user} = Accounts.update_user(student, %{research_opt_out: nil})
+
+      institution = insert(:institution, research_consent: :no_form)
+      deployment = insert(:lti_deployment, institution: institution)
+
+      section =
+        insert(:section,
+          type: :enrollable,
+          open_and_free: false,
+          institution: institution,
+          lti_1p3_deployment: deployment
+        )
+
+      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      result = live(conn, ~p"/sections/#{section.slug}")
+
+      refute match?({:error, {:redirect, %{to: "/research_consent" <> _}}}, result)
+    end
+
     test "redirected to section welcome view when student has opted in or out of research consent",
          context do
       {:ok, conn: conn, user: student} = user_conn(context)


### PR DESCRIPTION
## [BUG FIX] [MER-5717] Honor section institution research consent setting

### Ticket
https://eliterate.atlassian.net/browse/MER-5717

### Problem
On **Direct Delivery** courses, students were prompted with the OLI research consent form even when the course's institution had research consent turned **off** ("No Research Consent Form"). Setting the institution to `:no_form` and associating it with the course had no effect for direct-delivery (independent) learners.

### Root cause
`Oli.Delivery.user_research_consent_required?/1` decided consent **per user**: for independent learners it read the **global** platform setting and never consulted the section's institution. So a section's `:no_form` institution was ignored. (LTI learners were already institution-aware via a separate path.)

### Fix
Made the consent decision **section-aware** via a single resolver — "Option A + centralized resolver":

- `user_research_consent_required?(user, section)`: section's institution is authoritative when present; the global setting is the fallback only when the section has no institution. `/1` retained for callers with no section context (menu links) — behavior unchanged.
- `EnsureResearchConsent` plug passes `conn.assigns[:section]`.
- `show_research_consent/2` uses the same resolver and recovers the section by safely parsing `user_return_to` (only `/sections/:slug`), eliminating duplicated direct-vs-LTI logic.

This unifies LTI and direct delivery under one rule: **the section's institution decides; the system setting is the no-institution fallback.** No deployment-institution fallback (section `institution_id` is authoritative).

### Testing
- **Manual (dev):** institution → `No Research Consent Form`, linked to a direct-delivery section, fresh un-consented learner enrolls → lands directly in the course, no consent form. Confirmed the gate no longer redirects.
- **Automated:** unit tests for the resolver (no_form/oli_form precedence, no-institution fallback, LTI sections) + end-to-end gate tests through `/sections/:slug` for direct **and** LTI sections + controller tests for `show_research_consent`. Targeted suites green; compiles `--warnings-as-errors`; formatted.

### Product decision
Confirmed with product: a direct-delivery section with **no** institution keeps using the global setting (no behavior change).


[MER-5717]: https://eliterate.atlassian.net/browse/MER-5717