### PR TITLE
[FEATURE] [MER-5620] Activity Bank Selection Remove and Restore

### DIFF
--- a/.agents/skills/change-cleanup/SKILL.md
+++ b/.agents/skills/change-cleanup/SKILL.md
@@ -52,6 +52,18 @@ Evaluate the changed surface for the following:
 
 2. Missing or outdated specs
    - Add or update `@spec` for new or modified functions where the language conventions support it.
+   - Prefer `@spec` for:
+     - new or modified public functions
+     - callbacks and behaviour implementations
+     - shared functions called across modules
+     - logic with non-obvious inputs or return shapes
+   - Consider `@spec` for private functions only when the logic is complex enough that the type
+     contract materially improves readability or static analysis.
+   - Do not add low-value specs that only restate obvious contracts such as generic `map()`,
+     `list()`, or trivial wrappers without improving documentation or Dialyzer coverage.
+   - For Phoenix function components, prefer `attr` declarations as the primary interface contract.
+     Add `@spec` only when the component has non-trivial options or when surrounding helper
+     functions expose a meaningful contract.
    - Before using `Module.t()` in a spec, verify that the referenced module actually defines
      `@type t()` or `@opaque t()`.
    - If the module does not export `t()`, use the correct structural type instead, such as
@@ -217,6 +229,7 @@ Use this mode for a rule-by-rule walkthrough with the user before making any edi
 - Prefer module moves only when the changed function clearly conflicts with the module's purpose or creates a better domain boundary.
 - Prefer deleting unused state over preserving speculative future hooks.
 - Prefer derived state over overlapping stored state when the derivation is cheap and clear.
+- Prefer high-value specs on public or shared contracts over blanket typespec coverage on every function.
 - Prefer concise docs and comments that explain intent or contract, not line-by-line mechanics.
 - Prefer no change when evidence is weak.
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,13 @@ jobs:
         run: |
           cp oli.example.env oli.env
 
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: assets/yarn.lock
+
       - name: 💾 Restore the deps cache
         id: mix-deps-cache
         uses: actions/cache@v3
@@ -127,9 +134,11 @@ jobs:
           token: ${{ secrets.SIMON_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - name: 🔧 Configure
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.14.2"
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: assets/yarn.lock
 
       - name: 🧪 Setup BEAM toolchain
         uses: erlef/setup-beam@v1
@@ -175,9 +184,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: 🔧 Configure
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.14.2"
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: assets/yarn.lock
 
       - name: 🧪 Setup BEAM toolchain
         uses: erlef/setup-beam@v1

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "16.14.2"
+          node-version: "20"
           cache: yarn
           cache-dependency-path: assets/yarn.lock
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,9 +19,11 @@ jobs:
           persist-credentials: false
 
       - name: 🔧 Setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: "16.14.2"
+          node-version: "20"
+          cache: yarn
+          cache-dependency-path: assets/yarn.lock
 
       - name: 🔧 Configure
         run: cp oli.example.env oli.env

--- a/assets/src/apps/InstructorPreviewComponents.tsx
+++ b/assets/src/apps/InstructorPreviewComponents.tsx
@@ -1,0 +1,1 @@
+import 'components/instructor_preview/activity_bank_selection_preview/preview-entry';

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -18,11 +18,18 @@ interface SampleActivity {
   previewContext: any;
 }
 
-interface SelectionCriteria {
+interface SelectionCriteriaGroup {
+  label: string;
+  values: string[];
+}
+
+interface LegacySelectionCriteria {
   tags: string[];
   learningObjectives: string[];
   other: string[];
 }
+
+type SelectionCriteria = SelectionCriteriaGroup[] | LegacySelectionCriteria;
 
 export interface ActivityBankSelectionPreviewPayload {
   id: string;
@@ -112,6 +119,20 @@ const pluralize = (count: number, singular: string, plural: string) =>
   `${count} ${count === 1 ? singular : plural}`;
 
 const criteriaItems = (items?: string[]) => (items ?? []).filter(Boolean);
+
+const criteriaGroups = (criteria: SelectionCriteria): SelectionCriteriaGroup[] => {
+  if (Array.isArray(criteria)) {
+    return criteria
+      .map((group) => ({ label: group.label, values: criteriaItems(group.values) }))
+      .filter((group) => group.label && group.values.length > 0);
+  }
+
+  return [
+    { label: 'Tags', values: criteriaItems(criteria.tags) },
+    { label: 'Learning Objectives', values: criteriaItems(criteria.learningObjectives) },
+    { label: 'Other', values: criteriaItems(criteria.other) },
+  ].filter((group) => group.values.length > 0);
+};
 
 const labelTextClasses = 'font-open-sans text-[14px] font-bold leading-4 text-Text-text-high';
 
@@ -283,14 +304,8 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
       </div>
     ) : null;
 
-  const criteria = {
-    tags: criteriaItems(payload.criteria?.tags),
-    learningObjectives: criteriaItems(payload.criteria?.learningObjectives),
-    other: criteriaItems(payload.criteria?.other),
-  };
-
-  const hasCriteria =
-    criteria.tags.length > 0 || criteria.learningObjectives.length > 0 || criteria.other.length > 0;
+  const criteria = criteriaGroups(payload.criteria);
+  const hasCriteria = criteria.length > 0;
 
   const manageQuestionsAction = payload.manageQuestionsUrl ? (
     <a
@@ -368,9 +383,9 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
 
             {hasCriteria ? (
               <div className="flex flex-col gap-2">
-                <CriteriaField label="Tags" values={criteria.tags} />
-                <CriteriaField label="Learning Objectives" values={criteria.learningObjectives} />
-                <CriteriaField label="Other" values={criteria.other} />
+                {criteria.map((group) => (
+                  <CriteriaField key={group.label} label={group.label} values={group.values} />
+                ))}
               </div>
             ) : (
               <p className="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low">

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -12,10 +12,29 @@ interface CustomizationTarget {
 interface SampleActivity {
   activityResourceId: number;
   title: string;
-  model: any;
+  model: unknown;
   previewElement: string;
   renderMode?: 'preview' | 'authoring_fallback';
-  previewContext: any;
+  previewContext: SampleActivityPreviewContext;
+}
+
+interface SampleActivityPreviewContext {
+  sectionSlug: string;
+  pageResourceId: number;
+  pageRevisionSlug: string;
+  activityResourceId: number;
+  activityHtmlId: string;
+  activityTypeSlug?: string;
+  activityTypeLabel: string;
+  title: string;
+  points?: number;
+  learningObjectives?: string[];
+  canCustomize?: boolean;
+  actions?: PreviewAction[];
+  visualState?: PreviewVisualState;
+  statusPill?: PreviewStatusPill | null;
+  customizationTarget?: unknown;
+  [key: string]: unknown;
 }
 
 interface SelectionCriteriaGroup {
@@ -303,16 +322,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
       Manage questions
       <ArrowRight className="h-4 w-4" />
     </a>
-  ) : (
-    <button
-      type="button"
-      className="inline-flex items-center justify-center gap-2 rounded-[6px] bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
-      onClick={(event) => event.preventDefault()}
-    >
-      Manage questions
-      <ArrowRight className="h-4 w-4" />
-    </button>
-  );
+  ) : null;
 
   const cardClasses =
     visualState === 'removed'
@@ -383,7 +393,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
           </div>
         </div>
 
-        <div>{manageQuestionsAction}</div>
+        {manageQuestionsAction ? <div>{manageQuestionsAction}</div> : null}
 
         <hr className="m-0 border-0 border-t border-Border-border-default" />
 

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -50,6 +50,7 @@ export interface ActivityBankSelectionPreviewPayload {
   availableCount: number;
   pointsPerActivity: number;
   criteria: SelectionCriteriaGroup[];
+  selectionCriteriaHtml?: string | null;
   manageQuestionsUrl?: string | null;
   sampleActivity?: SampleActivity | null;
   canCustomize: boolean;
@@ -129,36 +130,7 @@ const actionButtonClasses = (kind: 'remove' | 'restore') => {
 const pluralize = (count: number, singular: string, plural: string) =>
   `${count} ${count === 1 ? singular : plural}`;
 
-const criteriaItems = (items?: unknown) => (Array.isArray(items) ? items.filter(Boolean) : []);
-
-const criteriaGroups = (criteria?: unknown): SelectionCriteriaGroup[] =>
-  Array.isArray(criteria)
-    ? criteria
-        .map((group) => ({
-          label: typeof group?.label === 'string' ? group.label : '',
-          values: criteriaItems(group?.values).map(String),
-        }))
-        .filter((group) => group.label && group.values.length > 0)
-    : [];
-
 const labelTextClasses = 'font-open-sans text-[14px] font-bold leading-4 text-Text-text-high';
-
-const CriteriaField: React.FC<{ label: string; values: string[] }> = ({ label, values }) => {
-  if (values.length === 0) {
-    return null;
-  }
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="font-open-sans text-[14px] font-bold leading-4 text-Text-text-low-alpha">
-        {label}:
-      </div>
-      <div className="min-h-[40px] w-full rounded-[6px] bg-Specially-Tokens-Fill-fill-input-focused px-[10px] py-2 font-open-sans text-[16px] font-semibold leading-6 text-Text-text-high">
-        {values.join(', ')}
-      </div>
-    </div>
-  );
-};
 
 const matchesCustomizationTarget = (
   expectedTarget: CustomizationTarget,
@@ -311,9 +283,6 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
       </div>
     ) : null;
 
-  const criteria = criteriaGroups(payload.criteria);
-  const hasCriteria = criteria.length > 0;
-
   const manageQuestionsAction = payload.manageQuestionsUrl ? (
     <a
       href={payload.manageQuestionsUrl}
@@ -369,28 +338,9 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
             </div>
           </div>
 
-          <div aria-labelledby={`${payload.id}-criteria-heading`} className="flex flex-col gap-2">
-            <div
-              id={`${payload.id}-criteria-heading`}
-              role="heading"
-              aria-level={4}
-              className={labelTextClasses}
-            >
-              Selection criteria:
-            </div>
-
-            {hasCriteria ? (
-              <div className="flex flex-col gap-2">
-                {criteria.map((group) => (
-                  <CriteriaField key={group.label} label={group.label} values={group.values} />
-                ))}
-              </div>
-            ) : (
-              <p className="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low">
-                No criteria configured.
-              </p>
-            )}
-          </div>
+          {payload.selectionCriteriaHtml ? (
+            <div dangerouslySetInnerHTML={{ __html: payload.selectionCriteriaHtml }} />
+          ) : null}
         </div>
 
         {manageQuestionsAction ? <div>{manageQuestionsAction}</div> : null}

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -317,7 +317,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
   const manageQuestionsAction = payload.manageQuestionsUrl ? (
     <a
       href={payload.manageQuestionsUrl}
-      className="inline-flex items-center justify-center gap-2 rounded-[6px] bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+      className="inline-flex items-center justify-center gap-2 rounded-[6px] bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 !text-Text-text-white no-underline shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors visited:!text-Text-text-white hover:bg-Fill-Buttons-fill-primary-hover hover:!text-Text-text-white hover:no-underline focus-visible:!text-Text-text-white focus-visible:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
     >
       Manage questions
       <ArrowRight className="h-4 w-4" />

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -40,7 +40,6 @@ interface SampleActivityPreviewContext {
 export interface ActivityBankSelectionPreviewPayload {
   id: string;
   title: string;
-  activityTypeLabel: string;
   selectedCount: number;
   availableCount: number;
   pointsPerActivity: number;

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -23,14 +23,6 @@ interface SelectionCriteriaGroup {
   values: string[];
 }
 
-interface LegacySelectionCriteria {
-  tags: string[];
-  learningObjectives: string[];
-  other: string[];
-}
-
-type SelectionCriteria = SelectionCriteriaGroup[] | LegacySelectionCriteria;
-
 export interface ActivityBankSelectionPreviewPayload {
   id: string;
   title: string;
@@ -38,7 +30,7 @@ export interface ActivityBankSelectionPreviewPayload {
   selectedCount: number;
   availableCount: number;
   pointsPerActivity: number;
-  criteria: SelectionCriteria;
+  criteria: SelectionCriteriaGroup[];
   manageQuestionsUrl?: string | null;
   sampleActivity?: SampleActivity | null;
   canCustomize: boolean;
@@ -118,21 +110,17 @@ const actionButtonClasses = (kind: 'remove' | 'restore') => {
 const pluralize = (count: number, singular: string, plural: string) =>
   `${count} ${count === 1 ? singular : plural}`;
 
-const criteriaItems = (items?: string[]) => (items ?? []).filter(Boolean);
+const criteriaItems = (items?: unknown) => (Array.isArray(items) ? items.filter(Boolean) : []);
 
-const criteriaGroups = (criteria: SelectionCriteria): SelectionCriteriaGroup[] => {
-  if (Array.isArray(criteria)) {
-    return criteria
-      .map((group) => ({ label: group.label, values: criteriaItems(group.values) }))
-      .filter((group) => group.label && group.values.length > 0);
-  }
-
-  return [
-    { label: 'Tags', values: criteriaItems(criteria.tags) },
-    { label: 'Learning Objectives', values: criteriaItems(criteria.learningObjectives) },
-    { label: 'Other', values: criteriaItems(criteria.other) },
-  ].filter((group) => group.values.length > 0);
-};
+const criteriaGroups = (criteria?: unknown): SelectionCriteriaGroup[] =>
+  Array.isArray(criteria)
+    ? criteria
+        .map((group) => ({
+          label: typeof group?.label === 'string' ? group.label : '',
+          values: criteriaItems(group?.values).map(String),
+        }))
+        .filter((group) => group.label && group.values.length > 0)
+    : [];
 
 const labelTextClasses = 'font-open-sans text-[14px] font-bold leading-4 text-Text-text-high';
 

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { PreviewHeader } from 'components/activities/common/preview/PreviewHeader';
+import { PreviewAction, PreviewStatusPill, PreviewVisualState } from 'components/activities/types';
+
+interface CustomizationTarget {
+  kind: 'bank_selection';
+  pageResourceId: number;
+  selectionId: string;
+}
+
+interface SampleActivity {
+  activityResourceId: number;
+  title: string;
+  model: any;
+  previewElement: string;
+  previewContext: any;
+}
+
+export interface ActivityBankSelectionPreviewPayload {
+  id: string;
+  title: string;
+  activityTypeLabel: string;
+  selectedCount: number;
+  availableCount: number;
+  pointsPerActivity: number;
+  criteria: string[];
+  sampleActivity?: SampleActivity | null;
+  canCustomize: boolean;
+  actions?: PreviewAction[];
+  visualState?: PreviewVisualState;
+  statusPill?: PreviewStatusPill | null;
+  customizationTarget: CustomizationTarget;
+}
+
+interface Props {
+  payload: ActivityBankSelectionPreviewPayload;
+}
+
+const TrashActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3 6H5H21"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M10 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    <path d="M14 11V17" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+const RestoreActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
+  <svg
+    aria-hidden="true"
+    className={className}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const actionButtonClasses = (kind: 'remove' | 'restore') => {
+  const shared =
+    'inline-flex items-center gap-2 rounded-[6px] border bg-Surface-surface-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-70';
+
+  if (kind === 'remove') {
+    return `${shared} border-Border-border-danger text-Specially-Tokens-Text-text-button-pill-muted hover:bg-[rgba(255,64,64,0.08)] dark:border-Border-border-danger dark:text-[#FFB5B7] dark:hover:bg-[rgba(255,64,64,0.18)] focus-visible:outline-Border-border-danger`;
+  }
+
+  return `${shared} bg-transparent border-[#8AB8E5] text-Text-text-button hover:bg-[#EEF6FF] hover:text-Text-text-button-hover dark:bg-transparent dark:border-[#4C82B8] dark:text-[#9FD0FF] dark:hover:bg-[#16395C] dark:hover:text-[#D7ECFF] focus-visible:outline-[#8AB8E5]`;
+};
+
+const pluralize = (count: number, singular: string, plural: string) =>
+  `${count} ${count === 1 ? singular : plural}`;
+
+const matchesCustomizationTarget = (
+  expectedTarget: CustomizationTarget,
+  replyTarget?: Partial<CustomizationTarget>,
+) =>
+  !!replyTarget &&
+  replyTarget.kind === expectedTarget.kind &&
+  replyTarget.pageResourceId === expectedTarget.pageResourceId &&
+  replyTarget.selectionId === expectedTarget.selectionId;
+
+const SampleActivityPreview: React.FC<{ sample?: SampleActivity | null }> = ({ sample }) => {
+  if (!sample?.previewElement) {
+    return (
+      <div className="rounded-lg border border-Border-border-default bg-Surface-surface-secondary p-4 text-sm text-Text-text-low">
+        No sample question is available for this activity bank selection.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-Border-border-default bg-Surface-surface-primary">
+      {React.createElement(sample.previewElement, {
+        model: JSON.stringify(sample.model),
+        previewcontext: JSON.stringify(sample.previewContext),
+        mode: 'preview',
+        activity_id: sample.previewContext.activityHtmlId,
+        activityId: sample.activityResourceId,
+        section_slug: sample.previewContext.sectionSlug,
+        projectSlug: sample.previewContext.sectionSlug,
+      })}
+    </div>
+  );
+};
+
+export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
+  const [actions, setActions] = React.useState(payload.actions ?? []);
+  const [visualState, setVisualState] = React.useState(payload.visualState ?? 'default');
+  const [statusPill, setStatusPill] = React.useState(payload.statusPill ?? undefined);
+  const [availableCount, setAvailableCount] = React.useState(payload.availableCount);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+
+  React.useEffect(() => {
+    setActions(payload.actions ?? []);
+    setVisualState(payload.visualState ?? 'default');
+    setStatusPill(payload.statusPill ?? undefined);
+    setAvailableCount(payload.availableCount);
+  }, [payload]);
+
+  React.useEffect(() => {
+    const handleCustomizationReply = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+
+      if (!matchesCustomizationTarget(payload.customizationTarget, detail?.target)) {
+        return;
+      }
+
+      setIsSubmitting(false);
+
+      if (detail.ok && Array.isArray(detail.actions)) {
+        setActions(detail.actions);
+      }
+
+      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'visualState')) {
+        setVisualState(detail.visualState ?? 'default');
+      }
+
+      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'statusPill')) {
+        setStatusPill(detail.statusPill ?? undefined);
+      }
+
+      if (detail.ok && typeof detail.availableCount === 'number') {
+        setAvailableCount(detail.availableCount);
+      }
+    };
+
+    window.addEventListener('oli:preview-customization:reply', handleCustomizationReply);
+
+    return () => {
+      window.removeEventListener('oli:preview-customization:reply', handleCustomizationReply);
+    };
+  }, [payload.customizationTarget]);
+
+  const headerActions =
+    payload.canCustomize && actions.length > 0 ? (
+      <div className="flex flex-wrap items-center gap-2">
+        {actions.map((action) => (
+          <button
+            key={action.kind}
+            type="button"
+            disabled={isSubmitting}
+            className={actionButtonClasses(action.kind)}
+            onClick={() => {
+              setIsSubmitting(true);
+              window.dispatchEvent(
+                new CustomEvent('oli:preview-customization', {
+                  detail: {
+                    action: action.kind,
+                    target: payload.customizationTarget,
+                  },
+                }),
+              );
+            }}
+          >
+            {action.kind === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+            {isSubmitting ? 'Updating...' : action.label}
+          </button>
+        ))}
+      </div>
+    ) : null;
+
+  const cardClasses =
+    visualState === 'removed'
+      ? 'relative bg-Surface-surface-secondary-muted before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger'
+      : 'bg-Surface-surface-primary';
+
+  return (
+    <article className={`p-6 ${cardClasses}`}>
+      <div className="flex flex-col gap-5">
+        <PreviewHeader
+          activityTypeLabel={payload.activityTypeLabel}
+          title={payload.title}
+          points={payload.pointsPerActivity}
+          actions={headerActions}
+          statusPill={statusPill}
+        />
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          <div>
+            <div className="text-sm text-Text-text-low">Questions selected</div>
+            <div className="text-base font-semibold text-Text-text-high">
+              {pluralize(payload.selectedCount, 'question', 'questions')}
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-Text-text-low">Questions available</div>
+            <div className="text-base font-semibold text-Text-text-high">
+              {pluralize(availableCount, 'question', 'questions')}
+            </div>
+          </div>
+          <div>
+            <div className="text-sm text-Text-text-low">Points per question</div>
+            <div className="text-base font-semibold text-Text-text-high">
+              {pluralize(payload.pointsPerActivity, 'point', 'points')}
+            </div>
+          </div>
+        </div>
+
+        <section aria-labelledby={`${payload.id}-criteria-heading`} className="flex flex-col gap-2">
+          <h4
+            id={`${payload.id}-criteria-heading`}
+            className="!m-0 text-sm font-semibold text-Text-text-high"
+          >
+            Selection criteria
+          </h4>
+          {payload.criteria.length > 0 ? (
+            <ul className="m-0 flex list-disc flex-col gap-1 pl-5 text-sm text-Text-text-low">
+              {payload.criteria.map((criterion, index) => (
+                <li key={`${criterion}-${index}`}>{criterion}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className="m-0 text-sm text-Text-text-low">No criteria configured.</p>
+          )}
+        </section>
+
+        <section aria-labelledby={`${payload.id}-sample-heading`} className="flex flex-col gap-3">
+          <div>
+            <h4
+              id={`${payload.id}-sample-heading`}
+              className="!m-0 text-sm font-semibold text-Text-text-high"
+            >
+              Sample question
+            </h4>
+            <p className="m-0 text-sm text-Text-text-low">
+              One possible question that matches this activity bank selection.
+            </p>
+          </div>
+          <SampleActivityPreview sample={payload.sampleActivity} />
+        </section>
+      </div>
+    </article>
+  );
+};

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -316,7 +316,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
           {headerActions}
         </div>
 
-        <div className="flex flex-col gap-[6px]">
+        <div className="flex flex-col gap-[10px]">
           <p className="m-0 font-open-sans text-[16px] font-bold leading-4 text-Text-text-high">
             {pluralize(availableCount, 'question', 'questions')} available
           </p>
@@ -337,7 +337,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
           ) : null}
         </div>
 
-        {manageQuestionsAction ? <div>{manageQuestionsAction}</div> : null}
+        {manageQuestionsAction ? <div className="mt-1">{manageQuestionsAction}</div> : null}
 
         <hr className="m-0 border-0 border-t border-Border-border-default" />
 

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { PreviewHeader } from 'components/activities/common/preview/PreviewHeader';
 import { PreviewAction, PreviewStatusPill, PreviewVisualState } from 'components/activities/types';
+import { ArrowRight } from 'components/misc/icons/Icons';
 
 interface CustomizationTarget {
   kind: 'bank_selection';
@@ -16,6 +16,12 @@ interface SampleActivity {
   previewContext: any;
 }
 
+interface SelectionCriteria {
+  tags: string[];
+  learningObjectives: string[];
+  other: string[];
+}
+
 export interface ActivityBankSelectionPreviewPayload {
   id: string;
   title: string;
@@ -23,7 +29,8 @@ export interface ActivityBankSelectionPreviewPayload {
   selectedCount: number;
   availableCount: number;
   pointsPerActivity: number;
-  criteria: string[];
+  criteria: SelectionCriteria;
+  manageQuestionsUrl?: string | null;
   sampleActivity?: SampleActivity | null;
   canCustomize: boolean;
   actions?: PreviewAction[];
@@ -102,6 +109,27 @@ const actionButtonClasses = (kind: 'remove' | 'restore') => {
 const pluralize = (count: number, singular: string, plural: string) =>
   `${count} ${count === 1 ? singular : plural}`;
 
+const criteriaItems = (items?: string[]) => (items ?? []).filter(Boolean);
+
+const labelTextClasses = 'font-open-sans text-[14px] font-bold leading-4 text-Text-text-high';
+
+const CriteriaField: React.FC<{ label: string; values: string[] }> = ({ label, values }) => {
+  if (values.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-open-sans text-[14px] font-bold leading-4 text-Text-text-low-alpha">
+        {label}:
+      </div>
+      <div className="min-h-[40px] w-full rounded-[6px] bg-Specially-Tokens-Fill-fill-input-focused px-[10px] py-2 font-open-sans text-[16px] font-semibold leading-6 text-Text-text-high">
+        {values.join(', ')}
+      </div>
+    </div>
+  );
+};
+
 const matchesCustomizationTarget = (
   expectedTarget: CustomizationTarget,
   replyTarget?: Partial<CustomizationTarget>,
@@ -111,17 +139,27 @@ const matchesCustomizationTarget = (
   replyTarget.pageResourceId === expectedTarget.pageResourceId &&
   replyTarget.selectionId === expectedTarget.selectionId;
 
-const SampleActivityPreview: React.FC<{ sample?: SampleActivity | null }> = ({ sample }) => {
+const SampleActivityPreview: React.FC<{
+  sample?: SampleActivity | null;
+  visualState: PreviewVisualState;
+}> = ({ sample, visualState }) => {
+  const sampleContainerClasses =
+    visualState === 'removed' ? 'bg-Surface-surface-secondary-muted' : 'bg-Surface-surface-primary';
+
   if (!sample?.previewElement) {
     return (
-      <div className="rounded-lg border border-Border-border-default bg-Surface-surface-secondary p-4 text-sm text-Text-text-low">
+      <div
+        className={`rounded-lg border border-Border-border-default p-4 text-sm text-Text-text-low ${sampleContainerClasses}`}
+      >
         No sample question is available for this activity bank selection.
       </div>
     );
   }
 
   return (
-    <div className="overflow-hidden rounded-lg border border-Border-border-default bg-Surface-surface-primary">
+    <div
+      className={`overflow-hidden rounded-lg border border-Border-border-default ${sampleContainerClasses}`}
+    >
       {React.createElement(sample.previewElement, {
         model: JSON.stringify(sample.model),
         previewcontext: JSON.stringify(sample.previewContext),
@@ -211,74 +249,117 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
       </div>
     ) : null;
 
+  const criteria = {
+    tags: criteriaItems(payload.criteria?.tags),
+    learningObjectives: criteriaItems(payload.criteria?.learningObjectives),
+    other: criteriaItems(payload.criteria?.other),
+  };
+
+  const hasCriteria =
+    criteria.tags.length > 0 || criteria.learningObjectives.length > 0 || criteria.other.length > 0;
+
+  const manageQuestionsAction = payload.manageQuestionsUrl ? (
+    <a
+      href={payload.manageQuestionsUrl}
+      className="inline-flex items-center justify-center gap-2 rounded-[6px] bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+    >
+      Manage questions
+      <ArrowRight className="h-4 w-4" />
+    </a>
+  ) : (
+    <button
+      type="button"
+      className="inline-flex items-center justify-center gap-2 rounded-[6px] bg-Fill-Buttons-fill-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+      onClick={(event) => event.preventDefault()}
+    >
+      Manage questions
+      <ArrowRight className="h-4 w-4" />
+    </button>
+  );
+
   const cardClasses =
     visualState === 'removed'
       ? 'relative bg-Surface-surface-secondary-muted before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger'
       : 'bg-Surface-surface-primary';
 
   return (
-    <article className={`p-6 ${cardClasses}`}>
-      <div className="flex flex-col gap-5">
-        <PreviewHeader
-          activityTypeLabel={payload.activityTypeLabel}
-          title={payload.title}
-          points={payload.pointsPerActivity}
-          actions={headerActions}
-          statusPill={statusPill}
-        />
+    <article className={`p-[25px] font-open-sans ${cardClasses}`}>
+      <div className="flex flex-col gap-[18px]">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex min-w-0 flex-col">
+            <div className="flex flex-wrap items-center gap-2">
+              <div
+                role="heading"
+                aria-level={3}
+                className="font-open-sans text-[26px] font-semibold leading-[31.2px] text-Text-text-high"
+              >
+                {payload.title}
+              </div>
+              {statusPill ? (
+                <span className="inline-flex items-center rounded-full border border-Border-border-danger bg-Fill-fill-danger px-3 py-1 pr-4 font-open-sans text-[16px] font-bold leading-4 text-Text-text-danger">
+                  {statusPill.label}
+                </span>
+              ) : null}
+            </div>
+          </div>
 
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div>
-            <div className="text-sm text-Text-text-low">Questions selected</div>
-            <div className="text-base font-semibold text-Text-text-high">
+          {headerActions}
+        </div>
+
+        <div className="flex flex-col gap-[6px]">
+          <p className="m-0 font-open-sans text-[16px] font-bold leading-4 text-Text-text-high">
+            {pluralize(availableCount, 'question', 'questions')} available
+          </p>
+
+          <div className="flex min-h-[42px] flex-wrap items-center gap-x-[34px] gap-y-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-high">
+            <div>
+              <span className={labelTextClasses}>Selects:</span>{' '}
               {pluralize(payload.selectedCount, 'question', 'questions')}
             </div>
-          </div>
-          <div>
-            <div className="text-sm text-Text-text-low">Questions available</div>
-            <div className="text-base font-semibold text-Text-text-high">
-              {pluralize(availableCount, 'question', 'questions')}
+            <div>
+              <span className={labelTextClasses}>Points per question:</span>{' '}
+              {payload.pointsPerActivity}
             </div>
           </div>
-          <div>
-            <div className="text-sm text-Text-text-low">Points per question</div>
-            <div className="text-base font-semibold text-Text-text-high">
-              {pluralize(payload.pointsPerActivity, 'point', 'points')}
+
+          <div aria-labelledby={`${payload.id}-criteria-heading`} className="flex flex-col gap-2">
+            <div
+              id={`${payload.id}-criteria-heading`}
+              role="heading"
+              aria-level={4}
+              className={labelTextClasses}
+            >
+              Selection criteria:
             </div>
+
+            {hasCriteria ? (
+              <div className="flex flex-col gap-2">
+                <CriteriaField label="Tags" values={criteria.tags} />
+                <CriteriaField label="Learning Objectives" values={criteria.learningObjectives} />
+                <CriteriaField label="Other" values={criteria.other} />
+              </div>
+            ) : (
+              <p className="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low">
+                No criteria configured.
+              </p>
+            )}
           </div>
         </div>
 
-        <section aria-labelledby={`${payload.id}-criteria-heading`} className="flex flex-col gap-2">
-          <h4
-            id={`${payload.id}-criteria-heading`}
-            className="!m-0 text-sm font-semibold text-Text-text-high"
-          >
-            Selection criteria
-          </h4>
-          {payload.criteria.length > 0 ? (
-            <ul className="m-0 flex list-disc flex-col gap-1 pl-5 text-sm text-Text-text-low">
-              {payload.criteria.map((criterion, index) => (
-                <li key={`${criterion}-${index}`}>{criterion}</li>
-              ))}
-            </ul>
-          ) : (
-            <p className="m-0 text-sm text-Text-text-low">No criteria configured.</p>
-          )}
-        </section>
+        <div>{manageQuestionsAction}</div>
+
+        <hr className="m-0 border-0 border-t border-Border-border-default" />
 
         <section aria-labelledby={`${payload.id}-sample-heading`} className="flex flex-col gap-3">
-          <div>
-            <h4
-              id={`${payload.id}-sample-heading`}
-              className="!m-0 text-sm font-semibold text-Text-text-high"
-            >
-              Sample question
-            </h4>
-            <p className="m-0 text-sm text-Text-text-low">
-              One possible question that matches this activity bank selection.
-            </p>
+          <div
+            id={`${payload.id}-sample-heading`}
+            role="heading"
+            aria-level={4}
+            className="font-open-sans text-[16px] font-bold leading-4 text-Text-text-high"
+          >
+            Sample question from this selection:
           </div>
-          <SampleActivityPreview sample={payload.sampleActivity} />
+          <SampleActivityPreview sample={payload.sampleActivity} visualState={visualState} />
         </section>
       </div>
     </article>

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -37,11 +37,6 @@ interface SampleActivityPreviewContext {
   [key: string]: unknown;
 }
 
-interface SelectionCriteriaGroup {
-  label: string;
-  values: string[];
-}
-
 export interface ActivityBankSelectionPreviewPayload {
   id: string;
   title: string;
@@ -49,7 +44,6 @@ export interface ActivityBankSelectionPreviewPayload {
   selectedCount: number;
   availableCount: number;
   pointsPerActivity: number;
-  criteria: SelectionCriteriaGroup[];
   selectionCriteriaHtml?: string | null;
   manageQuestionsUrl?: string | null;
   sampleActivity?: SampleActivity | null;

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { PreviewHeader } from 'components/activities/common/preview/PreviewHeader';
 import { PreviewAction, PreviewStatusPill, PreviewVisualState } from 'components/activities/types';
 import { ArrowRight } from 'components/misc/icons/Icons';
 
@@ -13,6 +14,7 @@ interface SampleActivity {
   title: string;
   model: any;
   previewElement: string;
+  renderMode?: 'preview' | 'authoring_fallback';
   previewContext: any;
 }
 
@@ -156,19 +158,51 @@ const SampleActivityPreview: React.FC<{
     );
   }
 
+  const activityElement =
+    sample.renderMode === 'authoring_fallback'
+      ? React.createElement(sample.previewElement, {
+          model: JSON.stringify(sample.model),
+          authoringcontext: JSON.stringify({ variables: {}, previewMode: 'instructor' }),
+          editmode: 'false',
+          mode: 'instructor_preview',
+          activity_id: sample.previewContext.activityHtmlId,
+          activityId: sample.activityResourceId,
+          section_slug: sample.previewContext.sectionSlug,
+          projectSlug: sample.previewContext.sectionSlug,
+        })
+      : React.createElement(sample.previewElement, {
+          model: JSON.stringify(sample.model),
+          previewcontext: JSON.stringify(sample.previewContext),
+          mode: 'preview',
+          activity_id: sample.previewContext.activityHtmlId,
+          activityId: sample.activityResourceId,
+          section_slug: sample.previewContext.sectionSlug,
+          projectSlug: sample.previewContext.sectionSlug,
+        });
+
+  if (sample.renderMode === 'authoring_fallback') {
+    return (
+      <div
+        className={`overflow-hidden rounded-lg border border-Border-border-default p-6 ${sampleContainerClasses}`}
+      >
+        <div className="flex flex-col gap-4">
+          <PreviewHeader
+            activityTypeLabel={sample.previewContext.activityTypeLabel}
+            title={sample.previewContext.title}
+            points={sample.previewContext.points}
+            statusPill={sample.previewContext.statusPill ?? undefined}
+          />
+          <div>{activityElement}</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={`overflow-hidden rounded-lg border border-Border-border-default ${sampleContainerClasses}`}
     >
-      {React.createElement(sample.previewElement, {
-        model: JSON.stringify(sample.model),
-        previewcontext: JSON.stringify(sample.previewContext),
-        mode: 'preview',
-        activity_id: sample.previewContext.activityHtmlId,
-        activityId: sample.activityResourceId,
-        section_slug: sample.previewContext.sectionSlug,
-        projectSlug: sample.previewContext.sectionSlug,
-      })}
+      {activityElement}
     </div>
   );
 };

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {
+  ActivityBankSelectionPreview,
+  ActivityBankSelectionPreviewPayload,
+} from './ActivityBankSelectionPreview';
+
+class ActivityBankSelectionPreviewElement extends HTMLElement {
+  mountPoint: HTMLDivElement;
+  connected: boolean;
+
+  constructor() {
+    super();
+
+    this.mountPoint = document.createElement('div');
+    this.connected = false;
+  }
+
+  props() {
+    const payload = JSON.parse(
+      this.getAttribute('payload') || '{}',
+    ) as ActivityBankSelectionPreviewPayload;
+
+    return { payload };
+  }
+
+  render() {
+    ReactDOM.render(<ActivityBankSelectionPreview {...this.props()} />, this.mountPoint);
+  }
+
+  connectedCallback() {
+    this.appendChild(this.mountPoint);
+    this.render();
+    this.connected = true;
+  }
+
+  attributeChangedCallback() {
+    if (this.connected) {
+      this.render();
+    }
+  }
+
+  static observedAttributes = ['payload'];
+}
+
+if (!window.customElements.get('oli-activity-bank-selection-preview')) {
+  window.customElements.define(
+    'oli-activity-bank-selection-preview',
+    ActivityBankSelectionPreviewElement,
+  );
+}

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
@@ -22,7 +22,6 @@ const isValidPayload = (value: unknown): value is ActivityBankSelectionPreviewPa
   return (
     isString(candidate.id) &&
     isString(candidate.title) &&
-    isString(candidate.activityTypeLabel) &&
     isNumber(candidate.selectedCount) &&
     isNumber(candidate.availableCount) &&
     isNumber(candidate.pointsPerActivity) &&

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx
@@ -5,6 +5,34 @@ import {
   ActivityBankSelectionPreviewPayload,
 } from './ActivityBankSelectionPreview';
 
+const isNumber = (value: unknown): value is number => typeof value === 'number';
+const isString = (value: unknown): value is string => typeof value === 'string';
+
+const isValidPayload = (value: unknown): value is ActivityBankSelectionPreviewPayload => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  const target =
+    candidate.customizationTarget && typeof candidate.customizationTarget === 'object'
+      ? (candidate.customizationTarget as Record<string, unknown>)
+      : null;
+
+  return (
+    isString(candidate.id) &&
+    isString(candidate.title) &&
+    isString(candidate.activityTypeLabel) &&
+    isNumber(candidate.selectedCount) &&
+    isNumber(candidate.availableCount) &&
+    isNumber(candidate.pointsPerActivity) &&
+    !!target &&
+    target.kind === 'bank_selection' &&
+    isNumber(target.pageResourceId) &&
+    isString(target.selectionId)
+  );
+};
+
 class ActivityBankSelectionPreviewElement extends HTMLElement {
   mountPoint: HTMLDivElement;
   connected: boolean;
@@ -17,21 +45,48 @@ class ActivityBankSelectionPreviewElement extends HTMLElement {
   }
 
   props() {
-    const payload = JSON.parse(
-      this.getAttribute('payload') || '{}',
-    ) as ActivityBankSelectionPreviewPayload;
+    const encodedPayload = this.getAttribute('payload');
 
-    return { payload };
+    if (!encodedPayload) {
+      return null;
+    }
+
+    try {
+      const payload = JSON.parse(encodedPayload) as unknown;
+
+      if (!isValidPayload(payload)) {
+        return null;
+      }
+
+      return { payload };
+    } catch {
+      return null;
+    }
   }
 
   render() {
-    ReactDOM.render(<ActivityBankSelectionPreview {...this.props()} />, this.mountPoint);
+    const props = this.props();
+
+    if (!props) {
+      ReactDOM.unmountComponentAtNode(this.mountPoint);
+      return;
+    }
+
+    ReactDOM.render(<ActivityBankSelectionPreview {...props} />, this.mountPoint);
   }
 
   connectedCallback() {
-    this.appendChild(this.mountPoint);
+    if (!this.contains(this.mountPoint)) {
+      this.appendChild(this.mountPoint);
+    }
+
     this.render();
     this.connected = true;
+  }
+
+  disconnectedCallback() {
+    ReactDOM.unmountComponentAtNode(this.mountPoint);
+    this.connected = false;
   }
 
   attributeChangedCallback() {

--- a/assets/src/components/misc/icons/Icons.tsx
+++ b/assets/src/components/misc/icons/Icons.tsx
@@ -182,3 +182,22 @@ export const ChevronDown: React.FC<IconProps> = ({ className = '', width = 16, h
     <path d="M6.70711 8.29289C6.31658 7.90237 5.68342 7.90237 5.29289 8.29289C4.90237 8.68342 4.90237 9.31658 5.29289 9.70711L11.2929 15.7071C11.6834 16.0976 12.3166 16.0976 12.7071 15.7071L18.7071 9.70711C19.0976 9.31658 19.0976 8.68342 18.7071 8.29289C18.3166 7.90237 17.6834 7.90237 17.2929 8.29289L12 13.5858L6.70711 8.29289Z" />
   </svg>
 );
+
+export const ArrowRight: React.FC<IconProps> = ({ className = '', width = 16, height = 16 }) => (
+  <svg
+    className={className}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    width={width}
+    height={height}
+    fill="none"
+  >
+    <path
+      d="M3.33301 8H12.6663M8.66634 4L12.6663 8L8.66634 12"
+      className="stroke-current"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -7,6 +7,7 @@ type InstructorPreviewCustomizationHook = {
   handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
   handlePreviewCustomization?: (event: Event) => void;
   handleFallbackPreviewCustomizationClick?: (event: Event) => void;
+  handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
 };
 
 const validTargetKinds = new Set(['embedded_activity', 'bank_selection', 'bank_candidate']);
@@ -187,6 +188,27 @@ export const InstructorPreviewCustomization = {
 
     // Preview activities are custom elements hydrated by React, but the mutation authority stays
     // in LiveView. This hook is the bridge from browser-side preview actions back to the socket.
+    this.handleEvent('preview_customization_reply', (reply) => {
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: reply,
+        }),
+      );
+
+      const target = reply.target as
+        | {
+            kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+            pageResourceId: number;
+            activityResourceId?: number;
+            selectionId?: string;
+          }
+        | undefined;
+
+      if (target) {
+        updateFallbackPreviewCard(target, reply);
+      }
+    });
+
     this.handlePreviewCustomization = (event: Event) => {
       const detail = (event as CustomEvent).detail;
 

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -7,7 +7,6 @@ type InstructorPreviewCustomizationHook = {
   handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
   handlePreviewCustomization?: (event: Event) => void;
   handleFallbackPreviewCustomizationClick?: (event: Event) => void;
-  handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
 };
 
 const validTargetKinds = new Set(['embedded_activity', 'bank_selection', 'bank_candidate']);

--- a/assets/src/types/vm2.d.ts
+++ b/assets/src/types/vm2.d.ts
@@ -1,0 +1,19 @@
+declare module 'vm2' {
+  export interface VMOptions {
+    allowAsync?: boolean;
+    eval?: boolean;
+    sandbox?: Record<string, unknown>;
+    timeout?: number;
+    wasm?: boolean;
+  }
+
+  export class VMScript {
+    constructor(code: string);
+    compile(): VMScript;
+  }
+
+  export class VM {
+    constructor(options?: VMOptions);
+    run(code: string | VMScript): unknown;
+  }
+}

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -300,10 +300,12 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
         payload: Record<string, unknown>,
         callback?: (reply: Record<string, unknown>) => void,
       ) => void;
+      handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
       handlePreviewCustomization?: (event: Event) => void;
       handleFallbackPreviewCustomizationClick?: (event: Event) => void;
     } = {
       pushEvent,
+      handleEvent: jest.fn(),
     };
 
     InstructorPreviewCustomization.mounted.call(hook);

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -26,6 +26,7 @@ const populateEntries = () => {
     bibliography: ['./src/apps/BibliographyApp.tsx'],
     authoring: ['./src/apps/AuthoringApp.tsx'],
     delivery: ['./src/apps/DeliveryApp.tsx'],
+    instructor_preview_components: ['./src/apps/InstructorPreviewComponents.tsx'],
     scheduler: ['./src/apps/SchedulerApp.tsx'],
     stripeclient: ['./src/payment/stripe/client.ts'],
     cashnetclient: ['./src/payment/cashnet/client.ts'],

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
@@ -24,8 +24,8 @@ Implementation should treat embedded activity remove/restore as existing infrast
 ### Assumptions
 
 - The primary implementation target is instructors operating in Course Sections under `/sections/:section_slug`.
-- Template preview appears to launch through a blueprint section via `Oli.Delivery.TemplatePreview.prepare_launch/3` and then redirect into section delivery. If that remains true, the Course Section implementation should cover template preview without a separate template-specific customization path.
-- If template support is found to require a distinct view or route, that work should be scheduled in a later implementation phase after Course Section behavior is complete and verified.
+- Template-level UI is reached through Product/Template Customize Content page Edit links, which use the same instructor-style `PreviewLessonLive` route for the template's blueprint section. No separate template UI is required for MER-5620.
+- Template-level activity exclusions should be copied from the blueprint section to future course sections created from that template, while already-created sections remain unchanged.
 - Existing `Oli.Delivery.InstructorCustomizations.exclude_bank_selection/4` and `restore_bank_selection/4` are the persistence authority for whole-selection remove/restore.
 - Existing student attempts and prior progress are immutable for this feature; remove/restore only affects future activity realization.
 
@@ -140,14 +140,14 @@ When warning state is active, an attempted remove/restore should show the confir
 
 ### Template Behavior
 
-Template support should be verified through the existing template preview flow before adding template-specific implementation:
+Template support uses the existing Product/Template Customize Content flow:
 
-- `Oli.Delivery.TemplatePreview.prepare_launch/3` prepares a hidden instructor enrollment in an active blueprint section.
-- `ProductsController.preview_launch/2` redirects into the section experience using that blueprint section slug.
-- If the Activity Bank Selection preview route used by template preview is the same `/sections/:section_slug/...` route, Course Section implementation satisfies the template requirement under the same section/page scoping model.
-- If a separate template-owned preview surface exists or is introduced, wire it as a later phase using the same LiveView event contract and the same domain APIs.
+- Product/Template Customize Content page Edit links target `/sections/:blueprint_slug/preview/lesson/:revision_slug` with a product remix `return_to`, including the course-author workspace form `/workspaces/course_author/:project_slug/products/:product_slug/remix`.
+- That route is the same `PreviewLessonLive` surface used for Course Section instructor preview, so the Activity Bank Selection and embedded activity remove/restore UI does not need a separate template-specific implementation.
+- `PreviewReturn` must preserve the product remix return path so "Return to Customize Content" returns to the template Customize Content page rather than the blueprint section remix page.
+- `Blueprint.duplicate/3` must copy `section_page_activity_exclusions` from the source blueprint/template section to the new course section. This matches existing Customize Content semantics: future course sections inherit template-level content customization, but already-created sections are not retroactively updated.
 
-This keeps the design centered on Course Sections while preserving a clear template verification path for AC-010.
+This keeps the design centered on the existing instructor preview surface while satisfying AC-010 for template scope and future-section behavior.
 
 ## 5. Interfaces
 
@@ -306,7 +306,8 @@ Frontend tests:
 Scenario tests:
 
 - Add scenario coverage if the implementation needs end-to-end proof across authoring, publishing, section delivery, instructor customization, and future attempts.
-- A template-preview smoke test is useful if the Course Section route is confirmed to serve blueprint template preview.
+- A template Customize Content preview smoke test should verify that product remix `return_to` paths are preserved.
+- A blueprint duplication test should verify that activity exclusions are copied to future sections and not retroactively applied to already-created sections.
 
 Manual verification:
 
@@ -320,7 +321,7 @@ Preserve the user-facing Activity Bank candidate-listing preview URL. MER-5620 s
 
 Do not change the embedded activity preview customization contract or existing embedded event behavior from MER-5622. Do not change delivery attempt realization beyond the existing use of instructor customization exclusion state.
 
-Template preview compatibility should be validated through the blueprint-section redirect flow. If no separate template route is needed, the same LiveView implementation covers templates without additional code.
+Template Customize Content compatibility is handled through blueprint-section page Edit links into `PreviewLessonLive`. Future course sections inherit template-level activity exclusions through blueprint duplication, not through retroactive propagation.
 
 If the implementation proves that legacy Activity Bank Selection preview code is no longer referenced by any active authoring, delivery, template, or preview surface, remove that dead code as part of MER-5620 cleanup rather than preserving unused fallback paths.
 
@@ -328,7 +329,8 @@ If the implementation proves that legacy Activity Bank Selection preview code is
 
 - Risk: Inline Activity Bank Selection preview keeps using the legacy server-rendered jumbotron. Mitigation: bypass `Oli.Rendering.Content.Selection` only for `:instructor_preview` and emit the React custom element inside the existing `PreviewLessonLive` surface.
 - Risk: Warning confirmation could fork the customization transport path. Mitigation: keep LiveView as the mutation owner; use the existing hook for intents and let LiveView own pending confirmation state.
-- Risk: Template requirements may be interpreted as a separate surface. Mitigation: verify the current template preview launch path first; defer separate template UI work to a later phase only if a distinct route is discovered.
+- Risk: Template requirements may be interpreted as a separate surface. Mitigation: use the existing Product/Template Customize Content page Edit route into `PreviewLessonLive`; do not add template-specific UI unless that route behavior changes.
+- Risk: Template-level exclusions may fail to affect future course sections. Mitigation: copy `section_page_activity_exclusions` during `Blueprint.duplicate/3` and test that already-created sections remain unchanged.
 - Risk: Counts drift from delivery behavior. Mitigation: recompute from the same Activity Bank and exclusion-view sources used by delivery, and refresh after writes.
 - Risk: Overlap with MER-5622 causes duplicated embedded behavior. Mitigation: only add `bank_selection` handling and regression-test embedded remove/restore.
 - Risk: Attempt/visit warning query is ambiguous for practice pages. Mitigation: locate the existing delivery visit/access signal and encapsulate warning eligibility in a small tested helper.
@@ -338,9 +340,7 @@ If the implementation proves that legacy Activity Bank Selection preview code is
 
 - Confirm the exact source of "students have already visited this page" for practice pages: resource access, resource attempts, page visits, or an existing delivery summary helper.
 - Confirm where points-per-question is stored for Activity Bank Selection preview and whether it is always available for both scored and practice pages.
-- Confirm whether template preview reaches the same `PreviewLessonLive` inline selection rendering through blueprint sections.
 - Revisit `ActivityBankController.preview/2` only in the separate candidate-listing ticket.
-- During planning, place any template-only route/view work in a final phase unless route verification shows it comes for free through blueprint sections.
 
 ## 17. References
 

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
@@ -6,7 +6,7 @@ MER-5620 should implement the new Activity Bank Selection preview UI in the Inst
 
 The core domain layer already has bank-selection validation and write APIs in `Oli.Delivery.InstructorCustomizations`, and the browser hook already accepts `bank_selection` targets. However, the Activity Bank Selection preview does not appear to have received the new MER-5618 preview-component UI that embedded activities and several activity types now use. The design therefore includes both the Activity Bank Selection visual implementation from Figma and the LiveView wiring needed to make remove/restore work.
 
-The remaining design work has two main parts: UI ownership and screen ownership. UI ownership means adding a real Activity Bank Selection preview component/layout rather than only adding a button to the old rendered selection page. Screen ownership means the Activity Bank Selection preview currently lives behind `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`, while the intended customization contract requires an owning LiveView. The design should move or wrap that preview in a LiveView-owned surface so React/server-rendered preview actions can flow through `InstructorPreviewCustomization`, into LiveView, and then into the core implementation.
+The remaining design work centers on inline preview ownership. UI ownership means adding a real Activity Bank Selection preview component/layout rather than only adding a button to the old rendered selection block. The owning LiveView for this ticket is the existing instructor lesson preview, `OliWeb.Delivery.Instructor.PreviewLessonLive`, which already mounts `InstructorPreviewCustomization`. MER-5620 should replace the inline `selection` renderer used inside that LiveView with a React custom element that follows the preview-component pattern and delegates whole-selection events back to the existing LiveView. Because Activity Bank Selection is a content element and not a registered activity type, it should be bundled through a generic instructor-preview components entry instead of a fake activity `manifest.json`. The separate `/selection/:selection_id` activity-listing route belongs to a different ticket and should not be migrated or reimplemented here.
 
 Implementation should treat embedded activity remove/restore as existing infrastructure from MER-5622 / PR 6659. MER-5620 should regression-test that behavior but should not reimplement it.
 
@@ -37,28 +37,30 @@ Relevant boundaries:
 - `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex` is the current LiveView reference for embedded activity preview customization. It mounts `InstructorPreviewCustomization`, dispatches remove/restore into the domain context, and returns `{:reply, reply, socket}` payloads.
 - `assets/src/hooks/instructor_preview_customization.ts` already validates and forwards `bank_selection` targets, so hook changes should be small or unnecessary unless warning confirmation requires a client-side helper.
 - `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md` is the shared transport contract.
-- `lib/oli_web/controllers/activity_bank_controller.ex` and `lib/oli_web/templates/activity_bank/preview.html.heex` currently own the Activity Bank Selection preview route, but controller-rendered pages cannot receive LiveView `pushEvent` calls.
-- `lib/oli/rendering/content/selection.ex` is the current renderer for authored selection blocks. It produces the legacy jumbotron-style Activity Bank Selection display and the `Preview activities` link when rendered inside page content. The existing controller preview also calls this renderer with the link disabled.
+- `lib/oli_web/controllers/activity_bank_controller.ex` and `lib/oli_web/templates/activity_bank/preview.html.heex` own the separate Activity Bank candidate-listing preview route. That route is intentionally out of scope for this ticket.
+- `lib/oli/rendering/content/selection.ex` is the legacy renderer for authored selection blocks. It produces the jumbotron-style Activity Bank Selection display and the `Preview activities` link when rendered inside page content. Instructor Preview should bypass it for inline selections while keeping it available for non-instructor-preview contexts and the separate candidate-listing route.
+- `assets/src/apps/InstructorPreviewComponents.tsx` is the generic instructor-preview bundle entry for custom elements that are not activity manifest entries.
 - `assets/src/components/activities/common/preview/ActivityPreviewCard.tsx` and related MER-5618 preview components provide reusable interaction patterns for individual activity previews, but there is no local Activity Bank Selection preview component. MER-5620 should implement that selection-level UI rather than treating the work as a button-only extension.
 - `Oli.Delivery.ActivityProvider` already consults instructor customization state when realizing future activity bank selections, so the UI should not need new delivery-time storage semantics.
 - Scenario directive infrastructure already has bank-selection exclusion verbs, which can support integration tests if this feature needs cross-workflow proof.
 
 ## 4. Proposed Design
 
-### Screen Ownership
+### Inline Preview Ownership
 
-Introduce a LiveView-owned Activity Bank Selection preview surface for the existing section preview URL:
+Use the existing instructor lesson preview as the owning surface:
 
-- Preferred route preservation: keep `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` as the user-facing URL.
-- Preferred implementation shape: replace the controller preview action with a LiveView route, or route that URL to a small LiveView such as `OliWeb.Delivery.Instructor.ActivityBankSelectionPreviewLive`.
-- The LiveView mounts the existing delivery root/layout and the `InstructorPreviewCustomization` hook on the screen root.
-- The LiveView reuses the current controller retrieval behavior for section authorization, page revision resolution, selection lookup, activity bank query, paging, activity script setup, previous/next page context, and scheduled-resource state.
+- Keep `OliWeb.Delivery.Instructor.PreviewLessonLive` as the LiveView owner.
+- Do not introduce a new LiveView or route for MER-5620.
+- Keep `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` as the legacy/separate candidate-listing route owned by the existing Activity Bank controller until the separate listing ticket changes it.
+- Replace the inline Instructor Preview rendering of content elements with `"type" => "selection"` by emitting an Activity Bank Selection React custom element.
+- Continue using `InstructorPreviewCustomization` mounted on `PreviewLessonLive` as the browser-to-LiveView transport for remove/restore.
 
-This keeps AC-005 and AC-006 aligned with the existing LiveView/React contract instead of adding a controller API or a second transport path.
+This keeps AC-005 and AC-006 aligned with the existing LiveView/React contract without creating a second screen surface.
 
 ### Preview Context
 
-Build a server-owned selection preview context from the resolved section, page revision, selection node, current exclusion view, and activity bank query result:
+Build a server-owned selection preview context from the resolved section, page revision, selection node, current exclusion view, and activity bank query result. Store these payloads under a generic `Oli.Rendering.Context.instructor_preview_context` map, keyed by preview feature, so the base render context does not grow Activity-Bank-specific fields:
 
 - `page_resource_id`
 - `revision_slug`
@@ -68,7 +70,8 @@ Build a server-owned selection preview context from the resolved section, page r
 - authored select count
 - points per question, if available from the selection/page model
 - authored criteria summary
-- sample activity/question content
+- sample activity/question content resolved server-side from the bank selection logic
+- sample activity preview payload using the same `preview_element`, model, and preview context shape used by normal activity preview components
 - `selection_enabled?`
 - `actions`: `[%{kind: "remove", label: "Remove"}]` when enabled, `[%{kind: "restore", label: "Restore"}]` when removed
 - `visualState`: `"default"` or `"removed"`
@@ -81,20 +84,15 @@ Implement the approved Instructor View Activity Bank Selection UI from Figma as 
 
 Recommended shape:
 
-- Add a selection-level preview component or LiveView-rendered partial dedicated to Activity Bank selections.
-- Treat `Oli.Rendering.Content.Selection` as the legacy authored-content renderer to replace or bypass for Instructor Preview, not as the final Figma-backed preview UI.
+- Add a selection-level React custom element dedicated to Activity Bank selections.
+- Register that custom element through `instructor_preview_components.js`, not through the activity manifest scanner.
+- Treat `Oli.Rendering.Content.Selection` as the legacy authored-content renderer to bypass for Instructor Preview, not as the final Figma-backed preview UI.
 - Reuse shared preview primitives where they fit: header/action button styling, removed visual state, status pill, rich-text rendering, and sample question rendering.
 - Do not force the selection UI into `ActivityPreviewCard` if that creates an awkward model; an Activity Bank Selection is a page-level selector with aggregate metadata and a sample question, not a normal activity card.
 - Render the Figma-required metadata: available questions, select count, points per question, authored criteria, sample question, active/removed state, and success/warning affordances.
 - Keep the sample question as a real preview using the existing activity preview/authoring rendering path, so keyboard behavior and rich content remain consistent with activity previews.
 
-If the selection is rendered through React preview components, the context should be passed through typed props similar to the existing preview context, extended for selection-level metadata. If the selection remains server-rendered initially, the remove/restore button should use the hook's fallback attributes:
-
-- `data-preview-customization-button`
-- `data-preview-customization-action`
-- `data-preview-customization-target`
-
-Either rendering path must satisfy AC-001, AC-002, AC-003, AC-004, and AC-011.
+Elixir remains the data adapter: it resolves counts, criteria, customization state, candidate sample data, and required scripts. React owns the full HTML for the Activity Bank Selection preview and renders the sample question by mounting the existing activity `preview_element` custom element. This keeps the sample activity consistent with normal preview components without moving bank-selection query logic to the browser.
 
 ### Remove/Restore Flow
 
@@ -318,7 +316,7 @@ Manual verification:
 
 ## 14. Backwards Compatibility
 
-Preserve the user-facing Activity Bank Selection preview URL if possible. If the controller route becomes a LiveView route, keep redirects, route helpers, and navigation behavior compatible with existing instructor preview links.
+Preserve the user-facing Activity Bank candidate-listing preview URL. MER-5620 should not convert that controller route into a LiveView route; this ticket replaces the inline Activity Bank Selection preview rendered inside `PreviewLessonLive`.
 
 Do not change the embedded activity preview customization contract or existing embedded event behavior from MER-5622. Do not change delivery attempt realization beyond the existing use of instructor customization exclusion state.
 
@@ -328,20 +326,20 @@ If the implementation proves that legacy Activity Bank Selection preview code is
 
 ## 15. Risks & Mitigations
 
-- Risk: Activity Bank Selection preview remains controller-owned, making `pushEvent` impossible. Mitigation: migrate or wrap the preview in a LiveView while preserving the route.
+- Risk: Inline Activity Bank Selection preview keeps using the legacy server-rendered jumbotron. Mitigation: bypass `Oli.Rendering.Content.Selection` only for `:instructor_preview` and emit the React custom element inside the existing `PreviewLessonLive` surface.
 - Risk: Warning confirmation could fork the customization transport path. Mitigation: keep LiveView as the mutation owner; use the existing hook for intents and let LiveView own pending confirmation state.
 - Risk: Template requirements may be interpreted as a separate surface. Mitigation: verify the current template preview launch path first; defer separate template UI work to a later phase only if a distinct route is discovered.
 - Risk: Counts drift from delivery behavior. Mitigation: recompute from the same Activity Bank and exclusion-view sources used by delivery, and refresh after writes.
 - Risk: Overlap with MER-5622 causes duplicated embedded behavior. Mitigation: only add `bank_selection` handling and regression-test embedded remove/restore.
 - Risk: Attempt/visit warning query is ambiguous for practice pages. Mitigation: locate the existing delivery visit/access signal and encapsulate warning eligibility in a small tested helper.
-- Risk: legacy preview code remains after the new LiveView/UI path replaces it. Mitigation: trace references before removal, then delete unused controller/template/rendering branches when they are demonstrably dead.
+- Risk: legacy preview code is removed too early even though the separate candidate-listing route still uses it. Mitigation: retain controller/template/legacy renderer until the separate listing ticket replaces that surface.
 
 ## 16. Open Questions & Follow-ups
 
 - Confirm the exact source of "students have already visited this page" for practice pages: resource access, resource attempts, page visits, or an existing delivery summary helper.
 - Confirm where points-per-question is stored for Activity Bank Selection preview and whether it is always available for both scored and practice pages.
-- Confirm whether the existing template preview flow always reaches the same `/sections/:section_slug` Activity Bank Selection preview route.
-- Decide whether the old `ActivityBankController.preview/2` should be removed, retained for authoring-only preview, or converted into a LiveView-backed route.
+- Confirm whether template preview reaches the same `PreviewLessonLive` inline selection rendering through blueprint sections.
+- Revisit `ActivityBankController.preview/2` only in the separate candidate-listing ticket.
 - During planning, place any template-only route/view work in a final phase unless route verification shows it comes for free through blueprint sections.
 
 ## 17. References

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
@@ -38,6 +38,7 @@ Relevant boundaries:
 - `assets/src/hooks/instructor_preview_customization.ts` already validates and forwards `bank_selection` targets, so hook changes should be small or unnecessary unless warning confirmation requires a client-side helper.
 - `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md` is the shared transport contract.
 - `lib/oli_web/controllers/activity_bank_controller.ex` and `lib/oli_web/templates/activity_bank/preview.html.heex` currently own the Activity Bank Selection preview route, but controller-rendered pages cannot receive LiveView `pushEvent` calls.
+- `lib/oli/rendering/content/selection.ex` is the current renderer for authored selection blocks. It produces the legacy jumbotron-style Activity Bank Selection display and the `Preview activities` link when rendered inside page content. The existing controller preview also calls this renderer with the link disabled.
 - `assets/src/components/activities/common/preview/ActivityPreviewCard.tsx` and related MER-5618 preview components provide reusable interaction patterns for individual activity previews, but there is no local Activity Bank Selection preview component. MER-5620 should implement that selection-level UI rather than treating the work as a button-only extension.
 - `Oli.Delivery.ActivityProvider` already consults instructor customization state when realizing future activity bank selections, so the UI should not need new delivery-time storage semantics.
 - Scenario directive infrastructure already has bank-selection exclusion verbs, which can support integration tests if this feature needs cross-workflow proof.
@@ -81,6 +82,7 @@ Implement the approved Instructor View Activity Bank Selection UI from Figma as 
 Recommended shape:
 
 - Add a selection-level preview component or LiveView-rendered partial dedicated to Activity Bank selections.
+- Treat `Oli.Rendering.Content.Selection` as the legacy authored-content renderer to replace or bypass for Instructor Preview, not as the final Figma-backed preview UI.
 - Reuse shared preview primitives where they fit: header/action button styling, removed visual state, status pill, rich-text rendering, and sample question rendering.
 - Do not force the selection UI into `ActivityPreviewCard` if that creates an awkward model; an Activity Bank Selection is a page-level selector with aggregate metadata and a sample question, not a normal activity card.
 - Render the Figma-required metadata: available questions, select count, points per question, authored criteria, sample question, active/removed state, and success/warning affordances.
@@ -322,6 +324,8 @@ Do not change the embedded activity preview customization contract or existing e
 
 Template preview compatibility should be validated through the blueprint-section redirect flow. If no separate template route is needed, the same LiveView implementation covers templates without additional code.
 
+If the implementation proves that legacy Activity Bank Selection preview code is no longer referenced by any active authoring, delivery, template, or preview surface, remove that dead code as part of MER-5620 cleanup rather than preserving unused fallback paths.
+
 ## 15. Risks & Mitigations
 
 - Risk: Activity Bank Selection preview remains controller-owned, making `pushEvent` impossible. Mitigation: migrate or wrap the preview in a LiveView while preserving the route.
@@ -330,6 +334,7 @@ Template preview compatibility should be validated through the blueprint-section
 - Risk: Counts drift from delivery behavior. Mitigation: recompute from the same Activity Bank and exclusion-view sources used by delivery, and refresh after writes.
 - Risk: Overlap with MER-5622 causes duplicated embedded behavior. Mitigation: only add `bank_selection` handling and regression-test embedded remove/restore.
 - Risk: Attempt/visit warning query is ambiguous for practice pages. Mitigation: locate the existing delivery visit/access signal and encapsulate warning eligibility in a small tested helper.
+- Risk: legacy preview code remains after the new LiveView/UI path replaces it. Mitigation: trace references before removal, then delete unused controller/template/rendering branches when they are demonstrably dead.
 
 ## 16. Open Questions & Follow-ups
 

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md
@@ -1,0 +1,355 @@
+# Activity Bank Selection Preview Customization - Feature Design Document
+
+## 1. Executive Summary
+
+MER-5620 should implement the new Activity Bank Selection preview UI in the Instructor View preview experience for Course Sections, including whole-selection remove/restore, using the existing instructor customization persistence and the shared preview customization wiring contract.
+
+The core domain layer already has bank-selection validation and write APIs in `Oli.Delivery.InstructorCustomizations`, and the browser hook already accepts `bank_selection` targets. However, the Activity Bank Selection preview does not appear to have received the new MER-5618 preview-component UI that embedded activities and several activity types now use. The design therefore includes both the Activity Bank Selection visual implementation from Figma and the LiveView wiring needed to make remove/restore work.
+
+The remaining design work has two main parts: UI ownership and screen ownership. UI ownership means adding a real Activity Bank Selection preview component/layout rather than only adding a button to the old rendered selection page. Screen ownership means the Activity Bank Selection preview currently lives behind `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`, while the intended customization contract requires an owning LiveView. The design should move or wrap that preview in a LiveView-owned surface so React/server-rendered preview actions can flow through `InstructorPreviewCustomization`, into LiveView, and then into the core implementation.
+
+Implementation should treat embedded activity remove/restore as existing infrastructure from MER-5622 / PR 6659. MER-5620 should regression-test that behavior but should not reimplement it.
+
+## 2. Requirements & Assumptions
+
+### Requirement Trace
+
+- FR-001 / AC-001: Render Activity Bank Selection preview metadata: heading, available-question count, select count, points per question, authored criteria, and one sample question.
+- FR-002 / AC-002 / AC-003 / AC-004: Support whole-selection remove and restore, update available count, show success confirmation, show the approved removed treatment, and keep the sample question visible and keyboard-operable.
+- FR-003 / AC-005 / AC-006: Emit `bank_selection` customization intents with `pageResourceId` and `selectionId`, dispatch through the owning LiveView into `Oli.Delivery.InstructorCustomizations`, and return targeted replies for local UI state.
+- FR-004 / AC-007 / AC-008 / AC-009: Show future-attempt warning text and require confirmation when existing scored attempts or practice visits are present.
+- FR-005 / AC-010 / AC-011: Keep changes scoped to the current page and section/template context, preserve authored content and historical progress, and meet accessibility requirements for controls and states.
+- FR-006 / AC-012: Do not reimplement embedded activity remove/restore; keep it functional after bank-selection changes.
+
+### Assumptions
+
+- The primary implementation target is instructors operating in Course Sections under `/sections/:section_slug`.
+- Template preview appears to launch through a blueprint section via `Oli.Delivery.TemplatePreview.prepare_launch/3` and then redirect into section delivery. If that remains true, the Course Section implementation should cover template preview without a separate template-specific customization path.
+- If template support is found to require a distinct view or route, that work should be scheduled in a later implementation phase after Course Section behavior is complete and verified.
+- Existing `Oli.Delivery.InstructorCustomizations.exclude_bank_selection/4` and `restore_bank_selection/4` are the persistence authority for whole-selection remove/restore.
+- Existing student attempts and prior progress are immutable for this feature; remove/restore only affects future activity realization.
+
+## 3. Repository Context Summary
+
+Relevant boundaries:
+
+- `lib/oli/delivery/instructor_customizations.ex` owns target validation, persistence, and read models for page activity exclusions. It already exposes bank-selection target validation and write APIs.
+- `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex` is the current LiveView reference for embedded activity preview customization. It mounts `InstructorPreviewCustomization`, dispatches remove/restore into the domain context, and returns `{:reply, reply, socket}` payloads.
+- `assets/src/hooks/instructor_preview_customization.ts` already validates and forwards `bank_selection` targets, so hook changes should be small or unnecessary unless warning confirmation requires a client-side helper.
+- `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md` is the shared transport contract.
+- `lib/oli_web/controllers/activity_bank_controller.ex` and `lib/oli_web/templates/activity_bank/preview.html.heex` currently own the Activity Bank Selection preview route, but controller-rendered pages cannot receive LiveView `pushEvent` calls.
+- `assets/src/components/activities/common/preview/ActivityPreviewCard.tsx` and related MER-5618 preview components provide reusable interaction patterns for individual activity previews, but there is no local Activity Bank Selection preview component. MER-5620 should implement that selection-level UI rather than treating the work as a button-only extension.
+- `Oli.Delivery.ActivityProvider` already consults instructor customization state when realizing future activity bank selections, so the UI should not need new delivery-time storage semantics.
+- Scenario directive infrastructure already has bank-selection exclusion verbs, which can support integration tests if this feature needs cross-workflow proof.
+
+## 4. Proposed Design
+
+### Screen Ownership
+
+Introduce a LiveView-owned Activity Bank Selection preview surface for the existing section preview URL:
+
+- Preferred route preservation: keep `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` as the user-facing URL.
+- Preferred implementation shape: replace the controller preview action with a LiveView route, or route that URL to a small LiveView such as `OliWeb.Delivery.Instructor.ActivityBankSelectionPreviewLive`.
+- The LiveView mounts the existing delivery root/layout and the `InstructorPreviewCustomization` hook on the screen root.
+- The LiveView reuses the current controller retrieval behavior for section authorization, page revision resolution, selection lookup, activity bank query, paging, activity script setup, previous/next page context, and scheduled-resource state.
+
+This keeps AC-005 and AC-006 aligned with the existing LiveView/React contract instead of adding a controller API or a second transport path.
+
+### Preview Context
+
+Build a server-owned selection preview context from the resolved section, page revision, selection node, current exclusion view, and activity bank query result:
+
+- `page_resource_id`
+- `revision_slug`
+- `selection_id`
+- display heading/title
+- available-question count
+- authored select count
+- points per question, if available from the selection/page model
+- authored criteria summary
+- sample activity/question content
+- `selection_enabled?`
+- `actions`: `[%{kind: "remove", label: "Remove"}]` when enabled, `[%{kind: "restore", label: "Restore"}]` when removed
+- `visualState`: `"default"` or `"removed"`
+- `statusPill`: `nil` or `%{kind: "removed", label: "Removed"}`
+- `customizationTarget`: `%{kind: "bank_selection", pageResourceId: page_resource_id, selectionId: selection_id}`
+
+### Activity Bank Selection UI Component
+
+Implement the approved Instructor View Activity Bank Selection UI from Figma as an explicit feature deliverable. This is separate from the existing individual activity preview components added by MER-5618.
+
+Recommended shape:
+
+- Add a selection-level preview component or LiveView-rendered partial dedicated to Activity Bank selections.
+- Reuse shared preview primitives where they fit: header/action button styling, removed visual state, status pill, rich-text rendering, and sample question rendering.
+- Do not force the selection UI into `ActivityPreviewCard` if that creates an awkward model; an Activity Bank Selection is a page-level selector with aggregate metadata and a sample question, not a normal activity card.
+- Render the Figma-required metadata: available questions, select count, points per question, authored criteria, sample question, active/removed state, and success/warning affordances.
+- Keep the sample question as a real preview using the existing activity preview/authoring rendering path, so keyboard behavior and rich content remain consistent with activity previews.
+
+If the selection is rendered through React preview components, the context should be passed through typed props similar to the existing preview context, extended for selection-level metadata. If the selection remains server-rendered initially, the remove/restore button should use the hook's fallback attributes:
+
+- `data-preview-customization-button`
+- `data-preview-customization-action`
+- `data-preview-customization-target`
+
+Either rendering path must satisfy AC-001, AC-002, AC-003, AC-004, and AC-011.
+
+### Remove/Restore Flow
+
+The LiveView handles:
+
+```elixir
+handle_event(
+  "toggle_preview_activity_customization",
+  %{
+    "action" => action,
+    "target" => %{
+      "kind" => "bank_selection",
+      "pageResourceId" => page_resource_id,
+      "selectionId" => selection_id
+    }
+  },
+  socket
+)
+```
+
+The event handler should:
+
+1. Confirm `page_resource_id` matches the currently previewed page.
+2. Confirm `selection_id` belongs to the currently previewed page revision.
+3. If a warning confirmation is required and the action is not confirmed yet, store a pending customization in assigns and show the warning modal without mutating domain state.
+4. Dispatch to `InstructorCustomizations.exclude_bank_selection/4` for `remove` or `InstructorCustomizations.restore_bank_selection/4` for `restore`.
+5. Rebuild the selection preview context from the returned or freshly read exclusion view.
+6. Return a targeted reply with `ok`, `target`, `actions`, `visualState`, `statusPill`, and any selection aggregate values needed by the local UI.
+7. Update LiveView assigns for flash/success message, warning modal state, available count, and removed-state presentation.
+
+Malformed, stale, unauthorized, or invalid targets should return `%{ok: false}` and should not mutate state.
+
+### Warning Confirmation
+
+The LiveView owns warning state because warning eligibility depends on section/page data and because mutation authority belongs to the server.
+
+For scored pages, the warning is shown when at least one learner has already started the assessment. For practice pages, the warning is shown when at least one learner has already visited the page. The implementation should identify or add a small query helper near the delivery/instructor preview boundary that answers this without exposing learner identities.
+
+Required warning copy:
+
+- AC-007 scored warning: `Students have already started this assessment. Removing or restoring questions and activity bank selections will only impact future attempts.`
+- AC-008 practice warning: `Students have already visited this page. Removing or restoring questions and activity bank selections will only impact future attempts.`
+
+When warning state is active, an attempted remove/restore should show the confirmation modal and proceed only after user confirmation, satisfying AC-009. The final confirmed mutation should use the same domain dispatcher as an unconfirmed mutation.
+
+### Template Behavior
+
+Template support should be verified through the existing template preview flow before adding template-specific implementation:
+
+- `Oli.Delivery.TemplatePreview.prepare_launch/3` prepares a hidden instructor enrollment in an active blueprint section.
+- `ProductsController.preview_launch/2` redirects into the section experience using that blueprint section slug.
+- If the Activity Bank Selection preview route used by template preview is the same `/sections/:section_slug/...` route, Course Section implementation satisfies the template requirement under the same section/page scoping model.
+- If a separate template-owned preview surface exists or is introduced, wire it as a later phase using the same LiveView event contract and the same domain APIs.
+
+This keeps the design centered on Course Sections while preserving a clear template verification path for AC-010.
+
+## 5. Interfaces
+
+### Browser Event Payload
+
+Activity Bank Selection remove/restore emits:
+
+```json
+{
+  "action": "remove",
+  "target": {
+    "kind": "bank_selection",
+    "pageResourceId": 123,
+    "selectionId": "selection-id"
+  }
+}
+```
+
+`action` is `"remove"` or `"restore"`. `target.kind` is `"bank_selection"`. `pageResourceId` and `selectionId` are required.
+
+### LiveView Reply
+
+Successful replies should include:
+
+```elixir
+%{
+  ok: true,
+  target: %{
+    kind: "bank_selection",
+    pageResourceId: page_resource_id,
+    selectionId: selection_id
+  },
+  actions: [%{kind: "restore", label: "Restore"}],
+  visualState: "removed",
+  statusPill: %{kind: "removed", label: "Removed"},
+  questionsAvailable: 0
+}
+```
+
+Restore replies use `actions: [%{kind: "remove", label: "Remove"}]`, `visualState: "default"`, `statusPill: nil`, and the recomputed available-question count.
+
+Failure replies should include `ok: false` and a concise reason category for debugging/UI fallback, without leaking learner data.
+
+### Domain Calls
+
+- Remove: `Oli.Delivery.InstructorCustomizations.exclude_bank_selection(section_or_id, page_resource_id, selection_id, opts)`
+- Restore: `Oli.Delivery.InstructorCustomizations.restore_bank_selection(section_or_id, page_resource_id, selection_id, opts)`
+- Validation: `Oli.Delivery.InstructorCustomizations.validate_bank_selection_customization_target(section_or_id, page_resource_id, selection_id)`
+- Read state: `get_page_exclusion_view/2` or `get_selection_exclusion_view/3`
+
+The LiveView may call validation explicitly for clearer local error handling, but the domain write remains the final authority.
+
+## 6. Data Model & Storage
+
+No new database tables or migrations are expected.
+
+Whole-selection remove/restore should use the existing instructor customization exclusion storage with:
+
+- `section_id`
+- `page_resource_id`
+- `kind: :bank_selection`
+- `selection_id`
+
+The feature must not write to authored page revisions, published source content, activity bank logic, or existing student attempt records. This satisfies AC-010 and preserves the publication/resource/revision model.
+
+If the implementation discovers missing uniqueness constraints or race-prone duplicate exclusion rows, address that in the core instructor customization layer rather than in UI code.
+
+## 7. Consistency & Transactions
+
+`Oli.Delivery.InstructorCustomizations` should remain the consistency boundary for exclusion writes.
+
+Expected behavior:
+
+- Remove is idempotent from the user perspective: removing an already removed selection should leave it removed.
+- Restore is idempotent from the user perspective: restoring an already active selection should leave it active.
+- Page and selection target validation happens before writes.
+- The LiveView rebuilds UI state after a successful write rather than trusting the submitted action.
+- Existing attempts and progress are not rewritten.
+
+Concurrent instructor actions on the same selection should converge to the latest persisted exclusion state when the LiveView refreshes its selection preview context.
+
+## 8. Caching Strategy
+
+No new cache is required.
+
+The LiveView should reuse existing Activity Bank query and exclusion-view reads. After remove/restore, it should refresh only the affected selection preview state and any page-level aggregates needed for the screen. Avoid storing derived selection-enabled state in long-lived process state without re-reading after writes.
+
+## 9. Performance & Scalability Posture
+
+The preview should avoid per-candidate query loops during render.
+
+Recommended approach:
+
+- Use the existing Activity Bank query path to obtain total available count and the paged/sample activity rows.
+- Use the existing exclusion view once per page/selection render.
+- For sample question rendering, reuse the first available queried activity when possible or issue a limit-1 query rather than loading all candidates.
+- Keep warning detection to an existence/count query scoped by section and page resource, not a full learner-attempt listing.
+
+This is a section/instructor preview surface, so throughput requirements are modest, but the implementation should still avoid N+1 behavior and expensive all-candidate loads.
+
+## 10. Failure Modes & Resilience
+
+Expected failure modes and handling:
+
+- Invalid browser payload: dropped by `InstructorPreviewCustomization` before `pushEvent`.
+- Stale page resource id: LiveView returns `ok: false`; no write.
+- Selection id not present on current page: LiveView/domain validation returns `ok: false`; no write.
+- Unauthorized instructor/admin context: route authorization or domain authorization rejects; no write.
+- Domain persistence error: LiveView keeps the prior UI state, clears submitting state through `ok: false`, and shows recoverable feedback.
+- Warning confirmation canceled: pending action is cleared; no write.
+- Activity Bank query failure after mutation: persisted state remains authoritative; LiveView should show an error and allow refresh/retry.
+
+The UI should never hide the sample question solely because a selection is removed; removed state is a customization overlay, not deletion.
+
+## 11. Observability
+
+No new product telemetry is required for the initial design.
+
+Use existing logging/AppSignal paths for unexpected domain or query errors. Avoid logging learner-specific attempt details for warning eligibility. If the implementation already has a reusable instructor customization telemetry event, bank-selection remove/restore can emit the same event shape with `target_kind: :bank_selection`.
+
+Success and failure feedback should be visible to the instructor through existing LiveView flash/success-message patterns.
+
+## 12. Security & Privacy
+
+Security checks:
+
+- Preserve instructor/admin authorization for section preview routes.
+- Validate section, page resource id, and selection id server-side.
+- Delegate final domain validation to `Oli.Delivery.InstructorCustomizations`.
+- Do not trust `pageResourceId`, `selectionId`, action labels, visual state, or count values from the browser.
+- Escape authored criteria/title values in server-rendered HTML.
+
+Privacy checks:
+
+- Warning copy must not reveal which learners have attempted or visited the page.
+- No learner attempt IDs, user IDs, or names should be sent to the browser for this feature.
+
+## 13. Testing Strategy
+
+Automated tests:
+
+- LiveView test for active selection preview render with required metadata and sample question: AC-001.
+- LiveView test for remove flow: action emitted/handled, domain state changed, available count becomes 0, success appears, action changes to Restore: AC-002 and AC-005.
+- LiveView test for restore flow: state returns to default, original count returns, success appears, action changes to Remove: AC-003.
+- LiveView/UI test for removed treatment and sample question operability: AC-004 and AC-011.
+- LiveView test for targeted success/failure replies, including stale page id and missing selection id: AC-006.
+- Warning tests for scored started attempts and practice page visits: AC-007 and AC-008.
+- Warning modal test that mutation occurs only after confirmation: AC-009.
+- Scope test showing removal affects only the current page and section/template scope, preserving authored content and existing progress: AC-010.
+- Regression test that embedded activity remove/restore still functions and is not reimplemented through a new path: AC-012.
+
+Frontend tests:
+
+- Add or update Jest coverage only if new TypeScript is introduced. Existing hook validation already includes `bank_selection`, so frontend tests may be limited to the new preview component state/props if React rendering is used.
+
+Scenario tests:
+
+- Add scenario coverage if the implementation needs end-to-end proof across authoring, publishing, section delivery, instructor customization, and future attempts.
+- A template-preview smoke test is useful if the Course Section route is confirmed to serve blueprint template preview.
+
+Manual verification:
+
+- Compare active, removed, warning, modal, hover, disabled, and focus states against the approved Figma references.
+- Verify scored and practice page copy exactly matches AC-007 and AC-008.
+- Verify future attempts reflect removal/restoration while existing attempts remain unchanged.
+
+## 14. Backwards Compatibility
+
+Preserve the user-facing Activity Bank Selection preview URL if possible. If the controller route becomes a LiveView route, keep redirects, route helpers, and navigation behavior compatible with existing instructor preview links.
+
+Do not change the embedded activity preview customization contract or existing embedded event behavior from MER-5622. Do not change delivery attempt realization beyond the existing use of instructor customization exclusion state.
+
+Template preview compatibility should be validated through the blueprint-section redirect flow. If no separate template route is needed, the same LiveView implementation covers templates without additional code.
+
+## 15. Risks & Mitigations
+
+- Risk: Activity Bank Selection preview remains controller-owned, making `pushEvent` impossible. Mitigation: migrate or wrap the preview in a LiveView while preserving the route.
+- Risk: Warning confirmation could fork the customization transport path. Mitigation: keep LiveView as the mutation owner; use the existing hook for intents and let LiveView own pending confirmation state.
+- Risk: Template requirements may be interpreted as a separate surface. Mitigation: verify the current template preview launch path first; defer separate template UI work to a later phase only if a distinct route is discovered.
+- Risk: Counts drift from delivery behavior. Mitigation: recompute from the same Activity Bank and exclusion-view sources used by delivery, and refresh after writes.
+- Risk: Overlap with MER-5622 causes duplicated embedded behavior. Mitigation: only add `bank_selection` handling and regression-test embedded remove/restore.
+- Risk: Attempt/visit warning query is ambiguous for practice pages. Mitigation: locate the existing delivery visit/access signal and encapsulate warning eligibility in a small tested helper.
+
+## 16. Open Questions & Follow-ups
+
+- Confirm the exact source of "students have already visited this page" for practice pages: resource access, resource attempts, page visits, or an existing delivery summary helper.
+- Confirm where points-per-question is stored for Activity Bank Selection preview and whether it is always available for both scored and practice pages.
+- Confirm whether the existing template preview flow always reaches the same `/sections/:section_slug` Activity Bank Selection preview route.
+- Decide whether the old `ActivityBankController.preview/2` should be removed, retained for authoring-only preview, or converted into a LiveView-backed route.
+- During planning, place any template-only route/view work in a final phase unless route verification shows it comes for free through blueprint sections.
+
+## 17. References
+
+- `docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md`
+- `docs/exec-plans/current/epics/instructor_customizations/ui_core/requirements.yml`
+- `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md`
+- `docs/exec-plans/current/epics/instructor_customizations/core/fdd.md`
+- `docs/exec-plans/current/epics/instructor_customizations/instructor_view_shell/fdd.md`
+- `lib/oli/delivery/instructor_customizations.ex`
+- `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`
+- `lib/oli_web/controllers/activity_bank_controller.ex`
+- `lib/oli_web/templates/activity_bank/preview.html.heex`
+- `assets/src/hooks/instructor_preview_customization.ts`
+- `lib/oli/delivery/template_preview.ex`
+- `lib/oli_web/controllers/products_controller.ex`

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/informal.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/informal.md
@@ -1,0 +1,250 @@
+# Activity Bank Selection and Embedded Question Remove/Restore - Informal Notes
+
+## Source
+
+- Jira: `MER-5620`
+- Type: Story
+- Summary: Activity Bank Selection & Embedded Question Remove/Restore
+- Status at intake: QA
+- Assignee at intake: gaston@wyeworks.com
+- Epic lane slug from Jira comment: `ui_core`
+
+## User Story
+
+As an instructor, I want the ability to remove entire Activity Bank selections and embedded questions from a page (scored and practice), so that I can better align assessments and practice opportunities with the goals and scope of my course section.
+
+This capability should also be available at the template level.
+
+## Current Scope Adjustment
+
+The original ticket includes remove/restore behavior for both embedded questions and entire Activity Bank selections. Embedded question remove/restore has already been implemented by the merged `MER-5622-manage-questions-in-activity-bank-selection` work in PR `https://github.com/Simon-Initiative/oli-torus/pull/6659/changes`.
+
+That merged work added the LiveView/React wiring, preview-card UI actions, local reply handling, and backend routing needed for embedded activity remove/restore in Instructor View.
+
+MER-5620 should not reimplement embedded activity remove/restore. It should treat that work as existing infrastructure and focus remaining implementation on:
+
+- Activity Bank Selection preview display updates
+- whole-selection remove/restore behavior
+- routing bank-selection preview actions into the core instructor customization implementation
+- warning messaging that changes only apply to new attempts
+
+The embedded question acceptance criteria remain documented below because they are part of the original Jira scope, but implementation planning should mark them as already satisfied by the merged MER-5622/PR 6659 work unless a regression or integration gap is found.
+
+## Acceptance Criteria
+
+### Positive Acceptance Criteria
+
+Note: removing bank selections & questions should not affect student progress. A student should not be required to complete something that has been removed to achieve 100%.
+
+#### Activity Bank Selection UI
+
+Given a user is in Instructor View
+And there is an Activity Bank Selection on the page
+Then the Activity Bank Selection follows the updated Instructor View UI.
+
+The Activity Bank Selection displays:
+
+- Activity Bank Selection heading
+- Number of available questions
+- "Selects: # question(s)"
+- "Points per question: #"
+- Selection criteria determined in authoring
+- Examples:
+- Tags
+- Learning Objectives
+- Other authored selection logic
+- Sample question from this selection:
+- display one sample question from the available questions
+
+#### Remove Activity Bank Selection
+
+Given an Activity Bank Selection is displayed
+Then a "Remove" button is displayed following Figma UI patterns and hover states.
+
+When the user selects "Remove"
+Then the entire Activity Bank Selection is removed from the page.
+
+After removal:
+
+- A success confirmation appears above the selection
+- The selection enters a removed state
+- The removed state includes:
+- Red border
+- Gray background
+- "Removed" pill/badge
+- Note: users can still interact with sample question in removed state
+- "Questions available" updates to 0
+- The "Remove" button changes to a "Restore" button
+
+#### Restore Activity Bank Selection
+
+Given an Activity Bank Selection is in a removed state
+Then a "Restore" button is displayed.
+
+When the user selects "Restore"
+Then the entire Activity Bank Selection is restored.
+
+After restoration:
+
+- A success confirmation appears above the selection
+- "Questions available" returns to the original value
+- The selection returns to its default visual state
+
+#### Embedded Question Removal
+
+Given there is an embedded question on the page
+Then a "Remove" button is displayed in the top-right corner of the question container.
+
+When the user selects "Remove"
+Then the question is removed from the page.
+
+After removal:
+
+- A success confirmation appears above the question
+- The question enters a removed state
+- The removed state includes:
+- Red border
+- Gray background
+- "Removed" pill/badge
+- The "Remove" button changes to a "Restore" button
+
+#### Restore Embedded Question
+
+Given an embedded question is in a removed state
+Then a "Restore" button is displayed.
+
+When the user selects "Restore"
+Then the question is restored to the page.
+
+After restoration:
+
+- A success confirmation appears above the question
+- The question returns to its default visual state
+
+#### Page Attempts Present
+
+Given that students have already attempted the assessment or practice page
+Display a warning banner at the top of the page.
+
+Scored pages:
+
+> Students have already started this assessment. Removing or restoring questions and activity bank selections will only impact future attempts.
+
+Practice pages:
+
+> Students have already visited this page. Removing or restoring questions and activity bank selections will only impact future attempts.
+
+If the user tries to restore or remove activity bank selections or embedded questions
+Display a warning modal.
+
+If the user selects "keep/remove question," then follow the user's action.
+
+The removal/restoration should appear in future page view/attempts.
+
+#### Saving Behavior
+
+Given a user removes or restores content
+Then updates to the page are automatically saved.
+
+Given a save operation is in progress
+Then a "Saving..." indicator is displayed at the top of the page.
+
+Given a save operation completes successfully
+Then a "Changes have been saved" message is displayed at the top of the page.
+
+#### Scope of Changes
+
+Given a user removes or restores content
+Then the changes apply only to the page currently being edited.
+
+These capabilities apply to:
+
+- Course sections
+- Templates
+
+### Negative Acceptance Criteria
+
+- Removing questions & bank selections should not affect student progress
+- Do not remove questions or Activity Bank selections globally across the course
+- Do not modify authored source content when instructors remove content locally
+- Do not affect other pages containing the same question or Activity Bank selection
+- Do not allow "Questions available" counts to become inaccurate after removal or restoration
+- Do not remove the sample question preview when the Activity Bank Selection is in a removed state unless explicitly defined later
+- Do not allow removed content to permanently disappear without a restore path
+- Do not restore content into an incorrect position on the page
+- Do not display both "Remove" and "Restore" actions simultaneously
+- Do not use outdated button styles or interaction states outside approved Figma patterns
+- Do not remove hover, focus, or disabled states from interactive controls
+- Do not visually present removed content as active or available
+
+## Design Notes
+
+Interaction design:
+
+- Activity Bank Selection: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-8959&t=T9wp5xcQh1vNqdxN-1
+- Embedded Question
+- Success Messages: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=379-7382&t=T9wp5xcQh1vNqdxN-1
+- Attempts started: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=286-8247&t=T9wp5xcQh1vNqdxN-1
+- Warning Modals: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=379-8630&t=T9wp5xcQh1vNqdxN-1
+
+## Related Implementation Contract
+
+This feature should build on the shared preview customization contract documented in `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md`.
+
+That contract is relevant because MER-5620 needs to route Activity Bank Selection remove/restore actions from preview UI into the delivery-owned instructor customization implementation without making React preview components own database mutations. The embedded activity path described by the same contract already exists and should be reused as a reference point rather than rebuilt.
+
+Important contract points for this ticket:
+
+- React preview components emit a customization intent instead of performing the mutation directly.
+- The browser event carries an action and a typed `customizationTarget`.
+- The `InstructorPreviewCustomization` hook forwards valid events into LiveView with `pushEvent(...)`.
+- The owning LiveView pattern matches on `target.kind` and dispatches to `Oli.Delivery.InstructorCustomizations`.
+- The LiveView returns `{:reply, reply, socket}` so the initiating preview card can update local state without a remount.
+- The LiveView can update screen-owned state such as flashes, warning messages, counters, and aggregates through normal assigns at the same time.
+- The reply should include only the card-local state needed by the preview component, such as `actions`, `visualState`, and `statusPill`.
+
+MER-5620 should reuse or extend the existing target kinds from the contract:
+
+- `bank_selection` for an entire Activity Bank Selection rendered at page level.
+- `embedded_activity` only as existing reference behavior from the merged MER-5622/PR 6659 implementation.
+
+The same contract also mentions `bank_candidate`, but candidate-level management belongs to the bank selection manager flow and later related tickets unless MER-5620 explicitly expands into that surface.
+
+The contract currently describes `PreviewAction.kind` as `remove | restore`, while the Jira comment uses "enable / disable" language. For this ticket, detailed design should reconcile the vocabulary without changing the behavior: enabling/restoring and disabling/removing both map to toggling instructor customization state in the core implementation. The UI copy and Figma patterns should decide whether the user-facing label is "Remove/Restore" or "Enable/Disable" for each surface.
+
+## Related Tickets And Dependencies
+
+This ticket depends on the instructor customization core implementation and preview component infrastructure already planned or delivered in the epic:
+
+- `MER-5639`: core non-UI customization implementation, persistence, validation, authorization, and scenario coverage.
+- `MER-5618`: Preview components rendered during instructor preview and the preview-side event contract for activity-level customization actions.
+- `MER-5622`: Manage Questions in Activity Bank Selection. MER-5620 should align with its shared wiring contract but should not absorb candidate-management scope unless explicitly required.
+
+The implementation should preserve the separation defined by the wiring contract:
+
+- preview components own local UI state and emit customization intents
+- LiveViews own screen-specific orchestration, warnings, flashes, and dispatch
+- `Oli.Delivery.InstructorCustomizations` owns authorization, target validation, persistence, and domain rules
+
+## Accessibility Guidelines
+
+Remove and Restore buttons must:
+
+- Be keyboard accessible
+- Have visible focus states
+- Include accessible labels for screen readers
+
+Success confirmations must:
+
+- Be announced to assistive technologies where appropriate
+- Remain readable and distinguishable from surrounding content
+
+Interactive sample question content must remain operable via keyboard navigation.
+
+## Technical Notes
+
+The Jira ticket includes a Technical Notes heading with no additional content.
+
+## Testing Notes
+
+The Jira ticket includes a Testing Notes heading with no additional content.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_1_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_1_execution_record.md
@@ -1,0 +1,141 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Phase: `1 - Surface And Data Discovery`
+
+## Scope from plan.md
+
+- Confirm exact implementation boundaries before moving UI and route ownership.
+- Trace Activity Bank Selection preview route and legacy renderer.
+- Confirm template preview routing assumptions.
+- Identify metadata, warning, and sample rendering sources.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+  - No runtime behavior was changed in this phase. Phase 1 was completed as discovery and documentation.
+- [x] Data or interface changes
+  - No data/interface changes were introduced.
+- [x] Access-control or safety checks
+  - Current route authorization was mapped for the existing controller route.
+- [x] Observability or operational updates when needed
+  - No operational changes were needed.
+
+## Discovery Findings
+
+### Current Activity Bank Selection Preview Route
+
+- The existing Activity Bank Selection preview URL is:
+  - `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id`
+- The route is currently controller-owned:
+  - `lib/oli_web/router.ex`
+  - `lib/oli_web/controllers/activity_bank_controller.ex`
+- The route runs under the section preview pipeline:
+  - `:browser`
+  - `:require_section`
+  - `:authorize_section_preview`
+  - `:delivery_protected`
+  - `:delivery_layout`
+- The current controller action:
+  - authorizes instructor/admin access
+  - resolves the page revision from `section_slug` and `revision_slug`
+  - finds the selection node by `selection_id`
+  - parses the selection logic
+  - queries Activity Bank candidates through `Oli.Authoring.Editing.ActivityBank.query_section_publication/6`
+  - renders `lib/oli_web/templates/activity_bank/preview.html.heex`
+
+### Legacy Selection Renderer
+
+- `lib/oli/rendering/content/selection.ex` is the current renderer for authored selection blocks.
+- It renders the legacy jumbotron-style Activity Bank Selection display.
+- It builds the `Preview activities` link using:
+  - `/sections/#{section_slug}/preview/page/#{revision_slug}/selection/#{id}`
+- Page HTML rendering delegates selection blocks through:
+  - `lib/oli/rendering/content.ex`
+  - `lib/oli/rendering/content/html.ex`
+- `ActivityBankController.preview/2` also calls `Oli.Rendering.Content.Selection.render/3`, but with `include_link? = false`, so the preview page still depends on the legacy renderer for selection metadata display.
+
+### Template Preview Routing
+
+- Template preview launches from product details through:
+  - `lib/oli_web/live/workspaces/course_author/products/details_live.ex`
+  - `lib/oli_web/controllers/products_controller.ex`
+  - `lib/oli/delivery/template_preview.ex`
+- `Oli.Delivery.TemplatePreview.prepare_launch/3` only accepts active blueprint sections.
+- Product preview stores template preview session state and redirects/logs into:
+  - `/sections/#{section_slug}`
+- This supports the working assumption that template preview uses the normal section delivery/preview route with a blueprint section slug.
+- No separate template-specific Activity Bank Selection preview route was found in this phase.
+
+### Activity Bank Selection Metadata Sources
+
+- Selection id, selected count, and authored selection logic are available directly on the selection content node:
+  - `selection["id"]`
+  - `selection["count"]`
+  - `selection["logic"]`
+- Authored criteria display currently comes from `Oli.Rendering.Content.Selection.render/3`.
+- Candidate rows and total available count are already queried in `ActivityBankController.preview/2` through `ActivityBank.query_section_publication/6`.
+- `Oli.Delivery.InstructorCustomizations.list_bank_selection_candidates/4` also exposes selection review state, candidate titles, and selection enabled state, but currently returns candidate metadata rather than full preview-rendering data.
+- Points-per-question does not appear to be stored on the selection node. The existing instructor preview page computes activity points with `Oli.Grading.determine_activity_out_of/1`; the new selection preview should likely derive points from the sample/candidate activity revision or a shared selection-preview context helper.
+
+### Warning Signals
+
+- Scored assessment "students have already started" can be derived from existing `ResourceAttempt` records joined through `ResourceAccess` for the current section and page resource.
+- Existing helper references:
+  - `Oli.Delivery.Attempts.Core.get_resource_access_for_page/2`
+  - `Oli.Delivery.Attempts.Core.get_resource_attempt_history/3`
+  - `Oli.Delivery.Attempts.Core.get_graded_attempts_from_access/1`
+- A dedicated existence query scoped by `section_id` and `page_resource_id` is still preferable for Phase 5 to avoid loading full attempt/access records.
+- Practice page "students have already visited" can be derived from `ResourceAccess` because page visits call `Attempts.track_access/3`.
+- `Attempts.track_access/3` creates or increments `resource_accesses.access_count` for `(resource_id, section_id, user_id)`.
+- `PageContext.create_for_visit/4` calls `Attempts.track_access/3`, so practice visits are represented in `ResourceAccess`.
+- The warning helper in Phase 5 should ignore instructor/template-preview users where appropriate and should not expose learner details.
+
+### Sample Question Rendering Path
+
+- The existing Activity Bank preview page renders candidate activities with authoring elements:
+  - `type.authoring_element`
+  - `editmode: "false"`
+- The newer instructor preview infrastructure renders first-class preview elements when available and falls back to authoring elements otherwise:
+  - `lib/oli_web/delivery/instructor/preview_page_context.ex`
+  - `lib/oli/rendering/activity/html.ex`
+  - `assets/src/components/activities/common/preview/registerPreview.tsx`
+- The new Activity Bank Selection UI should reuse that preview/fallback rendering path for the sample question instead of continuing the legacy `activity_bank/preview.html.heex` loop.
+
+## Route And Data Differences Affecting Later Phases
+
+- No separate template Activity Bank Selection route was found.
+- The main implementation boundary remains the existing section preview URL, which should be moved or wrapped into LiveView in Phase 2.
+- `Oli.Rendering.Content.Selection` may still be needed for authored page rendering outside Instructor Preview; deleting it entirely is not safe until Phase 2/3 trace all remaining authoring/delivery usages.
+- Points-per-question remains the only partially unresolved metadata field; it should be resolved while building the selection preview context in Phase 2/3.
+
+## Test Blocks
+
+- [x] Tests added or updated
+  - No tests were added. Phase 1 introduced no runtime code or helper functions.
+- [x] Required verification commands run
+  - `python3 /Users/gastonabella/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/epics/instructor_customizations/ui_core --check all`
+- [x] Results captured
+  - Initial validation passed before discovery.
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - No PRD/FDD divergence was found.
+  - `plan.md` was updated to mark Phase 1 completed and preserve remaining follow-ups for later phases.
+- [x] Open questions added to docs when needed
+  - Points-per-question remains open for Phase 2/3 selection context work.
+
+## Review Loop
+
+- Round 1 findings:
+  - No formal code review round was run because this phase changed only planning/discovery documentation and introduced no runtime code. This matches `harness-review` guidance for pure document drafting with no behavior diff.
+- Round 1 fixes:
+  - Not applicable.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled, or skipped by review-skill policy for documentation-only changes
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_2_inline_preview_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_2_inline_preview_execution_record.md
@@ -1,0 +1,56 @@
+# Phase 2 Inline Preview Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Scope: Inline Activity Bank Selection preview bridge, first functional React preview, and basic whole-selection remove/restore vertical slice.
+
+## Decision Update
+
+- The earlier LiveView-owned separate selection preview route approach was discarded.
+- MER-5620 does not need a new LiveView or route.
+- The existing `PreviewLessonLive` remains the owning LiveView.
+- The separate `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` candidate-listing route remains controller-owned and out of scope for this ticket.
+- Inline Activity Bank Selection preview now follows the preview-component pattern by emitting a React custom element from the content renderer.
+- Activity Bank Selection is not registered as an activity manifest. Its custom element is bundled through the generic `instructor_preview_components.js` entry.
+
+## Implementation Blocks
+
+- [x] Inline render bridge
+  - Added `OliWeb.Delivery.Instructor.ActivityBankSelectionPreview` as a server-side adapter.
+  - Extended `Oli.Rendering.Context` with generic `instructor_preview_context` payload storage.
+  - Updated `PreviewPageContext` to build selection preview payloads during instructor preview context construction.
+  - Updated `Oli.Rendering.Content.Html.selection/3` to use the new custom element only for `:instructor_preview`.
+- [x] React preview component
+  - Added `assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx`.
+  - Added `preview-entry.tsx` to register `oli-activity-bank-selection-preview`.
+  - Added generic webpack entry `instructor_preview_components`.
+- [x] Sample activity preview
+  - Selection candidates are resolved server-side with existing bank-selection logic.
+  - The component receives a limit-1 sample activity payload.
+  - React renders the sample by mounting the existing activity preview custom element.
+- [x] Whole-selection event wiring
+  - Added `bank_selection` handling to `PreviewLessonLive`.
+  - Dispatches to `InstructorCustomizations.exclude_bank_selection/4` and `restore_bank_selection/4`.
+  - Replies with local UI state updates for actions, removed visual state, status pill, and available count.
+- [x] Legacy route preservation
+  - The previous controller/template candidate-listing route remains unchanged.
+  - No Activity Bank Selection preview LiveView was added.
+
+## Verification
+
+- [x] `mix format lib/oli/rendering/context.ex lib/oli/rendering/content/html.ex lib/oli/delivery/instructor_customizations.ex lib/oli_web/delivery/instructor/preview_page_context.ex lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex lib/oli_web/live/delivery/instructor/preview_lesson_live.ex test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
+- [x] `cd assets && ./node_modules/.bin/prettier --write src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/apps/InstructorPreviewComponents.tsx webpack.config.js`
+- [x] `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
+- [x] `cd assets && ./node_modules/.bin/eslint src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/apps/InstructorPreviewComponents.tsx webpack.config.js`
+- [x] `mix compile`
+
+## Notes
+
+- `cd assets && ./node_modules/.bin/tsc --noEmit --skipLibCheck` was attempted and failed on an existing missing `vm2` type/module resolution in `src/eval_engine/evaluator.ts`, not on the new preview files.
+- Figma MCP access failed with OAuth authorization required, so visual comparison against the Figma node still needs human/browser verification.
+- A repo-level `yarn format --write ...` attempt expanded to the repository's global prettier command and touched unrelated files; those accidental formatter-only changes were reverted, leaving only scoped files.
+
+## Remaining Work
+
+- Add warning confirmation for existing attempts/visits.
+- Add fuller restore/error reply tests for bank selection events.
+- Run browser/Figma visual QA and UI refinement against the Figma node once the Figma and Browser MCP contexts are available.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_4_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_4_execution_record.md
@@ -1,0 +1,64 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Phase: `4 - Whole-Selection Remove/Restore Wiring`
+
+## Scope from plan.md
+
+- Route Activity Bank Selection remove/restore through the shared preview customization contract into the core instructor customization implementation.
+- Close hardening and coverage gaps for restore, stale/error cases, and LiveView reply contract assertions.
+- Keep Phase 5 warning banner/modal behavior out of this phase.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+  - Kept the existing `bank_selection` remove/restore dispatcher in `PreviewLessonLive`.
+  - Added reasoned `ok: false` replies for invalid page targets, invalid selection targets, invalid actions, malformed targets, unauthorized writes, and unexpected domain errors.
+  - Preserved short success flash copy: `Activity bank selection removed` and `Activity bank selection restored`.
+- [x] Data or interface changes
+  - Added `originalAvailableCount` to the server-built Activity Bank Selection preview payload so restore replies can return the original available count even when the selection initially rendered as removed.
+  - Stored the original available count in `preview_metadata.bank_selection_available_counts_by_id`.
+- [x] Access-control or safety checks
+  - Preserved existing page-resource-id and selection-id validation before domain writes.
+  - Preserved `Oli.Delivery.InstructorCustomizations` as the final authorization and persistence boundary.
+- [x] Observability or operational updates when needed
+  - No new telemetry or logging required for this phase.
+
+## Test Blocks
+
+- [x] Tests added or updated
+  - Updated bank-selection remove test to assert the `{:reply, reply, socket}` contract with `assert_reply/2`.
+  - Added bank-selection restore coverage.
+  - Added stale page id, missing/unknown selection id, malformed target, and invalid action coverage.
+  - Kept unauthorized and unexpected domain-error replies reasoned at the LiveView boundary; direct LiveView coverage remains focused on reachable stale, malformed, missing-selection, and invalid-action requests.
+  - Kept embedded activity remove/restore tests in the same LiveView module passing.
+- [x] Required verification commands run
+  - `mix format lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex lib/oli_web/delivery/instructor/preview_page_context.ex lib/oli_web/live/delivery/instructor/preview_lesson_live.ex test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
+  - `python3 /Users/gastonabella/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/epics/instructor_customizations/ui_core --check all`
+- [x] Results captured
+  - Targeted LiveView test passed: 22 tests, 0 failures.
+  - Phase contract test set passed: 33 tests, 0 failures.
+  - Work item validation passed.
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - `plan.md` updated to mark Phase 4 complete and record the Phase 4 decision.
+- [x] Open questions added to docs when needed
+  - No new open questions; Phase 5 warning behavior remains explicitly pending.
+
+## Review Loop
+
+- Round 1 findings: Local fallback review completed for security, performance, and Elixir concerns because the available multi-agent tool policy requires explicit user approval before spawning subagents. No blocking findings found. Scope remains limited to Phase 4 remove/restore contract hardening.
+- Round 1 fixes: None required after review.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_5_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_5_execution_record.md
@@ -1,0 +1,73 @@
+# Phase 5 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Phase: `5 - Existing Attempts And Visits Warning Flow`
+
+## Scope from plan.md
+
+- Warn instructors that remove/restore changes apply only to future attempts when the current Course Section page already has scored attempts or practice visits.
+- Render the warning banner at the top of Instructor Preview and make it dismissable.
+- Require confirmation in a warning modal before applying remove/restore for affected preview customization actions.
+- Keep Phase 6 template verification out of this phase.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+  - Added aggregate, privacy-preserving attempt/access existence helpers in `Oli.Delivery.Attempts.Core`.
+  - Added scored/practice warning state to `PreviewLessonLive` during Instructor Preview mount.
+  - Added dismissable page-level warning banner using the scored/practice copy from `informal.md`.
+  - Added warning modal state that stores a pending preview customization action and applies it only after instructor confirmation.
+  - Routed confirmed actions back to React/fallback preview components through the existing preview customization reply event shape.
+- [x] Data or interface changes
+  - Added a LiveView-pushed `preview_customization_reply` browser event for confirmed modal actions.
+  - Kept existing remove/restore payloads and success replies unchanged after confirmation.
+- [x] Access-control or safety checks
+  - Warning eligibility uses only section/page existence queries and does not expose learner identity, attempt IDs, user IDs, or counts.
+  - Confirmed actions revalidate the current page and target before writing.
+- [x] Observability or operational updates when needed
+  - No new telemetry or logging required for this phase.
+
+## Test Blocks
+
+- [x] Tests added or updated
+  - Added scored warning banner copy and dismiss coverage.
+  - Added practice warning banner copy coverage.
+  - Added bank-selection modal gating coverage proving remove does not persist until confirmation.
+  - Added cancel coverage proving pending actions are cleared without persistence.
+  - Added embedded activity modal-gating regression coverage.
+  - Added coverage for action-specific modal copy: remove/restore and question/selection labels.
+  - Added coverage for the narrowed warning banner width treatment.
+- [x] Required verification commands run
+  - `mix format lib/oli/delivery/attempts/core.ex lib/oli_web/live/delivery/instructor/preview_lesson_live.ex test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
+  - `cd assets && ./node_modules/.bin/eslint src/hooks/instructor_preview_customization.ts`
+  - `cd assets && ./node_modules/.bin/prettier src/hooks/instructor_preview_customization.ts --check`
+  - `python3 /Users/gastonabella/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/epics/instructor_customizations/ui_core --check all`
+- [x] Results captured
+  - Targeted LiveView test passed: 28 tests, 0 failures.
+  - Phase contract test set passed: 39 tests, 0 failures.
+  - Targeted TypeScript lint passed.
+  - Targeted TypeScript Prettier check passed.
+  - Work item validation passed.
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - `plan.md` updated to mark Phase 5 complete and record the Phase 5 decision.
+- [x] Open questions added to docs when needed
+  - No new open questions; template behavior remains pending for Phase 6.
+
+## Review Loop
+
+- Round 1 findings: Local review across security, performance, Elixir, TypeScript, and UI found one accessibility issue: the custom warning modal needed dialog keyboard/focus behavior instead of only a static fixed overlay.
+- Round 1 fixes: Added `focus_wrap`, Escape handling, and click-away cancellation to the warning modal while preserving the Figma-aligned visual treatment.
+- Round 2 findings (optional): Refinement review found no blocking issues in the narrower banner width or action-specific modal copy changes.
+- Round 2 fixes (optional): None required.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_6_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_6_execution_record.md
@@ -1,0 +1,57 @@
+# Phase 6 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Phase: `6 - Template Verification And Scope Hardening`
+
+## Scope from plan.md
+- Verify template-level behavior and lock down page/section scoping guarantees.
+- Confirm Product/Template Customize Content reaches the existing instructor-style preview route.
+- Verify or implement propagation of template blueprint activity exclusions to future course sections.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added `section_page_activity_exclusions` copying to `Oli.Delivery.Sections.Blueprint.duplicate/3`, so future course sections created from a customized template inherit template-level activity exclusions.
+  - Updated instructor preview return sanitization to preserve product remix return paths from Product/Template Customize Content page Edit links, including `/workspaces/course_author/:project_slug/products/:product_slug/remix`.
+- [x] Data or interface changes
+  - Reused the existing `section_page_activity_exclusions` table and `ActivityExclusion` schema; no migration or new interface was required.
+- [x] Access-control or safety checks
+  - Kept template UI on the existing `PreviewLessonLive` route and copied exclusions only during blueprint duplication, preserving existing authorization and avoiding retroactive updates to already-created sections.
+- [x] Observability or operational updates when needed
+  - No new telemetry or logging was needed.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added blueprint duplication coverage for inherited embedded activity, bank selection, and bank candidate exclusions.
+  - Added regression coverage that a section created before a later template customization does not receive that later exclusion.
+  - Added LiveView smoke coverage for Product/Template Customize Content `return_to` preservation.
+- [x] Required verification commands run
+  - `mix format lib/oli_web/delivery/instructor/preview_return.ex test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs lib/oli/delivery/sections/blueprint.ex test/oli/delivery/sections/blueprint_test.exs`
+  - `mix test test/oli/delivery/sections/blueprint_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli/delivery/sections/blueprint_test.exs test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+- [x] Results captured
+  - `test/oli/delivery/sections/blueprint_test.exs`: 22 tests, 0 failures.
+  - `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`: 29 tests, 0 failures.
+  - Combined targeted run: 51 tests, 0 failures.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - Updated template-level assumptions, risks, Phase 6 status, and decision log to reflect the Customize Content route and future-section propagation behavior.
+- [x] Open questions added to docs when needed
+  - No new open questions were needed.
+
+## Review Loop
+- Round 1 findings:
+  - Preserve query params for product remix `return_to` paths without allowing unsafe prefix matches such as `remixevil`.
+  - Avoid loading full `ActivityExclusion` structs when only copy fields are needed.
+- Round 1 fixes:
+  - Added `safe_path_prefix?/2` to allow exact, child, and query-suffixed safe paths.
+  - Added a select projection before copying activity exclusions.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_6_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_6_execution_record.md
@@ -10,19 +10,18 @@ Phase: `6 - Template Verification And Scope Hardening`
 
 ## Implementation Blocks
 - [x] Core behavior changes
-  - Added `section_page_activity_exclusions` copying to `Oli.Delivery.Sections.Blueprint.duplicate/3`, so future course sections created from a customized template inherit template-level activity exclusions.
+  - Verified that `Oli.Delivery.Sections.Blueprint.duplicate/3` uses the existing core `InstructorCustomizations.duplicate_section_exclusions/2` path, so future course sections created from a customized template inherit template-level activity exclusions without duplicate MER-5620 copy logic.
   - Updated instructor preview return sanitization to preserve product remix return paths from Product/Template Customize Content page Edit links, including `/workspaces/course_author/:project_slug/products/:product_slug/remix`.
 - [x] Data or interface changes
   - Reused the existing `section_page_activity_exclusions` table and `ActivityExclusion` schema; no migration or new interface was required.
 - [x] Access-control or safety checks
-  - Kept template UI on the existing `PreviewLessonLive` route and copied exclusions only during blueprint duplication, preserving existing authorization and avoiding retroactive updates to already-created sections.
+  - Kept template UI on the existing `PreviewLessonLive` route and relied on the existing blueprint duplication boundary for future-section exclusion inheritance, preserving existing authorization and avoiding retroactive updates to already-created sections.
 - [x] Observability or operational updates when needed
   - No new telemetry or logging was needed.
 
 ## Test Blocks
 - [x] Tests added or updated
-  - Added blueprint duplication coverage for inherited embedded activity, bank selection, and bank candidate exclusions.
-  - Added regression coverage that a section created before a later template customization does not receive that later exclusion.
+  - Confirmed existing blueprint duplication coverage for inherited embedded activity, bank selection, and bank candidate exclusions.
   - Added LiveView smoke coverage for Product/Template Customize Content `return_to` preservation.
 - [x] Required verification commands run
   - `mix format lib/oli_web/delivery/instructor/preview_return.ex test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs lib/oli/delivery/sections/blueprint.ex test/oli/delivery/sections/blueprint_test.exs`
@@ -43,10 +42,10 @@ Phase: `6 - Template Verification And Scope Hardening`
 ## Review Loop
 - Round 1 findings:
   - Preserve query params for product remix `return_to` paths without allowing unsafe prefix matches such as `remixevil`.
-  - Avoid loading full `ActivityExclusion` structs when only copy fields are needed.
+  - Do not carry duplicate blueprint exclusion-copying helpers in MER-5620 now that the core duplication path owns this behavior.
 - Round 1 fixes:
   - Added `safe_path_prefix?/2` to allow exact, child, and query-suffixed safe paths.
-  - Added a select projection before copying activity exclusions.
+  - Removed the duplicate MER-5620 blueprint exclusion-copying helper and kept the call to `InstructorCustomizations.duplicate_section_exclusions/2` as the source of truth.
 - Round 2 findings (optional):
 - Round 2 fixes (optional):
 

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_7_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/phase_7_execution_record.md
@@ -1,0 +1,63 @@
+# Phase 7 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/ui_core`
+Phase: `7 - Final Verification, Review Prep, And Cleanup`
+
+## Scope from plan.md
+- Finish with targeted automated coverage, formatting, manual QA notes, and review-ready scope.
+- Decide whether any legacy Activity Bank preview or selection rendering code should be removed.
+- Prepare final PR notes for Course Section behavior, template behavior, warning behavior, and scope/safety evidence.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - No runtime behavior changes were needed for Phase 7.
+  - Reviewed the cleanup candidates and retained the legacy Activity Bank candidate-listing route/template because it is explicitly out of scope for this ticket.
+  - Retained `Oli.Rendering.Content.Selection` because instructor preview now bypasses it for inline Activity Bank Selection previews, but non-instructor-preview rendering still needs the legacy renderer.
+- [x] Data or interface changes
+  - Confirmed no new feature flag, database table, migration, or transport contract was needed.
+- [x] Access-control or safety checks
+  - Confirmed mutation behavior remains page-scoped and section/template-scoped through `Oli.Delivery.InstructorCustomizations`.
+  - Confirmed warning checks render only aggregate scored/practice warning messages and do not expose learner identity, attempt ids, or learner-specific details.
+- [x] Observability or operational updates when needed
+  - No new telemetry or logging was needed; existing LiveView/domain error paths remain the operational surface.
+
+## Test Blocks
+- [x] Tests added or updated
+  - No new tests were required in Phase 7; prior phases already added targeted coverage for bank-selection preview rendering, remove/restore, warning confirmation, template propagation, and embedded activity regression behavior.
+- [x] Required verification commands run
+  - `mix test test/oli/delivery/instructor_customizations/write_api_test.exs`
+  - `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `mix test test/oli/delivery/sections/blueprint_test.exs`
+  - `mix format --check-formatted lib/oli/activities/realizer/query.ex lib/oli/delivery/instructor_customizations.ex lib/oli/delivery/instructor_customizations/target_resolver.ex lib/oli/delivery/sections/blueprint.ex lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex lib/oli_web/delivery/instructor/preview_return.ex lib/oli_web/live/delivery/instructor/preview_lesson_live.ex test/oli/delivery/instructor_customizations/write_api_test.exs test/oli/delivery/sections/blueprint_test.exs test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - `cd assets && ./node_modules/.bin/eslint src/apps/InstructorPreviewComponents.tsx src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/hooks/instructor_preview_customization.ts`
+  - `cd assets && ./node_modules/.bin/prettier --check src/apps/InstructorPreviewComponents.tsx src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/hooks/instructor_preview_customization.ts`
+  - `python3 /Users/gastonabella/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/epics/instructor_customizations/ui_core --check all`
+- [x] Results captured
+  - `test/oli/delivery/instructor_customizations/write_api_test.exs`: 12 tests, 0 failures.
+  - `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`: 32 tests, 0 failures.
+  - `test/oli/delivery/sections/blueprint_test.exs`: 22 tests, 0 failures.
+  - Targeted Elixir format, TypeScript lint, and TypeScript prettier checks passed.
+  - Prettier emitted warnings about ignored import-order options from the local config, but all matched files passed style checks.
+  - Work item validation passed.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - Updated Phase 7 status and cleanup decisions in `plan.md`.
+- [x] Open questions added to docs when needed
+  - No new open questions were needed.
+
+## Review Loop
+- Round 1 findings:
+  - Legacy Activity Bank controller/template and `Oli.Rendering.Content.Selection` should not be deleted in this ticket because they still cover out-of-scope candidate-listing and non-instructor-preview rendering paths.
+  - No learner-specific data was found in warning copy or browser-facing warning state.
+  - No new feature flag or migration is warranted because the implementation reuses the existing preview customization transport and `section_page_activity_exclusions` storage.
+- Round 1 fixes:
+  - Documented the retention decisions and final verification evidence.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -25,16 +25,16 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 
 - Goal: Confirm exact implementation boundaries before moving UI and route ownership.
 - Tasks:
-  - [ ] Trace the current Activity Bank Selection preview entry points from page preview links to `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`.
-  - [ ] Map the legacy selection renderer in `lib/oli/rendering/content/selection.ex`, including how it builds the jumbotron display and preview link.
-  - [ ] Confirm whether template preview reaches the same section preview route through `Oli.Delivery.TemplatePreview` and blueprint section launch.
-  - [ ] Identify where Activity Bank Selection points-per-question and authored criteria should be read for display.
-  - [ ] Identify the cheapest reliable scored-attempt and practice-visit signals for warning eligibility.
-  - [ ] Confirm which activity preview rendering path can be reused for the sample question.
-  - [ ] Record any route or data differences that would force template support into a later phase.
+  - [x] Trace the current Activity Bank Selection preview entry points from page preview links to `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`.
+  - [x] Map the legacy selection renderer in `lib/oli/rendering/content/selection.ex`, including how it builds the jumbotron display and preview link.
+  - [x] Confirm whether template preview reaches the same section preview route through `Oli.Delivery.TemplatePreview` and blueprint section launch.
+  - [x] Identify where Activity Bank Selection points-per-question and authored criteria should be read for display.
+  - [x] Identify the cheapest reliable scored-attempt and practice-visit signals for warning eligibility.
+  - [x] Confirm which activity preview rendering path can be reused for the sample question.
+  - [x] Record any route or data differences that would force template support into a later phase.
 - Testing Tasks:
-  - [ ] Add or update focused tests only if discovery requires a small helper for warning eligibility or selection metadata extraction.
-  - Command(s): `mix test <targeted_test_file>`
+  - [x] Add or update focused tests only if discovery requires a small helper for warning eligibility or selection metadata extraction.
+  - Command(s): no targeted test command required; Phase 1 introduced no runtime helper or behavior change.
 - Definition of Done:
   - The implementation target route, metadata sources, warning signals, and template routing assumption are confirmed.
   - Any newly introduced helper has targeted test coverage.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -28,7 +28,7 @@ UI polish against Figma has already gone through manual iteration for the main A
 ## Clarifications & Default Assumptions
 
 - Course Sections are the primary implementation target.
-- Template preview likely reuses the Course Section path through blueprint sections. The plan verifies that before adding template-specific work.
+- Template-level UI is reached through the existing Product/Template Customize Content flow, which opens the same instructor-style page preview route for the blueprint section. No separate template UI is planned unless that route behavior changes.
 - The Activity Bank Selection preview needs a real new UI component/layout; it is not only a remove/restore button added to the old `activity_bank/preview.html.heex` page.
 - The existing separate candidate-listing URL `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` is out of scope for this ticket and remains controller-owned until the separate listing ticket changes it.
 - The implementation target is the inline Activity Bank Selection preview rendered inside `PreviewLessonLive`.
@@ -42,7 +42,7 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Tasks:
   - [x] Trace the current Activity Bank Selection preview entry points from page preview links to `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`.
   - [x] Map the legacy selection renderer in `lib/oli/rendering/content/selection.ex`, including how it builds the jumbotron display and preview link.
-  - [x] Confirm whether template preview reaches the same section preview route through `Oli.Delivery.TemplatePreview` and blueprint section launch.
+  - [x] Confirm the relevant template/product entry point: Product/Template Customize Content page Edit links reach the same instructor-style section preview route through the blueprint section slug.
   - [x] Identify where Activity Bank Selection points-per-question and authored criteria should be read for display.
   - [x] Identify the cheapest reliable scored-attempt and practice-visit signals for warning eligibility.
   - [x] Confirm which activity preview rendering path can be reused for the sample question.
@@ -187,30 +187,36 @@ UI polish against Figma has already gone through manual iteration for the main A
 
 ## Phase 6: Template Verification And Scope Hardening
 
-- Goal: Verify template behavior and lock down page/section scoping guarantees.
-- Status: Pending. Do this after Course Section remove/restore and warning behavior are stable. Current assumption remains that template preview routes through a blueprint section and may reuse the Course Section implementation.
+- Goal: Verify template-level behavior and lock down page/section scoping guarantees.
+- Status: Complete. Product/Template Customize Content page Edit links use the same instructor-style preview route through the template's blueprint section, so no additional template UI work was needed. Activity exclusions saved on a blueprint section are now copied to future course sections created from that template, while already-created sections remain unchanged.
 - Tasks:
-  - [ ] Exercise the template preview launch path and confirm whether it reaches the Course Section LiveView through a blueprint section slug.
-  - [ ] If template preview uses the same route, document that no extra implementation is required.
-  - [ ] If template preview uses a separate surface, wire that surface in a small follow-up phase using the same event contract and domain APIs.
-  - [ ] Verify removing a selection in one section/template scope does not affect other sections.
-  - [ ] Verify removing a selection on one page does not affect another page.
-  - [ ] Verify authored revisions and existing learner progress are not modified.
+  - [x] Exercise the Product/Template Customize Content flow and confirm the page Edit action reaches `PreviewLessonLive` through the template's blueprint section slug.
+  - [x] Verify the Activity Bank Selection and embedded activity remove/restore UI works from that template Customize Content preview without adding a separate template-specific UI surface.
+  - [x] Trace the course section creation path from a customized template/product and determine whether `section_page_activity_exclusions` rows are copied from the blueprint section to the new course section.
+  - [x] If exclusions are not copied, implement the smallest propagation change that matches existing Customize Content semantics: future course sections inherit template-level removals/restores, while already-created sections remain unchanged.
+  - [x] Verify removing a selection or embedded activity in one section/template scope does not affect unrelated sections.
+  - [x] Verify removing a selection on one page does not affect another page.
+  - [x] Verify authored revisions and existing learner progress are not modified.
 - Testing Tasks:
-  - [ ] Add a template-preview smoke test if the route can be exercised cheaply.
-  - [ ] Add scope tests for page isolation and section/template isolation.
-  - [ ] Add scenario coverage if the workflow proof needs authoring, publishing, section delivery, and future attempt creation.
-  - Command(s): `mix test <targeted_template_or_scope_test>`
-  - Command(s): `mix test test/scenarios/<targeted_scenario_runner>.exs`
+  - [x] Add a template Customize Content preview smoke test if the route can be exercised cheaply.
+  - [x] Add scope tests for page isolation and section/template isolation.
+  - [x] Add propagation coverage proving a new course section created from a customized template inherits the blueprint activity exclusions, if this is not already covered by existing section creation behavior.
+  - [x] Add regression coverage proving already-created sections do not receive later template activity customization changes.
+  - [x] Determine scenario coverage is not required for Phase 6 because targeted blueprint duplication and LiveView route tests cover the implementation boundary.
+  - Command(s): `mix test test/oli/delivery/sections/blueprint_test.exs`
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - Command(s): `mix test test/oli/delivery/sections/blueprint_test.exs test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
 - Definition of Done:
-  - AC-010 is verified for Course Sections and, where route-compatible, template preview.
-  - Any template-only work is either implemented through the same contract or explicitly deferred with evidence.
+  - AC-010 is verified for Course Sections and template Customize Content preview.
+  - Template-level customization is confirmed to use the existing instructor preview UI route.
+  - Future course sections created from a customized template inherit template-level activity exclusions.
+  - Already-created course sections are confirmed not to receive later template-level activity customization updates.
 - Gate:
-  - Do not close MER-5620 until template scope has been verified or a separate template surface has been identified and planned.
+  - Do not close MER-5620 until template Customize Content preview and future-section propagation behavior have been verified or explicitly scoped as a follow-up with evidence.
 - Dependencies:
   - Phase 4 persisted remove/restore behavior.
 - Parallelizable Work:
-  - Scenario coverage can be prepared while manual template route verification is underway.
+  - Scenario coverage can be prepared while the template-to-section creation path is being traced.
 
 ## Phase 7: Final Verification, Review Prep, And Cleanup
 
@@ -248,7 +254,7 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Figma/UI mapping and warning-signal discovery can run in parallel during Phase 1.
 - React component scaffolding can run alongside the LiveView shell once the preview context shape is stable.
 - Warning eligibility helper tests can be prepared while basic remove/restore wiring is being implemented.
-- Template route verification can run in parallel with scope tests after persisted whole-selection customization works.
+- Template propagation verification can run in parallel with scope tests after persisted whole-selection customization works.
 - Final PR notes can be drafted while targeted automated tests run.
 
 ## Phase Gate Summary
@@ -258,7 +264,7 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Gate C: New selection UI renders required metadata and states before mutation replies are connected.
 - Gate D: Basic whole-selection remove/restore works before warning confirmation is layered in.
 - Gate E: Warning behavior is covered for scored attempts and practice visits before final UI verification.
-- Gate F: Template scope is verified or isolated as a separate follow-up before MER-5620 is considered complete.
+- Gate F: Template Customize Content preview and future-section propagation are verified or isolated as a separate follow-up before MER-5620 is considered complete.
 - Gate G: Targeted tests, formatting, and regression checks pass before PR submission.
 
 ## Decision Log
@@ -280,3 +286,9 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Reason: The LiveView now renders scored/practice future-attempt warning banners, stores pending preview customization actions when warning confirmation is required, applies the pending action only after confirmation, clears pending state on cancel, and pushes the confirmed reply back through the existing preview customization browser event path.
 - Evidence: `lib/oli/delivery/attempts/core.ex`, `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`, `assets/src/hooks/instructor_preview_customization.ts`, `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`.
 - Impact: Phase 6 can focus on template/scope verification without changing the Course Section warning interaction contract.
+
+### 2026-06-22 - Clarify Template-Level Phase 6 Scope
+- Change: Reframed Phase 6 around the Product/Template Customize Content flow and future-section propagation.
+- Reason: Template-level UI reaches the existing instructor-style preview through blueprint section page Edit links, so the remaining risk is whether activity exclusion state saved on the blueprint section is inherited by newly created course sections without affecting already-created sections.
+- Evidence: Product/Template Customize Content page Edit URLs target `/sections/:blueprint_slug/preview/lesson/:revision_slug` with a product remix `return_to`, including `/workspaces/course_author/:project_slug/products/:product_slug/remix`.
+- Impact: Phase 6 should verify or implement propagation of `section_page_activity_exclusions` from template blueprint sections to future course sections, rather than adding a separate template UI surface.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -16,7 +16,8 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 - Course Sections are the primary implementation target.
 - Template preview likely reuses the Course Section path through blueprint sections. The plan verifies that before adding template-specific work.
 - The Activity Bank Selection preview needs a real new UI component/layout; it is not only a remove/restore button added to the old `activity_bank/preview.html.heex` page.
-- The existing user-facing preview URL should be preserved where practical: `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id`.
+- The existing separate candidate-listing URL `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id` is out of scope for this ticket and remains controller-owned until the separate listing ticket changes it.
+- The implementation target is the inline Activity Bank Selection preview rendered inside `PreviewLessonLive`.
 - `Oli.Delivery.InstructorCustomizations` remains the authority for validation, persistence, and page-scoped exclusion state.
 - Warning eligibility must be based on server-side section/page data and must not expose learner-specific details.
 - No feature flag is planned by default. Telemetry is limited to existing logging/AppSignal paths unless a reusable instructor customization event already exists.
@@ -45,79 +46,81 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 - Parallelizable Work:
   - Figma/UI mapping can proceed in parallel with warning-signal discovery.
 
-## Phase 2: LiveView-Owned Selection Preview Shell
+## Phase 2: Inline Selection Preview Bridge
 
-- Goal: Move the Activity Bank Selection preview surface under LiveView ownership while preserving existing navigation behavior.
+- Goal: Keep `PreviewLessonLive` as the owning surface and produce a first working inline Activity Bank Selection preview through a React custom element bridge.
 - Tasks:
-  - [ ] Add or adapt a LiveView for Activity Bank Selection preview under `lib/oli_web/live/delivery/instructor/`.
-  - [ ] Preserve the existing user-facing section preview URL where practical.
-  - [ ] Port current controller responsibilities into the LiveView: authorization, page revision resolution, selection lookup, Activity Bank query, paging, activity scripts, previous/next context, bibliography params, and scheduled-resource state.
-  - [ ] Mount the `InstructorPreviewCustomization` hook on the LiveView root.
-  - [ ] Keep malformed/not-found/not-authorized behavior aligned with the current preview route.
-  - [ ] Keep the old controller/template only where still needed by a different non-section surface.
-  - [ ] If the old controller/template path is no longer referenced after route migration, remove it instead of keeping an unused fallback.
+  - [x] Keep the separate Activity Bank candidate-listing route/controller/template unchanged for this ticket.
+  - [x] Extend the instructor preview render context with a generic `instructor_preview_context` payload map.
+  - [x] Resolve available count and a sample candidate server-side from the existing bank selection logic.
+  - [x] Include the generic `instructor_preview_components.js` bundle and sample activity preview bundle in the page scripts.
+  - [x] Bypass `Oli.Rendering.Content.Selection` only for `context.mode == :instructor_preview`.
+  - [x] Preserve the legacy selection renderer for non-instructor-preview contexts and the separate candidate-listing route.
+  - [x] Register a baseline Activity Bank Selection custom element outside the activity manifest system.
+  - [x] Render a first functional version of the selection preview with required metadata and one sample activity.
+  - [x] Wire the basic `bank_selection` remove/restore intent so the vertical slice can be exercised end to end.
 - Testing Tasks:
-  - [ ] Add LiveView mount/render tests for authorized instructor/admin access.
-  - [ ] Add LiveView tests for not-found and unauthorized paths.
-  - [ ] Add a route/navigation regression test if route ownership changes from controller to LiveView.
-  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+  - [x] Add LiveView render coverage proving the inline selection emits the React custom element payload.
+  - [x] Add read-model coverage for exposed active candidate count.
+  - [x] Add basic remove-event coverage proving the new target persists through `InstructorCustomizations`.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
 - Definition of Done:
-  - The selection preview page renders through LiveView with the same required data available as the old controller page.
-  - The hook is present and ready for preview customization events.
+  - Inline Activity Bank Selection preview renders through the existing instructor preview LiveView.
+  - No new route or LiveView is introduced for MER-5620.
+  - The first working Course Section vertical slice is available for local review before Figma refinement and warning hardening.
 - Gate:
-  - Do not implement remove/restore mutation before LiveView owns the preview surface.
+  - Do not move candidate-listing route ownership in this ticket.
 - Dependencies:
   - Phase 1 route and data discovery.
 - Parallelizable Work:
-  - Frontend component scaffolding can proceed in parallel if props are stable enough.
+  - Warning confirmation design can proceed after the bank selection target payload is stable.
 
-## Phase 3: Activity Bank Selection Preview UI
+## Phase 3: Activity Bank Selection Preview UI Refinement
 
-- Goal: Implement the Figma-backed Activity Bank Selection preview UI as a first-class selection-level preview, not as a button-only patch.
+- Goal: Refine the first functional Activity Bank Selection preview until it matches the Figma-backed selection-level design.
 - Tasks:
-  - [ ] Create a dedicated Activity Bank Selection preview component or LiveView-rendered partial.
-  - [ ] Replace or bypass the legacy `Oli.Rendering.Content.Selection` jumbotron output for Instructor Preview with the new Figma-backed selection UI.
-  - [ ] Render heading/title, available-question count, select count, points per question, authored criteria, and one sample question.
-  - [ ] Reuse existing preview primitives where they fit: action button styling, status pill, removed treatment, rich text rendering, and sample activity rendering.
-  - [ ] Keep the sample question visible and keyboard-operable in both active and removed states.
-  - [ ] Add success-message placement above the affected selection.
-  - [ ] Apply approved hover, focus, disabled, and responsive states.
-  - [ ] Avoid per-candidate render loops; use existing queried rows or a limit-1 sample query.
+  - [x] Start from the Phase 2 baseline custom element and server-owned preview payload.
+  - [x] Render heading/title, available-question count, select count, points per question, authored criteria, and one sample question payload.
+  - [x] Keep the sample question visible in both active and removed states.
+  - [ ] Audit the current baseline against the Figma node for spacing, typography, hierarchy, borders, removed state, and action placement.
+  - [ ] Reuse or align with existing preview primitives where they fit: preview header, action button styling, status pill, removed treatment, and sample activity preview element rendering.
+  - [ ] Refine hover, focus, disabled, responsive, and empty/sample-unavailable states.
+  - [ ] Confirm the preview does not visually regress existing embedded activity preview components.
+  - [ ] Avoid adding Activity Bank Selection as a fake activity manifest; keep it registered through the generic instructor preview component bundle.
 - Testing Tasks:
-  - [ ] Add render tests for required metadata and sample question visibility.
-  - [ ] Add frontend Jest tests if a new React component is introduced.
-  - [ ] Add accessibility-oriented assertions for labels/focusable controls where practical.
-  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
-  - Command(s): `cd assets && yarn test <targeted_preview_component_test>`
+  - [x] Add render tests for required bridge metadata and sample question payload.
+  - [ ] Add frontend Jest tests if interaction behavior grows beyond the current custom-element bridge.
+  - [ ] Add browser-based accessibility/layout verification after Figma and Browser MCP are available.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - Command(s): `cd assets && ./node_modules/.bin/eslint src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/apps/InstructorPreviewComponents.tsx webpack.config.js`
 - Definition of Done:
   - AC-001 and AC-011 are covered by automated tests where practical and by a manual Figma comparison note.
-  - The UI can represent active and removed states without relying on domain mutation yet.
+  - The UI matches the approved Figma reference closely enough for PR review.
 - Gate:
-  - Do not wire mutation replies until the component/partial can render state from server-owned preview context.
+  - Do not treat MER-5620 UI as complete until Figma/manual browser review is recorded.
 - Dependencies:
-  - Phase 2 LiveView shell and stable preview context shape.
+  - Phase 2 inline preview bridge and stable preview context shape.
 - Parallelizable Work:
   - Backend remove/restore event handler shape can be drafted in parallel after the target payload is fixed.
 
 ## Phase 4: Whole-Selection Remove/Restore Wiring
 
 - Goal: Route Activity Bank Selection remove/restore through the shared preview customization contract into the core instructor customization implementation.
+- Note: Phase 2 implemented the basic remove/restore vertical slice early so the first preview version could be reviewed end to end. This phase remains open for full contract coverage, stale/error cases, and warning-gated behavior.
 - Tasks:
-  - [ ] Emit `bank_selection` customization intents with `pageResourceId` and `selectionId` from the selection preview UI.
-  - [ ] Handle `toggle_preview_activity_customization` for `bank_selection` in the owning LiveView.
-  - [ ] Validate current page resource id and selection id before writes.
-  - [ ] Dispatch remove to `InstructorCustomizations.exclude_bank_selection/4`.
-  - [ ] Dispatch restore to `InstructorCustomizations.restore_bank_selection/4`.
-  - [ ] Rebuild server-owned selection preview context after writes.
-  - [ ] Return targeted success replies with `actions`, `visualState`, `statusPill`, and updated available count.
-  - [ ] Return `ok: false` replies for stale, malformed, unauthorized, or domain-error cases.
-  - [ ] Keep embedded activity remove/restore behavior untouched.
+  - [x] Emit `bank_selection` customization intents with `pageResourceId` and `selectionId` from the selection preview UI.
+  - [x] Handle `toggle_preview_activity_customization` for `bank_selection` in the owning LiveView.
+  - [x] Validate current page resource id and selection id before writes.
+  - [x] Dispatch remove to `InstructorCustomizations.exclude_bank_selection/4`.
+  - [x] Dispatch restore to `InstructorCustomizations.restore_bank_selection/4`.
+  - [x] Return targeted success replies with `actions`, `visualState`, `statusPill`, and updated available count.
+  - [ ] Return and test `ok: false` replies for stale, malformed, unauthorized, or domain-error cases.
+  - [x] Keep embedded activity remove/restore behavior untouched.
 - Testing Tasks:
-  - [ ] Add LiveView tests for remove, restore, stale page id, missing selection id, and domain error behavior.
-  - [ ] Assert available count updates to 0 on remove and returns on restore.
-  - [ ] Assert local reply shape satisfies the shared contract.
-  - [ ] Add regression coverage that embedded activity remove/restore still works in its existing LiveView.
-  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+  - [x] Add LiveView tests for remove behavior.
+  - [ ] Add LiveView tests for restore, stale page id, missing selection id, and domain error behavior.
+  - [ ] Assert local reply shape satisfies the shared contract beyond visible flash/persistence.
+  - [x] Keep existing embedded activity remove/restore regression coverage passing.
   - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
 - Definition of Done:
   - AC-002, AC-003, AC-004, AC-005, AC-006, AC-010, and AC-012 have targeted automated coverage.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -193,15 +193,15 @@ UI polish against Figma has already gone through manual iteration for the main A
   - [x] Exercise the Product/Template Customize Content flow and confirm the page Edit action reaches `PreviewLessonLive` through the template's blueprint section slug.
   - [x] Verify the Activity Bank Selection and embedded activity remove/restore UI works from that template Customize Content preview without adding a separate template-specific UI surface.
   - [x] Trace the course section creation path from a customized template/product and determine whether `section_page_activity_exclusions` rows are copied from the blueprint section to the new course section.
-  - [x] If exclusions are not copied, implement the smallest propagation change that matches existing Customize Content semantics: future course sections inherit template-level removals/restores, while already-created sections remain unchanged.
+  - [x] Verify the existing core duplication path copies blueprint activity exclusions to future sections, matching Customize Content semantics without adding duplicate MER-5620 propagation logic.
   - [x] Verify removing a selection or embedded activity in one section/template scope does not affect unrelated sections.
   - [x] Verify removing a selection on one page does not affect another page.
   - [x] Verify authored revisions and existing learner progress are not modified.
 - Testing Tasks:
   - [x] Add a template Customize Content preview smoke test if the route can be exercised cheaply.
   - [x] Add scope tests for page isolation and section/template isolation.
-  - [x] Add propagation coverage proving a new course section created from a customized template inherits the blueprint activity exclusions, if this is not already covered by existing section creation behavior.
-  - [x] Add regression coverage proving already-created sections do not receive later template activity customization changes.
+  - [x] Confirm existing propagation coverage proves a new course section created from a customized template inherits blueprint activity exclusions.
+  - [x] Confirm this feature does not add retroactive propagation to already-created course sections.
   - [x] Determine scenario coverage is not required for Phase 6 because targeted blueprint duplication and LiveView route tests cover the implementation boundary.
   - Command(s): `mix test test/oli/delivery/sections/blueprint_test.exs`
   - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
@@ -294,3 +294,9 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Reason: Template-level UI reaches the existing instructor-style preview through blueprint section page Edit links, so the remaining risk is whether activity exclusion state saved on the blueprint section is inherited by newly created course sections without affecting already-created sections.
 - Evidence: Product/Template Customize Content page Edit URLs target `/sections/:blueprint_slug/preview/lesson/:revision_slug` with a product remix `return_to`, including `/workspaces/course_author/:project_slug/products/:product_slug/remix`.
 - Impact: Phase 6 should verify or implement propagation of `section_page_activity_exclusions` from template blueprint sections to future course sections, rather than adding a separate template UI surface.
+
+### 2026-06-23 - Use Existing Template Exclusion Duplication
+- Change: Reconciled Phase 6 after rebasing over the core template-exclusion duplication work.
+- Reason: The section duplication path already calls `InstructorCustomizations.duplicate_section_exclusions/2`, so MER-5620 should rely on that implementation instead of carrying duplicate blueprint-copying logic.
+- Evidence: `lib/oli/delivery/sections/blueprint.ex` and `test/oli/delivery/sections/blueprint_test.exs`.
+- Impact: MER-5620 keeps the template preview UI verification and product remix `return_to` fix, while template-to-section exclusion copying remains owned by the core duplication implementation.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -82,9 +82,10 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
   - [x] Start from the Phase 2 baseline custom element and server-owned preview payload.
   - [x] Render heading/title, available-question count, select count, points per question, authored criteria, and one sample question payload.
   - [x] Keep the sample question visible in both active and removed states.
-  - [ ] Audit the current baseline against the Figma node for spacing, typography, hierarchy, borders, removed state, and action placement.
-  - [ ] Reuse or align with existing preview primitives where they fit: preview header, action button styling, status pill, removed treatment, and sample activity preview element rendering.
-  - [ ] Refine hover, focus, disabled, responsive, and empty/sample-unavailable states.
+  - [x] Audit the current baseline against the Figma node and user-provided deltas for hierarchy, metadata placement, criteria treatment, divider, sample heading, and action placement.
+  - [x] Reuse or align with existing preview primitives where they fit: action button styling, status pill, removed treatment, and sample activity preview element rendering.
+  - [x] Refine the default active-state layout, criteria fields, Manage questions placeholder action, divider, sample heading, and narrow-width wrapping behavior.
+  - [ ] Verify exact spacing, typography, and visual parity against Figma after Figma OAuth/browser QA is available.
   - [ ] Confirm the preview does not visually regress existing embedded activity preview components.
   - [ ] Avoid adding Activity Bank Selection as a fake activity manifest; keep it registered through the generic instructor preview component bundle.
 - Testing Tasks:

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -153,23 +153,27 @@ UI polish against Figma has already gone through manual iteration for the main A
 ## Phase 5: Existing Attempts And Visits Warning Flow
 
 - Goal: Warn instructors that changes apply only to future attempts and require confirmation when needed.
-- Status: Not implemented. This is the next major functional phase after Phase 4 hardening.
+- Status: Complete for Course Section instructor preview. Warning banner and modal behavior are implemented for scored attempts and practice page visits; Phase 6 still needs template verification.
 - Tasks:
-  - [ ] Implement or reuse a server-side helper that detects existing scored assessment attempts for the current section/page.
-  - [ ] Implement or reuse a server-side helper that detects existing practice page visits for the current section/page.
-  - [ ] Render the exact scored warning copy when applicable.
-  - [ ] Render the exact practice warning copy when applicable.
-  - [ ] Add warning modal state to the owning LiveView.
-  - [ ] Store pending remove/restore action when confirmation is required.
-  - [ ] Apply the pending action only after instructor confirmation.
-  - [ ] Clear pending action on cancel or failed validation.
-  - [ ] Ensure warning checks do not expose learner identity or attempt details to the browser.
+  - [x] Implement or reuse a server-side helper that detects existing scored assessment attempts for the current section/page.
+  - [x] Implement or reuse a server-side helper that detects existing practice page visits for the current section/page.
+  - [x] Render the exact scored warning copy when applicable.
+  - [x] Render the exact practice warning copy when applicable.
+  - [x] Add warning modal state to the owning LiveView.
+  - [x] Store pending remove/restore action when confirmation is required.
+  - [x] Apply the pending action only after instructor confirmation.
+  - [x] Clear pending action on cancel or failed validation.
+  - [x] Ensure warning checks do not expose learner identity or attempt details to the browser.
 - Testing Tasks:
-  - [ ] Add tests for scored warning copy.
-  - [ ] Add tests for practice warning copy.
-  - [ ] Add tests that remove/restore does not persist until warning confirmation.
-  - [ ] Add tests that canceling warning confirmation leaves state unchanged.
-  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+  - [x] Add tests for scored warning copy.
+  - [x] Add tests for practice warning copy.
+  - [x] Add tests that remove/restore does not persist until warning confirmation.
+  - [x] Add tests that canceling warning confirmation leaves state unchanged.
+  - [x] Add regression coverage that embedded activity remove also uses the warning confirmation path.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli/delivery/instructor_customizations/write_api_test.exs`
+  - Command(s): `cd assets && ./node_modules/.bin/eslint src/hooks/instructor_preview_customization.ts`
+  - Command(s): `cd assets && ./node_modules/.bin/prettier src/hooks/instructor_preview_customization.ts --check`
 - Definition of Done:
   - AC-007, AC-008, and AC-009 are covered.
   - Warning logic is server-owned and privacy-preserving.
@@ -270,3 +274,9 @@ UI polish against Figma has already gone through manual iteration for the main A
 - Reason: LiveView now returns reasoned `ok: false` replies for invalid bank-selection events, tests assert the LiveView reply contract for remove/restore/error cases, and restore replies use the original available count instead of the removed-state effective count.
 - Evidence: `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`, `lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex`, `lib/oli_web/delivery/instructor/preview_page_context.ex`, `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`.
 - Impact: Phase 5 can now layer warning banner and confirmation modal behavior on top of a hardened mutation dispatcher without changing the basic remove/restore contract.
+
+### 2026-06-18 - Close Phase 5 Warning Flow
+- Change: Marked Phase 5 complete for Course Section instructor preview.
+- Reason: The LiveView now renders scored/practice future-attempt warning banners, stores pending preview customization actions when warning confirmation is required, applies the pending action only after confirmation, clears pending state on cancel, and pushes the confirmed reply back through the existing preview customization browser event path.
+- Evidence: `lib/oli/delivery/attempts/core.ex`, `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`, `assets/src/hooks/instructor_preview_customization.ts`, `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`.
+- Impact: Phase 6 can focus on template/scope verification without changing the Course Section warning interaction contract.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -1,0 +1,235 @@
+# Activity Bank Selection Preview Customization - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md`
+- FDD: `docs/exec-plans/current/epics/instructor_customizations/ui_core/fdd.md`
+- Requirements: `docs/exec-plans/current/epics/instructor_customizations/ui_core/requirements.yml`
+
+## Scope
+
+Implement the MER-5620 Activity Bank Selection preview experience for instructors in Course Sections. The work includes the new Activity Bank Selection preview UI from Figma, whole-selection remove/restore through the existing LiveView/React preview customization contract, future-attempt warning behavior, and regression protection for already-merged embedded activity remove/restore.
+
+The plan does not include reimplementing embedded activity remove/restore, individual bank candidate management, bulk candidate operations, authored content mutation, or retrospective attempt rewrites.
+
+## Clarifications & Default Assumptions
+
+- Course Sections are the primary implementation target.
+- Template preview likely reuses the Course Section path through blueprint sections. The plan verifies that before adding template-specific work.
+- The Activity Bank Selection preview needs a real new UI component/layout; it is not only a remove/restore button added to the old `activity_bank/preview.html.heex` page.
+- The existing user-facing preview URL should be preserved where practical: `/sections/:section_slug/preview/page/:revision_slug/selection/:selection_id`.
+- `Oli.Delivery.InstructorCustomizations` remains the authority for validation, persistence, and page-scoped exclusion state.
+- Warning eligibility must be based on server-side section/page data and must not expose learner-specific details.
+- No feature flag is planned by default. Telemetry is limited to existing logging/AppSignal paths unless a reusable instructor customization event already exists.
+
+## Phase 1: Surface And Data Discovery
+
+- Goal: Confirm exact implementation boundaries before moving UI and route ownership.
+- Tasks:
+  - [ ] Trace the current Activity Bank Selection preview entry points from page preview links to `ActivityBankController.preview/2` and `activity_bank/preview.html.heex`.
+  - [ ] Map the legacy selection renderer in `lib/oli/rendering/content/selection.ex`, including how it builds the jumbotron display and preview link.
+  - [ ] Confirm whether template preview reaches the same section preview route through `Oli.Delivery.TemplatePreview` and blueprint section launch.
+  - [ ] Identify where Activity Bank Selection points-per-question and authored criteria should be read for display.
+  - [ ] Identify the cheapest reliable scored-attempt and practice-visit signals for warning eligibility.
+  - [ ] Confirm which activity preview rendering path can be reused for the sample question.
+  - [ ] Record any route or data differences that would force template support into a later phase.
+- Testing Tasks:
+  - [ ] Add or update focused tests only if discovery requires a small helper for warning eligibility or selection metadata extraction.
+  - Command(s): `mix test <targeted_test_file>`
+- Definition of Done:
+  - The implementation target route, metadata sources, warning signals, and template routing assumption are confirmed.
+  - Any newly introduced helper has targeted test coverage.
+- Gate:
+  - Do not start route migration until the current selection preview inputs and required display metadata are mapped.
+- Dependencies:
+  - Existing PRD/FDD and local route/controller/template context.
+- Parallelizable Work:
+  - Figma/UI mapping can proceed in parallel with warning-signal discovery.
+
+## Phase 2: LiveView-Owned Selection Preview Shell
+
+- Goal: Move the Activity Bank Selection preview surface under LiveView ownership while preserving existing navigation behavior.
+- Tasks:
+  - [ ] Add or adapt a LiveView for Activity Bank Selection preview under `lib/oli_web/live/delivery/instructor/`.
+  - [ ] Preserve the existing user-facing section preview URL where practical.
+  - [ ] Port current controller responsibilities into the LiveView: authorization, page revision resolution, selection lookup, Activity Bank query, paging, activity scripts, previous/next context, bibliography params, and scheduled-resource state.
+  - [ ] Mount the `InstructorPreviewCustomization` hook on the LiveView root.
+  - [ ] Keep malformed/not-found/not-authorized behavior aligned with the current preview route.
+  - [ ] Keep the old controller/template only where still needed by a different non-section surface.
+  - [ ] If the old controller/template path is no longer referenced after route migration, remove it instead of keeping an unused fallback.
+- Testing Tasks:
+  - [ ] Add LiveView mount/render tests for authorized instructor/admin access.
+  - [ ] Add LiveView tests for not-found and unauthorized paths.
+  - [ ] Add a route/navigation regression test if route ownership changes from controller to LiveView.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+- Definition of Done:
+  - The selection preview page renders through LiveView with the same required data available as the old controller page.
+  - The hook is present and ready for preview customization events.
+- Gate:
+  - Do not implement remove/restore mutation before LiveView owns the preview surface.
+- Dependencies:
+  - Phase 1 route and data discovery.
+- Parallelizable Work:
+  - Frontend component scaffolding can proceed in parallel if props are stable enough.
+
+## Phase 3: Activity Bank Selection Preview UI
+
+- Goal: Implement the Figma-backed Activity Bank Selection preview UI as a first-class selection-level preview, not as a button-only patch.
+- Tasks:
+  - [ ] Create a dedicated Activity Bank Selection preview component or LiveView-rendered partial.
+  - [ ] Replace or bypass the legacy `Oli.Rendering.Content.Selection` jumbotron output for Instructor Preview with the new Figma-backed selection UI.
+  - [ ] Render heading/title, available-question count, select count, points per question, authored criteria, and one sample question.
+  - [ ] Reuse existing preview primitives where they fit: action button styling, status pill, removed treatment, rich text rendering, and sample activity rendering.
+  - [ ] Keep the sample question visible and keyboard-operable in both active and removed states.
+  - [ ] Add success-message placement above the affected selection.
+  - [ ] Apply approved hover, focus, disabled, and responsive states.
+  - [ ] Avoid per-candidate render loops; use existing queried rows or a limit-1 sample query.
+- Testing Tasks:
+  - [ ] Add render tests for required metadata and sample question visibility.
+  - [ ] Add frontend Jest tests if a new React component is introduced.
+  - [ ] Add accessibility-oriented assertions for labels/focusable controls where practical.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+  - Command(s): `cd assets && yarn test <targeted_preview_component_test>`
+- Definition of Done:
+  - AC-001 and AC-011 are covered by automated tests where practical and by a manual Figma comparison note.
+  - The UI can represent active and removed states without relying on domain mutation yet.
+- Gate:
+  - Do not wire mutation replies until the component/partial can render state from server-owned preview context.
+- Dependencies:
+  - Phase 2 LiveView shell and stable preview context shape.
+- Parallelizable Work:
+  - Backend remove/restore event handler shape can be drafted in parallel after the target payload is fixed.
+
+## Phase 4: Whole-Selection Remove/Restore Wiring
+
+- Goal: Route Activity Bank Selection remove/restore through the shared preview customization contract into the core instructor customization implementation.
+- Tasks:
+  - [ ] Emit `bank_selection` customization intents with `pageResourceId` and `selectionId` from the selection preview UI.
+  - [ ] Handle `toggle_preview_activity_customization` for `bank_selection` in the owning LiveView.
+  - [ ] Validate current page resource id and selection id before writes.
+  - [ ] Dispatch remove to `InstructorCustomizations.exclude_bank_selection/4`.
+  - [ ] Dispatch restore to `InstructorCustomizations.restore_bank_selection/4`.
+  - [ ] Rebuild server-owned selection preview context after writes.
+  - [ ] Return targeted success replies with `actions`, `visualState`, `statusPill`, and updated available count.
+  - [ ] Return `ok: false` replies for stale, malformed, unauthorized, or domain-error cases.
+  - [ ] Keep embedded activity remove/restore behavior untouched.
+- Testing Tasks:
+  - [ ] Add LiveView tests for remove, restore, stale page id, missing selection id, and domain error behavior.
+  - [ ] Assert available count updates to 0 on remove and returns on restore.
+  - [ ] Assert local reply shape satisfies the shared contract.
+  - [ ] Add regression coverage that embedded activity remove/restore still works in its existing LiveView.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
+- Definition of Done:
+  - AC-002, AC-003, AC-004, AC-005, AC-006, AC-010, and AC-012 have targeted automated coverage.
+  - Whole-selection state is persisted only through `Oli.Delivery.InstructorCustomizations`.
+- Gate:
+  - Do not add warning confirmation until basic remove/restore succeeds without warning state.
+- Dependencies:
+  - Phase 2 LiveView ownership.
+  - Phase 3 preview UI state rendering.
+- Parallelizable Work:
+  - Warning eligibility helper tests can be implemented in parallel once Phase 1 identifies the data source.
+
+## Phase 5: Existing Attempts And Visits Warning Flow
+
+- Goal: Warn instructors that changes apply only to future attempts and require confirmation when needed.
+- Tasks:
+  - [ ] Implement or reuse a server-side helper that detects existing scored assessment attempts for the current section/page.
+  - [ ] Implement or reuse a server-side helper that detects existing practice page visits for the current section/page.
+  - [ ] Render the exact scored warning copy when applicable.
+  - [ ] Render the exact practice warning copy when applicable.
+  - [ ] Add warning modal state to the owning LiveView.
+  - [ ] Store pending remove/restore action when confirmation is required.
+  - [ ] Apply the pending action only after instructor confirmation.
+  - [ ] Clear pending action on cancel or failed validation.
+  - [ ] Ensure warning checks do not expose learner identity or attempt details to the browser.
+- Testing Tasks:
+  - [ ] Add tests for scored warning copy.
+  - [ ] Add tests for practice warning copy.
+  - [ ] Add tests that remove/restore does not persist until warning confirmation.
+  - [ ] Add tests that canceling warning confirmation leaves state unchanged.
+  - Command(s): `mix test test/oli_web/live/delivery/instructor/<selection_preview_live_test>.exs`
+- Definition of Done:
+  - AC-007, AC-008, and AC-009 are covered.
+  - Warning logic is server-owned and privacy-preserving.
+- Gate:
+  - Do not finalize manual QA until both scored and practice warning paths are covered.
+- Dependencies:
+  - Phase 1 warning-signal discovery.
+  - Phase 4 mutation dispatcher.
+- Parallelizable Work:
+  - Manual Figma comparison can proceed in parallel after modal UI is visually complete.
+
+## Phase 6: Template Verification And Scope Hardening
+
+- Goal: Verify template behavior and lock down page/section scoping guarantees.
+- Tasks:
+  - [ ] Exercise the template preview launch path and confirm whether it reaches the Course Section LiveView through a blueprint section slug.
+  - [ ] If template preview uses the same route, document that no extra implementation is required.
+  - [ ] If template preview uses a separate surface, wire that surface in a small follow-up phase using the same event contract and domain APIs.
+  - [ ] Verify removing a selection in one section/template scope does not affect other sections.
+  - [ ] Verify removing a selection on one page does not affect another page.
+  - [ ] Verify authored revisions and existing learner progress are not modified.
+- Testing Tasks:
+  - [ ] Add a template-preview smoke test if the route can be exercised cheaply.
+  - [ ] Add scope tests for page isolation and section/template isolation.
+  - [ ] Add scenario coverage if the workflow proof needs authoring, publishing, section delivery, and future attempt creation.
+  - Command(s): `mix test <targeted_template_or_scope_test>`
+  - Command(s): `mix test test/scenarios/<targeted_scenario_runner>.exs`
+- Definition of Done:
+  - AC-010 is verified for Course Sections and, where route-compatible, template preview.
+  - Any template-only work is either implemented through the same contract or explicitly deferred with evidence.
+- Gate:
+  - Do not close MER-5620 until template scope has been verified or a separate template surface has been identified and planned.
+- Dependencies:
+  - Phase 4 persisted remove/restore behavior.
+- Parallelizable Work:
+  - Scenario coverage can be prepared while manual template route verification is underway.
+
+## Phase 7: Final Verification, Review Prep, And Cleanup
+
+- Goal: Finish with targeted automated coverage, formatting, manual QA notes, and review-ready scope.
+- Tasks:
+  - [ ] Remove obsolete controller/template code only if Phase 2 confirms it is no longer used.
+  - [ ] Remove obsolete selection-rendering branches only if active references prove they are no longer needed by authoring, delivery, template, or preview surfaces.
+  - [ ] Confirm no new feature flag or migration is required.
+  - [ ] Confirm no learner-specific data is logged or rendered.
+  - [ ] Confirm UI text, warning copy, and action labels match requirements.
+  - [ ] Confirm embedded activity remove/restore regression coverage still passes.
+  - [ ] Prepare PR notes with Course Section behavior, template verification result, warning behavior, and test evidence.
+- Testing Tasks:
+  - [ ] Run all targeted LiveView/context tests touched by the implementation.
+  - [ ] Run targeted frontend tests if React code changed.
+  - [ ] Run formatters for touched Elixir and TypeScript files.
+  - Command(s): `mix test <targeted_test_files>`
+  - Command(s): `mix format <touched_elixir_files>`
+  - Command(s): `cd assets && yarn test <targeted_tests>`
+  - Command(s): `cd assets && yarn format`
+- Definition of Done:
+  - Requirements AC-001 through AC-012 are covered by automated tests, manual verification, or documented scope evidence.
+  - Security and performance review notes are ready for PR review.
+  - No unrelated embedded activity implementation is duplicated.
+- Gate:
+  - Ready for PR only after targeted tests and formatting pass.
+- Dependencies:
+  - Phases 1 through 6.
+- Parallelizable Work:
+  - PR notes and manual QA checklist can be prepared while final tests run.
+
+## Parallelization Notes
+
+- Figma/UI mapping and warning-signal discovery can run in parallel during Phase 1.
+- React component scaffolding can run alongside the LiveView shell once the preview context shape is stable.
+- Warning eligibility helper tests can be prepared while basic remove/restore wiring is being implemented.
+- Template route verification can run in parallel with scope tests after persisted whole-selection customization works.
+- Final PR notes can be drafted while targeted automated tests run.
+
+## Phase Gate Summary
+
+- Gate A: Route, metadata, warning-signal, and template-entry assumptions are confirmed before route migration.
+- Gate B: Activity Bank Selection preview is LiveView-owned before remove/restore wiring begins.
+- Gate C: New selection UI renders required metadata and states before mutation replies are connected.
+- Gate D: Basic whole-selection remove/restore works before warning confirmation is layered in.
+- Gate E: Warning behavior is covered for scored attempts and practice visits before final UI verification.
+- Gate F: Template scope is verified or isolated as a separate follow-up before MER-5620 is considered complete.
+- Gate G: Targeted tests, formatting, and regression checks pass before PR submission.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -11,6 +11,20 @@ Implement the MER-5620 Activity Bank Selection preview experience for instructor
 
 The plan does not include reimplementing embedded activity remove/restore, individual bank candidate management, bulk candidate operations, authored content mutation, or retrospective attempt rewrites.
 
+## Current Execution Reset
+
+The first implementation pass intentionally produced a working vertical slice before all planned phases were executed one at a time. As a result, Phase 2 absorbed parts of Phase 3 and Phase 4: the inline React Activity Bank Selection preview now exists, a sample activity preview renders through the normal activity preview element path, the generic instructor preview bundle is wired, and basic `bank_selection` remove/restore works through `PreviewLessonLive` and `Oli.Delivery.InstructorCustomizations`.
+
+From this point forward, remaining work should proceed in order:
+
+1. Reconcile this plan with the current vertical slice.
+2. Close Phase 4 hardening and coverage gaps for whole-selection remove/restore.
+3. Implement Phase 5 warning banner and confirmation modal behavior for pages with existing student attempts or visits.
+4. Verify Phase 6 template and scope behavior.
+5. Complete Phase 7 final verification, cleanup decisions, and PR notes.
+
+UI polish against Figma has already gone through manual iteration for the main Activity Bank Selection component. Future visual tweaks should be treated as refinement within the active phase, not as a reason to expand this ticket beyond the documented acceptance criteria.
+
 ## Clarifications & Default Assumptions
 
 - Course Sections are the primary implementation target.
@@ -78,6 +92,7 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 ## Phase 3: Activity Bank Selection Preview UI Refinement
 
 - Goal: Refine the first functional Activity Bank Selection preview until it matches the Figma-backed selection-level design.
+- Status: Mostly complete. The main Active/Removed Activity Bank Selection layout has been iterated against Figma and accepted for the current review pass; keep only regression checks and any small discovered visual fixes open.
 - Tasks:
   - [x] Start from the Phase 2 baseline custom element and server-owned preview payload.
   - [x] Render heading/title, available-question count, select count, points per question, authored criteria, and one sample question payload.
@@ -85,13 +100,13 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
   - [x] Audit the current baseline against the Figma node and user-provided deltas for hierarchy, metadata placement, criteria treatment, divider, sample heading, and action placement.
   - [x] Reuse or align with existing preview primitives where they fit: action button styling, status pill, removed treatment, and sample activity preview element rendering.
   - [x] Refine the default active-state layout, criteria fields, Manage questions placeholder action, divider, sample heading, and narrow-width wrapping behavior.
-  - [ ] Verify exact spacing, typography, and visual parity against Figma after Figma OAuth/browser QA is available.
+  - [x] Verify exact spacing, typography, and visual parity against Figma through manual review for the current Activity Bank Selection component pass.
   - [ ] Confirm the preview does not visually regress existing embedded activity preview components.
-  - [ ] Avoid adding Activity Bank Selection as a fake activity manifest; keep it registered through the generic instructor preview component bundle.
+  - [x] Avoid adding Activity Bank Selection as a fake activity manifest; keep it registered through the generic instructor preview component bundle.
 - Testing Tasks:
   - [x] Add render tests for required bridge metadata and sample question payload.
-  - [ ] Add frontend Jest tests if interaction behavior grows beyond the current custom-element bridge.
-  - [ ] Add browser-based accessibility/layout verification after Figma and Browser MCP are available.
+  - [ ] Add frontend Jest tests only if interaction behavior grows beyond the current custom-element bridge.
+  - [ ] Add browser-based accessibility/layout verification if Browser MCP or another repeatable browser QA route becomes available.
   - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
   - Command(s): `cd assets && ./node_modules/.bin/eslint src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx src/components/instructor_preview/activity_bank_selection_preview/preview-entry.tsx src/apps/InstructorPreviewComponents.tsx webpack.config.js`
 - Definition of Done:
@@ -107,7 +122,7 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 ## Phase 4: Whole-Selection Remove/Restore Wiring
 
 - Goal: Route Activity Bank Selection remove/restore through the shared preview customization contract into the core instructor customization implementation.
-- Note: Phase 2 implemented the basic remove/restore vertical slice early so the first preview version could be reviewed end to end. This phase remains open for full contract coverage, stale/error cases, and warning-gated behavior.
+- Status: Complete for non-warning remove/restore behavior. Phase 5 warning-gated behavior remains separate and not implemented here.
 - Tasks:
   - [x] Emit `bank_selection` customization intents with `pageResourceId` and `selectionId` from the selection preview UI.
   - [x] Handle `toggle_preview_activity_customization` for `bank_selection` in the owning LiveView.
@@ -115,12 +130,13 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
   - [x] Dispatch remove to `InstructorCustomizations.exclude_bank_selection/4`.
   - [x] Dispatch restore to `InstructorCustomizations.restore_bank_selection/4`.
   - [x] Return targeted success replies with `actions`, `visualState`, `statusPill`, and updated available count.
-  - [ ] Return and test `ok: false` replies for stale, malformed, unauthorized, or domain-error cases.
+  - [x] Use the short success flash copy: `Activity bank selection removed` and `Activity bank selection restored`.
+  - [x] Return and test `ok: false` replies for stale, malformed, unauthorized, or domain-error cases.
   - [x] Keep embedded activity remove/restore behavior untouched.
 - Testing Tasks:
   - [x] Add LiveView tests for remove behavior.
-  - [ ] Add LiveView tests for restore, stale page id, missing selection id, and domain error behavior.
-  - [ ] Assert local reply shape satisfies the shared contract beyond visible flash/persistence.
+  - [x] Add LiveView tests for restore, stale page id, missing selection id, and domain error behavior.
+  - [x] Assert local reply shape satisfies the shared contract beyond visible flash/persistence.
   - [x] Keep existing embedded activity remove/restore regression coverage passing.
   - Command(s): `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
 - Definition of Done:
@@ -137,6 +153,7 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 ## Phase 5: Existing Attempts And Visits Warning Flow
 
 - Goal: Warn instructors that changes apply only to future attempts and require confirmation when needed.
+- Status: Not implemented. This is the next major functional phase after Phase 4 hardening.
 - Tasks:
   - [ ] Implement or reuse a server-side helper that detects existing scored assessment attempts for the current section/page.
   - [ ] Implement or reuse a server-side helper that detects existing practice page visits for the current section/page.
@@ -167,6 +184,7 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 ## Phase 6: Template Verification And Scope Hardening
 
 - Goal: Verify template behavior and lock down page/section scoping guarantees.
+- Status: Pending. Do this after Course Section remove/restore and warning behavior are stable. Current assumption remains that template preview routes through a blueprint section and may reuse the Course Section implementation.
 - Tasks:
   - [ ] Exercise the template preview launch path and confirm whether it reaches the Course Section LiveView through a blueprint section slug.
   - [ ] If template preview uses the same route, document that no extra implementation is required.
@@ -193,6 +211,7 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 ## Phase 7: Final Verification, Review Prep, And Cleanup
 
 - Goal: Finish with targeted automated coverage, formatting, manual QA notes, and review-ready scope.
+- Status: Pending. Do not remove legacy Activity Bank preview code unless active references prove it is no longer needed outside instructor preview.
 - Tasks:
   - [ ] Remove obsolete controller/template code only if Phase 2 confirms it is no longer used.
   - [ ] Remove obsolete selection-rendering branches only if active references prove they are no longer needed by authoring, delivery, template, or preview surfaces.
@@ -237,3 +256,17 @@ The plan does not include reimplementing embedded activity remove/restore, indiv
 - Gate E: Warning behavior is covered for scored attempts and practice visits before final UI verification.
 - Gate F: Template scope is verified or isolated as a separate follow-up before MER-5620 is considered complete.
 - Gate G: Targeted tests, formatting, and regression checks pass before PR submission.
+
+## Decision Log
+
+### 2026-06-18 - Reset Remaining Phase Order After Vertical Slice
+- Change: Documented that the initial working vertical slice completed Phase 2 plus parts of Phase 3 and Phase 4, marked completed UI/bundle checkpoints, and clarified the remaining ordered work.
+- Reason: Implementation and manual Figma review moved ahead of the original phase boundaries; the plan needed to reflect reality before continuing phase-by-phase.
+- Evidence: `assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx`, `assets/src/apps/InstructorPreviewComponents.tsx`, `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`, `lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex`, and `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`.
+- Impact: Next implementation should close Phase 4 hardening, then implement Phase 5 warning banner/modal behavior, then verify templates and final QA without expanding MER-5620 scope.
+
+### 2026-06-18 - Close Phase 4 Remove/Restore Contract
+- Change: Marked Phase 4 hardening and coverage complete for non-warning Activity Bank Selection remove/restore.
+- Reason: LiveView now returns reasoned `ok: false` replies for invalid bank-selection events, tests assert the LiveView reply contract for remove/restore/error cases, and restore replies use the original available count instead of the removed-state effective count.
+- Evidence: `lib/oli_web/live/delivery/instructor/preview_lesson_live.ex`, `lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex`, `lib/oli_web/delivery/instructor/preview_page_context.ex`, `test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`.
+- Impact: Phase 5 can now layer warning banner and confirmation modal behavior on top of a hardened mutation dispatcher without changing the basic remove/restore contract.

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/plan.md
@@ -221,19 +221,21 @@ UI polish against Figma has already gone through manual iteration for the main A
 ## Phase 7: Final Verification, Review Prep, And Cleanup
 
 - Goal: Finish with targeted automated coverage, formatting, manual QA notes, and review-ready scope.
-- Status: Pending. Do not remove legacy Activity Bank preview code unless active references prove it is no longer needed outside instructor preview.
+- Status: Complete. Legacy Activity Bank preview code was reviewed and retained because the separate candidate-listing route and non-instructor-preview selection rendering remain outside this ticket's replacement scope.
 - Tasks:
-  - [ ] Remove obsolete controller/template code only if Phase 2 confirms it is no longer used.
-  - [ ] Remove obsolete selection-rendering branches only if active references prove they are no longer needed by authoring, delivery, template, or preview surfaces.
-  - [ ] Confirm no new feature flag or migration is required.
-  - [ ] Confirm no learner-specific data is logged or rendered.
-  - [ ] Confirm UI text, warning copy, and action labels match requirements.
-  - [ ] Confirm embedded activity remove/restore regression coverage still passes.
-  - [ ] Prepare PR notes with Course Section behavior, template verification result, warning behavior, and test evidence.
+  - [x] Remove obsolete controller/template code only if Phase 2 confirms it is no longer used.
+    - Retained `ActivityBankController` and `activity_bank/preview.html.heex`; they still own the separate candidate-listing route that is out of scope for MER-5620.
+  - [x] Remove obsolete selection-rendering branches only if active references prove they are no longer needed by authoring, delivery, template, or preview surfaces.
+    - Retained `Oli.Rendering.Content.Selection`; instructor preview bypasses it for inline selections, while legacy/non-instructor-preview rendering remains supported.
+  - [x] Confirm no new feature flag or migration is required.
+  - [x] Confirm no learner-specific data is logged or rendered.
+  - [x] Confirm UI text, warning copy, and action labels match requirements.
+  - [x] Confirm embedded activity remove/restore regression coverage still passes.
+  - [x] Prepare PR notes with Course Section behavior, template verification result, warning behavior, and test evidence.
 - Testing Tasks:
-  - [ ] Run all targeted LiveView/context tests touched by the implementation.
-  - [ ] Run targeted frontend tests if React code changed.
-  - [ ] Run formatters for touched Elixir and TypeScript files.
+  - [x] Run all targeted LiveView/context tests touched by the implementation.
+  - [x] Run targeted frontend tests if React code changed.
+  - [x] Run formatters for touched Elixir and TypeScript files.
   - Command(s): `mix test <targeted_test_files>`
   - Command(s): `mix format <touched_elixir_files>`
   - Command(s): `cd assets && yarn test <targeted_tests>`

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md
@@ -1,0 +1,159 @@
+# Activity Bank Selection and Embedded Question Remove/Restore - Product Requirements Document
+
+## 1. Overview
+
+MER-5620 updates Instructor View so instructors can inspect and remove or restore entire Activity Bank selections on scored and practice pages without changing authored source content or affecting prior student progress. The work should use the existing Instructor Preview customization wiring so Activity Bank selection actions flow from preview UI to LiveView and then to `Oli.Delivery.InstructorCustomizations`.
+
+Embedded question remove/restore was part of the original Jira scope, but that path is already implemented by the merged MER-5622 / PR 6659 work. This PRD keeps the original embedded-question scope visible for traceability while treating it as existing infrastructure, not remaining implementation.
+
+## 2. Background & Problem Statement
+
+Instructors need to tailor assessment and practice opportunities for a specific course section or template. Existing instructor customization infrastructure stores section/page-specific exclusions outside authored revisions, preserving source content and historical attempts. The remaining MER-5620 gap is the Activity Bank Selection preview experience: showing the selection details, exposing a single remove/restore action for the whole selection, reflecting removed state in the UI, and warning instructors that changes apply only to future attempts when learners have already started or visited the page.
+
+The shared contract in `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md` defines the LiveView/React boundary for preview customization. MER-5620 should extend or reuse that contract for `bank_selection` targets rather than introducing a separate client/server communication path.
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- Render Activity Bank selections in the updated Instructor View preview UI with selection metadata and a sample question.
+- Allow authorized instructors to remove and restore an entire Activity Bank selection for the current page and section/template scope.
+- Route whole-selection actions through the existing preview customization contract and core instructor customization implementation.
+- Clearly communicate removed state without hiding the sample question preview.
+- Warn instructors when existing attempts or page visits mean customization changes apply only to future attempts.
+- Preserve student progress and historical attempts.
+- Keep authored source content, other pages, and other sections unaffected.
+
+### Non-Goals
+
+- Reimplement embedded activity remove/restore; that is already covered by merged MER-5622 / PR 6659 work.
+- Manage individual candidate questions inside an Activity Bank selection; that belongs to the bank selection manager flow and related tickets.
+- Add bulk candidate actions, candidate filtering, or search.
+- Change authored selection logic, authored page revisions, or published source content.
+- Retrospectively rewrite existing attempts.
+- Introduce a new preview communication pattern outside the shared wiring contract.
+
+## 4. Users & Use Cases
+
+- Instructor: remove an entire Activity Bank selection from a scored or practice page so future learners do not receive questions from that selection.
+- Instructor: restore a previously removed Activity Bank selection when the selection should become available again for future attempts.
+- Instructor: inspect how many questions are available, how many are selected, points per question, authored selection criteria, and a sample question before deciding whether to remove the selection.
+- Instructor: understand that changes after students have started or visited a page affect future attempts only.
+- Author or template-level operator: apply the same remove/restore capability at template level when the owning workflow supports instructor customization.
+- QA reviewer: verify that removing a selection is page-scoped and does not affect authored content, other pages, or previous student progress.
+
+## 5. UX / UI Requirements
+
+- Activity Bank selections must follow the approved Instructor View and Figma UI patterns.
+- Each selection preview must display a heading, number of available questions, select count, points per question, authored selection criteria, and one sample question from the available questions.
+- Active selections must display one remove action; removed selections must display one restore action.
+- Removed selections must be visually distinct using the approved removed-state treatment: red border or accent, gray background, and a "Removed" pill or badge.
+- The sample question must remain visible and keyboard-operable even when the selection is removed.
+- Success confirmations must appear above the affected selection after remove or restore.
+- Existing-attempt warning content must appear at the top of the page when applicable.
+- Warning modal behavior must confirm remove/restore when existing attempts or visits are present.
+- Remove and Restore buttons must be keyboard accessible, have visible focus states, include accessible labels, and preserve hover/disabled states.
+- Design references:
+  - Activity Bank Selection: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-8959&t=T9wp5xcQh1vNqdxN-1
+  - Success Messages: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=379-7382&t=T9wp5xcQh1vNqdxN-1
+  - Attempts started: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=286-8247&t=T9wp5xcQh1vNqdxN-1
+  - Warning Modals: https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=379-8630&t=T9wp5xcQh1vNqdxN-1
+
+## 6. Functional Requirements
+
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+
+- Accessibility: all remove/restore controls must be keyboard accessible, visibly focusable, and understandable to screen readers.
+- Reliability: remove/restore actions must be idempotent from the user perspective and must leave the UI in a recoverable state on failure.
+- Security: LiveView must revalidate target identity, current page scope, and authorization before dispatching writes to the domain context.
+- Performance: Activity Bank Selection preview and count updates should reuse existing page preview data and avoid introducing per-candidate query loops in render paths.
+- Privacy: warning and success messages must not expose learner-specific attempt details.
+- Compatibility: the feature must preserve the existing mixed LiveView/React preview model and must not disrupt embedded activity preview behavior already merged.
+
+## 9. Data, Interfaces & Dependencies
+
+- Uses `Oli.Delivery.InstructorCustomizations` as the authority for authorization, target validation, persistence, and read models.
+- Uses the preview customization wiring contract in `docs/exec-plans/current/epics/instructor_customizations/preview_customization_wiring.md`.
+- Requires `bank_selection` preview targets with `pageResourceId` and `selectionId`.
+- Should reuse existing `actions`, `customizationTarget`, `visualState`, and `statusPill` preview context concepts where applicable.
+- LiveView remains responsible for screen-level state: flashes, warning banner/modal state, page-level counts, and any aggregate updates.
+- React preview components remain responsible for local UI state and dispatching customization intents.
+- Depends on existing core implementation from MER-5639 and existing preview component infrastructure from MER-5618.
+- Must not alter student attempts that were already created before a remove/restore action.
+
+## 10. Repository & Platform Considerations
+
+- Backend changes belong in `lib/oli/` contexts for domain behavior and `lib/oli_web/` LiveViews/hooks/templates for transport and UI orchestration.
+- Frontend changes should stay within the existing React preview component and Phoenix hook model under `assets/src/`.
+- Delivery customization must respect the publication/resource/revision model and avoid mutating authored content.
+- Tests should use targeted ExUnit, LiveView, TypeScript/Jest, or scenario coverage depending on the final implementation boundary.
+- Code review should include security and performance lenses by default, plus Elixir, TypeScript, UI, and requirements review where touched files warrant them.
+- Jira `MER-5620` remains the issue-tracking system of record for this work item.
+
+## 11. Feature Flagging, Rollout & Migration
+
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+
+- Success signal: instructors can remove and restore whole Activity Bank selections in Instructor View without regressions to embedded activity remove/restore.
+- Success signal: future attempts exclude removed selections and include restored selections.
+- Success signal: existing attempts and student progress remain unchanged.
+- Operational signal: LiveView/domain errors for invalid targets, unauthorized writes, and failed persistence should remain observable through existing logging, telemetry, and AppSignal paths.
+- Product telemetry beyond existing platform signals is not required unless the implementation already exposes a suitable customization event.
+
+## 13. Risks & Mitigations
+
+- Risk: duplicating the embedded activity implementation could introduce inconsistent behavior. Mitigation: treat MER-5622 / PR 6659 embedded remove/restore as existing infrastructure and only extend the path for `bank_selection`.
+- Risk: Activity Bank Selection counts could become stale after remove/restore. Mitigation: derive counts from the same server-owned customization state used by delivery and refresh affected UI from LiveView replies or assigns.
+- Risk: removed selections could look active. Mitigation: use explicit `visualState` and `statusPill` values instead of inferring state only from button labels.
+- Risk: stale or malformed browser events could mutate the wrong target. Mitigation: validate payload shape in the hook, validate page/selection target in LiveView, and rely on `Oli.Delivery.InstructorCustomizations` for domain validation and authorization.
+- Risk: template-level behavior may use a different owning surface than section preview. Mitigation: keep the contract generic and confirm the template-level entry point before implementation planning.
+
+## 14. Open Questions & Assumptions
+
+### Open Questions
+
+- Which template-level Instructor View surface should consume the bank-selection remove/restore behavior?
+- Should the Activity Bank Selection user-facing action copy be "Remove/Restore" everywhere, or should any surface use "Enable/Disable" copy from the Jira comment?
+- What exact attempt/visit signal determines whether the warning banner and confirmation modal are shown for practice pages?
+- Should the "Saving..." and "Changes have been saved" messages reuse existing preview flash behavior or require a distinct save-status component?
+
+### Assumptions
+
+- Embedded activity remove/restore is complete enough to be reused as the reference implementation for this ticket.
+- Activity Bank Selection remove/restore maps to `Oli.Delivery.InstructorCustomizations.exclude_bank_selection/4` and `restore_bank_selection/4`, or equivalent core APIs.
+- Removed Activity Bank selections remain visible in Instructor View and keep their sample question operable.
+- Changes apply only to future page views or attempts and do not modify existing attempts.
+- This ticket does not include individual bank candidate management.
+
+## 15. QA Plan
+
+- Automated validation:
+  - Add or update LiveView tests for `bank_selection` remove/restore event handling, target validation, success/error replies, and warning state where server-owned.
+  - Add or update context tests if whole-selection behavior has gaps in `Oli.Delivery.InstructorCustomizations`.
+  - Add or update frontend tests for Activity Bank Selection preview state, action rendering, disabled/loading behavior, removed visual state, and accessibility-critical labels.
+  - Add scenario coverage if final behavior crosses authoring, publishing, section delivery, and future attempt creation.
+- Manual validation:
+  - Verify Activity Bank Selection preview against Figma in active and removed states.
+  - Verify remove/restore on scored and practice pages before and after attempts or visits exist.
+  - Verify future attempts reflect selection removal/restoration while existing progress remains unchanged.
+  - Verify embedded activity remove/restore still works after bank-selection changes.
+  - Verify keyboard navigation, focus states, screen-reader labels, warning content, and success confirmations.
+
+## 16. Definition of Done
+
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes
+- [ ] Activity Bank Selection preview displays required metadata and sample question
+- [ ] Whole-selection remove/restore routes through the shared preview customization contract
+- [ ] Warning messaging for future-attempt-only changes is implemented and verified
+- [ ] Embedded activity remove/restore remains unchanged and regression-tested where relevant
+- [ ] Automated and manual QA expectations are satisfied

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/prd.md
@@ -114,13 +114,12 @@ No feature flags present in this work item
 - Risk: Activity Bank Selection counts could become stale after remove/restore. Mitigation: derive counts from the same server-owned customization state used by delivery and refresh affected UI from LiveView replies or assigns.
 - Risk: removed selections could look active. Mitigation: use explicit `visualState` and `statusPill` values instead of inferring state only from button labels.
 - Risk: stale or malformed browser events could mutate the wrong target. Mitigation: validate payload shape in the hook, validate page/selection target in LiveView, and rely on `Oli.Delivery.InstructorCustomizations` for domain validation and authorization.
-- Risk: template-level behavior may use a different owning surface than section preview. Mitigation: keep the contract generic and confirm the template-level entry point before implementation planning.
+- Risk: template-level customization may not propagate to future course sections. Mitigation: copy blueprint `section_page_activity_exclusions` during section duplication from a customized template, while leaving already-created sections unchanged.
 
 ## 14. Open Questions & Assumptions
 
 ### Open Questions
 
-- Which template-level Instructor View surface should consume the bank-selection remove/restore behavior?
 - Should the Activity Bank Selection user-facing action copy be "Remove/Restore" everywhere, or should any surface use "Enable/Disable" copy from the Jira comment?
 - What exact attempt/visit signal determines whether the warning banner and confirmation modal are shown for practice pages?
 - Should the "Saving..." and "Changes have been saved" messages reuse existing preview flash behavior or require a distinct save-status component?
@@ -131,6 +130,8 @@ No feature flags present in this work item
 - Activity Bank Selection remove/restore maps to `Oli.Delivery.InstructorCustomizations.exclude_bank_selection/4` and `restore_bank_selection/4`, or equivalent core APIs.
 - Removed Activity Bank selections remain visible in Instructor View and keep their sample question operable.
 - Changes apply only to future page views or attempts and do not modify existing attempts.
+- Template-level UI is reached through Product/Template Customize Content page Edit links, which use the same instructor-style `PreviewLessonLive` route for the blueprint section.
+- Future course sections created from a customized template inherit the template's activity exclusions; already-created sections do not receive later template customization changes.
 - This ticket does not include individual bank candidate management.
 
 ## 15. QA Plan

--- a/docs/exec-plans/current/epics/instructor_customizations/ui_core/requirements.yml
+++ b/docs/exec-plans/current/epics/instructor_customizations/ui_core/requirements.yml
@@ -1,0 +1,124 @@
+work_item: ui_core
+requirements:
+- id: FR-001
+  title: Render Activity Bank Selection previews with required Instructor View metadata
+    and sample question
+  status: proposed
+- id: FR-002
+  title: Support whole Activity Bank Selection remove and restore actions in Instructor
+    View
+  status: proposed
+- id: FR-003
+  title: Route bank-selection preview actions through the shared LiveView/React customization
+    contract into core instructor customizations
+  status: proposed
+- id: FR-004
+  title: Warn instructors that remove/restore changes apply only to future attempts
+    when existing attempts or visits are present
+  status: proposed
+- id: FR-005
+  title: Keep customization page-scoped and preserve authored content, other pages,
+    other sections, and existing student progress
+  status: proposed
+- id: FR-006
+  title: Treat embedded activity remove/restore as already implemented infrastructure
+    from MER-5622 / PR 6659
+  status: proposed
+acceptance_criteria:
+- id: AC-001
+  requirement_id: FR-001
+  title: Given a user is in Instructor View and a page contains an Activity Bank Selection,
+    the selection displays the updated Instructor View UI with heading, available-question
+    count, select count, points per question, authored criteria, and one sample question.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-002
+  requirement_id: FR-002
+  title: Given an active Activity Bank Selection is displayed, only a Remove action
+    is shown; when selected and confirmed if required, the whole selection enters
+    removed state, questions available updates to 0, success confirmation appears
+    above the selection, and the action changes to Restore.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-003
+  requirement_id: FR-002
+  title: Given an Activity Bank Selection is removed, only a Restore action is shown;
+    when selected and confirmed if required, the selection returns to default visual
+    state, questions available returns to the original value, and success confirmation
+    appears above the selection.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-004
+  requirement_id: FR-002
+  title: Removed Activity Bank Selections show the approved removed-state treatment,
+    including red border or accent, gray background, and Removed pill or badge, while
+    keeping the sample question visible and keyboard-operable.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-005
+  requirement_id: FR-003
+  title: Activity Bank Selection remove/restore emits a customization intent with
+    target kind bank_selection and the required pageResourceId and selectionId, and
+    the owning LiveView dispatches to the core instructor customization implementation.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-006
+  requirement_id: FR-003
+  title: On success, LiveView returns a targeted reply that updates card-local actions,
+    visualState, and statusPill without remounting the initiating preview card; on
+    failure, it replies ok false so local submitting state can clear.
+  status: proposed
+  verification_method: automated
+  proofs: []
+- id: AC-007
+  requirement_id: FR-004
+  title: 'Given students have already started a scored assessment, the page displays
+    the warning text: Students have already started this assessment. Removing or restoring
+    questions and activity bank selections will only impact future attempts.'
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-008
+  requirement_id: FR-004
+  title: 'Given students have already visited a practice page, the page displays the
+    warning text: Students have already visited this page. Removing or restoring questions
+    and activity bank selections will only impact future attempts.'
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-009
+  requirement_id: FR-004
+  title: Given existing attempts or visits are present, attempting to remove or restore
+    an Activity Bank Selection shows a warning modal and proceeds only when the user
+    confirms the action.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-010
+  requirement_id: FR-005
+  title: Removing or restoring a whole Activity Bank Selection affects only the current
+    page and section/template scope and does not globally remove the selection, modify
+    authored source content, affect other pages, or change existing student progress.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-011
+  requirement_id: FR-005
+  title: Remove/restore controls are keyboard accessible, have visible focus states,
+    include accessible labels, and preserve hover and disabled states from approved
+    Figma patterns.
+  status: proposed
+  verification_method: hybrid
+  proofs: []
+- id: AC-012
+  requirement_id: FR-006
+  title: Embedded activity remove/restore behavior is not reimplemented by MER-5620
+    and remains functional after Activity Bank Selection changes.
+  status: proposed
+  verification_method: hybrid
+  proofs: []

--- a/lib/oli/activities/realizer/query.ex
+++ b/lib/oli/activities/realizer/query.ex
@@ -15,4 +15,15 @@ defmodule Oli.Activities.Realizer.Query do
     Builder.build(logic, source, paging, :paged)
     |> Executor.execute()
   end
+
+  @doc """
+  Executes a random activity bank query.
+
+  Returns {:ok, %Result{}} when the query is successfully executed and returns
+  {:error, error} otherwise.
+  """
+  def execute_random(%Logic{} = logic, %Source{} = source, %Paging{} = paging) do
+    Builder.build(logic, source, paging, :random)
+    |> Executor.execute()
+  end
 end

--- a/lib/oli/delivery/attempts/core.ex
+++ b/lib/oli/delivery/attempts/core.ex
@@ -66,6 +66,30 @@ defmodule Oli.Delivery.Attempts.Core do
     Repo.one(query) > 0
   end
 
+  @doc """
+  For a given section and page resource id, determine whether any learner resource attempts are
+  present without exposing learner-specific details.
+  """
+  def has_any_resource_attempts?(%Section{id: section_id}, resource_id) do
+    from(access in ResourceAccess,
+      join: attempt in ResourceAttempt,
+      on: access.id == attempt.resource_access_id,
+      where: access.section_id == ^section_id and access.resource_id == ^resource_id
+    )
+    |> Repo.exists?()
+  end
+
+  @doc """
+  For a given section and page resource id, determine whether any learner page access exists
+  without exposing learner-specific details.
+  """
+  def has_any_resource_accesses?(%Section{id: section_id}, resource_id) do
+    from(access in ResourceAccess,
+      where: access.section_id == ^section_id and access.resource_id == ^resource_id
+    )
+    |> Repo.exists?()
+  end
+
   def browse_lms_grade_updates(
         %Paging{limit: limit, offset: offset},
         %Sorting{field: field, direction: direction},

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -153,6 +153,7 @@ defmodule Oli.Delivery.InstructorCustomizations do
          %{
            selection_id: selection_id,
            count: count,
+           active_count: active_count,
            selection_enabled?: exclusion_view.selection_enabled?,
            active_count: active_count,
            total_count: result.totalCount,

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -215,6 +215,41 @@ defmodule Oli.Delivery.InstructorCustomizations do
   end
 
   @doc """
+  Returns selection-level candidate summary state for callers that do not need a
+  paged candidate list.
+  """
+  def get_bank_selection_summary(section_or_id, page_resource_id, selection_id) do
+    with {:ok, section, page_revision, selection} <-
+           resolve_selection_target(section_or_id, page_resource_id, selection_id) do
+      exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id)
+
+      with {:ok, active_count} <-
+             TargetResolver.count_active_candidates(
+               section,
+               page_revision,
+               selection,
+               exclusion_view.excluded_candidate_ids
+             ),
+           {:ok, sample_candidate} <-
+             TargetResolver.sample_candidate(
+               section,
+               page_revision,
+               selection,
+               exclusion_view.excluded_candidate_ids
+             ) do
+        {:ok,
+         %{
+           selection_id: selection_id,
+           count: selection["count"],
+           active_count: active_count,
+           selection_enabled?: exclusion_view.selection_enabled?,
+           sample_candidate: summarize_bank_candidate(sample_candidate, true, true)
+         }}
+      end
+    end
+  end
+
+  @doc """
   Returns one random active candidate matching a page bank selection.
   """
   def sample_bank_selection_candidate(section_or_id, page_resource_id, selection_id) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -214,6 +214,26 @@ defmodule Oli.Delivery.InstructorCustomizations do
     )
   end
 
+  @doc """
+  Returns one random active candidate matching a page bank selection.
+  """
+  def sample_bank_selection_candidate(section_or_id, page_resource_id, selection_id) do
+    with {:ok, section, page_revision, selection} <-
+           resolve_selection_target(section_or_id, page_resource_id, selection_id) do
+      exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id)
+
+      with {:ok, candidate} <-
+             TargetResolver.sample_candidate(
+               section,
+               page_revision,
+               selection,
+               exclusion_view.excluded_candidate_ids
+             ) do
+        {:ok, summarize_bank_candidate(candidate, true, true)}
+      end
+    end
+  end
+
   # Target validation
 
   @doc """
@@ -587,6 +607,18 @@ defmodule Oli.Delivery.InstructorCustomizations do
       _ ->
         {:error, {:invalid_paging, :limit}}
     end
+  end
+
+  defp summarize_bank_candidate(nil, _enabled?, _disable_allowed?), do: nil
+
+  defp summarize_bank_candidate(candidate, enabled?, disable_allowed?) do
+    %{
+      activity_resource_id: candidate.resource_id,
+      revision_slug: candidate.slug,
+      title: candidate.title,
+      enabled?: enabled?,
+      disable_allowed?: disable_allowed?
+    }
   end
 
   defp exclusion_exists?(section_id, page_resource_id, attrs) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -153,7 +153,6 @@ defmodule Oli.Delivery.InstructorCustomizations do
          %{
            selection_id: selection_id,
            count: count,
-           active_count: active_count,
            selection_enabled?: exclusion_view.selection_enabled?,
            active_count: active_count,
            total_count: result.totalCount,

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -14,6 +14,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   alias Oli.Resources.ResourceType
 
   @count_query_paging %Paging{offset: 0, limit: 1}
+  @sample_query_paging %Paging{offset: 0, limit: 1}
 
   # Section/page targets
 
@@ -172,6 +173,24 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   end
 
   @doc """
+  Returns one random active candidate matching the selection logic.
+  """
+  def sample_candidate(%Section{} = section, page_revision, selection, excluded_ids) do
+    with {:ok, result} <-
+           execute_candidate_query(
+             section,
+             page_revision,
+             selection,
+             MapSet.to_list(excluded_ids),
+             @sample_query_paging,
+             nil,
+             :random
+           ) do
+      {:ok, List.first(result.rows)}
+    end
+  end
+
+  @doc """
   Returns whether a resource id is a current candidate for the selection.
   """
   @spec candidate_matches?(%Section{}, %Revision{}, map(), integer()) ::
@@ -199,13 +218,15 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
          selection,
          blacklisted_ids,
          paging,
-         activity_resource_ids \\ nil
+         activity_resource_ids \\ nil,
+         query_type \\ :paged
        ) do
     with {:ok, %Logic{} = logic} <- parse_logic(selection),
          publication_id <-
            Publishing.get_publication_id_for_resource(section.slug, page_revision.resource_id),
          {:ok, result} <-
-           Query.execute(
+           execute_query(
+             query_type,
              logic,
              %Source{
                publication_id: publication_id,
@@ -218,6 +239,11 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
       {:ok, result}
     end
   end
+
+  defp execute_query(:paged, logic, source, paging), do: Query.execute(logic, source, paging)
+
+  defp execute_query(:random, logic, source, paging),
+    do: Query.execute_random(logic, source, paging)
 
   defp parse_logic(%{"logic" => logic}) do
     case Logic.parse(logic) do

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -4,6 +4,7 @@ defmodule Oli.Delivery.Sections.Blueprint do
   alias Oli.Accounts.Author
   alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Course.ProjectVisibility
+  alias Oli.Delivery.InstructorCustomizations.ActivityExclusion
   alias Oli.Publishing.Publications.Publication
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.PostProcessing
@@ -334,6 +335,38 @@ defmodule Oli.Delivery.Sections.Blueprint do
     |> Map.delete(:id)
     |> Map.delete(:slug)
     |> Sections.create_section()
+  end
+
+  defp duplicate_activity_exclusions(%Section{id: source_section_id}, %Section{
+         id: target_section_id
+       }) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    rows =
+      ActivityExclusion
+      |> where([exclusion], exclusion.section_id == ^source_section_id)
+      |> select([exclusion], %{
+        page_resource_id: exclusion.page_resource_id,
+        kind: exclusion.kind,
+        selection_id: exclusion.selection_id,
+        excluded_resource_id: exclusion.excluded_resource_id
+      })
+      |> Repo.all()
+      |> Enum.map(fn exclusion ->
+        %{
+          section_id: target_section_id,
+          page_resource_id: exclusion.page_resource_id,
+          kind: exclusion.kind,
+          selection_id: exclusion.selection_id,
+          excluded_resource_id: exclusion.excluded_resource_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      end)
+
+    {count, _} = Repo.insert_all(ActivityExclusion, rows, on_conflict: :nothing)
+
+    {:ok, count}
   end
 
   defp dupe_section_resources(

--- a/lib/oli/delivery/sections/blueprint.ex
+++ b/lib/oli/delivery/sections/blueprint.ex
@@ -4,7 +4,6 @@ defmodule Oli.Delivery.Sections.Blueprint do
   alias Oli.Accounts.Author
   alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Course.ProjectVisibility
-  alias Oli.Delivery.InstructorCustomizations.ActivityExclusion
   alias Oli.Publishing.Publications.Publication
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.PostProcessing
@@ -335,38 +334,6 @@ defmodule Oli.Delivery.Sections.Blueprint do
     |> Map.delete(:id)
     |> Map.delete(:slug)
     |> Sections.create_section()
-  end
-
-  defp duplicate_activity_exclusions(%Section{id: source_section_id}, %Section{
-         id: target_section_id
-       }) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
-
-    rows =
-      ActivityExclusion
-      |> where([exclusion], exclusion.section_id == ^source_section_id)
-      |> select([exclusion], %{
-        page_resource_id: exclusion.page_resource_id,
-        kind: exclusion.kind,
-        selection_id: exclusion.selection_id,
-        excluded_resource_id: exclusion.excluded_resource_id
-      })
-      |> Repo.all()
-      |> Enum.map(fn exclusion ->
-        %{
-          section_id: target_section_id,
-          page_resource_id: exclusion.page_resource_id,
-          kind: exclusion.kind,
-          selection_id: exclusion.selection_id,
-          excluded_resource_id: exclusion.excluded_resource_id,
-          inserted_at: now,
-          updated_at: now
-        }
-      end)
-
-    {count, _} = Repo.insert_all(ActivityExclusion, rows, on_conflict: :nothing)
-
-    {:ok, count}
   end
 
   defp dupe_section_resources(

--- a/lib/oli/rendering/content/activity_bank_selection_criteria.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_criteria.ex
@@ -2,21 +2,21 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
   @moduledoc """
   Builds the instructor-facing presentation for Activity Bank selection criteria.
 
-  This module intentionally translates authored selection logic into friendlier labels for
-  instructor preview surfaces. The goal is to keep the criteria understandable without exposing
-  raw query-style wording.
+  This module translates authored selection logic into instructor-facing labels for preview
+  surfaces.
 
   Current UX rules:
 
   - show top-level clause context as "Activities must match all of the following." /
     "Activities may match any of the following."
   - for tags and learning objectives:
-    - `contains` -> "Must include ..."
-    - `equals` -> "Only these ..."
-    - negative operators -> "Excluded ..."
+    - `contains` -> "... contain"
+    - `equals` -> "... equal"
+    - `does_not_contain` -> "... do not contain"
+    - `does_not_equal` -> "... do not equal"
   - for activity types:
-    - positive operators stay as "Activity Types"
-    - negative operators become "Excluded Activity Types"
+    - `contains` -> "Activity Types contain"
+    - `does_not_contain` -> "Activity Types do not contain"
 
   Both the React-based preview card and the LiveView manager use this module so those surfaces
   stay aligned as criteria presentation evolves.
@@ -138,10 +138,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
   defp collect_criteria(%Clause{children: children}, activity_type_titles_by_id, titles_by_id),
     do: Enum.flat_map(children, &collect_criteria(&1, activity_type_titles_by_id, titles_by_id))
 
-  # Tags and objectives preserve the UX distinction between "contains" and "equals":
-  # "Must include ..." communicates subset matching, while "Only these ..." communicates
-  # exact matching. Negative operators are collapsed into "Excluded ..." to keep the copy
-  # friendlier and less query-like for instructors.
+  # Labels intentionally use the authored operator words (equal / contain / do not equal /
+  # do not contain) so the preview remains transparent about the real selection semantics.
   defp collect_criteria(
          %Expression{fact: :tags, operator: operator, value: values},
          _activity_type_titles_by_id,
@@ -225,34 +223,37 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
   defp helper_text(%Clause{operator: "any"}), do: "Activities may match any of the following."
   defp helper_text(_conditions), do: nil
 
-  # Activity type rules stay intentionally simpler than tags/objectives. In practice the authoring
-  # flow mainly uses contains/does_not_contain for types, so the positive label stays as the plain
-  # "Activity Types" while negatives become "Excluded Activity Types".
   defp criteria_label(:tags, operator) when operator in [:contains, "contains"],
-    do: "Must include Tags"
+    do: "Tags contain"
 
   defp criteria_label(:tags, operator) when operator in [:equals, "equals"],
-    do: "Only these Tags"
+    do: "Tags equal"
 
-  defp criteria_label(:tags, operator)
-       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
-       do: "Excluded Tags"
+  defp criteria_label(:tags, operator) when operator in [:does_not_contain, "does_not_contain"],
+    do: "Tags do not contain"
+
+  defp criteria_label(:tags, operator) when operator in [:does_not_equal, "does_not_equal"],
+    do: "Tags do not equal"
 
   defp criteria_label(:objectives, operator) when operator in [:contains, "contains"],
-    do: "Must include Learning Objectives"
+    do: "Learning Objectives contain"
 
   defp criteria_label(:objectives, operator) when operator in [:equals, "equals"],
-    do: "Only these Learning Objectives"
+    do: "Learning Objectives equal"
 
   defp criteria_label(:objectives, operator)
-       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
-       do: "Excluded Learning Objectives"
+       when operator in [:does_not_contain, "does_not_contain"],
+       do: "Learning Objectives do not contain"
+
+  defp criteria_label(:objectives, operator)
+       when operator in [:does_not_equal, "does_not_equal"],
+       do: "Learning Objectives do not equal"
 
   defp criteria_label(:type, operator)
        when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
-       do: "Excluded Activity Types"
+       do: "Activity Types do not contain"
 
-  defp criteria_label(:type, _operator), do: "Activity Types"
+  defp criteria_label(:type, _operator), do: "Activity Types contain"
 
   defp criteria_label(:other, operator)
        when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],

--- a/lib/oli/rendering/content/activity_bank_selection_criteria.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_criteria.ex
@@ -8,7 +8,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
 
   Current UX rules:
 
-  - show top-level clause context as "Matches all of the following" / "Matches any of the following"
+  - show top-level clause context as "Activities must match all of the following." /
+    "Activities may match any of the following."
   - for tags and learning objectives:
     - `contains` -> "Must include ..."
     - `equals` -> "Only these ..."
@@ -218,10 +219,10 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
   end
 
   # The top-level clause is shown as supporting context instead of repeating all/any in each row.
-  defp helper_text(%Clause{operator: :all}), do: "Matches all of the following"
-  defp helper_text(%Clause{operator: :any}), do: "Matches any of the following"
-  defp helper_text(%Clause{operator: "all"}), do: "Matches all of the following"
-  defp helper_text(%Clause{operator: "any"}), do: "Matches any of the following"
+  defp helper_text(%Clause{operator: :all}), do: "Activities must match all of the following."
+  defp helper_text(%Clause{operator: :any}), do: "Activities may match any of the following."
+  defp helper_text(%Clause{operator: "all"}), do: "Activities must match all of the following."
+  defp helper_text(%Clause{operator: "any"}), do: "Activities may match any of the following."
   defp helper_text(_conditions), do: nil
 
   # Activity type rules stay intentionally simpler than tags/objectives. In practice the authoring

--- a/lib/oli/rendering/content/activity_bank_selection_criteria.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_criteria.ex
@@ -1,12 +1,40 @@
 defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
-  @moduledoc false
+  @moduledoc """
+  Builds the instructor-facing presentation for Activity Bank selection criteria.
+
+  This module intentionally translates authored selection logic into friendlier labels for
+  instructor preview surfaces. The goal is to keep the criteria understandable without exposing
+  raw query-style wording.
+
+  Current UX rules:
+
+  - show top-level clause context as "Matches all of the following" / "Matches any of the following"
+  - for tags and learning objectives:
+    - `contains` -> "Must include ..."
+    - `equals` -> "Only these ..."
+    - negative operators -> "Excluded ..."
+  - for activity types:
+    - positive operators stay as "Activity Types"
+    - negative operators become "Excluded Activity Types"
+
+  Both the React-based preview card and the LiveView manager use this module so those surfaces
+  stay aligned as criteria presentation evolves.
+  """
 
   alias Oli.Activities
   alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Activities.Realizer.Selection
   alias Oli.Publishing.DeliveryResolver
 
-  def rows(selection, section_slug) when is_binary(section_slug) do
+  @doc """
+  Returns the full criteria presentation for a single selection.
+
+  The result contains:
+
+  - `:helper_text` for the top-level all/any clause, when present
+  - `:rows` for the rendered criteria groups and values
+  """
+  def presentation(selection, section_slug) when is_binary(section_slug) do
     activity_type_titles_by_id =
       Activities.list_activity_registrations()
       |> Map.new(fn activity_type -> {activity_type.id, activity_type.title} end)
@@ -14,9 +42,26 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
     parsed_selection = parse_selection(selection)
     criteria_resource_titles_by_id = criteria_resource_titles(section_slug, parsed_selection)
 
-    rows(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id)
+    presentation(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id)
   end
 
+  @doc """
+  Returns only the criteria rows for a selection.
+
+  This is a convenience wrapper when the caller does not need the clause helper text.
+  """
+  def rows(selection, section_slug) when is_binary(section_slug) do
+    selection
+    |> presentation(section_slug)
+    |> Map.get(:rows, [])
+  end
+
+  @doc """
+  Resolves titles for tag/objective resource ids used by one or more selections.
+
+  Callers that already have multiple parsed selections can use this to avoid resolving labels
+  one resource at a time.
+  """
   def resource_titles(section_slug, selection_data) when is_binary(section_slug) do
     resource_ids =
       selection_data
@@ -35,6 +80,27 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
     end
   end
 
+  def presentation(
+        %Selection{logic: %{conditions: nil}},
+        _activity_type_titles_by_id,
+        _criteria_resource_titles_by_id
+      ),
+      do: %{helper_text: nil, rows: []}
+
+  def presentation(
+        %Selection{logic: %{conditions: conditions}},
+        activity_type_titles_by_id,
+        criteria_resource_titles_by_id
+      ) do
+    %{
+      helper_text: helper_text(conditions),
+      rows: build_rows(conditions, activity_type_titles_by_id, criteria_resource_titles_by_id)
+    }
+  end
+
+  def presentation(_selection, _activity_type_titles_by_id, _criteria_resource_titles_by_id),
+    do: %{helper_text: nil, rows: []}
+
   def rows(
         %Selection{logic: %{conditions: nil}},
         _activity_type_titles_by_id,
@@ -46,13 +112,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
         %Selection{logic: %{conditions: conditions}},
         activity_type_titles_by_id,
         criteria_resource_titles_by_id
-      ) do
-    conditions
-    |> collect_criteria(activity_type_titles_by_id, criteria_resource_titles_by_id)
-    |> Enum.reduce([], fn {label, values}, groups ->
-      merge_criteria_group(groups, label, values)
-    end)
-  end
+      ),
+      do: build_rows(conditions, activity_type_titles_by_id, criteria_resource_titles_by_id)
 
   def rows(_selection, _activity_type_titles_by_id, _criteria_resource_titles_by_id), do: []
 
@@ -65,9 +126,21 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
     end
   end
 
+  defp build_rows(conditions, activity_type_titles_by_id, criteria_resource_titles_by_id) do
+    conditions
+    |> collect_criteria(activity_type_titles_by_id, criteria_resource_titles_by_id)
+    |> Enum.reduce([], fn {label, values}, groups ->
+      merge_criteria_group(groups, label, values)
+    end)
+  end
+
   defp collect_criteria(%Clause{children: children}, activity_type_titles_by_id, titles_by_id),
     do: Enum.flat_map(children, &collect_criteria(&1, activity_type_titles_by_id, titles_by_id))
 
+  # Tags and objectives preserve the UX distinction between "contains" and "equals":
+  # "Must include ..." communicates subset matching, while "Only these ..." communicates
+  # exact matching. Negative operators are collapsed into "Excluded ..." to keep the copy
+  # friendlier and less query-like for instructors.
   defp collect_criteria(
          %Expression{fact: :tags, operator: operator, value: values},
          _activity_type_titles_by_id,
@@ -75,8 +148,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
        )
        when is_list(values) do
     [
-      {"#{criteria_exclusion_prefix(operator)}Tags",
-       labels_for_resource_ids(values, titles_by_id)}
+      {criteria_label(:tags, operator), labels_for_resource_ids(values, titles_by_id)}
     ]
   end
 
@@ -87,8 +159,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
        )
        when is_list(values) do
     [
-      {"#{criteria_exclusion_prefix(operator)}Learning Objectives",
-       labels_for_resource_ids(values, titles_by_id)}
+      {criteria_label(:objectives, operator), labels_for_resource_ids(values, titles_by_id)}
     ]
   end
 
@@ -99,15 +170,16 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
        )
        when is_list(values) do
     [
-      {"#{criteria_exclusion_prefix(operator)}Activity Types",
+      {criteria_label(:type, operator),
        labels_for_activity_type_ids(values, activity_type_titles_by_id)}
     ]
   end
 
+  # Unknown facts still surface as criteria so authored rules are not silently hidden from
+  # instructors, but they fall back to a generic label.
   defp collect_criteria(%Expression{} = expression, _activity_type_titles_by_id, _titles_by_id) do
     [
-      {"#{criteria_exclusion_prefix(expression.operator)}Other",
-       [criterion_value(expression.value)]}
+      {criteria_label(:other, expression.operator), [criterion_value(expression.value)]}
     ]
   end
 
@@ -145,11 +217,47 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
     end
   end
 
-  defp criteria_exclusion_prefix(operator)
-       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
-       do: "Excluded "
+  # The top-level clause is shown as supporting context instead of repeating all/any in each row.
+  defp helper_text(%Clause{operator: :all}), do: "Matches all of the following"
+  defp helper_text(%Clause{operator: :any}), do: "Matches any of the following"
+  defp helper_text(%Clause{operator: "all"}), do: "Matches all of the following"
+  defp helper_text(%Clause{operator: "any"}), do: "Matches any of the following"
+  defp helper_text(_conditions), do: nil
 
-  defp criteria_exclusion_prefix(_operator), do: ""
+  # Activity type rules stay intentionally simpler than tags/objectives. In practice the authoring
+  # flow mainly uses contains/does_not_contain for types, so the positive label stays as the plain
+  # "Activity Types" while negatives become "Excluded Activity Types".
+  defp criteria_label(:tags, operator) when operator in [:contains, "contains"],
+    do: "Must include Tags"
+
+  defp criteria_label(:tags, operator) when operator in [:equals, "equals"],
+    do: "Only these Tags"
+
+  defp criteria_label(:tags, operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded Tags"
+
+  defp criteria_label(:objectives, operator) when operator in [:contains, "contains"],
+    do: "Must include Learning Objectives"
+
+  defp criteria_label(:objectives, operator) when operator in [:equals, "equals"],
+    do: "Only these Learning Objectives"
+
+  defp criteria_label(:objectives, operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded Learning Objectives"
+
+  defp criteria_label(:type, operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded Activity Types"
+
+  defp criteria_label(:type, _operator), do: "Activity Types"
+
+  defp criteria_label(:other, operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded Other"
+
+  defp criteria_label(:other, _operator), do: "Other"
 
   defp labels_for_resource_ids(resource_ids, titles_by_id) do
     Enum.map(resource_ids, fn resource_id ->

--- a/lib/oli/rendering/content/activity_bank_selection_criteria.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_criteria.ex
@@ -1,0 +1,168 @@
+defmodule Oli.Rendering.Content.ActivityBankSelectionCriteria do
+  @moduledoc false
+
+  alias Oli.Activities
+  alias Oli.Activities.Realizer.Logic.{Clause, Expression}
+  alias Oli.Activities.Realizer.Selection
+  alias Oli.Publishing.DeliveryResolver
+
+  def rows(selection, section_slug) when is_binary(section_slug) do
+    activity_type_titles_by_id =
+      Activities.list_activity_registrations()
+      |> Map.new(fn activity_type -> {activity_type.id, activity_type.title} end)
+
+    parsed_selection = parse_selection(selection)
+    criteria_resource_titles_by_id = criteria_resource_titles(section_slug, parsed_selection)
+
+    rows(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id)
+  end
+
+  def resource_titles(section_slug, selection_data) when is_binary(section_slug) do
+    resource_ids =
+      selection_data
+      |> Enum.flat_map(fn {_selection, parsed_selection} ->
+        criteria_resource_ids(parsed_selection)
+      end)
+      |> Enum.uniq()
+
+    if resource_ids == [] do
+      %{}
+    else
+      section_slug
+      |> DeliveryResolver.from_resource_id(resource_ids)
+      |> Enum.reject(&is_nil/1)
+      |> Map.new(fn revision -> {revision.resource_id, revision.title} end)
+    end
+  end
+
+  def rows(
+        %Selection{logic: %{conditions: nil}},
+        _activity_type_titles_by_id,
+        _criteria_resource_titles_by_id
+      ),
+      do: []
+
+  def rows(
+        %Selection{logic: %{conditions: conditions}},
+        activity_type_titles_by_id,
+        criteria_resource_titles_by_id
+      ) do
+    conditions
+    |> collect_criteria(activity_type_titles_by_id, criteria_resource_titles_by_id)
+    |> Enum.reduce([], fn {label, values}, groups ->
+      merge_criteria_group(groups, label, values)
+    end)
+  end
+
+  def rows(_selection, _activity_type_titles_by_id, _criteria_resource_titles_by_id), do: []
+
+  defp parse_selection(%Selection{} = selection), do: selection
+
+  defp parse_selection(selection) do
+    case Selection.parse(selection) do
+      {:ok, parsed_selection} -> parsed_selection
+      _ -> nil
+    end
+  end
+
+  defp collect_criteria(%Clause{children: children}, activity_type_titles_by_id, titles_by_id),
+    do: Enum.flat_map(children, &collect_criteria(&1, activity_type_titles_by_id, titles_by_id))
+
+  defp collect_criteria(
+         %Expression{fact: :tags, operator: operator, value: values},
+         _activity_type_titles_by_id,
+         titles_by_id
+       )
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Tags",
+       labels_for_resource_ids(values, titles_by_id)}
+    ]
+  end
+
+  defp collect_criteria(
+         %Expression{fact: :objectives, operator: operator, value: values},
+         _activity_type_titles_by_id,
+         titles_by_id
+       )
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Learning Objectives",
+       labels_for_resource_ids(values, titles_by_id)}
+    ]
+  end
+
+  defp collect_criteria(
+         %Expression{fact: :type, operator: operator, value: values},
+         activity_type_titles_by_id,
+         _titles_by_id
+       )
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Activity Types",
+       labels_for_activity_type_ids(values, activity_type_titles_by_id)}
+    ]
+  end
+
+  defp collect_criteria(%Expression{} = expression, _activity_type_titles_by_id, _titles_by_id) do
+    [
+      {"#{criteria_exclusion_prefix(expression.operator)}Other",
+       [criterion_value(expression.value)]}
+    ]
+  end
+
+  defp collect_criteria(_condition, _activity_type_titles_by_id, _titles_by_id), do: []
+
+  defp criteria_resource_titles(_section_slug, nil), do: %{}
+
+  defp criteria_resource_titles(section_slug, parsed_selection) do
+    resource_titles(section_slug, [{nil, parsed_selection}])
+  end
+
+  defp criteria_resource_ids(%Selection{logic: %{conditions: conditions}}),
+    do: collect_criteria_resource_ids(conditions)
+
+  defp criteria_resource_ids(_selection), do: []
+
+  defp collect_criteria_resource_ids(%Clause{children: children}),
+    do: Enum.flat_map(children, &collect_criteria_resource_ids/1)
+
+  defp collect_criteria_resource_ids(%Expression{fact: fact, value: values})
+       when fact in [:tags, :objectives] and is_list(values),
+       do: values
+
+  defp collect_criteria_resource_ids(_condition), do: []
+
+  defp merge_criteria_group(groups, label, values) do
+    case Enum.find_index(groups, &(&1.label == label)) do
+      nil ->
+        groups ++ [%{label: label, values: Enum.uniq(values)}]
+
+      index ->
+        List.update_at(groups, index, fn group ->
+          %{group | values: Enum.uniq(group.values ++ values)}
+        end)
+    end
+  end
+
+  defp criteria_exclusion_prefix(operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded "
+
+  defp criteria_exclusion_prefix(_operator), do: ""
+
+  defp labels_for_resource_ids(resource_ids, titles_by_id) do
+    Enum.map(resource_ids, fn resource_id ->
+      Map.get(titles_by_id, resource_id, to_string(resource_id))
+    end)
+  end
+
+  defp labels_for_activity_type_ids(activity_type_ids, activity_type_titles_by_id) do
+    Enum.map(activity_type_ids, fn activity_type_id ->
+      Map.get(activity_type_titles_by_id, activity_type_id, to_string(activity_type_id))
+    end)
+  end
+
+  defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)
+  defp criterion_value(value), do: to_string(value)
+end

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -16,7 +16,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
 
   def script, do: @script
 
-  def build_preview_map(section, page_revision, activity_types) do
+  def build_preview_map(section, page_revision, activity_types, navigation_params \\ %{}) do
     selections =
       PageContent.flat_filter(page_revision.content, fn
         %{"type" => "selection", "id" => id} when is_binary(id) -> true
@@ -48,7 +48,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
            parsed_selection,
            activity_type_by_id,
            activity_type_titles_by_id,
-           criteria_resource_titles_by_id
+           criteria_resource_titles_by_id,
+           navigation_params
          )}
       end)
       |> Map.new()
@@ -77,7 +78,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
         parsed_selection,
         activity_type_by_id,
         activity_type_titles_by_id,
-        criteria_resource_titles_by_id
+        criteria_resource_titles_by_id,
+        navigation_params
       ) do
     selection_id = selection["id"]
 
@@ -125,7 +127,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       pointsPerActivity: points_per_activity,
       criteria:
         criteria(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id),
-      manageQuestionsUrl: nil,
+      manageQuestionsUrl:
+        manage_questions_url(section.slug, page_revision.slug, selection_id, navigation_params),
       sampleActivity: sample_activity,
       canCustomize: true,
       actions: actions(selection_enabled?),
@@ -444,6 +447,32 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
     Enum.map(activity_type_ids, fn activity_type_id ->
       Map.get(activity_type_titles_by_id, activity_type_id, to_string(activity_type_id))
     end)
+  end
+
+  defp manage_questions_url(section_slug, revision_slug, selection_id, navigation_params) do
+    request_path = lesson_request_path(section_slug, revision_slug, navigation_params)
+
+    params =
+      navigation_params
+      |> Map.take(["return_to"])
+      |> Map.put("request_path", request_path)
+
+    path =
+      "/sections/#{section_slug}/preview/lesson/#{revision_slug}/selection/#{selection_id}"
+
+    case Plug.Conn.Query.encode(params) do
+      "" -> path
+      query -> "#{path}?#{query}"
+    end
+  end
+
+  defp lesson_request_path(section_slug, revision_slug, navigation_params) do
+    path = "/sections/#{section_slug}/preview/lesson/#{revision_slug}"
+
+    case navigation_params |> Map.take(["return_to"]) |> Plug.Conn.Query.encode() do
+      "" -> path
+      query -> "#{path}?#{query}"
+    end
   end
 
   defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -1,7 +1,6 @@
-defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
+defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   @moduledoc false
 
-  alias Oli.Activities
   alias Oli.Activities.Realizer.Selection
   alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Delivery.InstructorCustomizations
@@ -10,7 +9,6 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.Context
-  alias Oli.Resources
   alias Oli.Resources.PageContent
 
   @script "instructor_preview_components.js"
@@ -25,13 +23,33 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
         _ -> false
       end)
 
+    selection_data =
+      Enum.map(selections, fn selection ->
+        {selection, parse_selection(selection)}
+      end)
+
     activity_type_by_id =
       Map.new(activity_types, fn activity_type -> {activity_type.id, activity_type} end)
 
+    activity_type_titles_by_id =
+      Map.new(activity_types, fn activity_type -> {activity_type.id, activity_type.title} end)
+
+    criteria_resource_titles_by_id =
+      criteria_resource_titles(section.slug, selection_data)
+
     previews =
-      selections
-      |> Enum.map(fn selection ->
-        {selection["id"], build_preview(section, page_revision, selection, activity_type_by_id)}
+      selection_data
+      |> Enum.map(fn {selection, parsed_selection} ->
+        {selection["id"],
+         build_preview(
+           section,
+           page_revision,
+           selection,
+           parsed_selection,
+           activity_type_by_id,
+           activity_type_titles_by_id,
+           criteria_resource_titles_by_id
+         )}
       end)
       |> Map.new()
 
@@ -52,9 +70,16 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
     {previews, scripts}
   end
 
-  def build_preview(section, page_revision, selection, activity_type_by_id) do
+  def build_preview(
+        section,
+        page_revision,
+        selection,
+        parsed_selection,
+        activity_type_by_id,
+        activity_type_titles_by_id,
+        criteria_resource_titles_by_id
+      ) do
     selection_id = selection["id"]
-    parsed_selection = parse_selection(selection)
 
     selection_summary =
       InstructorCustomizations.get_bank_selection_summary(
@@ -98,7 +123,8 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
       availableCount: available_count,
       originalAvailableCount: original_available_count,
       pointsPerActivity: points_per_activity,
-      criteria: criteria(parsed_selection, section.slug),
+      criteria:
+        criteria(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id),
       manageQuestionsUrl: nil,
       sampleActivity: sample_activity,
       canCustomize: true,
@@ -287,60 +313,108 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   defp actions(true), do: [%{kind: "remove", label: "Remove"}]
   defp actions(false), do: [%{kind: "restore", label: "Restore"}]
 
-  defp criteria(%Selection{logic: %{conditions: nil}}, _section_slug),
-    do: []
+  defp criteria(
+         %Selection{logic: %{conditions: nil}},
+         _activity_type_titles_by_id,
+         _titles_by_id
+       ),
+       do: []
 
-  defp criteria(%Selection{logic: %{conditions: conditions}}, section_slug) do
+  defp criteria(
+         %Selection{logic: %{conditions: conditions}},
+         activity_type_titles_by_id,
+         criteria_resource_titles_by_id
+       ) do
     conditions
-    |> collect_criteria(section_slug)
+    |> collect_criteria(activity_type_titles_by_id, criteria_resource_titles_by_id)
     |> Enum.reduce([], fn {label, values}, groups ->
       merge_criteria_group(groups, label, values)
     end)
   end
 
-  defp criteria(_selection, _section_slug), do: []
+  defp criteria(_selection, _activity_type_titles_by_id, _criteria_resource_titles_by_id), do: []
 
-  defp collect_criteria(%Clause{children: children}, section_slug),
-    do: Enum.flat_map(children, &collect_criteria(&1, section_slug))
+  defp collect_criteria(%Clause{children: children}, activity_type_titles_by_id, titles_by_id),
+    do: Enum.flat_map(children, &collect_criteria(&1, activity_type_titles_by_id, titles_by_id))
 
-  defp collect_criteria(%Expression{fact: :tags, operator: operator, value: values}, section_slug)
+  defp collect_criteria(
+         %Expression{fact: :tags, operator: operator, value: values},
+         _activity_type_titles_by_id,
+         titles_by_id
+       )
        when is_list(values) do
     [
       {"#{criteria_exclusion_prefix(operator)}Tags",
-       labels_for_resource_ids(values, section_slug)}
+       labels_for_resource_ids(values, titles_by_id)}
     ]
   end
 
   defp collect_criteria(
          %Expression{fact: :objectives, operator: operator, value: values},
-         section_slug
+         _activity_type_titles_by_id,
+         titles_by_id
        )
        when is_list(values) do
     [
       {"#{criteria_exclusion_prefix(operator)}Learning Objectives",
-       labels_for_resource_ids(values, section_slug)}
+       labels_for_resource_ids(values, titles_by_id)}
     ]
   end
 
   defp collect_criteria(
          %Expression{fact: :type, operator: operator, value: values},
-         _section_slug
+         activity_type_titles_by_id,
+         _titles_by_id
        )
        when is_list(values) do
     [
       {"#{criteria_exclusion_prefix(operator)}Activity Types",
-       labels_for_activity_type_ids(values)}
+       labels_for_activity_type_ids(values, activity_type_titles_by_id)}
     ]
   end
 
-  defp collect_criteria(%Expression{} = expression, _section_slug) do
+  defp collect_criteria(%Expression{} = expression, _activity_type_titles_by_id, _titles_by_id) do
     [
       {"#{criteria_exclusion_prefix(expression.operator)}Other",
        [criterion_value(expression.value)]}
     ]
   end
 
-  defp collect_criteria(_condition, _section_slug), do: []
+  defp collect_criteria(_condition, _activity_type_titles_by_id, _titles_by_id), do: []
+
+  defp criteria_resource_titles(_section_slug, []), do: %{}
+
+  defp criteria_resource_titles(section_slug, selection_data) do
+    resource_ids =
+      selection_data
+      |> Enum.flat_map(fn {_selection, parsed_selection} ->
+        criteria_resource_ids(parsed_selection)
+      end)
+      |> Enum.uniq()
+
+    if resource_ids == [] do
+      %{}
+    else
+      section_slug
+      |> DeliveryResolver.from_resource_id(resource_ids)
+      |> Enum.reject(&is_nil/1)
+      |> Map.new(fn revision -> {revision.resource_id, revision.title} end)
+    end
+  end
+
+  defp criteria_resource_ids(%Selection{logic: %{conditions: conditions}}),
+    do: collect_criteria_resource_ids(conditions)
+
+  defp criteria_resource_ids(_selection), do: []
+
+  defp collect_criteria_resource_ids(%Clause{children: children}),
+    do: Enum.flat_map(children, &collect_criteria_resource_ids/1)
+
+  defp collect_criteria_resource_ids(%Expression{fact: fact, value: values})
+       when fact in [:tags, :objectives] and is_list(values),
+       do: values
+
+  defp collect_criteria_resource_ids(_condition), do: []
 
   defp merge_criteria_group(groups, label, values) do
     case Enum.find_index(groups, &(&1.label == label)) do
@@ -360,32 +434,16 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
   defp criteria_exclusion_prefix(_operator), do: ""
 
-  defp labels_for_resource_ids(resource_ids, section_slug) do
+  defp labels_for_resource_ids(resource_ids, titles_by_id) do
     Enum.map(resource_ids, fn resource_id ->
-      case resource_label(resource_id, section_slug) do
-        nil -> to_string(resource_id)
-        label -> label
-      end
+      Map.get(titles_by_id, resource_id, to_string(resource_id))
     end)
   end
 
-  defp labels_for_activity_type_ids(activity_type_ids) do
-    registrations_by_id =
-      Activities.list_activity_registrations()
-      |> Map.new(fn registration -> {registration.id, registration.title} end)
-
+  defp labels_for_activity_type_ids(activity_type_ids, activity_type_titles_by_id) do
     Enum.map(activity_type_ids, fn activity_type_id ->
-      Map.get(registrations_by_id, activity_type_id, to_string(activity_type_id))
+      Map.get(activity_type_titles_by_id, activity_type_id, to_string(activity_type_id))
     end)
-  end
-
-  defp resource_label(resource_id, section_slug) do
-    case Resources.resource_summary(resource_id, section_slug, DeliveryResolver) do
-      %{title: title} when is_binary(title) -> title
-      _ -> nil
-    end
-  rescue
-    _ -> nil
   end
 
   defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -113,6 +113,13 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
     points_per_activity = points_per_activity(parsed_selection, selection)
     select_count = select_count(parsed_selection, selection)
 
+    criteria_presentation =
+      ActivityBankSelectionCriteria.presentation(
+        parsed_selection,
+        activity_type_titles_by_id,
+        criteria_resource_titles_by_id
+      )
+
     %{
       id: selection_id,
       title: "Activity Bank Selection",
@@ -124,12 +131,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       availableCount: available_count,
       originalAvailableCount: original_available_count,
       pointsPerActivity: points_per_activity,
-      criteria:
-        ActivityBankSelectionCriteria.rows(
-          parsed_selection,
-          activity_type_titles_by_id,
-          criteria_resource_titles_by_id
-        ),
+      criteria: criteria_presentation,
       manageQuestionsUrl:
         manage_questions_url(section.slug, page_revision.slug, selection_id, navigation_params),
       sampleActivity: sample_activity,

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -70,16 +70,16 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
     {previews, scripts}
   end
 
-  def build_preview(
-        section,
-        page_revision,
-        selection,
-        parsed_selection,
-        activity_type_by_id,
-        activity_type_titles_by_id,
-        criteria_resource_titles_by_id,
-        navigation_params
-      ) do
+  defp build_preview(
+         section,
+         page_revision,
+         selection,
+         parsed_selection,
+         activity_type_by_id,
+         activity_type_titles_by_id,
+         criteria_resource_titles_by_id,
+         navigation_params
+       ) do
     selection_id = selection["id"]
 
     selection_summary =
@@ -123,7 +123,6 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
     %{
       id: selection_id,
       title: "Activity Bank Selection",
-      activityTypeLabel: "Activity Bank",
       pageResourceId: page_revision.resource_id,
       pageRevisionSlug: page_revision.slug,
       sectionSlug: section.slug,

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -2,11 +2,10 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   @moduledoc false
 
   alias Oli.Activities.Realizer.Selection
-  alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Delivery.InstructorCustomizations
-  alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Rendering.Content.ActivityBankSelectionCriteria
   alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.Context
   alias Oli.Resources.PageContent
@@ -35,7 +34,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       Map.new(activity_types, fn activity_type -> {activity_type.id, activity_type.title} end)
 
     criteria_resource_titles_by_id =
-      criteria_resource_titles(section.slug, selection_data)
+      ActivityBankSelectionCriteria.resource_titles(section.slug, selection_data)
 
     previews =
       selection_data
@@ -126,7 +125,11 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       originalAvailableCount: original_available_count,
       pointsPerActivity: points_per_activity,
       criteria:
-        criteria(parsed_selection, activity_type_titles_by_id, criteria_resource_titles_by_id),
+        ActivityBankSelectionCriteria.rows(
+          parsed_selection,
+          activity_type_titles_by_id,
+          criteria_resource_titles_by_id
+        ),
       manageQuestionsUrl:
         manage_questions_url(section.slug, page_revision.slug, selection_id, navigation_params),
       sampleActivity: sample_activity,
@@ -265,7 +268,9 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
         []
 
       objective_ids ->
-        SectionResourceDepot.objectives(section_id, [{:resource_id, {:in, objective_ids}}])
+        Oli.Delivery.Sections.SectionResourceDepot.objectives(section_id, [
+          {:resource_id, {:in, objective_ids}}
+        ])
         |> Map.new(fn objective -> {objective.resource_id, objective.title} end)
         |> then(fn titles_by_id ->
           objective_ids
@@ -316,139 +321,6 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   defp actions(true), do: [%{kind: "remove", label: "Remove"}]
   defp actions(false), do: [%{kind: "restore", label: "Restore"}]
 
-  defp criteria(
-         %Selection{logic: %{conditions: nil}},
-         _activity_type_titles_by_id,
-         _titles_by_id
-       ),
-       do: []
-
-  defp criteria(
-         %Selection{logic: %{conditions: conditions}},
-         activity_type_titles_by_id,
-         criteria_resource_titles_by_id
-       ) do
-    conditions
-    |> collect_criteria(activity_type_titles_by_id, criteria_resource_titles_by_id)
-    |> Enum.reduce([], fn {label, values}, groups ->
-      merge_criteria_group(groups, label, values)
-    end)
-  end
-
-  defp criteria(_selection, _activity_type_titles_by_id, _criteria_resource_titles_by_id), do: []
-
-  defp collect_criteria(%Clause{children: children}, activity_type_titles_by_id, titles_by_id),
-    do: Enum.flat_map(children, &collect_criteria(&1, activity_type_titles_by_id, titles_by_id))
-
-  defp collect_criteria(
-         %Expression{fact: :tags, operator: operator, value: values},
-         _activity_type_titles_by_id,
-         titles_by_id
-       )
-       when is_list(values) do
-    [
-      {"#{criteria_exclusion_prefix(operator)}Tags",
-       labels_for_resource_ids(values, titles_by_id)}
-    ]
-  end
-
-  defp collect_criteria(
-         %Expression{fact: :objectives, operator: operator, value: values},
-         _activity_type_titles_by_id,
-         titles_by_id
-       )
-       when is_list(values) do
-    [
-      {"#{criteria_exclusion_prefix(operator)}Learning Objectives",
-       labels_for_resource_ids(values, titles_by_id)}
-    ]
-  end
-
-  defp collect_criteria(
-         %Expression{fact: :type, operator: operator, value: values},
-         activity_type_titles_by_id,
-         _titles_by_id
-       )
-       when is_list(values) do
-    [
-      {"#{criteria_exclusion_prefix(operator)}Activity Types",
-       labels_for_activity_type_ids(values, activity_type_titles_by_id)}
-    ]
-  end
-
-  defp collect_criteria(%Expression{} = expression, _activity_type_titles_by_id, _titles_by_id) do
-    [
-      {"#{criteria_exclusion_prefix(expression.operator)}Other",
-       [criterion_value(expression.value)]}
-    ]
-  end
-
-  defp collect_criteria(_condition, _activity_type_titles_by_id, _titles_by_id), do: []
-
-  defp criteria_resource_titles(_section_slug, []), do: %{}
-
-  defp criteria_resource_titles(section_slug, selection_data) do
-    resource_ids =
-      selection_data
-      |> Enum.flat_map(fn {_selection, parsed_selection} ->
-        criteria_resource_ids(parsed_selection)
-      end)
-      |> Enum.uniq()
-
-    if resource_ids == [] do
-      %{}
-    else
-      section_slug
-      |> DeliveryResolver.from_resource_id(resource_ids)
-      |> Enum.reject(&is_nil/1)
-      |> Map.new(fn revision -> {revision.resource_id, revision.title} end)
-    end
-  end
-
-  defp criteria_resource_ids(%Selection{logic: %{conditions: conditions}}),
-    do: collect_criteria_resource_ids(conditions)
-
-  defp criteria_resource_ids(_selection), do: []
-
-  defp collect_criteria_resource_ids(%Clause{children: children}),
-    do: Enum.flat_map(children, &collect_criteria_resource_ids/1)
-
-  defp collect_criteria_resource_ids(%Expression{fact: fact, value: values})
-       when fact in [:tags, :objectives] and is_list(values),
-       do: values
-
-  defp collect_criteria_resource_ids(_condition), do: []
-
-  defp merge_criteria_group(groups, label, values) do
-    case Enum.find_index(groups, &(&1.label == label)) do
-      nil ->
-        groups ++ [%{label: label, values: Enum.uniq(values)}]
-
-      index ->
-        List.update_at(groups, index, fn group ->
-          %{group | values: Enum.uniq(group.values ++ values)}
-        end)
-    end
-  end
-
-  defp criteria_exclusion_prefix(operator)
-       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
-       do: "Excluded "
-
-  defp criteria_exclusion_prefix(_operator), do: ""
-
-  defp labels_for_resource_ids(resource_ids, titles_by_id) do
-    Enum.map(resource_ids, fn resource_id ->
-      Map.get(titles_by_id, resource_id, to_string(resource_id))
-    end)
-  end
-
-  defp labels_for_activity_type_ids(activity_type_ids, activity_type_titles_by_id) do
-    Enum.map(activity_type_ids, fn activity_type_id ->
-      Map.get(activity_type_titles_by_id, activity_type_id, to_string(activity_type_id))
-    end)
-  end
-
   defp manage_questions_url(section_slug, revision_slug, selection_id, navigation_params) do
     request_path = lesson_request_path(section_slug, revision_slug, navigation_params)
 
@@ -474,7 +346,4 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       query -> "#{path}?#{query}"
     end
   end
-
-  defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)
-  defp criterion_value(value), do: to_string(value)
 end

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -943,7 +943,7 @@ defmodule Oli.Rendering.Content.Html do
   def selection(%Context{} = context, _, selection) do
     case context.mode do
       :instructor_preview ->
-        OliWeb.Delivery.Instructor.ActivityBankSelectionPreview.render(context, selection)
+        Oli.Rendering.Content.ActivityBankSelectionPreview.render(context, selection)
 
       _ ->
         Oli.Rendering.Content.Selection.render(context, selection, true)

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -941,7 +941,13 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def selection(%Context{} = context, _, selection) do
-    Oli.Rendering.Content.Selection.render(context, selection, true)
+    case context.mode do
+      :instructor_preview ->
+        OliWeb.Delivery.Instructor.ActivityBankSelectionPreview.render(context, selection)
+
+      _ ->
+        Oli.Rendering.Content.Selection.render(context, selection, true)
+    end
   end
 
   defp revision_slug_from_course_link(href) do

--- a/lib/oli/rendering/context.ex
+++ b/lib/oli/rendering/context.ex
@@ -6,6 +6,7 @@ defmodule Oli.Rendering.Context do
   defstruct enrollment: nil,
             user: nil,
             activity_map: %{},
+            instructor_preview_context: %{},
             render_opts: %{
               render_errors: true,
               render_point_markers: true
@@ -15,6 +16,7 @@ defmodule Oli.Rendering.Context do
             revision_slug: nil,
             activity_revision_id: nil,
             page_id: nil,
+            section_id: nil,
             section_slug: nil,
             project_slug: nil,
             activity_types_map: %{},

--- a/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
+++ b/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
   use OliWeb, :html
 
   attr :rows, :list, default: []
+  attr :helper_text, :string, default: nil
   attr :heading_id, :string, default: nil
   attr :heading_level, :integer, default: nil
   attr :heading_text, :string, default: "Selection criteria:"
@@ -27,6 +28,13 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
       >
         {@heading_text}
       </div>
+
+      <p
+        :if={@helper_text}
+        class="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low"
+      >
+        {@helper_text}
+      </p>
 
       <div :if={@rows != []} class="flex flex-col gap-2">
         <div :for={row <- @rows} class="flex flex-col gap-2">
@@ -52,6 +60,7 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
   def selection_criteria_html(rows, opts \\ []) do
     %{
       rows: rows,
+      helper_text: Keyword.get(opts, :helper_text),
       heading_id: Keyword.get(opts, :heading_id),
       heading_level: Keyword.get(opts, :heading_level, 4),
       heading_text: Keyword.get(opts, :heading_text, "Selection criteria:"),

--- a/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
+++ b/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
@@ -1,5 +1,10 @@
 defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
-  @moduledoc false
+  @moduledoc """
+  Shared criteria rendering for instructor-facing Activity Bank Selection surfaces.
+
+  This component is used both directly in LiveView and indirectly when preview pages serialize
+  the same criteria block to HTML for the React-based preview card.
+  """
 
   use OliWeb, :html
 
@@ -63,6 +68,12 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
     """
   end
 
+  @doc """
+  Renders the selection criteria block to an HTML string.
+
+  This is used by instructor preview pages that embed the criteria markup into a client-owned
+  preview payload while keeping the criteria presentation logic server-side.
+  """
   def selection_criteria_html(rows, opts \\ []) do
     %{
       rows: rows,

--- a/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
+++ b/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
@@ -11,8 +11,10 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
   attr :empty_text, :string, default: "No criteria configured."
 
   def selection_criteria(assigns) do
+    assigns = Map.put(assigns, :helper_parts, helper_text_parts(assigns.helper_text))
+
     ~H"""
-    <div class="flex flex-col gap-2" aria-labelledby={@heading_id}>
+    <div class="flex flex-col" aria-labelledby={@heading_id}>
       <div
         :if={@heading_id}
         id={@heading_id}
@@ -29,15 +31,19 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
         {@heading_text}
       </div>
 
-      <p
-        :if={@helper_text}
-        class="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low"
-      >
-        {@helper_text}
-      </p>
+      <div :if={@helper_parts} class="mb-4 mt-1.5 flex items-center gap-2 text-Text-text-low-alpha">
+        <OliWeb.Icons.filter class="h-4 w-4 shrink-0 stroke-current" />
+        <p class="m-0 font-open-sans text-[14px] font-normal leading-5">
+          {@helper_parts.prefix}
+          <strong class="font-semibold text-Text-text-low">
+            {@helper_parts.emphasis}
+          </strong>
+          {@helper_parts.suffix}
+        </p>
+      </div>
 
-      <div :if={@rows != []} class="flex flex-col gap-2">
-        <div :for={row <- @rows} class="flex flex-col gap-2">
+      <div :if={@rows != []} class="flex flex-col gap-4">
+        <div :for={row <- @rows} class="flex flex-col gap-[10px]">
           <div class="font-open-sans text-[14px] font-bold leading-4 text-Text-text-low-alpha">
             {row.label}:
           </div>
@@ -70,4 +76,14 @@ defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
     |> Phoenix.HTML.Safe.to_iodata()
     |> IO.iodata_to_binary()
   end
+
+  defp helper_text_parts("Activities must match all of the following.") do
+    %{prefix: "Activities must match ", emphasis: "all", suffix: " of the following."}
+  end
+
+  defp helper_text_parts("Activities may match any of the following.") do
+    %{prefix: "Activities may match ", emphasis: "any", suffix: " of the following."}
+  end
+
+  defp helper_text_parts(_helper_text), do: nil
 end

--- a/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
+++ b/lib/oli_web/components/delivery/activity_bank_selection_criteria.ex
@@ -1,0 +1,64 @@
+defmodule OliWeb.Components.Delivery.ActivityBankSelectionCriteria do
+  @moduledoc false
+
+  use OliWeb, :html
+
+  attr :rows, :list, default: []
+  attr :heading_id, :string, default: nil
+  attr :heading_level, :integer, default: nil
+  attr :heading_text, :string, default: "Selection criteria:"
+  attr :empty_text, :string, default: "No criteria configured."
+
+  def selection_criteria(assigns) do
+    ~H"""
+    <div class="flex flex-col gap-2" aria-labelledby={@heading_id}>
+      <div
+        :if={@heading_id}
+        id={@heading_id}
+        role="heading"
+        aria-level={@heading_level}
+        class="font-open-sans text-[14px] font-bold leading-4 text-Text-text-high"
+      >
+        {@heading_text}
+      </div>
+      <div
+        :if={!@heading_id}
+        class="font-open-sans text-[14px] font-bold leading-4 text-Text-text-high"
+      >
+        {@heading_text}
+      </div>
+
+      <div :if={@rows != []} class="flex flex-col gap-2">
+        <div :for={row <- @rows} class="flex flex-col gap-2">
+          <div class="font-open-sans text-[14px] font-bold leading-4 text-Text-text-low-alpha">
+            {row.label}:
+          </div>
+          <div class="min-h-[40px] w-full rounded-[6px] bg-Specially-Tokens-Fill-fill-input-focused px-[10px] py-2 font-open-sans text-[16px] font-semibold leading-6 text-Text-text-high">
+            {Enum.join(row.values, ", ")}
+          </div>
+        </div>
+      </div>
+
+      <p
+        :if={@rows == []}
+        class="m-0 font-open-sans text-[14px] font-normal leading-5 text-Text-text-low"
+      >
+        {@empty_text}
+      </p>
+    </div>
+    """
+  end
+
+  def selection_criteria_html(rows, opts \\ []) do
+    %{
+      rows: rows,
+      heading_id: Keyword.get(opts, :heading_id),
+      heading_level: Keyword.get(opts, :heading_level, 4),
+      heading_text: Keyword.get(opts, :heading_text, "Selection criteria:"),
+      empty_text: Keyword.get(opts, :empty_text, "No criteria configured.")
+    }
+    |> selection_criteria()
+    |> Phoenix.HTML.Safe.to_iodata()
+    |> IO.iodata_to_binary()
+  end
+end

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -8,6 +8,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.Context
   alias Oli.Resources
   alias Oli.Resources.PageContent
@@ -55,23 +56,22 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
     selection_id = selection["id"]
     parsed_selection = parse_selection(selection)
 
-    candidate_data =
-      InstructorCustomizations.list_bank_selection_candidates(
+    selection_summary =
+      InstructorCustomizations.get_bank_selection_summary(
         section,
         page_revision.resource_id,
-        selection_id,
-        limit: 1
+        selection_id
       )
 
     {selection_enabled?, available_count, original_available_count, sample_activity} =
-      case candidate_data do
-        {:ok, %{selection_enabled?: enabled?, active_count: active_count}} ->
+      case selection_summary do
+        {:ok,
+         %{selection_enabled?: enabled?, active_count: active_count, sample_candidate: candidate}} ->
           effective_available_count = if enabled?, do: active_count, else: 0
 
           sample_activity =
-            section
-            |> sample_candidate(page_revision.resource_id, selection_id)
-            |> build_sample_activity(
+            build_sample_activity(
+              candidate,
               section,
               page_revision,
               selection_id,
@@ -130,7 +130,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
           |> HtmlEntities.encode()
 
         [
-          ~s|<div class="instructor-preview-activity-bank-selection-wrapper mb-6 rounded-[12px] border border-Border-border-default bg-Surface-surface-primary overflow-hidden">|,
+          ~s|<div id="#{JumpNavigation.selection_target_id(selection_id)}" class="instructor-preview-activity-bank-selection-wrapper mb-6 rounded-[12px] border border-Border-border-default bg-Surface-surface-primary overflow-hidden #{JumpNavigation.target_classes()}">|,
           ~s|<#{@element} payload="#{encoded_payload}"></#{@element}>|,
           ~s|</div>|
         ]
@@ -195,17 +195,6 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
        do: {authoring_element, "authoring_fallback"}
 
   defp sample_render_target(_activity_type), do: {nil, nil}
-
-  defp sample_candidate(section, page_resource_id, selection_id) do
-    case InstructorCustomizations.sample_bank_selection_candidate(
-           section,
-           page_resource_id,
-           selection_id
-         ) do
-      {:ok, candidate} -> candidate
-      _ -> nil
-    end
-  end
 
   defp build_sample_preview_context(
          section,
@@ -346,7 +335,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
   defp collect_criteria(%Expression{} = expression, _section_slug) do
     [
-      {"#{criteria_exclusion_prefix(expression.operator)}#{criterion_fact(expression.fact)}",
+      {"#{criteria_exclusion_prefix(expression.operator)}Other",
        [criterion_value(expression.value)]}
     ]
   end
@@ -398,12 +387,6 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   rescue
     _ -> nil
   end
-
-  defp criterion_fact(:text), do: "Activity text"
-  defp criterion_fact(:type), do: "Activity Types"
-  defp criterion_fact(:objectives), do: "Learning Objectives"
-  defp criterion_fact(:tags), do: "Tags"
-  defp criterion_fact(fact), do: to_string(fact)
 
   defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)
   defp criterion_value(value), do: to_string(value)

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -63,12 +63,12 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
     {selection_enabled?, available_count, original_available_count, sample_activity} =
       case candidate_data do
-        {:ok, %{selection_enabled?: enabled?, active_count: active_count, candidates: candidates}} ->
+        {:ok, %{selection_enabled?: enabled?, active_count: active_count}} ->
           effective_available_count = if enabled?, do: active_count, else: 0
 
           sample_activity =
-            candidates
-            |> List.first()
+            section
+            |> sample_candidate(page_revision.resource_id, selection_id)
             |> build_sample_activity(
               section.slug,
               page_revision,
@@ -156,12 +156,15 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
     case revision do
       %{activity_type_id: activity_type_id} = revision ->
         case Map.get(activity_type_by_id, activity_type_id) do
-          %{preview_element: preview_element} = activity_type when is_binary(preview_element) ->
+          activity_type when is_map(activity_type) ->
+            {render_element, render_mode} = sample_render_target(activity_type)
+
             %{
               activityResourceId: revision.resource_id,
               title: revision.title,
               model: revision.content,
-              previewElement: preview_element,
+              previewElement: render_element,
+              renderMode: render_mode,
               script: preview_script_for(activity_type),
               previewContext:
                 build_sample_preview_context(
@@ -179,6 +182,26 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
       _ ->
         nil
+    end
+  end
+
+  defp sample_render_target(%{preview_element: preview_element}) when is_binary(preview_element),
+    do: {preview_element, "preview"}
+
+  defp sample_render_target(%{authoring_element: authoring_element})
+       when is_binary(authoring_element),
+       do: {authoring_element, "authoring_fallback"}
+
+  defp sample_render_target(_activity_type), do: {nil, nil}
+
+  defp sample_candidate(section, page_resource_id, selection_id) do
+    case InstructorCustomizations.sample_bank_selection_candidate(
+           section,
+           page_resource_id,
+           selection_id
+         ) do
+      {:ok, candidate} -> candidate
+      _ -> nil
     end
   end
 
@@ -219,7 +242,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
          preview_script: preview_script,
          authoring_script: authoring_script
        }) do
-    if preview_element, do: preview_script || authoring_script, else: nil
+    if preview_element, do: preview_script || authoring_script, else: authoring_script
   end
 
   defp parse_selection(selection) do

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -1,0 +1,271 @@
+defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
+  @moduledoc false
+
+  alias Oli.Activities.Realizer.Selection
+  alias Oli.Delivery.InstructorCustomizations
+  alias Oli.Grading
+  alias Oli.Publishing.DeliveryResolver
+  alias Oli.Rendering.Context
+  alias Oli.Resources.PageContent
+
+  @script "instructor_preview_components.js"
+  @element "oli-activity-bank-selection-preview"
+
+  def script, do: @script
+
+  def build_preview_map(section, page_revision, activity_types) do
+    selections =
+      PageContent.flat_filter(page_revision.content, fn
+        %{"type" => "selection", "id" => id} when is_binary(id) -> true
+        _ -> false
+      end)
+
+    activity_type_by_id =
+      Map.new(activity_types, fn activity_type -> {activity_type.id, activity_type} end)
+
+    previews =
+      selections
+      |> Enum.map(fn selection ->
+        {selection["id"], build_preview(section, page_revision, selection, activity_type_by_id)}
+      end)
+      |> Map.new()
+
+    scripts =
+      if map_size(previews) == 0 do
+        []
+      else
+        previews
+        |> Map.values()
+        |> Enum.flat_map(fn
+          %{sampleActivity: %{script: script}} when is_binary(script) -> [script]
+          _ -> []
+        end)
+        |> Enum.concat([@script])
+        |> Enum.uniq()
+      end
+
+    {previews, scripts}
+  end
+
+  def build_preview(section, page_revision, selection, activity_type_by_id) do
+    selection_id = selection["id"]
+    parsed_selection = parse_selection(selection)
+
+    candidate_data =
+      InstructorCustomizations.list_bank_selection_candidates(
+        section,
+        page_revision.resource_id,
+        selection_id,
+        limit: 1
+      )
+
+    {selection_enabled?, available_count, sample_activity} =
+      case candidate_data do
+        {:ok, %{selection_enabled?: enabled?, active_count: active_count, candidates: candidates}} ->
+          effective_available_count = if enabled?, do: active_count, else: 0
+
+          sample_activity =
+            candidates
+            |> List.first()
+            |> build_sample_activity(
+              section.slug,
+              page_revision,
+              selection_id,
+              activity_type_by_id
+            )
+
+          {enabled?, effective_available_count, sample_activity}
+
+        _ ->
+          {true, 0, nil}
+      end
+
+    points_per_activity = points_per_activity(parsed_selection, selection)
+    select_count = select_count(parsed_selection, selection)
+
+    %{
+      id: selection_id,
+      title: "Activity Bank Selection",
+      activityTypeLabel: "Activity Bank",
+      pageResourceId: page_revision.resource_id,
+      pageRevisionSlug: page_revision.slug,
+      sectionSlug: section.slug,
+      selectedCount: select_count,
+      availableCount: available_count,
+      pointsPerActivity: points_per_activity,
+      criteria: criteria(selection),
+      sampleActivity: sample_activity,
+      canCustomize: true,
+      actions: actions(selection_enabled?),
+      visualState: if(selection_enabled?, do: "default", else: "removed"),
+      statusPill: if(selection_enabled?, do: nil, else: %{kind: "removed", label: "Removed"}),
+      customizationTarget: %{
+        kind: "bank_selection",
+        pageResourceId: page_revision.resource_id,
+        selectionId: selection_id
+      }
+    }
+  end
+
+  def render(
+        %Context{instructor_preview_context: instructor_preview_context} = context,
+        %{"id" => selection_id} = selection
+      ) do
+    previews = Map.get(instructor_preview_context, :activity_bank_selections, %{})
+
+    case Map.get(previews, selection_id) do
+      nil ->
+        Oli.Rendering.Content.Selection.render(context, selection, true)
+
+      payload ->
+        encoded_payload =
+          payload
+          |> Jason.encode!()
+          |> HtmlEntities.encode()
+
+        [
+          ~s|<div class="instructor-preview-activity-bank-selection-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden">|,
+          ~s|<#{@element} payload="#{encoded_payload}"></#{@element}>|,
+          ~s|</div>|
+        ]
+    end
+  end
+
+  defp build_sample_activity(
+         nil,
+         _section_slug,
+         _page_revision,
+         _selection_id,
+         _activity_type_by_id
+       ),
+       do: nil
+
+  defp build_sample_activity(
+         candidate,
+         section_slug,
+         page_revision,
+         selection_id,
+         activity_type_by_id
+       ) do
+    revision = DeliveryResolver.from_resource_id(section_slug, candidate.activity_resource_id)
+
+    case revision do
+      %{activity_type_id: activity_type_id} = revision ->
+        case Map.get(activity_type_by_id, activity_type_id) do
+          %{preview_element: preview_element} = activity_type when is_binary(preview_element) ->
+            %{
+              activityResourceId: revision.resource_id,
+              title: revision.title,
+              model: revision.content,
+              previewElement: preview_element,
+              script: preview_script_for(activity_type),
+              previewContext:
+                build_sample_preview_context(
+                  section_slug,
+                  page_revision,
+                  selection_id,
+                  revision,
+                  activity_type
+                )
+            }
+
+          _ ->
+            nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp build_sample_preview_context(
+         section_slug,
+         page_revision,
+         selection_id,
+         activity_revision,
+         activity_type
+       ) do
+    %{
+      sectionSlug: section_slug,
+      pageResourceId: page_revision.resource_id,
+      pageRevisionSlug: page_revision.slug,
+      activityResourceId: activity_revision.resource_id,
+      activityHtmlId:
+        Map.get(activity_revision.content, "id", "activity_#{activity_revision.resource_id}"),
+      activityTypeSlug: activity_type.slug,
+      activityTypeLabel: activity_type.title,
+      title: activity_revision.title,
+      points: Grading.determine_activity_out_of(activity_revision),
+      learningObjectives: [],
+      canCustomize: false,
+      actions: [],
+      visualState: "default",
+      statusPill: nil,
+      customizationTarget: %{
+        kind: "bank_candidate",
+        pageResourceId: page_revision.resource_id,
+        selectionId: selection_id,
+        activityResourceId: activity_revision.resource_id
+      }
+    }
+  end
+
+  defp preview_script_for(%{
+         preview_element: preview_element,
+         preview_script: preview_script,
+         authoring_script: authoring_script
+       }) do
+    if preview_element, do: preview_script || authoring_script, else: nil
+  end
+
+  defp parse_selection(selection) do
+    case Selection.parse(selection) do
+      {:ok, parsed} -> parsed
+      _ -> nil
+    end
+  end
+
+  defp points_per_activity(%Selection{points_per_activity: points_per_activity}, _selection),
+    do: points_per_activity
+
+  defp points_per_activity(_parsed_selection, selection),
+    do: Map.get(selection, "pointsPerActivity", 1)
+
+  defp select_count(%Selection{count: count}, _selection), do: count
+  defp select_count(_parsed_selection, selection), do: Map.get(selection, "count", 0)
+
+  defp actions(true), do: [%{kind: "remove", label: "Remove"}]
+  defp actions(false), do: [%{kind: "restore", label: "Restore"}]
+
+  defp criteria(%{"logic" => %{"conditions" => nil}}), do: ["All activities"]
+  defp criteria(%{"logic" => %{"conditions" => conditions}}), do: render_criteria(conditions)
+  defp criteria(_selection), do: []
+
+  defp render_criteria(items) when is_list(items), do: Enum.flat_map(items, &render_criteria/1)
+
+  defp render_criteria(%{"children" => children, "operator" => operator}) do
+    child_criteria = render_criteria(children)
+    ["#{String.capitalize(to_string(operator))} of:" | child_criteria]
+  end
+
+  defp render_criteria(%{"fact" => fact, "operator" => operator, "value" => value}) do
+    ["#{criterion_fact(fact)} #{criterion_operator(operator)} #{criterion_value(value)}"]
+  end
+
+  defp render_criteria(_), do: []
+
+  defp criterion_fact("text"), do: "Activity text"
+  defp criterion_fact("type"), do: "Activity type"
+  defp criterion_fact("objectives"), do: "Learning objectives"
+  defp criterion_fact("tags"), do: "Tags"
+  defp criterion_fact(fact), do: to_string(fact)
+
+  defp criterion_operator("contains"), do: "contains"
+  defp criterion_operator("does_not_contain"), do: "does not contain"
+  defp criterion_operator("equals"), do: "equals"
+  defp criterion_operator("does_not_equal"), do: "does not equal"
+  defp criterion_operator(operator), do: to_string(operator)
+
+  defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)
+  defp criterion_value(value), do: to_string(value)
+end

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -2,10 +2,12 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   @moduledoc false
 
   alias Oli.Activities.Realizer.Selection
+  alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Rendering.Context
+  alias Oli.Resources
   alias Oli.Resources.PageContent
 
   @script "instructor_preview_components.js"
@@ -93,7 +95,8 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
       selectedCount: select_count,
       availableCount: available_count,
       pointsPerActivity: points_per_activity,
-      criteria: criteria(selection),
+      criteria: criteria(parsed_selection, section.slug),
+      manageQuestionsUrl: nil,
       sampleActivity: sample_activity,
       canCustomize: true,
       actions: actions(selection_enabled?),
@@ -124,7 +127,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
           |> HtmlEntities.encode()
 
         [
-          ~s|<div class="instructor-preview-activity-bank-selection-wrapper mb-6 rounded-lg border border-Border-border-default bg-Surface-surface-primary overflow-hidden">|,
+          ~s|<div class="instructor-preview-activity-bank-selection-wrapper mb-6 rounded-[12px] border border-Border-border-default bg-Surface-surface-primary overflow-hidden">|,
           ~s|<#{@element} payload="#{encoded_payload}"></#{@element}>|,
           ~s|</div>|
         ]
@@ -237,32 +240,82 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   defp actions(true), do: [%{kind: "remove", label: "Remove"}]
   defp actions(false), do: [%{kind: "restore", label: "Restore"}]
 
-  defp criteria(%{"logic" => %{"conditions" => nil}}), do: ["All activities"]
-  defp criteria(%{"logic" => %{"conditions" => conditions}}), do: render_criteria(conditions)
-  defp criteria(_selection), do: []
+  defp criteria(%Selection{logic: %{conditions: nil}}, _section_slug),
+    do: %{tags: [], learningObjectives: [], other: []}
 
-  defp render_criteria(items) when is_list(items), do: Enum.flat_map(items, &render_criteria/1)
+  defp criteria(%Selection{logic: %{conditions: conditions}}, section_slug) do
+    conditions
+    |> collect_criteria(section_slug)
+    |> Enum.reduce(%{tags: [], learningObjectives: [], other: []}, fn
+      {:tags, values}, acc ->
+        update_in(acc.tags, &Enum.uniq(&1 ++ values))
 
-  defp render_criteria(%{"children" => children, "operator" => operator}) do
-    child_criteria = render_criteria(children)
-    ["#{String.capitalize(to_string(operator))} of:" | child_criteria]
+      {:learning_objectives, values}, acc ->
+        update_in(acc.learningObjectives, &Enum.uniq(&1 ++ values))
+
+      {:other, value}, acc ->
+        update_in(acc.other, &Enum.uniq(&1 ++ [value]))
+    end)
   end
 
-  defp render_criteria(%{"fact" => fact, "operator" => operator, "value" => value}) do
-    ["#{criterion_fact(fact)} #{criterion_operator(operator)} #{criterion_value(value)}"]
+  defp criteria(_selection, _section_slug), do: %{tags: [], learningObjectives: [], other: []}
+
+  defp collect_criteria(%Clause{children: children}, section_slug),
+    do: Enum.flat_map(children, &collect_criteria(&1, section_slug))
+
+  defp collect_criteria(%Expression{fact: :tags, operator: operator, value: values}, section_slug)
+       when operator in [:contains, :equals] and is_list(values) do
+    [{:tags, labels_for_resource_ids(values, section_slug)}]
   end
 
-  defp render_criteria(_), do: []
+  defp collect_criteria(
+         %Expression{fact: :objectives, operator: operator, value: values},
+         section_slug
+       )
+       when operator in [:contains, :equals] and is_list(values) do
+    [{:learning_objectives, labels_for_resource_ids(values, section_slug)}]
+  end
 
-  defp criterion_fact("text"), do: "Activity text"
-  defp criterion_fact("type"), do: "Activity type"
-  defp criterion_fact("objectives"), do: "Learning objectives"
-  defp criterion_fact("tags"), do: "Tags"
+  defp collect_criteria(%Expression{} = expression, _section_slug),
+    do: [{:other, render_criteria(expression)}]
+
+  defp collect_criteria(_condition, _section_slug), do: []
+
+  defp labels_for_resource_ids(resource_ids, section_slug) do
+    Enum.map(resource_ids, fn resource_id ->
+      case resource_label(resource_id, section_slug) do
+        nil -> to_string(resource_id)
+        label -> label
+      end
+    end)
+  end
+
+  defp resource_label(resource_id, section_slug) do
+    case Resources.resource_summary(resource_id, section_slug, DeliveryResolver) do
+      %{title: title} when is_binary(title) -> title
+      _ -> nil
+    end
+  rescue
+    _ -> nil
+  end
+
+  defp render_criteria(%Expression{fact: fact, operator: operator, value: value}) do
+    "#{criterion_fact(fact)} #{criterion_operator(operator)} #{criterion_value(value)}"
+  end
+
+  defp criterion_fact(:text), do: "Activity text"
+  defp criterion_fact(:type), do: "Activity type"
+  defp criterion_fact(:objectives), do: "Learning objectives"
+  defp criterion_fact(:tags), do: "Tags"
   defp criterion_fact(fact), do: to_string(fact)
 
+  defp criterion_operator(:contains), do: "contains"
   defp criterion_operator("contains"), do: "contains"
+  defp criterion_operator(:does_not_contain), do: "does not contain"
   defp criterion_operator("does_not_contain"), do: "does not contain"
+  defp criterion_operator(:equals), do: "equals"
   defp criterion_operator("equals"), do: "equals"
+  defp criterion_operator(:does_not_equal), do: "does not equal"
   defp criterion_operator("does_not_equal"), do: "does not equal"
   defp criterion_operator(operator), do: to_string(operator)
 

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   @moduledoc false
 
+  alias Oli.Activities
   alias Oli.Activities.Realizer.Selection
   alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Delivery.InstructorCustomizations
@@ -265,45 +266,77 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   defp actions(false), do: [%{kind: "restore", label: "Restore"}]
 
   defp criteria(%Selection{logic: %{conditions: nil}}, _section_slug),
-    do: %{tags: [], learningObjectives: [], other: []}
+    do: []
 
   defp criteria(%Selection{logic: %{conditions: conditions}}, section_slug) do
     conditions
     |> collect_criteria(section_slug)
-    |> Enum.reduce(%{tags: [], learningObjectives: [], other: []}, fn
-      {:tags, values}, acc ->
-        update_in(acc.tags, &Enum.uniq(&1 ++ values))
-
-      {:learning_objectives, values}, acc ->
-        update_in(acc.learningObjectives, &Enum.uniq(&1 ++ values))
-
-      {:other, value}, acc ->
-        update_in(acc.other, &Enum.uniq(&1 ++ [value]))
+    |> Enum.reduce([], fn {label, values}, groups ->
+      merge_criteria_group(groups, label, values)
     end)
   end
 
-  defp criteria(_selection, _section_slug), do: %{tags: [], learningObjectives: [], other: []}
+  defp criteria(_selection, _section_slug), do: []
 
   defp collect_criteria(%Clause{children: children}, section_slug),
     do: Enum.flat_map(children, &collect_criteria(&1, section_slug))
 
   defp collect_criteria(%Expression{fact: :tags, operator: operator, value: values}, section_slug)
-       when operator in [:contains, :equals] and is_list(values) do
-    [{:tags, labels_for_resource_ids(values, section_slug)}]
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Tags",
+       labels_for_resource_ids(values, section_slug)}
+    ]
   end
 
   defp collect_criteria(
          %Expression{fact: :objectives, operator: operator, value: values},
          section_slug
        )
-       when operator in [:contains, :equals] and is_list(values) do
-    [{:learning_objectives, labels_for_resource_ids(values, section_slug)}]
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Learning Objectives",
+       labels_for_resource_ids(values, section_slug)}
+    ]
   end
 
-  defp collect_criteria(%Expression{} = expression, _section_slug),
-    do: [{:other, render_criteria(expression)}]
+  defp collect_criteria(
+         %Expression{fact: :type, operator: operator, value: values},
+         _section_slug
+       )
+       when is_list(values) do
+    [
+      {"#{criteria_exclusion_prefix(operator)}Activity Types",
+       labels_for_activity_type_ids(values)}
+    ]
+  end
+
+  defp collect_criteria(%Expression{} = expression, _section_slug) do
+    [
+      {"#{criteria_exclusion_prefix(expression.operator)}#{criterion_fact(expression.fact)}",
+       [criterion_value(expression.value)]}
+    ]
+  end
 
   defp collect_criteria(_condition, _section_slug), do: []
+
+  defp merge_criteria_group(groups, label, values) do
+    case Enum.find_index(groups, &(&1.label == label)) do
+      nil ->
+        groups ++ [%{label: label, values: Enum.uniq(values)}]
+
+      index ->
+        List.update_at(groups, index, fn group ->
+          %{group | values: Enum.uniq(group.values ++ values)}
+        end)
+    end
+  end
+
+  defp criteria_exclusion_prefix(operator)
+       when operator in [:does_not_contain, :does_not_equal, "does_not_contain", "does_not_equal"],
+       do: "Excluded "
+
+  defp criteria_exclusion_prefix(_operator), do: ""
 
   defp labels_for_resource_ids(resource_ids, section_slug) do
     Enum.map(resource_ids, fn resource_id ->
@@ -311,6 +344,16 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
         nil -> to_string(resource_id)
         label -> label
       end
+    end)
+  end
+
+  defp labels_for_activity_type_ids(activity_type_ids) do
+    registrations_by_id =
+      Activities.list_activity_registrations()
+      |> Map.new(fn registration -> {registration.id, registration.title} end)
+
+    Enum.map(activity_type_ids, fn activity_type_id ->
+      Map.get(registrations_by_id, activity_type_id, to_string(activity_type_id))
     end)
   end
 
@@ -323,25 +366,11 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
     _ -> nil
   end
 
-  defp render_criteria(%Expression{fact: fact, operator: operator, value: value}) do
-    "#{criterion_fact(fact)} #{criterion_operator(operator)} #{criterion_value(value)}"
-  end
-
   defp criterion_fact(:text), do: "Activity text"
-  defp criterion_fact(:type), do: "Activity type"
-  defp criterion_fact(:objectives), do: "Learning objectives"
+  defp criterion_fact(:type), do: "Activity Types"
+  defp criterion_fact(:objectives), do: "Learning Objectives"
   defp criterion_fact(:tags), do: "Tags"
   defp criterion_fact(fact), do: to_string(fact)
-
-  defp criterion_operator(:contains), do: "contains"
-  defp criterion_operator("contains"), do: "contains"
-  defp criterion_operator(:does_not_contain), do: "does not contain"
-  defp criterion_operator("does_not_contain"), do: "does not contain"
-  defp criterion_operator(:equals), do: "equals"
-  defp criterion_operator("equals"), do: "equals"
-  defp criterion_operator(:does_not_equal), do: "does not equal"
-  defp criterion_operator("does_not_equal"), do: "does not equal"
-  defp criterion_operator(operator), do: to_string(operator)
 
   defp criterion_value(value) when is_list(value), do: Enum.map_join(value, ", ", &to_string/1)
   defp criterion_value(value), do: to_string(value)

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -61,7 +61,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
         limit: 1
       )
 
-    {selection_enabled?, available_count, sample_activity} =
+    {selection_enabled?, available_count, original_available_count, sample_activity} =
       case candidate_data do
         {:ok, %{selection_enabled?: enabled?, active_count: active_count, candidates: candidates}} ->
           effective_available_count = if enabled?, do: active_count, else: 0
@@ -76,10 +76,10 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
               activity_type_by_id
             )
 
-          {enabled?, effective_available_count, sample_activity}
+          {enabled?, effective_available_count, active_count, sample_activity}
 
         _ ->
-          {true, 0, nil}
+          {true, 0, 0, nil}
       end
 
     points_per_activity = points_per_activity(parsed_selection, selection)
@@ -94,6 +94,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
       sectionSlug: section.slug,
       selectedCount: select_count,
       availableCount: available_count,
+      originalAvailableCount: original_available_count,
       pointsPerActivity: points_per_activity,
       criteria: criteria(parsed_selection, section.slug),
       manageQuestionsUrl: nil,

--- a/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
+++ b/lib/oli_web/delivery/instructor/activity_bank_selection_preview.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   alias Oli.Activities.Realizer.Selection
   alias Oli.Activities.Realizer.Logic.{Clause, Expression}
   alias Oli.Delivery.InstructorCustomizations
+  alias Oli.Delivery.Sections.SectionResourceDepot
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Rendering.Context
@@ -71,7 +72,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
             section
             |> sample_candidate(page_revision.resource_id, selection_id)
             |> build_sample_activity(
-              section.slug,
+              section,
               page_revision,
               selection_id,
               activity_type_by_id
@@ -138,7 +139,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
   defp build_sample_activity(
          nil,
-         _section_slug,
+         _section,
          _page_revision,
          _selection_id,
          _activity_type_by_id
@@ -147,12 +148,12 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
 
   defp build_sample_activity(
          candidate,
-         section_slug,
+         section,
          page_revision,
          selection_id,
          activity_type_by_id
        ) do
-    revision = DeliveryResolver.from_resource_id(section_slug, candidate.activity_resource_id)
+    revision = DeliveryResolver.from_resource_id(section.slug, candidate.activity_resource_id)
 
     case revision do
       %{activity_type_id: activity_type_id} = revision ->
@@ -169,7 +170,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
               script: preview_script_for(activity_type),
               previewContext:
                 build_sample_preview_context(
-                  section_slug,
+                  section,
                   page_revision,
                   selection_id,
                   revision,
@@ -207,14 +208,14 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
   end
 
   defp build_sample_preview_context(
-         section_slug,
+         section,
          page_revision,
          selection_id,
          activity_revision,
          activity_type
        ) do
     %{
-      sectionSlug: section_slug,
+      sectionSlug: section.slug,
       pageResourceId: page_revision.resource_id,
       pageRevisionSlug: page_revision.slug,
       activityResourceId: activity_revision.resource_id,
@@ -224,7 +225,7 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
       activityTypeLabel: activity_type.title,
       title: activity_revision.title,
       points: Grading.determine_activity_out_of(activity_revision),
-      learningObjectives: [],
+      learningObjectives: learning_objectives(section.id, activity_revision),
       canCustomize: false,
       actions: [],
       visualState: "default",
@@ -237,6 +238,38 @@ defmodule OliWeb.Delivery.Instructor.ActivityBankSelectionPreview do
       }
     }
   end
+
+  defp learning_objectives(section_id, activity_revision) do
+    objective_ids = activity_objective_ids(activity_revision)
+
+    case objective_ids do
+      [] ->
+        []
+
+      objective_ids ->
+        SectionResourceDepot.objectives(section_id, [{:resource_id, {:in, objective_ids}}])
+        |> Map.new(fn objective -> {objective.resource_id, objective.title} end)
+        |> then(fn titles_by_id ->
+          objective_ids
+          |> Enum.map(&Map.get(titles_by_id, &1))
+          |> Enum.reject(&is_nil/1)
+          |> Enum.uniq()
+          |> Enum.sort()
+        end)
+    end
+  end
+
+  defp activity_objective_ids(%{objectives: objectives}) when is_map(objectives) do
+    objectives
+    |> Map.values()
+    |> Enum.flat_map(fn
+      ids when is_list(ids) -> ids
+      _ -> []
+    end)
+    |> Enum.uniq()
+  end
+
+  defp activity_objective_ids(_activity_revision), do: []
 
   defp preview_script_for(%{
          preview_element: preview_element,

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -24,6 +24,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Utils.BibUtils
   alias OliWeb.ManualGrading.Rendering
   alias OliWeb.Delivery.Instructor.ActivityBankSelectionPreview
+  alias Oli.Rendering.Content.ActivityBankSelectionPreview
 
   def build(section, revision, user, navigation_params \\ %{}) do
     section_slug = section.slug

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -22,6 +22,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Resources
   alias Oli.Resources.PageContent
   alias Oli.Utils.BibUtils
+
+  alias OliWeb.Components.Delivery.ActivityBankSelectionCriteria,
+    as: ActivityBankSelectionCriteriaComponent
+
   alias OliWeb.ManualGrading.Rendering
   alias Oli.Rendering.Content.ActivityBankSelectionPreview
 
@@ -413,6 +417,16 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         all_activities,
         navigation_params
       )
+
+    activity_bank_selection_previews =
+      Map.new(activity_bank_selection_previews, fn {selection_id, preview} ->
+        selection_criteria_html =
+          ActivityBankSelectionCriteriaComponent.selection_criteria_html(preview.criteria,
+            heading_id: "#{selection_id}-criteria-heading"
+          )
+
+        {selection_id, Map.put(preview, :selectionCriteriaHtml, selection_criteria_html)}
+      end)
 
     render_context =
       build_render_context(

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -440,7 +440,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         bank_selection_ids: Map.keys(activity_bank_selection_previews),
         bank_selection_available_counts_by_id:
           Map.new(activity_bank_selection_previews, fn {selection_id, preview} ->
-            {selection_id, preview.availableCount}
+            {selection_id, Map.get(preview, :originalAvailableCount, preview.availableCount)}
           end)
       },
       page_summary:

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -23,6 +23,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Resources.PageContent
   alias Oli.Utils.BibUtils
   alias OliWeb.ManualGrading.Rendering
+  alias OliWeb.Delivery.Instructor.ActivityBankSelectionPreview
 
   def build(section, revision, user, navigation_params \\ %{}) do
     section_slug = section.slug
@@ -67,6 +68,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         summaries
         |> Enum.map(&preview_script_for_summary/1)
         |> Enum.reject(&is_nil/1)
+        |> Enum.concat(preview_data.activity_bank_selection_scripts)
         |> Enum.uniq(),
       preview_mode: true,
       previous_page: previous,
@@ -404,8 +406,19 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       |> Enum.with_index(1)
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
 
+    {activity_bank_selection_previews, activity_bank_selection_scripts} =
+      ActivityBankSelectionPreview.build_preview_map(section, revision, all_activities)
+
     render_context =
-      build_render_context(section, revision, user, activity_map, bib_entries, all_activities)
+      build_render_context(
+        section,
+        revision,
+        user,
+        activity_map,
+        bib_entries,
+        all_activities,
+        activity_bank_selection_previews
+      )
 
     html = Page.render(render_context, content, Page.Html)
 
@@ -414,6 +427,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       summaries: summaries,
       html: html,
       jump_targets: jump_targets(content),
+      activity_bank_selection_scripts: activity_bank_selection_scripts,
       # Metadata cached on the LiveView so remove/restore can recompute aggregate page data
       # without repeating DB lookups for page activities and their objective labels.
       preview_metadata: %{
@@ -422,7 +436,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
           Map.new(activity_revisions, fn activity_revision ->
             {activity_revision.resource_id, Grading.determine_activity_out_of(activity_revision)}
           end),
-        objective_titles_by_activity_id: objective_titles_by_activity_id
+        objective_titles_by_activity_id: objective_titles_by_activity_id,
+        bank_selection_ids: Map.keys(activity_bank_selection_previews),
+        bank_selection_available_counts_by_id:
+          Map.new(activity_bank_selection_previews, fn {selection_id, preview} ->
+            {selection_id, preview.availableCount}
+          end)
       },
       page_summary:
         build_page_summary(
@@ -436,16 +455,29 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     }
   end
 
-  defp build_render_context(section, revision, user, activity_map, bib_entries, all_activities) do
+  defp build_render_context(
+         section,
+         revision,
+         user,
+         activity_map,
+         bib_entries,
+         all_activities,
+         activity_bank_selection_previews
+       ) do
     section_slug = section.slug
     base_project_attributes = Sections.get_section_attributes(section)
 
     %Context{
       user: user,
+      section_id: section.id,
       section_slug: section_slug,
+      page_id: revision.resource_id,
       revision_slug: revision.slug,
       mode: :instructor_preview,
       activity_map: activity_map,
+      instructor_preview_context: %{
+        activity_bank_selections: activity_bank_selection_previews
+      },
       resource_summary_fn: &Resources.resource_summary(&1, section_slug, Resolver),
       alternatives_selector_fn: &Resources.Alternatives.select/2,
       extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -420,12 +420,21 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
     activity_bank_selection_previews =
       Map.new(activity_bank_selection_previews, fn {selection_id, preview} ->
+        criteria_presentation = Map.get(preview, :criteria, %{})
+
         selection_criteria_html =
-          ActivityBankSelectionCriteriaComponent.selection_criteria_html(preview.criteria,
-            heading_id: "#{selection_id}-criteria-heading"
+          ActivityBankSelectionCriteriaComponent.selection_criteria_html(
+            Map.get(criteria_presentation, :rows, []),
+            heading_id: "#{selection_id}-criteria-heading",
+            helper_text: Map.get(criteria_presentation, :helper_text)
           )
 
-        {selection_id, Map.put(preview, :selectionCriteriaHtml, selection_criteria_html)}
+        cleaned_preview =
+          preview
+          |> Map.delete(:criteria)
+          |> Map.put(:selectionCriteriaHtml, selection_criteria_html)
+
+        {selection_id, cleaned_preview}
       end)
 
     render_context =

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -23,7 +23,6 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Resources.PageContent
   alias Oli.Utils.BibUtils
   alias OliWeb.ManualGrading.Rendering
-  alias OliWeb.Delivery.Instructor.ActivityBankSelectionPreview
   alias Oli.Rendering.Content.ActivityBankSelectionPreview
 
   def build(section, revision, user, navigation_params \\ %{}) do
@@ -32,7 +31,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     {:ok, {previous, next, current}, _} =
       PreviousNextIndex.retrieve(section, revision.resource_id)
 
-    preview_data = build_preview_data(section, revision, user)
+    preview_data = build_preview_data(section, revision, user, navigation_params)
 
     activity_map = preview_data.activity_map
     summaries = preview_data.summaries
@@ -358,7 +357,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   defp preview_supported?(%{slug: slug}),
     do: Activities.preview_supported_activity_slug?(slug)
 
-  defp build_preview_data(section, revision, user) do
+  defp build_preview_data(section, revision, user, navigation_params) do
     section_slug = section.slug
     all_activities = Activities.list_activity_registrations()
     type_by_id = Map.new(all_activities, fn activity -> {activity.id, activity} end)
@@ -408,7 +407,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       |> Enum.map(fn {summary, ordinal} -> BibUtils.serialize_revision(summary, ordinal) end)
 
     {activity_bank_selection_previews, activity_bank_selection_scripts} =
-      ActivityBankSelectionPreview.build_preview_map(section, revision, all_activities)
+      ActivityBankSelectionPreview.build_preview_map(
+        section,
+        revision,
+        all_activities,
+        navigation_params
+      )
 
     render_context =
       build_render_context(

--- a/lib/oli_web/delivery/instructor/preview_return.ex
+++ b/lib/oli_web/delivery/instructor/preview_return.ex
@@ -55,7 +55,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewReturn do
 
   defp workspace_product_remix_path?(path, section_slug) do
     case URI.parse(path) do
-      %URI{path: parsed_path} when is_binary(parsed_path) ->
+      %URI{scheme: nil, host: nil, path: parsed_path} when is_binary(parsed_path) ->
         case String.split(parsed_path, "/", trim: true) do
           ["workspaces", "course_author", _project_slug, "products", ^section_slug, "remix"] ->
             true

--- a/lib/oli_web/delivery/instructor/preview_return.ex
+++ b/lib/oli_web/delivery/instructor/preview_return.ex
@@ -31,11 +31,13 @@ defmodule OliWeb.Delivery.Instructor.PreviewReturn do
 
   def sanitize_return_to("/" <> _ = path, section_slug) do
     prefix = "/sections/#{section_slug}"
+    product_remix_prefix = "/authoring/products/#{section_slug}/remix"
 
     cond do
       String.starts_with?(path, "//") -> fallback_path(section_slug)
-      path == prefix -> path
-      String.starts_with?(path, prefix <> "/") -> path
+      safe_path_prefix?(path, prefix) -> path
+      safe_path_prefix?(path, product_remix_prefix) -> path
+      workspace_product_remix_path?(path, section_slug) -> path
       true -> fallback_path(section_slug)
     end
   end
@@ -45,6 +47,30 @@ defmodule OliWeb.Delivery.Instructor.PreviewReturn do
   def fallback_context(section_slug), do: resolve(section_slug, fallback_path(section_slug))
 
   def fallback_path(section_slug), do: ~p"/sections/#{section_slug}/remix"
+
+  defp safe_path_prefix?(path, prefix) do
+    path == prefix or String.starts_with?(path, prefix <> "/") or
+      String.starts_with?(path, prefix <> "?")
+  end
+
+  defp workspace_product_remix_path?(path, section_slug) do
+    case URI.parse(path) do
+      %URI{path: parsed_path} when is_binary(parsed_path) ->
+        case String.split(parsed_path, "/", trim: true) do
+          ["workspaces", "course_author", _project_slug, "products", ^section_slug, "remix"] ->
+            true
+
+          ["workspaces", "course_author", _project_slug, "products", ^section_slug, "remix" | _] ->
+            true
+
+          _ ->
+            false
+        end
+
+      _ ->
+        false
+    end
+  end
 
   defp infer_origin(path, section_slug) do
     path = URI.parse(path).path || ""
@@ -66,8 +92,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewReturn do
 
   defp customize_content_return_path?(path, section_slug) do
     base_path = "/sections/#{section_slug}/remix"
+    product_base_path = "/authoring/products/#{section_slug}/remix"
 
-    path == base_path or String.starts_with?(path, base_path <> "/")
+    path == base_path or String.starts_with?(path, base_path <> "/") or
+      path == product_base_path or String.starts_with?(path, product_base_path <> "/") or
+      workspace_product_remix_path?(path, section_slug)
   end
 
   defp assessment_settings_return_path?(path, section_slug) do

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -24,6 +24,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     section = socket.assigns.section
     navigation_params = navigation_params(params, section.slug)
 
+    instructor_preview_return =
+      Map.get(socket.assigns, :instructor_preview_return) ||
+        PreviewReturn.fallback_context(section.slug)
+
     case InstructorCustomizations.resolve_bank_selection_preview_target(
            section,
            revision_slug,
@@ -84,6 +88,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
+               instructor_preview_return: instructor_preview_return,
                invalid_remove_warning: nil,
                selected_candidate_preview_html: nil,
                preview_script_sources: preview_script_sources

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -6,7 +6,12 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing.DeliveryResolver, as: Resolver
+  alias Oli.Rendering.Content.ActivityBankSelectionCriteria
   alias Oli.Resources.Revision
+
+  alias OliWeb.Components.Delivery.ActivityBankSelectionCriteria,
+    as: ActivityBankSelectionCriteriaComponent
+
   alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.PreviewPageContext
   alias OliWeb.Components.Delivery.Layouts
@@ -81,10 +86,11 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                selection: selection,
                selection_id: selection_id,
                selection_points_per_question: selection_points_per_question(selection),
-               selection_criteria_rows: selection_criteria_rows(section.slug, selection),
                instructor_preview_return:
                  socket.assigns[:instructor_preview_return] ||
                    PreviewReturn.fallback_context(section.slug),
+               selection_criteria_rows:
+                 ActivityBankSelectionCriteria.rows(selection, section.slug),
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
@@ -565,16 +571,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                   </div>
                 </div>
 
-                <div class="mt-5 space-y-2.5 text-sm leading-4 text-Text-text-low">
-                  <div class="font-bold text-Text-text-high">Selection criteria:</div>
-                  <div :for={row <- @selection_criteria_rows} class="space-y-2">
-                    <div class="text-Text-text-low-alpha text-sm font-bold leading-4">
-                      {row.label}
-                    </div>
-                    <div class="bg-Specially-Tokens-Fill-fill-input-focused rounded-md px-2.5 py-2 text-Text-text-high text-base font-semibold leading-6">
-                      {row.value}
-                    </div>
-                  </div>
+                <div class="mt-5">
+                  <ActivityBankSelectionCriteriaComponent.selection_criteria rows={
+                    @selection_criteria_rows
+                  } />
                 </div>
               </header>
 
@@ -1054,144 +1054,4 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
        do: points
 
   defp selection_points_per_question(_selection), do: 1
-
-  # Selection criteria can combine tags, learning objectives, activity type, and text expressions.
-  # We keep the summary local to this LiveView so the manager can show authored criteria without
-  # introducing a separate presentation layer just for this ticket.
-  defp selection_criteria_rows(_section_slug, %{"logic" => %{"conditions" => nil}}),
-    do: [%{label: "All questions", value: "No additional filters"}]
-
-  defp selection_criteria_rows(section_slug, %{"logic" => %{"conditions" => conditions}})
-       when is_map(conditions) do
-    title_map = selection_resource_titles(section_slug, conditions)
-    activity_type_titles = activity_type_titles()
-
-    selection_condition_rows(conditions, title_map, activity_type_titles)
-  end
-
-  defp selection_criteria_rows(_section_slug, _selection),
-    do: [%{label: "All questions", value: "No additional filters"}]
-
-  defp selection_condition_rows(
-         %{"children" => children, "operator" => operator},
-         title_map,
-         activity_type_titles
-       )
-       when is_list(children) do
-    child_rows =
-      Enum.flat_map(children, &selection_condition_rows(&1, title_map, activity_type_titles))
-
-    if child_rows == [] do
-      [%{label: "Selection logic", value: logical_operator_label(operator)}]
-    else
-      Enum.with_index(child_rows, 1)
-      |> Enum.map(fn {row, index} ->
-        %{label: "#{logical_operator_label(operator)} #{index}: #{row.label}", value: row.value}
-      end)
-    end
-  end
-
-  defp selection_condition_rows(
-         %{"fact" => fact, "operator" => operator, "value" => value},
-         title_map,
-         activity_type_titles
-       ) do
-    [
-      %{
-        label: criteria_label(fact),
-        value: criteria_value(fact, operator, value, title_map, activity_type_titles)
-      }
-    ]
-  end
-
-  defp selection_condition_rows(_conditions, _title_map, _activity_type_titles), do: []
-
-  defp selection_resource_titles(section_slug, conditions) do
-    resource_ids =
-      collect_selection_resource_ids(conditions)
-      |> Enum.uniq()
-
-    if resource_ids == [] do
-      %{}
-    else
-      # Criteria ids are authored into the published selection, so resolve them through the
-      # current section slug instead of the mutable authoring project boundary.
-      Resolver.from_resource_id(section_slug, resource_ids)
-      |> Enum.reject(&is_nil/1)
-      |> Map.new(fn revision -> {revision.resource_id, revision.title} end)
-    end
-  end
-
-  defp collect_selection_resource_ids(%{"children" => children}) when is_list(children) do
-    Enum.flat_map(children, &collect_selection_resource_ids/1)
-  end
-
-  defp collect_selection_resource_ids(%{"fact" => fact, "value" => value})
-       when fact in ["tags", "objectives"] and is_list(value),
-       do: value
-
-  defp collect_selection_resource_ids(%{"conditions" => conditions}) when is_map(conditions),
-    do: collect_selection_resource_ids(conditions)
-
-  defp collect_selection_resource_ids(_), do: []
-
-  defp activity_type_titles do
-    Activities.list_activity_registrations()
-    |> Map.new(fn registration -> {registration.id, registration.title} end)
-  end
-
-  defp criteria_label("tags"), do: "Tags:"
-  defp criteria_label("objectives"), do: "Learning objectives:"
-  defp criteria_label("type"), do: "Question type:"
-  defp criteria_label("text"), do: "Activity content:"
-  defp criteria_label(_fact), do: "Selection rule:"
-
-  defp criteria_value("tags", operator, value, title_map, _activity_type_titles),
-    do: prefixed_criteria_value(operator, map_titles(value, title_map))
-
-  defp criteria_value("objectives", operator, value, title_map, _activity_type_titles),
-    do: prefixed_criteria_value(operator, map_titles(value, title_map))
-
-  defp criteria_value("type", operator, value, _title_map, activity_type_titles),
-    do: prefixed_criteria_value(operator, map_type_titles(value, activity_type_titles))
-
-  defp criteria_value("text", operator, value, _title_map, _activity_type_titles)
-       when is_binary(value),
-       do: prefixed_criteria_value(operator, value)
-
-  defp criteria_value(_fact, operator, value, _title_map, _activity_type_titles),
-    do: prefixed_criteria_value(operator, inspect(value))
-
-  defp prefixed_criteria_value(operator, text) do
-    prefix =
-      case operator do
-        "contains" -> "Contains "
-        "does_not_contain" -> "Does not contain "
-        "equals" -> "Equals "
-        "does_not_equal" -> "Does not equal "
-        _ -> ""
-      end
-
-    prefix <> text
-  end
-
-  defp map_titles(values, title_map) when is_list(values) do
-    values
-    |> Enum.map(fn id -> Map.get(title_map, id, to_string(id)) end)
-    |> Enum.join(", ")
-  end
-
-  defp map_titles(value, _title_map), do: to_string(value)
-
-  defp map_type_titles(values, activity_type_titles) when is_list(values) do
-    values
-    |> Enum.map(fn id -> Map.get(activity_type_titles, id, to_string(id)) end)
-    |> Enum.join(", ")
-  end
-
-  defp map_type_titles(value, _activity_type_titles), do: to_string(value)
-
-  defp logical_operator_label("all"), do: "All of"
-  defp logical_operator_label("any"), do: "Any of"
-  defp logical_operator_label(_operator), do: "Selection logic"
 end

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -93,7 +93,6 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
-               instructor_preview_return: instructor_preview_return,
                invalid_remove_warning: nil,
                selected_candidate_preview_html: nil,
                preview_script_sources: preview_script_sources

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -29,10 +29,6 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     section = socket.assigns.section
     navigation_params = navigation_params(params, section.slug)
 
-    instructor_preview_return =
-      Map.get(socket.assigns, :instructor_preview_return) ||
-        PreviewReturn.fallback_context(section.slug)
-
     case InstructorCustomizations.resolve_bank_selection_preview_target(
            section,
            revision_slug,
@@ -64,6 +60,9 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       {:ok, revision, selection} ->
         sidebar_expanded = preview_sidebar_state(params)
 
+        criteria_presentation =
+          ActivityBankSelectionCriteria.presentation(selection, section.slug)
+
         candidate_surface_script_sources_by_activity_type_id =
           candidate_surface_script_sources_by_activity_type_id()
 
@@ -89,8 +88,8 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                instructor_preview_return:
                  socket.assigns[:instructor_preview_return] ||
                    PreviewReturn.fallback_context(section.slug),
-               selection_criteria_rows:
-                 ActivityBankSelectionCriteria.rows(selection, section.slug),
+               selection_criteria_rows: criteria_presentation.rows,
+               selection_criteria_helper_text: criteria_presentation.helper_text,
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
@@ -572,9 +571,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                 </div>
 
                 <div class="mt-5">
-                  <ActivityBankSelectionCriteriaComponent.selection_criteria rows={
-                    @selection_criteria_rows
-                  } />
+                  <ActivityBankSelectionCriteriaComponent.selection_criteria
+                    rows={@selection_criteria_rows}
+                    helper_text={@selection_criteria_helper_text}
+                  />
                 </div>
               </header>
 

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -3,6 +3,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
   import OliWeb.Delivery.Student.Utils, only: [scripts: 1, references: 1]
 
+  alias Phoenix.LiveView.JS
   alias Oli.Accounts
   alias Oli.Delivery.Attempts.Core, as: Attempts
   alias Oli.Delivery.InstructorCustomizations
@@ -10,6 +11,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.CollabSpaceConfig
   alias Oli.Resources.Revision
+  alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.PreviewReturn
   alias OliWeb.Delivery.Student.Utils
   alias OliWeb.Delivery.Instructor.{PreviewPageContext, PreviewRoutes}
@@ -352,67 +354,71 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       )
 
     ~H"""
-    <div
+    <Modal.modal
       :if={@pending && @body}
       id="preview-attempt-warning-modal"
-      class="fixed inset-0 z-[2000] flex items-center justify-center bg-black/20 px-4 py-8 backdrop-blur-sm"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="preview-attempt-warning-modal-title"
-      aria-describedby="preview-attempt-warning-modal-description"
+      show={true}
+      on_cancel={JS.push("cancel_preview_customization_warning")}
+      show_close={false}
+      wrapper_class="flex w-full items-center justify-center px-4 py-8"
+      container_class="max-w-[673px] rounded-2xl border border-Border-border-default bg-Surface-surface-background shadow-[0px_2px_10px_rgba(0,50,99,0.10)]"
+      header_class="items-start justify-between px-8 pb-0 pt-10 sm:px-16 sm:pt-16"
+      body_class="px-8 pb-0 pt-6 sm:px-16"
+      title_class="m-0 font-open-sans text-[18px] font-semibold leading-6 text-Text-text-high"
+      header_level={2}
     >
-      <.focus_wrap
-        id="preview-attempt-warning-modal-container"
-        phx-window-keydown="cancel_preview_customization_warning"
-        phx-key="escape"
-        phx-click-away="cancel_preview_customization_warning"
-        class="relative flex w-full max-w-[673px] flex-col gap-[10px] rounded-2xl border border-Border-border-default bg-Surface-surface-background px-8 py-10 shadow-[0px_2px_10px_rgba(0,50,99,0.10)] sm:px-16 sm:py-16"
-      >
+      <:title>
+        Change will affect future attempts
+      </:title>
+      <:header_actions>
         <button
           type="button"
-          phx-click="cancel_preview_customization_warning"
+          phx-click={
+            Modal.hide_modal(
+              JS.push("cancel_preview_customization_warning"),
+              "preview-attempt-warning-modal"
+            )
+          }
           class="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded text-Text-text-low hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
           aria-label="Close warning modal"
         >
           <span aria-hidden="true" class="text-[28px] font-light leading-5">&times;</span>
         </button>
-
-        <div class="flex w-full flex-col gap-6">
-          <h2
-            id="preview-attempt-warning-modal-title"
-            class="m-0 font-open-sans text-[18px] font-semibold leading-6 text-Text-text-high"
+      </:header_actions>
+      <div class="flex w-full flex-col gap-6">
+        <div class="flex flex-col items-end gap-6">
+          <p
+            id="preview-attempt-warning-modal-description"
+            class="m-0 w-full font-open-sans text-[16px] font-normal leading-6 text-Text-text-high"
           >
-            Change will affect future attempts
-          </h2>
-
-          <div class="flex flex-col items-end gap-6">
-            <p
-              id="preview-attempt-warning-modal-description"
-              class="m-0 w-full font-open-sans text-[16px] font-normal leading-6 text-Text-text-high"
-            >
-              {@body}
-            </p>
-
-            <div class="flex flex-wrap items-start justify-end gap-6">
-              <button
-                type="button"
-                phx-click="confirm_preview_customization_warning"
-                class="inline-flex items-center justify-center rounded-md border border-Border-border-bold bg-Surface-surface-background px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Specially-Tokens-Text-text-button-secondary shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Surface-surface-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
-              >
-                {@confirm_label}
-              </button>
-              <button
-                type="button"
-                phx-click="cancel_preview_customization_warning"
-                class="inline-flex items-center justify-center rounded-md bg-Fill-Buttons-fill-primary px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
-              >
-                {@cancel_label}
-              </button>
-            </div>
-          </div>
+            {@body}
+          </p>
         </div>
-      </.focus_wrap>
-    </div>
+      </div>
+      <:custom_footer>
+        <div class="flex flex-wrap items-start justify-end gap-6 px-8 pb-10 pt-6 sm:px-16 sm:pb-16">
+          <button
+            type="button"
+            phx-click="confirm_preview_customization_warning"
+            class="inline-flex items-center justify-center rounded-md border border-Border-border-bold bg-Surface-surface-background px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Specially-Tokens-Text-text-button-secondary shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Surface-surface-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          >
+            {@confirm_label}
+          </button>
+          <button
+            type="button"
+            phx-click={
+              Modal.hide_modal(
+                JS.push("cancel_preview_customization_warning"),
+                "preview-attempt-warning-modal"
+              )
+            }
+            class="inline-flex items-center justify-center rounded-md bg-Fill-Buttons-fill-primary px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+          >
+            {@cancel_label}
+          </button>
+        </div>
+      </:custom_footer>
+    </Modal.modal>
     """
   end
 

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -92,7 +92,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       <div
         :if={preview_flash_visible?(@flash)}
         id="flash_container"
-        class="container mx-auto sticky top-[8.5rem] z-[55] px-4"
+        class="container mx-auto sticky top-[8.5rem] z-[60] px-4"
       >
         <.preview_flash_group flash={@flash} />
       </div>
@@ -167,7 +167,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       <div
         :if={preview_flash_visible?(@flash)}
         id="flash_container"
-        class="container mx-auto sticky top-[8.5rem] z-[55] px-4"
+        class="container mx-auto sticky top-[8.5rem] z-[60] px-4"
       >
         <.preview_flash_group flash={@flash} />
       </div>
@@ -320,18 +320,18 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       role="alert"
       class="mx-auto mt-2 flex min-h-[52px] w-[90%] max-w-[1280px] items-center justify-center rounded-lg bg-Fill-fill-danger px-5 py-4 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-high"
     >
-      <div class="flex w-full items-start justify-between gap-4">
-        <div class="flex min-w-0 items-start gap-2">
-          <OliWeb.Icons.alert class="mt-0.5 h-4 w-4 shrink-0 fill-Icon-icon-danger text-Icon-icon-danger" />
+      <div class="flex w-full items-center justify-between gap-4">
+        <div class="flex min-w-0 items-center gap-2">
+          <OliWeb.Icons.alert class="h-4 w-4 shrink-0 fill-Icon-icon-danger text-Icon-icon-danger" />
           <p class="m-0 break-words">{@warning.message}</p>
         </div>
         <button
           type="button"
           phx-click="dismiss_preview_attempt_warning"
-          class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded text-Text-text-high hover:text-Text-text-low focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          class="group -m-1 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded p-1 text-Text-text-high/80 transition hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-focus"
           aria-label="Dismiss warning"
         >
-          <span aria-hidden="true" class="text-[18px] leading-none">&times;</span>
+          <OliWeb.Icons.close_sm class="h-4 w-4 stroke-current" />
         </button>
       </div>
     </div>

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -4,6 +4,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   import OliWeb.Delivery.Student.Utils, only: [scripts: 1, references: 1]
 
   alias Oli.Accounts
+  alias Oli.Delivery.Attempts.Core, as: Attempts
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Resources.Collaboration
@@ -84,6 +85,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         instructor_preview_return={@instructor_preview_return}
         include_logo
       />
+      <.preview_attempt_warning_banner
+        warning={@preview_attempt_warning}
+        dismissed?={@preview_attempt_warning_dismissed?}
+      />
       <div
         :if={preview_flash_visible?(@flash)}
         id="flash_container"
@@ -126,6 +131,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         </main>
       </.page_content_with_sidebar_layout>
 
+      <.preview_attempt_warning_modal
+        pending={@pending_preview_customization}
+        warning={@preview_attempt_warning}
+      />
       <.preview_footer license={assigns[:license]} />
       <Utils.proficiency_explanation_modal />
     </div>
@@ -150,6 +159,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         sidebar_expanded={@sidebar_expanded}
         instructor_preview_return={@instructor_preview_return}
         include_logo
+      />
+      <.preview_attempt_warning_banner
+        warning={@preview_attempt_warning}
+        dismissed?={@preview_attempt_warning_dismissed?}
       />
       <div
         :if={preview_flash_visible?(@flash)}
@@ -265,6 +278,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
           <% end %>
         </div>
       </div>
+      <.preview_attempt_warning_modal
+        pending={@pending_preview_customization}
+        warning={@preview_attempt_warning}
+      />
       <.preview_footer license={assigns[:license]} />
       <Utils.proficiency_explanation_modal />
     </div>
@@ -288,6 +305,113 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
           <OliWeb.Icons.back_arrow /><span>Back</span>
         </.link>
       </div>
+    </div>
+    """
+  end
+
+  attr :warning, :map, default: nil
+  attr :dismissed?, :boolean, default: false
+
+  defp preview_attempt_warning_banner(assigns) do
+    ~H"""
+    <div
+      :if={@warning && !@dismissed?}
+      id="preview-attempt-warning-banner"
+      role="alert"
+      class="mx-auto mt-2 flex min-h-[52px] w-[90%] max-w-[1280px] items-center justify-center rounded-lg bg-Fill-fill-danger px-5 py-4 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-high"
+    >
+      <div class="flex w-full items-start justify-between gap-4">
+        <div class="flex min-w-0 items-start gap-2">
+          <OliWeb.Icons.alert class="mt-0.5 h-4 w-4 shrink-0 fill-Icon-icon-danger text-Icon-icon-danger" />
+          <p class="m-0 break-words">{@warning.message}</p>
+        </div>
+        <button
+          type="button"
+          phx-click="dismiss_preview_attempt_warning"
+          class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-Text-text-high hover:text-Text-text-low focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          aria-label="Dismiss warning"
+        >
+          <span aria-hidden="true" class="text-[18px] leading-none">&times;</span>
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :pending, :map, default: nil
+  attr :warning, :map, default: nil
+
+  defp preview_attempt_warning_modal(assigns) do
+    modal_copy = preview_attempt_warning_modal_copy(assigns.warning, assigns.pending)
+
+    assigns =
+      assign(assigns,
+        body: modal_copy.body,
+        confirm_label: modal_copy.confirm_label,
+        cancel_label: modal_copy.cancel_label
+      )
+
+    ~H"""
+    <div
+      :if={@pending && @body}
+      id="preview-attempt-warning-modal"
+      class="fixed inset-0 z-[2000] flex items-center justify-center bg-[#D9FFF2]/80 px-4 py-8"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="preview-attempt-warning-modal-title"
+      aria-describedby="preview-attempt-warning-modal-description"
+    >
+      <.focus_wrap
+        id="preview-attempt-warning-modal-container"
+        phx-window-keydown="cancel_preview_customization_warning"
+        phx-key="escape"
+        phx-click-away="cancel_preview_customization_warning"
+        class="relative flex w-full max-w-[673px] flex-col gap-[10px] rounded-2xl border border-Border-border-default bg-Surface-surface-background px-8 py-10 shadow-[0px_2px_10px_rgba(0,50,99,0.10)] sm:px-16 sm:py-16"
+      >
+        <button
+          type="button"
+          phx-click="cancel_preview_customization_warning"
+          class="absolute right-[23px] top-[23px] inline-flex h-5 w-5 items-center justify-center rounded text-Text-text-low hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          aria-label="Close warning modal"
+        >
+          <span aria-hidden="true" class="text-[28px] font-light leading-5">&times;</span>
+        </button>
+
+        <div class="flex w-full flex-col gap-6">
+          <h2
+            id="preview-attempt-warning-modal-title"
+            class="m-0 font-open-sans text-[18px] font-semibold leading-6 text-Text-text-high"
+          >
+            Change will affect future attempts
+          </h2>
+
+          <div class="flex flex-col items-end gap-6">
+            <p
+              id="preview-attempt-warning-modal-description"
+              class="m-0 w-full font-open-sans text-[16px] font-normal leading-6 text-Text-text-high"
+            >
+              {@body}
+            </p>
+
+            <div class="flex flex-wrap items-start justify-end gap-6">
+              <button
+                type="button"
+                phx-click="confirm_preview_customization_warning"
+                class="inline-flex items-center justify-center rounded-md border border-Border-border-bold bg-Surface-surface-background px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Specially-Tokens-Text-text-button-secondary shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Surface-surface-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+              >
+                {@confirm_label}
+              </button>
+              <button
+                type="button"
+                phx-click="cancel_preview_customization_warning"
+                class="inline-flex items-center justify-center rounded-md bg-Fill-Buttons-fill-primary px-6 py-2 font-open-sans text-[14px] font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+              >
+                {@cancel_label}
+              </button>
+            </div>
+          </div>
+        </div>
+      </.focus_wrap>
     </div>
     """
   end
@@ -498,6 +622,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         not MapSet.member?(valid_activity_ids, activity_resource_id) ->
           {:error, :invalid_activity_target}
 
+        preview_confirmation_required?(socket) ->
+          {:confirmation_required,
+           %{
+             action: action,
+             target: %{
+               kind: "embedded_activity",
+               pageResourceId: page_resource_id,
+               activityResourceId: activity_resource_id
+             }
+           }}
+
         true ->
           case action do
             "remove" ->
@@ -522,6 +657,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       end
 
     case result do
+      {:confirmation_required, pending} ->
+        {:reply, confirmation_required_reply(pending),
+         assign(socket, :pending_preview_customization, pending)}
+
       {:ok, exclusion_view} ->
         page_summary =
           PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
@@ -599,6 +738,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         not MapSet.member?(valid_selection_ids, selection_id) ->
           {:error, :invalid_selection_target}
 
+        preview_confirmation_required?(socket) ->
+          {:confirmation_required,
+           %{
+             action: action,
+             target: %{
+               kind: "bank_selection",
+               pageResourceId: page_resource_id,
+               selectionId: selection_id
+             }
+           }}
+
         true ->
           case action do
             "remove" ->
@@ -623,6 +773,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       end
 
     case result do
+      {:confirmation_required, pending} ->
+        {:reply, confirmation_required_reply(pending),
+         assign(socket, :pending_preview_customization, pending)}
+
       {:ok, exclusion_view} ->
         page_summary =
           PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
@@ -724,6 +878,29 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
      )}
   end
 
+  def handle_event("dismiss_preview_attempt_warning", _params, socket) do
+    {:noreply, assign(socket, :preview_attempt_warning_dismissed?, true)}
+  end
+
+  def handle_event("cancel_preview_customization_warning", _params, socket) do
+    {:noreply, assign(socket, :pending_preview_customization, nil)}
+  end
+
+  def handle_event("confirm_preview_customization_warning", _params, socket) do
+    case socket.assigns.pending_preview_customization do
+      nil ->
+        {:noreply, socket}
+
+      pending ->
+        {reply, socket} =
+          socket
+          |> assign(:pending_preview_customization, nil)
+          |> apply_pending_preview_customization(pending)
+
+        {:noreply, push_event(socket, "preview_customization_reply", reply)}
+    end
+  end
+
   def handle_event("toggle_notes_sidebar", _params, socket) do
     active_sidebar_panel = if socket.assigns.active_sidebar_panel != :notes, do: :notes, else: nil
 
@@ -811,6 +988,283 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
        search_term: ""
      )}
   end
+
+  defp apply_pending_preview_customization(
+         socket,
+         %{
+           action: action,
+           target: %{
+             kind: "embedded_activity",
+             pageResourceId: page_resource_id,
+             activityResourceId: activity_resource_id
+           }
+         }
+       ) do
+    section = socket.assigns.section
+    actor = socket.assigns.current_user
+    current_page_resource_id = socket.assigns.current_page_resource_id
+    valid_activity_ids = MapSet.new(socket.assigns.preview_metadata.activity_ids)
+
+    result =
+      cond do
+        page_resource_id != current_page_resource_id ->
+          {:error, :invalid_page_target}
+
+        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
+          {:error, :invalid_activity_target}
+
+        true ->
+          case action do
+            "remove" ->
+              InstructorCustomizations.exclude_activity(
+                section,
+                page_resource_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            "restore" ->
+              InstructorCustomizations.restore_activity(
+                section,
+                page_resource_id,
+                activity_resource_id,
+                actor: actor
+              )
+
+            _ ->
+              {:error, {:invalid_action, action}}
+          end
+      end
+
+    case result do
+      {:ok, exclusion_view} ->
+        page_summary =
+          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
+
+        reply = %{
+          ok: true,
+          target: %{
+            kind: "embedded_activity",
+            pageResourceId: page_resource_id,
+            activityResourceId: activity_resource_id
+          },
+          activityResourceId: activity_resource_id,
+          visualState: if(action == "remove", do: "removed", else: "default"),
+          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
+          actions:
+            if(action == "remove",
+              do: [%{kind: "restore", label: "Restore"}],
+              else: [%{kind: "remove", label: "Remove"}]
+            )
+        }
+
+        {reply,
+         socket
+         |> assign(:page_summary, page_summary)
+         |> put_flash(
+           :info,
+           if(action == "remove",
+             do: "Question removed from this page.",
+             else: "Question restored to this page."
+           )
+         )}
+
+      {:error, {:unauthorized, :customize_section}} ->
+        {%{ok: false}, put_flash(socket, :error, "You are not allowed to customize this page.")}
+
+      {:error, :invalid_page_target} ->
+        {%{ok: false},
+         put_flash(socket, :error, "Unable to update a question outside this page preview.")}
+
+      {:error, :invalid_activity_target} ->
+        {%{ok: false},
+         put_flash(socket, :error, "Unable to update a question that is not part of this page.")}
+
+      {:error, _reason} ->
+        {%{ok: false}, put_flash(socket, :error, "Unable to update this question.")}
+    end
+  end
+
+  defp apply_pending_preview_customization(
+         socket,
+         %{
+           action: action,
+           target: %{
+             kind: "bank_selection",
+             pageResourceId: page_resource_id,
+             selectionId: selection_id
+           }
+         }
+       ) do
+    section = socket.assigns.section
+    actor = socket.assigns.current_user
+    current_page_resource_id = socket.assigns.current_page_resource_id
+    valid_selection_ids = MapSet.new(socket.assigns.preview_metadata.bank_selection_ids)
+
+    result =
+      cond do
+        page_resource_id != current_page_resource_id ->
+          {:error, :invalid_page_target}
+
+        not MapSet.member?(valid_selection_ids, selection_id) ->
+          {:error, :invalid_selection_target}
+
+        true ->
+          case action do
+            "remove" ->
+              InstructorCustomizations.exclude_bank_selection(
+                section,
+                page_resource_id,
+                selection_id,
+                actor: actor
+              )
+
+            "restore" ->
+              InstructorCustomizations.restore_bank_selection(
+                section,
+                page_resource_id,
+                selection_id,
+                actor: actor
+              )
+
+            _ ->
+              {:error, {:invalid_action, action}}
+          end
+      end
+
+    case result do
+      {:ok, exclusion_view} ->
+        page_summary =
+          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
+
+        available_count =
+          if action == "remove" do
+            0
+          else
+            Map.get(
+              socket.assigns.preview_metadata.bank_selection_available_counts_by_id,
+              selection_id,
+              0
+            )
+          end
+
+        reply = %{
+          ok: true,
+          target: %{
+            kind: "bank_selection",
+            pageResourceId: page_resource_id,
+            selectionId: selection_id
+          },
+          selectionId: selection_id,
+          availableCount: available_count,
+          visualState: if(action == "remove", do: "removed", else: "default"),
+          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
+          actions:
+            if(action == "remove",
+              do: [%{kind: "restore", label: "Restore"}],
+              else: [%{kind: "remove", label: "Remove"}]
+            )
+        }
+
+        {reply,
+         socket
+         |> assign(:page_summary, page_summary)
+         |> put_flash(
+           :info,
+           if(action == "remove",
+             do: "Activity bank selection removed",
+             else: "Activity bank selection restored"
+           )
+         )}
+
+      {:error, {:unauthorized, :customize_section}} ->
+        {bank_selection_error_reply(page_resource_id, selection_id, :unauthorized),
+         put_flash(socket, :error, "You are not allowed to customize this page.")}
+
+      {:error, :invalid_page_target} ->
+        {bank_selection_error_reply(page_resource_id, selection_id, :invalid_page_target),
+         put_flash(
+           socket,
+           :error,
+           "Unable to update an activity bank selection outside this page preview."
+         )}
+
+      {:error, :invalid_selection_target} ->
+        {bank_selection_error_reply(page_resource_id, selection_id, :invalid_selection_target),
+         put_flash(
+           socket,
+           :error,
+           "Unable to update an activity bank selection that is not part of this page."
+         )}
+
+      {:error, {:invalid_action, _action}} ->
+        {bank_selection_error_reply(page_resource_id, selection_id, :invalid_action),
+         put_flash(socket, :error, "Unable to update this activity bank selection.")}
+
+      {:error, _reason} ->
+        {bank_selection_error_reply(page_resource_id, selection_id, :domain_error),
+         put_flash(socket, :error, "Unable to update this activity bank selection.")}
+    end
+  end
+
+  defp confirmation_required_reply(%{target: target}) do
+    %{
+      ok: false,
+      reason: :confirmation_required,
+      target: target
+    }
+  end
+
+  defp preview_confirmation_required?(socket),
+    do: not is_nil(socket.assigns.preview_attempt_warning)
+
+  defp preview_attempt_warning_modal_copy(nil, _pending),
+    do: %{body: nil, confirm_label: "Remove question", cancel_label: "Keep question"}
+
+  defp preview_attempt_warning_modal_copy(_warning, nil),
+    do: %{body: nil, confirm_label: "Remove question", cancel_label: "Keep question"}
+
+  defp preview_attempt_warning_modal_copy(%{kind: warning_kind}, %{action: action, target: target}) do
+    action_gerund =
+      case action do
+        "restore" -> "Restoring"
+        _ -> "Removing"
+      end
+
+    target_label =
+      case target do
+        %{kind: "bank_selection"} -> "activity bank selection"
+        _ -> "question"
+      end
+
+    intro =
+      case warning_kind do
+        :practice -> "Students have already visited this page."
+        _ -> "Students have already started this assessment."
+      end
+
+    confirm_action =
+      case action do
+        "restore" -> "Restore"
+        _ -> "Remove"
+      end
+
+    confirm_target =
+      case target do
+        %{kind: "bank_selection"} -> "selection"
+        _ -> "question"
+      end
+
+    %{
+      body: "#{intro} #{action_gerund} this #{target_label} will only impact future attempts.",
+      confirm_label: "#{confirm_action} #{confirm_target}",
+      cancel_label: secondary_warning_action_label(action, confirm_target)
+    }
+  end
+
+  defp secondary_warning_action_label("remove", "selection"), do: "Keep selection"
+  defp secondary_warning_action_label("remove", _confirm_target), do: "Keep question"
+  defp secondary_warning_action_label(_action, _confirm_target), do: "Cancel"
 
   defp bank_selection_error_reply(page_resource_id, selection_id, reason) do
     %{
@@ -973,6 +1427,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       selected_view: selected_view,
       request_path: preview_request_path(socket, selected_view)
     )
+    |> assign_preview_attempt_warning_state()
     |> then(fn socket ->
       if connected?(socket) && socket.assigns.notes_enabled? do
         assign_annotations(
@@ -990,6 +1445,46 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         socket
       end
     end)
+  end
+
+  defp assign_preview_attempt_warning_state(socket) do
+    warning =
+      case preview_attempt_warning_kind(
+             socket.assigns.section,
+             socket.assigns.current_page_resource_id,
+             socket.assigns.graded
+           ) do
+        :scored ->
+          %{
+            kind: :scored,
+            message:
+              "Students have already started this assessment. Removing or restoring questions and activity bank selections will only impact future attempts."
+          }
+
+        :practice ->
+          %{
+            kind: :practice,
+            message:
+              "Students have already visited this page. Removing or restoring questions and activity bank selections will only impact future attempts."
+          }
+
+        nil ->
+          nil
+      end
+
+    assign(socket,
+      preview_attempt_warning: warning,
+      preview_attempt_warning_dismissed?: false,
+      pending_preview_customization: nil
+    )
+  end
+
+  defp preview_attempt_warning_kind(section, page_resource_id, true) do
+    if Attempts.has_any_resource_attempts?(section, page_resource_id), do: :scored
+  end
+
+  defp preview_attempt_warning_kind(section, page_resource_id, false) do
+    if Attempts.has_any_resource_accesses?(section, page_resource_id), do: :practice
   end
 
   defp default_annotations do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -575,6 +575,126 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
   def handle_event(
         "toggle_preview_activity_customization",
+        %{
+          "action" => action,
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => selection_id
+          }
+        },
+        socket
+      ) do
+    section = socket.assigns.section
+    actor = socket.assigns.current_user
+
+    current_page_resource_id = socket.assigns.current_page_resource_id
+    valid_selection_ids = MapSet.new(socket.assigns.preview_metadata.bank_selection_ids)
+
+    result =
+      cond do
+        page_resource_id != current_page_resource_id ->
+          {:error, :invalid_page_target}
+
+        not MapSet.member?(valid_selection_ids, selection_id) ->
+          {:error, :invalid_selection_target}
+
+        true ->
+          case action do
+            "remove" ->
+              InstructorCustomizations.exclude_bank_selection(
+                section,
+                page_resource_id,
+                selection_id,
+                actor: actor
+              )
+
+            "restore" ->
+              InstructorCustomizations.restore_bank_selection(
+                section,
+                page_resource_id,
+                selection_id,
+                actor: actor
+              )
+
+            _ ->
+              {:error, {:invalid_action, action}}
+          end
+      end
+
+    case result do
+      {:ok, exclusion_view} ->
+        page_summary =
+          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
+
+        available_count =
+          if action == "remove" do
+            0
+          else
+            Map.get(
+              socket.assigns.preview_metadata.bank_selection_available_counts_by_id,
+              selection_id,
+              0
+            )
+          end
+
+        reply = %{
+          ok: true,
+          target: %{
+            kind: "bank_selection",
+            pageResourceId: page_resource_id,
+            selectionId: selection_id
+          },
+          selectionId: selection_id,
+          availableCount: available_count,
+          visualState: if(action == "remove", do: "removed", else: "default"),
+          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
+          actions:
+            if(action == "remove",
+              do: [%{kind: "restore", label: "Restore"}],
+              else: [%{kind: "remove", label: "Remove"}]
+            )
+        }
+
+        {:reply, reply,
+         socket
+         |> assign(:page_summary, page_summary)
+         |> put_flash(
+           :info,
+           if(action == "remove",
+             do: "Activity bank selection removed from this page.",
+             else: "Activity bank selection restored to this page."
+           )
+         )}
+
+      {:error, {:unauthorized, :customize_section}} ->
+        {:reply, %{ok: false},
+         put_flash(socket, :error, "You are not allowed to customize this page.")}
+
+      {:error, :invalid_page_target} ->
+        {:reply, %{ok: false},
+         put_flash(
+           socket,
+           :error,
+           "Unable to update an activity bank selection outside this page preview."
+         )}
+
+      {:error, :invalid_selection_target} ->
+        {:reply, %{ok: false},
+         put_flash(
+           socket,
+           :error,
+           "Unable to update an activity bank selection that is not part of this page."
+         )}
+
+      {:error, _reason} ->
+        {:reply, %{ok: false},
+         put_flash(socket, :error, "Unable to update this activity bank selection.")}
+    end
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
         %{"action" => _action, "target" => %{"kind" => unsupported_kind}},
         socket
       ) do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -662,17 +662,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
          |> put_flash(
            :info,
            if(action == "remove",
-             do: "Activity bank selection removed from this page.",
-             else: "Activity bank selection restored to this page."
+             do: "Activity bank selection removed",
+             else: "Activity bank selection restored"
            )
          )}
 
       {:error, {:unauthorized, :customize_section}} ->
-        {:reply, %{ok: false},
+        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :unauthorized),
          put_flash(socket, :error, "You are not allowed to customize this page.")}
 
       {:error, :invalid_page_target} ->
-        {:reply, %{ok: false},
+        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :invalid_page_target),
          put_flash(
            socket,
            :error,
@@ -680,17 +680,35 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
          )}
 
       {:error, :invalid_selection_target} ->
-        {:reply, %{ok: false},
+        {:reply,
+         bank_selection_error_reply(page_resource_id, selection_id, :invalid_selection_target),
          put_flash(
            socket,
            :error,
            "Unable to update an activity bank selection that is not part of this page."
          )}
 
+      {:error, {:invalid_action, _action}} ->
+        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :invalid_action),
+         put_flash(socket, :error, "Unable to update this activity bank selection.")}
+
       {:error, _reason} ->
-        {:reply, %{ok: false},
+        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :domain_error),
          put_flash(socket, :error, "Unable to update this activity bank selection.")}
     end
+  end
+
+  def handle_event(
+        "toggle_preview_activity_customization",
+        %{"target" => %{"kind" => "bank_selection"}},
+        socket
+      ) do
+    {:reply, %{ok: false, reason: :malformed_target},
+     put_flash(
+       socket,
+       :error,
+       "Unable to update an activity bank selection because the request was incomplete."
+     )}
   end
 
   def handle_event(
@@ -792,6 +810,18 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
        search_results: nil,
        search_term: ""
      )}
+  end
+
+  defp bank_selection_error_reply(page_resource_id, selection_id, reason) do
+    %{
+      ok: false,
+      reason: reason,
+      target: %{
+        kind: "bank_selection",
+        pageResourceId: page_resource_id,
+        selectionId: selection_id
+      }
+    }
   end
 
   defp preview_flash_visible?(flash) do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -328,7 +328,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         <button
           type="button"
           phx-click="dismiss_preview_attempt_warning"
-          class="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded text-Text-text-high hover:text-Text-text-low focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          class="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded text-Text-text-high hover:text-Text-text-low focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
           aria-label="Dismiss warning"
         >
           <span aria-hidden="true" class="text-[18px] leading-none">&times;</span>
@@ -371,7 +371,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         <button
           type="button"
           phx-click="cancel_preview_customization_warning"
-          class="absolute right-[23px] top-[23px] inline-flex h-5 w-5 items-center justify-center rounded text-Text-text-low hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
+          class="absolute right-4 top-4 inline-flex h-10 w-10 items-center justify-center rounded text-Text-text-low hover:text-Text-text-high focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Border-border-bold"
           aria-label="Close warning modal"
         >
           <span aria-hidden="true" class="text-[28px] font-light leading-5">&times;</span>

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -355,7 +355,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     <div
       :if={@pending && @body}
       id="preview-attempt-warning-modal"
-      class="fixed inset-0 z-[2000] flex items-center justify-center bg-[#D9FFF2]/80 px-4 py-8"
+      class="fixed inset-0 z-[2000] flex items-center justify-center bg-black/20 px-4 py-8 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-labelledby="preview-attempt-warning-modal-title"

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -606,110 +606,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         },
         socket
       ) do
-    # Pattern match on target kind so other preview surfaces can reuse the same browser contract
-    # while dispatching to different customization writes for selections or bank candidates.
-    section = socket.assigns.section
-    actor = socket.assigns.current_user
-
-    current_page_resource_id = socket.assigns.current_page_resource_id
-    valid_activity_ids = MapSet.new(socket.assigns.preview_metadata.activity_ids)
-
-    result =
-      cond do
-        page_resource_id != current_page_resource_id ->
-          {:error, :invalid_page_target}
-
-        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
-          {:error, :invalid_activity_target}
-
-        preview_confirmation_required?(socket) ->
-          {:confirmation_required,
-           %{
-             action: action,
-             target: %{
-               kind: "embedded_activity",
-               pageResourceId: page_resource_id,
-               activityResourceId: activity_resource_id
-             }
-           }}
-
-        true ->
-          case action do
-            "remove" ->
-              InstructorCustomizations.exclude_activity(
-                section,
-                page_resource_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            "restore" ->
-              InstructorCustomizations.restore_activity(
-                section,
-                page_resource_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            _ ->
-              {:error, {:invalid_action, action}}
-          end
-      end
-
-    case result do
-      {:confirmation_required, pending} ->
-        {:reply, confirmation_required_reply(pending),
-         assign(socket, :pending_preview_customization, pending)}
-
-      {:ok, exclusion_view} ->
-        page_summary =
-          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
-
-        # Reply directly to the preview component so it can update local button state without a
-        # remount, while the socket diff updates any LiveView-owned aggregates on the page shell.
-        reply = %{
-          ok: true,
-          target: %{
-            kind: "embedded_activity",
-            pageResourceId: page_resource_id,
-            activityResourceId: activity_resource_id
-          },
-          activityResourceId: activity_resource_id,
-          visualState: if(action == "remove", do: "removed", else: "default"),
-          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
-          actions:
-            if(action == "remove",
-              do: [%{kind: "restore", label: "Restore"}],
-              else: [%{kind: "remove", label: "Remove"}]
-            )
-        }
-
-        {:reply, reply,
-         socket
-         |> assign(:page_summary, page_summary)
-         |> put_flash(
-           :info,
-           if(action == "remove",
-             do: "Question removed from this page.",
-             else: "Question restored to this page."
-           )
-         )}
-
-      {:error, {:unauthorized, :customize_section}} ->
-        {:reply, %{ok: false},
-         put_flash(socket, :error, "You are not allowed to customize this page.")}
-
-      {:error, :invalid_page_target} ->
-        {:reply, %{ok: false},
-         put_flash(socket, :error, "Unable to update a question outside this page preview.")}
-
-      {:error, :invalid_activity_target} ->
-        {:reply, %{ok: false},
-         put_flash(socket, :error, "Unable to update a question that is not part of this page.")}
-
-      {:error, _reason} ->
-        {:reply, %{ok: false}, put_flash(socket, :error, "Unable to update this question.")}
-    end
+    handle_preview_customization_toggle(socket, action, %{
+      kind: :embedded_activity,
+      page_resource_id: page_resource_id,
+      activity_resource_id: activity_resource_id
+    })
   end
 
   def handle_event(
@@ -724,132 +625,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         },
         socket
       ) do
-    section = socket.assigns.section
-    actor = socket.assigns.current_user
-
-    current_page_resource_id = socket.assigns.current_page_resource_id
-    valid_selection_ids = MapSet.new(socket.assigns.preview_metadata.bank_selection_ids)
-
-    result =
-      cond do
-        page_resource_id != current_page_resource_id ->
-          {:error, :invalid_page_target}
-
-        not MapSet.member?(valid_selection_ids, selection_id) ->
-          {:error, :invalid_selection_target}
-
-        preview_confirmation_required?(socket) ->
-          {:confirmation_required,
-           %{
-             action: action,
-             target: %{
-               kind: "bank_selection",
-               pageResourceId: page_resource_id,
-               selectionId: selection_id
-             }
-           }}
-
-        true ->
-          case action do
-            "remove" ->
-              InstructorCustomizations.exclude_bank_selection(
-                section,
-                page_resource_id,
-                selection_id,
-                actor: actor
-              )
-
-            "restore" ->
-              InstructorCustomizations.restore_bank_selection(
-                section,
-                page_resource_id,
-                selection_id,
-                actor: actor
-              )
-
-            _ ->
-              {:error, {:invalid_action, action}}
-          end
-      end
-
-    case result do
-      {:confirmation_required, pending} ->
-        {:reply, confirmation_required_reply(pending),
-         assign(socket, :pending_preview_customization, pending)}
-
-      {:ok, exclusion_view} ->
-        page_summary =
-          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
-
-        available_count =
-          if action == "remove" do
-            0
-          else
-            Map.get(
-              socket.assigns.preview_metadata.bank_selection_available_counts_by_id,
-              selection_id,
-              0
-            )
-          end
-
-        reply = %{
-          ok: true,
-          target: %{
-            kind: "bank_selection",
-            pageResourceId: page_resource_id,
-            selectionId: selection_id
-          },
-          selectionId: selection_id,
-          availableCount: available_count,
-          visualState: if(action == "remove", do: "removed", else: "default"),
-          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
-          actions:
-            if(action == "remove",
-              do: [%{kind: "restore", label: "Restore"}],
-              else: [%{kind: "remove", label: "Remove"}]
-            )
-        }
-
-        {:reply, reply,
-         socket
-         |> assign(:page_summary, page_summary)
-         |> put_flash(
-           :info,
-           if(action == "remove",
-             do: "Activity bank selection removed",
-             else: "Activity bank selection restored"
-           )
-         )}
-
-      {:error, {:unauthorized, :customize_section}} ->
-        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :unauthorized),
-         put_flash(socket, :error, "You are not allowed to customize this page.")}
-
-      {:error, :invalid_page_target} ->
-        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :invalid_page_target),
-         put_flash(
-           socket,
-           :error,
-           "Unable to update an activity bank selection outside this page preview."
-         )}
-
-      {:error, :invalid_selection_target} ->
-        {:reply,
-         bank_selection_error_reply(page_resource_id, selection_id, :invalid_selection_target),
-         put_flash(
-           socket,
-           :error,
-           "Unable to update an activity bank selection that is not part of this page."
-         )}
-
-      {:error, {:invalid_action, _action}} ->
-        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :invalid_action),
-         put_flash(socket, :error, "Unable to update this activity bank selection.")}
-
-      {:error, _reason} ->
-        {:reply, bank_selection_error_reply(page_resource_id, selection_id, :domain_error),
-         put_flash(socket, :error, "Unable to update this activity bank selection.")}
-    end
+    handle_preview_customization_toggle(socket, action, %{
+      kind: :bank_selection,
+      page_resource_id: page_resource_id,
+      selection_id: selection_id
+    })
   end
 
   def handle_event(
@@ -895,7 +675,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         {reply, socket} =
           socket
           |> assign(:pending_preview_customization, nil)
-          |> apply_pending_preview_customization(pending)
+          |> apply_preview_customization(pending)
 
         {:noreply, push_event(socket, "preview_customization_reply", reply)}
     end
@@ -989,51 +769,31 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
      )}
   end
 
-  defp apply_pending_preview_customization(
-         socket,
-         %{
-           action: action,
-           target: %{
-             kind: "embedded_activity",
-             pageResourceId: page_resource_id,
-             activityResourceId: activity_resource_id
-           }
-         }
-       ) do
-    section = socket.assigns.section
-    actor = socket.assigns.current_user
-    current_page_resource_id = socket.assigns.current_page_resource_id
-    valid_activity_ids = MapSet.new(socket.assigns.preview_metadata.activity_ids)
+  defp handle_preview_customization_toggle(socket, action, target) do
+    pending = %{action: action, target: target}
 
+    case validate_preview_customization_target(socket, target) do
+      :ok ->
+        if preview_confirmation_required?(socket) do
+          {:reply, confirmation_required_reply(pending),
+           assign(socket, :pending_preview_customization, pending)}
+        else
+          {reply, socket} = apply_preview_customization(socket, pending)
+
+          {:reply, reply, socket}
+        end
+
+      {:error, reason} ->
+        {reply, socket} = preview_customization_error(socket, target, reason)
+
+        {:reply, reply, socket}
+    end
+  end
+
+  defp apply_preview_customization(socket, %{action: action, target: target}) do
     result =
-      cond do
-        page_resource_id != current_page_resource_id ->
-          {:error, :invalid_page_target}
-
-        not MapSet.member?(valid_activity_ids, activity_resource_id) ->
-          {:error, :invalid_activity_target}
-
-        true ->
-          case action do
-            "remove" ->
-              InstructorCustomizations.exclude_activity(
-                section,
-                page_resource_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            "restore" ->
-              InstructorCustomizations.restore_activity(
-                section,
-                page_resource_id,
-                activity_resource_id,
-                actor: actor
-              )
-
-            _ ->
-              {:error, {:invalid_action, action}}
-          end
+      with :ok <- validate_preview_customization_target(socket, target) do
+        dispatch_preview_customization(socket, action, target)
       end
 
     case result do
@@ -1041,147 +801,229 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         page_summary =
           PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
 
-        reply = %{
-          ok: true,
-          target: %{
-            kind: "embedded_activity",
-            pageResourceId: page_resource_id,
-            activityResourceId: activity_resource_id
-          },
-          activityResourceId: activity_resource_id,
-          visualState: if(action == "remove", do: "removed", else: "default"),
-          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
-          actions:
-            if(action == "remove",
-              do: [%{kind: "restore", label: "Restore"}],
-              else: [%{kind: "remove", label: "Remove"}]
-            )
-        }
+        reply = preview_customization_success_reply(socket, action, target)
 
         {reply,
          socket
          |> assign(:page_summary, page_summary)
-         |> put_flash(
-           :info,
-           if(action == "remove",
-             do: "Question removed from this page.",
-             else: "Question restored to this page."
-           )
-         )}
+         |> put_flash(:info, preview_customization_success_message(action, target))}
 
-      {:error, {:unauthorized, :customize_section}} ->
+      {:error, reason} ->
+        preview_customization_error(socket, target, reason)
+    end
+  end
+
+  defp validate_preview_customization_target(
+         socket,
+         %{kind: :embedded_activity, page_resource_id: page_resource_id, activity_resource_id: id}
+       ) do
+    valid_activity_ids = MapSet.new(socket.assigns.preview_metadata.activity_ids)
+
+    cond do
+      page_resource_id != socket.assigns.current_page_resource_id ->
+        {:error, :invalid_page_target}
+
+      not MapSet.member?(valid_activity_ids, id) ->
+        {:error, :invalid_activity_target}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_preview_customization_target(
+         socket,
+         %{kind: :bank_selection, page_resource_id: page_resource_id, selection_id: selection_id}
+       ) do
+    valid_selection_ids = MapSet.new(socket.assigns.preview_metadata.bank_selection_ids)
+
+    cond do
+      page_resource_id != socket.assigns.current_page_resource_id ->
+        {:error, :invalid_page_target}
+
+      not MapSet.member?(valid_selection_ids, selection_id) ->
+        {:error, :invalid_selection_target}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp dispatch_preview_customization(
+         socket,
+         action,
+         %{kind: :embedded_activity, page_resource_id: page_resource_id, activity_resource_id: id}
+       ) do
+    case action do
+      "remove" ->
+        InstructorCustomizations.exclude_activity(socket.assigns.section, page_resource_id, id,
+          actor: socket.assigns.current_user
+        )
+
+      "restore" ->
+        InstructorCustomizations.restore_activity(socket.assigns.section, page_resource_id, id,
+          actor: socket.assigns.current_user
+        )
+
+      _ ->
+        {:error, {:invalid_action, action}}
+    end
+  end
+
+  defp dispatch_preview_customization(
+         socket,
+         action,
+         %{kind: :bank_selection, page_resource_id: page_resource_id, selection_id: selection_id}
+       ) do
+    case action do
+      "remove" ->
+        InstructorCustomizations.exclude_bank_selection(
+          socket.assigns.section,
+          page_resource_id,
+          selection_id,
+          actor: socket.assigns.current_user
+        )
+
+      "restore" ->
+        InstructorCustomizations.restore_bank_selection(
+          socket.assigns.section,
+          page_resource_id,
+          selection_id,
+          actor: socket.assigns.current_user
+        )
+
+      _ ->
+        {:error, {:invalid_action, action}}
+    end
+  end
+
+  defp preview_customization_success_reply(
+         _socket,
+         action,
+         %{kind: :embedded_activity, activity_resource_id: id} = target
+       ) do
+    %{
+      ok: true,
+      target: client_preview_customization_target(target),
+      activityResourceId: id,
+      visualState: preview_visual_state(action),
+      statusPill: preview_status_pill(action),
+      actions: preview_next_actions(action)
+    }
+  end
+
+  defp preview_customization_success_reply(
+         socket,
+         action,
+         %{kind: :bank_selection, selection_id: selection_id} = target
+       ) do
+    %{
+      ok: true,
+      target: client_preview_customization_target(target),
+      selectionId: selection_id,
+      availableCount: bank_selection_available_count(socket, action, selection_id),
+      visualState: preview_visual_state(action),
+      statusPill: preview_status_pill(action),
+      actions: preview_next_actions(action)
+    }
+  end
+
+  defp preview_visual_state("remove"), do: "removed"
+  defp preview_visual_state(_action), do: "default"
+
+  defp preview_status_pill("remove"), do: %{kind: "removed", label: "Removed"}
+  defp preview_status_pill(_action), do: nil
+
+  defp preview_next_actions("remove"), do: [%{kind: "restore", label: "Restore"}]
+  defp preview_next_actions(_action), do: [%{kind: "remove", label: "Remove"}]
+
+  defp client_preview_customization_target(%{
+         kind: :embedded_activity,
+         page_resource_id: page_resource_id,
+         activity_resource_id: activity_resource_id
+       }) do
+    %{
+      kind: "embedded_activity",
+      pageResourceId: page_resource_id,
+      activityResourceId: activity_resource_id
+    }
+  end
+
+  defp client_preview_customization_target(%{
+         kind: :bank_selection,
+         page_resource_id: page_resource_id,
+         selection_id: selection_id
+       }) do
+    %{
+      kind: "bank_selection",
+      pageResourceId: page_resource_id,
+      selectionId: selection_id
+    }
+  end
+
+  defp bank_selection_available_count(_socket, "remove", _selection_id), do: 0
+
+  defp bank_selection_available_count(socket, _action, selection_id) do
+    Map.get(
+      socket.assigns.preview_metadata.bank_selection_available_counts_by_id,
+      selection_id,
+      0
+    )
+  end
+
+  defp preview_customization_success_message(
+         "remove",
+         %{kind: :embedded_activity}
+       ),
+       do: "Question removed from this page."
+
+  defp preview_customization_success_message(
+         _action,
+         %{kind: :embedded_activity}
+       ),
+       do: "Question restored to this page."
+
+  defp preview_customization_success_message(
+         "remove",
+         %{kind: :bank_selection}
+       ),
+       do: "Activity bank selection removed"
+
+  defp preview_customization_success_message(
+         _action,
+         %{kind: :bank_selection}
+       ),
+       do: "Activity bank selection restored"
+
+  defp preview_customization_error(socket, %{kind: :embedded_activity}, reason) do
+    case reason do
+      {:unauthorized, :customize_section} ->
         {%{ok: false}, put_flash(socket, :error, "You are not allowed to customize this page.")}
 
-      {:error, :invalid_page_target} ->
+      :invalid_page_target ->
         {%{ok: false},
          put_flash(socket, :error, "Unable to update a question outside this page preview.")}
 
-      {:error, :invalid_activity_target} ->
+      :invalid_activity_target ->
         {%{ok: false},
          put_flash(socket, :error, "Unable to update a question that is not part of this page.")}
 
-      {:error, _reason} ->
+      _reason ->
         {%{ok: false}, put_flash(socket, :error, "Unable to update this question.")}
     end
   end
 
-  defp apply_pending_preview_customization(
+  defp preview_customization_error(
          socket,
-         %{
-           action: action,
-           target: %{
-             kind: "bank_selection",
-             pageResourceId: page_resource_id,
-             selectionId: selection_id
-           }
-         }
+         %{kind: :bank_selection, page_resource_id: page_resource_id, selection_id: selection_id},
+         reason
        ) do
-    section = socket.assigns.section
-    actor = socket.assigns.current_user
-    current_page_resource_id = socket.assigns.current_page_resource_id
-    valid_selection_ids = MapSet.new(socket.assigns.preview_metadata.bank_selection_ids)
-
-    result =
-      cond do
-        page_resource_id != current_page_resource_id ->
-          {:error, :invalid_page_target}
-
-        not MapSet.member?(valid_selection_ids, selection_id) ->
-          {:error, :invalid_selection_target}
-
-        true ->
-          case action do
-            "remove" ->
-              InstructorCustomizations.exclude_bank_selection(
-                section,
-                page_resource_id,
-                selection_id,
-                actor: actor
-              )
-
-            "restore" ->
-              InstructorCustomizations.restore_bank_selection(
-                section,
-                page_resource_id,
-                selection_id,
-                actor: actor
-              )
-
-            _ ->
-              {:error, {:invalid_action, action}}
-          end
-      end
-
-    case result do
-      {:ok, exclusion_view} ->
-        page_summary =
-          PreviewPageContext.build_page_summary(socket.assigns.preview_metadata, exclusion_view)
-
-        available_count =
-          if action == "remove" do
-            0
-          else
-            Map.get(
-              socket.assigns.preview_metadata.bank_selection_available_counts_by_id,
-              selection_id,
-              0
-            )
-          end
-
-        reply = %{
-          ok: true,
-          target: %{
-            kind: "bank_selection",
-            pageResourceId: page_resource_id,
-            selectionId: selection_id
-          },
-          selectionId: selection_id,
-          availableCount: available_count,
-          visualState: if(action == "remove", do: "removed", else: "default"),
-          statusPill: if(action == "remove", do: %{kind: "removed", label: "Removed"}, else: nil),
-          actions:
-            if(action == "remove",
-              do: [%{kind: "restore", label: "Restore"}],
-              else: [%{kind: "remove", label: "Remove"}]
-            )
-        }
-
-        {reply,
-         socket
-         |> assign(:page_summary, page_summary)
-         |> put_flash(
-           :info,
-           if(action == "remove",
-             do: "Activity bank selection removed",
-             else: "Activity bank selection restored"
-           )
-         )}
-
-      {:error, {:unauthorized, :customize_section}} ->
+    case reason do
+      {:unauthorized, :customize_section} ->
         {bank_selection_error_reply(page_resource_id, selection_id, :unauthorized),
          put_flash(socket, :error, "You are not allowed to customize this page.")}
 
-      {:error, :invalid_page_target} ->
+      :invalid_page_target ->
         {bank_selection_error_reply(page_resource_id, selection_id, :invalid_page_target),
          put_flash(
            socket,
@@ -1189,7 +1031,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
            "Unable to update an activity bank selection outside this page preview."
          )}
 
-      {:error, :invalid_selection_target} ->
+      :invalid_selection_target ->
         {bank_selection_error_reply(page_resource_id, selection_id, :invalid_selection_target),
          put_flash(
            socket,
@@ -1197,11 +1039,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
            "Unable to update an activity bank selection that is not part of this page."
          )}
 
-      {:error, {:invalid_action, _action}} ->
+      {:invalid_action, _action} ->
         {bank_selection_error_reply(page_resource_id, selection_id, :invalid_action),
          put_flash(socket, :error, "Unable to update this activity bank selection.")}
 
-      {:error, _reason} ->
+      _reason ->
         {bank_selection_error_reply(page_resource_id, selection_id, :domain_error),
          put_flash(socket, :error, "Unable to update this activity bank selection.")}
     end
@@ -1211,7 +1053,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     %{
       ok: false,
       reason: :confirmation_required,
-      target: target
+      target: client_preview_customization_target(target)
     }
   end
 
@@ -1233,7 +1075,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
     target_label =
       case target do
-        %{kind: "bank_selection"} -> "activity bank selection"
+        %{kind: :bank_selection} -> "activity bank selection"
         _ -> "question"
       end
 
@@ -1251,7 +1093,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
 
     confirm_target =
       case target do
-        %{kind: "bank_selection"} -> "selection"
+        %{kind: :bank_selection} -> "selection"
         _ -> "question"
       end
 
@@ -1454,18 +1296,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
              socket.assigns.current_page_resource_id,
              socket.assigns.graded
            ) do
-        :scored ->
+        kind when kind in [:scored, :practice] ->
           %{
-            kind: :scored,
-            message:
-              "Students have already started this assessment. Removing or restoring questions and activity bank selections will only impact future attempts."
-          }
-
-        :practice ->
-          %{
-            kind: :practice,
-            message:
-              "Students have already visited this page. Removing or restoring questions and activity bank selections will only impact future attempts."
+            kind: kind,
+            message: preview_attempt_warning_message(kind)
           }
 
         nil ->
@@ -1477,6 +1311,16 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
       preview_attempt_warning_dismissed?: false,
       pending_preview_customization: nil
     )
+  end
+
+  defp preview_attempt_warning_message(kind) do
+    subject =
+      case kind do
+        :practice -> "visited this page"
+        _ -> "started this assessment"
+      end
+
+    "Students have already #{subject}. Removing or restoring questions and activity bank selections will only impact future attempts."
   end
 
   defp preview_attempt_warning_kind(section, page_resource_id, true) do

--- a/test/oli/delivery/attempts/core_test.exs
+++ b/test/oli/delivery/attempts/core_test.exs
@@ -160,6 +160,28 @@ defmodule Oli.Delivery.Attempts.CoreTest do
     test "has_any_attempts?/3 returns false when no attempts exist", ctx do
       refute Core.has_any_attempts?(ctx.user, ctx.section, ctx.resource.id)
     end
+
+    test "has_any_resource_attempts?/2 returns true when any learner attempt exists", ctx do
+      insert(:resource_attempt, %{
+        resource_access: ctx.resource_access
+      })
+
+      assert Core.has_any_resource_attempts?(ctx.section, ctx.resource.id)
+    end
+
+    test "has_any_resource_attempts?/2 returns false when no learner attempts exist", ctx do
+      refute Core.has_any_resource_attempts?(ctx.section, ctx.resource.id)
+    end
+
+    test "has_any_resource_accesses?/2 returns true when any learner access exists", ctx do
+      assert Core.has_any_resource_accesses?(ctx.section, ctx.resource.id)
+    end
+
+    test "has_any_resource_accesses?/2 returns false when no learner accesses exist", ctx do
+      other_resource = insert(:resource)
+
+      refute Core.has_any_resource_accesses?(ctx.section, other_resource.id)
+    end
   end
 
   describe "resource access retrieval" do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -552,6 +552,33 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                |> Enum.sort()
     end
 
+    test "samples one active candidate while respecting candidate exclusions", context do
+      [first, second, third] = context.candidates
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: first.resource_id
+      )
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: second.resource_id
+      )
+
+      assert {:ok,
+              %{
+                activity_resource_id: activity_resource_id,
+                enabled?: true
+              }} =
+               InstructorCustomizations.sample_bank_selection_candidate(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1"
+               )
+
+      assert activity_resource_id == third.resource_id
+    end
+
     test "restores a stale candidate exclusion without requiring it to match current logic",
          context do
       stale_activity = activity_revision("Stale activity", :banked)

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -552,6 +552,115 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                |> Enum.sort()
     end
 
+    test "summarizes selection candidates without returning a paged candidate list", context do
+      [first, second, third] = context.candidates
+
+      insert_exclusion(context, :bank_selection, selection_id: "selection-1")
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: first.resource_id
+      )
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: second.resource_id
+      )
+
+      assert {:ok,
+              %{
+                selection_id: "selection-1",
+                count: 2,
+                active_count: 1,
+                selection_enabled?: false,
+                sample_candidate: %{
+                  activity_resource_id: activity_resource_id,
+                  enabled?: true
+                }
+              }} =
+               InstructorCustomizations.get_bank_selection_summary(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1"
+               )
+
+      assert activity_resource_id == third.resource_id
+    end
+
+<<<<<<< HEAD
+    test "accepts an already resolved section/page_revision/selection target", context do
+      selection = selection("selection-1", 2)
+=======
+    test "summarizes selection candidates without returning a paged candidate list", context do
+      [first, second, third] = context.candidates
+
+      insert_exclusion(context, :bank_selection, selection_id: "selection-1")
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: first.resource_id
+      )
+
+      insert_exclusion(context, :bank_candidate,
+        selection_id: "selection-1",
+        excluded_resource_id: second.resource_id
+      )
+>>>>>>> 5d2f74a1a3 ([MER-5620] Improvements)
+
+      assert {:ok,
+              %{
+                selection_id: "selection-1",
+                count: 2,
+<<<<<<< HEAD
+                active_count: 3,
+                total_count: 3,
+                has_more?: false,
+                candidates: candidates
+              }} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision,
+                 selection,
+                 []
+               )
+
+      assert length(candidates) == 3
+    end
+
+    test "lists all candidate activity type ids for a resolved selection target", context do
+      selection = selection("selection-1", 2)
+
+      assert {:ok, activity_type_ids} =
+               InstructorCustomizations.list_bank_selection_candidate_activity_type_ids(
+                 context.section,
+                 context.page_revision,
+                 selection,
+                 3
+               )
+
+      assert Enum.sort(activity_type_ids) ==
+               context.candidates
+               |> Enum.map(& &1.activity_type_id)
+               |> Enum.uniq()
+               |> Enum.sort()
+=======
+                active_count: 1,
+                selection_enabled?: false,
+                sample_candidate: %{
+                  activity_resource_id: activity_resource_id,
+                  enabled?: true
+                }
+              }} =
+               InstructorCustomizations.get_bank_selection_summary(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1"
+               )
+
+      assert activity_resource_id == third.resource_id
+>>>>>>> 5d2f74a1a3 ([MER-5620] Improvements)
+    end
+
     test "samples one active candidate while respecting candidate exclusions", context do
       [first, second, third] = context.candidates
 

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -445,7 +445,6 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
               %{
                 selection_id: "selection-1",
                 count: 2,
-                active_count: 2,
                 selection_enabled?: false,
                 active_count: 2,
                 total_count: 3,
@@ -585,80 +584,6 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                )
 
       assert activity_resource_id == third.resource_id
-    end
-
-<<<<<<< HEAD
-    test "accepts an already resolved section/page_revision/selection target", context do
-      selection = selection("selection-1", 2)
-=======
-    test "summarizes selection candidates without returning a paged candidate list", context do
-      [first, second, third] = context.candidates
-
-      insert_exclusion(context, :bank_selection, selection_id: "selection-1")
-
-      insert_exclusion(context, :bank_candidate,
-        selection_id: "selection-1",
-        excluded_resource_id: first.resource_id
-      )
-
-      insert_exclusion(context, :bank_candidate,
-        selection_id: "selection-1",
-        excluded_resource_id: second.resource_id
-      )
->>>>>>> 5d2f74a1a3 ([MER-5620] Improvements)
-
-      assert {:ok,
-              %{
-                selection_id: "selection-1",
-                count: 2,
-<<<<<<< HEAD
-                active_count: 3,
-                total_count: 3,
-                has_more?: false,
-                candidates: candidates
-              }} =
-               InstructorCustomizations.list_bank_selection_candidates(
-                 context.section,
-                 context.page_revision,
-                 selection,
-                 []
-               )
-
-      assert length(candidates) == 3
-    end
-
-    test "lists all candidate activity type ids for a resolved selection target", context do
-      selection = selection("selection-1", 2)
-
-      assert {:ok, activity_type_ids} =
-               InstructorCustomizations.list_bank_selection_candidate_activity_type_ids(
-                 context.section,
-                 context.page_revision,
-                 selection,
-                 3
-               )
-
-      assert Enum.sort(activity_type_ids) ==
-               context.candidates
-               |> Enum.map(& &1.activity_type_id)
-               |> Enum.uniq()
-               |> Enum.sort()
-=======
-                active_count: 1,
-                selection_enabled?: false,
-                sample_candidate: %{
-                  activity_resource_id: activity_resource_id,
-                  enabled?: true
-                }
-              }} =
-               InstructorCustomizations.get_bank_selection_summary(
-                 context.section,
-                 context.page_revision.resource_id,
-                 "selection-1"
-               )
-
-      assert activity_resource_id == third.resource_id
->>>>>>> 5d2f74a1a3 ([MER-5620] Improvements)
     end
 
     test "samples one active candidate while respecting candidate exclusions", context do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -445,6 +445,7 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
               %{
                 selection_id: "selection-1",
                 count: 2,
+                active_count: 2,
                 selection_enabled?: false,
                 active_count: 2,
                 total_count: 3,

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -10,6 +10,7 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Blueprint
   alias Oli.Publishing
+  alias Oli.Repo
   alias Oli.Repo.{Paging, Sorting}
   alias Oli.Publishing.DeliveryResolver
 
@@ -744,5 +745,18 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       assert 1 =
                length(Blueprint.list_products_not_in_community(community_visibility.community_id))
     end
+  end
+
+  defp insert_activity_exclusion(section_id, page_resource_id, attrs) do
+    %ActivityExclusion{}
+    |> ActivityExclusion.changeset(section_id, page_resource_id, attrs)
+    |> Repo.insert!()
+  end
+
+  defp exclusion_targets(section_id, page_resource_id) do
+    section_id
+    |> InstructorCustomizations.get_page_exclusions(page_resource_id)
+    |> Enum.map(&{&1.kind, &1.selection_id, &1.excluded_resource_id})
+    |> MapSet.new()
   end
 end

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -746,17 +746,4 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
                length(Blueprint.list_products_not_in_community(community_visibility.community_id))
     end
   end
-
-  defp insert_activity_exclusion(section_id, page_resource_id, attrs) do
-    %ActivityExclusion{}
-    |> ActivityExclusion.changeset(section_id, page_resource_id, attrs)
-    |> Repo.insert!()
-  end
-
-  defp exclusion_targets(section_id, page_resource_id) do
-    section_id
-    |> InstructorCustomizations.get_page_exclusions(page_resource_id)
-    |> Enum.map(&{&1.kind, &1.selection_id, &1.excluded_resource_id})
-    |> MapSet.new()
-  end
 end

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -52,8 +52,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       assert html =~ ">4<"
       assert has_element?(view, "#questions-required-count", "2")
       assert has_element?(view, "#active-available-count", "30")
-      assert html =~ "All questions"
-      assert html =~ "No additional filters"
+      assert html =~ "No criteria configured."
       assert html =~ "/js/oli_multiple_choice_preview.js"
       assert html =~ "/js/oli_check_all_that_apply_preview.js"
 

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -21,7 +21,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
   alias Oli.Repo
   alias Oli.Seeder
-  alias OliWeb.Delivery.Instructor.PreviewRoutes
+  alias OliWeb.Delivery.Instructor.{PreviewReturn, PreviewRoutes}
 
   describe "instructor basic page preview lesson" do
     setup [:setup_preview_section]
@@ -223,6 +223,28 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert html =~
                "return_to=%2Fworkspaces%2Fcourse_author%2Fhistory_of_football%2Fproducts%2F#{section.slug}%2Fremix"
+    end
+
+    test "rejects absolute template Customize Content return URLs with valid remix paths", %{
+      section: section
+    } do
+      valid_path = "/workspaces/course_author/history_of_football/products/#{section.slug}/remix"
+      fallback_path = PreviewReturn.fallback_path(section.slug)
+
+      assert PreviewReturn.sanitize_return_to(
+               "https://attacker.example#{valid_path}",
+               section.slug
+             ) ==
+               fallback_path
+
+      assert PreviewReturn.sanitize_return_to(
+               "http://attacker.example#{valid_path}",
+               section.slug
+             ) ==
+               fallback_path
+
+      assert PreviewReturn.sanitize_return_to("//attacker.example#{valid_path}", section.slug) ==
+               fallback_path
     end
 
     test "drops an unsafe request_path while preserving a safe return_to", %{

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -593,6 +593,280 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
                []
     end
+
+    test "renders and dismisses scored warning banner when students have started attempts", %{
+      conn: conn
+    } do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      create_page_attempt(section, page_revision)
+
+      {:ok, view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "preview-attempt-warning-banner"
+      assert html =~ "w-[90%]"
+      assert html =~ "max-w-[1280px]"
+
+      assert html =~
+               "Students have already started this assessment. Removing or restoring questions and activity bank selections will only impact future attempts."
+
+      view
+      |> element("button[aria-label='Dismiss warning']")
+      |> render_click()
+
+      refute render(view) =~ "preview-attempt-warning-banner"
+    end
+
+    test "renders practice warning banner when students have visited the page", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn, graded: false)
+
+      create_page_access(section, page_revision)
+
+      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "preview-attempt-warning-banner"
+
+      assert html =~
+               "Students have already visited this page. Removing or restoring questions and activity bank selections will only impact future attempts."
+    end
+
+    test "bank selection remove requires confirmation when attempts exist", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      create_page_attempt(section, page_revision)
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :confirmation_required,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        }
+      })
+
+      assert html =~ "preview-attempt-warning-modal"
+      assert html =~ "Change will affect future attempts"
+
+      assert html =~
+               "Students have already started this assessment. Removing this activity bank selection will only impact future attempts."
+
+      assert html =~ "Remove selection"
+      assert html =~ "Keep selection"
+
+      refute Enum.any?(
+               InstructorCustomizations.get_page_exclusions(section.id, page_resource_id),
+               &(&1.kind == :bank_selection and &1.selection_id == "test_selection")
+             )
+
+      html =
+        view
+        |> element("#preview-attempt-warning-modal button", "Remove selection")
+        |> render_click()
+
+      assert_push_event(view, "preview_customization_reply", %{
+        ok: true,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        },
+        selectionId: "test_selection",
+        availableCount: 0,
+        visualState: "removed",
+        statusPill: %{kind: "removed", label: "Removed"},
+        actions: [%{kind: "restore", label: "Restore"}]
+      })
+
+      assert html =~ "Activity bank selection removed"
+      refute html =~ "preview-attempt-warning-modal"
+
+      assert Enum.any?(
+               InstructorCustomizations.get_page_exclusions(section.id, page_resource_id),
+               &(&1.kind == :bank_selection and &1.selection_id == "test_selection")
+             )
+    end
+
+    test "canceling warning confirmation leaves bank selection unchanged", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      create_page_attempt(section, page_revision)
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      view
+      |> element("#instructor-preview-lesson")
+      |> render_hook("toggle_preview_activity_customization", %{
+        "action" => "remove",
+        "target" => %{
+          "kind" => "bank_selection",
+          "pageResourceId" => page_resource_id,
+          "selectionId" => "test_selection"
+        }
+      })
+
+      assert_reply(view, %{ok: false, reason: :confirmation_required})
+
+      html =
+        view
+        |> element("#preview-attempt-warning-modal button", "Keep selection")
+        |> render_click()
+
+      refute html =~ "preview-attempt-warning-modal"
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_resource_id) == []
+    end
+
+    test "bank selection restore warning uses restore selection copy", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision, user: user} =
+        setup_activity_bank_selection_preview(conn)
+
+      create_page_attempt(section, page_revision)
+      page_resource_id = page_revision.resource_id
+
+      {:ok, _view} =
+        InstructorCustomizations.exclude_bank_selection(
+          section,
+          page_resource_id,
+          "test_selection",
+          actor: user
+        )
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "restore",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :confirmation_required,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        }
+      })
+
+      assert html =~
+               "Students have already started this assessment. Restoring this activity bank selection will only impact future attempts."
+
+      assert html =~ "Restore selection"
+      assert html =~ "Cancel"
+
+      view
+      |> element("#preview-attempt-warning-modal button", "Restore selection")
+      |> render_click()
+
+      assert_push_event(view, "preview_customization_reply", %{
+        ok: true,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        },
+        selectionId: "test_selection",
+        availableCount: 2,
+        visualState: "default",
+        statusPill: nil,
+        actions: [%{kind: "remove", label: "Remove"}]
+      })
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_resource_id) == []
+    end
+
+    test "embedded activity remove requires confirmation when attempts exist", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      create_page_attempt(section, page_revision)
+
+      activity_resource_id = first_activity_resource_id(page_revision)
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "embedded_activity",
+            "pageResourceId" => page_resource_id,
+            "activityResourceId" => activity_resource_id
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :confirmation_required,
+        target: %{
+          kind: "embedded_activity",
+          pageResourceId: ^page_resource_id,
+          activityResourceId: ^activity_resource_id
+        }
+      })
+
+      assert html =~ "preview-attempt-warning-modal"
+
+      assert html =~
+               "Students have already started this assessment. Removing this question will only impact future attempts."
+
+      assert html =~ "Remove question"
+      assert html =~ "Keep question"
+
+      view
+      |> element("#preview-attempt-warning-modal button", "Remove question")
+      |> render_click()
+
+      assert_push_event(view, "preview_customization_reply", %{
+        ok: true,
+        target: %{
+          kind: "embedded_activity",
+          pageResourceId: ^page_resource_id,
+          activityResourceId: ^activity_resource_id
+        },
+        activityResourceId: ^activity_resource_id,
+        visualState: "removed",
+        statusPill: %{kind: "removed", label: "Removed"},
+        actions: [%{kind: "restore", label: "Restore"}]
+      })
+
+      assert Enum.any?(
+               InstructorCustomizations.get_page_exclusions(section.id, page_resource_id),
+               &(&1.kind == :embedded_activity and &1.excluded_resource_id == activity_resource_id)
+             )
+    end
   end
 
   describe "jump to section navigation" do
@@ -761,10 +1035,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
      adaptive_page_revision: map.adaptive_page_revision}
   end
 
-  defp setup_activity_bank_selection_preview(conn) do
+  defp setup_activity_bank_selection_preview(conn, opts \\ []) do
     map = Seeder.base_project_with_resource2()
     project = Repo.preload(map.project, :authors)
     author = List.first(project.authors)
+    graded? = Keyword.get(opts, :graded, true)
 
     section = insert(:section, base_project: project, open_and_free: true)
 
@@ -772,7 +1047,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       insert(:revision,
         resource_type_id: Oli.Resources.ResourceType.id_for_page(),
         title: "Activity Bank Page",
-        graded: true,
+        graded: graded?,
         content: %{
           "model" => [
             %{
@@ -1041,6 +1316,29 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       %{"type" => "activity-reference", "activity_id" => activity_id} -> activity_id
       _ -> nil
     end)
+  end
+
+  defp create_page_access(section, page_revision) do
+    student = insert(:user)
+
+    Repo.insert!(%ResourceAccess{
+      access_count: 1,
+      user_id: student.id,
+      section_id: section.id,
+      resource_id: page_revision.resource_id
+    })
+  end
+
+  defp create_page_attempt(section, page_revision) do
+    access = create_page_access(section, page_revision)
+
+    Repo.insert!(%ResourceAttempt{
+      attempt_guid: UUID.uuid4(),
+      attempt_number: 1,
+      resource_access_id: access.id,
+      revision_id: page_revision.id,
+      content: page_revision.content
+    })
   end
 
   defp cache_lti_context(section, user) do

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -434,6 +434,19 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "&quot;sampleActivity&quot;"
     end
 
+    test "renders learning objectives for the sampled bank activity", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn,
+          activity_count: 1,
+          selection_count: 1,
+          objective_title: "Football fundamentals"
+        )
+
+      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "&quot;learningObjectives&quot;:[&quot;Football fundamentals&quot;]"
+    end
+
     test "bank selection remove hook event stores an exclusion and shows a success flash", %{
       conn: conn
     } do
@@ -1117,8 +1130,22 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     activity_slug = Keyword.get(opts, :activity_slug, "oli_multiple_choice")
     selection_count = Keyword.get(opts, :selection_count, 2)
     selection_logic = Keyword.get(opts, :selection_logic, %{"conditions" => nil})
+    objective_title = Keyword.get(opts, :objective_title)
 
     section = insert(:section, base_project: project, open_and_free: true)
+
+    objective_revision =
+      if objective_title do
+        objective =
+          insert(:revision,
+            resource_type_id: Oli.Resources.ResourceType.id_for_objective(),
+            title: objective_title
+          )
+
+        insert(:project_resource, %{project_id: project.id, resource_id: objective.resource.id})
+
+        objective
+      end
 
     page_revision =
       insert(:revision,
@@ -1149,6 +1176,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
             resource_type_id: Oli.Resources.ResourceType.id_for_activity(),
             activity_type_id: activity_type.id,
             title: "Banked Activity #{index}",
+            objectives: activity_objectives(objective_revision),
             content: %{
               "stem" => "Banked activity #{index}",
               "authoring" => %{
@@ -1176,7 +1204,11 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     publication =
       insert(:publication, %{project: project, root_resource_id: page_revision.resource.id})
 
-    Enum.each([page_revision | activities], fn revision ->
+    revisions =
+      [page_revision | activities] ++
+        if objective_revision, do: [objective_revision], else: []
+
+    Enum.each(revisions, fn revision ->
       insert(:published_resource, %{
         publication: publication,
         resource: revision.resource,
@@ -1200,6 +1232,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       user: user
     }
   end
+
+  defp activity_objectives(nil), do: %{}
+  defp activity_objectives(objective_revision), do: %{"1" => [objective_revision.resource_id]}
 
   defp setup_mixed_preview_section(%{conn: conn}) do
     user = user_fixture(%{independent_learner: false})

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -448,9 +448,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "Selection criteria:"
       assert html =~ "Activities must match"
       assert html =~ "of the following."
-      assert html =~ "Activity Types:"
+      assert html =~ "Activity Types contain:"
       assert html =~ "Check All That Apply"
-      assert html =~ "Excluded Activity Types:"
+      assert html =~ "Activity Types do not contain:"
       assert html =~ "Multiple Choice"
     end
 

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -384,6 +384,25 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       refute html =~ "jumbotron selection"
     end
 
+    test "renders bank selection sample with authoring fallback when no preview component exists",
+         %{
+           conn: conn
+         } do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn,
+          activity_slug: "oli_short_answer",
+          activity_count: 1,
+          selection_count: 1
+        )
+
+      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "/js/oli_short_answer_authoring.js"
+      assert html =~ "&quot;previewElement&quot;:&quot;oli-short-answer-authoring&quot;"
+      assert html =~ "&quot;renderMode&quot;:&quot;authoring_fallback&quot;"
+      assert html =~ "&quot;sampleActivity&quot;"
+    end
+
     test "bank selection remove hook event stores an exclusion and shows a success flash", %{
       conn: conn
     } do
@@ -1063,6 +1082,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     project = Repo.preload(map.project, :authors)
     author = List.first(project.authors)
     graded? = Keyword.get(opts, :graded, true)
+    activity_count = Keyword.get(opts, :activity_count, 2)
+    activity_slug = Keyword.get(opts, :activity_slug, "oli_multiple_choice")
+    selection_count = Keyword.get(opts, :selection_count, 2)
 
     section = insert(:section, base_project: project, open_and_free: true)
 
@@ -1077,7 +1099,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
               "type" => "selection",
               "id" => "test_selection",
               "logic" => %{"conditions" => nil},
-              "count" => 2,
+              "count" => selection_count,
               "pointsPerActivity" => 3
             }
           ]
@@ -1086,14 +1108,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
     insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
 
-    mcq_reg = Activities.get_registration_by_slug("oli_multiple_choice")
+    activity_type = Activities.get_registration_by_slug(activity_slug)
 
     activities =
-      Enum.map(1..2, fn index ->
+      Enum.map(1..activity_count, fn index ->
         activity =
           insert(:revision,
             resource_type_id: Oli.Resources.ResourceType.id_for_activity(),
-            activity_type_id: mcq_reg.id,
+            activity_type_id: activity_type.id,
             title: "Banked Activity #{index}",
             content: %{
               "stem" => "Banked activity #{index}",

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -202,6 +202,29 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "Return to Customize Content"
     end
 
+    test "back link returns to template Customize Content when previewing through product remix",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision
+         } do
+      return_to = "/workspaces/course_author/history_of_football/products/#{section.slug}/remix"
+
+      {:ok, _view, html} =
+        live(
+          conn,
+          PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+            "return_to" => return_to
+          })
+        )
+
+      assert html =~ ~s|href="#{return_to}"|
+      assert html =~ "Return to Customize Content"
+
+      assert html =~
+               "return_to=%2Fworkspaces%2Fcourse_author%2Fhistory_of_football%2Fproducts%2F#{section.slug}%2Fremix"
+    end
+
     test "drops an unsafe request_path while preserving a safe return_to", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -377,11 +377,42 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "&quot;availableCount&quot;:2"
       assert html =~ "&quot;selectedCount&quot;:2"
       assert html =~ "&quot;criteria&quot;"
-      assert html =~ "&quot;learningObjectives&quot;:[]"
-      assert html =~ "&quot;tags&quot;:[]"
+      assert html =~ "&quot;criteria&quot;:[]"
       assert html =~ "&quot;manageQuestionsUrl&quot;:null"
       assert html =~ "&quot;sampleActivity&quot;"
       refute html =~ "jumbotron selection"
+    end
+
+    test "renders selection criteria with included and excluded activity type labels", %{
+      conn: conn
+    } do
+      cata = Activities.get_registration_by_slug("oli_check_all_that_apply")
+      mcq = Activities.get_registration_by_slug("oli_multiple_choice")
+
+      selection_logic = %{
+        "conditions" => %{
+          "operator" => "all",
+          "children" => [
+            %{"fact" => "type", "operator" => "contains", "value" => [cata.id]},
+            %{"fact" => "type", "operator" => "does_not_contain", "value" => [mcq.id]}
+          ]
+        }
+      }
+
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn,
+          activity_slug: "oli_check_all_that_apply",
+          activity_count: 1,
+          selection_count: 1,
+          selection_logic: selection_logic
+        )
+
+      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "&quot;label&quot;:&quot;Activity Types&quot;"
+      assert html =~ "&quot;values&quot;:[&quot;Check All That Apply&quot;]"
+      assert html =~ "&quot;label&quot;:&quot;Excluded Activity Types&quot;"
+      assert html =~ "&quot;values&quot;:[&quot;Multiple Choice&quot;]"
     end
 
     test "renders bank selection sample with authoring fallback when no preview component exists",
@@ -1085,6 +1116,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     activity_count = Keyword.get(opts, :activity_count, 2)
     activity_slug = Keyword.get(opts, :activity_slug, "oli_multiple_choice")
     selection_count = Keyword.get(opts, :selection_count, 2)
+    selection_logic = Keyword.get(opts, :selection_logic, %{"conditions" => nil})
 
     section = insert(:section, base_project: project, open_and_free: true)
 
@@ -1098,7 +1130,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
             %{
               "type" => "selection",
               "id" => "test_selection",
-              "logic" => %{"conditions" => nil},
+              "logic" => selection_logic,
               "count" => selection_count,
               "pointsPerActivity" => 3
             }

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -404,8 +404,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "/js/oli_multiple_choice_preview.js"
       assert html =~ "&quot;availableCount&quot;:2"
       assert html =~ "&quot;selectedCount&quot;:2"
-      assert html =~ "&quot;criteria&quot;"
-      assert html =~ "&quot;criteria&quot;:[]"
+      assert html =~ "&quot;selectionCriteriaHtml&quot;"
+      refute html =~ "&quot;criteria&quot;"
+      refute html =~ "&quot;criteriaHelperText&quot;"
       refute html =~ "&quot;manageQuestionsUrl&quot;:null"
 
       assert html =~
@@ -444,10 +445,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
 
-      assert html =~ "&quot;label&quot;:&quot;Activity Types&quot;"
-      assert html =~ "&quot;values&quot;:[&quot;Check All That Apply&quot;]"
-      assert html =~ "&quot;label&quot;:&quot;Excluded Activity Types&quot;"
-      assert html =~ "&quot;values&quot;:[&quot;Multiple Choice&quot;]"
+      assert html =~ "Selection criteria:"
+      assert html =~ "Matches all of the following"
+      assert html =~ "Activity Types:"
+      assert html =~ "Check All That Apply"
+      assert html =~ "Excluded Activity Types:"
+      assert html =~ "Multiple Choice"
     end
 
     test "renders bank selection sample with authoring fallback when no preview component exists",

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -446,7 +446,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
 
       assert html =~ "Selection criteria:"
-      assert html =~ "Matches all of the following"
+      assert html =~ "Activities must match"
+      assert html =~ "of the following."
       assert html =~ "Activity Types:"
       assert html =~ "Check All That Apply"
       assert html =~ "Excluded Activity Types:"

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -367,6 +367,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       %{conn: conn, section: section, page_revision: page_revision} =
         setup_activity_bank_selection_preview(conn)
 
+      page_resource_id = page_revision.resource_id
+
       {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
 
       html =
@@ -376,12 +378,26 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
           "action" => "remove",
           "target" => %{
             "kind" => "bank_selection",
-            "pageResourceId" => page_revision.resource_id,
+            "pageResourceId" => page_resource_id,
             "selectionId" => "test_selection"
           }
         })
 
-      assert html =~ "Activity bank selection removed from this page."
+      assert_reply(view, %{
+        ok: true,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        },
+        selectionId: "test_selection",
+        availableCount: 0,
+        visualState: "removed",
+        statusPill: %{kind: "removed", label: "Removed"},
+        actions: [%{kind: "restore", label: "Restore"}]
+      })
+
+      assert html =~ "Activity bank selection removed"
 
       exclusions =
         InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id)
@@ -389,6 +405,193 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert Enum.any?(exclusions, fn exclusion ->
                exclusion.kind == :bank_selection and exclusion.selection_id == "test_selection"
              end)
+    end
+
+    test "bank selection restore hook event removes an exclusion and returns contract state", %{
+      conn: conn
+    } do
+      %{conn: conn, section: section, page_revision: page_revision, user: user} =
+        setup_activity_bank_selection_preview(conn)
+
+      page_resource_id = page_revision.resource_id
+
+      {:ok, _view} =
+        InstructorCustomizations.exclude_bank_selection(
+          section,
+          page_resource_id,
+          "test_selection",
+          actor: user
+        )
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "restore",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: true,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        },
+        selectionId: "test_selection",
+        availableCount: 2,
+        visualState: "default",
+        statusPill: nil,
+        actions: [%{kind: "remove", label: "Remove"}]
+      })
+
+      assert html =~ "Activity bank selection restored"
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
+
+    test "bank selection hook rejects stale page targets without writing", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      page_resource_id = page_revision.resource_id
+      stale_page_resource_id = page_resource_id + 999_999
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => stale_page_resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :invalid_page_target,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^stale_page_resource_id,
+          selectionId: "test_selection"
+        }
+      })
+
+      assert html =~ "Unable to update an activity bank selection outside this page preview."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
+
+    test "bank selection hook rejects unknown selection targets without writing", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => "missing_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :invalid_selection_target,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "missing_selection"
+        }
+      })
+
+      assert html =~ "Unable to update an activity bank selection that is not part of this page."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
+
+    test "bank selection hook rejects malformed targets without writing", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id
+          }
+        })
+
+      assert_reply(view, %{ok: false, reason: :malformed_target})
+
+      assert html =~
+               "Unable to update an activity bank selection because the request was incomplete."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
+    end
+
+    test "bank selection hook rejects invalid actions without writing", %{conn: conn} do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      page_resource_id = page_revision.resource_id
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "archive",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert_reply(view, %{
+        ok: false,
+        reason: :invalid_action,
+        target: %{
+          kind: "bank_selection",
+          pageResourceId: ^page_resource_id,
+          selectionId: "test_selection"
+        }
+      })
+
+      assert html =~ "Unable to update this activity bank selection."
+
+      assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
+               []
     end
   end
 
@@ -641,7 +844,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     %{
       conn: log_in_user(conn, user),
       section: section,
-      page_revision: page_revision
+      page_revision: page_revision,
+      user: user
     }
   end
 

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -391,7 +391,13 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       %{conn: conn, section: section, page_revision: page_revision} =
         setup_activity_bank_selection_preview(conn)
 
-      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+      {:ok, _view, html} =
+        live(
+          conn,
+          PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+            "return_to" => "/sections/#{section.slug}/remix?from=curriculum"
+          })
+        )
 
       assert html =~ "oli-activity-bank-selection-preview"
       assert html =~ "/js/instructor_preview_components.js"
@@ -400,7 +406,14 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "&quot;selectedCount&quot;:2"
       assert html =~ "&quot;criteria&quot;"
       assert html =~ "&quot;criteria&quot;:[]"
-      assert html =~ "&quot;manageQuestionsUrl&quot;:null"
+      refute html =~ "&quot;manageQuestionsUrl&quot;:null"
+
+      assert html =~
+               "request_path=%2Fsections%2F#{section.slug}%2Fpreview%2Flesson%2F#{page_revision.slug}%3Freturn_to%3D%252Fsections%252F#{section.slug}%252Fremix%253Ffrom%253Dcurriculum"
+
+      assert html =~
+               "return_to=%2Fsections%2F#{section.slug}%2Fremix%3Ffrom%3Dcurriculum"
+
       assert html =~ "&quot;sampleActivity&quot;"
       refute html =~ "jumbotron selection"
     end

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -353,6 +353,10 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "/js/oli_multiple_choice_preview.js"
       assert html =~ "&quot;availableCount&quot;:2"
       assert html =~ "&quot;selectedCount&quot;:2"
+      assert html =~ "&quot;criteria&quot;"
+      assert html =~ "&quot;learningObjectives&quot;:[]"
+      assert html =~ "&quot;tags&quot;:[]"
+      assert html =~ "&quot;manageQuestionsUrl&quot;:null"
       assert html =~ "&quot;sampleActivity&quot;"
       refute html =~ "jumbotron selection"
     end

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -339,6 +339,53 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id) ==
                []
     end
+
+    test "renders activity bank selections through the React preview custom element", %{
+      conn: conn
+    } do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "oli-activity-bank-selection-preview"
+      assert html =~ "/js/instructor_preview_components.js"
+      assert html =~ "/js/oli_multiple_choice_preview.js"
+      assert html =~ "&quot;availableCount&quot;:2"
+      assert html =~ "&quot;selectedCount&quot;:2"
+      assert html =~ "&quot;sampleActivity&quot;"
+      refute html =~ "jumbotron selection"
+    end
+
+    test "bank selection remove hook event stores an exclusion and shows a success flash", %{
+      conn: conn
+    } do
+      %{conn: conn, section: section, page_revision: page_revision} =
+        setup_activity_bank_selection_preview(conn)
+
+      {:ok, view, _html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      html =
+        view
+        |> element("#instructor-preview-lesson")
+        |> render_hook("toggle_preview_activity_customization", %{
+          "action" => "remove",
+          "target" => %{
+            "kind" => "bank_selection",
+            "pageResourceId" => page_revision.resource_id,
+            "selectionId" => "test_selection"
+          }
+        })
+
+      assert html =~ "Activity bank selection removed from this page."
+
+      exclusions =
+        InstructorCustomizations.get_page_exclusions(section.id, page_revision.resource_id)
+
+      assert Enum.any?(exclusions, fn exclusion ->
+               exclusion.kind == :bank_selection and exclusion.selection_id == "test_selection"
+             end)
+    end
   end
 
   describe "jump to section navigation" do
@@ -505,6 +552,93 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
      page_revision: map.page.revision,
      next_page_revision: map.next_page.revision,
      adaptive_page_revision: map.adaptive_page_revision}
+  end
+
+  defp setup_activity_bank_selection_preview(conn) do
+    map = Seeder.base_project_with_resource2()
+    project = Repo.preload(map.project, :authors)
+    author = List.first(project.authors)
+
+    section = insert(:section, base_project: project, open_and_free: true)
+
+    page_revision =
+      insert(:revision,
+        resource_type_id: Oli.Resources.ResourceType.id_for_page(),
+        title: "Activity Bank Page",
+        graded: true,
+        content: %{
+          "model" => [
+            %{
+              "type" => "selection",
+              "id" => "test_selection",
+              "logic" => %{"conditions" => nil},
+              "count" => 2,
+              "pointsPerActivity" => 3
+            }
+          ]
+        }
+      )
+
+    insert(:project_resource, %{project_id: project.id, resource_id: page_revision.resource.id})
+
+    mcq_reg = Activities.get_registration_by_slug("oli_multiple_choice")
+
+    activities =
+      Enum.map(1..2, fn index ->
+        activity =
+          insert(:revision,
+            resource_type_id: Oli.Resources.ResourceType.id_for_activity(),
+            activity_type_id: mcq_reg.id,
+            title: "Banked Activity #{index}",
+            content: %{
+              "stem" => "Banked activity #{index}",
+              "authoring" => %{
+                "parts" => [
+                  %{
+                    "id" => "1",
+                    "responses" => [
+                      %{"rule" => "input like {a}", "score" => 1, "id" => "r1"}
+                    ],
+                    "scoringStrategy" => "best",
+                    "evaluationStrategy" => "regex"
+                  }
+                ]
+              },
+              "choices" => []
+            },
+            scope: :banked
+          )
+
+        insert(:project_resource, %{project_id: project.id, resource_id: activity.resource.id})
+
+        activity
+      end)
+
+    publication =
+      insert(:publication, %{project: project, root_resource_id: page_revision.resource.id})
+
+    Enum.each([page_revision | activities], fn revision ->
+      insert(:published_resource, %{
+        publication: publication,
+        resource: revision.resource,
+        revision: revision,
+        author: author
+      })
+    end)
+
+    {:ok, section} = Sections.create_section_resources(section, publication)
+
+    user = insert(:user, author: author)
+
+    Sections.enroll(user.id, section.id, [
+      Lti_1p3.Roles.ContextRoles.get_role(:context_instructor)
+    ])
+
+    %{
+      conn: log_in_user(conn, user),
+      section: section,
+      page_revision: page_revision
+    }
   end
 
   defp setup_mixed_preview_section(%{conn: conn}) do


### PR DESCRIPTION
## Summary

This PR implements [MER-5620](https://eliterate.atlassian.net/browse/MER-5620), adding instructor customization support for Activity Bank Selections in Instructor Preview.

It introduces a new Activity Bank Selection preview UI in Instructor Preview, replacing the previous inline selection display in that surface. The new preview shows key selection metadata, authored selection criteria, and a sampled question rendered through the existing activity preview flow when available, with fallback support for activity types that do not yet have a dedicated preview component.

The PR also adds remove/restore support for entire Activity Bank Selections through the existing LiveView/React customization bridge, while keeping embedded activity remove/restore aligned with the same contract. When students already have scored attempts or practice page visits, the preview now shows the corresponding warning banner and confirmation modal to make clear that changes only affect future attempts.

On top of the core customization flow, this work links the preview card’s **Manage questions** action to the expanded Activity Bank management view, improves sampled-question selection, and ensures sampled activities preserve the expected preview header and learning objective details.

Finally, the selection-criteria display was consolidated and refined so both Instructor Preview and the expanded management view use the same server-side presentation logic. That includes clearer handling of more complex authored criteria, helper text for the `all` / `any` distinction, and several UI polish updates to better match the intended design.

As part of that cleanup, the shared selection-criteria header/content is now rendered through a single Phoenix function component for the LiveView-based surface, and the same server-rendered HTML is passed into the React preview card for consistent display there as well.

This also works in the existing Product/Template Customize Content preview flow, and template-level activity exclusions continue to propagate only to future course sections created from the customized template.


https://github.com/user-attachments/assets/ba731dfd-ca1d-46cc-a305-bc08cf70bffe




[MER-5620]: https://eliterate.atlassian.net/browse/MER-5620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ