### PR TITLE
[BUG FIX] [MER-5696] pass paywall check as if instructor in template preview

### DIFF
--- a/lib/oli/analytics/datasets.ex
+++ b/lib/oli/analytics/datasets.ex
@@ -345,7 +345,6 @@ defmodule Oli.Analytics.Datasets do
       DatasetJob
       |> join(:left, [j], proj in Oli.Authoring.Course.Project, on: j.project_id == proj.id)
       |> distinct(true)
-      |> order_by([_j, proj], asc: proj.title, asc: proj.id)
       |> select([_j, proj], %{id: proj.id, title: proj.title})
 
     Repo.all(query)
@@ -366,7 +365,6 @@ defmodule Oli.Analytics.Datasets do
       |> join(:left, [j], u in Oli.Accounts.Author, on: j.initiated_by_id == u.id)
       |> distinct(true)
       |> where(^filter_by_project_id)
-      |> order_by([_j, u], asc: u.email, asc: u.id)
       |> select([_j, u], %{id: u.id, email: u.email})
 
     Repo.all(query)

--- a/lib/oli/analytics/datasets.ex
+++ b/lib/oli/analytics/datasets.ex
@@ -345,6 +345,7 @@ defmodule Oli.Analytics.Datasets do
       DatasetJob
       |> join(:left, [j], proj in Oli.Authoring.Course.Project, on: j.project_id == proj.id)
       |> distinct(true)
+      |> order_by([_j, proj], asc: proj.title, asc: proj.id)
       |> select([_j, proj], %{id: proj.id, title: proj.title})
 
     Repo.all(query)
@@ -365,6 +366,7 @@ defmodule Oli.Analytics.Datasets do
       |> join(:left, [j], u in Oli.Accounts.Author, on: j.initiated_by_id == u.id)
       |> distinct(true)
       |> where(^filter_by_project_id)
+      |> order_by([_j, u], asc: u.email, asc: u.id)
       |> select([_j, u], %{id: u.id, email: u.email})
 
     Repo.all(query)

--- a/lib/oli_web/live_session_plugs/set_paywall_summary.ex
+++ b/lib/oli_web/live_session_plugs/set_paywall_summary.ex
@@ -2,18 +2,27 @@ defmodule OliWeb.LiveSessionPlugs.SetPaywallSummary do
   import Phoenix.Component, only: [assign: 2]
   use Appsignal.Instrumentation.Decorators
   alias Oli.Delivery.Paywall
+  alias Oli.Delivery.Paywall.AccessSummary
+  alias OliWeb.TemplatePreviewMode
 
   @decorate transaction_event("SetPaywallSummary")
   def on_mount(
         :default,
         _params,
-        _session,
+        session,
         %{assigns: %{current_user: current_user, section: section}} = socket
       )
       when not is_nil(section) and not is_nil(current_user) do
+    summary =
+      if TemplatePreviewMode.active?(session, section) do
+        AccessSummary.instructor()
+      else
+        Paywall.summarize_access(current_user, section)
+      end
+
     {:cont,
      assign(socket,
-       paywall_summary: Paywall.summarize_access(current_user, section)
+       paywall_summary: summary
      )}
   end
 

--- a/lib/oli_web/plugs/enforce_paywall.ex
+++ b/lib/oli_web/plugs/enforce_paywall.ex
@@ -5,6 +5,7 @@ defmodule Oli.Plugs.EnforcePaywall do
   alias OliWeb.Router.Helpers, as: Routes
   alias Oli.Delivery.Paywall
   alias Oli.Delivery.Paywall.AccessSummary
+  alias OliWeb.TemplatePreviewMode
 
   def init(opts), do: opts
 
@@ -13,7 +14,12 @@ defmodule Oli.Plugs.EnforcePaywall do
     section = conn.assigns.section
     user = conn.assigns.current_user
 
-    summary = Paywall.summarize_access(user, section)
+    summary =
+      if TemplatePreviewMode.active?(conn, section) do
+        AccessSummary.instructor()
+      else
+        Paywall.summarize_access(user, section)
+      end
 
     case summary do
       %AccessSummary{available: true} ->

--- a/lib/oli_web/template_preview_mode.ex
+++ b/lib/oli_web/template_preview_mode.ex
@@ -1,0 +1,23 @@
+defmodule OliWeb.TemplatePreviewMode do
+  @moduledoc """
+  Helpers for recognizing an active template preview delivery session.
+  """
+
+  import Plug.Conn, only: [get_session: 2]
+
+  alias Oli.Delivery.Sections.Section
+
+  def active?(%Plug.Conn{} = conn, %Section{} = section) do
+    section.type == :blueprint and
+      get_session(conn, :template_preview_mode) == true and
+      get_session(conn, :template_preview_section_slug) == section.slug
+  end
+
+  def active?(session, %Section{} = section) when is_map(session) do
+    section.type == :blueprint and
+      session["template_preview_mode"] == true and
+      session["template_preview_section_slug"] == section.slug
+  end
+
+  def active?(_session_or_conn, _section), do: false
+end

--- a/test/oli/analytics/datasets_test.exs
+++ b/test/oli/analytics/datasets_test.exs
@@ -534,7 +534,6 @@ defmodule Oli.Analytics.Datasets.Test do
       assert result == [%{id: project.id, title: project.title}]
     end
 
-    @tag :flaky
     test "initiator values", %{project: project, author: author1, author2: author2} do
       job(%{
         status: :pending,
@@ -570,12 +569,15 @@ defmodule Oli.Analytics.Datasets.Test do
 
       result = Datasets.get_initiator_values()
       assert length(result) == 2
-      result = Enum.sort(result)
 
-      assert result == [
-               %{id: author1.id, email: author1.email},
-               %{id: author2.id, email: author2.email}
-             ]
+      expected =
+        [
+          %{id: author1.id, email: author1.email},
+          %{id: author2.id, email: author2.email}
+        ]
+        |> Enum.sort_by(&{&1.email, &1.id})
+
+      assert result == expected
     end
   end
 end

--- a/test/oli/analytics/datasets_test.exs
+++ b/test/oli/analytics/datasets_test.exs
@@ -577,7 +577,7 @@ defmodule Oli.Analytics.Datasets.Test do
         ]
         |> Enum.sort_by(&{&1.email, &1.id})
 
-      assert result == expected
+      assert Enum.sort_by(result, &{&1.email, &1.id}) == expected
     end
   end
 end

--- a/test/oli_web/live_session_plugs/set_paywall_summary_test.exs
+++ b/test/oli_web/live_session_plugs/set_paywall_summary_test.exs
@@ -1,0 +1,82 @@
+defmodule OliWeb.LiveSessionPlugs.SetPaywallSummaryTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+
+  alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Delivery.Sections
+  alias OliWeb.LiveSessionPlugs.SetPaywallSummary
+  alias Phoenix.LiveView
+
+  describe "on_mount/4" do
+    setup do
+      stub_real_current_time()
+      :ok
+    end
+
+    test "uses instructor summary for active template preview even when user is in grace period" do
+      section =
+        insert(:section, %{
+          type: :blueprint,
+          requires_payment: true,
+          amount: Money.new(:USD, 100),
+          has_grace_period: true,
+          grace_period_days: 14,
+          grace_period_strategy: :relative_to_student
+        })
+
+      user = preview_user()
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      socket = socket(user, section)
+
+      assert {:cont, socket} = SetPaywallSummary.on_mount(:default, %{}, %{}, socket)
+      assert socket.assigns.paywall_summary.reason == :within_grace_period
+
+      session = %{
+        "template_preview_mode" => true,
+        "template_preview_section_slug" => section.slug
+      }
+
+      assert {:cont, socket} =
+               SetPaywallSummary.on_mount(:default, %{}, session, socket(user, section))
+
+      assert socket.assigns.paywall_summary.available
+      assert socket.assigns.paywall_summary.reason == :instructor
+    end
+
+    test "does not use preview summary when section slug does not match" do
+      section =
+        insert(:section, %{
+          type: :blueprint,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
+      user = preview_user()
+
+      session = %{
+        "template_preview_mode" => true,
+        "template_preview_section_slug" => "other-section"
+      }
+
+      assert {:cont, socket} =
+               SetPaywallSummary.on_mount(:default, %{}, session, socket(user, section))
+
+      refute socket.assigns.paywall_summary.available
+      assert socket.assigns.paywall_summary.reason == :not_paid
+    end
+  end
+
+  defp socket(user, section) do
+    %LiveView.Socket{
+      endpoint: OliWeb.Endpoint,
+      assigns: %{__changed__: %{}, current_user: user, section: section}
+    }
+  end
+
+  defp preview_user do
+    insert(:user)
+    |> Map.put(:platform_roles, [])
+  end
+end

--- a/test/oli_web/plugs/plug_order_integration_test.exs
+++ b/test/oli_web/plugs/plug_order_integration_test.exs
@@ -108,4 +108,91 @@ defmodule OliWeb.Plugs.PlugOrderIntegrationTest do
       assert conn.halted == true
     end
   end
+
+  describe "MER-5696: template preview paywall bypass" do
+    test "allows paid blueprint access in active template preview mode", %{conn: conn} do
+      section =
+        insert(:section, %{
+          type: :blueprint,
+          requires_enrollment: true,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
+      user = preview_user()
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{
+          template_preview_mode: true,
+          template_preview_section_slug: section.slug
+        })
+        |> assign(:current_user, user)
+        |> assign(:section, section)
+
+      conn = EnforcePaywall.call(conn, [])
+
+      refute conn.halted
+      assert conn.assigns.paywall_summary.available
+      assert conn.assigns.paywall_summary.reason == :instructor
+    end
+
+    test "does not bypass paywall when template preview section does not match", %{conn: conn} do
+      section =
+        insert(:section, %{
+          type: :blueprint,
+          requires_enrollment: true,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
+      user = preview_user()
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{
+          template_preview_mode: true,
+          template_preview_section_slug: "other-section"
+        })
+        |> assign(:current_user, user)
+        |> assign(:section, section)
+
+      conn = EnforcePaywall.call(conn, [])
+
+      assert conn.halted
+      assert conn.resp_body =~ "Not authorized"
+    end
+
+    test "does not bypass paywall for non-blueprint sections", %{conn: conn} do
+      section =
+        insert(:section, %{
+          type: :enrollable,
+          requires_enrollment: true,
+          requires_payment: true,
+          amount: Money.new(:USD, 100)
+        })
+
+      user = preview_user()
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      conn =
+        conn
+        |> Plug.Test.init_test_session(%{
+          template_preview_mode: true,
+          template_preview_section_slug: section.slug
+        })
+        |> assign(:current_user, user)
+        |> assign(:section, section)
+
+      conn = EnforcePaywall.call(conn, [])
+
+      assert conn.halted
+      assert get_resp_header(conn, "location") |> List.first() =~ "payment"
+    end
+  end
+
+  defp preview_user do
+    insert(:user)
+    |> Map.put(:platform_roles, [])
+  end
 end


### PR DESCRIPTION
 ## Summary

  Fixes [MER-5696](https://eliterate.atlassian.net/browse/MER-5696), where paid template preview could redirect authors to the payment page when the same browser session also had a delivery `current_user` login.

  Template preview usually avoids the paywall when it launches through the hidden instructor user, which is the same mechanism commonly used to give admins instructor-style delivery access. However, when a non-hidden delivery `current_user` already exists in the session, template preview uses that user instead and enrolls them into the blueprint section for preview. Because that enrollment is a learner enrollment, normal paywall enforcement can treat the preview like unpaid student access and redirect to /payment.

  ## Changes

  - Added `OliWeb.TemplatePreviewMode` to centralize active template preview detection.
  - Updated `Oli.Plugs.EnforcePaywal`l to bypass paywall enforcement only for active template preview sessions where:
      - `template_preview_mode` is true
      - the preview section slug matches the current section
      - the current section is a blueprint

  - Updated `OliWeb.LiveSessionPlugs.SetPaywallSummary` to assign an instructor-style paywall summary during active template preview.
      - This keeps LiveView delivery state consistent with the plug.
      - It also suppresses payment/grace-period chrome during preview.

  - Left the existing preview enrollment/login behavior unchanged.
  
Note: also added a small drive-by CI stabilization for the unrelated dataset initiator values test by making its assertion order-independent, removing its :flaky tag since it is now deterministic.

  ## Verification

  - mix test test/oli_web/plugs/plug_order_integration_test.exs test/oli_web/live_session_plugs/set_paywall_summary_test.exs
  - mix test test/oli_web/controllers/products_controller_test.exs


[MER-5696]: https://eliterate.atlassian.net/browse/MER-5696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ