### PR TITLE
[ENHANCEMENT] [MER-5625] Correct randomized-bank LO minimum coverage and query performance

### DIFF
--- a/lib/oli/activities/realizer/query/batch.ex
+++ b/lib/oli/activities/realizer/query/batch.ex
@@ -1,0 +1,105 @@
+defmodule Oli.Activities.Realizer.Query.Batch do
+  @moduledoc """
+  Executes multiple realizer queries in a single database round trip.
+  """
+
+  alias Oli.Activities.Realizer.Logic
+  alias Oli.Activities.Realizer.Query.Builder
+  alias Oli.Activities.Realizer.Query.Paging
+  alias Oli.Activities.Realizer.Query.Result
+  alias Oli.Activities.Realizer.Query.Source
+  alias Oli.Repo
+  alias Oli.Resources.Revision
+
+  @type query_id :: String.t()
+  @type query_spec :: {query_id(), %Logic{}, Source.t()}
+
+  @doc """
+  Executes query specs and returns `%Result{}` values keyed by query id.
+  """
+  @spec execute([query_spec()], Paging.t(), :paged | :random) ::
+          {:ok, %{query_id() => %Result{}}} | {:error, term()}
+  def execute([], %Paging{}, view_type) when view_type in [:paged, :random], do: {:ok, %{}}
+
+  def execute(query_specs, %Paging{} = paging, view_type)
+      when is_list(query_specs) and view_type in [:paged, :random] do
+    with {:ok, {sql, params}} <- build(query_specs, paging, view_type),
+         {:ok, %Postgrex.Result{} = result} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
+      {:ok, results_by_query_id(result, query_specs)}
+    end
+  end
+
+  defp build(query_specs, paging, view_type) do
+    query_specs
+    |> Enum.reduce({[], [], 0}, fn {query_id, %Logic{} = logic, %Source{} = source},
+                                   {branches, param_groups, param_count} ->
+      {sql, sql_params} = Builder.build(logic, source, paging, view_type)
+
+      query_id_param = param_count + 1
+      shifted_sql = shift_sql_parameters(sql, query_id_param)
+
+      branch =
+        "SELECT $#{query_id_param}::text AS query_id, query_rows.* FROM (#{shifted_sql}) AS query_rows"
+
+      {[branch | branches], [[query_id | sql_params] | param_groups],
+       param_count + 1 + length(sql_params)}
+    end)
+    |> then(fn {branches, param_groups, _param_count} ->
+      params =
+        param_groups
+        |> Enum.reverse()
+        |> Enum.flat_map(& &1)
+
+      {:ok, {branches |> Enum.reverse() |> Enum.join(" UNION ALL "), params}}
+    end)
+  end
+
+  defp shift_sql_parameters(sql, offset) do
+    Regex.replace(~r/\$(\d+)/, sql, fn _match, number ->
+      "$#{String.to_integer(number) + offset}"
+    end)
+  end
+
+  defp results_by_query_id(%Postgrex.Result{rows: rows, columns: columns}, query_specs) do
+    query_id_index = Enum.find_index(columns, &(&1 == "query_id"))
+    count_index = Enum.find_index(columns, &(&1 == "full_count"))
+    revision_column_indexes = revision_column_indexes(columns)
+
+    empty_results =
+      Map.new(query_specs, fn {query_id, %Logic{}, %Source{}} ->
+        {query_id, %Result{rows: [], rowCount: 0, totalCount: 0}}
+      end)
+
+    rows
+    |> Enum.reduce(empty_results, fn row, acc ->
+      query_id = Enum.at(row, query_id_index)
+      revision = revision_from_row(row, revision_column_indexes)
+      full_count = if count_index, do: Enum.at(row, count_index), else: 0
+
+      Map.update!(acc, query_id, fn %Result{} = result ->
+        %Result{
+          result
+          | rows: [revision | result.rows],
+            rowCount: result.rowCount + 1,
+            totalCount: full_count
+        }
+      end)
+    end)
+    |> Map.new(fn {query_id, %Result{} = result} ->
+      {query_id, %Result{result | rows: Enum.reverse(result.rows)}}
+    end)
+  end
+
+  defp revision_column_indexes(columns) do
+    columns
+    |> Enum.with_index()
+    |> Enum.reject(fn {column, _index} -> column in ["query_id", "full_count"] end)
+    |> Enum.map(fn {column, index} -> {index, String.to_existing_atom(column)} end)
+  end
+
+  defp revision_from_row(row, revision_column_indexes) do
+    revision_column_indexes
+    |> Enum.map(fn {index, column} -> {column, Enum.at(row, index)} end)
+    |> then(&Repo.load(Revision, &1))
+  end
+end

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -242,11 +242,49 @@ defmodule Oli.Delivery.InstructorCustomizations do
              excluded_ids,
              %Paging{offset: 0, limit: @preview_summary_candidate_limit}
            ) do
-      if result.totalCount > result.rowCount do
-        {:error, {:too_many_candidates, result.totalCount}}
-      else
-        {:ok, result.rows}
-      end
+      bounded_candidate_revisions_result(result)
+    end
+  end
+
+  @doc """
+  Lists current candidate revisions for all resolved bank selections on a page.
+
+  Results are keyed by selection id so callers can build page-level summaries
+  without issuing a separate candidate query for each selection.
+  """
+  @spec list_bank_selection_candidate_revisions_by_selection_id(
+          %Section{},
+          %Revision{},
+          [map()],
+          %{optional(String.t()) => MapSet.t(integer())}
+        ) :: {:ok, %{String.t() => {:ok, [%Revision{}]} | {:error, term()}}} | {:error, term()}
+  def list_bank_selection_candidate_revisions_by_selection_id(
+        %Section{} = section,
+        %Revision{} = page_revision,
+        selections,
+        excluded_ids_by_selection_id \\ %{}
+      )
+      when is_list(selections) and is_map(excluded_ids_by_selection_id) do
+    with {:ok, results_by_selection_id} <-
+           TargetResolver.list_active_candidates_by_selection_id(
+             section,
+             page_revision,
+             selections,
+             excluded_ids_by_selection_id,
+             %Paging{offset: 0, limit: @preview_summary_candidate_limit}
+           ) do
+      {:ok,
+       Map.new(results_by_selection_id, fn {selection_id, result} ->
+         {selection_id, bounded_candidate_revisions_result(result)}
+       end)}
+    end
+  end
+
+  defp bounded_candidate_revisions_result(result) do
+    if result.totalCount > result.rowCount do
+      {:error, {:too_many_candidates, result.totalCount}}
+    else
+      {:ok, result.rows}
     end
   end
 

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -18,6 +18,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
   @count_query_paging %Paging{offset: 0, limit: 1}
   @sample_query_paging %Paging{offset: 0, limit: 1}
+  @candidate_query_chunk_size 10
 
   # Section/page targets
 
@@ -152,7 +153,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   end
 
   @doc """
-  Lists bank candidates for all page selections in one database round trip.
+  Lists bank candidates for all page selections in bounded database round trips.
   """
   @spec list_active_candidates_by_selection_id(
           %Section{},
@@ -172,17 +173,23 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     publication_id =
       Publishing.get_publication_id_for_resource(section.slug, page_revision.resource_id)
 
-    with {:ok, query} <-
-           build_candidate_queries_by_selection_id(
-             section,
-             selections,
-             excluded_ids_by_selection_id,
-             publication_id,
-             paging
-           ),
-         {:ok, %Postgrex.Result{} = result} <- execute_candidate_queries(query) do
-      {:ok, candidate_results_by_selection_id(result, selections)}
-    end
+    selections
+    |> Enum.chunk_every(@candidate_query_chunk_size)
+    |> Enum.reduce_while({:ok, %{}}, fn chunk, {:ok, acc} ->
+      with {:ok, query} <-
+             build_candidate_queries_by_selection_id(
+               section,
+               chunk,
+               excluded_ids_by_selection_id,
+               publication_id,
+               paging
+             ),
+           {:ok, %Postgrex.Result{} = result} <- execute_candidate_queries(query) do
+        {:cont, {:ok, Map.merge(acc, candidate_results_by_selection_id(result, chunk))}}
+      else
+        error -> {:halt, error}
+      end
+    end)
   end
 
   @doc """
@@ -355,7 +362,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
         params =
           param_groups
           |> Enum.reverse()
-          |> List.flatten()
+          |> Enum.flat_map(& &1)
 
         {:ok, {branches |> Enum.reverse() |> Enum.join(" UNION ALL "), params}}
 
@@ -389,22 +396,25 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
         {selection["id"], %Result{rows: [], rowCount: 0, totalCount: 0}}
       end)
 
-    rows
-    |> Enum.map(fn row ->
-      selection_id = Enum.at(row, selection_index)
-      revision = candidate_revision_from_row(row, revision_column_indexes)
-      full_count = if count_index, do: Enum.at(row, count_index), else: 0
+    rows_by_selection_id =
+      Enum.reduce(rows, empty_results, fn row, acc ->
+        selection_id = Enum.at(row, selection_index)
+        revision = candidate_revision_from_row(row, revision_column_indexes)
+        full_count = if count_index, do: Enum.at(row, count_index), else: 0
 
-      {selection_id, revision, full_count}
-    end)
-    |> Enum.group_by(fn {selection_id, _revision, _full_count} -> selection_id end)
-    |> Map.new(fn {selection_id, candidate_rows} ->
-      rows = Enum.map(candidate_rows, fn {_selection_id, revision, _full_count} -> revision end)
-      total_count = candidate_rows |> List.first() |> elem(2)
+        Map.update!(acc, selection_id, fn %Result{} = result ->
+          %Result{
+            result
+            | rows: [revision | result.rows],
+              rowCount: result.rowCount + 1,
+              totalCount: full_count
+          }
+        end)
+      end)
 
-      {selection_id, %Result{rows: rows, rowCount: length(rows), totalCount: total_count}}
+    Map.new(rows_by_selection_id, fn {selection_id, %Result{} = result} ->
+      {selection_id, %Result{result | rows: Enum.reverse(result.rows)}}
     end)
-    |> then(&Map.merge(empty_results, &1))
   end
 
   defp revision_column_indexes(columns) do

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -3,12 +3,15 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
   alias Oli.Activities.Realizer.Logic
   alias Oli.Activities.Realizer.Query
+  alias Oli.Activities.Realizer.Query.Builder
   alias Oli.Activities.Realizer.Query.Paging
+  alias Oli.Activities.Realizer.Query.Result
   alias Oli.Activities.Realizer.Query.Source
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
+  alias Oli.Repo
   alias Oli.Resources.Revision
   alias Oli.Resources.PageContent
   alias Oli.Resources.ResourceType
@@ -149,6 +152,40 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   end
 
   @doc """
+  Lists bank candidates for all page selections in one database round trip.
+  """
+  @spec list_active_candidates_by_selection_id(
+          %Section{},
+          %Revision{},
+          [map()],
+          %{optional(String.t()) => MapSet.t(integer())},
+          %Paging{}
+        ) :: {:ok, %{String.t() => %Result{}}} | {:error, term()}
+  def list_active_candidates_by_selection_id(
+        %Section{} = section,
+        %Revision{} = page_revision,
+        selections,
+        excluded_ids_by_selection_id,
+        %Paging{} = paging
+      )
+      when is_list(selections) and is_map(excluded_ids_by_selection_id) do
+    publication_id =
+      Publishing.get_publication_id_for_resource(section.slug, page_revision.resource_id)
+
+    with {:ok, query} <-
+           build_candidate_queries_by_selection_id(
+             section,
+             selections,
+             excluded_ids_by_selection_id,
+             publication_id,
+             paging
+           ),
+         {:ok, %Postgrex.Result{} = result} <- execute_candidate_queries(query) do
+      {:ok, candidate_results_by_selection_id(result, selections)}
+    end
+  end
+
+  @doc """
   Counts candidates matching the selection logic after excluding resource ids.
   """
   @spec count_active_candidates(%Section{}, %Revision{}, map(), MapSet.t(integer())) ::
@@ -265,6 +302,108 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
   defp execute_query(:random, logic, source, paging),
     do: Query.execute_random(logic, source, paging)
+
+  defp build_candidate_queries_by_selection_id(
+         section,
+         selections,
+         excluded_ids_by_selection_id,
+         publication_id,
+         paging
+       ) do
+    case Enum.reduce_while(selections, {:ok, [], []}, fn selection, {:ok, branches, params} ->
+           selection_id = selection["id"]
+
+           with {:ok, %Logic{} = logic} <- parse_logic(selection) do
+             excluded_ids =
+               excluded_ids_by_selection_id
+               |> Map.get(selection_id, MapSet.new())
+               |> MapSet.to_list()
+
+             {sql, sql_params} =
+               Builder.build(
+                 logic,
+                 %Source{
+                   publication_id: publication_id,
+                   section_slug: section.slug,
+                   blacklisted_activity_ids: excluded_ids
+                 },
+                 paging,
+                 :paged
+               )
+
+             # Each selection keeps its own realizer SQL; wrap each branch with a selection id
+             # and shift placeholders so all branches can run as one UNION query.
+             selection_id_param = length(params) + 1
+             shifted_sql = shift_sql_parameters(sql, selection_id_param)
+
+             branch =
+               "SELECT $#{selection_id_param}::text AS selection_id, candidate_rows.* FROM (#{shifted_sql}) AS candidate_rows"
+
+             {:cont, {:ok, [branch | branches], params ++ [selection_id] ++ sql_params}}
+           else
+             error -> {:halt, error}
+           end
+         end) do
+      {:ok, [], _params} ->
+        {:ok, {nil, []}}
+
+      {:ok, branches, params} ->
+        {:ok, {branches |> Enum.reverse() |> Enum.join(" UNION ALL "), params}}
+
+      error ->
+        error
+    end
+  end
+
+  defp shift_sql_parameters(sql, offset) do
+    Regex.replace(~r/\$(\d+)/, sql, fn _match, number ->
+      "$#{String.to_integer(number) + offset}"
+    end)
+  end
+
+  defp execute_candidate_queries({nil, _params}) do
+    {:ok, %Postgrex.Result{columns: [], rows: [], num_rows: 0}}
+  end
+
+  defp execute_candidate_queries({sql, params}), do: Ecto.Adapters.SQL.query(Repo, sql, params)
+
+  defp candidate_results_by_selection_id(
+         %Postgrex.Result{rows: rows, columns: columns},
+         selections
+       ) do
+    selection_index = Enum.find_index(columns, &(&1 == "selection_id"))
+    count_index = Enum.find_index(columns, &(&1 == "full_count"))
+
+    empty_results =
+      Map.new(selections, fn selection ->
+        {selection["id"], %Result{rows: [], rowCount: 0, totalCount: 0}}
+      end)
+
+    rows
+    |> Enum.map(fn row ->
+      selection_id = Enum.at(row, selection_index)
+      revision = candidate_revision_from_row(row, columns)
+      full_count = if count_index, do: Enum.at(row, count_index), else: 0
+
+      {selection_id, revision, full_count}
+    end)
+    |> Enum.group_by(fn {selection_id, _revision, _full_count} -> selection_id end)
+    |> Map.new(fn {selection_id, candidate_rows} ->
+      rows = Enum.map(candidate_rows, fn {_selection_id, revision, _full_count} -> revision end)
+      total_count = candidate_rows |> List.first() |> elem(2)
+
+      {selection_id, %Result{rows: rows, rowCount: length(rows), totalCount: total_count}}
+    end)
+    |> then(&Map.merge(empty_results, &1))
+  end
+
+  defp candidate_revision_from_row(row, columns) do
+    columns
+    |> Enum.zip(row)
+    |> Enum.reject(fn {column, _value} -> column in ["selection_id", "full_count"] end)
+    |> Enum.map(fn {column, value} -> {String.to_existing_atom(column), value} end)
+    |> then(&Repo.load(Revision, &1))
+  end
 
   defp parse_logic(%{"logic" => logic}) do
     case Logic.parse(logic) do

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -310,7 +310,9 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
          publication_id,
          paging
        ) do
-    case Enum.reduce_while(selections, {:ok, [], []}, fn selection, {:ok, branches, params} ->
+    case Enum.reduce_while(selections, {:ok, [], [], 0}, fn selection,
+                                                            {:ok, branches, param_groups,
+                                                             param_count} ->
            selection_id = selection["id"]
 
            with {:ok, %Logic{} = logic} <- parse_logic(selection) do
@@ -333,21 +335,28 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
              # Each selection keeps its own realizer SQL; wrap each branch with a selection id
              # and shift placeholders so all branches can run as one UNION query.
-             selection_id_param = length(params) + 1
+             selection_id_param = param_count + 1
              shifted_sql = shift_sql_parameters(sql, selection_id_param)
 
              branch =
                "SELECT $#{selection_id_param}::text AS selection_id, candidate_rows.* FROM (#{shifted_sql}) AS candidate_rows"
 
-             {:cont, {:ok, [branch | branches], params ++ [selection_id] ++ sql_params}}
+             {:cont,
+              {:ok, [branch | branches], [[selection_id | sql_params] | param_groups],
+               param_count + 1 + length(sql_params)}}
            else
              error -> {:halt, error}
            end
          end) do
-      {:ok, [], _params} ->
+      {:ok, [], _param_groups, _param_count} ->
         {:ok, {nil, []}}
 
-      {:ok, branches, params} ->
+      {:ok, branches, param_groups, _param_count} ->
+        params =
+          param_groups
+          |> Enum.reverse()
+          |> List.flatten()
+
         {:ok, {branches |> Enum.reverse() |> Enum.join(" UNION ALL "), params}}
 
       error ->
@@ -373,6 +382,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
        ) do
     selection_index = Enum.find_index(columns, &(&1 == "selection_id"))
     count_index = Enum.find_index(columns, &(&1 == "full_count"))
+    revision_column_indexes = revision_column_indexes(columns)
 
     empty_results =
       Map.new(selections, fn selection ->
@@ -382,7 +392,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     rows
     |> Enum.map(fn row ->
       selection_id = Enum.at(row, selection_index)
-      revision = candidate_revision_from_row(row, columns)
+      revision = candidate_revision_from_row(row, revision_column_indexes)
       full_count = if count_index, do: Enum.at(row, count_index), else: 0
 
       {selection_id, revision, full_count}
@@ -397,11 +407,16 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     |> then(&Map.merge(empty_results, &1))
   end
 
-  defp candidate_revision_from_row(row, columns) do
+  defp revision_column_indexes(columns) do
     columns
-    |> Enum.zip(row)
-    |> Enum.reject(fn {column, _value} -> column in ["selection_id", "full_count"] end)
-    |> Enum.map(fn {column, value} -> {String.to_existing_atom(column), value} end)
+    |> Enum.with_index()
+    |> Enum.reject(fn {column, _index} -> column in ["selection_id", "full_count"] end)
+    |> Enum.map(fn {column, index} -> {index, String.to_existing_atom(column)} end)
+  end
+
+  defp candidate_revision_from_row(row, revision_column_indexes) do
+    revision_column_indexes
+    |> Enum.map(fn {index, column} -> {column, Enum.at(row, index)} end)
     |> then(&Repo.load(Revision, &1))
   end
 

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -3,7 +3,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
   alias Oli.Activities.Realizer.Logic
   alias Oli.Activities.Realizer.Query
-  alias Oli.Activities.Realizer.Query.Builder
+  alias Oli.Activities.Realizer.Query.Batch
   alias Oli.Activities.Realizer.Query.Paging
   alias Oli.Activities.Realizer.Query.Result
   alias Oli.Activities.Realizer.Query.Source
@@ -11,7 +11,6 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
-  alias Oli.Repo
   alias Oli.Resources.Revision
   alias Oli.Resources.PageContent
   alias Oli.Resources.ResourceType
@@ -176,16 +175,15 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     selections
     |> Enum.chunk_every(@candidate_query_chunk_size)
     |> Enum.reduce_while({:ok, %{}}, fn chunk, {:ok, acc} ->
-      with {:ok, query} <-
-             build_candidate_queries_by_selection_id(
+      with {:ok, query_specs} <-
+             build_candidate_query_specs(
                section,
                chunk,
                excluded_ids_by_selection_id,
-               publication_id,
-               paging
+               publication_id
              ),
-           {:ok, %Postgrex.Result{} = result} <- execute_candidate_queries(query) do
-        {:cont, {:ok, Map.merge(acc, candidate_results_by_selection_id(result, chunk))}}
+           {:ok, results_by_selection_id} <- Batch.execute(query_specs, paging, :paged) do
+        {:cont, {:ok, Map.merge(acc, results_by_selection_id)}}
       else
         error -> {:halt, error}
       end
@@ -310,124 +308,36 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   defp execute_query(:random, logic, source, paging),
     do: Query.execute_random(logic, source, paging)
 
-  defp build_candidate_queries_by_selection_id(
+  defp build_candidate_query_specs(
          section,
          selections,
          excluded_ids_by_selection_id,
-         publication_id,
-         paging
+         publication_id
        ) do
-    case Enum.reduce_while(selections, {:ok, [], [], 0}, fn selection,
-                                                            {:ok, branches, param_groups,
-                                                             param_count} ->
-           selection_id = selection["id"]
+    Enum.reduce_while(selections, {:ok, []}, fn selection, {:ok, acc} ->
+      with {:ok, %Logic{} = logic} <- parse_logic(selection) do
+        selection_id = selection["id"]
 
-           with {:ok, %Logic{} = logic} <- parse_logic(selection) do
-             excluded_ids =
-               excluded_ids_by_selection_id
-               |> Map.get(selection_id, MapSet.new())
-               |> MapSet.to_list()
+        excluded_ids =
+          excluded_ids_by_selection_id
+          |> Map.get(selection_id, MapSet.new())
+          |> MapSet.to_list()
 
-             {sql, sql_params} =
-               Builder.build(
-                 logic,
-                 %Source{
-                   publication_id: publication_id,
-                   section_slug: section.slug,
-                   blacklisted_activity_ids: excluded_ids
-                 },
-                 paging,
-                 :paged
-               )
+        source = %Source{
+          publication_id: publication_id,
+          section_slug: section.slug,
+          blacklisted_activity_ids: excluded_ids
+        }
 
-             # Each selection keeps its own realizer SQL; wrap each branch with a selection id
-             # and shift placeholders so all branches can run as one UNION query.
-             selection_id_param = param_count + 1
-             shifted_sql = shift_sql_parameters(sql, selection_id_param)
-
-             branch =
-               "SELECT $#{selection_id_param}::text AS selection_id, candidate_rows.* FROM (#{shifted_sql}) AS candidate_rows"
-
-             {:cont,
-              {:ok, [branch | branches], [[selection_id | sql_params] | param_groups],
-               param_count + 1 + length(sql_params)}}
-           else
-             error -> {:halt, error}
-           end
-         end) do
-      {:ok, [], _param_groups, _param_count} ->
-        {:ok, {nil, []}}
-
-      {:ok, branches, param_groups, _param_count} ->
-        params =
-          param_groups
-          |> Enum.reverse()
-          |> Enum.flat_map(& &1)
-
-        {:ok, {branches |> Enum.reverse() |> Enum.join(" UNION ALL "), params}}
-
-      error ->
-        error
+        {:cont, {:ok, [{selection_id, logic, source} | acc]}}
+      else
+        error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, query_specs} -> {:ok, Enum.reverse(query_specs)}
+      error -> error
     end
-  end
-
-  defp shift_sql_parameters(sql, offset) do
-    Regex.replace(~r/\$(\d+)/, sql, fn _match, number ->
-      "$#{String.to_integer(number) + offset}"
-    end)
-  end
-
-  defp execute_candidate_queries({nil, _params}) do
-    {:ok, %Postgrex.Result{columns: [], rows: [], num_rows: 0}}
-  end
-
-  defp execute_candidate_queries({sql, params}), do: Ecto.Adapters.SQL.query(Repo, sql, params)
-
-  defp candidate_results_by_selection_id(
-         %Postgrex.Result{rows: rows, columns: columns},
-         selections
-       ) do
-    selection_index = Enum.find_index(columns, &(&1 == "selection_id"))
-    count_index = Enum.find_index(columns, &(&1 == "full_count"))
-    revision_column_indexes = revision_column_indexes(columns)
-
-    empty_results =
-      Map.new(selections, fn selection ->
-        {selection["id"], %Result{rows: [], rowCount: 0, totalCount: 0}}
-      end)
-
-    rows_by_selection_id =
-      Enum.reduce(rows, empty_results, fn row, acc ->
-        selection_id = Enum.at(row, selection_index)
-        revision = candidate_revision_from_row(row, revision_column_indexes)
-        full_count = if count_index, do: Enum.at(row, count_index), else: 0
-
-        Map.update!(acc, selection_id, fn %Result{} = result ->
-          %Result{
-            result
-            | rows: [revision | result.rows],
-              rowCount: result.rowCount + 1,
-              totalCount: full_count
-          }
-        end)
-      end)
-
-    Map.new(rows_by_selection_id, fn {selection_id, %Result{} = result} ->
-      {selection_id, %Result{result | rows: Enum.reverse(result.rows)}}
-    end)
-  end
-
-  defp revision_column_indexes(columns) do
-    columns
-    |> Enum.with_index()
-    |> Enum.reject(fn {column, _index} -> column in ["selection_id", "full_count"] end)
-    |> Enum.map(fn {column, index} -> {index, String.to_existing_atom(column)} end)
-  end
-
-  defp candidate_revision_from_row(row, revision_column_indexes) do
-    revision_column_indexes
-    |> Enum.map(fn {index, column} -> {column, Enum.at(row, index)} end)
-    |> then(&Repo.load(Revision, &1))
   end
 
   defp parse_logic(%{"logic" => logic}) do

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -807,10 +807,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
     do: %{}
 
   defp bank_selection_coverage_by_objective_id(summary, exclusion_view) do
+    active_candidates = active_bank_candidate_summaries(summary, exclusion_view)
+    active_total = length(active_candidates)
+    selected_count = min(summary.count, active_total)
+
     active_counts_by_objective_id =
-      summary
-      |> active_bank_candidate_summaries(exclusion_view)
-      |> Enum.reduce(%{}, fn candidate, acc ->
+      Enum.reduce(active_candidates, %{}, fn candidate, acc ->
         Enum.reduce(candidate.objective_ids, acc, fn objective_id, objective_acc ->
           Map.update(objective_acc, objective_id, 1, &(&1 + 1))
         end)
@@ -821,9 +823,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
       {objective_id,
        %{
-         # A randomized bank can select zero questions for any individual LO even when the
-         # selection itself remains fulfillable.
-         min: 0,
+         min: max(selected_count - (active_total - active_count), 0),
          max: min(summary.count, active_count)
        }}
     end)
@@ -895,32 +895,41 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   end
 
   defp bank_selection_candidate_results_by_selection_id(section, page_revision, selections) do
-    Map.new(selections, fn selection ->
-      {selection["id"],
-       list_bank_selection_candidate_revisions(section, page_revision, selection)}
-    end)
-  end
-
-  defp list_bank_selection_candidate_revisions(section, page_revision, selection) do
-    case InstructorCustomizations.list_bank_selection_candidate_revisions(
+    case InstructorCustomizations.list_bank_selection_candidate_revisions_by_selection_id(
            section,
            page_revision,
-           selection,
-           MapSet.new()
+           selections,
+           %{}
          ) do
+      {:ok, results_by_selection_id} ->
+        Map.new(results_by_selection_id, fn {selection_id, result} ->
+          {selection_id, normalize_bank_selection_candidate_result(selection_id, result)}
+        end)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Unable to summarize instructor preview bank selections for page #{page_revision.resource_id}: #{inspect(reason)}"
+        )
+
+        Map.new(selections, fn selection -> {selection["id"], {:error, reason}} end)
+    end
+  end
+
+  defp normalize_bank_selection_candidate_result(selection_id, result) do
+    case result do
       {:ok, revisions} ->
         {:ok, revisions}
 
       {:error, {:too_many_candidates, candidate_count}} ->
         Logger.warning(
-          "Unable to fully summarize instructor preview bank selection #{inspect(selection["id"])} because it has #{candidate_count} candidates"
+          "Unable to fully summarize instructor preview bank selection #{inspect(selection_id)} because it has #{candidate_count} candidates"
         )
 
         {:too_large, candidate_count}
 
       {:error, reason} ->
         Logger.warning(
-          "Unable to summarize instructor preview bank selection #{inspect(selection["id"])}: #{inspect(reason)}"
+          "Unable to summarize instructor preview bank selection #{inspect(selection_id)}: #{inspect(reason)}"
         )
 
         {:error, reason}

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -908,11 +908,35 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
       {:error, reason} ->
         Logger.warning(
-          "Unable to summarize instructor preview bank selections for page #{page_revision.resource_id}: #{inspect(reason)}"
+          "Unable to bulk summarize instructor preview bank selections for page #{page_revision.resource_id}; falling back to per-selection summaries: #{inspect(reason)}"
         )
 
-        Map.new(selections, fn selection -> {selection["id"], {:error, reason}} end)
+        fallback_bank_selection_candidate_results_by_selection_id(
+          section,
+          page_revision,
+          selections
+        )
     end
+  end
+
+  defp fallback_bank_selection_candidate_results_by_selection_id(
+         section,
+         page_revision,
+         selections
+       ) do
+    Map.new(selections, fn selection ->
+      selection_id = selection["id"]
+
+      result =
+        InstructorCustomizations.list_bank_selection_candidate_revisions(
+          section,
+          page_revision,
+          selection,
+          MapSet.new()
+        )
+
+      {selection_id, normalize_bank_selection_candidate_result(selection_id, result)}
+    end)
   end
 
   defp normalize_bank_selection_candidate_result(selection_id, result) do

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -14,7 +14,6 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.PreviewReturn
   alias OliWeb.Delivery.Student.Utils
-  alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.{PreviewPageContext, PreviewRoutes}
   alias OliWeb.Components.Delivery.Layouts
   alias OliWeb.Delivery.Student.Lesson.Annotations

--- a/test/oli/activities/realizer/query_execution_test.exs
+++ b/test/oli/activities/realizer/query_execution_test.exs
@@ -3,6 +3,7 @@ defmodule Oli.Activities.Query.ExecutorTest do
 
   alias Oli.Activities.Realizer.Logic
   alias Oli.Activities.Realizer.Logic.Expression
+  alias Oli.Activities.Realizer.Query.Batch
   alias Oli.Activities.Realizer.Query.Builder
   alias Oli.Activities.Realizer.Query.Source
   alias Oli.Activities.Realizer.Query.Paging
@@ -182,6 +183,119 @@ defmodule Oli.Activities.Query.ExecutorTest do
       {:ok, %Result{rowCount: 1, totalCount: 1}} =
         Builder.build(logic, source, paging, :paged)
         |> Executor.execute()
+    end
+
+    test "batch executes paged queries keyed by query id", %{
+      publication: publication,
+      first_banked_activity: first_banked_activity,
+      second_banked_activity: second_banked_activity
+    } do
+      source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [],
+        section_slug: ""
+      }
+
+      paging = %Paging{limit: 2, offset: 0}
+
+      first_logic = %Logic{
+        conditions: %Expression{fact: :text, operator: :contains, value: "question"}
+      }
+
+      second_logic = %Logic{
+        conditions: %Expression{fact: :text, operator: :contains, value: "another"}
+      }
+
+      assert {:ok,
+              %{
+                "first" => %Result{rows: [first_revision], rowCount: 1, totalCount: 1},
+                "second" => %Result{rows: [second_revision], rowCount: 1, totalCount: 1}
+              }} =
+               Batch.execute(
+                 [
+                   {"first", first_logic, source},
+                   {"second", second_logic, source}
+                 ],
+                 paging,
+                 :paged
+               )
+
+      assert first_revision.resource_id == first_banked_activity.resource.id
+      assert second_revision.resource_id == second_banked_activity.resource.id
+    end
+
+    test "batch preserves empty results for query ids", %{publication: publication} do
+      source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [],
+        section_slug: ""
+      }
+
+      paging = %Paging{limit: 1, offset: 0}
+
+      matching_logic = %Logic{
+        conditions: %Expression{fact: :objectives, operator: :contains, value: [1]}
+      }
+
+      empty_logic = %Logic{
+        conditions: %Expression{fact: :objectives, operator: :contains, value: [999_999]}
+      }
+
+      assert {:ok,
+              %{
+                "matching" => %Result{rowCount: 1, totalCount: 2},
+                "empty" => %Result{rows: [], rowCount: 0, totalCount: 0}
+              }} =
+               Batch.execute(
+                 [
+                   {"matching", matching_logic, source},
+                   {"empty", empty_logic, source}
+                 ],
+                 paging,
+                 :paged
+               )
+    end
+
+    test "batch honors source exclusions per query", %{
+      publication: publication,
+      first_banked_activity: first_banked_activity,
+      second_banked_activity: second_banked_activity
+    } do
+      paging = %Paging{limit: 2, offset: 0}
+      logic = %Logic{conditions: %Expression{fact: :objectives, operator: :contains, value: [1]}}
+
+      first_source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [second_banked_activity.resource.id],
+        section_slug: ""
+      }
+
+      second_source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [first_banked_activity.resource.id],
+        section_slug: ""
+      }
+
+      assert {:ok,
+              %{
+                "first-only" => %Result{rows: [first_revision], rowCount: 1, totalCount: 1},
+                "second-only" => %Result{rows: [second_revision], rowCount: 1, totalCount: 1}
+              }} =
+               Batch.execute(
+                 [
+                   {"first-only", logic, first_source},
+                   {"second-only", logic, second_source}
+                 ],
+                 paging,
+                 :paged
+               )
+
+      assert first_revision.resource_id == first_banked_activity.resource.id
+      assert second_revision.resource_id == second_banked_activity.resource.id
+    end
+
+    test "batch returns an empty map for no query specs" do
+      assert {:ok, %{}} = Batch.execute([], %Paging{limit: 1, offset: 0}, :paged)
     end
 
     test "queries for activity type", %{publication: publication} do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -552,22 +552,28 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     end
 
     test "lists batched selection candidates with parameterized text logic", context do
-      matching_selection = text_selection("matching-text-selection", "Candidate")
+      matching_selections =
+        Enum.map(1..12, fn index ->
+          text_selection("matching-text-selection-#{index}", "Candidate")
+        end)
+
       empty_selection = text_selection("empty-text-selection", "Embedded")
 
-      assert {:ok,
-              %{
-                "matching-text-selection" => {:ok, matching_candidates},
-                "empty-text-selection" => {:ok, []}
-              }} =
+      assert {:ok, results_by_selection_id} =
                InstructorCustomizations.list_bank_selection_candidate_revisions_by_selection_id(
                  context.section,
                  context.page_revision,
-                 [matching_selection, empty_selection]
+                 matching_selections ++ [empty_selection]
                )
 
-      assert matching_candidates |> Enum.map(& &1.resource_id) |> Enum.sort() ==
-               context.candidates |> Enum.map(& &1.resource_id) |> Enum.sort()
+      assert Map.fetch!(results_by_selection_id, "empty-text-selection") == {:ok, []}
+
+      for selection <- matching_selections do
+        assert {:ok, matching_candidates} = Map.fetch!(results_by_selection_id, selection["id"])
+
+        assert matching_candidates |> Enum.map(& &1.resource_id) |> Enum.sort() ==
+                 context.candidates |> Enum.map(& &1.resource_id) |> Enum.sort()
+      end
     end
 
     test "summarizes selection candidates without returning a paged candidate list", context do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -551,6 +551,25 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                |> Enum.sort()
     end
 
+    test "lists batched selection candidates with parameterized text logic", context do
+      matching_selection = text_selection("matching-text-selection", "Candidate")
+      empty_selection = text_selection("empty-text-selection", "Embedded")
+
+      assert {:ok,
+              %{
+                "matching-text-selection" => {:ok, matching_candidates},
+                "empty-text-selection" => {:ok, []}
+              }} =
+               InstructorCustomizations.list_bank_selection_candidate_revisions_by_selection_id(
+                 context.section,
+                 context.page_revision,
+                 [matching_selection, empty_selection]
+               )
+
+      assert matching_candidates |> Enum.map(& &1.resource_id) |> Enum.sort() ==
+               context.candidates |> Enum.map(& &1.resource_id) |> Enum.sort()
+    end
+
     test "summarizes selection candidates without returning a paged candidate list", context do
       [first, second, third] = context.candidates
 
@@ -651,6 +670,21 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
 
   defp selection(id, count) do
     %{"type" => "selection", "id" => id, "logic" => %{"conditions" => nil}, "count" => count}
+  end
+
+  defp text_selection(id, text) do
+    %{
+      "type" => "selection",
+      "id" => id,
+      "logic" => %{
+        "conditions" => %{
+          "fact" => "text",
+          "operator" => "contains",
+          "value" => text
+        }
+      },
+      "count" => 1
+    }
   end
 
   defp exclusion_count(context, kind) do

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -1082,6 +1082,38 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ ~s|aria-label="Overall Points Available 18"|
     end
 
+    @tag capture_log: true
+    test "bulk candidate summary errors fall back to per-selection results", %{
+      section: section,
+      user: user,
+      page_revision: page_revision
+    } do
+      invalid_selection = %{
+        "type" => "selection",
+        "id" => "invalid-bank",
+        "logic" => %{
+          "conditions" => %{
+            "fact" => "unsupported",
+            "operator" => "contains",
+            "value" => [1]
+          }
+        },
+        "count" => 1,
+        "pointsPerActivity" => 4
+      }
+
+      page_revision = %{
+        page_revision
+        | content: update_in(page_revision.content, ["model"], &(&1 ++ [invalid_selection]))
+      }
+
+      preview_context = PreviewPageContext.build(section, page_revision, user)
+
+      assert preview_context.page_summary.available_points == 18
+      assert objective_question_range(preview_context.page_summary, "Thermodynamics") == {2, 3}
+      assert objective_question_range(preview_context.page_summary, "Kinetics") == {0, 1}
+    end
+
     test "excluded bank selections contribute zero coverage and no available points", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -1076,7 +1076,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert html =~ "Thermodynamics"
       assert html =~ "Kinetics"
-      assert html =~ "1-3 questions"
+      assert html =~ "2-3 questions"
       assert html =~ "0-1 questions"
       assert html =~ "Overall Points Available"
       assert html =~ ~s|aria-label="Overall Points Available 18"|
@@ -1158,7 +1158,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
         PreviewPageContext.build_page_summary(preview_context.preview_metadata, exclusion_view)
 
       assert page_summary.available_points == 14
-      assert objective_question_range(page_summary, "Thermodynamics") == {1, 2}
+      assert objective_question_range(page_summary, "Thermodynamics") == {2, 2}
       assert objective_question_range(page_summary, "Kinetics") == {0, 0}
     end
   end


### PR DESCRIPTION
- Batch instructor preview bank candidate lookup across all selections on a page to avoid issuing one candidate query per randomized bank.
- Reuse the bounded candidate result handling for single-selection and batched preview summary paths.
- Correct randomized-bank LO minimum coverage so ranges reflect guaranteed coverage when the selection count forces at least one candidate for an objective.
- Remove a duplicate `Modal` alias in the instructor preview LiveView.


<img width="919" height="538" alt="image" src="https://github.com/user-attachments/assets/bcdf5079-9148-4f9b-a0de-215642430507" />


See: https://eliterate.atlassian.net/browse/MER-5625