### PR TITLE
[ENHANCEMENT] [MER-5729] Adding ARIA Labels to the Hub & Spoke Component

### DIFF
--- a/assets/src/components/parts/janus-hub-spoke/HubSpoke.tsx
+++ b/assets/src/components/parts/janus-hub-spoke/HubSpoke.tsx
@@ -270,7 +270,7 @@ const HubSpoke: React.FC<PartComponentProps<hubSpokeModel>> = (props) => {
     <React.Fragment>
       {ready ? (
         <>
-          <div data-janus-type={tagName} style={styles} className={`hub-spoke spoke-${layoutType}`}>
+          <div data-janus-type={tagName} style={styles} className={`hub-spoke spoke-${layoutType}`} role="navigation" aria-label="Menu of items">
             {layoutType === 'horizontalLayout' ? (
               <div className="spoke-items-row">
                 {options.map((item, index) => (

--- a/assets/src/components/parts/janus-hub-spoke/HubSpoke.tsx
+++ b/assets/src/components/parts/janus-hub-spoke/HubSpoke.tsx
@@ -270,7 +270,13 @@ const HubSpoke: React.FC<PartComponentProps<hubSpokeModel>> = (props) => {
     <React.Fragment>
       {ready ? (
         <>
-          <div data-janus-type={tagName} style={styles} className={`hub-spoke spoke-${layoutType}`} role="navigation" aria-label="Menu of items">
+          <div
+            data-janus-type={tagName}
+            style={styles}
+            className={`hub-spoke spoke-${layoutType}`}
+            role="navigation"
+            aria-label="Menu of items"
+          >
             {layoutType === 'horizontalLayout' ? (
               <div className="spoke-items-row">
                 {options.map((item, index) => (


### PR DESCRIPTION
This is a super simple edit to the Simple Author Component Hub and Spoke. It's meant to have an Aria-label that reads "Menu of Items". This was a simple add-on, as I just needed to add the aria-label prop to the main React component. When using VoiceOver on Mac, the "Menu of Items" is read, and each subsequent spoke is read based on its title. 