### PR TITLE
[BUG FIX] [MER-5721] fix section "Preview course as Student" so doesn't show instructor preview ui

### DIFF
--- a/lib/oli_web/components/layouts/student_delivery.html.heex
+++ b/lib/oli_web/components/layouts/student_delivery.html.heex
@@ -5,7 +5,7 @@
   />
   <div class="sticky top-0 z-50">
     <Components.Delivery.Layouts.instructor_preview_header
-      :if={@preview_mode}
+      :if={OliWeb.Delivery.Instructor.PreviewMode.instructor_preview?(assigns)}
       return_context={preview_return_context(assigns)}
     />
     <Components.Delivery.Layouts.header

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1088,8 +1088,25 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp instructor_preview_request?(conn) do
-    Map.has_key?(conn.query_params, "return_to") or Map.has_key?(conn.params, "return_to")
+    not is_nil(safe_preview_return_to(conn))
   end
+
+  defp safe_preview_return_to(conn) do
+    section_slug = preview_section_slug(conn)
+    return_to = conn.query_params["return_to"] || conn.params["return_to"]
+
+    cond do
+      not is_binary(section_slug) -> nil
+      not is_binary(return_to) -> nil
+      return_to == "" -> nil
+      PreviewReturn.sanitize_return_to(return_to, section_slug) == return_to -> return_to
+      true -> nil
+    end
+  end
+
+  defp preview_section_slug(%{params: %{"section_slug" => section_slug}}), do: section_slug
+  defp preview_section_slug(%{assigns: %{section: %{slug: section_slug}}}), do: section_slug
+  defp preview_section_slug(_conn), do: nil
 
   defp render_student_page_preview(conn, section_slug, revision) do
     section = conn.assigns.section
@@ -1706,10 +1723,9 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp resolve_preview_return(conn) do
-    section_slug = conn.assigns.section.slug
-    return_to = conn.query_params["return_to"]
+    section_slug = preview_section_slug(conn)
 
-    if is_binary(return_to) and return_to != "" do
+    if return_to = safe_preview_return_to(conn) do
       PreviewReturn.resolve(section_slug, return_to)
     else
       PreviewReturn.fallback_context(section_slug)

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1066,19 +1066,44 @@ defmodule OliWeb.PageDeliveryController do
               user,
               revision.content,
               revision.graded,
-              activity_types
+              activity_types,
+              is_instructor: instructor_preview_request?(conn)
             )
         end
 
       revision ->
-        redirect(conn,
-          to:
-            PreviewRoutes.lesson_path(
-              section_slug,
-              revision.slug,
-              preview_lesson_redirect_params(conn)
-            )
-        )
+        if instructor_preview_request?(conn) do
+          redirect(conn,
+            to:
+              PreviewRoutes.lesson_path(
+                section_slug,
+                revision.slug,
+                preview_lesson_redirect_params(conn)
+              )
+          )
+        else
+          render_student_page_preview(conn, section_slug, revision)
+        end
+    end
+  end
+
+  defp instructor_preview_request?(conn) do
+    Map.has_key?(conn.query_params, "return_to") or Map.has_key?(conn.params, "return_to")
+  end
+
+  defp render_student_page_preview(conn, section_slug, revision) do
+    section = conn.assigns.section
+    user = current_preview_user(conn)
+    datashop_session_id = Plug.Conn.get_session(conn, :datashop_session_id)
+
+    conn = assign(conn, :preview_mode, true)
+
+    if is_nil(user) do
+      render(conn, "not_authorized.html")
+    else
+      section
+      |> PageContext.create_for_visit(revision.slug, user, datashop_session_id)
+      |> render_page(conn, section_slug, true)
     end
   end
 
@@ -1175,7 +1200,7 @@ defmodule OliWeb.PageDeliveryController do
          content,
          graded,
          activity_types,
-         opts \\ []
+         opts
        ) do
     section = conn.assigns.section
 
@@ -1209,7 +1234,7 @@ defmodule OliWeb.PageDeliveryController do
         previewMode: Keyword.get(opts, :preview_mode, true),
         reviewMode: Keyword.get(opts, :review_mode, false),
         preserveCapiIframeSize: Keyword.get(opts, :preserve_capi_iframe_size, false),
-        isInstructor: true
+        isInstructor: Keyword.get(opts, :is_instructor, true)
       },
       instructor_preview_return: resolve_preview_return(conn)
     )

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1096,8 +1096,8 @@ defmodule OliWeb.PageDeliveryController do
   defp authorized_instructor_preview?(conn) do
     section_slug = preview_section_slug(conn)
 
-    Sections.is_instructor?(conn.assigns[:current_user], section_slug) or
-      Accounts.is_admin?(conn.assigns[:current_author])
+    Accounts.is_admin?(conn.assigns[:current_author]) or
+      Sections.is_instructor?(conn.assigns[:current_user], section_slug)
   end
 
   defp safe_preview_return_to(conn) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -1088,7 +1088,14 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp instructor_preview_request?(conn) do
-    not is_nil(safe_preview_return_to(conn))
+    authorized_instructor_preview?(conn) and not is_nil(safe_preview_return_to(conn))
+  end
+
+  defp authorized_instructor_preview?(conn) do
+    section_slug = preview_section_slug(conn)
+
+    Sections.is_instructor?(conn.assigns[:current_user], section_slug) or
+      Accounts.is_admin?(conn.assigns[:current_author])
   end
 
   defp safe_preview_return_to(conn) do

--- a/lib/oli_web/controllers/page_delivery_controller.ex
+++ b/lib/oli_web/controllers/page_delivery_controller.ex
@@ -995,6 +995,8 @@ defmodule OliWeb.PageDeliveryController do
           "revision_slug" => revision_slug
         }
       ) do
+    instructor_preview? = instructor_preview_request?(conn)
+
     case Resolver.from_revision_slug(section_slug, revision_slug) do
       %{content: %{"advancedDelivery" => true}} = revision ->
         case conn.assigns.current_user do
@@ -1067,12 +1069,12 @@ defmodule OliWeb.PageDeliveryController do
               revision.content,
               revision.graded,
               activity_types,
-              is_instructor: instructor_preview_request?(conn)
+              is_instructor: instructor_preview?
             )
         end
 
       revision ->
-        if instructor_preview_request?(conn) do
+        if instructor_preview? do
           redirect(conn,
             to:
               PreviewRoutes.lesson_path(
@@ -1088,7 +1090,7 @@ defmodule OliWeb.PageDeliveryController do
   end
 
   defp instructor_preview_request?(conn) do
-    authorized_instructor_preview?(conn) and not is_nil(safe_preview_return_to(conn))
+    not is_nil(safe_preview_return_to(conn)) and authorized_instructor_preview?(conn)
   end
 
   defp authorized_instructor_preview?(conn) do

--- a/lib/oli_web/delivery/instructor/preview_mode.ex
+++ b/lib/oli_web/delivery/instructor/preview_mode.ex
@@ -1,0 +1,37 @@
+defmodule OliWeb.Delivery.Instructor.PreviewMode do
+  @moduledoc """
+  Small predicates for the instructor preview shell.
+
+  Student section preview and instructor preview currently share several `/sections/:slug/preview`
+  routes. The distinguishing signal for the instructor preview shell is the presence of an
+  `instructor_preview_return` context, derived from a safe `return_to` URL. Plain student section
+  preview has `preview_mode: true` without that return context.
+  """
+
+  def preview_mode?(%{assigns: assigns}), do: preview_mode?(assigns)
+
+  def preview_mode?(assigns) when is_map(assigns), do: Map.get(assigns, :preview_mode) == true
+
+  def preview_mode?(_), do: false
+
+  def instructor_preview?(%{assigns: assigns}), do: instructor_preview?(assigns)
+
+  def instructor_preview?(assigns) when is_map(assigns) do
+    preview_mode?(assigns) and
+      assigns
+      |> Map.get(:instructor_preview_return)
+      |> return_context?()
+  end
+
+  def instructor_preview?(_), do: false
+
+  def student_section_preview?(%{assigns: assigns}), do: student_section_preview?(assigns)
+
+  def student_section_preview?(assigns) when is_map(assigns),
+    do: preview_mode?(assigns) and not instructor_preview?(assigns)
+
+  def student_section_preview?(_), do: false
+
+  defp return_context?(%{path: path}) when is_binary(path) and path != "", do: true
+  defp return_context?(_), do: false
+end

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -794,11 +794,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   end
 
   defp assign_preview_shell_state(socket) do
+    instructor_preview_return =
+      socket.assigns[:instructor_preview_return] ||
+        PreviewReturn.fallback_context(socket.assigns.section_slug)
+
     selected_view =
       preview_selected_view(
         Map.get(socket.assigns.navigation_params, "request_path") ||
-          socket.assigns.instructor_preview_return.path
+          instructor_preview_return.path
       )
+
+    socket = assign(socket, :instructor_preview_return, instructor_preview_return)
 
     socket
     |> assign(

--- a/lib/oli_web/live/delivery/student/utils.ex
+++ b/lib/oli_web/live/delivery/student/utils.ex
@@ -424,10 +424,14 @@ defmodule OliWeb.Delivery.Student.Utils do
 
     case {preview_mode, params} do
       {true, %{} = params} when map_size(params) == 0 ->
-        PreviewRoutes.lesson_path(section_slug, revision_slug)
+        ~p"/sections/#{section_slug}/preview/page/#{revision_slug}"
+
+      {true, %{} = params}
+      when is_map_key(params, :return_to) or is_map_key(params, "return_to") ->
+        PreviewRoutes.lesson_path(section_slug, revision_slug, params)
 
       {true, params} ->
-        PreviewRoutes.lesson_path(section_slug, revision_slug, params)
+        ~p"/sections/#{section_slug}/preview/page/#{revision_slug}?#{params}"
 
       {false, %{} = params} when map_size(params) == 0 ->
         ~p"/sections/#{section_slug}/lesson/#{revision_slug}"

--- a/lib/oli_web/live_session_plugs/set_instructor_preview_return.ex
+++ b/lib/oli_web/live_session_plugs/set_instructor_preview_return.ex
@@ -7,20 +7,17 @@ defmodule OliWeb.LiveSessionPlugs.SetInstructorPreviewReturn do
     {:cont, socket}
   end
 
-  def on_mount(
-        :default,
-        %{"return_to" => return_to},
-        _session,
-        %{assigns: %{section: %{slug: section_slug}}} = socket
-      )
-      when is_binary(return_to) and return_to != "" do
-    {:cont,
-     assign(socket,
-       instructor_preview_return: PreviewReturn.resolve(section_slug, return_to)
-     )}
-  end
+  def on_mount(:default, params, _session, socket) do
+    case {params, socket.assigns[:section]} do
+      {%{"return_to" => return_to}, %{slug: section_slug}}
+      when is_binary(return_to) and return_to != "" ->
+        {:cont,
+         assign(socket,
+           instructor_preview_return: PreviewReturn.resolve(section_slug, return_to)
+         )}
 
-  def on_mount(:default, _params, _session, socket) do
-    {:cont, socket}
+      _ ->
+        {:cont, socket}
+    end
   end
 end

--- a/lib/oli_web/live_session_plugs/set_instructor_preview_return.ex
+++ b/lib/oli_web/live_session_plugs/set_instructor_preview_return.ex
@@ -7,10 +7,16 @@ defmodule OliWeb.LiveSessionPlugs.SetInstructorPreviewReturn do
     {:cont, socket}
   end
 
-  def on_mount(:default, params, _session, %{assigns: %{section: %{slug: section_slug}}} = socket) do
+  def on_mount(
+        :default,
+        %{"return_to" => return_to},
+        _session,
+        %{assigns: %{section: %{slug: section_slug}}} = socket
+      )
+      when is_binary(return_to) and return_to != "" do
     {:cont,
      assign(socket,
-       instructor_preview_return: PreviewReturn.resolve(section_slug, params["return_to"])
+       instructor_preview_return: PreviewReturn.resolve(section_slug, return_to)
      )}
   end
 

--- a/lib/oli_web/templates/resource/advanced_page_preview.html.heex
+++ b/lib/oli_web/templates/resource/advanced_page_preview.html.heex
@@ -27,7 +27,10 @@
   }
 </style>
 
-<div :if={Map.get(assigns, :instructor_preview_return)} class="fixed inset-x-0 top-0 z-[1060]">
+<div
+  :if={OliWeb.Delivery.Instructor.PreviewMode.instructor_preview?(assigns)}
+  class="fixed inset-x-0 top-0 z-[1060]"
+>
   <OliWeb.Components.Delivery.Layouts.instructor_preview_header return_context={
     Map.get(assigns, :instructor_preview_return)
   } />
@@ -55,7 +58,9 @@
 <div
   id="delivery_container"
   class={
-    if Map.get(assigns, :instructor_preview_return), do: "adaptive-preview-shell pt-20", else: ""
+    if OliWeb.Delivery.Instructor.PreviewMode.instructor_preview?(assigns),
+      do: "adaptive-preview-shell pt-20",
+      else: ""
   }
 >
   {react_component("Components.Delivery", @app_params)}

--- a/test/oli_web/components/delivery/assignments/assignment_card_test.exs
+++ b/test/oli_web/components/delivery/assignments/assignment_card_test.exs
@@ -187,7 +187,7 @@ defmodule OliWeb.Components.Delivery.AssignmentCardTest do
 
       html = render_component(&AssignmentCard.render/1, assigns)
 
-      assert html =~ "/sections/test-section/preview/lesson/test-assignment"
+      assert html =~ "/sections/test-section/preview/page/test-assignment"
       assert html =~ "request_path=%2Fsections%2Ftest-section%2Fpreview%2Fassignments"
     end
 

--- a/test/oli_web/components/delivery/deliberate_practice_card_test.exs
+++ b/test/oli_web/components/delivery/deliberate_practice_card_test.exs
@@ -6,7 +6,7 @@ defmodule OliWeb.Components.Delivery.DeliberatePracticeCardTest do
   alias OliWeb.Components.Delivery.DeliberatePractice
 
   describe "practice_card/1" do
-    test "uses the new preview lesson route in preview mode" do
+    test "uses the student preview page route in preview mode" do
       assigns = %{
         dark: false,
         practice: %{
@@ -21,7 +21,7 @@ defmodule OliWeb.Components.Delivery.DeliberatePracticeCardTest do
 
       html = render_component(&DeliberatePractice.practice_card/1, assigns)
 
-      assert html =~ "/sections/test-section/preview/lesson/practice-title"
+      assert html =~ "/sections/test-section/preview/page/practice-title"
       assert html =~ "request_path=%2Fsections%2Ftest-section%2Fpreview%2Fpractice"
     end
   end

--- a/test/oli_web/components/delivery/exploration_card_test.exs
+++ b/test/oli_web/components/delivery/exploration_card_test.exs
@@ -63,7 +63,7 @@ defmodule OliWeb.Components.Delivery.ExplorationCardTest do
 
       html = render_component(&ExplorationCard.render/1, assigns)
 
-      assert html =~ "/sections/test-section/preview/lesson/test-exploration"
+      assert html =~ "/sections/test-section/preview/page/test-exploration"
       assert html =~ "request_path=%2Fsections%2Ftest-section%2Fpreview%2Fexplorations"
     end
 

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -2172,7 +2172,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                })
     end
 
-    test "page preview drops unsupported and unsafe query params when redirecting basic pages",
+    test "page preview ignores unsafe return_to when rendering basic pages",
          %{
            conn: conn,
            user: user,
@@ -2190,7 +2190,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
           }
         )
 
-      assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, page_revision.slug)
+      html = html_response(conn, 200)
+      assert html =~ page_revision.title
+      refute html =~ "instructor-preview-activity-wrapper"
     end
 
     test "page preview renders basic mixed pages in student preview", %{

--- a/test/oli_web/controllers/page_delivery_controller_test.exs
+++ b/test/oli_web/controllers/page_delivery_controller_test.exs
@@ -2135,7 +2135,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html_response(conn, 200) =~ section.title
     end
 
-    test "page preview - redirects basic pages to the preview lesson route", %{
+    test "page preview - renders basic pages in student preview", %{
       conn: conn,
       user: user,
       revision: revision,
@@ -2146,7 +2146,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> log_in_user(user)
         |> get(Routes.page_delivery_path(conn, :page_preview, section.slug, revision.slug))
 
-      assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, revision.slug)
+      html = html_response(conn, 200)
+      assert html =~ revision.title
+      refute html =~ "instructor-preview-activity-wrapper"
     end
 
     test "page preview preserves query params when redirecting basic pages",
@@ -2191,7 +2193,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, page_revision.slug)
     end
 
-    test "page preview redirects basic mixed pages before rendering activity preview scripts", %{
+    test "page preview renders basic mixed pages in student preview", %{
       conn: conn,
       user: user
     } do
@@ -2202,7 +2204,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
         |> log_in_user(user)
         |> get(Routes.page_delivery_path(conn, :page_preview, section.slug, page_revision.slug))
 
-      assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, page_revision.slug)
+      html = html_response(conn, 200)
+      assert html =~ page_revision.title
+      refute html =~ "instructor-preview-activity-wrapper"
     end
 
     test "page preview - adaptive renders ok", %{
@@ -2245,7 +2249,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
                "Instructor preview of adaptive activities by admin accounts is not supported"
     end
 
-    test "page preview - graded basic pages redirect without rendering prologue", %{
+    test "page preview - graded basic pages render as student preview", %{
       conn: conn,
       section: section,
       page_revision: page_revision
@@ -2256,7 +2260,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
           Routes.page_delivery_path(conn, :page_preview, section.slug, page_revision.slug)
         )
 
-      assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, page_revision.slug)
+      html = html_response(conn, 200)
+      assert html =~ page_revision.title
+      refute html =~ "instructor-preview-activity-wrapper"
     end
 
     test "index preview - can access if the user is logged in as instructor", %{
@@ -2274,7 +2280,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         )
 
       assert html_response(conn, 200) =~ section.title
-      assert html_response(conn, 200) =~ "instructor-preview-header"
+      refute html_response(conn, 200) =~ "instructor-preview-header"
     end
 
     test "index preview - can access if the user is logged in as admin", %{
@@ -2291,7 +2297,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
         )
 
       assert html_response(conn, 200) =~ section.title
-      assert html_response(conn, 200) =~ "instructor-preview-header"
+      refute html_response(conn, 200) =~ "instructor-preview-header"
     end
 
     test "activity bank selection preview route remains outside preview lesson LiveView", %{
@@ -2332,7 +2338,7 @@ defmodule OliWeb.PageDeliveryControllerTest do
       assert html =~ "instructor-preview-lesson"
     end
 
-    test "shows page index based navigation redirects to preview lesson route", %{
+    test "shows page index based navigation renders student preview", %{
       conn: conn,
       section: section,
       page_revision: page_revision
@@ -2343,7 +2349,9 @@ defmodule OliWeb.PageDeliveryControllerTest do
           Routes.page_delivery_path(conn, :page_preview, section.slug, page_revision.slug)
         )
 
-      assert redirected_to(conn) == PreviewRoutes.lesson_path(section.slug, page_revision.slug)
+      html = html_response(conn, 200)
+      assert html =~ page_revision.title
+      refute html =~ "instructor-preview-activity-wrapper"
     end
   end
 

--- a/test/oli_web/live/delivery/student/assignments_live_test.exs
+++ b/test/oli_web/live/delivery/student/assignments_live_test.exs
@@ -432,11 +432,9 @@ defmodule OliWeb.Delivery.Student.AssignmentsLiveTest do
           request_path:
             StudentUtils.assignments_live_path(section.slug,
               preview_mode: true,
-              sidebar_expanded: true,
-              return_to: "/sections/#{section.slug}/remix"
+              sidebar_expanded: true
             ),
-          preview_mode: true,
-          return_to: "/sections/#{section.slug}/remix"
+          preview_mode: true
         )
       )
     end

--- a/test/oli_web/live/delivery/student/explorations_live_test.exs
+++ b/test/oli_web/live/delivery/student/explorations_live_test.exs
@@ -311,11 +311,9 @@ defmodule OliWeb.Delivery.Student.ExplorationsLiveTest do
           request_path:
             StudentUtils.explorations_live_path(section.slug,
               preview_mode: true,
-              sidebar_expanded: true,
-              return_to: "/sections/#{section.slug}/remix"
+              sidebar_expanded: true
             ),
-          preview_mode: true,
-          return_to: "/sections/#{section.slug}/remix"
+          preview_mode: true
         )
       )
 

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1272,8 +1272,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                "href=\"#{StudentUtils.lesson_live_path(section.slug, page_1.slug,
                request_path: ~p"/sections/#{section.slug}/preview?sidebar_expanded=true",
                preview_mode: true,
-               sidebar_expanded: true,
-               return_to: "/sections/#{section.slug}/remix")}\""
+               sidebar_expanded: true)}\""
              )
 
       assert element(
@@ -1283,8 +1282,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
                target_resource_id: page_2.resource_id,
                request_path: ~p"/sections/#{section.slug}/preview?sidebar_expanded=true",
                preview_mode: true,
-               sidebar_expanded: true,
-               return_to: "/sections/#{section.slug}/remix")}\""
+               sidebar_expanded: true)}\""
              )
 
       {:error, {:live_redirect, %{kind: :push, to: assignments_path}}} =
@@ -1295,11 +1293,9 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert_same_url(
         assignments_path,
         StudentUtils.assignments_live_path(section.slug,
-          request_path:
-            ~p"/sections/#{section.slug}/preview?#{[sidebar_expanded: true, return_to: "/sections/#{section.slug}/remix"]}",
+          request_path: ~p"/sections/#{section.slug}/preview?#{[sidebar_expanded: true]}",
           preview_mode: true,
-          sidebar_expanded: true,
-          return_to: "/sections/#{section.slug}/remix"
+          sidebar_expanded: true
         )
       )
 
@@ -1313,11 +1309,9 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert_same_url(
         schedule_path,
         StudentUtils.schedule_live_path(section.slug,
-          request_path:
-            ~p"/sections/#{section.slug}/preview?#{[sidebar_expanded: true, return_to: "/sections/#{section.slug}/remix"]}",
+          request_path: ~p"/sections/#{section.slug}/preview?#{[sidebar_expanded: true]}",
           preview_mode: true,
-          sidebar_expanded: true,
-          return_to: "/sections/#{section.slug}/remix"
+          sidebar_expanded: true
         )
       )
     end

--- a/test/oli_web/live/delivery/student/learn_live_test.exs
+++ b/test/oli_web/live/delivery/student/learn_live_test.exs
@@ -2971,7 +2971,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       {:ok, view, _html} =
         live(conn, "/sections/#{section.slug}/preview/learn?selected_view=gallery")
 
-      assert has_element?(view, "#instructor-preview-header")
+      refute has_element?(view, "#instructor-preview-header")
 
       # Verify we're in gallery view
       assert has_element?(view, ~s{div[id=view_selector] div}, "Gallery")
@@ -3258,20 +3258,20 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       stub_current_time(~U[2023-11-04 20:00:00Z])
       {:ok, view, _html} = live(conn, "/sections/#{section.slug}/preview")
 
-      assert has_element?(view, "#instructor-preview-header")
+      refute has_element?(view, "#instructor-preview-header")
 
       view
       |> element(~s{nav[id='desktop-nav-menu'] a[id='desktop_discussions_nav_link']})
       |> render_click()
 
       redirect_path =
-        ~p"/sections/#{section.slug}/preview/discussions?#{%{sidebar_expanded: true, return_to: "/sections/#{section.slug}/remix"}}"
+        ~p"/sections/#{section.slug}/preview/discussions?#{%{sidebar_expanded: true}}"
 
       assert_redirect(view, redirect_path)
 
       {:ok, view, _html} = live(conn, redirect_path)
 
-      assert has_element?(view, "#instructor-preview-header")
+      refute has_element?(view, "#instructor-preview-header")
       assert view |> has_element?(~s{h1}, "Notes")
     end
 
@@ -3287,7 +3287,7 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       stub_current_time(~U[2023-11-04 20:00:00Z])
       {:ok, view, _html} = live(conn, "/sections/#{section.slug}/preview")
 
-      assert has_element?(view, "#instructor-preview-header")
+      refute has_element?(view, "#instructor-preview-header")
 
       view
       |> element(~s{nav[id='desktop-nav-menu'] a[id='desktop_practice_nav_link']})
@@ -3296,15 +3296,14 @@ defmodule OliWeb.Delivery.Student.ContentLiveTest do
       redirect_path =
         Utils.practice_live_path(section.slug,
           preview_mode: true,
-          sidebar_expanded: true,
-          return_to: "/sections/#{section.slug}/remix"
+          sidebar_expanded: true
         )
 
       assert_redirect(view, redirect_path)
 
       {:ok, view, _html} = live(conn, redirect_path)
 
-      assert has_element?(view, "#instructor-preview-header")
+      refute has_element?(view, "#instructor-preview-header")
       assert view |> element(~s{h1.text-4xl}) |> render() =~ "Your Practice Pages"
     end
   end

--- a/test/oli_web/live/delivery/student/schedule_live_test.exs
+++ b/test/oli_web/live/delivery/student/schedule_live_test.exs
@@ -639,11 +639,9 @@ defmodule OliWeb.Delivery.Student.ScheduleLiveTest do
           request_path:
             StudentUtils.schedule_live_path(section.slug,
               preview_mode: true,
-              sidebar_expanded: true,
-              return_to: "/sections/#{section.slug}/remix"
+              sidebar_expanded: true
             ),
-          preview_mode: true,
-          return_to: "/sections/#{section.slug}/remix"
+          preview_mode: true
         )
       )
     end
@@ -912,11 +910,9 @@ defmodule OliWeb.Delivery.Student.ScheduleLiveTest do
           request_path:
             StudentUtils.schedule_live_path(section.slug,
               preview_mode: true,
-              sidebar_expanded: true,
-              return_to: "/sections/#{section.slug}/remix"
+              sidebar_expanded: true
             ),
-          preview_mode: true,
-          return_to: "/sections/#{section.slug}/remix"
+          preview_mode: true
         )
       )
     end

--- a/test/oli_web/live/delivery/student/utils_test.exs
+++ b/test/oli_web/live/delivery/student/utils_test.exs
@@ -241,7 +241,7 @@ defmodule OliWeb.Delivery.Student.UtilsTest do
                preview_mode: true,
                request_path: "/sections/math/preview"
              ) ==
-               "/sections/math/preview/lesson/intro?request_path=%2Fsections%2Fmath%2Fpreview"
+               "/sections/math/preview/page/intro?request_path=%2Fsections%2Fmath%2Fpreview"
 
       assert Utils.learn_live_path("math", request_path: "/sections/math") ==
                "/sections/math/learn?request_path=%2Fsections%2Fmath"


### PR DESCRIPTION


 ## Summary

  [MER-5721](https://eliterate.atlassian.net/browse/MER-5721) Fixes student section preview so it no longer enters the instructor preview rendering path. "Student section preview" means the preview mode accessed via "Preview Course as Student" on Section Manage page, intended to show course as student will see it.

  The “Preview Course as Student” flow should show student-facing delivery preview. It should not show the instructor preview header, and page content should not render through instructor preview activity rendering with customization/authoring affordances.

  ## Root Cause

  Recent instructor preview work added a new instructor preview shell and routed preview page links through `/sections/:slug/preview/lesson/:revision_slug`.

  That route is the instructor preview LiveView path. It renders pages with instructor preview context, including instructor preview activity rendering and related customization controls.

  The existing student section preview also used the shared `/sections/:slug/preview namespace`. Because both flows were represented mostly as `preview_mode: true`, student section preview links could be generated which pointed into the instructor preview route. As a result, “Preview Course as Student” led to course page previews with the instructor preview header and rendering embedded activities as instructor preview instead of student delivery preview.

  ## Changes

  - Student section preview page links now route to `/sections/:slug/preview/page/:revision_slug` unless instructor preview return context is present.
  - Instructor preview still routes to `/sections/:slug/preview/lesson/:revision_slug` when launched with `return_to`.
  - `/preview/page/:revision_slug` now renders basic pages through student delivery preview unless the request is identified as instructor preview.
  - Advanced page preview passes isInstructor based on whether the request is instructor preview.
  - The instructor preview header is only shown when instructor preview return context exists.
  - Direct instructor preview lesson routes still get a fallback return context.
  - Added small predicates documenting the current distinction:
      - `instructor_preview?/1`
      - `student_section_preview?/1`

  - Updated tests so student section preview expectations point to student preview page routes rather than instructor preview lesson routes.

  ## Verification

  Ran focused preview-related tests:

  ```
mix test test/oli_web/controllers/page_delivery_controller_test.exs test/oli_web/live/delivery/student/index_live_test.exs test/oli_web/live/delivery/
  student/learn_live_test.exs
  mix test test/oli_web/components/delivery/exploration_card_test.exs test/oli_web/components/delivery/assignments/assignment_card_test.exs test/oli_web/
  components/delivery/deliberate_practice_card_test.exs test/oli_web/live/delivery/student/explorations_live_test.exs test/oli_web/live/delivery/student/
  assignments_live_test.exs test/oli_web/live/delivery/student/schedule_live_test.exs test/oli_web/live/delivery/student/utils_test.exs

```

[MER-5721]: https://eliterate.atlassian.net/browse/MER-5721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ