### PR TITLE
[BUG FIX] [MER-5257] Repair instructor_email GenAI config on existing servers + admin UI

### DIFF
--- a/lib/oli_web/live/gen_ai/feature_configs_view.ex
+++ b/lib/oli_web/live/gen_ai/feature_configs_view.ex
@@ -179,14 +179,12 @@ defmodule OliWeb.GenAI.FeatureConfigsView do
         <div>
           <label for="feature" class="block text-sm font-medium text-gray-700">Feature</label>
           <select id="feature" name="feature" value={@selected_feature} class={@form_control_classes}>
-            <option value="student_dialogue" selected={@selected_feature == :student_dialogue}>
-              Student Dialogue
-            </option>
             <option
-              value="instructor_dashboard_recommendation"
-              selected={@selected_feature == :instructor_dashboard_recommendation}
+              :for={{label, value} <- feature_options()}
+              value={value}
+              selected={@selected_feature == value}
             >
-              Instructor Dashboard Recommendation
+              {label}
             </option>
           </select>
         </div>
@@ -261,10 +259,7 @@ defmodule OliWeb.GenAI.FeatureConfigsView do
           type="select"
           disabled={true}
           class={@form_control_classes}
-          options={[
-            {"Student Dialogue", :student_dialogue},
-            {"Instructor Dashboard Recommendation", :instructor_dashboard_recommendation}
-          ]}
+          options={feature_options()}
           label="Feature"
         />
         <.input
@@ -502,5 +497,23 @@ defmodule OliWeb.GenAI.FeatureConfigsView do
     |> Enum.map(fn sc ->
       {sc.name, sc.id}
     end)
+  end
+
+  @doc """
+  Feature dropdown options derived from the `FeatureConfig` whitelist so the form
+  never drifts from the supported features (the cause of MER-5257: `instructor_email`
+  was added to the whitelist but not to the hardcoded dropdowns).
+  """
+  def feature_options do
+    Enum.map(FeatureConfig.features(), fn feature ->
+      {humanize_feature(feature), feature}
+    end)
+  end
+
+  defp humanize_feature(feature) do
+    feature
+    |> Atom.to_string()
+    |> String.split("_")
+    |> Enum.map_join(" ", &String.capitalize/1)
   end
 end

--- a/priv/repo/migrations/20260630120000_repair_instructor_email_feature_config_default.exs
+++ b/priv/repo/migrations/20260630120000_repair_instructor_email_feature_config_default.exs
@@ -1,0 +1,75 @@
+defmodule Oli.Repo.Migrations.RepairInstructorEmailFeatureConfigDefault do
+  use Ecto.Migration
+
+  @moduledoc """
+  Repairs the global `:instructor_email` GenAI feature config on already-running
+  environments (MER-5257 follow-up).
+
+  The original migration `20260513120000_add_instructor_email_feature_config`
+  created the global config only when a `completions_service_configs` row named
+  exactly `standard-no-backup` existed. Servers seeded before that name was
+  introduced (e.g. Tokamaka, Proton) name their bundle `standard`, so the
+  `WHERE name = 'standard-no-backup'` select matched nothing and the email
+  feature was left unconfigured for every section — `FeatureConfig.load_for/2`
+  returns `:missing_feature_config` and the Draft Email modal shows
+  "AI email generation is not configured for this course."
+
+  This backfill removes the hardcoded-name dependency: it derives the model from
+  the global `student_dialogue` feature config's service config (the canonical
+  GenAI default, seeded on every environment), falling back to the lowest-id
+  `registered_models` row. Both inserts are guarded by `WHERE NOT EXISTS` because
+  the unique index on `[:section_id, :feature]` does not prevent duplicate global
+  rows when `section_id IS NULL` (Postgres treats NULLs as distinct), and the
+  source selects are bounded to a single deterministic row because
+  `completions_service_configs.name` is not unique.
+
+  Intent is to guarantee the feature is *configured*, not to guarantee best
+  provider quality; operators can re-point the model afterward via the admin UI.
+  `down` is a no-op: deleting a global row later could remove operator-modified
+  production configuration.
+  """
+
+  def up do
+    execute("""
+    INSERT INTO completions_service_configs
+      (name, primary_model_id, backup_model_id, inserted_at, updated_at)
+    SELECT 'instructor-email-default', src.model_id, NULL, NOW(), NOW()
+    FROM (
+      SELECT COALESCE(
+        (SELECT sc.primary_model_id
+           FROM gen_ai_feature_configs g
+           JOIN completions_service_configs sc ON sc.id = g.service_config_id
+          WHERE g.feature = 'student_dialogue' AND g.section_id IS NULL
+          ORDER BY g.id
+          LIMIT 1),
+        (SELECT id FROM registered_models ORDER BY id LIMIT 1)
+      ) AS model_id
+    ) src
+    WHERE src.model_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM completions_service_configs
+         WHERE name = 'instructor-email-default'
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM gen_ai_feature_configs
+         WHERE feature = 'instructor_email' AND section_id IS NULL
+      );
+    """)
+
+    execute("""
+    INSERT INTO gen_ai_feature_configs
+      (feature, service_config_id, section_id, inserted_at, updated_at)
+    SELECT 'instructor_email', sc.id, NULL, NOW(), NOW()
+    FROM completions_service_configs sc
+    WHERE sc.name = 'instructor-email-default'
+      AND NOT EXISTS (
+        SELECT 1 FROM gen_ai_feature_configs
+         WHERE feature = 'instructor_email' AND section_id IS NULL
+      )
+    ORDER BY sc.id
+    LIMIT 1;
+    """)
+  end
+
+  def down, do: :ok
+end

--- a/test/oli/repo/migrations/repair_instructor_email_feature_config_default_test.exs
+++ b/test/oli/repo/migrations/repair_instructor_email_feature_config_default_test.exs
@@ -1,0 +1,198 @@
+defmodule Oli.Repo.Migrations.RepairInstructorEmailFeatureConfigDefaultTest do
+  @moduledoc """
+  Verifies the backfill logic of
+  `20260630120000_repair_instructor_email_feature_config_default`.
+
+  The two statements below mirror the migration's `up/0` verbatim. The migration
+  keeps its SQL self-contained (safe-migration guidance: independent from app
+  code), so the test re-runs the identical SQL against a sandboxed DB to exercise
+  the real behavior: name-agnostic source, single-row determinism, and
+  `WHERE NOT EXISTS` idempotency.
+  """
+  use Oli.DataCase
+
+  import Ecto.Query
+
+  alias Oli.GenAI.Completions.{RegisteredModel, ServiceConfig}
+  alias Oli.GenAI.FeatureConfig
+  alias Oli.Repo
+
+  @service_config_sql """
+  INSERT INTO completions_service_configs
+    (name, primary_model_id, backup_model_id, inserted_at, updated_at)
+  SELECT 'instructor-email-default', src.model_id, NULL, NOW(), NOW()
+  FROM (
+    SELECT COALESCE(
+      (SELECT sc.primary_model_id
+         FROM gen_ai_feature_configs g
+         JOIN completions_service_configs sc ON sc.id = g.service_config_id
+        WHERE g.feature = 'student_dialogue' AND g.section_id IS NULL
+        ORDER BY g.id
+        LIMIT 1),
+      (SELECT id FROM registered_models ORDER BY id LIMIT 1)
+    ) AS model_id
+  ) src
+  WHERE src.model_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM completions_service_configs
+       WHERE name = 'instructor-email-default'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM gen_ai_feature_configs
+       WHERE feature = 'instructor_email' AND section_id IS NULL
+    );
+  """
+
+  @feature_config_sql """
+  INSERT INTO gen_ai_feature_configs
+    (feature, service_config_id, section_id, inserted_at, updated_at)
+  SELECT 'instructor_email', sc.id, NULL, NOW(), NOW()
+  FROM completions_service_configs sc
+  WHERE sc.name = 'instructor-email-default'
+    AND NOT EXISTS (
+      SELECT 1 FROM gen_ai_feature_configs
+       WHERE feature = 'instructor_email' AND section_id IS NULL
+    )
+  ORDER BY sc.id
+  LIMIT 1;
+  """
+
+  # The test DB is seeded with the full GenAI defaults (including an
+  # instructor_email global). Wipe the three tables so each scenario below
+  # exercises the backfill from a known, controlled state. The sandbox rolls
+  # this back after every test.
+  setup do
+    Repo.delete_all(FeatureConfig)
+    Repo.delete_all(ServiceConfig)
+    Repo.delete_all(RegisteredModel)
+    :ok
+  end
+
+  defp backfill! do
+    Repo.query!(@service_config_sql)
+    Repo.query!(@feature_config_sql)
+  end
+
+  defp insert_model(name) do
+    Repo.insert!(%RegisteredModel{
+      name: name,
+      provider: :open_ai,
+      model: "gpt-4",
+      url_template: "https://api.example.com",
+      api_key: "secret",
+      timeout: 8000,
+      recv_timeout: 60_000
+    })
+  end
+
+  defp global_email_configs do
+    Repo.all(
+      from(g in FeatureConfig, where: g.feature == :instructor_email and is_nil(g.section_id))
+    )
+  end
+
+  describe "Tokamaka shape: existing config named 'standard', no 'standard-no-backup'" do
+    setup do
+      model = insert_model("Primary Model")
+
+      service_config =
+        Repo.insert!(%ServiceConfig{name: "standard", primary_model_id: model.id})
+
+      # The canonical GenAI default seeded on every environment.
+      Repo.insert!(%FeatureConfig{
+        feature: :student_dialogue,
+        service_config_id: service_config.id,
+        section_id: nil
+      })
+
+      %{model: model}
+    end
+
+    test "creates exactly one global instructor_email config from the student_dialogue default",
+         %{model: model} do
+      backfill!()
+
+      email_service_config = Repo.get_by!(ServiceConfig, name: "instructor-email-default")
+      assert email_service_config.primary_model_id == model.id
+      assert is_nil(email_service_config.backup_model_id)
+
+      assert [config] = global_email_configs()
+      assert config.service_config_id == email_service_config.id
+    end
+
+    test "is idempotent across repeated runs" do
+      backfill!()
+      backfill!()
+      backfill!()
+
+      assert Repo.aggregate(
+               from(s in ServiceConfig, where: s.name == "instructor-email-default"),
+               :count
+             ) == 1
+
+      assert length(global_email_configs()) == 1
+    end
+  end
+
+  describe "fallback when no student_dialogue default exists" do
+    test "derives the model from the lowest-id registered model" do
+      lowest = insert_model("Lowest")
+      _higher = insert_model("Higher")
+
+      backfill!()
+
+      email_service_config = Repo.get_by!(ServiceConfig, name: "instructor-email-default")
+      assert email_service_config.primary_model_id == lowest.id
+      assert [_config] = global_email_configs()
+    end
+
+    test "creates nothing when there is no source model at all" do
+      backfill!()
+
+      assert Repo.aggregate(
+               from(s in ServiceConfig, where: s.name == "instructor-email-default"),
+               :count
+             ) == 0
+
+      assert global_email_configs() == []
+    end
+  end
+
+  describe "a global instructor_email config already exists" do
+    test "creates no orphan instructor-email-default service config" do
+      model = insert_model("Primary Model")
+
+      other_config =
+        Repo.insert!(%ServiceConfig{name: "standard", primary_model_id: model.id})
+
+      # Operator/console already provisioned the global config against another
+      # service config (e.g. an earlier manual workaround). The backfill must
+      # no-op entirely, not leave behind an unused instructor-email-default.
+      Repo.insert!(%FeatureConfig{
+        feature: :instructor_email,
+        service_config_id: other_config.id,
+        section_id: nil
+      })
+
+      backfill!()
+
+      refute Repo.exists?(from(s in ServiceConfig, where: s.name == "instructor-email-default"))
+      assert [config] = global_email_configs()
+      assert config.service_config_id == other_config.id
+    end
+  end
+
+  describe "duplicate-named service configs" do
+    test "inserts a single global feature row even if 'instructor-email-default' is duplicated" do
+      model = insert_model("Primary Model")
+      Repo.insert!(%ServiceConfig{name: "instructor-email-default", primary_model_id: model.id})
+      Repo.insert!(%ServiceConfig{name: "instructor-email-default", primary_model_id: model.id})
+
+      # Service config insert is a no-op (name already present); feature insert
+      # must still bind to exactly one row via ORDER BY ... LIMIT 1.
+      backfill!()
+
+      assert length(global_email_configs()) == 1
+    end
+  end
+end

--- a/test/oli_web/live/gen_ai/feature_configs_view_test.exs
+++ b/test/oli_web/live/gen_ai/feature_configs_view_test.exs
@@ -1,0 +1,79 @@
+defmodule OliWeb.GenAI.FeatureConfigsViewTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.GenAI.Completions.{RegisteredModel, ServiceConfig}
+  alias Oli.GenAI.FeatureConfig
+  alias OliWeb.GenAI.FeatureConfigsView
+  alias Oli.Repo
+
+  @route Routes.live_path(OliWeb.Endpoint, FeatureConfigsView)
+
+  describe "feature_options/0" do
+    test "covers every feature in the FeatureConfig whitelist" do
+      option_values = FeatureConfigsView.feature_options() |> Enum.map(fn {_label, v} -> v end)
+
+      # Guards the MER-5257 drift: the dropdowns must always reflect the
+      # whitelist, so a newly supported feature can never be silently
+      # unselectable again.
+      assert Enum.sort(option_values) == Enum.sort(FeatureConfig.features())
+    end
+
+    test "includes :instructor_email with a human-readable label" do
+      assert {"Instructor Email", :instructor_email} in FeatureConfigsView.feature_options()
+    end
+
+    test "humanizes multi-word feature atoms" do
+      assert {"Instructor Dashboard Recommendation", :instructor_dashboard_recommendation} in FeatureConfigsView.feature_options()
+    end
+  end
+
+  describe "rendered admin page" do
+    setup [:admin_conn, :create_feature_config]
+
+    test "Create and Edit feature dropdowns expose instructor_email", %{conn: conn} do
+      {:ok, _view, html} = live(conn, @route)
+
+      # The actual changed UI surfaces, not just the helper: both dropdowns
+      # render the option, proving the templates consume feature_options/0.
+      assert html =~ ~s(value="instructor_email")
+      assert html =~ "Instructor Email"
+    end
+
+    test "selecting instructor_email in the Create form does not crash", %{conn: conn} do
+      {:ok, view, _html} = live(conn, @route)
+
+      html =
+        view
+        |> element("form[phx-change=\"feature_changed\"]")
+        |> render_change(%{"feature" => "instructor_email"})
+
+      assert html =~ ~s(value="instructor_email")
+    end
+  end
+
+  defp create_feature_config(_context) do
+    model =
+      Repo.insert!(%RegisteredModel{
+        name: "Test Model",
+        provider: :null,
+        model: "null",
+        url_template: "http://localhost",
+        api_key: "secret",
+        timeout: 8000,
+        recv_timeout: 60_000
+      })
+
+    service_config = Repo.insert!(%ServiceConfig{name: "standard", primary_model_id: model.id})
+
+    feature_config =
+      Repo.insert!(%FeatureConfig{
+        feature: :student_dialogue,
+        service_config_id: service_config.id,
+        section_id: nil
+      })
+
+    {:ok, service_config: service_config, feature_config: feature_config}
+  end
+end


### PR DESCRIPTION
## Problem
On already-seeded servers such as Tokamaka, the Draft Email modal can show "AI email generation is not configured for this course." because no `instructor_email` GenAI feature config exists.

## Root Cause
The MER-5257 backfill migration in #6556 created the global `instructor_email` config only when a service config named exactly `standard-no-backup` existed. Earlier-seeded servers may use `standard`, so the select matched nothing and no global config was created.

Separately, the admin Feature Configs UI did not list `instructor_email` in its Create/Edit dropdowns, so the UI could drift from the `FeatureConfig` whitelist.

## Fix
- Add a forward-only, idempotent repair migration that backfills the global `instructor_email` config.
- Derive the service model from the global `student_dialogue` default, with a fallback to the lowest registered model.
- Guard inserts with `WHERE NOT EXISTS` checks, including the existing-global case, so reruns and manually repaired environments do not create duplicates or orphan service configs.
- Render admin feature dropdowns from `FeatureConfig.features()`.

## Testing
- Migration coverage for Tokamaka shape (`standard` service config), idempotency, fallback model selection, no source no-op, duplicate service-config names, and no orphan when a global config already exists.
- LiveView coverage for `instructor_email` dropdown exposure and the Create-form `feature_changed` path.
- Full suite green.
- Verified locally; not run against the real Tokamaka DB.


<img width="1153" height="603" alt="image" src="https://github.com/user-attachments/assets/74a7bb55-2993-4579-9006-cccde077d5fc" />

