### PR TITLE
[ENHANCEMENT] [MER-5730] Add ARIA Label to Video Component in Advanced Author

### DIFF
--- a/assets/src/components/parts/janus-video/Video.tsx
+++ b/assets/src/components/parts/janus-video/Video.tsx
@@ -262,6 +262,7 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
     enableReplay = true,
     subtitles,
     alt,
+    ariaLabel,
   } = model;
 
   const subtitleTracks: SubtitleTrack[] = (
@@ -458,12 +459,25 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
     });
   };
 
+  const trimmedAriaLabel = ariaLabel?.trim();
+  const trimmedDescription = alt?.trim();
+  const descriptionId = `video-desc-${id}`;
+  const hasDescription = Boolean(trimmedDescription);
+  const videoAriaLabel = trimmedAriaLabel
+    ? `Play ${trimmedAriaLabel}`
+    : trimmedDescription
+    ? `Video. Description: ${trimmedDescription}`
+    : 'Play video';
+  const videoAriaDescription = trimmedDescription || undefined;
+  const videoAriaDescribedBy = hasDescription ? descriptionId : undefined;
+
   const iframeTag = (
     <div
       tabIndex={0}
       role="group"
-      aria-label={alt && alt.trim() ? `Video. Description: ${alt}` : 'Video'}
-      aria-describedby={alt && alt.trim() ? `video-desc-${id}` : undefined}
+      aria-label={videoAriaLabel}
+      aria-describedby={videoAriaDescribedBy}
+      aria-description={videoAriaDescription}
     >
       <YouTube
         videoId={videoId}
@@ -491,8 +505,9 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
       onEnded={handleVideoEnd}
       onPlay={handleVideoPlay}
       onPause={handleVideoPause}
-      aria-label={alt && alt.trim() ? `Video. Description: ${alt}` : 'Video'}
-      aria-describedby={alt && alt.trim() ? `video-desc-${id}` : undefined}
+      aria-label={videoAriaLabel}
+      aria-describedby={videoAriaDescribedBy}
+      aria-description={videoAriaDescription}
     >
       <source src={finalSrc} />
       <source src={srcAsWebm} />
@@ -514,14 +529,12 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
   );
 
   const elementTag = youtubeRegex.test(src) ? iframeTag : videoTag;
-  const descriptionId = `video-desc-${id}`;
-  const hasDescription = alt && alt.trim();
 
   return ready ? (
     <div
       data-janus-type={tagName}
       style={{ width: '100%', height: '100%' }}
-      aria-describedby={hasDescription ? descriptionId : undefined}
+      aria-describedby={videoAriaDescribedBy}
     >
       <style>
         {`
@@ -533,7 +546,7 @@ const Video: React.FC<PartComponentProps<VideoModel>> = (props) => {
       </style>
       {hasDescription && (
         <span id={descriptionId} className="sr-only">
-          Description: {alt}
+          Description: {trimmedDescription}
         </span>
       )}
       {elementTag}

--- a/assets/src/components/parts/janus-video/schema.ts
+++ b/assets/src/components/parts/janus-video/schema.ts
@@ -7,6 +7,7 @@ import { JanusAbsolutePositioned, JanusCustomCss } from '../types/parts';
 export interface VideoModel extends JanusAbsolutePositioned, JanusCustomCss {
   src: string;
   alt: string;
+  ariaLabel: string;
   triggerCheck: boolean;
   autoPlay: boolean;
   startTime: number;
@@ -32,6 +33,10 @@ export const schema: JSONSchema7Object = {
   },
   src: {
     title: 'Source',
+    type: 'string',
+  },
+  ariaLabel: {
+    title: 'ARIA Label',
     type: 'string',
   },
   alt: {
@@ -92,6 +97,10 @@ export const schema: JSONSchema7Object = {
 export const simpleSchema: JSONSchema7Object = {
   src: {
     title: 'Source',
+    type: 'string',
+  },
+  ariaLabel: {
+    title: 'ARIA Label',
     type: 'string',
   },
   alt: {
@@ -201,6 +210,7 @@ export const createSchema = (): Partial<VideoModel> => ({
   endTime: 0,
   src: '',
   alt: '',
+  ariaLabel: '',
   customCssClass: '',
   triggerCheck: false,
   subtitles: [],


### PR DESCRIPTION
This is an update to the video component in Advanced Author and Simple Author to add an ARIA label. The edit is also backward-compatible: previous components with "alt text" will still be announced by the screen reader. The ARIA label also has default strings in case it's blank (Play video), but the description will not be read if it does not have any filled in string. 