### PR TITLE
[BUG FIX] [MER-5756] fix automated reveal of paginated questions

### DIFF
--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -18,6 +18,11 @@ export interface PaginationControlsProps {
 type Page = List<Element>;
 type DisplayItem = { type: 'page'; index: number; key: string } | { type: 'ellipsis'; key: string };
 
+const clampPageIndex = (pageIndex: number, pageCount: number) => {
+  const maxIndex = Math.max(0, pageCount - 1);
+  return Math.min(Math.max(0, pageIndex), maxIndex);
+};
+
 export const PaginationControls = (props: PaginationControlsProps) => {
   const controls = useRef<HTMLDivElement>(null);
   const pageCount = useRef(0);
@@ -38,8 +43,7 @@ export const PaginationControls = (props: PaginationControlsProps) => {
     const handleShowContentPage = (e: Events.TorusEventMap[Events.Registry.ShowContentPage]) => {
       // Check if this event targets this pagination group.
       if (e.detail.forId === props.forId) {
-        const maxIndex = Math.max(0, pageCount.current - 1);
-        setActive(Math.min(Math.max(0, e.detail.index), maxIndex));
+        setActive(clampPageIndex(e.detail.index, pageCount.current));
       }
     };
 
@@ -94,8 +98,7 @@ export const PaginationControls = (props: PaginationControlsProps) => {
   }, [pages, active]);
 
   const onSelectPage = (pageIndex: number) => {
-    const maxIndex = Math.max(0, pages.count() - 1);
-    setActive(Math.min(Math.max(0, pageIndex), maxIndex));
+    setActive(clampPageIndex(pageIndex, pages.count()));
   };
 
   const totalPages = pages.count();

--- a/assets/src/components/misc/PaginationControls.tsx
+++ b/assets/src/components/misc/PaginationControls.tsx
@@ -20,6 +20,7 @@ type DisplayItem = { type: 'page'; index: number; key: string } | { type: 'ellip
 
 export const PaginationControls = (props: PaginationControlsProps) => {
   const controls = useRef<HTMLDivElement>(null);
+  const pageCount = useRef(0);
   const [pages, setPages] = useState(List<Page>());
   const [active, setActive] = useState(0);
   const isAtLeastSmall = useMediaQuery(MediaSize.sm);
@@ -34,13 +35,20 @@ export const PaginationControls = (props: PaginationControlsProps) => {
   };
 
   useEffect(() => {
-    document.addEventListener(Events.Registry.ShowContentPage, (e) => {
-      // check if this activity belongs to the survey being reset
+    const handleShowContentPage = (e: Events.TorusEventMap[Events.Registry.ShowContentPage]) => {
+      // Check if this event targets this pagination group.
       if (e.detail.forId === props.forId) {
-        onSelectPage(e.detail.index);
+        const maxIndex = Math.max(0, pageCount.current - 1);
+        setActive(Math.min(Math.max(0, e.detail.index), maxIndex));
       }
-    });
-  }, []);
+    };
+
+    document.addEventListener(Events.Registry.ShowContentPage, handleShowContentPage);
+
+    return () => {
+      document.removeEventListener(Events.Registry.ShowContentPage, handleShowContentPage);
+    };
+  }, [props.forId]);
 
   useEffect(() => {
     const parentElement = controls?.current?.parentElement?.parentElement;
@@ -77,6 +85,8 @@ export const PaginationControls = (props: PaginationControlsProps) => {
   }, [controls]);
 
   useEffect(() => {
+    pageCount.current = pages.count();
+
     if (props.paginationMode === 'normal') {
       hideAll();
     }

--- a/assets/src/data/persistence/pagination.ts
+++ b/assets/src/data/persistence/pagination.ts
@@ -7,6 +7,10 @@ export function updatePaginationState(
   forId: string,
   index: number[],
 ) {
+  if (!attemptGuid) {
+    return Promise.resolve({});
+  }
+
   // At the moment adding an entry to a list that is a value of a key is a multi step operation,
   // that involves two server requests:
   //

--- a/assets/test/components/misc/PaginationControls_test.tsx
+++ b/assets/test/components/misc/PaginationControls_test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { PaginationControls } from 'components/misc/PaginationControls';
-import * as Events from 'data/events';
 import { PaginationMode } from 'data/content/resource';
+import * as Events from 'data/events';
 
 const setupMatchMedia = (matches: boolean) => {
   window.matchMedia = jest.fn().mockImplementation((query: string) => {

--- a/assets/test/components/misc/PaginationControls_test.tsx
+++ b/assets/test/components/misc/PaginationControls_test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { PaginationControls } from 'components/misc/PaginationControls';
+import * as Events from 'data/events';
+import { PaginationMode } from 'data/content/resource';
 
 const setupMatchMedia = (matches: boolean) => {
   window.matchMedia = jest.fn().mockImplementation((query: string) => {
@@ -25,11 +27,19 @@ const setupMatchMedia = (matches: boolean) => {
   });
 };
 
-const renderPaginationControls = (pageCount: number, initiallyVisible: number[] = [0]) => {
+const renderPaginationControls = (
+  pageCount: number,
+  initiallyVisible: number[] = [0],
+  paginationMode: PaginationMode = 'normal',
+) => {
   const elements: React.ReactNode[] = [];
   for (let i = 0; i < pageCount; i += 1) {
     elements.push(<div key={`break-${i}`} className="content-break" />);
-    elements.push(<div key={`content-${i}`}>Page {i + 1} content</div>);
+    elements.push(
+      <div key={`content-${i}`} data-testid={`page-${i}`}>
+        Page {i + 1} content
+      </div>,
+    );
   }
 
   return render(
@@ -38,7 +48,7 @@ const renderPaginationControls = (pageCount: number, initiallyVisible: number[] 
       <div>
         <PaginationControls
           forId="pagination-test"
-          paginationMode="normal"
+          paginationMode={paginationMode}
           sectionSlug="section-slug"
           pageAttemptGuid="attempt-guid"
           initiallyVisible={initiallyVisible}
@@ -117,5 +127,19 @@ describe('PaginationControls', () => {
       expect(screen.getByRole('button', { name: label })).toBeInTheDocument();
     }
     expect(screen.queryByText('...')).not.toBeInTheDocument();
+  });
+
+  it('reveals an automated page after pagination pages have initialized', async () => {
+    setupMatchMedia(true);
+    const { getByTestId } = renderPaginationControls(2, [0], 'automatedReveal');
+
+    await waitFor(() => expect(getByTestId('page-0')).toHaveClass('show'));
+    expect(getByTestId('page-1')).not.toHaveClass('show');
+
+    act(() => {
+      document.dispatchEvent(Events.makeShowContentPage({ forId: 'pagination-test', index: 1 }));
+    });
+
+    await waitFor(() => expect(getByTestId('page-1')).toHaveClass('show'));
   });
 });

--- a/assets/test/data/persistence/pagination_test.ts
+++ b/assets/test/data/persistence/pagination_test.ts
@@ -8,9 +8,9 @@ jest.mock('../../../src/data/persistence/extrinsic', () => ({
 
 describe('updatePaginationState', () => {
   it('does not persist pagination state without a resource attempt guid', async () => {
-    await expect(updatePaginationState('section_slug' as any, '', 'group-id', [1])).resolves.toEqual(
-      {},
-    );
+    await expect(
+      updatePaginationState('section_slug' as any, '', 'group-id', [1]),
+    ).resolves.toEqual({});
 
     expect(Extrinsic.readAttempt).not.toHaveBeenCalled();
     expect(Extrinsic.upsertAttempt).not.toHaveBeenCalled();

--- a/assets/test/data/persistence/pagination_test.ts
+++ b/assets/test/data/persistence/pagination_test.ts
@@ -1,0 +1,18 @@
+import * as Extrinsic from '../../../src/data/persistence/extrinsic';
+import { updatePaginationState } from '../../../src/data/persistence/pagination';
+
+jest.mock('../../../src/data/persistence/extrinsic', () => ({
+  readAttempt: jest.fn(),
+  upsertAttempt: jest.fn(),
+}));
+
+describe('updatePaginationState', () => {
+  it('does not persist pagination state without a resource attempt guid', async () => {
+    await expect(updatePaginationState('section_slug' as any, '', 'group-id', [1])).resolves.toEqual(
+      {},
+    );
+
+    expect(Extrinsic.readAttempt).not.toHaveBeenCalled();
+    expect(Extrinsic.upsertAttempt).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
 ## Summary

  Fixes MER-5756: basic-page branching questions using “reveal questions by automation” stopped revealing subsequent paginated questions after the first response.

  The regression was introduced by #6152 / `a6a03c4c141` (`[MER-4470] condense pagination links on mobile devices`). That PR added defensive clamping in `PaginationControls.onSelectPage` based on `pages.count()`. The clamp itself is reasonable, but the automation event listener for the `oli-show-content-page` event was registered only once during the initial render, picking up an instance of onSelectPage that closed over `pages` when `pages` was still empty. As a result, automated reveal events saw `pages.count() === 0` and clamped every requested page back to page `0`.

  This meant learner delivery received the branching `show_page` action correctly, but the requested next page was never shown.

  ## Changes

  - Keep the latest pagination page count in a ref so the one-time automation event listener can clamp
  against the initialized page count.
  - Add a regression test that dispatches `oli-show-content-page` after pagination initialization and
  verifies the next page is revealed.

  ## Drive-by cleanup

  - Skip pagination-state persistence when there is no resource attempt guid as happens in authoring preview. This prevents authoring-preview 404s like `/resource_attempt/?keys[]=paginationState` which, though in fact harmless, add noise to the console window. 
  - Add a small test for the empty-attempt-guid persistence guard.

  ## Verification

  - `cd assets && yarn test test/components/misc/PaginationControls_test.tsx test/data/persistence/
  pagination_test.ts --runInBand`
  - `cd assets && yarn run check-types`

[MER-4470]: https://eliterate.atlassian.net/browse/MER-4470?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ