### PR TITLE
[BUG FIX] [MER-5622] Preserve bank selection return scroll target

### DIFF
--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -323,7 +323,9 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   defp actions(false), do: [%{kind: "restore", label: "Restore"}]
 
   defp manage_questions_url(section_slug, revision_slug, selection_id, navigation_params) do
-    request_path = lesson_request_path(section_slug, revision_slug, navigation_params)
+    request_path =
+      lesson_request_path(section_slug, revision_slug, navigation_params)
+      |> put_path_fragment(JumpNavigation.selection_target_id(selection_id))
 
     params =
       navigation_params
@@ -346,5 +348,12 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       "" -> path
       query -> "#{path}?#{query}"
     end
+  end
+
+  defp put_path_fragment(path, fragment) when is_binary(path) and is_binary(fragment) do
+    path
+    |> URI.parse()
+    |> Map.put(:fragment, fragment)
+    |> URI.to_string()
   end
 end

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -7,6 +7,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Delivery.InstructorCustomizations
   alias Oli.Delivery.Sections
+  alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Resources.Collaboration.CollabSpaceConfig
   alias Oli.Resources.ResourceType
   alias OliWeb.Delivery.Instructor.PreviewPageContext
@@ -33,7 +34,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       request_path =
         PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
           "sidebar_expanded" => "false"
-        })
+        }) <> "#" <> JumpNavigation.selection_target_id("selection-1")
 
       {:ok, view, html} =
         live(
@@ -280,7 +281,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       request_path =
         PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
           "sidebar_expanded" => "false"
-        })
+        }) <> "#" <> JumpNavigation.selection_target_id("selection-1")
 
       {:ok, view, _html} =
         live(

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -432,10 +432,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       refute html =~ "&quot;criteriaHelperText&quot;"
       refute html =~ "&quot;manageQuestionsUrl&quot;:null"
 
-      assert html =~
-               "request_path=%2Fsections%2F#{section.slug}%2Fpreview%2Flesson%2F#{page_revision.slug}"
+      expected_request_path =
+        PreviewRoutes.lesson_path(section.slug, page_revision.slug, %{
+          "return_to" => "/sections/#{section.slug}/remix?from=curriculum"
+        }) <> "#" <> JumpNavigation.selection_target_id("test_selection")
 
-      assert html =~ JumpNavigation.selection_target_id("test_selection")
+      assert html =~ "request_path=#{URI.encode_www_form(expected_request_path)}"
 
       assert html =~
                "return_to=%2Fsections%2F#{section.slug}%2Fremix%3Ffrom%3Dcurriculum"

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -433,7 +433,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       refute html =~ "&quot;manageQuestionsUrl&quot;:null"
 
       assert html =~
-               "request_path=%2Fsections%2F#{section.slug}%2Fpreview%2Flesson%2F#{page_revision.slug}%3Freturn_to%3D%252Fsections%252F#{section.slug}%252Fremix%253Ffrom%253Dcurriculum"
+               "request_path=%2Fsections%2F#{section.slug}%2Fpreview%2Flesson%2F#{page_revision.slug}"
+
+      assert html =~ JumpNavigation.selection_target_id("test_selection")
 
       assert html =~
                "return_to=%2Fsections%2F#{section.slug}%2Fremix%3Ffrom%3Dcurriculum"


### PR DESCRIPTION
## Jira
https://eliterate.atlassian.net/browse/MER-5622

Link to comment in the ticket: https://eliterate.atlassian.net/browse/MER-5622?focusedCommentId=54840

## Summary
- preserve the preview return target when entering Manage Questions from an activity bank selection
- route the manager back action to the selection jump target in the preview
- preserve the same return target when the invalid-removal modal redirects through Remove bank
- add regression coverage for the preview payload and manager return behavior

## Bug Origin
When exiting the Manage Questions view, instructors were returned to the preview page but landed at the top instead of back at the relevant activity bank selection.

## Fix
The Manage Questions URL now carries the preview lesson return path with the selection jump fragment, so both the manager back link and the Remove bank redirect reuse the existing preview autoscroll target.

## Validation
- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- `mix test test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`

## Video

https://github.com/user-attachments/assets/a86d5643-18b0-4524-aa3e-9a28044bfd36



