### PR TITLE
[FEATURE] [MER-5622] Add instructor bank selection manager

### DIFF
--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -144,6 +144,7 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     setActions(previewContext.actions ?? []);
     setVisualState(previewContext.visualState ?? 'default');
     setStatusPill(previewContext.statusPill);
+    setIsSubmitting(false);
   }, [
     previewContext.activityResourceId,
     previewContext.actions,

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -4,6 +4,7 @@ type InstructorPreviewCustomizationHook = {
     payload: Record<string, unknown>,
     callback?: (reply: Record<string, unknown>) => void,
   ) => void;
+  handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
   handlePreviewCustomization?: (event: Event) => void;
   handleFallbackPreviewCustomizationClick?: (event: Event) => void;
 };
@@ -274,6 +275,14 @@ export const InstructorPreviewCustomization = {
         updateFallbackPreviewCard(detail.target, reply);
       });
     };
+
+    this.handleEvent('preview_customization_reply', (reply) => {
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: reply,
+        }),
+      );
+    });
 
     window.addEventListener('oli:preview-customization', this.handlePreviewCustomization);
     window.addEventListener('click', this.handleFallbackPreviewCustomizationClick as EventListener);

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -276,7 +276,7 @@ export const InstructorPreviewCustomization = {
       });
     };
 
-    this.handleEvent('preview_customization_reply', (reply) => {
+    this.handleEvent?.('preview_customization_reply', (reply) => {
       window.dispatchEvent(
         new CustomEvent('oli:preview-customization:reply', {
           detail: reply,

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/design/bank_selection_manager.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/design/bank_selection_manager.md
@@ -1,0 +1,137 @@
+# UI Implementation Brief
+
+## Design Sources
+
+- Primary source:
+  - `MER-5622` Figma manager view `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7391`
+- Supporting sources:
+  - warning modal `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-15926`
+  - `docs/exec-plans/current/epics/instructor_customizations/overview.md`
+  - `docs/exec-plans/current/epics/instructor_customizations/plan.md`
+  - `docs/exec-plans/current/epics/instructor_customizations/core/informal.md`
+  - existing preview question brief `docs/exec-plans/current/epics/instructor_customizations/preview_components/design/preview_question_ui.md`
+- Jira references:
+  - `MER-5622`
+- Figma node ids / links:
+  - manager surface `185:7391`
+  - invalid-removal modal `185:15926`
+
+## Implementation Surface
+
+- Surface: `liveview/heex`
+- Target user flow:
+  - preview-authorized instructor/admin opens a standalone management route for one activity bank selection, reviews candidate questions, previews the selected candidate, and removes or restores candidates for that selection.
+- Responsive considerations:
+  - Figma is desktop-first and split-panel.
+  - First-pass implementation should preserve the two-column desktop layout and stack gracefully on smaller widths rather than inventing new interaction patterns.
+- Interaction/state considerations:
+  - global Instructor View header remains the origin-return action
+  - local back returns to the preview page location/anchor
+  - one selected row drives the right preview panel
+  - the right preview panel is the primary `Remove` / `Restore` action surface in this work item
+  - removed rows show muted state plus `Removed` pill
+  - invalid removals open a modal instead of persisting
+
+## Design System Alignment
+
+- Shared vs local decision:
+  - `keep feature-local`
+- Rationale:
+  - the surface is a preview-specific workflow composition, not a cross-feature primitive.
+  - it should reuse existing shared shell, header, modal, button, and icon patterns where they already fit, but the manager layout itself should remain local to the instructor preview workflow.
+- Existing design-system references consulted:
+  - delivery shell/header in `lib/oli_web/components/delivery/layouts.ex`
+  - modal component in `lib/oli_web/components/modal.ex`
+  - Torus button and icon semantics via existing HEEx components and `lib/oli_web/icons.ex`
+
+## Token Mapping
+
+- Background / surface:
+  - keep the existing preview shell surfaces and white panel surfaces already used in Instructor View
+- Text:
+  - use existing heading/high-emphasis tokens for title and count
+  - use muted text tokens for selection metadata and secondary table text
+- Border / divider:
+  - use existing neutral border tokens for split panels, row separators, and modal borders
+- Fill / accent:
+  - reuse preview/instructor accent treatment already established by the Instructor View shell
+  - use the existing primary action blue token family for actionable buttons/links
+- Icon:
+  - reuse existing back/chevron/trash-capable iconography from `OliWeb.Icons`
+- Spacing / layout:
+  - favor tokenized spacing utilities already used in preview and delivery LiveViews before introducing arbitrary values
+- Typography:
+  - stay aligned with existing preview shell typography rather than hardcoding Figma font values
+- Token gaps requiring approval:
+  - none identified for the initial spec
+
+## Icon Mapping
+
+- Existing icons to reuse:
+  - back arrow from the preview shell
+  - chevron/down caret for expandable affordances where needed
+  - trash/remove icon from the existing HEEx icon layer if the surface keeps the iconized button treatment from Figma
+- Icons that need extension:
+  - none currently
+- Notes on surface-specific icon implementation:
+  - because this surface is LiveView/HEEx, prefer `OliWeb.Icons` over React-side icon modules
+
+## Component Reuse Plan
+
+- Existing components/patterns to reuse:
+  - `Layouts.instructor_preview_header/1`
+  - shared delivery header from `lib/oli_web/components/delivery/layouts.ex`
+  - shared modal component from `lib/oli_web/components/modal.ex`
+  - existing preview-render hydration path via `RenderedActivity.render/1` and current hooks
+- Components to extend:
+  - `PreviewRoutes` for the new selection-manager path helper
+  - preview-session routing under the existing instructor preview live session
+- Interaction-contract guidance:
+  - React preview components embedded in LiveView should stay presentational.
+  - This work should reuse the preview action integration established by the prior embedded-activity preview implementation rather than redefining hook/reply/local-state mechanics here.
+  - For this manager surface, the relevant target kind is `bank_candidate` for candidate-row `Remove` / `Restore`.
+  - LiveView remains the source of truth for whether a candidate is enabled or removed.
+  - The left list should reflect that state and drive selection, but bulk or multi-select mutation controls belong to later work.
+- Proposed extractions:
+  - none beyond small feature-local helpers or components near the new LiveView if the template becomes too dense
+- States that must be supported:
+  - default loaded state with one selected candidate
+  - removed row state
+  - incremental appended row state
+  - invalid-removal warning modal
+  - whole-bank removal success followed by redirect back to the originating preview page context
+  - success-flash state after mutation
+
+## File Targets
+
+- Primary implementation files:
+  - `lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex`
+  - `lib/oli_web/delivery/instructor/preview_routes.ex`
+  - `lib/oli_web/router.ex`
+- Shared component targets:
+  - reuse existing layout/modal components instead of creating new shared primitives
+- Feature-local component targets:
+  - optional helper/presenter near `lib/oli_web/live/delivery/instructor/`
+  - targeted tests under `test/oli_web/live/delivery/instructor/`
+- Styling/token touch points:
+  - existing preview/delivery HEEx utility patterns
+
+## Preview Target Usage
+
+- This work assumes the preceding preview-page PR already establishes the shared React <-> LiveView action pipeline.
+- The manager implementation should only extend that existing model with the target kinds relevant to this surface:
+  - `bank_candidate` for candidate-row `Remove` / `Restore`
+- In this work item, the action originates from the right-hand preview rather than from a bulk-action control in the left list.
+
+## Open Questions / Requires Approval
+
+- Unmapped colors or tokens:
+  - none blocking
+- Missing design states:
+  - no explicit mobile variant is shown in the provided Figma nodes
+- Ambiguous interactions:
+  - confirm whether attempts-started warning integration is in-scope here or an inbound shared-warning dependency
+- Reuse/extraction decisions needing confirmation:
+  - none beyond keeping the manager surface feature-local
+- Anything else that should be confirmed before coding:
+  - none beyond the shared attempts-started warning decision

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md
@@ -76,6 +76,9 @@
     - computes its ordinal/preview metadata conservatively
     - calls `ActivityHelpers.preview_render/6`
   - this keeps browser-side preview hydration identical to the existing preview activity path
+- Preview-route target resolution:
+  - prefer a dedicated `InstructorCustomizations` entry point for `(section, revision_slug, selection_id)` so mount can resolve page type and selection membership in one step instead of splitting that logic across the LiveView
+  - the public context boundary may delegate internally to `TargetResolver`, but web callers should stay coupled to `InstructorCustomizations`
 - Warning modal:
   - use the shared modal component under `lib/oli_web/components/modal.ex`
   - store modal state in assigns with dynamic copy derived from the insufficient-candidates error payload
@@ -84,7 +87,7 @@
 1. Mount resolves:
    - section and page revision through existing preview session assigns
    - safe preview navigation params (`return_to`, `request_path`)
-   - selection metadata through `list_bank_selection_candidates/4`
+   - selection target validity through mount-time route resolution
 2. Initial assigns include:
    - first candidate page
    - active available count derived from the loaded rows and exclusion view or directly from context response
@@ -105,6 +108,7 @@
    - on success, navigate back to the originating preview page context instead of leaving the user on a disabled manager surface
 7. User scrolls or clicks load-more trigger:
    - LiveView requests the next page via `list_bank_selection_candidates/4`
+   - once mount has already resolved `%Section{}`, `%Revision{}`, and the selection map, the LiveView should use the resolved-target function head to avoid repeating page/selection resolution queries on each load
    - append rows while preserving current removed/selected state
 
 ### 4.3 Lifecycle & Ownership
@@ -165,6 +169,11 @@
     - `preview_loaded?`
 - Optional helper interface:
   - `render_selection_candidate_preview(section, page_revision, candidate_revision, opts \\ []) :: {:ok, rendered_html} | {:error, reason}`
+- Candidate-listing efficiency contract:
+  - `list_bank_selection_candidates/4` should support both:
+    - `(section_or_id, page_resource_id, selection_id, opts)` for general callers
+    - `(%Section{}, %Revision{}, selection_map, opts)` for already resolved preview-session callers
+  - the manager LiveView should prefer the resolved-target head after mount so paging and refresh flows do not repeat target-resolution queries unnecessarily
 
 ## 6. Data Model & Storage
 - No new database tables or schema changes are required.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md
@@ -1,0 +1,256 @@
+# Bank Selection Manager - Functional Design Document
+
+## 1. Executive Summary
+`MER-5622` adds a new preview-session LiveView dedicated to one activity bank selection. The LiveView reuses the Instructor View shell and return context from `MER-5617`, the preview rendering contract from `MER-5618`, and the delivery-side customization APIs from `MER-5639`. It focuses on the manager route, local back contract, candidate-list paging behavior, right-hand preview rendering, and warning flows for candidate management. The simplest adequate design is a server-driven LiveView with a paged candidate list and a single selected-candidate preview, not a new React app or a reuse of the legacy controller preview.
+
+## 2. Requirements & Assumptions
+- Functional requirements:
+  - provide a standalone preview-session LiveView route for one page selection
+  - preserve the persistent Instructor View header while introducing local back-to-page behavior
+  - list bank candidates with active/removed state, dynamic active count, and incremental loading
+  - preview the selected candidate using the existing preview activity pipeline
+  - remove and restore candidates through `Oli.Delivery.InstructorCustomizations`
+  - block invalid removals with a dynamic warning modal and provide a whole-bank removal path from that modal
+- Non-functional requirements:
+  - keep authorization server-side and preview-context-safe
+  - avoid loading the entire candidate bank in one request
+  - keep state ownership in LiveView/UI, not in domain contexts
+  - preserve accessibility semantics for table-like row selection and warning modal interaction
+- Assumptions:
+  - `MER-5618` preview rendering is available for the right-hand panel by the time this work is implemented
+
+### 2.1 Requirements Traceability
+- `AC-001`, `AC-002`:
+  - covered by the new preview-session LiveView route, server-side authorization, and preview-context sanitation
+- `AC-003`, `AC-004`:
+  - covered by reuse of the shared Instructor View header plus a separate local back target contract
+- `AC-005`, `AC-006`, `AC-007`:
+  - covered by paged candidate loading, row-state mapping from `list_bank_selection_candidates/4`, and incremental append/reset behavior
+- `AC-008`:
+  - covered by candidate selection state and right-panel preview rendering through the preview activity pipeline
+- `AC-009`, `AC-010`:
+  - covered by LiveView mutation events calling `exclude_bank_candidate/5` and `restore_bank_candidate/5` with refreshed candidate state
+- `AC-011`, `AC-012`:
+  - covered by explicit invalid-removal modal state and a whole-bank removal event that calls `exclude_bank_selection/4`
+- `AC-013`:
+  - covered by LiveView flash feedback after successful remove, restore, and whole-bank removal actions
+
+## 3. Repository Context Summary
+- What we know:
+  - `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex` already establishes preview-mode shell behavior, safe `return_to` handling, and local preview back-link semantics for page preview surfaces.
+  - `lib/oli_web/components/delivery/layouts.ex` already provides the reusable `instructor_preview_header/1` and shared delivery header used in preview mode.
+  - `lib/oli/delivery/instructor_customizations.ex` already exposes:
+    - `list_bank_selection_candidates/4`
+    - `get_selection_exclusion_view/3`
+    - `exclude_bank_candidate/5`
+    - `restore_bank_candidate/5`
+    - `exclude_bank_selection/4`
+  - the candidate listing API already returns paged rows, active count semantics through `disable_allowed?`, and selection-enabled state.
+  - `OliWeb.Components.Delivery.ActivityHelpers.preview_render/6` and `OliWeb.ManualGrading.RenderedActivity.render/1` already provide a practical server-side path for rendering one activity preview with the same browser hooks used elsewhere.
+  - the old `ActivityBankController` preview route is controller-rendered and not aligned to the reusable Instructor View shell.
+- Unknowns to confirm:
+  - whether attempts-started warning logic already exists as a reusable contract by the time implementation begins
+
+## 4. Proposed Design
+### 4.1 Component Roles & Interactions
+- New LiveView:
+  - add `OliWeb.Delivery.Instructor.BankSelectionManagerLive`
+  - mount under the existing preview live session at a route like `/sections/:section_slug/preview/lesson/:revision_slug/selection/:selection_id`
+  - own UI state:
+    - current candidate page(s)
+    - selected candidate id
+    - selected preview HTML
+    - current active candidate count
+    - local back target
+    - modal/warning state
+- Preview route helpers:
+  - extend `OliWeb.Delivery.Instructor.PreviewRoutes` with a dedicated selection-manager path helper
+  - preserve `return_to` and `request_path` sanitation rules already used by preview lesson routes
+- Preview shell reuse:
+  - render `Layouts.instructor_preview_header/1` for the global return action
+  - render the shared delivery header below it
+  - implement a manager-local back control that targets the originating preview page/anchor contract
+- Candidate preview helper:
+  - add a small server-side helper module or function near the instructor preview boundary that:
+    - resolves one candidate revision
+    - computes its ordinal/preview metadata conservatively
+    - calls `ActivityHelpers.preview_render/6`
+  - this keeps browser-side preview hydration identical to the existing preview activity path
+- Warning modal:
+  - use the shared modal component under `lib/oli_web/components/modal.ex`
+  - store modal state in assigns with dynamic copy derived from the insufficient-candidates error payload
+
+### 4.2 State & Data Flow
+1. Mount resolves:
+   - section and page revision through existing preview session assigns
+   - safe preview navigation params (`return_to`, `request_path`)
+   - selection metadata through `list_bank_selection_candidates/4`
+2. Initial assigns include:
+   - first candidate page
+   - active available count derived from the loaded rows and exclusion view or directly from context response
+   - selected candidate defaulting to the first visible candidate
+   - preview HTML for that selected candidate
+3. User selects a candidate row:
+   - LiveView updates `selected_candidate_id`
+   - LiveView re-renders right-panel preview HTML for that candidate
+4. User clicks `Remove` from the right-hand preview:
+   - if row `disable_allowed?` is true, call `exclude_bank_candidate/5`
+   - on success, refresh visible candidate state and active count, keep selection stable where possible, and show success flash
+   - if the context returns `{:insufficient_selection_candidates, %{...}}`, open warning modal instead of persisting
+5. User clicks `Restore` from the right-hand preview:
+   - call `restore_bank_candidate/5`
+   - refresh visible state/count and show success flash
+6. User confirms `Remove bank` from the modal:
+   - call `exclude_bank_selection/4`
+   - on success, navigate back to the originating preview page context instead of leaving the user on a disabled manager surface
+7. User scrolls or clicks load-more trigger:
+   - LiveView requests the next page via `list_bank_selection_candidates/4`
+   - append rows while preserving current removed/selected state
+
+### 4.3 Lifecycle & Ownership
+- Backend ownership:
+  - selection validation, authorization, remove/restore persistence, and count rule enforcement remain in `Oli.Delivery.InstructorCustomizations`
+- LiveView ownership:
+  - route params, local back contract, selected-row state, preview HTML caching, load-more behavior, flash messages, and warning-modal orchestration
+  - post-success redirect back to the originating preview page after whole-bank removal from the invalid-removal modal
+  - authoritative enabled/removed state for each candidate row
+- Browser-hook ownership:
+  - existing preview custom-element hydration and MathJax/survey helper hooks remain responsible for rendering the preview HTML once inserted
+- React preview-component ownership:
+  - preview components remain primarily presentational even when they surface customization controls
+  - preview components should not infer mutation behavior from activity type, route, or preview mode branches
+  - the right-hand preview emits `Remove` / `Restore` intents through the already-established preview action contract and updates local preview state from the LiveView reply
+- Future-ticket ownership:
+  - `MER-5620` owns wiring a page-level `Manage Questions` link into this surface
+  - `MER-5623` and `MER-5624` extend this LiveView with bulk actions and filtering rather than replacing it
+
+### 4.4 Alternatives Considered
+- Reuse `ActivityBankController` and restyle it:
+  - rejected because it is controller-owned, uses the old layout, and would duplicate newer preview-session shell logic
+- Build a React app mounted inside preview:
+  - rejected because the workflow is primarily server-driven, depends on preview-session routing/authorization, and benefits from reusing existing LiveView shell/navigation patterns
+- Render previews by manually composing activity-specific HTML:
+  - rejected because it would fork the preview rendering contract from `MER-5618` and create a second activity-preview stack
+- Load all candidates eagerly:
+  - rejected because the candidate list API is already paged and the ticket explicitly calls for endless scroll behavior
+
+## 5. Interfaces
+- New route helper:
+  - `PreviewRoutes.selection_path(section_slug, revision_slug, selection_id, params \\ [])`
+- New LiveView events:
+  - `"select_candidate"` with `%{"activity_resource_id" => id}`
+  - `"load_more_candidates"` with paging cursor/offset
+  - `"confirm_remove_bank"`
+  - `"dismiss_invalid_remove_warning"`
+- Established preview customization integration:
+  - assume the preceding preview-page work already establishes the shared React <-> LiveView communication pattern for preview actions
+  - this feature should reuse that integration rather than redefining transport, reply handling, hook behavior, or local preview-component state rules
+  - in this work item, the right-hand preview is the primary UI surface that issues `Remove` / `Restore`
+  - this LiveView only needs to supply the `bank_candidate` target for those preview-driven actions
+  - the left candidate list is selection/navigation and state-reflection UI in this work item, not a bulk-mutation surface
+- LiveView dispatch expectation for preview-action events:
+  - when the incoming action targets `bank_candidate`, the handler should dispatch:
+    - `Remove` -> `exclude_bank_candidate/5`
+    - `Restore` -> `restore_bank_candidate/5`
+  - whole-bank removal remains a manager-owned modal action and should dispatch `exclude_bank_selection/4`
+- View model shape:
+  - row entries should preserve:
+    - `activity_resource_id`
+    - `revision_slug`
+    - `title`
+    - `enabled?`
+    - `disable_allowed?`
+  - plus local UI-derived flags:
+    - `selected?`
+    - `preview_loaded?`
+- Optional helper interface:
+  - `render_selection_candidate_preview(section, page_revision, candidate_revision, opts \\ []) :: {:ok, rendered_html} | {:error, reason}`
+
+## 6. Data Model & Storage
+- No new database tables or schema changes are required.
+- The LiveView reads and writes through the existing `activity_exclusions` storage owned by `Oli.Delivery.InstructorCustomizations`.
+- In-memory LiveView state adds:
+  - loaded candidate pages
+  - selected candidate id
+  - rendered preview cache for visible candidates if needed for performance
+  - modal state for invalid removal
+
+## 7. Consistency & Transactions
+- Remove/restore and whole-bank disable operations rely on the existing transaction and locking guarantees already implemented in `Oli.Delivery.InstructorCustomizations`.
+- The LiveView should treat context responses as authoritative and refresh visible state from the returned view/list response rather than applying optimistic client-only diffs.
+- When a loaded page becomes stale after a mutation, the LiveView should recompute visible row state from fresh context data before rendering.
+
+## 8. Caching Strategy
+- No new cross-request cache is required.
+- It is acceptable to keep an in-memory preview HTML cache for currently visible candidates during one LiveView session to avoid rerendering the same selected candidate repeatedly.
+- Cache entries should be invalidated when the selected visible row set changes materially or when the session reloads.
+
+## 9. Performance & Scalability Posture
+- Use the existing paged candidate query with the default limit as the initial page size.
+- Implement endless loading by requesting subsequent pages, not by increasing limit unboundedly.
+- Keep only the visible/loaded candidate subset in assigns instead of the entire matching bank.
+- Avoid repeated DB queries for the same preview when the selected candidate has not changed.
+
+## 10. Failure Modes & Resilience
+- Unauthorized access:
+  - route should deny access consistently with existing preview authorization
+- Invalid selection/page route:
+  - LiveView should render a not-found or redirect-safe fallback rather than crashing
+- Preview rendering failure for one candidate:
+  - show a bounded error state in the right panel while keeping the candidate list usable
+- Remove action races with external changes:
+  - rely on context-level validation and show the returned error/warning state instead of persisting stale assumptions
+- Direct route used outside the normal page-preview path:
+  - acceptable; the route remains functional for direct/manual navigation
+
+## 11. Observability
+- Log or surface unexpected preview-render failures for candidate right-panel rendering.
+- Reuse existing AppSignal/LiveView error reporting for route and event failures.
+- No new product analytics are required; this is a preview customization workflow, not a learner flow.
+
+## 12. Security & Privacy
+- All mutations must pass the current preview actor into `Oli.Delivery.InstructorCustomizations` so authorization remains server-side.
+- Route parameters must continue to use safe internal-path sanitation for preview return context.
+- Candidate preview payloads must contain only preview-safe instructional content and must not expose learner attempt data.
+
+## 13. Testing Strategy
+- LiveView tests:
+  - route render and authorization
+  - local back contract
+  - default selected candidate and preview update on row selection
+  - remove/restore success flows and flash messages
+  - invalid-removal modal flow and whole-bank removal path
+  - incremental loading behavior and state preservation across appended pages
+- Elixir tests:
+  - preview route helper coverage
+  - candidate preview helper coverage
+  - any presenter functions for count/state shaping
+- Manual QA:
+  - compare manager view and warning modal against Figma
+  - confirm keyboard operation and focus handling across rows/actions/modal
+
+## 14. Backwards Compatibility
+- The existing controller-backed bank preview route may remain temporarily; this work item does not need to delete it.
+- No authored content, publication, or learner delivery behavior changes.
+- Preview page shell behavior outside candidate management remains unchanged by this work item.
+
+## 15. Risks & Mitigations
+- Route-level integration depends on adjacent preview work; keep the manager focused on candidate management and its route/helper contract stable.
+- Preview helper drifts from `MER-5618` rendering: mitigate by routing all right-panel rendering through the shared preview helper path.
+- Endless-load UX becomes brittle in LiveView: start with deterministic paged append behavior and explicit tests around selection/state retention.
+- Whole-bank remove outcome ambiguity: document the unresolved navigation choice and finalize it before implementation.
+ - Whole-bank remove redirect could drop success visibility if not handled carefully: carry success feedback through the redirect target using standard flash behavior.
+
+## 16. Open Questions & Follow-ups
+- Confirm whether attempts-started warning support should be part of this work item or treated as an inbound shared-warning dependency when implementation begins.
+- Align `MER-5620` documentation to the same server-authored preview-action contract so page preview and bank-selection management do not diverge into separate React event models.
+- `MER-5620` will wire the `Manage Questions` CTA from the page-level bank-selection card into this route.
+- `MER-5623` remains the place for any same-state multi-select or bulk remove/restore behavior from the left candidate list.
+
+## 17. References
+- `docs/exec-plans/current/epics/instructor_customizations/overview.md`
+- `docs/exec-plans/current/epics/instructor_customizations/plan.md`
+- `docs/exec-plans/current/epics/instructor_customizations/core/informal.md`
+- Jira `MER-5622`
+- Figma manager node `185:7391`
+- Figma warning modal node `185:15926`

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_1_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_1_execution_record.md
@@ -1,0 +1,39 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager`
+Phase: `1`
+
+## Scope from plan.md
+- introduce the standalone preview-session destination route and validate mount-time scope
+- add the route helper, preview-session LiveView route, mount validation, and safe navigation-param handling
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed (not needed for this route-and-mount slice)
+
+Implementation note:
+- Phase 1 introduced an already-resolved `list_bank_selection_candidates/4` function head that accepts `%Section{}`, `%Revision{}`, and the selection map directly. The reason is to let later manager phases reuse the mount-resolved preview target instead of repeating page/selection resolution queries during candidate-list loads and refreshes.
+- Phase 1 also extracted preview-route target resolution for `(section, revision_slug, selection_id)` into the customization target resolver so the LiveView mount can distinguish missing pages, adaptive pages, and invalid selections through one shared entry point.
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed (no open questions remained after the phase-1 refactors)
+
+## Review Loop
+- Round 1 findings: no material findings in the phase-1 diff after targeted review against route/mount scope
+- Round 1 fixes: none required
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_2_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_2_execution_record.md
@@ -1,0 +1,48 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager`
+Phase: `2`
+
+## Scope from plan.md
+- render the management workspace shell with the reusable preview headers and a local back contract
+- load and append candidate rows incrementally while preserving selection state
+- surface selection metadata, active-available count, and removed-row styling in the left pane
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed (not needed for this shell-and-list slice)
+
+Implementation note:
+- Phase 2 extended `list_bank_selection_candidates/4` to return lightweight paging metadata (`offset`, `limit`, `has_more?`, `total_count`, `active_count`) alongside the current candidate rows. The manager uses that response directly so incremental loads can append deterministically without recomputing count state in LiveView.
+- Phase 2 now reads `points per question` from the authored selection's `pointsPerActivity` field and renders the selection-criteria summary from the selection logic itself, so the shell reflects the same authored bank-selection metadata shown in authoring instead of placeholder copy.
+- Phase 2 intentionally keeps the right pane as a structural preview placeholder. The selected row contract, local back behavior, and candidate paging state are now stable inputs for Phase 3 preview rendering.
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+Verification commands:
+- `mix compile`
+- `mix test test/oli/delivery/instructor_customizations/write_api_test.exs`
+- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+- [x] Open questions added to docs when needed (no new open questions were introduced in phase 2)
+
+## Review Loop
+- Round 1 findings:
+  - The local back control was regenerating a generic lesson-preview URL instead of preserving the sanitized `request_path` when the manager had an explicit origin-page path.
+- Round 1 fixes:
+  - Updated the manager LiveView to prefer the sanitized `request_path` for the local back target and tightened the LiveView test to assert the exact link href.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_3_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_3_execution_record.md
@@ -1,0 +1,45 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager`
+Phase: `3`
+
+## Scope from plan.md
+- preview the currently selected candidate through the shared preview activity pipeline
+- keep row selection and right-panel rendering on the same instructor-preview contract already used elsewhere
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed (not needed for this preview-render slice)
+
+Implementation note:
+- Phase 3 adds `PreviewPageContext.build_bank_candidate_preview/4` as the bank-selection manager's server-side entry point for rendering one candidate through the existing instructor-preview stack. The helper reuses the same `ActivitySummary` / `Html.activity` contract already used by page preview instead of introducing a separate preview renderer for bank candidates.
+- The manager LiveView now keeps only the selected candidate preview HTML and the union of required preview scripts in assigns. Candidate selection updates the right panel directly, while the left list remains the source of selection state.
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+Verification commands:
+- `mix compile`
+- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged (plan only; no PRD/FDD divergence in this slice)
+- [x] Open questions added to docs when needed (no new open questions were introduced in phase 3)
+
+## Review Loop
+- Round 1 findings:
+  - The initial row-selection tests assumed preview titles would be present in server HTML, but preview-capable activities still render their titles inside hydrated custom elements.
+- Round 1 fixes:
+  - Updated the tests to assert the selected preview container itself, while keeping a direct helper test that proves preview HTML and scripts are returned for the candidate.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_4_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_4_execution_record.md
@@ -1,0 +1,48 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager`
+Phase: `4`
+
+## Scope from plan.md
+- support candidate remove/restore through the existing preview customization contract
+- refresh the visible candidate list and counts from authoritative context responses after each mutation
+- block invalid removals with a warning modal and offer the whole-bank removal path
+- carry success feedback for remove, restore, and whole-bank removal outcomes
+
+## Implementation Blocks
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed (not needed for this mutation-and-modal slice)
+
+Implementation note:
+- Phase 4 keeps the existing `{:reply, reply, socket}` contract for the preview action bridge, but stops hand-editing the visible row state after a mutation. After successful remove/restore, the LiveView now reloads the visible candidate window from `list_bank_selection_candidates/4`, preserving selected/checked state while taking `enabled?`, `disable_allowed?`, and `active_count` from the authoritative context response.
+- When `exclude_bank_candidate/5` returns `{:insufficient_selection_candidates, %{...}}`, the manager now opens a stable modal rendered through `OliWeb.Components.Modal` instead of silently failing. The modal copy is derived from the returned `count` and `active_candidates` values, and the confirm path calls `exclude_bank_selection/4` before redirecting back to the originating preview path with a success flash.
+
+## Test Blocks
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+Verification commands:
+- `mix compile`
+- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+- `mix test test/oli/delivery/instructor_customizations/write_api_test.exs`
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged (plan only; no PRD/FDD divergence in this slice)
+- [x] Open questions added to docs when needed (no new open questions were introduced in phase 4)
+
+## Review Loop
+- Round 1 findings:
+  - No material findings. Security/performance/UI review of this slice did not surface regressions beyond the known repository-wide seed/inventory log noise during tests.
+- Round 1 fixes:
+  - Not needed.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_5_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/phase_5_execution_record.md
@@ -1,0 +1,40 @@
+# Phase 5 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager`
+Phase: `5`
+
+## Scope from plan.md
+- run final targeted verification for the manager route and mutation flows
+- compare the implemented manager and warning modal against the referenced Figma nodes
+- verify keyboard and focus behavior for the warning modal
+- sync any implementation clarifications back into the work item docs
+
+## Verification Summary
+- Automated verification:
+  - `mix compile`
+  - `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`
+- Manual browser verification:
+  - opened the bank selection manager in instructor preview mode on Browser MCP
+  - removed candidates until the selection reached the minimum available-count threshold
+  - confirmed the invalid-removal modal appears when another remove would violate the minimum
+  - dismissed the modal via `Escape`
+  - reopened and dismissed the modal via the close `X`
+  - reopened and dismissed the modal via `Keep question`
+  - confirmed the preview action button returns to `Remove` and does not remain stuck in `Updating...`
+  - confirmed modal focus starts on the close control and cycles through `Remove bank` and `Keep question`
+
+## Figma Comparison
+- Modal:
+  - title, body copy emphasis, button order, close-button placement, and centering were verified against node `185:15926`
+- Manager:
+  - no material regressions were observed during the targeted manual pass; remaining differences, if any, were below the threshold that would block this work item
+
+## Documentation Sync
+- `plan.md` Phase 5 checklist updated to reflect completed QA hardening and verification work
+- no PRD/FDD changes were required from the final QA pass
+
+## Outcome
+- [x] Final automated verification passed
+- [x] Manual browser QA passed
+- [x] Keyboard/focus checks passed
+- [x] Phase 5 complete

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
@@ -91,14 +91,14 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
 ## Phase 4: Mutation Flows, Warning Modal, And Feedback
 - Goal: support remove/restore, invalid-removal protection, whole-bank removal from the modal, and success feedback.
 - Tasks:
-  - [ ] Implement `Remove` and `Restore` event handlers through `Oli.Delivery.InstructorCustomizations`.
-  - [ ] Refresh visible rows and active count from authoritative context responses after each mutation.
-  - [ ] Implement the invalid-removal warning modal with dynamic copy from the insufficient-candidates error payload.
-  - [ ] Implement the `Remove bank` path from the modal through `exclude_bank_selection/4`.
-  - [ ] Add success flash messages for remove, restore, and whole-bank removal outcomes.
+  - [x] Implement `Remove` and `Restore` event handlers through `Oli.Delivery.InstructorCustomizations`.
+  - [x] Refresh visible rows and active count from authoritative context responses after each mutation.
+  - [x] Implement the invalid-removal warning modal with dynamic copy from the insufficient-candidates error payload.
+  - [x] Implement the `Remove bank` path from the modal through `exclude_bank_selection/4`.
+  - [x] Add success flash messages for remove, restore, and whole-bank removal outcomes.
 - Testing Tasks:
-  - [ ] Add LiveView tests for successful remove/restore, invalid-removal modal flow, and whole-bank removal behavior.
-  - [ ] Add tests for count refresh and mutually exclusive actions per row.
+  - [x] Add LiveView tests for successful remove/restore, invalid-removal modal flow, and whole-bank removal behavior.
+  - [x] Add tests for count refresh and mutually exclusive actions per row.
   - Command(s): `mix test test/oli_web/live/delivery/instructor`
 - Definition of Done:
   - remove/restore auto-save correctly

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
@@ -49,13 +49,13 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
 ## Phase 2: Shell, Local Back Contract, And Candidate List Surface
 - Goal: render the Figma-aligned management workspace with paged candidate rows and selection state.
 - Tasks:
-  - [ ] Build the LiveView layout using the reusable Instructor View header and delivery header.
-  - [ ] Add the local back control and origin-page contract separate from the persistent header return.
-  - [ ] Render selection metadata, active available count, and candidate rows with removed-state styling.
-  - [ ] Implement incremental candidate loading from `list_bank_selection_candidates/4`, using the already resolved `%Section{}`, `%Revision{}`, and selection map once mount has established them.
-  - [ ] Keep selected-row state stable as additional pages load.
+  - [x] Build the LiveView layout using the reusable Instructor View header and delivery header.
+  - [x] Add the local back control and origin-page contract separate from the persistent header return.
+  - [x] Render selection metadata, active available count, and candidate rows with removed-state styling.
+  - [x] Implement incremental candidate loading from `list_bank_selection_candidates/4`, using the already resolved `%Section{}`, `%Revision{}`, and selection map once mount has established them.
+  - [x] Keep selected-row state stable as additional pages load.
 - Testing Tasks:
-  - [ ] Add LiveView tests for shell rendering, local back behavior, removed-state row styling, and paged append behavior.
+  - [x] Add LiveView tests for shell rendering, local back behavior, removed-state row styling, and paged append behavior.
   - Command(s): `mix test test/oli_web/live/delivery/instructor`
 - Definition of Done:
   - the management surface matches the intended structural layout
@@ -70,13 +70,13 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
 ## Phase 3: Right-Panel Preview Rendering
 - Goal: preview the currently selected candidate through the shared preview activity pipeline.
 - Tasks:
-  - [ ] Add a server-side helper or presenter for rendering one candidate preview.
-  - [ ] Default selection to the first visible row when present.
-  - [ ] Update the right panel dynamically when the user selects another row.
-  - [ ] Reuse existing browser hooks/components needed to hydrate preview custom elements in the rendered HTML.
+  - [x] Add a server-side helper or presenter for rendering one candidate preview.
+  - [x] Default selection to the first visible row when present.
+  - [x] Update the right panel dynamically when the user selects another row.
+  - [x] Reuse existing browser hooks/components needed to hydrate preview custom elements in the rendered HTML.
 - Testing Tasks:
-  - [ ] Add Elixir tests for the preview-render helper.
-  - [ ] Add LiveView tests proving row selection updates the right-hand preview.
+  - [x] Add Elixir tests for the preview-render helper.
+  - [x] Add LiveView tests proving row selection updates the right-hand preview.
   - Command(s): `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`
 - Definition of Done:
   - selecting a candidate updates the right panel without introducing a new preview stack

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
@@ -114,13 +114,13 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
 ## Phase 5: QA Hardening And Spec Sync
 - Goal: close the work item with targeted verification, accessibility checks, and spec updates if implementation details drift.
 - Tasks:
-  - [ ] Run targeted LiveView and helper tests across the new route and mutation flows.
-  - [ ] Perform manual comparison against the manager and modal Figma nodes.
-  - [ ] Verify keyboard/focus behavior across row actions and modal controls.
-  - [ ] Reconcile any implementation-driven clarifications back into the work item docs.
+  - [x] Run targeted LiveView and helper tests across the new route and mutation flows.
+  - [x] Perform manual comparison against the manager and modal Figma nodes.
+  - [x] Verify keyboard/focus behavior across row actions and modal controls.
+  - [x] Reconcile any implementation-driven clarifications back into the work item docs.
 - Testing Tasks:
-  - [ ] Run the final targeted backend/UI test commands.
-  - [ ] Run `mix format` on touched Elixir files.
+  - [x] Run the final targeted backend/UI test commands.
+  - [x] Run `mix format` on touched Elixir files.
   - Command(s): `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`, `mix format`
 - Definition of Done:
   - automated coverage and manual verification both confirm the management workflow is ready for later entry-point wiring

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
@@ -1,0 +1,144 @@
+# Bank Selection Manager - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/prd.md`
+- FDD: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md`
+
+## Scope
+Deliver `MER-5622` as the standalone bank-selection management LiveView inside preview mode. The work covers the destination route, shared preview shell integration, paged candidate browsing, right-panel question preview, selection-candidate remove/restore flows, invalid-removal warning handling, and success feedback. It explicitly excludes the page-level `Manage Questions` launch link wiring from `PreviewLessonLive`.
+
+## Clarifications & Default Assumptions
+- `MER-5620` or a follow-up ticket will wire the page-level CTA into this route later.
+- `Remove` / `Restore` in this work item are triggered from the right-hand preview through the existing preview action contract; the left list owns selection state and reflects removed/enabled state.
+- Any left-list multi-select or bulk mutation behavior is out of scope here and belongs to `MER-5623`.
+- The new surface reuses the preview-shell header contract from `MER-5617` and preview activity rendering from `MER-5618`.
+- Initial endless-scroll behavior may be implemented as deterministic paged append in LiveView; no browser-side virtualization is assumed.
+- No feature flag is planned for this work item.
+
+### Requirements Traceability
+- `AC-001`, `AC-002`:
+  - covered by Phase 1 through the new route, mount validation, and preview context handling
+- `AC-003`, `AC-004`:
+  - covered by Phase 2 through shell/header reuse and local back behavior
+- `AC-005`, `AC-006`, `AC-007`, `AC-008`:
+  - covered by Phases 2 and 3 through the paged candidate list, row states, and right-panel preview
+- `AC-009`, `AC-010`, `AC-011`, `AC-012`, `AC-013`:
+  - covered by Phase 4 through mutation events, modal handling, whole-bank removal, and flash feedback
+
+## Phase 1: Route And Preview Session Integration
+- Goal: introduce the standalone preview-session destination route and validate mount-time scope.
+- Tasks:
+  - [ ] Add `PreviewRoutes.selection_path/4`.
+  - [ ] Add a new LiveView route under the existing preview live session.
+  - [ ] Resolve and validate section/page/selection targets during mount.
+  - [ ] Preserve safe `return_to` and `request_path` handling for the new route.
+- Testing Tasks:
+  - [ ] Add route-helper and authorization coverage.
+  - [ ] Add LiveView tests for valid and invalid route access.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor`
+- Definition of Done:
+  - authorized preview users can open the selection-manager route directly
+  - invalid targets fail safely without crashing the preview session
+- Gate:
+  - route and mount tests pass
+- Dependencies:
+  - existing preview-shell/session work from `MER-5617`
+- Parallelizable Work:
+  - route helper and mount validation can proceed in parallel with initial UI skeleton work once the path shape is fixed
+
+## Phase 2: Shell, Local Back Contract, And Candidate List Surface
+- Goal: render the Figma-aligned management workspace with paged candidate rows and selection state.
+- Tasks:
+  - [ ] Build the LiveView layout using the reusable Instructor View header and delivery header.
+  - [ ] Add the local back control and origin-page contract separate from the persistent header return.
+  - [ ] Render selection metadata, active available count, and candidate rows with removed-state styling.
+  - [ ] Implement incremental candidate loading from `list_bank_selection_candidates/4`.
+  - [ ] Keep selected-row state stable as additional pages load.
+- Testing Tasks:
+  - [ ] Add LiveView tests for shell rendering, local back behavior, removed-state row styling, and paged append behavior.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor`
+- Definition of Done:
+  - the management surface matches the intended structural layout
+  - candidate rows load incrementally and preserve selected state
+- Gate:
+  - list-state and navigation tests pass
+- Dependencies:
+  - Phase 1
+- Parallelizable Work:
+  - UI structure and paged state helpers can be split once mount assigns are stable
+
+## Phase 3: Right-Panel Preview Rendering
+- Goal: preview the currently selected candidate through the shared preview activity pipeline.
+- Tasks:
+  - [ ] Add a server-side helper or presenter for rendering one candidate preview.
+  - [ ] Default selection to the first visible row when present.
+  - [ ] Update the right panel dynamically when the user selects another row.
+  - [ ] Reuse existing browser hooks/components needed to hydrate preview custom elements in the rendered HTML.
+- Testing Tasks:
+  - [ ] Add Elixir tests for the preview-render helper.
+  - [ ] Add LiveView tests proving row selection updates the right-hand preview.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`
+- Definition of Done:
+  - selecting a candidate updates the right panel without introducing a new preview stack
+- Gate:
+  - preview helper and row-selection tests pass
+- Dependencies:
+  - Phase 2
+  - preview rendering contract from `MER-5618`
+- Parallelizable Work:
+  - helper extraction and panel markup can proceed in parallel once the selected-row state contract is settled
+
+## Phase 4: Mutation Flows, Warning Modal, And Feedback
+- Goal: support remove/restore, invalid-removal protection, whole-bank removal from the modal, and success feedback.
+- Tasks:
+  - [ ] Implement `Remove` and `Restore` event handlers through `Oli.Delivery.InstructorCustomizations`.
+  - [ ] Refresh visible rows and active count from authoritative context responses after each mutation.
+  - [ ] Implement the invalid-removal warning modal with dynamic copy from the insufficient-candidates error payload.
+  - [ ] Implement the `Remove bank` path from the modal through `exclude_bank_selection/4`.
+  - [ ] Add success flash messages for remove, restore, and whole-bank removal outcomes.
+- Testing Tasks:
+  - [ ] Add LiveView tests for successful remove/restore, invalid-removal modal flow, and whole-bank removal behavior.
+  - [ ] Add tests for count refresh and mutually exclusive actions per row.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor`
+- Definition of Done:
+  - remove/restore auto-save correctly
+  - invalid removals warn instead of silently persisting
+  - success feedback is visible after mutations
+- Gate:
+  - mutation and warning-flow tests pass
+- Dependencies:
+  - Phase 3
+- Parallelizable Work:
+  - success-flash copy and modal rendering can be developed alongside the mutation event handlers
+
+## Phase 5: QA Hardening And Spec Sync
+- Goal: close the work item with targeted verification, accessibility checks, and spec updates if implementation details drift.
+- Tasks:
+  - [ ] Run targeted LiveView and helper tests across the new route and mutation flows.
+  - [ ] Perform manual comparison against the manager and modal Figma nodes.
+  - [ ] Verify keyboard/focus behavior across row actions and modal controls.
+  - [ ] Reconcile any implementation-driven clarifications back into the work item docs.
+- Testing Tasks:
+  - [ ] Run the final targeted backend/UI test commands.
+  - [ ] Run `mix format` on touched Elixir files.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`, `mix format`
+- Definition of Done:
+  - automated coverage and manual verification both confirm the management workflow is ready for later entry-point wiring
+- Gate:
+  - tests pass, formatting is clean, and docs stay aligned with final behavior
+- Dependencies:
+  - Phases 1 through 4
+- Parallelizable Work:
+  - docs reconciliation and manual QA can run while any last low-risk test adjustments land
+
+## Parallelization Notes
+- Route/helper work can start before the final UI layout is complete.
+- Candidate-list state management and preview-render helper extraction are the main independent threads after mount behavior is fixed.
+- Mutation flows should wait until selected-row and count-refresh state contracts are stable.
+
+## Phase Gate Summary
+- Gate A: standalone route and preview-session integration are stable.
+- Gate B: Figma-aligned shell, local back contract, and paged candidate list are stable.
+- Gate C: right-panel preview reuses the shared preview stack correctly.
+- Gate D: remove/restore and invalid-removal warning flows are correct and user-visible.
+- Gate E: targeted QA and spec reconciliation are complete.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/plan.md
@@ -28,13 +28,13 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
 ## Phase 1: Route And Preview Session Integration
 - Goal: introduce the standalone preview-session destination route and validate mount-time scope.
 - Tasks:
-  - [ ] Add `PreviewRoutes.selection_path/4`.
-  - [ ] Add a new LiveView route under the existing preview live session.
-  - [ ] Resolve and validate section/page/selection targets during mount.
-  - [ ] Preserve safe `return_to` and `request_path` handling for the new route.
+  - [x] Add `PreviewRoutes.selection_path/4`.
+  - [x] Add a new LiveView route under the existing preview live session.
+  - [x] Resolve and validate section/page/selection targets during mount.
+  - [x] Preserve safe `return_to` and `request_path` handling for the new route.
 - Testing Tasks:
-  - [ ] Add route-helper and authorization coverage.
-  - [ ] Add LiveView tests for valid and invalid route access.
+  - [x] Add route-helper and authorization coverage.
+  - [x] Add LiveView tests for valid and invalid route access.
   - Command(s): `mix test test/oli_web/live/delivery/instructor`
 - Definition of Done:
   - authorized preview users can open the selection-manager route directly
@@ -52,7 +52,7 @@ Deliver `MER-5622` as the standalone bank-selection management LiveView inside p
   - [ ] Build the LiveView layout using the reusable Instructor View header and delivery header.
   - [ ] Add the local back control and origin-page contract separate from the persistent header return.
   - [ ] Render selection metadata, active available count, and candidate rows with removed-state styling.
-  - [ ] Implement incremental candidate loading from `list_bank_selection_candidates/4`.
+  - [ ] Implement incremental candidate loading from `list_bank_selection_candidates/4`, using the already resolved `%Section{}`, `%Revision{}`, and selection map once mount has established them.
   - [ ] Keep selected-row state stable as additional pages load.
 - Testing Tasks:
   - [ ] Add LiveView tests for shell rendering, local back behavior, removed-state row styling, and paged append behavior.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/prd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/prd.md
@@ -1,0 +1,127 @@
+# Bank Selection Manager - Product Requirements Document
+
+## 1. Overview
+`MER-5622` introduces a dedicated Instructor View management surface for one activity bank selection on one basic page. The work item delivers a standalone LiveView where instructors can browse candidate questions, inspect the selected question through the existing preview rendering contract, remove or restore candidates for that selection, and handle invalid-removal warnings without mutating authored content.
+
+## 2. Background & Problem Statement
+The delivery-side customization backend now supports section- and page-specific exclusion of individual candidates inside an activity bank selection. What is still missing is the instructor-facing workspace for using that capability. The legacy bank preview controller is read-only, controller-rendered, and structurally different from the newer Instructor View shell. Jira for `MER-5622` expects a secondary Instructor View workflow with its own local back behavior, selection-scoped question management, dynamic preview, removed-state affordances, and minimum-count protection. Without a dedicated management LiveView, preview routing would need to either resurrect the old controller preview or embed complex selection-management logic into the page shell instead of reusing a dedicated workflow.
+
+## 3. Goals & Non-Goals
+### Goals
+- Deliver a standalone Instructor View LiveView route for managing one bank selection on one preview page.
+- Preserve the global Instructor View header and return context while adding a local back-to-page action for the manager.
+- Show current active-question count, selection criteria summary, candidate list state, and a dynamic preview panel.
+- Allow remove and restore actions for selection candidates using the existing delivery customization context.
+- Prevent invalid candidate removal through an explicit warning workflow when the selection would fall below its required count.
+- Reuse the existing preview rendering contract for the right-hand question preview instead of inventing a separate rendering stack.
+
+### Non-Goals
+- Rendering the `Manage Questions` CTA inside `PreviewLessonLive`.
+- Wiring navigation from the page-level bank-selection card into this LiveView.
+- Implementing multi-select or bulk actions from `MER-5623`.
+- Implementing search, learning-objective filters, or question-type filters from `MER-5624`.
+- Reworking page-level embedded-question and whole-selection controls that belong to `MER-5620`.
+- Changing learner delivery, authored resources, or historical attempts.
+
+## 4. Users & Use Cases
+- Instructor: opens a bank-selection manager for one page selection, reviews which candidate questions are currently available, and removes or restores individual questions to fit section needs.
+- Author or admin in preview mode: reviews the same management workflow without changing authored source content.
+- Engineering team: uses the standalone selection-manager route and its `bank_candidate` target usage as the destination consumed by preview-page workflows.
+
+## 5. UX / UI Requirements
+- The management surface must follow the approved Figma nodes:
+  - manager view: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7391`
+  - minimum-count warning modal: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-15926`
+- The surface must render inside the reusable Instructor View shell so the persistent header and origin-specific return label remain visible.
+- A local back control must return to the originating preview page location rather than duplicating the persistent header exit action.
+- The page body must include:
+  - bank-selection title/header
+  - active available-question count
+  - selection criteria summary
+  - left-side candidate table/list
+  - right-side question preview panel
+- Candidate rows must show a removed state with muted styling and a `Removed` pill when excluded for that selection.
+- Candidate actions must be mutually exclusive:
+  - active candidates show `Remove`
+  - removed candidates show `Restore`
+- The minimum-count warning modal must explain the required count and resulting remaining count using live selection data.
+- When the user confirms `Remove bank` from the minimum-count warning modal, the manager must disable the whole selection and immediately navigate back to the originating preview page context.
+- Successful changes must show positive user feedback after auto-save actions complete.
+- Filter/search controls visible in the Figma node are future-ticket context only and should not become functional scope in this work item.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+- Accessibility: local back, row selection, remove/restore controls, and warning-modal actions must be keyboard accessible, expose visible focus states, and provide accessible labels.
+- Reliability: remove/restore actions must auto-save through the delivery customization context and leave the active-question count consistent with persisted state.
+- Security and authorization: only preview-authorized instructor/admin users may access the management route or perform selection-candidate mutations.
+- Performance: candidate browsing must avoid loading the entire matching bank into the LiveView process at once; the list should load incrementally from the existing paged candidate query.
+- Compatibility: the work item must not require bank-selection rendering in `PreviewLessonLive` to exist yet, and it must not regress the existing preview shell or legacy bank-preview controller while both coexist.
+
+## 9. Data, Interfaces & Dependencies
+- Depends on `MER-5639` and its delivery-owned `Oli.Delivery.InstructorCustomizations` APIs for listing candidates, excluding/restoring candidates, and excluding the whole bank selection.
+- Depends on `MER-5617` for the reusable Instructor View shell/header contract and local-vs-global back semantics.
+- Depends on `MER-5618` for preview-mode activity rendering that can be reused in the right-hand question preview.
+- Assumes `MER-5620` will add the page-preview `Manage Questions` launch path into this route later while keeping page-level bank-selection behavior outside this work item's scope.
+- Reuses the existing preview route inputs:
+  - `section_slug`
+  - page `revision_slug`
+  - `selection_id`
+  - safe `return_to` / `request_path` preview context
+- May need a small server-side preview helper to render one candidate question through the same preview component pipeline already used in Instructor View.
+
+## 10. Repository & Platform Considerations
+- The implementation surface is primarily `liveview/heex`, with server-rendered preview HTML and existing browser hooks used to hydrate preview custom elements.
+- Domain rules must stay in `Oli.Delivery.InstructorCustomizations`; the new LiveView should orchestrate UI state only.
+- LiveView is the source of truth for each candidate's enabled/removed state.
+- The right-hand preview uses the already-established preview action contract to emit `Remove` / `Restore` intents for `bank_candidate` targets back to the LiveView.
+- The new route should live under the existing preview LiveView session so preview-mode assigns and the global return context are reused.
+- LiveView tests are the primary automated test layer for route access, local navigation behavior, UI state transitions, and warning-modal flows.
+- Targeted ExUnit tests should cover any new preview helper that assembles candidate preview HTML from the existing rendering pipeline.
+
+## 11. Feature Flagging, Rollout & Migration
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+- Operational success is primarily workflow correctness:
+  - preview-authorized users can open the management surface directly
+  - remove/restore actions persist and update the count correctly
+  - invalid removals trigger the warning modal instead of silently persisting
+- Existing logs and AppSignal coverage should remain sufficient for route/render failures and mutation errors.
+
+## 13. Risks & Mitigations
+- Sequencing risk with adjacent preview work: keep page-level bank-selection behavior out of scope and document the manager route expectations explicitly so this LiveView stays focused on candidate management.
+- Preview-stack duplication risk: reuse the existing preview rendering contract for the right panel instead of introducing a separate bespoke question preview implementation.
+- Large-bank memory risk: use incremental paging/endless-load behavior backed by the existing paged candidate query rather than loading all candidates into assigns.
+- Return-navigation confusion: preserve the separation between the persistent Instructor View header exit and the local back-to-page action in both docs and tests.
+- Warning-flow drift: align the invalid-removal modal copy and action structure to the approved Figma node rather than reusing unrelated legacy modals.
+
+## 14. Open Questions & Assumptions
+### Open Questions
+- Should the attempts-started warning reuse an already-shared warning contract by the time implementation begins, or does this work item need to own the first LiveView integration of that warning pattern for selection-candidate actions?
+
+### Assumptions
+- The legacy controller-backed bank preview may remain in the repo temporarily while the new management LiveView lands.
+- The right-hand preview panel can rely on the preview-mode activity contract from `MER-5618` and does not need to invent new browser-side rendering elements.
+- Candidate list filters shown in Figma are explicitly deferred to later tickets and should not block the initial manager implementation.
+
+## 15. QA Plan
+- Automated validation:
+  - LiveView tests for authorization, route rendering, local back behavior, row selection, remove/restore, and minimum-count warning flows
+  - targeted Elixir tests for any new candidate-preview rendering helper and route helper functions
+  - targeted tests proving incremental candidate loading preserves row state and selected-preview behavior
+- Manual validation:
+  - open the route directly for a valid preview section/page/selection and compare to the approved Figma nodes
+  - verify local back returns to the originating page anchor/location contract
+  - verify removed rows show muted styling and `Removed` pill
+  - verify invalid removals surface the warning modal with correct dynamic counts and copy
+  - verify successful remove/restore actions show success feedback and update the visible count immediately
+
+## 16. Definition of Done
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/requirements.yml
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/requirements.yml
@@ -1,0 +1,109 @@
+work_item: bank_selection_manager
+requirements:
+- title: Provide a standalone preview-session management route for one activity bank
+    selection without requiring page-level entry-point wiring in the same work item
+  status: proposed
+  id: FR-001
+- title: Preserve the reusable Instructor View shell while adding local back-to-page
+    behavior for the bank-selection manager
+  status: proposed
+  id: FR-002
+- title: List and page selection candidates with active count, removed-state styling,
+    and one selected preview target
+  status: proposed
+  id: FR-003
+- title: Render the selected candidate through the shared Instructor View preview
+    rendering pipeline
+  status: proposed
+  id: FR-004
+- title: Persist selection-specific remove and restore actions through the delivery
+    customization context
+  status: proposed
+  id: FR-005
+- title: Block invalid removals with a dynamic warning modal and support whole-bank
+    removal from that modal
+  status: proposed
+  id: FR-006
+- title: Show success feedback after completed management actions
+  status: proposed
+  id: FR-007
+acceptance_criteria:
+- title: A preview-authorized instructor or admin can open the bank-selection manager
+    route for a valid section slug, page revision slug, and selection id
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-001
+- title: The manager route reuses safe preview return-context handling and rejects
+    or safely falls back on invalid internal navigation targets
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-002
+- title: The management surface renders the persistent Instructor View header plus
+    a separate local back action that returns to the originating preview page context
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-003
+- title: Entering the management surface loads the view at the top and preserves the
+    contract needed for later return to the originating preview-page location
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-004
+- title: The body shows selection title, active available-question count, selection
+    criteria summary, a left candidate list, and a right question preview panel
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-005
+- title: Removed candidates render in a distinct removed state with muted styling,
+    a Removed pill, and a Restore action while active candidates show Remove instead
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-006
+- title: The candidate list loads incrementally rather than materializing the entire
+    matching bank in one response and preserves row state across appended pages
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-007
+- title: Selecting a candidate row updates the right-hand preview dynamically using
+    the existing preview activity pipeline rather than a new bespoke rendering stack
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-008
+- title: Removing an active candidate persists the selection-specific exclusion, refreshes
+    the active count, and updates the row state without requiring manual save
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-009
+- title: Restoring a removed candidate persists the re-enable action, refreshes the
+    active count, and returns the row to its default visual state
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-010
+- title: Attempting to remove a candidate that would leave fewer active questions
+    than the selection count opens a warning modal with dynamic copy and does not
+    persist the candidate removal
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-011
+- title: Confirming Remove bank from the invalid-removal modal disables the whole
+    bank selection through the existing delivery customization context
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-012
+- title: Successful remove, restore, and whole-bank removal actions show success feedback
+    to the instructor
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-013

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -115,11 +115,13 @@ defmodule Oli.Delivery.InstructorCustomizations do
 
   Callers that already resolved the page revision and selection for the current
   preview session can pass `%Section{}`, `%Revision{}`, and the selection map
-  directly to avoid repeating target-resolution queries.
+  directly to avoid repeating target-resolution queries. The response includes
+  both candidate rows and lightweight paging/count metadata so preview surfaces
+  can append additional pages without recomputing selection state locally.
   """
   @spec list_bank_selection_candidates(
-          Section.t() | integer(),
-          Revision.t() | integer(),
+          %Section{} | integer(),
+          %Revision{} | integer(),
           map() | String.t(),
           keyword()
         ) ::
@@ -152,6 +154,11 @@ defmodule Oli.Delivery.InstructorCustomizations do
            selection_id: selection_id,
            count: count,
            selection_enabled?: exclusion_view.selection_enabled?,
+           active_count: active_count,
+           total_count: result.totalCount,
+           offset: paging.offset,
+           limit: paging.limit,
+           has_more?: paging.offset + result.rowCount < result.totalCount,
            candidates:
              Enum.map(result.rows, fn candidate ->
                enabled? =
@@ -178,6 +185,34 @@ defmodule Oli.Delivery.InstructorCustomizations do
     end
   end
 
+  @doc """
+  Returns every activity type id currently matched by a resolved bank selection.
+
+  Preview surfaces can use this to preload the scripts needed by the whole
+  selection once, instead of recalculating script deltas as more candidate rows
+  are paged in.
+  """
+  @spec list_bank_selection_candidate_activity_type_ids(
+          %Section{},
+          %Revision{},
+          map(),
+          non_neg_integer()
+        ) :: {:ok, [integer()]} | {:error, term()}
+  def list_bank_selection_candidate_activity_type_ids(
+        %Section{} = section,
+        %Revision{} = page_revision,
+        selection,
+        total_count
+      )
+      when is_integer(total_count) and total_count >= 0 do
+    TargetResolver.list_candidate_activity_type_ids(
+      section,
+      page_revision,
+      selection,
+      total_count
+    )
+  end
+
   # Target validation
 
   @doc """
@@ -188,8 +223,8 @@ defmodule Oli.Delivery.InstructorCustomizations do
   `InstructorCustomizations` context instead of exposing `TargetResolver`
   directly to web callers.
   """
-  @spec resolve_bank_selection_preview_target(Section.t() | integer(), String.t(), String.t()) ::
-          {:ok, Revision.t(), map()} | {:error, term()}
+  @spec resolve_bank_selection_preview_target(%Section{} | integer(), String.t(), String.t()) ::
+          {:ok, %Revision{}, map()} | {:error, term()}
   def resolve_bank_selection_preview_target(section_or_id, revision_slug, selection_id)
       when is_binary(revision_slug) and is_binary(selection_id) do
     with {:ok, section} <- TargetResolver.resolve_section(section_or_id) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -18,6 +18,7 @@ defmodule Oli.Delivery.InstructorCustomizations do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Resources.Revision
   alias Oli.Repo
 
   @default_candidate_limit 25
@@ -111,11 +112,30 @@ defmodule Oli.Delivery.InstructorCustomizations do
 
   @doc """
   Returns candidate review state for callers that already authorized access.
+
+  Callers that already resolved the page revision and selection for the current
+  preview session can pass `%Section{}`, `%Revision{}`, and the selection map
+  directly to avoid repeating target-resolution queries.
   """
-  def list_bank_selection_candidates(section_or_id, page_resource_id, selection_id, opts \\ []) do
-    with {:ok, section, page_revision, selection} <-
-           resolve_selection_target(section_or_id, page_resource_id, selection_id),
-         {:ok, paging} <- normalize_candidate_paging(opts),
+  @spec list_bank_selection_candidates(
+          Section.t() | integer(),
+          Revision.t() | integer(),
+          map() | String.t(),
+          keyword()
+        ) ::
+          {:ok, map()} | {:error, term()}
+  def list_bank_selection_candidates(section_or_id, page_resource_id, selection_id, opts \\ [])
+
+  def list_bank_selection_candidates(
+        %Section{} = section,
+        %Revision{} = page_revision,
+        %{"id" => selection_id, "count" => count} = selection,
+        opts
+      )
+      when is_binary(selection_id) do
+    page_resource_id = page_revision.resource_id
+
+    with {:ok, paging} <- normalize_candidate_paging(opts),
          {:ok, result} <-
            TargetResolver.list_candidates(section, page_revision, selection, paging) do
       exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id)
@@ -127,8 +147,6 @@ defmodule Oli.Delivery.InstructorCustomizations do
                selection,
                exclusion_view.excluded_candidate_ids
              ) do
-        count = selection["count"]
-
         {:ok,
          %{
            selection_id: selection_id,
@@ -152,7 +170,32 @@ defmodule Oli.Delivery.InstructorCustomizations do
     end
   end
 
+  def list_bank_selection_candidates(section_or_id, page_resource_id, selection_id, opts)
+      when is_integer(page_resource_id) and is_binary(selection_id) do
+    with {:ok, section, page_revision, selection} <-
+           resolve_selection_target(section_or_id, page_resource_id, selection_id) do
+      list_bank_selection_candidates(section, page_revision, selection, opts)
+    end
+  end
+
   # Target validation
+
+  @doc """
+  Resolves the preview-route target for one bank selection on one page revision slug.
+
+  This is the public preview-route boundary used by LiveViews and controllers.
+  It keeps route-level section/page/selection lookup behind the
+  `InstructorCustomizations` context instead of exposing `TargetResolver`
+  directly to web callers.
+  """
+  @spec resolve_bank_selection_preview_target(Section.t() | integer(), String.t(), String.t()) ::
+          {:ok, Revision.t(), map()} | {:error, term()}
+  def resolve_bank_selection_preview_target(section_or_id, revision_slug, selection_id)
+      when is_binary(revision_slug) and is_binary(selection_id) do
+    with {:ok, section} <- TargetResolver.resolve_section(section_or_id) do
+      TargetResolver.resolve_bank_selection_preview_target(section, revision_slug, selection_id)
+    end
+  end
 
   @doc """
   Validates that an embedded activity target belongs to the section page.

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -20,6 +20,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Resolves a section struct or id into a current section record.
   """
+  @spec resolve_section(%Section{} | integer()) :: {:ok, %Section{}} | {:error, term()}
   def resolve_section(%Section{id: id}), do: resolve_section(id)
 
   def resolve_section(id) when is_integer(id) do
@@ -32,6 +33,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Resolves a section page resource to its current non-adaptive page revision.
   """
+  @spec resolve_page(%Section{}, integer()) :: {:ok, %Revision{}} | {:error, term()}
   def resolve_page(%Section{} = section, page_resource_id) when is_integer(page_resource_id) do
     case Sections.get_section_revision_for_resource(section.slug, page_resource_id) do
       nil ->
@@ -49,8 +51,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Resolves the preview-route target for one bank selection on one page revision slug.
   """
-  @spec resolve_bank_selection_preview_target(Section.t(), String.t(), String.t()) ::
-          {:ok, Revision.t(), map()} | {:error, term()}
+  @spec resolve_bank_selection_preview_target(%Section{}, String.t(), String.t()) ::
+          {:ok, %Revision{}, map()} | {:error, term()}
   def resolve_bank_selection_preview_target(
         %Section{} = section,
         revision_slug,
@@ -73,6 +75,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Validates that an embedded activity reference exists in the given page revision.
   """
+  @spec validate_embedded_activity_reference(%Revision{}, integer()) :: :ok | {:error, term()}
   def validate_embedded_activity_reference(page_revision, activity_resource_id)
       when is_integer(activity_resource_id) do
     activity =
@@ -90,6 +93,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Resolves a bank selection element from the given page revision content.
   """
+  @spec resolve_selection(%Revision{}, String.t()) :: {:ok, map()} | {:error, term()}
   def resolve_selection(page_revision, selection_id) when is_binary(selection_id) do
     selections =
       PageContent.flat_filter(page_revision.content, fn
@@ -116,6 +120,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Lists current bank candidates matching the selection logic.
   """
+  @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t()) ::
+          {:ok, map()} | {:error, term()}
   def list_candidates(%Section{} = section, page_revision, selection, %Paging{} = paging) do
     execute_candidate_query(section, page_revision, selection, [], paging)
   end
@@ -123,6 +129,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @doc """
   Counts candidates matching the selection logic after excluding resource ids.
   """
+  @spec count_active_candidates(%Section{}, %Revision{}, map(), MapSet.t(integer())) ::
+          {:ok, non_neg_integer()} | {:error, term()}
   def count_active_candidates(%Section{} = section, page_revision, selection, excluded_ids) do
     with {:ok, result} <-
            execute_candidate_query(
@@ -137,8 +145,37 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   end
 
   @doc """
+  Lists all candidate activity type ids for a resolved selection target.
+  """
+  @spec list_candidate_activity_type_ids(%Section{}, %Revision{}, map(), non_neg_integer()) ::
+          {:ok, [integer()]} | {:error, term()}
+  def list_candidate_activity_type_ids(
+        %Section{} = section,
+        page_revision,
+        selection,
+        total_count
+      )
+      when is_integer(total_count) and total_count >= 0 do
+    with {:ok, result} <-
+           execute_candidate_query(
+             section,
+             page_revision,
+             selection,
+             [],
+             %Paging{offset: 0, limit: max(total_count, 1)}
+           ) do
+      {:ok,
+       result.rows
+       |> Enum.map(& &1.activity_type_id)
+       |> Enum.uniq()}
+    end
+  end
+
+  @doc """
   Returns whether a resource id is a current candidate for the selection.
   """
+  @spec candidate_matches?(%Section{}, %Revision{}, map(), integer()) ::
+          {:ok, boolean()} | {:error, term()}
   def candidate_matches?(%Section{} = section, page_revision, selection, candidate_resource_id)
       when is_integer(candidate_resource_id) do
     # A returned revision proves the candidate belongs to the published bank and

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -8,6 +8,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Resources.Revision
   alias Oli.Resources.PageContent
   alias Oli.Resources.ResourceType
 
@@ -44,6 +46,28 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     end
   end
 
+  @doc """
+  Resolves the preview-route target for one bank selection on one page revision slug.
+  """
+  @spec resolve_bank_selection_preview_target(Section.t(), String.t(), String.t()) ::
+          {:ok, Revision.t(), map()} | {:error, term()}
+  def resolve_bank_selection_preview_target(
+        %Section{} = section,
+        revision_slug,
+        selection_id
+      )
+      when is_binary(revision_slug) and is_binary(selection_id) do
+    with revision when not is_nil(revision) <-
+           DeliveryResolver.from_revision_slug(section.slug, revision_slug),
+         {:ok, page_revision} <- ensure_basic_page_revision(revision),
+         {:ok, selection} <- resolve_selection(page_revision, selection_id) do
+      {:ok, page_revision, selection}
+    else
+      nil -> {:error, {:not_found, :page}}
+      error -> error
+    end
+  end
+
   # Page content targets
 
   @doc """
@@ -76,6 +100,14 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     case selections do
       [selection | _] -> {:ok, selection}
       [] -> {:error, {:not_found, :selection}}
+    end
+  end
+
+  defp ensure_basic_page_revision(revision) do
+    case {ResourceType.is_page(revision), ResourceType.is_adaptive_page(revision)} do
+      {true, false} -> {:ok, revision}
+      {true, true} -> {:error, {:invalid_page_type, :adaptive}}
+      _ -> {:error, {:not_found, :page}}
     end
   end
 

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -20,6 +20,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Rendering.{Context, Page}
   alias Oli.Resources
   alias Oli.Utils.BibUtils
+  alias OliWeb.ManualGrading.Rendering
 
   def build(section, revision, user, navigation_params \\ %{}) do
     section_slug = section.slug
@@ -142,6 +143,108 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       preview_metadata.objective_titles_by_activity_id
     )
   end
+
+  @doc """
+  Builds preview HTML for a single bank candidate inside the bank-selection
+  manager LiveView.
+
+  This keeps the manager on the same instructor-preview rendering contract used
+  by page preview, while letting the manager decide separately whether the
+  candidate should expose customization actions or removed styling. Callers are
+  expected to pass the current `can_customize?` / `actions` state for the
+  selected candidate so the right-side manager preview stays aligned with the
+  list's removed/restored state.
+  """
+  @spec build_bank_candidate_preview(
+          %Sections.Section{},
+          %Resources.Revision{},
+          %Resources.Revision{},
+          keyword()
+        ) :: {:ok, %{html: String.t()}} | {:error, term()}
+  def build_bank_candidate_preview(section, page_revision, activity_revision, opts \\ [])
+
+  def build_bank_candidate_preview(
+        %Sections.Section{} = section,
+        %Resources.Revision{} = page_revision,
+        %Resources.Revision{} = activity_revision,
+        opts
+      ) do
+    all_activities = Activities.list_activity_registrations()
+    activity_types_map = Map.new(all_activities, fn activity -> {activity.id, activity} end)
+
+    with {:ok, activity_type} <- Map.fetch(activity_types_map, activity_revision.activity_type_id) do
+      learning_objectives =
+        preview_objective_titles_by_activity_id(section.id, [activity_revision])
+        |> Map.get(activity_revision.resource_id, [])
+
+      summary =
+        %ActivitySummary{
+          id: activity_revision.resource_id,
+          script: preview_script_for(activity_type),
+          attempt_guid: nil,
+          state: nil,
+          lifecycle_state: :active,
+          model:
+            activity_revision.content
+            |> Jason.encode!()
+            |> Oli.Delivery.Page.ActivityContext.encode(),
+          delivery_element: activity_type.delivery_element,
+          authoring_element: activity_type.authoring_element,
+          preview_element: activity_type.preview_element,
+          preview_script: activity_type.preview_script,
+          graded: page_revision.graded,
+          activity_type_slug: activity_type.slug,
+          preview_context:
+            build_preview_context(
+              section.slug,
+              page_revision,
+              activity_revision,
+              activity_type,
+              learning_objectives,
+              can_customize?: Keyword.get(opts, :can_customize?, false),
+              actions: Keyword.get(opts, :actions, []),
+              visual_state: Keyword.get(opts, :visual_state, "default"),
+              status_pill: Keyword.get(opts, :status_pill),
+              customization_target: %{
+                kind: "bank_candidate",
+                pageResourceId: page_revision.resource_id,
+                selectionId: Keyword.get(opts, :selection_id),
+                activityResourceId: activity_revision.resource_id
+              }
+            ),
+          bib_refs: Map.get(activity_revision.content, "bibrefs", [])
+        }
+
+      context = %Context{
+        section_slug: section.slug,
+        revision_slug: page_revision.slug,
+        page_id: page_revision.resource_id,
+        mode: :instructor_preview,
+        activity_map: %{activity_revision.resource_id => summary},
+        activity_types_map: activity_types_map,
+        bib_app_params: [],
+        submitted_surveys: %{}
+      }
+
+      {:ok,
+       %{
+         html:
+           context
+           |> Rendering.render(:instructor_preview)
+           |> IO.iodata_to_binary()
+       }}
+    end
+  end
+
+  @doc """
+  Resolves the preview-side script filename for one activity registration.
+
+  Manager-style LiveViews can use this to preload every script needed by the
+  currently visible bank candidates, so switching the selected preview does not
+  depend on script tags added later by a LiveView patch.
+  """
+  @spec preview_script_for_registration(map()) :: String.t() | nil
+  def preview_script_for_registration(activity_type), do: preview_script_for(activity_type)
 
   defp activity_ids(content) do
     content
@@ -323,13 +426,32 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
           page_revision,
           activity_revision,
           type,
-          preview_supported?(type),
-          InstructorCustomizations.activity_enabled?(
-            exclusion_view,
-            activity_revision.resource_id
-          ),
-          preview_actions(exclusion_view, activity_revision.resource_id),
-          learning_objectives
+          learning_objectives,
+          can_customize?: preview_supported?(type),
+          actions: preview_actions(exclusion_view, activity_revision.resource_id),
+          visual_state:
+            if(
+              InstructorCustomizations.activity_enabled?(
+                exclusion_view,
+                activity_revision.resource_id
+              ),
+              do: "default",
+              else: "removed"
+            ),
+          status_pill:
+            if(
+              InstructorCustomizations.activity_enabled?(
+                exclusion_view,
+                activity_revision.resource_id
+              ),
+              do: nil,
+              else: %{kind: "removed", label: "Removed"}
+            ),
+          customization_target: %{
+            kind: "embedded_activity",
+            pageResourceId: page_revision.resource_id,
+            activityResourceId: activity_revision.resource_id
+          }
         ),
       bib_refs: Map.get(activity_revision.content, "bibrefs", [])
     }
@@ -402,10 +524,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
          page_revision,
          activity_revision,
          activity_type,
-         can_customize?,
-         activity_enabled?,
-         actions,
-         learning_objectives
+         learning_objectives,
+         opts
        ) do
     %{
       sectionSlug: section_slug,
@@ -419,22 +539,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       title: activity_revision.title,
       points: Grading.determine_activity_out_of(activity_revision),
       learningObjectives: learning_objectives,
-      canCustomize: can_customize?,
-      actions: actions,
+      canCustomize: Keyword.get(opts, :can_customize?, false),
+      actions: Keyword.get(opts, :actions, []),
       # Visual removed treatment is context-specific. Preview page cards use it so excluded
       # embedded activities are obvious in-place, while other surfaces can omit it and still
       # reuse the same Remove/Restore action contract.
-      visualState: if(activity_enabled?, do: "default", else: "removed"),
-      statusPill: if(activity_enabled?, do: nil, else: %{kind: "removed", label: "Removed"}),
-      # Preview page components emit a generic customization target back to whatever LiveView owns
-      # them. On this surface we only expect page-level targets such as embedded activities and,
-      # in future activity-bank rendering, whole bank selections. Candidate-level targets belong
-      # to the separate bank selection manager LiveView, not to the page preview.
-      customizationTarget: %{
-        kind: "embedded_activity",
-        pageResourceId: page_revision.resource_id,
-        activityResourceId: activity_revision.resource_id
-      }
+      visualState: Keyword.get(opts, :visual_state, "default"),
+      statusPill: Keyword.get(opts, :status_pill),
+      customizationTarget: Keyword.get(opts, :customization_target)
     }
   end
 

--- a/lib/oli_web/delivery/instructor/preview_routes.ex
+++ b/lib/oli_web/delivery/instructor/preview_routes.ex
@@ -29,6 +29,15 @@ defmodule OliWeb.Delivery.Instructor.PreviewRoutes do
   def page_path(section_slug, revision_slug, params),
     do: ~p"/sections/#{section_slug}/preview/page/#{revision_slug}?#{params}"
 
+  def selection_path(section_slug, revision_slug, selection_id, params \\ [])
+
+  def selection_path(section_slug, revision_slug, selection_id, params) when params in [[], %{}],
+    do: ~p"/sections/#{section_slug}/preview/lesson/#{revision_slug}/selection/#{selection_id}"
+
+  def selection_path(section_slug, revision_slug, selection_id, params),
+    do:
+      ~p"/sections/#{section_slug}/preview/lesson/#{revision_slug}/selection/#{selection_id}?#{params}"
+
   def container_path(section_slug, revision_slug, params \\ [])
 
   def container_path(section_slug, revision_slug, params) when params in [[], %{}],

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -148,26 +148,16 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   end
 
   def handle_event("toggle_all_candidate_checkboxes", _params, socket) do
+    visible_candidate_ids = visible_candidate_ids(socket.assigns.candidates)
+
     checked_candidate_ids =
       if all_visible_candidates_checked?(
            socket.assigns.candidates,
            socket.assigns.checked_candidate_ids
          ) do
-        Enum.reduce(
-          visible_candidate_ids(socket.assigns.candidates),
-          socket.assigns.checked_candidate_ids,
-          fn id, acc ->
-            MapSet.delete(acc, id)
-          end
-        )
+        MapSet.new()
       else
-        Enum.reduce(
-          visible_candidate_ids(socket.assigns.candidates),
-          socket.assigns.checked_candidate_ids,
-          fn id, acc ->
-            MapSet.put(acc, id)
-          end
-        )
+        MapSet.new(visible_candidate_ids)
       end
 
     {:noreply, assign(socket, :checked_candidate_ids, checked_candidate_ids)}

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -1,0 +1,140 @@
+defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
+  use OliWeb, :live_view
+
+  alias Oli.Delivery.InstructorCustomizations
+  alias OliWeb.Components.Delivery.Layouts
+  alias OliWeb.Delivery.Instructor.{PreviewReturn, PreviewRoutes}
+
+  def mount(
+        %{"revision_slug" => revision_slug, "selection_id" => selection_id} = params,
+        _session,
+        socket
+      ) do
+    section = socket.assigns.section
+    navigation_params = navigation_params(params, section.slug)
+
+    case InstructorCustomizations.resolve_bank_selection_preview_target(
+           section,
+           revision_slug,
+           selection_id
+         ) do
+      {:error, {:not_found, :page}} ->
+        {:ok, redirect(socket, to: PreviewRoutes.learn_path(section.slug, navigation_params))}
+
+      {:error, {:invalid_page_type, :adaptive}} ->
+        {:ok,
+         redirect(
+           socket,
+           to:
+             PreviewRoutes.page_path(
+               section.slug,
+               revision_slug,
+               adaptive_redirect_params(params)
+             )
+         )}
+
+      {:error, {:not_found, :selection}} ->
+        {:ok,
+         socket
+         |> put_flash(:error, "We couldn’t find that activity bank selection for this page.")
+         |> redirect(
+           to: PreviewRoutes.lesson_path(section.slug, revision_slug, navigation_params)
+         )}
+
+      {:ok, revision, selection} ->
+        {:ok,
+         socket
+         |> assign(
+           page_revision: revision,
+           current_page_resource_id: revision.resource_id,
+           selection: selection,
+           selection_id: selection_id,
+           navigation_params: navigation_params,
+           request_path: PreviewRoutes.lesson_path(section.slug, revision.slug, navigation_params)
+         )}
+
+      {:error, _reason} ->
+        {:ok,
+         socket
+         |> put_flash(:error, "Unable to open this activity bank manager.")
+         |> redirect(
+           to: PreviewRoutes.lesson_path(section.slug, revision_slug, navigation_params)
+         )}
+    end
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id="bank-selection-manager" data-preview-mode={@preview_mode}>
+      <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
+      <Layouts.header
+        ctx={@ctx}
+        is_admin={@is_admin}
+        section={@section}
+        preview_mode={@preview_mode}
+        sidebar_expanded={true}
+        instructor_preview_return={@instructor_preview_return}
+        include_logo
+      />
+
+      <div class="flex-1 flex flex-col w-full">
+        <div class="flex-1 mt-4 sm:mt-20 px-4 sm:px-[80px] relative">
+          <div class="container mx-auto max-w-[1200px] pb-20 pt-6">
+            <div class="rounded-lg border border-Border-border-default bg-Surface-surface-primary p-6">
+              <h1 class="text-2xl font-semibold text-Text-text-high">Manage Questions</h1>
+              <p class="mt-2 text-sm text-Text-text-low">
+                Selection manager route initialized for selection <span class="font-semibold">{@selection_id}</span>.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  defp navigation_params(params, section_slug) do
+    %{}
+    |> maybe_put_sanitized_navigation_param("return_to", params["return_to"], section_slug)
+    |> maybe_put_sanitized_navigation_param("request_path", params["request_path"], section_slug)
+  end
+
+  defp adaptive_redirect_params(params) do
+    section_slug = params["section_slug"]
+
+    []
+    |> maybe_put_adaptive_redirect_param(:return_to, params["return_to"], section_slug)
+    |> maybe_put_adaptive_redirect_param(:request_path, params["request_path"], section_slug)
+  end
+
+  defp maybe_put_sanitized_navigation_param(navigation_params, _key, value, _section_slug)
+       when value in [nil, ""] do
+    navigation_params
+  end
+
+  defp maybe_put_sanitized_navigation_param(navigation_params, key, value, section_slug)
+       when is_binary(value) do
+    case PreviewReturn.sanitize_return_to(value, section_slug) do
+      ^value -> Map.put(navigation_params, key, value)
+      _fallback -> navigation_params
+    end
+  end
+
+  defp maybe_put_sanitized_navigation_param(navigation_params, _key, _value, _section_slug),
+    do: navigation_params
+
+  defp maybe_put_adaptive_redirect_param(params, _key, value, _section_slug)
+       when value in [nil, ""] do
+    params
+  end
+
+  defp maybe_put_adaptive_redirect_param(params, key, value, section_slug)
+       when is_binary(value) and is_binary(section_slug) do
+    case PreviewReturn.sanitize_return_to(value, section_slug) do
+      ^value -> Keyword.put(params, key, value)
+      _fallback -> params
+    end
+  end
+
+  defp maybe_put_adaptive_redirect_param(params, _key, _value, _section_slug), do: params
+end

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -1,9 +1,18 @@
 defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   use OliWeb, :live_view
 
+  alias Oli.Activities
   alias Oli.Delivery.InstructorCustomizations
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Publishing.DeliveryResolver, as: Resolver
+  alias Oli.Resources.Revision
+  alias OliWeb.Delivery.Instructor.PreviewPageContext
   alias OliWeb.Components.Delivery.Layouts
   alias OliWeb.Delivery.Instructor.{PreviewReturn, PreviewRoutes}
+  alias OliWeb.Icons
+  alias OliWeb.ManualGrading.RenderedActivity
+
+  @candidate_row_limit 25
 
   def mount(
         %{"revision_slug" => revision_slug, "selection_id" => selection_id} = params,
@@ -42,16 +51,48 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
          )}
 
       {:ok, revision, selection} ->
-        {:ok,
-         socket
-         |> assign(
-           page_revision: revision,
-           current_page_resource_id: revision.resource_id,
-           selection: selection,
-           selection_id: selection_id,
-           navigation_params: navigation_params,
-           request_path: PreviewRoutes.lesson_path(section.slug, revision.slug, navigation_params)
-         )}
+        sidebar_expanded = preview_sidebar_state(params)
+
+        candidate_surface_script_sources_by_activity_type_id =
+          candidate_surface_script_sources_by_activity_type_id()
+
+        case load_candidates(section, revision, selection) do
+          {:ok, candidate_page} ->
+            preview_script_sources =
+              candidate_surface_script_sources_for_selection(
+                section,
+                revision,
+                selection,
+                candidate_page.total_count,
+                candidate_surface_script_sources_by_activity_type_id
+              )
+
+            {:ok,
+             socket
+             |> assign(
+               page_revision: revision,
+               current_page_resource_id: revision.resource_id,
+               selection: selection,
+               selection_id: selection_id,
+               selection_points_per_question: selection_points_per_question(selection),
+               selection_criteria_rows: selection_criteria_rows(section.slug, selection),
+               navigation_params: navigation_params,
+               sidebar_expanded: sidebar_expanded,
+               request_path: local_back_path(section.slug, revision.slug, navigation_params),
+               selected_candidate_preview_html: nil,
+               preview_script_sources: preview_script_sources
+             )
+             |> assign_candidate_page(candidate_page)
+             |> assign_selected_candidate_preview(), layout: false}
+
+          {:error, _reason} ->
+            {:ok,
+             socket
+             |> put_flash(:error, "Unable to load questions for this activity bank.")
+             |> redirect(
+               to: PreviewRoutes.lesson_path(section.slug, revision.slug, navigation_params)
+             )}
+        end
 
       {:error, _reason} ->
         {:ok,
@@ -63,34 +104,692 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     end
   end
 
+  def handle_event("select_candidate", %{"activity_resource_id" => activity_resource_id}, socket) do
+    selected_candidate_id = parse_integer(activity_resource_id)
+
+    cond do
+      selected_candidate_id == socket.assigns.selected_candidate_id ->
+        {:noreply, socket}
+
+      Enum.any?(socket.assigns.candidates, &(&1.activity_resource_id == selected_candidate_id)) ->
+        {:noreply,
+         socket
+         |> assign(:selected_candidate_id, selected_candidate_id)
+         |> assign_selected_candidate_preview()}
+
+      true ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event(
+        "toggle_candidate_checkbox",
+        %{"activity_resource_id" => activity_resource_id},
+        socket
+      ) do
+    candidate_id = parse_integer(activity_resource_id)
+
+    if Enum.any?(socket.assigns.candidates, &(&1.activity_resource_id == candidate_id)) do
+      {:noreply,
+       update(
+         socket,
+         :checked_candidate_ids,
+         &toggle_checked_candidate_id(&1, candidate_id)
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("toggle_all_candidate_checkboxes", _params, socket) do
+    checked_candidate_ids =
+      if all_visible_candidates_checked?(
+           socket.assigns.candidates,
+           socket.assigns.checked_candidate_ids
+         ) do
+        Enum.reduce(
+          visible_candidate_ids(socket.assigns.candidates),
+          socket.assigns.checked_candidate_ids,
+          fn id, acc ->
+            MapSet.delete(acc, id)
+          end
+        )
+      else
+        Enum.reduce(
+          visible_candidate_ids(socket.assigns.candidates),
+          socket.assigns.checked_candidate_ids,
+          fn id, acc ->
+            MapSet.put(acc, id)
+          end
+        )
+      end
+
+    {:noreply, assign(socket, :checked_candidate_ids, checked_candidate_ids)}
+  end
+
+  def handle_event(
+        "load_more_candidates",
+        _params,
+        %{assigns: %{has_more_candidates?: false}} = socket
+      ) do
+    {:noreply, socket}
+  end
+
+  def handle_event("load_more_candidates", _params, socket) do
+    %{
+      section: section,
+      page_revision: page_revision,
+      selection: selection,
+      candidate_offset: candidate_offset
+    } = socket.assigns
+
+    case load_candidates(section, page_revision, selection, offset: candidate_offset) do
+      {:ok, candidate_page} ->
+        {:noreply, append_candidate_page(socket, candidate_page)}
+
+      {:error, _reason} ->
+        {:noreply,
+         put_flash(socket, :error, "Unable to load more questions for this activity bank.")}
+    end
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
+        %{
+          "action" => action,
+          "target" => %{
+            "kind" => "bank_candidate",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => selection_id,
+            "activityResourceId" => activity_resource_id
+          }
+        },
+        socket
+      ) do
+    section = socket.assigns.section
+    actor = socket.assigns.current_user
+
+    target = %{
+      kind: "bank_candidate",
+      pageResourceId: page_resource_id,
+      selectionId: selection_id,
+      activityResourceId: activity_resource_id
+    }
+
+    current_page_resource_id = socket.assigns.current_page_resource_id
+    current_selection_id = socket.assigns.selection_id
+
+    valid_activity_ids =
+      MapSet.new(Enum.map(socket.assigns.candidates, & &1.activity_resource_id))
+
+    result =
+      cond do
+        page_resource_id != current_page_resource_id ->
+          {:error, :invalid_page_target}
+
+        selection_id != current_selection_id ->
+          {:error, :invalid_selection_target}
+
+        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
+          {:error, :invalid_activity_target}
+
+        true ->
+          case action do
+            "remove" ->
+              InstructorCustomizations.exclude_bank_candidate(
+                section,
+                page_resource_id,
+                selection_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            "restore" ->
+              InstructorCustomizations.restore_bank_candidate(
+                section,
+                page_resource_id,
+                selection_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            _ ->
+              {:error, {:invalid_action, action}}
+          end
+      end
+
+    case result do
+      {:ok, _exclusion_view} ->
+        active_available_count =
+          if action == "remove" do
+            max(socket.assigns.active_available_count - 1, 0)
+          else
+            socket.assigns.active_available_count + 1
+          end
+
+        candidates =
+          update_candidate_customization_state(
+            socket.assigns.candidates,
+            activity_resource_id,
+            action,
+            active_available_count,
+            socket.assigns.selection_count
+          )
+
+        reply = %{
+          ok: true,
+          target: target,
+          activityResourceId: activity_resource_id,
+          visualState: "default",
+          statusPill: nil,
+          actions:
+            if(action == "remove",
+              do: [%{kind: "restore", label: "Restore"}],
+              else: [%{kind: "remove", label: "Remove"}]
+            )
+        }
+
+        socket =
+          socket
+          |> assign(:candidates, candidates)
+          |> assign(:active_available_count, active_available_count)
+          |> maybe_refresh_selected_candidate_preview(activity_resource_id)
+          |> put_flash(
+            :info,
+            if(action == "remove",
+              do: "Question removed from this activity bank selection.",
+              else: "Question restored to this activity bank selection."
+            )
+          )
+
+        {:reply, reply, socket}
+
+      {:error, {:unauthorized, :customize_section}} ->
+        reply = %{ok: false, target: target}
+
+        socket =
+          put_flash(socket, :error, "You are not allowed to customize this activity bank.")
+
+        {:reply, reply, socket}
+
+      {:error, :invalid_page_target} ->
+        reply = %{ok: false, target: target}
+
+        socket =
+          put_flash(
+            socket,
+            :error,
+            "Unable to update a question outside this activity bank manager."
+          )
+
+        {:reply, reply, socket}
+
+      {:error, :invalid_selection_target} ->
+        reply = %{ok: false, target: target}
+
+        socket =
+          put_flash(
+            socket,
+            :error,
+            "Unable to update a question outside the current activity bank selection."
+          )
+
+        {:reply, reply, socket}
+
+      {:error, :invalid_activity_target} ->
+        reply = %{ok: false, target: target}
+
+        socket =
+          put_flash(socket, :error, "Unable to update a question that is not in this list.")
+
+        {:reply, reply, socket}
+
+      {:error, _reason} ->
+        reply = %{ok: false, target: target}
+
+        socket = put_flash(socket, :error, "Unable to update this activity bank question.")
+
+        {:reply, reply, socket}
+    end
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
+        %{"action" => _action, "target" => %{"kind" => unsupported_kind}},
+        socket
+      ) do
+    reply = %{ok: false, target: %{kind: unsupported_kind}}
+
+    socket =
+      put_flash(
+        socket,
+        :error,
+        "Unsupported customization target #{unsupported_kind} for this activity bank manager."
+      )
+
+    {:reply, reply, socket}
+  end
+
   def render(assigns) do
     ~H"""
-    <div id="bank-selection-manager" data-preview-mode={@preview_mode}>
+    <div
+      id="bank-selection-manager"
+      data-preview-mode={@preview_mode}
+      class="bg-Surface-surface-primary"
+    >
+      <script>
+        window.userToken = "<%= @user_token %>";
+      </script>
+
       <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
       <Layouts.header
         ctx={@ctx}
         is_admin={@is_admin}
         section={@section}
         preview_mode={@preview_mode}
-        sidebar_expanded={true}
+        sidebar_expanded={@sidebar_expanded}
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
+      <div id="flash_container" class="container mx-auto sticky top-[8.5rem] z-[55] px-4">
+        <.preview_flash_group flash={@flash} />
+      </div>
 
+      <div id="bank-selection-customization-bridge" phx-hook="InstructorPreviewCustomization"></div>
+      <div
+        id="bank-selection-preview-script-loader"
+        phx-hook="LoadSurveyScripts"
+        data-preview-activity-bridge="true"
+        data-script-sources={Jason.encode!(@preview_script_sources || [])}
+      >
+      </div>
       <div class="flex-1 flex flex-col w-full">
         <div class="flex-1 mt-4 sm:mt-20 px-4 sm:px-[80px] relative">
-          <div class="container mx-auto max-w-[1200px] pb-20 pt-6">
-            <div class="rounded-lg border border-Border-border-default bg-Surface-surface-primary p-6">
-              <h1 class="text-2xl font-semibold text-Text-text-high">Manage Questions</h1>
-              <p class="mt-2 text-sm text-Text-text-low">
-                Selection manager route initialized for selection <span class="font-semibold">{@selection_id}</span>.
-              </p>
+          <div class="container mx-auto max-w-[1240px] pb-20 pt-6">
+            <.local_back_nav request_path={@request_path} />
+
+            <div class="mt-8">
+              <header>
+                <h1 class="text-2xl font-bold leading-8 text-Text-text-high">
+                  Activity Bank Selection
+                </h1>
+                <p class="mt-4 text-base font-bold leading-4 text-Text-text-high">
+                  <span id="active-available-count">{@active_available_count}</span>
+                  questions available
+                </p>
+
+                <div class="mt-6 flex flex-wrap items-center gap-x-8 gap-y-2 text-sm leading-4 text-Text-text-high">
+                  <div class="flex items-center gap-1">
+                    <span class="font-bold text-Text-text-high">Selects:</span>
+                    <span id="questions-required-count">
+                      {@selection_count} {if @selection_count == 1,
+                        do: "question",
+                        else: "questions"}
+                    </span>
+                  </div>
+                  <div class="flex items-center gap-1">
+                    <span class="font-bold text-Text-text-high">Points per question:</span>
+                    <span>{@selection_points_per_question}</span>
+                  </div>
+                </div>
+
+                <div class="mt-5 space-y-2.5 text-sm leading-4 text-Text-text-low">
+                  <div class="font-bold text-Text-text-high">Selection criteria:</div>
+                  <div :for={row <- @selection_criteria_rows} class="space-y-2">
+                    <div class="text-Text-text-low-alpha text-sm font-bold leading-4">
+                      {row.label}
+                    </div>
+                    <div class="bg-Specially-Tokens-Fill-fill-input-focused rounded-md px-2.5 py-2 text-Text-text-high text-base font-semibold leading-6">
+                      {row.value}
+                    </div>
+                  </div>
+                </div>
+              </header>
+
+              <div class="mt-10">
+                <div class="mt-4 text-sm font-normaltext-gray-500 leading-5">
+                  Showing {length(@candidates)} of {@total_candidate_count} questions
+                </div>
+
+                <div class="mt-2 grid xl:grid-cols-[420px_minmax(0,1fr)]">
+                  <div
+                    id="candidate-list"
+                    role="listbox"
+                    aria-label="Candidate questions"
+                    class="min-w-0 border-t border-Border-border-default"
+                  >
+                    <div class="grid grid-cols-[28px_minmax(0,1fr)] shrink-0 items-center gap-2 border-b border-Table-table-border bg-Table-table-top-row p-2.5 h-12 text-Text-text-high text-base font-semibold">
+                      <input
+                        id="candidate-list-header-checkbox"
+                        type="checkbox"
+                        aria-label="Select all visible questions"
+                        checked={all_visible_candidates_checked?(@candidates, @checked_candidate_ids)}
+                        phx-click="toggle_all_candidate_checkboxes"
+                        class="h-4 w-4 rounded-[2px] border-Border-border-default text-Fill-Buttons-fill-primary focus:ring-Fill-Buttons-fill-primary"
+                      />
+                      <span>Question</span>
+                    </div>
+
+                    <div class="flex flex-col h-[calc(100vh-300px)] overflow-scroll">
+                      <div
+                        :for={candidate <- @candidates}
+                        id={"candidate-row-#{candidate.activity_resource_id}"}
+                        role="option"
+                        aria-selected={candidate_selected?(candidate, @selected_candidate_id)}
+                        data-candidate-enabled={to_string(candidate.enabled?)}
+                        class={candidate_row_classes(candidate, @selected_candidate_id)}
+                      >
+                        <input
+                          id={"candidate-checkbox-#{candidate.activity_resource_id}"}
+                          type="checkbox"
+                          aria-label={"Select #{candidate.title}"}
+                          checked={candidate_checked?(candidate, @checked_candidate_ids)}
+                          phx-click="toggle_candidate_checkbox"
+                          phx-value-activity_resource_id={candidate.activity_resource_id}
+                          class="h-4 w-4 rounded-[2px] border-Border-border-default text-Fill-Buttons-fill-primary focus:ring-Fill-Buttons-fill-primary"
+                        />
+                        <button
+                          id={"candidate-select-#{candidate.activity_resource_id}"}
+                          type="button"
+                          phx-click="select_candidate"
+                          phx-value-activity_resource_id={candidate.activity_resource_id}
+                          class="min-w-0 text-left"
+                        >
+                          <div class="truncate text-base font-medium text-Text-text-high">
+                            {candidate.title}
+                          </div>
+                          <div
+                            :if={!candidate.enabled?}
+                            class="mt-2.5 inline-flex items-center rounded-full border border-Border-border-danger bg-Fill-fill-danger px-3 text-sm font-normal text-Text-text-danger"
+                          >
+                            Removed
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+
+                    <div
+                      :if={remaining_candidate_count(@total_candidate_count, @candidates) > 0}
+                      class="px-4 py-3"
+                    >
+                      <button
+                        id="load-more-candidates"
+                        type="button"
+                        phx-click="load_more_candidates"
+                        class="inline-flex cursor-pointer rounded-md px-6 py-2 text-sm font-semibold text-Text-text-button transition hover:text-Text-text-button-hover"
+                      >
+                        Load {min(
+                          remaining_candidate_count(@total_candidate_count, @candidates),
+                          @candidate_limit
+                        )} more ({remaining_candidate_count(@total_candidate_count, @candidates)} remaining)
+                      </button>
+                    </div>
+                  </div>
+
+                  <%= if candidate = selected_candidate(@candidates, @selected_candidate_id) do %>
+                    <%= if @selected_candidate_preview_html do %>
+                      <div
+                        id={"selected-candidate-preview-shell-#{candidate.activity_resource_id}"}
+                        phx-update="ignore"
+                        class="-mt-5 ml-1"
+                      >
+                        <RenderedActivity.render
+                          id={"selected-candidate-preview-#{candidate.activity_resource_id}"}
+                          rendered_activity={@selected_candidate_preview_html}
+                        />
+                      </div>
+                    <% else %>
+                      <div class="rounded-lg border border-dashed border-Border-border-default bg-Surface-surface-secondary-hover px-6 py-12 text-center text-sm text-Text-text-low">
+                        We couldn’t render a preview for this question right now.
+                      </div>
+                    <% end %>
+                  <% else %>
+                    <div class="rounded-lg border border-dashed border-Border-border-default bg-Surface-surface-secondary-hover px-6 py-12 text-center text-sm text-Text-text-low">
+                      No matching questions are currently available for this activity bank selection.
+                    </div>
+                  <% end %>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
     """
+  end
+
+  attr :request_path, :string, required: true
+
+  defp local_back_nav(assigns) do
+    ~H"""
+    <div class="inline-flex">
+      <.link
+        href={@request_path}
+        class="inline-flex items-center gap-1.5 text-xs font-semibold text-Text-text-low transition hover:text-Text-text-high"
+      >
+        <Icons.back_arrow class="h-3.5 w-3.5 [&>path]:stroke-current" />
+        <span>Back</span>
+      </.link>
+    </div>
+    """
+  end
+
+  defp assign_candidate_page(socket, candidate_page) do
+    candidates = candidate_page.candidates
+
+    socket
+    |> assign(
+      candidates: candidates,
+      checked_candidate_ids: MapSet.new(),
+      selection_count: candidate_page.count,
+      active_available_count: candidate_page.active_count,
+      total_candidate_count: candidate_page.total_count,
+      candidate_offset: length(candidates),
+      candidate_limit: candidate_page.limit,
+      has_more_candidates?: candidate_page.has_more?,
+      selected_candidate_id: default_selected_candidate_id(candidates)
+    )
+  end
+
+  defp append_candidate_page(socket, candidate_page) do
+    candidates =
+      socket.assigns.candidates ++
+        Enum.reject(candidate_page.candidates, fn appended ->
+          Enum.any?(
+            socket.assigns.candidates,
+            &(&1.activity_resource_id == appended.activity_resource_id)
+          )
+        end)
+
+    socket
+    |> assign(
+      candidates: candidates,
+      checked_candidate_ids:
+        normalize_checked_candidate_ids(candidates, socket.assigns.checked_candidate_ids),
+      selection_count: candidate_page.count,
+      active_available_count: candidate_page.active_count,
+      total_candidate_count: candidate_page.total_count,
+      candidate_offset: length(candidates),
+      candidate_limit: candidate_page.limit,
+      has_more_candidates?: candidate_page.has_more?,
+      selected_candidate_id:
+        socket.assigns.selected_candidate_id || default_selected_candidate_id(candidates)
+    )
+  end
+
+  defp load_candidates(%Section{} = section, %Revision{} = page_revision, selection, opts \\ []) do
+    InstructorCustomizations.list_bank_selection_candidates(
+      section,
+      page_revision,
+      selection,
+      Keyword.put_new(opts, :limit, @candidate_row_limit)
+    )
+  end
+
+  defp default_selected_candidate_id([candidate | _]), do: candidate.activity_resource_id
+  defp default_selected_candidate_id([]), do: nil
+
+  defp assign_selected_candidate_preview(socket) do
+    case selected_candidate(socket.assigns.candidates, socket.assigns.selected_candidate_id) do
+      nil ->
+        assign(socket, :selected_candidate_preview_html, nil)
+
+      candidate ->
+        with %Revision{} = activity_revision <-
+               Resolver.from_resource_id(
+                 socket.assigns.section.slug,
+                 candidate.activity_resource_id
+               ),
+             {:ok, %{html: html}} <-
+               PreviewPageContext.build_bank_candidate_preview(
+                 socket.assigns.section,
+                 socket.assigns.page_revision,
+                 activity_revision,
+                 selection_id: socket.assigns.selection_id,
+                 can_customize?: true,
+                 actions: candidate_preview_actions(candidate)
+               ) do
+          assign(socket, :selected_candidate_preview_html, html)
+        else
+          _ ->
+            assign(socket, :selected_candidate_preview_html, nil)
+        end
+    end
+  end
+
+  # The preview card updates its button immediately from the LiveView reply, but the
+  # server-side HTML for the currently selected candidate must stay in sync as well.
+  # Otherwise any later patch/remount (for example, after clearing a flash) can recreate
+  # the selected preview from stale HTML and revert Remove/Restore locally.
+  defp maybe_refresh_selected_candidate_preview(socket, activity_resource_id)
+       when socket.assigns.selected_candidate_id == activity_resource_id do
+    assign_selected_candidate_preview(socket)
+  end
+
+  defp maybe_refresh_selected_candidate_preview(socket, _activity_resource_id), do: socket
+
+  defp candidate_preview_actions(candidate) do
+    if candidate.enabled? do
+      [%{kind: "remove", label: "Remove"}]
+    else
+      [%{kind: "restore", label: "Restore"}]
+    end
+  end
+
+  # Each activity type contributes whichever script the instructor-preview surface actually
+  # needs: preview JS for types with dedicated preview support, or authoring JS for the
+  # fallback path used by activity types that are not yet preview-capable (see Oli.Activities.preview_supported_activity_slug?).
+  defp candidate_surface_script_sources_by_activity_type_id do
+    Activities.list_activity_registrations()
+    |> Enum.reduce(%{}, fn activity_type, acc ->
+      case PreviewPageContext.preview_script_for_registration(activity_type) do
+        nil -> acc
+        script -> Map.put(acc, activity_type.id, "/js/#{script}")
+      end
+    end)
+  end
+
+  defp candidate_surface_script_sources_for_selection(
+         section,
+         page_revision,
+         selection,
+         total_count,
+         script_sources_by_activity_type_id
+       ) do
+    case InstructorCustomizations.list_bank_selection_candidate_activity_type_ids(
+           section,
+           page_revision,
+           selection,
+           total_count
+         ) do
+      {:ok, activity_type_ids} ->
+        activity_type_ids
+        |> Enum.map(&Map.get(script_sources_by_activity_type_id, &1))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.uniq()
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp update_candidate_customization_state(
+         candidates,
+         activity_resource_id,
+         action,
+         active_available_count,
+         selection_count
+       ) do
+    Enum.map(candidates, fn candidate ->
+      enabled? =
+        cond do
+          candidate.activity_resource_id == activity_resource_id and action == "remove" -> false
+          candidate.activity_resource_id == activity_resource_id and action == "restore" -> true
+          true -> candidate.enabled?
+        end
+
+      %{
+        candidate
+        | enabled?: enabled?,
+          disable_allowed?: !enabled? or active_available_count > selection_count
+      }
+    end)
+  end
+
+  defp selected_candidate(candidates, selected_candidate_id) do
+    Enum.find(candidates, &(&1.activity_resource_id == selected_candidate_id))
+  end
+
+  defp toggle_checked_candidate_id(checked_candidate_ids, candidate_id) do
+    if MapSet.member?(checked_candidate_ids, candidate_id) do
+      MapSet.delete(checked_candidate_ids, candidate_id)
+    else
+      MapSet.put(checked_candidate_ids, candidate_id)
+    end
+  end
+
+  defp normalize_checked_candidate_ids(candidates, checked_candidate_ids) do
+    visible_candidate_ids = MapSet.new(visible_candidate_ids(candidates))
+
+    MapSet.intersection(checked_candidate_ids, visible_candidate_ids)
+  end
+
+  defp visible_candidate_ids(candidates) do
+    Enum.map(candidates, & &1.activity_resource_id)
+  end
+
+  defp candidate_checked?(candidate, checked_candidate_ids) do
+    MapSet.member?(checked_candidate_ids, candidate.activity_resource_id)
+  end
+
+  defp all_visible_candidates_checked?([], _checked_candidate_ids), do: false
+
+  defp all_visible_candidates_checked?(candidates, checked_candidate_ids) do
+    Enum.all?(candidates, &candidate_checked?(&1, checked_candidate_ids))
+  end
+
+  defp remaining_candidate_count(total_candidate_count, candidates) do
+    max(total_candidate_count - length(candidates), 0)
+  end
+
+  defp candidate_selected?(candidate, selected_candidate_id) do
+    candidate.activity_resource_id == selected_candidate_id
+  end
+
+  defp candidate_row_classes(candidate, selected_candidate_id) do
+    selected? = candidate_selected?(candidate, selected_candidate_id)
+
+    [
+      "grid w-full grid-cols-[28px_minmax(0,1fr)] shrink-0 items-center gap-2 border-b border-Table-table-border p-2.5 text-left transition focus:outline-none focus-visible:ring-2 focus-visible:ring-Fill-Buttons-fill-primary",
+      if(selected?,
+        do: "bg-Table-table-select",
+        else: "bg-Surface-surface-primary hover:bg-Surface-surface-secondary-hover"
+      ),
+      if(!candidate.enabled?,
+        do: "bg-Surface-surface-secondary-muted opacity-60 h-[88px]",
+        else: "h-12"
+      )
+    ]
   end
 
   defp navigation_params(params, section_slug) do
@@ -137,4 +836,210 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   end
 
   defp maybe_put_adaptive_redirect_param(params, _key, _value, _section_slug), do: params
+
+  defp local_back_path(section_slug, revision_slug, navigation_params) do
+    case Map.get(navigation_params, "request_path") do
+      path when is_binary(path) and path != "" ->
+        path
+
+      _ ->
+        PreviewRoutes.lesson_path(section_slug, revision_slug, navigation_params)
+    end
+  end
+
+  defp preview_sidebar_state(params) do
+    case Map.get(params, "sidebar_expanded") do
+      "false" ->
+        false
+
+      "true" ->
+        true
+
+      _ ->
+        case params["return_to"] || params["request_path"] do
+          path when is_binary(path) ->
+            sidebar_expanded_from_path(path)
+
+          _ ->
+            true
+        end
+    end
+  end
+
+  defp sidebar_expanded_from_path(path) when is_binary(path) do
+    case URI.parse(path) do
+      %URI{query: query} when is_binary(query) and query != "" ->
+        query_params = Plug.Conn.Query.decode(query)
+
+        case Map.get(query_params, "sidebar_expanded") do
+          "false" -> false
+          _ -> true
+        end
+
+      _ ->
+        true
+    end
+  end
+
+  defp sidebar_expanded_from_path(_), do: true
+
+  defp parse_integer(value) when is_integer(value), do: value
+
+  defp parse_integer(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} -> parsed
+      _ -> nil
+    end
+  end
+
+  defp parse_integer(_value), do: nil
+
+  # Selection-level settings come from the authored bank-selection node itself, not from the
+  # candidate activity revisions. Authoring exposes this as `pointsPerActivity`, and delivery
+  # normalizes it with the same default of 1 when the key is absent.
+  defp selection_points_per_question(%{"pointsPerActivity" => points})
+       when is_integer(points) and points > 0,
+       do: points
+
+  defp selection_points_per_question(_selection), do: 1
+
+  # Selection criteria can combine tags, learning objectives, activity type, and text expressions.
+  # We keep the summary local to this LiveView so the manager can show authored criteria without
+  # introducing a separate presentation layer just for this ticket.
+  defp selection_criteria_rows(_section_slug, %{"logic" => %{"conditions" => nil}}),
+    do: [%{label: "All questions", value: "No additional filters"}]
+
+  defp selection_criteria_rows(section_slug, %{"logic" => %{"conditions" => conditions}})
+       when is_map(conditions) do
+    title_map = selection_resource_titles(section_slug, conditions)
+    activity_type_titles = activity_type_titles()
+
+    selection_condition_rows(conditions, title_map, activity_type_titles)
+  end
+
+  defp selection_criteria_rows(_section_slug, _selection),
+    do: [%{label: "All questions", value: "No additional filters"}]
+
+  defp selection_condition_rows(
+         %{"children" => children, "operator" => operator},
+         title_map,
+         activity_type_titles
+       )
+       when is_list(children) do
+    child_rows =
+      Enum.flat_map(children, &selection_condition_rows(&1, title_map, activity_type_titles))
+
+    if child_rows == [] do
+      [%{label: "Selection logic", value: logical_operator_label(operator)}]
+    else
+      Enum.with_index(child_rows, 1)
+      |> Enum.map(fn {row, index} ->
+        %{label: "#{logical_operator_label(operator)} #{index}: #{row.label}", value: row.value}
+      end)
+    end
+  end
+
+  defp selection_condition_rows(
+         %{"fact" => fact, "operator" => operator, "value" => value},
+         title_map,
+         activity_type_titles
+       ) do
+    [
+      %{
+        label: criteria_label(fact),
+        value: criteria_value(fact, operator, value, title_map, activity_type_titles)
+      }
+    ]
+  end
+
+  defp selection_condition_rows(_conditions, _title_map, _activity_type_titles), do: []
+
+  defp selection_resource_titles(section_slug, conditions) do
+    resource_ids =
+      collect_selection_resource_ids(conditions)
+      |> Enum.uniq()
+
+    if resource_ids == [] do
+      %{}
+    else
+      # Criteria ids are authored into the published selection, so resolve them through the
+      # current section slug instead of the mutable authoring project boundary.
+      Resolver.from_resource_id(section_slug, resource_ids)
+      |> Enum.reject(&is_nil/1)
+      |> Map.new(fn revision -> {revision.resource_id, revision.title} end)
+    end
+  end
+
+  defp collect_selection_resource_ids(%{"children" => children}) when is_list(children) do
+    Enum.flat_map(children, &collect_selection_resource_ids/1)
+  end
+
+  defp collect_selection_resource_ids(%{"fact" => fact, "value" => value})
+       when fact in ["tags", "objectives"] and is_list(value),
+       do: value
+
+  defp collect_selection_resource_ids(%{"conditions" => conditions}) when is_map(conditions),
+    do: collect_selection_resource_ids(conditions)
+
+  defp collect_selection_resource_ids(_), do: []
+
+  defp activity_type_titles do
+    Activities.list_activity_registrations()
+    |> Map.new(fn registration -> {registration.id, registration.title} end)
+  end
+
+  defp criteria_label("tags"), do: "Tags:"
+  defp criteria_label("objectives"), do: "Learning objectives:"
+  defp criteria_label("type"), do: "Question type:"
+  defp criteria_label("text"), do: "Activity content:"
+  defp criteria_label(_fact), do: "Selection rule:"
+
+  defp criteria_value("tags", operator, value, title_map, _activity_type_titles),
+    do: prefixed_criteria_value(operator, map_titles(value, title_map))
+
+  defp criteria_value("objectives", operator, value, title_map, _activity_type_titles),
+    do: prefixed_criteria_value(operator, map_titles(value, title_map))
+
+  defp criteria_value("type", operator, value, _title_map, activity_type_titles),
+    do: prefixed_criteria_value(operator, map_type_titles(value, activity_type_titles))
+
+  defp criteria_value("text", operator, value, _title_map, _activity_type_titles)
+       when is_binary(value),
+       do: prefixed_criteria_value(operator, value)
+
+  defp criteria_value(_fact, operator, value, _title_map, _activity_type_titles),
+    do: prefixed_criteria_value(operator, inspect(value))
+
+  defp prefixed_criteria_value(operator, text) do
+    prefix =
+      case operator do
+        "contains" -> "Contains "
+        "does_not_contain" -> "Does not contain "
+        "equals" -> "Equals "
+        "does_not_equal" -> "Does not equal "
+        _ -> ""
+      end
+
+    prefix <> text
+  end
+
+  defp map_titles(values, title_map) when is_list(values) do
+    values
+    |> Enum.map(fn id -> Map.get(title_map, id, to_string(id)) end)
+    |> Enum.join(", ")
+  end
+
+  defp map_titles(value, _title_map), do: to_string(value)
+
+  defp map_type_titles(values, activity_type_titles) when is_list(values) do
+    values
+    |> Enum.map(fn id -> Map.get(activity_type_titles, id, to_string(id)) end)
+    |> Enum.join(", ")
+  end
+
+  defp map_type_titles(value, _activity_type_titles), do: to_string(value)
+
+  defp logical_operator_label("all"), do: "All of"
+  defp logical_operator_label("any"), do: "Any of"
+  defp logical_operator_label(_operator), do: "Selection logic"
 end

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -1,11 +1,13 @@
 defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   use OliWeb, :live_view
 
+  alias Phoenix.LiveView.JS
   alias Oli.Activities
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Resources.Revision
+  alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.PreviewPageContext
   alias OliWeb.Components.Delivery.Layouts
   alias OliWeb.Delivery.Instructor.{PreviewReturn, PreviewRoutes}
@@ -79,6 +81,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
+               invalid_remove_warning: nil,
                selected_candidate_preview_html: nil,
                preview_script_sources: preview_script_sources
              )
@@ -167,6 +170,52 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     {:noreply, assign(socket, :checked_candidate_ids, checked_candidate_ids)}
   end
 
+  def handle_event("dismiss_invalid_remove_warning", _params, socket) do
+    socket =
+      case socket.assigns.invalid_remove_warning do
+        %{target: target} ->
+          # The React preview card sets a local "Updating..." state before the mutation round-trip.
+          # Dismissing this modal is a failed/remove-aborted outcome, so we push a synthetic reply
+          # back through the preview bridge to clear that client-only pending state.
+          push_event(socket, "preview_customization_reply", %{ok: false, target: target})
+
+        _ ->
+          socket
+      end
+
+    {:noreply, assign(socket, :invalid_remove_warning, nil)}
+  end
+
+  def handle_event("confirm_remove_bank", _params, socket) do
+    %{
+      section: section,
+      current_page_resource_id: page_resource_id,
+      selection_id: selection_id,
+      request_path: request_path,
+      current_user: actor
+    } = socket.assigns
+
+    case InstructorCustomizations.exclude_bank_selection(
+           section,
+           page_resource_id,
+           selection_id,
+           actor: actor
+         ) do
+      {:ok, _view} ->
+        {:noreply,
+         socket
+         |> assign(:invalid_remove_warning, nil)
+         |> put_flash(:info, "Activity bank selection removed from this page.")
+         |> redirect(to: request_path)}
+
+      {:error, _reason} ->
+        {:noreply,
+         socket
+         |> assign(:invalid_remove_warning, nil)
+         |> put_flash(:error, "Unable to remove this activity bank selection.")}
+    end
+  end
+
   def handle_event(
         "load_more_candidates",
         _params,
@@ -206,9 +255,6 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         },
         socket
       ) do
-    section = socket.assigns.section
-    actor = socket.assigns.current_user
-
     target = %{
       kind: "bank_candidate",
       pageResourceId: page_resource_id,
@@ -216,141 +262,13 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       activityResourceId: activity_resource_id
     }
 
-    current_page_resource_id = socket.assigns.current_page_resource_id
-    current_selection_id = socket.assigns.selection_id
-
-    valid_activity_ids =
-      MapSet.new(Enum.map(socket.assigns.candidates, & &1.activity_resource_id))
-
     result =
-      cond do
-        page_resource_id != current_page_resource_id ->
-          {:error, :invalid_page_target}
-
-        selection_id != current_selection_id ->
-          {:error, :invalid_selection_target}
-
-        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
-          {:error, :invalid_activity_target}
-
-        true ->
-          case action do
-            "remove" ->
-              InstructorCustomizations.exclude_bank_candidate(
-                section,
-                page_resource_id,
-                selection_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            "restore" ->
-              InstructorCustomizations.restore_bank_candidate(
-                section,
-                page_resource_id,
-                selection_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            _ ->
-              {:error, {:invalid_action, action}}
-          end
+      with :ok <- validate_bank_candidate_target(socket, target),
+           result <- run_bank_candidate_customization(socket, action, target) do
+        result
       end
 
-    case result do
-      {:ok, _exclusion_view} ->
-        active_available_count =
-          if action == "remove" do
-            max(socket.assigns.active_available_count - 1, 0)
-          else
-            socket.assigns.active_available_count + 1
-          end
-
-        candidates =
-          update_candidate_customization_state(
-            socket.assigns.candidates,
-            activity_resource_id,
-            action,
-            active_available_count,
-            socket.assigns.selection_count
-          )
-
-        reply = %{
-          ok: true,
-          target: target,
-          activityResourceId: activity_resource_id,
-          visualState: "default",
-          statusPill: nil,
-          actions:
-            if(action == "remove",
-              do: [%{kind: "restore", label: "Restore"}],
-              else: [%{kind: "remove", label: "Remove"}]
-            )
-        }
-
-        socket =
-          socket
-          |> assign(:candidates, candidates)
-          |> assign(:active_available_count, active_available_count)
-          |> maybe_refresh_selected_candidate_preview(activity_resource_id)
-          |> put_flash(
-            :info,
-            if(action == "remove",
-              do: "Question removed from this activity bank selection.",
-              else: "Question restored to this activity bank selection."
-            )
-          )
-
-        {:reply, reply, socket}
-
-      {:error, {:unauthorized, :customize_section}} ->
-        reply = %{ok: false, target: target}
-
-        socket =
-          put_flash(socket, :error, "You are not allowed to customize this activity bank.")
-
-        {:reply, reply, socket}
-
-      {:error, :invalid_page_target} ->
-        reply = %{ok: false, target: target}
-
-        socket =
-          put_flash(
-            socket,
-            :error,
-            "Unable to update a question outside this activity bank manager."
-          )
-
-        {:reply, reply, socket}
-
-      {:error, :invalid_selection_target} ->
-        reply = %{ok: false, target: target}
-
-        socket =
-          put_flash(
-            socket,
-            :error,
-            "Unable to update a question outside the current activity bank selection."
-          )
-
-        {:reply, reply, socket}
-
-      {:error, :invalid_activity_target} ->
-        reply = %{ok: false, target: target}
-
-        socket =
-          put_flash(socket, :error, "Unable to update a question that is not in this list.")
-
-        {:reply, reply, socket}
-
-      {:error, _reason} ->
-        reply = %{ok: false, target: target}
-
-        socket = put_flash(socket, :error, "Unable to update this activity bank question.")
-
-        {:reply, reply, socket}
-    end
+    handle_bank_candidate_customization_result(socket, target, action, result)
   end
 
   def handle_event(
@@ -368,6 +286,158 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       )
 
     {:reply, reply, socket}
+  end
+
+  defp validate_bank_candidate_target(socket, target) do
+    cond do
+      target.pageResourceId != socket.assigns.current_page_resource_id ->
+        {:error, :invalid_page_target}
+
+      target.selectionId != socket.assigns.selection_id ->
+        {:error, :invalid_selection_target}
+
+      not candidate_visible?(socket.assigns.candidates, target.activityResourceId) ->
+        {:error, :invalid_activity_target}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp run_bank_candidate_customization(socket, "remove", target) do
+    InstructorCustomizations.exclude_bank_candidate(
+      socket.assigns.section,
+      target.pageResourceId,
+      target.selectionId,
+      target.activityResourceId,
+      actor: socket.assigns.current_user
+    )
+  end
+
+  defp run_bank_candidate_customization(socket, "restore", target) do
+    InstructorCustomizations.restore_bank_candidate(
+      socket.assigns.section,
+      target.pageResourceId,
+      target.selectionId,
+      target.activityResourceId,
+      actor: socket.assigns.current_user
+    )
+  end
+
+  defp run_bank_candidate_customization(_socket, action, _target) do
+    {:error, {:invalid_action, action}}
+  end
+
+  defp handle_bank_candidate_customization_result(socket, target, action, {:ok, _exclusion_view}) do
+    reply = successful_bank_candidate_reply(target, action)
+
+    with {:ok, refreshed_socket} <- refresh_candidate_page(socket) do
+      {:reply, reply,
+       refreshed_socket
+       |> assign(:invalid_remove_warning, nil)
+       |> put_flash(:info, bank_candidate_success_message(action))}
+    else
+      {:error, _reason} ->
+        {:reply, %{ok: false, target: target},
+         put_flash(socket, :error, "Unable to refresh this activity bank question.")}
+    end
+  end
+
+  defp handle_bank_candidate_customization_result(
+         socket,
+         target,
+         _action,
+         {:error,
+          {:insufficient_selection_candidates,
+           %{count: count, active_candidates: active_candidates} = warning}}
+       ) do
+    candidate = selected_candidate(socket.assigns.candidates, target.activityResourceId)
+    reply = %{ok: false, target: target}
+    warning = Map.put(warning, :target, target)
+
+    {:reply, reply,
+     assign(
+       socket,
+       :invalid_remove_warning,
+       invalid_remove_warning_assigns(candidate, count, active_candidates, warning)
+     )}
+  end
+
+  defp handle_bank_candidate_customization_result(
+         socket,
+         target,
+         _action,
+         {:error, {:unauthorized, :customize_section}}
+       ) do
+    {:reply, %{ok: false, target: target},
+     put_flash(socket, :error, "You are not allowed to customize this activity bank.")}
+  end
+
+  defp handle_bank_candidate_customization_result(
+         socket,
+         target,
+         _action,
+         {:error, :invalid_page_target}
+       ) do
+    {:reply, %{ok: false, target: target},
+     put_flash(socket, :error, "Unable to update a question outside this activity bank manager.")}
+  end
+
+  defp handle_bank_candidate_customization_result(
+         socket,
+         target,
+         _action,
+         {:error, :invalid_selection_target}
+       ) do
+    {:reply, %{ok: false, target: target},
+     put_flash(
+       socket,
+       :error,
+       "Unable to update a question outside the current activity bank selection."
+     )}
+  end
+
+  defp handle_bank_candidate_customization_result(
+         socket,
+         target,
+         _action,
+         {:error, :invalid_activity_target}
+       ) do
+    {:reply, %{ok: false, target: target},
+     put_flash(socket, :error, "Unable to update a question that is not in this list.")}
+  end
+
+  defp handle_bank_candidate_customization_result(socket, target, _action, {:error, _reason}) do
+    {:reply, %{ok: false, target: target},
+     put_flash(socket, :error, "Unable to update this activity bank question.")}
+  end
+
+  defp successful_bank_candidate_reply(target, action) do
+    %{
+      ok: true,
+      target: target,
+      activityResourceId: target.activityResourceId,
+      visualState: "default",
+      statusPill: nil,
+      actions:
+        if(action == "remove",
+          do: [%{kind: "restore", label: "Restore"}],
+          else: [%{kind: "remove", label: "Remove"}]
+        )
+    }
+  end
+
+  defp bank_candidate_success_message("remove"),
+    do: "Question removed from this activity bank selection."
+
+  defp bank_candidate_success_message("restore"),
+    do: "Question restored to this activity bank selection."
+
+  defp bank_candidate_success_message(_action),
+    do: "Activity bank question updated."
+
+  defp candidate_visible?(candidates, activity_resource_id) do
+    Enum.any?(candidates, &(&1.activity_resource_id == activity_resource_id))
   end
 
   def render(assigns) do
@@ -403,6 +473,67 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         data-script-sources={Jason.encode!(@preview_script_sources || [])}
       >
       </div>
+      <Modal.modal
+        :if={@invalid_remove_warning}
+        id="invalid-remove-bank-modal"
+        show={true}
+        on_cancel={JS.push("dismiss_invalid_remove_warning")}
+        show_close={false}
+        wrapper_class="flex w-full items-center justify-center p-4 sm:p-6"
+        container_class="max-w-[673px] rounded-2xl border border-Border-border-default bg-Surface-surface-background shadow-[0px_2px_10px_0px_rgba(0,50,99,0.10)]"
+        header_class="items-start justify-between px-8 pb-0 pt-8 sm:px-16 sm:pt-16"
+        body_class="px-8 pb-8 pt-6 sm:px-16 sm:pb-16"
+        title_class="font-open-sans text-[18px] font-semibold leading-6 text-Text-text-high"
+      >
+        <:title>
+          {@invalid_remove_warning.title}
+        </:title>
+        <:header_actions>
+          <button
+            type="button"
+            class="absolute right-6 top-6 inline-flex h-5 w-5 items-center justify-center text-Icon-icon-default transition hover:text-Icon-icon-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary sm:right-6 sm:top-6"
+            phx-click={
+              Modal.hide_modal(JS.push("dismiss_invalid_remove_warning"), "invalid-remove-bank-modal")
+            }
+            aria-label="Close modal"
+          >
+            <Icons.close_sm class="h-4 w-4 stroke-current" />
+          </button>
+        </:header_actions>
+        <p class="font-open-sans text-base font-normal leading-6 text-Text-text-high">
+          This activity bank selection <strong class="font-open-sans font-bold text-Text-text-high">
+            requires {@invalid_remove_warning.count} {question_word(@invalid_remove_warning.count)}
+          </strong>, and removing this <strong class="font-open-sans font-bold text-Text-text-high">
+            would leave only {@invalid_remove_warning.active_candidates}
+          </strong>. To make changes, you can remove the entire activity bank selection.
+        </p>
+        <:custom_footer>
+          <div class="flex flex-wrap justify-end gap-4 px-8 pb-8 sm:gap-6 sm:px-16 sm:pb-16">
+            <button
+              id="invalid-remove-bank-modal-remove-bank"
+              type="button"
+              phx-click="confirm_remove_bank"
+              phx-disable-with="Removing bank..."
+              class="inline-flex items-center justify-center rounded-md border border-Border-border-bold bg-Surface-surface-background px-6 py-2 font-open-sans text-sm font-semibold leading-4 text-Specially-Tokens-Text-text-button-secondary shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] transition hover:border-Border-border-bold-hover hover:bg-Surface-surface-secondary-hover hover:text-Specially-Tokens-Text-text-button-secondary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+            >
+              Remove bank
+            </button>
+            <button
+              id="invalid-remove-bank-modal-keep-question"
+              type="button"
+              phx-click={
+                Modal.hide_modal(
+                  JS.push("dismiss_invalid_remove_warning"),
+                  "invalid-remove-bank-modal"
+                )
+              }
+              class="inline-flex items-center justify-center rounded-md bg-Fill-Buttons-fill-primary px-6 py-2 font-open-sans text-sm font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_0px_rgba(0,52,99,0.10)] transition hover:bg-Fill-Buttons-fill-primary-hover hover:text-Specially-Tokens-Text-text-button-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+            >
+              Keep question
+            </button>
+          </div>
+        </:custom_footer>
+      </Modal.modal>
       <div class="flex-1 flex flex-col w-full">
         <div class="flex-1 mt-4 sm:mt-20 px-4 sm:px-[80px] relative">
           <div class="container mx-auto max-w-[1240px] pb-20 pt-6">
@@ -626,6 +757,21 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     )
   end
 
+  defp refresh_candidate_page(socket) do
+    visible_candidate_count =
+      max(length(socket.assigns.candidates), socket.assigns.candidate_limit)
+
+    with {:ok, candidate_page} <-
+           load_candidates(
+             socket.assigns.section,
+             socket.assigns.page_revision,
+             socket.assigns.selection,
+             limit: visible_candidate_count
+           ) do
+      {:ok, replace_candidate_page(socket, candidate_page)}
+    end
+  end
+
   defp default_selected_candidate_id([candidate | _]), do: candidate.activity_resource_id
   defp default_selected_candidate_id([]), do: nil
 
@@ -656,17 +802,6 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         end
     end
   end
-
-  # The preview card updates its button immediately from the LiveView reply, but the
-  # server-side HTML for the currently selected candidate must stay in sync as well.
-  # Otherwise any later patch/remount (for example, after clearing a flash) can recreate
-  # the selected preview from stale HTML and revert Remove/Restore locally.
-  defp maybe_refresh_selected_candidate_preview(socket, activity_resource_id)
-       when socket.assigns.selected_candidate_id == activity_resource_id do
-    assign_selected_candidate_preview(socket)
-  end
-
-  defp maybe_refresh_selected_candidate_preview(socket, _activity_resource_id), do: socket
 
   defp candidate_preview_actions(candidate) do
     if candidate.enabled? do
@@ -713,31 +848,34 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     end
   end
 
-  defp update_candidate_customization_state(
-         candidates,
-         activity_resource_id,
-         action,
-         active_available_count,
-         selection_count
-       ) do
-    Enum.map(candidates, fn candidate ->
-      enabled? =
-        cond do
-          candidate.activity_resource_id == activity_resource_id and action == "remove" -> false
-          candidate.activity_resource_id == activity_resource_id and action == "restore" -> true
-          true -> candidate.enabled?
-        end
-
-      %{
-        candidate
-        | enabled?: enabled?,
-          disable_allowed?: !enabled? or active_available_count > selection_count
-      }
-    end)
-  end
-
   defp selected_candidate(candidates, selected_candidate_id) do
     Enum.find(candidates, &(&1.activity_resource_id == selected_candidate_id))
+  end
+
+  defp replace_candidate_page(socket, candidate_page) do
+    candidates = candidate_page.candidates
+
+    selected_candidate_id =
+      if Enum.any?(candidates, &(&1.activity_resource_id == socket.assigns.selected_candidate_id)) do
+        socket.assigns.selected_candidate_id
+      else
+        default_selected_candidate_id(candidates)
+      end
+
+    socket
+    |> assign(
+      candidates: candidates,
+      checked_candidate_ids:
+        normalize_checked_candidate_ids(candidates, socket.assigns.checked_candidate_ids),
+      selection_count: candidate_page.count,
+      active_available_count: candidate_page.active_count,
+      total_candidate_count: candidate_page.total_count,
+      candidate_offset: length(candidates),
+      candidate_limit: candidate_page.limit,
+      has_more_candidates?: candidate_page.has_more?,
+      selected_candidate_id: selected_candidate_id
+    )
+    |> assign_selected_candidate_preview()
   end
 
   defp toggle_checked_candidate_id(checked_candidate_ids, candidate_id) do
@@ -791,6 +929,19 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       )
     ]
   end
+
+  defp invalid_remove_warning_assigns(_candidate, count, active_candidates, warning) do
+    %{
+      warning: warning,
+      title: "Cannot remove this question",
+      count: count,
+      active_candidates: active_candidates,
+      target: Map.get(warning, :target) || Map.get(warning, "target")
+    }
+  end
+
+  defp question_word(1), do: "question"
+  defp question_word(_count), do: "questions"
 
   defp navigation_params(params, section_slug) do
     %{}

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -133,6 +133,9 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     candidate_id = parse_integer(activity_resource_id)
 
     if Enum.any?(socket.assigns.candidates, &(&1.activity_resource_id == candidate_id)) do
+      # MER-5623 adds the bulk action side effect for these checkbox selections. In MER-5622
+      # we only persist the visible checked state so the follow-up can reuse the same selection
+      # model without coupling this ticket to batch remove/restore behavior.
       {:noreply,
        update(
          socket,
@@ -578,7 +581,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
               </header>
 
               <div class="mt-10">
-                <div class="mt-4 text-sm font-normaltext-gray-500 leading-5">
+                <div class="mt-4 text-sm font-normal text-gray-500 leading-5">
                   Showing {length(@candidates)} of {@total_candidate_count} questions
                 </div>
 

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
            :sidebar_expanded,
            sidebar_expanded
          )
-         |> assign_preview_shell_state()}
+         |> assign_preview_shell_state(), layout: false}
     end
   end
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1559,6 +1559,12 @@ defmodule OliWeb.Router do
         OliWeb.LiveSessionPlugs.SetInstructorPreviewReturn
       ] do
       live("/lesson/:revision_slug", Delivery.Instructor.PreviewLessonLive, :preview)
+
+      live(
+        "/lesson/:revision_slug/selection/:selection_id",
+        Delivery.Instructor.BankSelectionManagerLive,
+        :preview
+      )
     end
 
     scope "/" do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -86,6 +86,46 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
   end
 
   describe "authorization and target validation" do
+    test "resolves preview-route bank-selection targets through the public context", context do
+      assert {:ok, page_revision, selection} =
+               InstructorCustomizations.resolve_bank_selection_preview_target(
+                 context.section,
+                 context.page_revision.slug,
+                 "selection-1"
+               )
+
+      assert page_revision.id == context.page_revision.id
+      assert selection["id"] == "selection-1"
+      assert selection["count"] == 2
+    end
+
+    test "returns page-not-found for an unknown preview revision slug", context do
+      assert {:error, {:not_found, :page}} =
+               InstructorCustomizations.resolve_bank_selection_preview_target(
+                 context.section,
+                 "missing-revision-slug",
+                 "selection-1"
+               )
+    end
+
+    test "returns adaptive-page errors for unsupported preview targets", context do
+      assert {:error, {:invalid_page_type, :adaptive}} =
+               InstructorCustomizations.resolve_bank_selection_preview_target(
+                 context.section,
+                 context.adaptive_revision.slug,
+                 "selection-1"
+               )
+    end
+
+    test "returns selection-not-found for an unknown bank selection id", context do
+      assert {:error, {:not_found, :selection}} =
+               InstructorCustomizations.resolve_bank_selection_preview_target(
+                 context.section,
+                 context.page_revision.slug,
+                 "missing-selection"
+               )
+    end
+
     test "requires an instructor or admin-equivalent actor", context do
       unauthorized_user = insert(:user)
 
@@ -463,6 +503,20 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  context.section,
                  context.page_revision.resource_id,
                  "selection-1"
+               )
+
+      assert length(candidates) == 3
+    end
+
+    test "accepts an already resolved section/page_revision/selection target", context do
+      selection = selection("selection-1", 2)
+
+      assert {:ok, %{selection_id: "selection-1", count: 2, candidates: candidates}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision,
+                 selection,
+                 []
                )
 
       assert length(candidates) == 3

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -446,6 +446,9 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                 selection_id: "selection-1",
                 count: 2,
                 selection_enabled?: false,
+                active_count: 2,
+                total_count: 3,
+                has_more?: false,
                 candidates: candidates
               }} =
                InstructorCustomizations.list_bank_selection_candidates(
@@ -486,7 +489,7 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  limit: "1"
                )
 
-      assert {:ok, %{candidates: [candidate]}} =
+      assert {:ok, %{candidates: [candidate], total_count: 3, has_more?: true, limit: 1}} =
                InstructorCustomizations.list_bank_selection_candidates(
                  context.section,
                  context.page_revision.resource_id,
@@ -498,7 +501,7 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     end
 
     test "uses a standard default page size for candidate review", context do
-      assert {:ok, %{candidates: candidates}} =
+      assert {:ok, %{candidates: candidates, total_count: 3, has_more?: false, active_count: 3}} =
                InstructorCustomizations.list_bank_selection_candidates(
                  context.section,
                  context.page_revision.resource_id,
@@ -511,7 +514,15 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     test "accepts an already resolved section/page_revision/selection target", context do
       selection = selection("selection-1", 2)
 
-      assert {:ok, %{selection_id: "selection-1", count: 2, candidates: candidates}} =
+      assert {:ok,
+              %{
+                selection_id: "selection-1",
+                count: 2,
+                active_count: 3,
+                total_count: 3,
+                has_more?: false,
+                candidates: candidates
+              }} =
                InstructorCustomizations.list_bank_selection_candidates(
                  context.section,
                  context.page_revision,
@@ -520,6 +531,24 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                )
 
       assert length(candidates) == 3
+    end
+
+    test "lists all candidate activity type ids for a resolved selection target", context do
+      selection = selection("selection-1", 2)
+
+      assert {:ok, activity_type_ids} =
+               InstructorCustomizations.list_bank_selection_candidate_activity_type_ids(
+                 context.section,
+                 context.page_revision,
+                 selection,
+                 3
+               )
+
+      assert Enum.sort(activity_type_ids) ==
+               context.candidates
+               |> Enum.map(& &1.activity_type_id)
+               |> Enum.uniq()
+               |> Enum.sort()
     end
 
     test "restores a stale candidate exclusion without requiring it to match current logic",

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -1,0 +1,134 @@
+defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.Delivery.Sections
+  alias Oli.Resources.Collaboration.CollabSpaceConfig
+  alias Oli.Seeder
+  alias OliWeb.Delivery.Instructor.PreviewRoutes
+
+  describe "bank selection manager preview route" do
+    setup [:setup_preview_section_with_selection]
+
+    test "selection_path helper points to the preview-session live route", %{
+      section: section,
+      page_revision: page_revision
+    } do
+      assert PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1") ==
+               "/sections/#{section.slug}/preview/lesson/#{page_revision.slug}/selection/selection-1"
+    end
+
+    test "authorized preview users can open the selection manager route directly", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      {:ok, _view, html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert html =~ ~s|id="instructor-preview-header"|
+      assert html =~ ~s|id="bank-selection-manager"|
+      assert html =~ "Selection manager route initialized for selection"
+      assert html =~ "selection-1"
+    end
+
+    test "invalid selection redirects safely back to lesson preview and preserves only safe navigation params",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision
+         } do
+      {:error, {:redirect, %{to: path, flash: flash}}} =
+        live(
+          conn,
+          PreviewRoutes.selection_path(section.slug, page_revision.slug, "missing-selection", %{
+            "return_to" => "/sections/#{section.slug}/remix?from=curriculum",
+            "request_path" => "https://example.com/bad"
+          })
+        )
+
+      assert path ==
+               PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+                 "return_to" => "/sections/#{section.slug}/remix?from=curriculum"
+               })
+
+      assert flash["error"] == "We couldn’t find that activity bank selection for this page."
+    end
+
+    test "learner access is redirected out of preview mode by the existing section-preview plug",
+         %{
+           section: section,
+           page_revision: page_revision
+         } do
+      learner = user_fixture(%{independent_learner: false})
+
+      enroll_user_to_section(learner, section, :context_learner)
+      cache_lti_context(section, learner)
+
+      conn = build_conn() |> log_in_user(learner)
+
+      {:error, {:redirect, %{to: path}}} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert path ==
+               "/sections/#{section.slug}/lesson/#{page_revision.slug}/selection/selection-1"
+    end
+  end
+
+  defp setup_preview_section_with_selection(%{conn: conn}) do
+    user = user_fixture(%{independent_learner: false})
+
+    map =
+      Seeder.base_project_with_resource2()
+      |> Seeder.add_page(
+        %{
+          graded: true,
+          title: "bank selection page",
+          content: %{
+            "model" => [
+              %{
+                "type" => "selection",
+                "id" => "selection-1",
+                "logic" => %{"conditions" => nil},
+                "count" => 2
+              }
+            ]
+          }
+        },
+        :container,
+        :page
+      )
+
+    {:ok, publication} =
+      Oli.Publishing.publish_project(map.project, "bank selection preview", map.author.id)
+
+    map =
+      map
+      |> Map.merge(%{publication: publication})
+      |> Seeder.create_section()
+      |> Seeder.create_section_resources()
+
+    page_section_resource = Sections.get_section_resource(map.section.id, map.page.resource.id)
+
+    {:ok, _updated_section_resource} =
+      Sections.update_section_resource(page_section_resource, %{
+        collab_space_config: %CollabSpaceConfig{status: :enabled}
+      })
+
+    enroll_user_to_section(user, map.section, :context_instructor)
+    cache_lti_context(map.section, user)
+
+    {:ok,
+     conn: log_in_user(conn, user),
+     user: user,
+     section: map.section,
+     page_revision: map.page.revision}
+  end
+
+  defp cache_lti_context(section, user) do
+    Oli.Lti.TestHelpers.all_default_claims()
+    |> put_in(["https://purl.imsglobal.org/spec/lti/claim/context", "id"], section.context_id)
+    |> cache_lti_params(user.id)
+  end
+end

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -1,11 +1,15 @@
 defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
   use OliWeb.ConnCase
 
+  import Oli.Factory
   import Phoenix.LiveViewTest
 
+  alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections
   alias Oli.Resources.Collaboration.CollabSpaceConfig
-  alias Oli.Seeder
+  alias Oli.Resources.ResourceType
+  alias OliWeb.Delivery.Instructor.PreviewPageContext
   alias OliWeb.Delivery.Instructor.PreviewRoutes
 
   describe "bank selection manager preview route" do
@@ -19,18 +23,238 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
                "/sections/#{section.slug}/preview/lesson/#{page_revision.slug}/selection/selection-1"
     end
 
-    test "authorized preview users can open the selection manager route directly", %{
-      conn: conn,
-      section: section,
-      page_revision: page_revision
-    } do
-      {:ok, _view, html} =
-        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+    test "authorized preview users can open the manager shell with counts, rows, and local back behavior",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate
+         } do
+      request_path =
+        PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+          "sidebar_expanded" => "false"
+        })
+
+      {:ok, view, html} =
+        live(
+          conn,
+          PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1", %{
+            "request_path" => request_path,
+            "return_to" => "/sections/#{section.slug}/remix?from=curriculum"
+          })
+        )
 
       assert html =~ ~s|id="instructor-preview-header"|
       assert html =~ ~s|id="bank-selection-manager"|
-      assert html =~ "Selection manager route initialized for selection"
-      assert html =~ "selection-1"
+      assert html =~ "Activity Bank Selection"
+      assert html =~ "Selection criteria"
+      assert html =~ "Points per question:"
+      assert html =~ ">4<"
+      assert has_element?(view, "#questions-required-count", "2")
+      assert has_element?(view, "#active-available-count", "30")
+      assert html =~ "All questions"
+      assert html =~ "No additional filters"
+      assert html =~ "/js/oli_multiple_choice_preview.js"
+      assert html =~ "/js/oli_check_all_that_apply_preview.js"
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{first_candidate.resource_id}"
+             )
+
+      assert has_element?(
+               view,
+               ~s{a[href="#{request_path}"]},
+               "Back"
+             )
+
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "#load-more-candidates", "Load 5 more (5 remaining)")
+    end
+
+    test "bank candidate preview helper returns preview html", %{
+      section: section,
+      page_revision: page_revision,
+      first_candidate: first_candidate
+    } do
+      assert {:ok, %{html: html}} =
+               PreviewPageContext.build_bank_candidate_preview(
+                 section,
+                 page_revision,
+                 first_candidate,
+                 selection_id: "selection-1",
+                 can_customize?: true,
+                 actions: [%{kind: "remove", label: "Remove"}]
+               )
+
+      assert html =~ first_candidate.title
+      assert html =~ "Remove"
+    end
+
+    test "removed candidate rows render removed styling and status text", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      first_candidate: first_candidate,
+      user: user
+    } do
+      assert {:ok, _view} =
+               InstructorCustomizations.exclude_bank_candidate(
+                 section,
+                 page_revision.resource_id,
+                 "selection-1",
+                 first_candidate.resource_id,
+                 actor: user
+               )
+
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert has_element?(
+               view,
+               "#candidate-row-#{first_candidate.resource_id}[data-candidate-enabled=\"false\"]",
+               "Removed"
+             )
+    end
+
+    test "selected row stays selected after loading an additional candidate page", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      second_candidate: second_candidate,
+      last_candidate: last_candidate
+    } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      refute has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+
+      view
+      |> element("#candidate-select-#{second_candidate.resource_id}")
+      |> render_click()
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{second_candidate.resource_id}"
+             )
+
+      view
+      |> element("#load-more-candidates")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{second_candidate.resource_id}"
+             )
+    end
+
+    test "candidate checkboxes toggle independently from preview selection and header checkbox toggles all visible rows",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
+      refute has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+
+      view
+      |> element("#candidate-checkbox-#{second_candidate.resource_id}")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+      assert has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
+
+      view
+      |> element("#candidate-list-header-checkbox")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-list-header-checkbox[checked]")
+      assert has_element?(view, "#candidate-checkbox-#{first_candidate.resource_id}[checked]")
+      assert has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+
+      view
+      |> element("#candidate-list-header-checkbox")
+      |> render_click()
+
+      refute has_element?(view, "#candidate-list-header-checkbox[checked]")
+      refute has_element?(view, "#candidate-checkbox-#{first_candidate.resource_id}[checked]")
+      refute has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+      assert has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
+    end
+
+    test "bank candidate customization events update exclusion state and row counts", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision,
+      first_candidate: first_candidate
+    } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      payload = %{
+        "action" => "remove",
+        "target" => %{
+          "kind" => "bank_candidate",
+          "pageResourceId" => page_revision.resource_id,
+          "selectionId" => "selection-1",
+          "activityResourceId" => first_candidate.resource_id
+        }
+      }
+
+      _reply =
+        view
+        |> element("#bank-selection-customization-bridge")
+        |> render_hook("toggle_preview_activity_customization", payload)
+
+      assert has_element?(
+               view,
+               "#candidate-row-#{first_candidate.resource_id}[data-candidate-enabled=\"false\"]",
+               "Removed"
+             )
+
+      assert has_element?(view, "#active-available-count", "29")
+
+      assert has_element?(
+               view,
+               "#flash_container",
+               "Question removed from this activity bank selection."
+             )
+
+      exclusions =
+        InstructorCustomizations.get_page_exclusions(section, page_revision.resource_id)
+
+      assert Enum.any?(exclusions, fn exclusion ->
+               exclusion.kind == :bank_candidate and
+                 exclusion.selection_id == "selection-1" and
+                 exclusion.excluded_resource_id == first_candidate.resource_id
+             end)
+
+      restore_payload = put_in(payload, ["action"], "restore")
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("toggle_preview_activity_customization", restore_payload)
+
+      assert has_element?(
+               view,
+               "#candidate-row-#{first_candidate.resource_id}[data-candidate-enabled=\"true\"]"
+             )
+
+      refute Enum.any?(
+               InstructorCustomizations.get_page_exclusions(section, page_revision.resource_id),
+               fn exclusion ->
+                 exclusion.kind == :bank_candidate and
+                   exclusion.selection_id == "selection-1" and
+                   exclusion.excluded_resource_id == first_candidate.resource_id
+               end
+             )
     end
 
     test "invalid selection redirects safely back to lesson preview and preserves only safe navigation params",
@@ -77,53 +301,98 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
   end
 
   defp setup_preview_section_with_selection(%{conn: conn}) do
-    user = user_fixture(%{independent_learner: false})
+    author = insert(:author)
+    project = insert(:project, authors: [author])
 
-    map =
-      Seeder.base_project_with_resource2()
-      |> Seeder.add_page(
-        %{
-          graded: true,
-          title: "bank selection page",
-          content: %{
-            "model" => [
-              %{
-                "type" => "selection",
-                "id" => "selection-1",
-                "logic" => %{"conditions" => nil},
-                "count" => 2
-              }
-            ]
-          }
-        },
-        :container,
-        :page
+    activity_types = [
+      Oli.Activities.get_registration_by_slug("oli_multiple_choice"),
+      Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
+    ]
+
+    candidates =
+      Enum.map(1..30, fn index ->
+        activity_type = Enum.at(activity_types, rem(index - 1, length(activity_types)))
+
+        insert(:revision,
+          resource_type_id: ResourceType.id_for_activity(),
+          activity_type_id: activity_type.id,
+          title: "Candidate #{index}",
+          scope: "banked",
+          content: %{"model" => %{"stem" => "Candidate #{index}"}}
+        )
+      end)
+
+    page_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_page(),
+        title: "bank selection page",
+        slug: "bank_selection_page_preview",
+        content: %{
+          "model" => [
+            %{
+              "type" => "selection",
+              "id" => "selection-1",
+              "logic" => %{"conditions" => nil},
+              "count" => 2,
+              "pointsPerActivity" => 4
+            }
+          ]
+        }
       )
 
-    {:ok, publication} =
-      Oli.Publishing.publish_project(map.project, "bank selection preview", map.author.id)
+    root_revision =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_container(),
+        title: "Root",
+        children: [page_revision.resource_id],
+        content: %{}
+      )
 
-    map =
-      map
-      |> Map.merge(%{publication: publication})
-      |> Seeder.create_section()
-      |> Seeder.create_section_resources()
+    revisions = [root_revision, page_revision | candidates]
 
-    page_section_resource = Sections.get_section_resource(map.section.id, map.page.resource.id)
+    Enum.each(revisions, fn revision ->
+      insert(:project_resource, project_id: project.id, resource_id: revision.resource_id)
+    end)
+
+    publication =
+      insert(:publication, project: project, root_resource_id: root_revision.resource_id)
+
+    Enum.each(revisions, fn revision ->
+      insert(:published_resource,
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      )
+    end)
+
+    section = insert(:section, base_project: project)
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    page_section_resource = Sections.get_section_resource(section.id, page_revision.resource_id)
 
     {:ok, _updated_section_resource} =
       Sections.update_section_resource(page_section_resource, %{
+        graded: true,
         collab_space_config: %CollabSpaceConfig{status: :enabled}
       })
 
-    enroll_user_to_section(user, map.section, :context_instructor)
-    cache_lti_context(map.section, user)
+    user = user_fixture(%{independent_learner: false})
+
+    Sections.enroll(user.id, section.id, [
+      ContextRoles.get_role(:context_instructor)
+    ])
+
+    cache_lti_context(section, user)
 
     {:ok,
      conn: log_in_user(conn, user),
      user: user,
-     section: map.section,
-     page_revision: map.page.revision}
+     section: section,
+     page_revision: page_revision,
+     first_candidate: hd(candidates),
+     second_candidate: Enum.at(candidates, 1),
+     last_candidate: List.last(candidates)}
   end
 
   defp cache_lti_context(section, user) do

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -257,6 +257,115 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
              )
     end
 
+    test "invalid candidate removal opens a warning modal and remove bank redirects with flash",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           user: user,
+           candidates: candidates,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate
+         } do
+      Enum.each(Enum.drop(candidates, 3), fn candidate ->
+        assert {:ok, _view} =
+                 InstructorCustomizations.exclude_bank_candidate(
+                   section,
+                   page_revision.resource_id,
+                   "selection-1",
+                   candidate.resource_id,
+                   actor: user
+                 )
+      end)
+
+      request_path =
+        PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+          "sidebar_expanded" => "false"
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1", %{
+            "request_path" => request_path
+          })
+        )
+
+      first_remove = %{
+        "action" => "remove",
+        "target" => %{
+          "kind" => "bank_candidate",
+          "pageResourceId" => page_revision.resource_id,
+          "selectionId" => "selection-1",
+          "activityResourceId" => first_candidate.resource_id
+        }
+      }
+
+      second_remove =
+        put_in(
+          first_remove,
+          ["target", "activityResourceId"],
+          second_candidate.resource_id
+        )
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("toggle_preview_activity_customization", first_remove)
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("toggle_preview_activity_customization", second_remove)
+
+      assert has_element?(
+               view,
+               "#invalid-remove-bank-modal",
+               "Cannot remove this question"
+             )
+
+      assert has_element?(
+               view,
+               "#invalid-remove-bank-modal",
+               "This activity bank selection requires 2 questions"
+             )
+
+      assert has_element?(view, "#invalid-remove-bank-modal", "would leave only 1")
+
+      assert has_element?(
+               view,
+               "#candidate-row-#{second_candidate.resource_id}[data-candidate-enabled=\"true\"]"
+             )
+
+      dismiss_html =
+        view
+        |> element("#invalid-remove-bank-modal-keep-question")
+        |> render_click()
+
+      refute dismiss_html =~ "Cannot remove this question"
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("toggle_preview_activity_customization", second_remove)
+
+      assert has_element?(view, "#invalid-remove-bank-modal-remove-bank", "Remove bank")
+      assert has_element?(view, "#invalid-remove-bank-modal-keep-question", "Keep question")
+
+      view
+      |> element("#invalid-remove-bank-modal-remove-bank")
+      |> render_click()
+
+      {path, flash} = assert_redirect(view)
+
+      assert path == request_path
+      assert flash["info"] == "Activity bank selection removed from this page."
+
+      exclusions =
+        InstructorCustomizations.get_page_exclusions(section, page_revision.resource_id)
+
+      assert Enum.any?(exclusions, fn exclusion ->
+               exclusion.kind == :bank_selection and exclusion.selection_id == "selection-1"
+             end)
+    end
+
     test "invalid selection redirects safely back to lesson preview and preserves only safe navigation params",
          %{
            conn: conn,
@@ -390,6 +499,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
      user: user,
      section: section,
      page_revision: page_revision,
+     candidates: candidates,
      first_candidate: hd(candidates),
      second_candidate: Enum.at(candidates, 1),
      last_candidate: List.last(candidates)}


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5622

## Summary

Adds the full instructor-facing bank selection manager workflow for preview mode. This delivers the dedicated selection route, the Figma-aligned management surface, preview-shell integration, candidate paging, right-panel question preview, remove/restore flows, invalid-removal warning handling, whole-bank removal, and final QA hardening across the full five-phase plan.

## What Was Added

- Added a standalone preview-session LiveView route for managing one bank selection on one preview page.
- Reused the Instructor View shell and delivery header while adding the manager-local back behavior.
- Implemented incremental candidate loading, removed-state rendering, and active-question count updates.
- Added right-panel candidate preview rendering through the existing preview activity pipeline.
- Wired preview-driven `Remove` / `Restore` actions for `bank_candidate` targets into LiveView mutations.
- Added the invalid-removal warning modal, including the whole-bank removal path and redirect back to the preview page with flash feedback.
- Fixed modal lifecycle and pending-action reply handling so warning dismissal clears React-side updating state and the modal can be reopened reliably.
- Hardened preview lesson layout behavior to avoid the transient default live layout flash on redirect.
- Added and updated targeted LiveView/component coverage plus phase execution records for phases 4 and 5.

## Validation

- `mix format`
- `mix compile`
- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
- `mix test test/oli/delivery/instructor_customizations/write_api_test.exs`
- `mix test test/oli_web/live/delivery/instructor test/oli_web/components/delivery`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- Manual browser QA against the Figma manager and modal designs, including modal reopen, dismiss paths, focus/keyboard behavior, remove/restore flows, and whole-bank removal redirect feedback

## Video


https://github.com/user-attachments/assets/f9c7dedd-0c0a-40f0-82a5-f5c895417a63

