### PR TITLE
[BUG FIX] [MER-5723] Mark adaptive practice pages complete on finalize

### DIFF
--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -245,9 +245,7 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
          revision: %{content: %{"advancedDelivery" => true}},
          resource_access_id: resource_access_id
        }) do
-    resource_access_id
-    |> Oli.Delivery.Attempts.Core.get_resource_access()
-    |> Oli.Delivery.Metrics.mark_progress_completed()
+    Oli.Delivery.Metrics.mark_progress_completed(resource_access_id)
   end
 
   defp maybe_mark_adaptive_progress_completed(_), do: {:ok, nil}

--- a/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
+++ b/lib/oli/delivery/attempts/page_lifecycle/ungraded.ex
@@ -58,6 +58,8 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
   end
 
   @impl Lifecycle
+  @spec finalize(FinalizationContext.t()) ::
+          {:ok, FinalizationSummary.t()} | {:error, term()}
   @decorate transaction_event("Ungraded.finalize")
   def finalize(%FinalizationContext{
         resource_attempt: %ResourceAttempt{lifecycle_state: :active} = resource_attempt,
@@ -68,16 +70,19 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
     update_attrs =
       determine_finalization_attrs(resource_attempt, now)
 
-    {:ok, updated_resource_attempt} = update_resource_attempt(resource_attempt, update_attrs)
-
-    {:ok,
-     %FinalizationSummary{
-       graded: false,
-       lifecycle_state: updated_resource_attempt.lifecycle_state,
-       resource_access: nil,
-       part_attempt_guids: nil,
-       effective_settings: effective_settings
-     }}
+    with {:ok, updated_resource_attempt} <-
+           update_resource_attempt(resource_attempt, update_attrs),
+         {:ok, _resource_access} <-
+           maybe_mark_adaptive_progress_completed(updated_resource_attempt) do
+      {:ok,
+       %FinalizationSummary{
+         graded: false,
+         lifecycle_state: updated_resource_attempt.lifecycle_state,
+         resource_access: nil,
+         part_attempt_guids: nil,
+         effective_settings: effective_settings
+       }}
+    end
   end
 
   @impl Lifecycle
@@ -235,4 +240,15 @@ defmodule Oli.Delivery.Attempts.PageLifecycle.Ungraded do
           lifecycle_state in [:evaluated, :submitted] or !scoreable
       end)
   end
+
+  defp maybe_mark_adaptive_progress_completed(%ResourceAttempt{
+         revision: %{content: %{"advancedDelivery" => true}},
+         resource_access_id: resource_access_id
+       }) do
+    resource_access_id
+    |> Oli.Delivery.Attempts.Core.get_resource_access()
+    |> Oli.Delivery.Metrics.mark_progress_completed()
+  end
+
+  defp maybe_mark_adaptive_progress_completed(_), do: {:ok, nil}
 end

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1198,6 +1198,13 @@ defmodule Oli.Delivery.Metrics do
     end
   end
 
+  def mark_progress_completed(resource_access_id) when is_integer(resource_access_id) do
+    case Core.get_resource_access(resource_access_id) do
+      nil -> {:error, :resource_access_not_found}
+      ra -> mark_progress_completed(ra)
+    end
+  end
+
   def mark_progress_completed(%ResourceAccess{} = ra) do
     Core.update_resource_access(ra, %{progress: 1.0})
   end

--- a/test/oli/delivery/attempts/page_lifecycle_test.exs
+++ b/test/oli/delivery/attempts/page_lifecycle_test.exs
@@ -480,9 +480,13 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
 
       resource_attempt = Core.get_resource_attempt_by(attempt_guid: ungraded_attempt.attempt_guid)
 
+      resource_access =
+        Repo.get!(Oli.Delivery.Attempts.Core.ResourceAccess, resource_attempt.resource_access_id)
+
       assert resource_attempt.lifecycle_state == :evaluated
       assert resource_attempt.score == 2.0
       assert resource_attempt.out_of == 4.0
+      assert resource_access.progress == 1.0
     end
 
     test "ungraded adaptive finalization stays submitted when manual grading is still pending",
@@ -502,11 +506,15 @@ defmodule Oli.Delivery.Attempts.PageLifecycleTest do
       resource_attempt =
         Core.get_resource_attempt_by(attempt_guid: ungraded_pending_attempt.attempt_guid)
 
+      resource_access =
+        Repo.get!(Oli.Delivery.Attempts.Core.ResourceAccess, resource_attempt.resource_access_id)
+
       assert resource_attempt.lifecycle_state == :submitted
       assert is_nil(resource_attempt.date_evaluated)
       refute is_nil(resource_attempt.date_submitted)
       assert is_nil(resource_attempt.score)
       assert is_nil(resource_attempt.out_of)
+      assert resource_access.progress == 1.0
     end
   end
 end

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -298,6 +298,21 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       assert this_user_progress == 0.5
     end
 
+    test "mark_progress_completed/1 updates progress when given a resource_access_id" do
+      resource_access = insert(:resource_access, progress: 0.25)
+
+      assert {:ok, _resource_access} = Metrics.mark_progress_completed(resource_access.id)
+
+      updated_resource_access = Oli.Repo.get!(ResourceAccess, resource_access.id)
+
+      assert updated_resource_access.progress == 1.0
+    end
+
+    test "mark_progress_completed/1 returns an error for an unknown resource_access_id" do
+      assert {:error, :resource_access_not_found} =
+               Metrics.mark_progress_completed(-1)
+    end
+
     test "progress_across_for_pages/3 calculates correctly", %{
       mod1_pages: mod1_pages,
       this_user: this_user,


### PR DESCRIPTION
# MER-5723 Adaptive pages not always showing 100% completion

Jira ticket: https://eliterate.atlassian.net/browse/MER-5723

## Summary

This fixes a regression where adaptive practice pages could finish successfully while still showing partial completion, such as `77%`, instead of `100%`.

The issue affected adaptive pages with branching paths, where learners can validly complete the lesson without visiting every screen.

## Root Cause

Adaptive ungraded page finalization was updating the `resource_attempt` lifecycle and rollup state, but it was no longer forcing the associated `resource_access.progress` to `1.0`.

Historically, that completion update was handled from the client-side adaptive finish flow. That path was removed in the adaptive payment/review flow refactor, and the backend finalize path did not take over responsibility for marking progress complete.

Regression introduced by:

- `MER-5049 / MER-5054` in PR `#6401`, which removed the client-side `mark_completed` adaptive finish behavior

## Changes

- Add a regression test proving that ungraded adaptive page finalization sets page progress to `100%`
- Cover both finalized adaptive outcomes:
  - evaluated attempts
  - submitted attempts with manual grading still pending
- Update the backend ungraded adaptive finalize path to mark the related `resource_access` as complete

## Why This Fix

The fix is implemented in the backend finalization path instead of restoring the client-side behavior.

That keeps the business rule in the authoritative server-side workflow and ensures adaptive practice completion does not depend on a specific UI path or frontend caller.

The completion update is also kept atomic with the existing `PageLifecycle.finalize/3` transaction, so adaptive ungraded finalization and progress completion now succeed or fail together.

## Verification


https://github.com/user-attachments/assets/c1a29b96-04c7-4106-b942-803327a78821



Executed:

```bash
mix test test/oli/delivery/attempts/page_lifecycle_test.exs
mix format lib/oli/delivery/attempts/page_lifecycle/ungraded.ex test/oli/delivery/attempts/page_lifecycle_test.exs
```

Result:

- regression reproduced before the fix with `resource_access.progress == 0.0`
- targeted test module passes after the fix

## Risk

Low.

The change is narrowly scoped to ungraded adaptive page finalization and does not alter the in-progress activity-based progress calculation during the attempt.
