### PR TITLE
[BUG FIX] [MER-5731] Fix Black Text Color in MCQ Component

### DIFF
--- a/assets/src/components/parts/janus-text-flow/TextFlow.tsx
+++ b/assets/src/components/parts/janus-text-flow/TextFlow.tsx
@@ -35,9 +35,6 @@ export const getStylesToOverwrite = (node: MarkupTree, child: MarkupTree, fontSi
     // PMP-526
     style.backgroundColor = '';
   }
-  if (node.tag === 'p' && child.tag === 'span' && child.style.color === '#000000') {
-    style.color = 'inherit';
-  }
   if (!(child.style && child.style.fontSize) && fontSize) {
     style.fontSize = `${fontSize}px`;
   }

--- a/assets/src/components/parts/janus-text-flow/TextFlowAuthor.tsx
+++ b/assets/src/components/parts/janus-text-flow/TextFlowAuthor.tsx
@@ -37,9 +37,6 @@ export const getStylesToOverwrite = (node: MarkupTree, child: MarkupTree, fontSi
     // PMP-526
     style.backgroundColor = '';
   }
-  if (node.tag === 'p' && child.tag === 'span' && child.style.color === '#000000') {
-    style.color = 'inherit';
-  }
   if (!(child.style && child.style.fontSize) && fontSize) {
     style.fontSize = `${fontSize}px`;
   }


### PR DESCRIPTION
This was to fix the color selector in the MCQ component in Simple Author. When choosing #000 on simple author text in the MCQ, the original behavior was to choose Dark Grey. That was because in the TextFlow.tsx and TextFlowAuthor.tsx files, there was an inherited rule specifically for #000. This caused any black font to be rendered in the parent node's color instead of black. I removed the conditionals from both files, and now users (authors) can select "true" black as a font color. 