### PR TITLE
[ENHANCEMENT] [MER-5627] Update assignment terms page - Rework

### DIFF
--- a/lib/oli_web/live/delivery/student/prologue_live.ex
+++ b/lib/oli_web/live/delivery/student/prologue_live.ex
@@ -431,11 +431,9 @@ defmodule OliWeb.Delivery.Student.PrologueLive do
   defp format_schedule_datetime(:now, _ctx), do: "Now"
 
   defp format_schedule_datetime(datetime, ctx) do
-    FormatDateTime.to_formatted_datetime(
-      datetime,
-      ctx,
-      "{WDfull}, {Mfull} {D}, {YYYY} at {h12}:{m}{am} {Z}"
-    )
+    local_datetime = FormatDateTime.convert_datetime(datetime, ctx)
+
+    "#{Timex.format!(local_datetime, "{WDfull}, {Mfull} {D}, {YYYY} at {h12}:{m} {AM}")} #{local_datetime.zone_abbr}"
   end
 
   defp format_submitted_at(nil, _ctx), do: nil

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1292,7 +1292,8 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
 
       enroll_and_mark_visited(user, section)
 
-      conn = Plug.Test.init_test_session(conn, %{browser_timezone: "America/Argentina/Buenos_Aires"})
+      conn =
+        Plug.Test.init_test_session(conn, %{browser_timezone: "America/Argentina/Buenos_Aires"})
 
       {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
 

--- a/test/oli_web/live/delivery/student/prologue_live_test.exs
+++ b/test/oli_web/live/delivery/student/prologue_live_test.exs
@@ -1287,6 +1287,21 @@ defmodule OliWeb.Delivery.Student.PrologueLiveTest do
       assert view |> element("#page_due_terms") |> render() =~ "Tuesday, November 14, 2023"
     end
 
+    test "page terms render the schedule using the user's timezone value", ctx do
+      %{conn: conn, user: user, section: section, page_2: page_2} = ctx
+
+      enroll_and_mark_visited(user, section)
+
+      conn = Plug.Test.init_test_session(conn, %{browser_timezone: "America/Argentina/Buenos_Aires"})
+
+      {:ok, view, _html} = live(conn, Utils.prologue_live_path(section.slug, page_2.slug))
+
+      html = view |> element("#page_due_terms") |> render()
+
+      assert html =~ "Available:"
+      assert html =~ "-03"
+    end
+
     test "page terms are shown correctly when page is scheduled", ctx do
       %{conn: conn, user: user, section: section, page_2: page_2} = ctx
 


### PR DESCRIPTION
[MER-5627](https://eliterate.atlassian.net/browse/MER-5627)

## Summary
Update the prologue assignment terms schedule to match the Figma date and time presentation.

### Changes

- Adjusted the schedule date rendering in PrologueLive to match the expected prologue copy
    and formatting.

- Kept the browser timezone value in the display, including the timezone suffix shown by the
    formatter.

- Preserved the existing layout and assignment terms structure.

### Verification

- mix test test/oli_web/live/delivery/student/prologue_live_test.exs:1290

[MER-5627]: https://eliterate.atlassian.net/browse/MER-5627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ