### PR TITLE
[BUG FIX] [MER-5716] Add default instructor dashboard recommendation config

### DIFF
--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -233,12 +233,6 @@ case Oli.Repo.all(RegisteredModel) do
       section_id: nil
     })
 
-    Oli.Repo.insert!(%FeatureConfig{
-      feature: :instructor_dashboard_recommendation,
-      service_config_id: service_config.id,
-      section_id: nil
-    })
-
     # Dedicated ServiceConfig for the instructor email feature (MER-5257).
     # Fresh installs land the row here. Existing servers (Tokamaka, Proton)
     # get the row via the companion migration
@@ -260,6 +254,27 @@ case Oli.Repo.all(RegisteredModel) do
   _ ->
     # already seeded
     nil
+end
+
+default_service_config_name = "standard-no-backup"
+
+default_service_config =
+  Oli.Repo.get_by(Oli.GenAI.Completions.ServiceConfig, name: default_service_config_name)
+
+default_feature_config_exists? =
+  Oli.Repo.exists?(
+    from(fc in FeatureConfig,
+      where:
+        fc.feature == :instructor_dashboard_recommendation and is_nil(fc.section_id)
+    )
+  )
+
+if default_service_config && !default_feature_config_exists? do
+  Oli.Repo.insert!(%FeatureConfig{
+    feature: :instructor_dashboard_recommendation,
+    service_config_id: default_service_config.id,
+    section_id: nil
+  })
 end
 
 # only seed with sample data if in development mode

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -264,8 +264,7 @@ default_service_config =
 default_feature_config_exists? =
   Oli.Repo.exists?(
     from(fc in FeatureConfig,
-      where:
-        fc.feature == :instructor_dashboard_recommendation and is_nil(fc.section_id)
+      where: fc.feature == :instructor_dashboard_recommendation and is_nil(fc.section_id)
     )
   )
 


### PR DESCRIPTION
[MER-5716](https://eliterate.atlassian.net/browse/MER-5716)

## Summary
Add an idempotent seed for the global `instructor_dashboard_recommendation` GenAI feature config.

### Changes
- Added a separate idempotent check in `priv/repo/seeds.exs` for the missing global `gen_ai_feature_configs` row
- The seed reuses the existing `standard-no-backup` service config
- Kept the setup aligned with the existing seed flow so new installs and deployments both get the default

### Verification
- `mix test test/oli/gen_ai/feature_config_test.exs test/oli/gen_ai_test.exs`

[MER-5716]: https://eliterate.atlassian.net/browse/MER-5716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ