### PR TITLE
[ENHANCEMENT] [MER-5420] Advanced Author Adaptive Page Research Spike

### DIFF
--- a/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
+++ b/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
@@ -33,6 +33,24 @@ export class StudentCoursePO {
     await Verifier.expectIsVisible(l);
   }
 
+  async openPage(pageName: string) {
+    const pageTitle = this.page.getByRole('heading', { name: pageName, exact: true, level: 5 });
+    const pageCard = this.page
+      .locator('div[phx-click="navigate_to_resource"]')
+      .filter({ has: pageTitle })
+      .first();
+
+    await Verifier.expectIsVisible(pageTitle);
+    await Promise.all([
+      this.page.waitForURL((url) => url.pathname.includes('/adaptive_lesson/'), {
+        timeout: 15000,
+      }),
+      pageCard.click({ force: true }),
+    ]);
+
+    await Verifier.expectIsVisible(this.page.getByRole('heading', { name: pageName, exact: true }));
+  }
+
   async goToCourseIfPrompted() {
     const wizard = this.onboardingWizard;
 

--- a/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
+++ b/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
@@ -24,7 +24,7 @@ export class BasicPracticePagePO {
   private readonly pageTitleInput: Locator;
   private readonly pageTitleSaveButton: Locator;
   private readonly adaptiveReadOnlyInput: Locator;
-  private readonly adaptiveReadOnlyToggle: Locator;
+  private readonly advancedAuthorToolbar: Locator;
   private readonly captionAudio: Locator;
   private readonly figure: Locator;
   private readonly textbox: Locator;
@@ -60,7 +60,7 @@ export class BasicPracticePagePO {
     this.adaptiveReadOnlyInput = page.locator(
       '#adaptive_read_only_toggle input[name="adaptive_read_only"]',
     );
-    this.adaptiveReadOnlyToggle = page.locator('#adaptive_read_only_toggle label');
+    this.advancedAuthorToolbar = page.locator('#advanced-authoring nav.aa-header-nav');
     this.captionAudio = page.getByRole('paragraph').filter({ hasText: 'Caption (optional)' });
     this.figure = this.page.getByRole('figure', { name: 'Figure Title' });
     this.textbox = this.figure.getByRole('textbox');
@@ -69,6 +69,56 @@ export class BasicPracticePagePO {
 
   async verifyTitlePage(titlePage = 'New Page') {
     await Verifier.expectHasText(this.pageTitle, titlePage);
+  }
+
+  async clickAdvancedAuthorMultipleChoiceButton() {
+    await this.advancedAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
+    await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
+      timeout: 30000,
+    });
+
+    await this.page.evaluate(() => {
+      const mcqButton = document
+        .querySelector(
+          '#advanced-authoring nav.aa-header-nav button img[src="/images/icons/icon-part-mcq.svg"]',
+        )
+        ?.closest('button');
+
+      if (!mcqButton) {
+        throw new Error('MCQ toolbar button was not found.');
+      }
+
+      mcqButton.click();
+    });
+  }
+
+  async ensureAdvancedAuthorEditable() {
+    const hasToggle = (await this.adaptiveReadOnlyInput.count().catch(() => 0)) > 0;
+    if (!hasToggle) return this.assertAdvancedAuthorEditable();
+
+    await expect(this.adaptiveReadOnlyInput).toBeEnabled({ timeout: 30000 });
+
+    if (!(await this.adaptiveReadOnlyInput.isChecked().catch(() => false))) {
+      return this.assertAdvancedAuthorEditable();
+    }
+
+    await this.page.evaluate(() => {
+      const input = document.querySelector<HTMLInputElement>('input[name="adaptive_read_only"]');
+
+      if (input?.checked) {
+        input.click();
+      }
+    });
+
+    await expect(this.adaptiveReadOnlyInput).not.toBeChecked({ timeout: 10000 });
+    await this.assertAdvancedAuthorEditable();
+  }
+
+  private async assertAdvancedAuthorEditable() {
+    await expect(this.editTitleButton, 'Advanced authoring should be editable.').toBeEnabled({
+      timeout: 15000,
+    });
+    await this.advancedAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
   }
 
   async renameTitle(titlePage: string) {
@@ -85,14 +135,7 @@ export class BasicPracticePagePO {
   private async ensureTitleEditingEnabled() {
     if (await this.editTitleButton.isEnabled().catch(() => false)) return;
 
-    if ((await this.adaptiveReadOnlyInput.count().catch(() => 0)) > 0) {
-      await expect(this.adaptiveReadOnlyInput).toBeEnabled({ timeout: 10000 });
-
-      if (await this.adaptiveReadOnlyInput.isChecked().catch(() => false)) {
-        await this.adaptiveReadOnlyToggle.click();
-        await expect(this.adaptiveReadOnlyInput).not.toBeChecked({ timeout: 10000 });
-      }
-    }
+    await this.ensureAdvancedAuthorEditable();
 
     await expect(this.editTitleButton, 'Page title edit button should be enabled.').toBeEnabled({
       timeout: 15000,

--- a/assets/automation/src/systems/torus/pom/project/CurriculumPO.ts
+++ b/assets/automation/src/systems/torus/pom/project/CurriculumPO.ts
@@ -49,7 +49,18 @@ export class CurriculumPO {
 
   async clickAdaptivePracticeButton() {
     await this.adaptivePracticeButton.click();
-    if (await this.pageEditorIsOpen()) return true;
+    const editorTitleBar = this.page.locator('div.TitleBar');
+
+    try {
+      await Promise.race([
+        this.page.waitForURL(/\/curriculum\/[^/]+\/edit$/, { timeout: 10000 }),
+        editorTitleBar.waitFor({ state: 'visible', timeout: 10000 }),
+      ]);
+      return true;
+    } catch {
+      // fall through to the curriculum entry verification below
+    }
+
     await this.verifyPage('New Advanced Author Page', 'Edit Page', 'last');
     return false;
   }

--- a/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
+++ b/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 import { FileManager } from '@core/FileManager';
 import { Table } from '@core/Table';
 import { Utils } from '@core/Utils';
@@ -162,6 +162,17 @@ export class CurriculumTask {
     await this.basicPP.renameTitle(titlePage);
     await this.returnToCurriculum();
     await this.curriculum.expectPageVisible(titlePage);
+  }
+
+  @step('Create an adaptive page in Advanced Author')
+  async createAdaptivePageInAdvancedAuthor(stayInEditor = false) {
+    await this.addPage('adaptive-practice', true);
+    await this.basicPP.ensureAdvancedAuthorEditable();
+    await this.basicPP.waitForChangesSaved().catch(() => void 0);
+    if (!stayInEditor) {
+      await this.returnToCurriculum();
+      await this.curriculum.expectPageVisible('New Advanced Author Page');
+    }
   }
 
   @step('Enter a page from the project. Type: {type}')
@@ -576,6 +587,18 @@ export class CurriculumTask {
     await this.basicPP.clickInsertButtonIcon();
     await this.basicPP.selectActivity(activity);
     await this.basicPP.waitForChangesSaved();
+  }
+
+  @step('Add a multiple choice question in Advanced Author')
+  async addAdvancedAuthorMultipleChoiceQuestion() {
+    await this.basicPP.clickAdvancedAuthorMultipleChoiceButton();
+    await this.page.waitForFunction(
+      () => document.querySelectorAll('janus-mcq').length > 0,
+      undefined,
+      { timeout: 30000 },
+    );
+    await expect(this.page.locator('janus-mcq').first()).toBeVisible({ timeout: 30000 });
+    await this.basicPP.waitForChangesSaved().catch(() => void 0);
   }
 
   @step("Add activities with questions '{editorTitle}', '{activityType}' and '{questionText}'")

--- a/assets/automation/src/systems/torus/tasks/ProjectTask.ts
+++ b/assets/automation/src/systems/torus/tasks/ProjectTask.ts
@@ -94,9 +94,7 @@ export class ProjectTask {
 
   @step('Publish project')
   async publishProject(description?: string) {
-    if (description) {
-      await this.publishP.fillDescription(description);
-    }
+    await this.publishP.fillDescription(description ?? 'Automated publish').catch(() => void 0);
 
     const autoPush = await this.publishP.autoPushIsChecked();
     if (!autoPush && autoPush != null) {

--- a/assets/automation/src/systems/torus/tasks/StudentTask.ts
+++ b/assets/automation/src/systems/torus/tasks/StudentTask.ts
@@ -44,9 +44,4 @@ export class StudentTask {
       await this.studentCourse.presentPage(name);
     }
   }
-
-  @step('Open resource "{pageName}"')
-  async openResource(pageName: string) {
-    await this.studentCourse.openPage(pageName);
-  }
 }

--- a/assets/automation/src/systems/torus/tasks/StudentTask.ts
+++ b/assets/automation/src/systems/torus/tasks/StudentTask.ts
@@ -44,4 +44,9 @@ export class StudentTask {
       await this.studentCourse.presentPage(name);
     }
   }
+
+  @step('Open resource "{pageName}"')
+  async openResource(pageName: string) {
+    await this.studentCourse.openPage(pageName);
+  }
 }

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -1,0 +1,120 @@
+import { expect } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import { setRuntimeConfig } from '@core/runtimeConfig';
+import { HomeTask } from '@tasks/HomeTask';
+import { ProjectTask } from '@tasks/ProjectTask';
+import { CurriculumTask } from '@tasks/CurriculumTask';
+import { StudentTask } from '@tasks/StudentTask';
+import { TYPE_USER } from '@pom/types/type-user';
+
+const runId = `-${Date.now()}`;
+const baseUrl = 'http://localhost';
+const defaultPassword = 'changeme123456';
+const adminPassword = 'changeme123456';
+const projectName = `TQA-19-automation${runId}`;
+const adaptivePageTitle = 'New Advanced Author Page';
+const scenarioPath = `${__dirname}/playwright_adaptive_authoring.yaml`;
+
+setRuntimeConfig({
+  baseUrl,
+  scenarioToken: 'my-token',
+  loginData: {
+    student: {
+      type: TYPE_USER.student,
+      pageTitle: 'OLI Torus',
+      role: 'Student',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Hi, Jane',
+      email: `student${runId}@example.com`,
+      name: 'Jane',
+      last_name: 'Student',
+      pass: defaultPassword,
+    },
+    instructor: {
+      type: TYPE_USER.instructor,
+      pageTitle: 'OLI Torus',
+      role: 'Instructor',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Instructor Dashboard',
+      email: `instructor${runId}@example.com`,
+      pass: defaultPassword,
+      header: 'Instructor Dashboard',
+    },
+    author: {
+      type: TYPE_USER.author,
+      pageTitle: 'OLI Torus',
+      role: 'Course Author',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Course Author',
+      email: `author${runId}@example.com`,
+      pass: defaultPassword,
+      header: 'Course Author',
+    },
+    administrator: {
+      type: TYPE_USER.administrator,
+      pageTitle: 'OLI Torus',
+      role: 'Course Author',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Course Author',
+      email: `admin${runId}@example.com`,
+      pass: adminPassword,
+      header: 'Course Author',
+    },
+  },
+});
+
+test.beforeAll(async ({ seedScenario }) => {
+  await seedScenario(scenarioPath, {
+    RUN_ID: runId,
+  });
+});
+
+test('Author creates an adaptive page with MCQ and student resolves it', async ({ browser }) => {
+  test.setTimeout(180_000);
+  const authorContext = await browser.newContext();
+  const studentContext = await browser.newContext();
+
+  try {
+    const authorPage = await authorContext.newPage();
+    const studentPage = await studentContext.newPage();
+
+    const authorHomeTask = new HomeTask(authorPage);
+    const authorProjectTask = new ProjectTask(authorPage);
+    const authorCurriculumTask = new CurriculumTask(authorPage);
+
+    const studentHomeTask = new HomeTask(studentPage);
+    const studentTask = new StudentTask(studentPage);
+
+    // Author flow: create the adaptive page and add the MCQ activity.
+    await authorHomeTask.goToSite(baseUrl);
+    await authorHomeTask.login('author');
+    await authorProjectTask.searchAndEnterProject(projectName);
+    await authorHomeTask.enterToCurriculum();
+    await authorCurriculumTask.createAdaptivePageInAdvancedAuthor(true);
+    await authorCurriculumTask.addAdvancedAuthorMultipleChoiceQuestion();
+
+    // Publish the authored page so it becomes available to learners.
+    await authorHomeTask.enterToPublish();
+    await authorProjectTask.publishProject();
+
+    // Student flow: open the published page from Learn.
+    await studentHomeTask.goToSite(baseUrl);
+    await studentHomeTask.login('student');
+    await studentTask.searchProject(projectName);
+    await studentHomeTask.enterToLearn();
+    await studentTask.validateResource([adaptivePageTitle]);
+    await studentTask.openResource(adaptivePageTitle);
+
+    // Validate that the MCQ is rendered and can be answered.
+    await expect(studentPage.locator('janus-mcq').first()).toBeVisible();
+    const correctChoice = studentPage.getByRole('radio').first();
+    await expect(correctChoice).toBeVisible();
+    await correctChoice.click();
+    await expect(studentPage.getByRole('radio', { name: 'Option 1' })).toBeChecked();
+    await expect(studentPage.getByRole('radio', { name: 'Option 2' })).not.toBeChecked();
+    await expect(studentPage.getByRole('radio', { name: 'Option 3' })).not.toBeChecked();
+  } finally {
+    await studentContext.close();
+    await authorContext.close();
+  }
+});

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -110,7 +110,7 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
     // Validate that the MCQ is rendered and can be answered.
     await expect(studentPage.locator('janus-mcq').first()).toBeVisible();
     await expect(studentPage.getByRole('radio').first()).toBeVisible();
-    await studentPage.getByRole('radio').first().click();
+    await studentPage.getByRole('radio', { name: 'Option 1' }).click();
     await expect(studentPage.getByRole('radio', { name: 'Option 1' })).toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 2' })).not.toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 3' })).not.toBeChecked();

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -6,6 +6,7 @@ import { ProjectTask } from '@tasks/ProjectTask';
 import { CurriculumTask } from '@tasks/CurriculumTask';
 import { StudentTask } from '@tasks/StudentTask';
 import { TYPE_USER } from '@pom/types/type-user';
+import { StudentCoursePO } from '@pom/course/StudentCoursePO';
 
 const runId = `-${Date.now()}`;
 const baseUrl = 'http://localhost';
@@ -84,6 +85,7 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
 
     const studentHomeTask = new HomeTask(studentPage);
     const studentTask = new StudentTask(studentPage);
+    const studentCourse = new StudentCoursePO(studentPage);
 
     // Author flow: create the adaptive page and add the MCQ activity.
     await authorHomeTask.goToSite(baseUrl);
@@ -103,13 +105,12 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
     await studentTask.searchProject(projectName);
     await studentHomeTask.enterToLearn();
     await studentTask.validateResource([adaptivePageTitle]);
-    await studentTask.openResource(adaptivePageTitle);
+    await studentCourse.openPage(adaptivePageTitle);
 
     // Validate that the MCQ is rendered and can be answered.
     await expect(studentPage.locator('janus-mcq').first()).toBeVisible();
-    const correctChoice = studentPage.getByRole('radio').first();
-    await expect(correctChoice).toBeVisible();
-    await correctChoice.click();
+    await expect(studentPage.getByRole('radio').first()).toBeVisible();
+    await studentPage.getByRole('radio').first().click();
     await expect(studentPage.getByRole('radio', { name: 'Option 1' })).toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 2' })).not.toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 3' })).not.toBeChecked();

--- a/assets/automation/tests/torus/course_authoring/playwright_adaptive_authoring.yaml
+++ b/assets/automation/tests/torus/course_authoring/playwright_adaptive_authoring.yaml
@@ -1,0 +1,54 @@
+# Seeds Playwright adaptive authoring data for MER-5420.
+# Parameters:
+#   RUN_ID - optional suffix to make project names unique (defaults to "")
+
+- user:
+    name: 'playwright_instructor'
+    type: 'instructor'
+    email: 'instructor${RUN_ID}@example.com'
+    given_name: 'Playwright'
+    family_name: 'Instructor'
+    password: 'changeme123456'
+    can_create_sections: true
+
+- user:
+    name: 'playwright_student'
+    type: 'student'
+    email: 'student${RUN_ID}@example.com'
+    given_name: 'Jane'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
+    name: 'playwright_author'
+    type: 'author'
+    email: 'author${RUN_ID}@example.com'
+    given_name: 'Playwright'
+    family_name: 'Author'
+    password: 'changeme123456'
+
+- project:
+    name: 'TQA-19-automation${RUN_ID}'
+    title: 'TQA-19-automation${RUN_ID}'
+    visibility: global
+    root:
+      children:
+        - page: 'Page 1'
+
+- section:
+    name: 'TQA-19-automation${RUN_ID}'
+    title: 'TQA-19-automation${RUN_ID}'
+    from: 'TQA-19-automation${RUN_ID}'
+    open_and_free: true
+
+- enroll:
+    user: 'playwright_instructor'
+    email: 'instructor${RUN_ID}@example.com'
+    section: 'TQA-19-automation${RUN_ID}'
+    role: instructor
+
+- enroll:
+    user: 'playwright_student'
+    email: 'student${RUN_ID}@example.com'
+    section: 'TQA-19-automation${RUN_ID}'
+    role: student


### PR DESCRIPTION
[MER-5420](https://eliterate.atlassian.net/browse/MER-5420)

## Summary

This research spike validates that adaptive pages in Advanced Author can be authored correctly through Playwright. The main goal was to confirm that the authoring flow on an adaptive page is viable, and that the page can be exercised from different roles without running into meaningful blockers.

For this spike, MCQ was used as the representative Advanced Author scenario. The flow starts from an `Oli.Scenario` to bootstrap state, creates the adaptive page as the `author` role, adds an MCQ, publishes the lesson, and then switches to an independent `student` context to confirm that the published page appears in Learn and that the activity can be resolved without issues.

As a result of the spike, we confirmed that this approach is feasible and reusable. In particular, it showed that adaptive pages can be manipulated quite directly from different roles, in this case `author` and `student`, without hitting blocking friction in the end-to-end flow. That gives us a clear basis for expanding Advanced Author coverage following the spreadsheet-driven cases, keeping authoring and learner-side validation in the same end-to-end path while separating responsibilities into two browser contexts.

### Validation

- Adaptive page creation in Advanced Author is covered with Playwright
- MCQ authoring is exercised in the Advanced Author editor
- The created page is published and opened from the student side
- The student can interact with the MCQ successfully
- The spike confirms that Advanced Author authoring is viable and that the dual author/student pattern is an effective way to validate it

[MER-5420]: https://eliterate.atlassian.net/browse/MER-5420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ