### PR TITLE
[FEATURE] [MER-5624] Filter Questions Within Activity Bank Selections

### DIFF
--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/implementation_brief.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/implementation_brief.md
@@ -195,7 +195,7 @@ Tasks:
 - Generate question type options from questions in the current activity bank selection candidate set.
 - Include both available and removed questions when generating options.
 - Implement multi-select dropdowns with selected state and clear behavior.
-- Combine visibility, search, LO, and question type filters as AND criteria.
+- Combine filter families with AND semantics. Multiple selected Learning Objectives or Question Types should match any selected option within that family.
 - Add tests for option generation, multi-select behavior, and combined filtering.
 
 Commit:
@@ -230,7 +230,7 @@ Likely coverage:
 - Search updates results dynamically.
 - LO/type options are generated only from current selection candidates.
 - LO/type filters are multi-select.
-- Combined filters narrow with AND semantics.
+- Combined filter families narrow with AND semantics; multi-select values within LO and type filters match any selected option.
 - Clear All resets all filters.
 - Empty result state renders explanatory copy.
 - Existing remove/restore and selected-preview flows preserve active filters.
@@ -250,4 +250,3 @@ Expected commands:
 - Searching question content may be limited by what the current candidate query exposes; if content matching is expensive, prefer a targeted query-level implementation.
 - `MER-5623` branch behavior may change table selection or bulk-action state. Keep this ticket compatible with current branch behavior and document any follow-up once `MER-5623` merges.
 - Dropdown and filter toolbar states are partially unspecified in Figma. Use sensible token-aligned states and expect visual iteration.
-

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/implementation_brief.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/implementation_brief.md
@@ -1,0 +1,253 @@
+# Bank Selection Filters - Lightweight Implementation Brief
+
+Source ticket: `MER-5624`
+
+This document captures the lightweight UI implementation brief and phased execution plan agreed in chat on 2026-06-29. It is intentionally smaller than a full PRD/FDD/plan pack and is meant to support a `harness-work` style implementation with phase-by-phase review and commits.
+
+## Current Decision
+
+Use a lightweight process, not the full feature planning lane.
+
+- Implementation should extend the existing bank-selection manager LiveView.
+- Work should proceed in explicit phases.
+- Each phase should be reviewed before continuing.
+- Each implementation phase should land as its own commit.
+- Do not implement the whole ticket in one pass.
+
+## Important Dependency Note
+
+`MER-5623` is currently in review / pull request and should not be assumed to be implemented on this branch.
+
+Implication:
+
+- Treat bulk-action preservation requirements as compatibility constraints.
+- Do not build on unpublished `MER-5623` branch behavior unless it has been merged into the current branch.
+- If checkbox-only state from `MER-5622` exists, preserve it where practical.
+- If full bulk actions are absent, document the preservation boundary in the phase summary instead of inventing `MER-5623` behavior.
+
+## Design Sources
+
+- Full filter component, including Show All/Available/Removed toggles plus search, learning-objective filter, and question-type filter:
+  `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7440&t=SNzWnAHAxamIxKZQ-4`
+- Search bar plus learning-objective and question-type filter component detail:
+  `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=305-11129&t=SNzWnAHAxamIxKZQ-4`
+- Learning Objectives dropdown example:
+  `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=385-6445&t=SNzWnAHAxamIxKZQ-4`
+- In-page manager context:
+  `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7391`
+
+## Implementation Surface
+
+Surface: `liveview/heex`
+
+Rationale:
+
+- `OliWeb.Delivery.Instructor.BankSelectionManagerLive` already owns candidate state, paging, selected preview, remove/restore events, and warning flows.
+- Filtering should remain server-driven so it can apply to the full candidate set, not only currently loaded rows.
+- React preview components should not own filter state or filtering behavior.
+
+## Design System Alignment
+
+Shared vs local decision: `keep feature-local`
+
+- The composed toolbar is domain-specific to activity bank selection candidate management.
+- Use existing token classes and `OliWeb.Icons`.
+- Do not force a new shared filter component unless implementation reveals a clean, already-existing reusable primitive.
+- Do not create or modify design tokens in this ticket.
+
+Potential reuse:
+
+- Search input visual pattern can borrow from instructor insights / student support tile conventions.
+- Toggle buttons can follow the local filter button pattern from instructor dashboard tiles.
+- Dropdown button styling can use existing tokenized Tailwind classes and `Icons.chevron_down`.
+- Clear All should use `Icons.trash`.
+
+## Token Mapping
+
+- Toolbar surface: `bg-Surface-surface-primary`
+- Primary toggle background: `bg-Background-bg-primary`
+- Search/dropdown input fill: `bg-Specially-Tokens-Fill-fill-input`
+- Active toggle text/border: `text-Text-text-button`, `border-Text-text-button`
+- Inactive text: `text-Text-text-high`
+- Inactive borders: `border-Border-border-default` or `border-Specially-Tokens-Border-border-input`
+- Hover/focus: use existing button/input focus rings, usually `focus-visible:outline-Fill-Buttons-fill-primary`
+- Filter typography: `font-open-sans text-[16px] font-semibold leading-6`
+- Clear All typography: `text-sm font-normal`
+- Dropdown option typography: `text-sm font-normal leading-6`
+- Figma shadow: `0px 2px 10px rgba(0,50,99,0.1)` may be represented with an existing local arbitrary shadow if no tokenized equivalent exists.
+
+## Interaction Decisions
+
+- Keep the current manager count copy: `Showing X of Y questions`.
+- Primary visibility filter is single-select.
+- Default primary visibility filter is Show All.
+- Search should update dynamically with debounce and require no manual submit.
+- Search should filter server-side across the full candidate set.
+- Learning Objective and Question Type filters should be multi-select.
+- Filter option sets should be generated from the current activity bank selection candidate set, including available and removed questions.
+- Changing filters should reset pagination to the first filtered page.
+- If the selected candidate is filtered out, select the first visible filtered row.
+- If no rows match, show an explanatory empty state and no candidate preview.
+- Clear All resets primary visibility to Show All and clears search, learning objectives, and question types.
+- Remove/restore, preview selection, candidate checkbox interactions, and future bulk actions should not unintentionally reset active filters.
+
+## Open Design-State Handling
+
+Figma does not show every state. Use pragmatic defaults and adjust in later review if needed.
+
+- Selected secondary filters can be indicated with selected count or active styling.
+- Long LO labels should truncate or wrap only inside the dropdown, without widening the toolbar unexpectedly.
+- Empty LO/type option lists should render a small explanatory disabled row or keep the dropdown disabled.
+- Dropdown focus/hover states should use existing tokenized focus and hover behavior.
+
+## File Targets
+
+Likely primary files:
+
+- `lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex`
+- tests under `test/oli_web/live/delivery/instructor/`
+
+Possible domain/context files if server-side filtering belongs below the LiveView:
+
+- `lib/oli/delivery/instructor_customizations.ex`
+- related tests under `test/oli/delivery/instructor_customizations/`
+
+Avoid touching:
+
+- React preview components unless a filter-related visual bridge bug is discovered.
+- Shared `design_tokens/` primitives unless reuse becomes clearly justified and explicitly approved.
+- Broader epic docs unless implementation changes those documented assumptions.
+
+## Phased Execution Plan
+
+### Phase 0: Preparation And Branch Reality Check
+
+Goal: establish exact current branch state before implementation.
+
+Tasks:
+
+- Confirm `MER-5623` is not present on this branch.
+- Inspect existing manager LiveView tests.
+- Identify the current candidate row view model fields available for title, content, objective data, question type, and enabled/removed state.
+- Decide whether candidate filtering can be added to the existing `list_bank_selection_candidates/4` path or needs a small companion query/view model helper.
+
+Commit:
+
+- Optional planning-only commit for `informal.md` and this brief, if desired.
+
+### Phase 1: Filter Contract And Server-Side Listing
+
+Goal: add the filtering data contract without final UI polish.
+
+Tasks:
+
+- Add a filter state shape to `BankSelectionManagerLive`.
+- Thread filters through candidate load, refresh, and pagination.
+- Reset offset when filters change.
+- Keep the current `Showing X of Y questions` behavior, updated for filtered totals.
+- Preserve selected candidate when still visible; otherwise select the first visible filtered candidate.
+- Add focused tests for filter state transitions and pagination reset.
+
+Commit:
+
+- Commit phase 1 after tests pass.
+
+### Phase 2: Primary Visibility Filters
+
+Goal: implement Show All, Show Available, and Show Removed.
+
+Tasks:
+
+- Add the primary single-select filter UI above the candidate table.
+- Default to Show All.
+- Show Available excludes removed rows.
+- Show Removed excludes available rows.
+- Add empty state messaging for no matching questions.
+- Add LiveView tests for all three states and mutual exclusivity.
+
+Commit:
+
+- Commit phase 2 after tests pass.
+
+### Phase 3: Search
+
+Goal: add dynamic text search.
+
+Tasks:
+
+- Add the search input matching the Figma toolbar.
+- Search should debounce and update without manual submit.
+- Search title and question content where practical from the available data/query layer.
+- Preserve search through preview selection, remove/restore, and checkbox interactions.
+- Add tests for title/content matching and no manual submit requirement.
+
+Commit:
+
+- Commit phase 3 after tests pass.
+
+### Phase 4: Learning Objective And Question Type Filters
+
+Goal: add the two multi-select dropdown filters.
+
+Tasks:
+
+- Generate LO options from questions in the current activity bank selection candidate set.
+- Generate question type options from questions in the current activity bank selection candidate set.
+- Include both available and removed questions when generating options.
+- Implement multi-select dropdowns with selected state and clear behavior.
+- Combine visibility, search, LO, and question type filters as AND criteria.
+- Add tests for option generation, multi-select behavior, and combined filtering.
+
+Commit:
+
+- Commit phase 4 after tests pass.
+
+### Phase 5: Clear All, Preservation, Polish, And Review
+
+Goal: close the ticket behavior and prepare for PR review.
+
+Tasks:
+
+- Implement Clear All Filters.
+- Confirm filters are not reset by remove actions, restore actions, preview interactions, checkbox interactions, or future-compatible bulk-action hooks.
+- Verify empty, long-label, selected-filter, and dropdown-open states.
+- Run targeted formatting and tests.
+- Run review lenses relevant to the change: security, performance, Elixir/LiveView, and UI.
+
+Commit:
+
+- Commit phase 5 after final verification passes.
+
+## Test Strategy
+
+Use LiveView tests as the primary layer because this is server-driven UI state.
+
+Likely coverage:
+
+- Initial render defaults to Show All.
+- Primary filters are mutually exclusive.
+- Visibility filters include/exclude removed rows correctly.
+- Search updates results dynamically.
+- LO/type options are generated only from current selection candidates.
+- LO/type filters are multi-select.
+- Combined filters narrow with AND semantics.
+- Clear All resets all filters.
+- Empty result state renders explanatory copy.
+- Existing remove/restore and selected-preview flows preserve active filters.
+- Pagination resets on filter changes and continues to load filtered results.
+
+Add domain/context tests only if filtering logic moves into `Oli.Delivery.InstructorCustomizations`.
+
+Expected commands:
+
+- targeted LiveView test module under `test/oli_web/live/delivery/instructor/`
+- targeted context tests if context code changes
+- `mix format` on touched Elixir files
+
+## Risks
+
+- Full-set filtering may require new or adjusted queries so the UI does not load all candidates into LiveView memory.
+- Searching question content may be limited by what the current candidate query exposes; if content matching is expensive, prefer a targeted query-level implementation.
+- `MER-5623` branch behavior may change table selection or bulk-action state. Keep this ticket compatible with current branch behavior and document any follow-up once `MER-5623` merges.
+- Dropdown and filter toolbar states are partially unspecified in Figma. Use sensible token-aligned states and expect visual iteration.
+

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/informal.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/informal.md
@@ -1,0 +1,108 @@
+# Bank Selection Filters - Informal Notes
+
+Source: Jira `MER-5624` read with `acli jira workitem view MER-5624` on 2026-06-29.
+
+## Jira Summary
+
+- Key: `MER-5624`
+- Type: Story
+- Status at capture time: In Progress
+- Epic context: `instructor_customizations`
+- Title: Filter Questions within Activity Bank Selection
+
+## User Story
+
+As an instructor, I want to filter questions within an Activity Bank Selection, so that I can efficiently manage large question pools and quickly find relevant questions.
+
+## Acceptance Criteria Summary
+
+### Primary Visibility Filters
+
+- In the Activity Bank Selection management view, display a primary single-select filter group above the question table.
+- Primary options:
+  - Show All
+  - Show Available
+  - Show Removed
+- Default state is Show All.
+- Show Available displays only available questions.
+- Show Removed displays only removed questions.
+- Show All displays both available and removed questions.
+- Only one primary filter can be active at a time.
+
+### Secondary Filters
+
+- Display a second filter layer with:
+  - Search
+  - Learning Objectives
+  - Question Type
+- Reuse the search and filter component from instructor insights where practical.
+
+### Search
+
+- Search updates table results dynamically as the user types.
+- Search should match question title and question content where applicable.
+- Search should not require manual submission.
+
+### Learning Objective Filter
+
+- Users can multi-select learning objectives.
+- Options are generated dynamically from learning objectives attached to questions in the current Activity Bank Selection table, including both removed and available rows.
+- Selecting one or more objectives narrows the table to matching questions.
+
+### Question Type Filter
+
+- Users can multi-select question types.
+- Options are generated dynamically from question types present in the current Activity Bank Selection table, including both removed and available rows.
+- Selecting one or more question types narrows the table to matching questions.
+
+### Combined Filtering
+
+- Filters combine to narrow results.
+- Example combined state:
+  - Show Available
+  - Learning Objective filter
+  - Question Type filter
+  - Search text
+- Results should match all active filter criteria.
+
+### Clear All Filters
+
+- Clear All Filters clears secondary filters.
+- Search input is cleared.
+- Primary visibility resets to Show All.
+- Table returns to the default unfiltered state.
+
+### Table State Updates
+
+- Table updates dynamically without a page refresh.
+- Empty result sets show explanatory messaging, for example: "No questions match the selected filters."
+
+## Negative Acceptance Criteria
+
+- Do not allow Show All, Show Available, and Show Removed to be selected simultaneously.
+- Do not display learning objectives that are not attached to questions in the current Activity Bank Selection table.
+- Do not display question types that are not present in the current Activity Bank Selection table.
+- Do not return removed questions when Show Available is active.
+- Do not return available questions when Show Removed is active.
+- Do not require manual submission for search filtering.
+- Do not clear active filters unintentionally during table interactions.
+- Do not reset filters during:
+  - remove actions
+  - restore actions
+  - bulk actions
+  - question preview interactions
+- Do not display an empty table without explanatory messaging.
+
+## Design References
+
+- Filter toolbar: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=305-11129`
+- In-page context: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7391`
+- Full filter component, including Show All/Available/Removed toggles plus search, learning-objective filter, and question-type filter: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=185-7440&t=SNzWnAHAxamIxKZQ-4`
+- Search bar plus learning-objective and question-type filter component detail: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=305-11129&t=SNzWnAHAxamIxKZQ-4`
+- Learning Objectives dropdown example: `https://www.figma.com/design/wcAE7fov1FNgjpCA7KSO9m/Instructors-Customize-Assessments?node-id=385-6445&t=SNzWnAHAxamIxKZQ-4`
+
+## Local Context
+
+- The epic plan lists `MER-5624` under the Selection-UI lane after `MER-5622` and `MER-5623`.
+- `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/prd.md` explicitly excludes search, learning-objective filters, and question-type filters from `MER-5622`.
+- `docs/exec-plans/current/epics/instructor_customizations/bank_selection_manager/fdd.md` says `MER-5623` and `MER-5624` should extend the same bank-selection manager LiveView rather than replace it.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_0_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_0_execution_record.md
@@ -1,0 +1,169 @@
+# Phase 0 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters`
+Phase: `0 - Preparation And Branch Reality Check`
+
+## Scope From Lightweight Plan
+
+- Confirm `MER-5623` is not present on this branch.
+- Inspect existing manager LiveView tests.
+- Identify the current candidate row view model fields available for title, content, objective data, question type, and enabled/removed state.
+- Decide whether candidate filtering can be added to the existing `list_bank_selection_candidates/4` path or needs a companion query/view model helper.
+
+## Findings
+
+### `MER-5623` Branch State
+
+`MER-5623` should not be assumed available in this branch.
+
+Observed current branch state:
+
+- `BankSelectionManagerLive` has checkbox UI and events:
+  - `toggle_candidate_checkbox`
+  - `toggle_all_candidate_checkboxes`
+  - `checked_candidate_ids`
+- The LiveView comment explicitly says `MER-5623` adds the bulk action side effect later.
+- No same-state bulk remove/restore actions for bank-selection candidates were found in this branch.
+
+Implementation implication:
+
+- `MER-5624` should preserve current checkbox state where practical.
+- Do not introduce bulk mutation behavior in this ticket.
+- Preserve compatibility for future `MER-5623`, but do not depend on unpublished branch behavior.
+
+### Existing Tests
+
+Primary LiveView coverage exists in:
+
+- `test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+
+Current coverage includes:
+
+- preview route/helper behavior
+- authorized manager render
+- removed candidate row styling
+- selected preview preservation across load-more
+- candidate checkbox/header checkbox behavior
+- remove/restore via preview customization bridge
+- invalid remove warning modal
+- invalid selection redirect
+- learner redirect out of preview mode
+
+Relevant context coverage exists in:
+
+- `test/oli/delivery/instructor_customizations/write_api_test.exs`
+
+Current coverage includes:
+
+- `list_bank_selection_candidates/4`
+- paging validation
+- active count and disable-allowed computation
+- resolved section/page/selection target overload
+- candidate activity type id listing
+
+Baseline command run:
+
+```bash
+mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- `10 tests, 0 failures`
+
+### Current Candidate View Model
+
+`Oli.Delivery.InstructorCustomizations.list_bank_selection_candidates/4` currently returns candidate rows shaped as:
+
+- `activity_resource_id`
+- `revision_slug`
+- `title`
+- `enabled?`
+- `disable_allowed?`
+
+The underlying query result rows have access to revision fields such as:
+
+- `resource_id`
+- `slug`
+- `title`
+- `content`
+- `objectives`
+- `activity_type_id`
+
+Implementation implication:
+
+- The current LiveView row model is enough for primary visibility filters.
+- Search by title/content, Learning Objective filters, and Question Type filters need either:
+  - an expanded row/view model, or
+  - companion option/filter helpers in `InstructorCustomizations` / `TargetResolver`.
+
+### Query Boundary
+
+The safest boundary for server-side filtering is the existing candidate query path:
+
+- `Oli.Delivery.InstructorCustomizations.list_bank_selection_candidates/4`
+- `Oli.Delivery.InstructorCustomizations.TargetResolver.list_candidates/4`
+- `Oli.Activities.Realizer.Query.execute/3`
+
+Reason:
+
+- The realizer already supports bank logic facts for:
+  - `text`
+  - `objectives`
+  - `type`
+- The existing query path already handles:
+  - selection logic
+  - publication/section source
+  - paging
+  - blacklist/exclusions
+  - total counts
+- Filtering only the currently loaded LiveView rows would be incorrect for paged banks.
+
+Recommendation for Phase 1:
+
+- Add a small filter contract to `InstructorCustomizations.list_bank_selection_candidates/4` opts.
+- Keep paging in the existing query path.
+- Compose `MER-5624` filters into the resolved selection logic before executing the realizer query.
+- Use query-level filtering for search, objectives, and activity type whenever possible.
+- Keep primary visibility filtering coordinated with exclusion state so Show Available and Show Removed compute accurate totals.
+
+### Option Generation
+
+Learning Objective and Question Type options must come from the full current selection candidate set, including both available and removed rows.
+
+Recommended Phase 1/4 support:
+
+- Add a compact helper that returns filter option data for a resolved bank selection.
+- Do not derive options from currently loaded rows.
+- For question types, reuse activity registration metadata for labels where possible.
+- For learning objectives, resolve objective resource ids to titles through the section/publication resolver path used elsewhere in delivery.
+
+## Implementation Blocks
+
+- [x] Core behavior changes: no functional behavior changed in Phase 0.
+- [x] Data or interface changes: no runtime interface changed in Phase 0.
+- [x] Access-control or safety checks: confirmed existing LiveView route coverage remains the relevant safety baseline.
+- [x] Observability or operational updates: not applicable for Phase 0.
+
+## Test Blocks
+
+- [x] Existing targeted LiveView tests run.
+- [x] Results captured.
+
+## Work-Item Sync
+
+- [x] Phase 0 findings recorded in this execution record.
+- [x] No PRD/FDD updates required for this lightweight work item.
+
+## Review Loop
+
+- Round 1 findings: not run; Phase 0 changed documentation only.
+- Round 1 fixes: not applicable.
+
+## Done Definition
+
+- [x] Phase tasks complete.
+- [x] Baseline targeted test passes.
+- [x] Review completed when enabled: not applicable for documentation-only Phase 0.
+- [x] Validation passes: not run; this lightweight work item intentionally does not include the full PRD/FDD/requirements harness document set.
+

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_1_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_1_execution_record.md
@@ -1,0 +1,91 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters`
+Phase: `1 - Filter Contract And Server-Side Listing`
+
+## Scope From Lightweight Plan
+
+- Add a filter state shape to `BankSelectionManagerLive`.
+- Thread filters through candidate load, refresh, and pagination.
+- Reset offset when filters change.
+- Keep the current `Showing X of Y questions` behavior, updated for filtered totals.
+- Preserve selected candidate when still visible; otherwise select the first visible filtered candidate.
+- Add focused tests for filter state transitions and pagination reset.
+
+## Implementation Summary
+
+- Added a server-side candidate filter contract under `InstructorCustomizations.list_bank_selection_candidates/4`.
+- Normalized `objective_ids` and `activity_type_ids` from atom-keyed or string-keyed filter maps.
+- Composed validated filters into the existing activity-bank realizer logic in `TargetResolver`.
+- Kept candidate filtering in the existing query path so totals and paging apply to the full candidate set, not only loaded rows.
+- Preserved the unfiltered active-count calculation used by `disable_allowed?` safety checks.
+- Added LiveView filter state and a `filter_candidates` event.
+- Preserved active filters during load-more and refresh paths.
+- Relied on the existing page replacement flow to reset pagination and select the first visible candidate when the prior selection is filtered out.
+
+## Scope Boundaries
+
+- No final toolbar UI was added in this phase.
+- No visibility filter, text search, option generation, dropdown UI, or Clear All behavior was added.
+- No `MER-5623` bulk-action behavior was introduced or assumed.
+
+## Implementation Blocks
+
+- [x] Core behavior changes: filter contract added for objective and activity type ids.
+- [x] Data or interface changes: `list_candidates/5` added under `TargetResolver`; existing `list_candidates/4` remains as the compatibility path.
+- [x] Access-control or safety checks: existing LiveView route and event authorization boundaries unchanged.
+- [x] Observability or operational updates: not applicable for Phase 1.
+
+## Test Blocks
+
+- [x] Context tests cover activity type filtering before paging.
+- [x] Context tests cover invalid filter rejection.
+- [x] LiveView tests cover filter event pagination reset and selected preview replacement.
+- [x] Existing targeted suites rerun.
+
+## Verification
+
+```bash
+mix format lib/oli/delivery/instructor_customizations.ex lib/oli/delivery/instructor_customizations/target_resolver.ex lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex test/oli/delivery/instructor_customizations/write_api_test.exs test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- Passed.
+
+```bash
+mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- `11 tests, 0 failures`
+
+```bash
+mix test test/oli/delivery/instructor_customizations/write_api_test.exs
+```
+
+Result:
+
+- `21 tests, 0 failures`
+
+Note:
+
+- A parallel test attempt hit test database setup contention with `duplicate key value violates unique constraint "pg_database_datname_index"` for `oli_test`. The affected context suite passed when rerun by itself.
+
+## Work-Item Sync
+
+- [x] Phase 1 implementation result recorded in this execution record.
+- [x] Full PRD/FDD/requirements harness docs intentionally not introduced for this lightweight work item.
+
+## Review Loop
+
+- Round 1 findings: self-review found one defensive struct-update improvement in `TargetResolver.apply_candidate_filters/2`.
+- Round 1 fixes: changed filter composition to preserve the parsed `Logic` struct while replacing `conditions`.
+
+## Done Definition
+
+- [x] Phase tasks complete.
+- [x] Targeted tests pass.
+- [x] Review completed when enabled: self-review only; no formal harness review run for this phase.
+- [x] Validation passes: not run; this lightweight work item intentionally does not include the full PRD/FDD/requirements harness document set.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_2_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_2_execution_record.md
@@ -1,0 +1,94 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters`
+Phase: `2 - Primary Visibility Filters`
+
+## Scope From Lightweight Plan
+
+- Add the primary single-select filter UI above the candidate table.
+- Default to Show All.
+- Show Available excludes removed rows.
+- Show Removed excludes available rows.
+- Add empty state messaging for no matching questions.
+- Add LiveView tests for all three states and mutual exclusivity.
+
+## Implementation Summary
+
+- Added `visibility` to the candidate filter state with values `:all`, `:available`, and `:removed`.
+- Added normalization for atom-keyed and string-keyed visibility filters in `InstructorCustomizations`.
+- Applied visibility before paging in the existing candidate query path:
+  - Show All leaves the candidate query unscoped by exclusion state.
+  - Show Available passes removed candidate ids as a blacklist.
+  - Show Removed restricts the query to removed candidate ids.
+- Added a scoped `TargetResolver.list_candidates/6` entry point so visibility can reuse existing realizer paging and totals.
+- Added a local LiveView primary visibility control with `aria-pressed` state.
+- Added a candidate-list empty state when the current filter has no matching rows.
+- Preserved the Phase 1 `filter_candidates` bridge while making absent filter params preserve current filter state.
+
+## Scope Boundaries
+
+- No search input was added.
+- No Learning Objective or Question Type dropdown was added.
+- No Clear All behavior was added.
+- No `MER-5623` bulk-action behavior was introduced or assumed.
+
+## Implementation Blocks
+
+- [x] Core behavior changes: visibility filtering added server-side before paging.
+- [x] Data or interface changes: `visibility` added to the lightweight candidate filter map; existing callers default to Show All.
+- [x] Access-control or safety checks: unchanged; visibility filtering uses the existing authorized LiveView/context boundary.
+- [x] Observability or operational updates: not applicable for Phase 2.
+
+## Test Blocks
+
+- [x] Context tests cover visibility filtering before paging.
+- [x] Context tests cover invalid visibility rejection.
+- [x] LiveView tests cover default Show All state, Available, Removed, and mutual exclusivity.
+- [x] LiveView tests cover empty state for no removed candidates.
+
+## Verification
+
+```bash
+mix format lib/oli/delivery/instructor_customizations.ex lib/oli/delivery/instructor_customizations/target_resolver.ex lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex test/oli/delivery/instructor_customizations/write_api_test.exs test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- Passed.
+
+```bash
+mix test test/oli/delivery/instructor_customizations/write_api_test.exs
+```
+
+Result:
+
+- `22 tests, 0 failures`
+
+Note:
+
+- The context suite emitted the existing inventory recovery ownership log during test shutdown, but all tests passed.
+
+```bash
+mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- `13 tests, 0 failures`
+
+## Work-Item Sync
+
+- [x] Phase 2 implementation result recorded in this execution record.
+- [x] Full PRD/FDD/requirements harness docs intentionally not introduced for this lightweight work item.
+
+## Review Loop
+
+- Round 1 findings: LiveView test run exposed an Elixir grouping warning because a helper was placed between `handle_event/3` clauses.
+- Round 1 fixes: moved the helper below the grouped event clauses and reran targeted tests.
+
+## Done Definition
+
+- [x] Phase tasks complete.
+- [x] Targeted tests pass.
+- [x] Review completed when enabled: self-review only; no formal harness review run for this phase.
+- [x] Validation passes: not run; this lightweight work item intentionally does not include the full PRD/FDD/requirements harness document set.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_3_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_3_execution_record.md
@@ -1,0 +1,111 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters`
+Phase: `3 - Search`
+
+## Scope From Lightweight Plan
+
+- Add the search input matching the Figma toolbar.
+- Search should debounce and update without manual submit.
+- Search title and question content where practical from the available data/query layer.
+- Preserve search through preview selection, remove/restore, and checkbox interactions.
+- Add tests for title/content matching and no manual submit requirement.
+
+## Pre-Work Correction
+
+- A `ui_workflow` run was started by mistake before this phase.
+- The partial runtime state created outside the repo under `~/.codex/memories/oli-torus-ng/ui-work/MER-5624/` was removed.
+- The partial code patch from that aborted run was reverted before implementing this phase through `harness-work`.
+
+## Implementation Summary
+
+- Added `text_search` to the bank candidate filter contract.
+- Normalized search text in `InstructorCustomizations`.
+- Composed search into the existing activity-bank realizer logic using the `:text` fact.
+- Sanitized free-text search into a simple `to_tsquery` conjunction so ordinary input with spaces/punctuation does not become raw query syntax.
+- Added a Figma-aligned search input to the local filter toolbar with:
+  - existing `Icons.search`
+  - `phx-change="filter_candidates"`
+  - `phx-debounce="300"`
+  - token-aligned input fill, border, typography, and focus behavior
+- Preserved current filter state when search events omit visibility, objective, or activity type params.
+- Kept search server-side and before paging so totals and `Load more` stay correct.
+- Updated the realizer SQL builder to use the correct parameter index for multiple text expressions in a single logic tree.
+
+## Scope Boundaries
+
+- No Learning Objective dropdown was added.
+- No Question Type dropdown was added.
+- No Clear All behavior was added.
+- No `MER-5623` bulk-action behavior was introduced or assumed.
+
+## Implementation Blocks
+
+- [x] Core behavior changes: dynamic text search added server-side before paging.
+- [x] Data or interface changes: `text_search` added to the lightweight candidate filter map.
+- [x] Access-control or safety checks: unchanged; search uses the existing authorized LiveView/context boundary.
+- [x] Observability or operational updates: not applicable for Phase 3.
+
+## Test Blocks
+
+- [x] Context tests cover text search before paging.
+- [x] Context tests cover search combined with visibility filters.
+- [x] Context tests cover invalid search filter input.
+- [x] LiveView tests cover dynamic `phx-change` search without manual submit.
+- [x] LiveView tests cover search preservation after remove.
+- [x] Realizer tests cover multiple text expressions using distinct SQL params.
+
+## Verification
+
+```bash
+mix format lib/oli/delivery/instructor_customizations.ex lib/oli/delivery/instructor_customizations/target_resolver.ex lib/oli/activities/realizer/query/builder.ex lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex test/oli/delivery/instructor_customizations/write_api_test.exs test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs test/oli/activities/realizer/query_execution_test.exs
+```
+
+Result:
+
+- Passed.
+
+```bash
+mix test test/oli/delivery/instructor_customizations/write_api_test.exs
+```
+
+Result:
+
+- `24 tests, 0 failures`
+
+```bash
+mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+```
+
+Result:
+
+- `14 tests, 0 failures`
+
+```bash
+mix test test/oli/activities/realizer/query_execution_test.exs
+```
+
+Result:
+
+- `9 tests, 0 failures`
+
+Note:
+
+- The context and LiveView suites emitted the existing inventory recovery ownership log during test shutdown, but all tests passed.
+
+## Work-Item Sync
+
+- [x] Phase 3 implementation result recorded in this execution record.
+- [x] Full PRD/FDD/requirements harness docs intentionally not introduced for this lightweight work item.
+
+## Review Loop
+
+- Round 1 findings: the first realizer test used a Postgres full-text stopword and did not exercise the intended query path.
+- Round 1 fixes: updated the fixture text to use searchable terms and reran the targeted suite.
+
+## Done Definition
+
+- [x] Phase tasks complete.
+- [x] Targeted tests pass.
+- [x] Review completed when enabled: self-review only; no formal harness review run for this phase.
+- [x] Validation passes: not run; this lightweight work item intentionally does not include the full PRD/FDD/requirements harness document set.

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_4_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_4_execution_record.md
@@ -16,7 +16,7 @@ This phase also corrected the Phase 3 search placement so the search input now l
 - Learning Objective options are derived from the full current candidate set, including removed questions.
 - Question Type options are derived from the full current candidate set, including removed questions.
 - Added local multi-select dropdown controls for Learning Objectives and Question Type.
-- Combined visibility, text search, LO, and question type filters with AND semantics through the existing candidate filter contract.
+- Combined visibility, text search, LO, and question type filter families with AND semantics through the existing candidate filter contract. Multi-select values within LO and Question Type match any selected option.
 - Moved the search input into a separate advanced filter toolbar below the visibility buttons.
 - Preserved the existing `Showing X of Y questions` behavior for filtered totals.
 

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_4_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_4_execution_record.md
@@ -1,0 +1,43 @@
+# Phase 4 Execution Record
+
+Date: 2026-06-30
+
+Ticket: `MER-5624`
+
+## Scope
+
+Implemented the Learning Objective and Question Type filter phase from `implementation_brief.md`.
+
+This phase also corrected the Phase 3 search placement so the search input now lives in the separate advanced filter bar beneath the Show All / Available / Removed controls, matching the Figma structure referenced in the brief.
+
+## Implementation Summary
+
+- Added server-side candidate filter option generation for the current bank selection.
+- Learning Objective options are derived from the full current candidate set, including removed questions.
+- Question Type options are derived from the full current candidate set, including removed questions.
+- Added local multi-select dropdown controls for Learning Objectives and Question Type.
+- Combined visibility, text search, LO, and question type filters with AND semantics through the existing candidate filter contract.
+- Moved the search input into a separate advanced filter toolbar below the visibility buttons.
+- Preserved the existing `Showing X of Y questions` behavior for filtered totals.
+
+## Verification
+
+Commands run:
+
+- `mix format lib/oli/delivery/instructor_customizations.ex lib/oli/delivery/instructor_customizations/target_resolver.ex lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex test/oli/delivery/instructor_customizations/write_api_test.exs test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+- `mix test test/oli/delivery/instructor_customizations/write_api_test.exs`
+- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+
+Results:
+
+- Context tests passed.
+- LiveView tests passed.
+
+## Notes
+
+- Clear All remains intentionally out of scope for this phase and is reserved for Phase 5.
+- The multi-select controls are feature-local because the composed toolbar remains specific to bank selection candidate management.
+- Follow-up UI review changed the advanced toolbar to size to its contents instead of forcing full width.
+- Multi-select dropdowns now stay open while checkbox selections change, close on click-away, and toggle closed when the same dropdown button is clicked again.
+- Learning Objective multi-select now matches any selected LO within that filter family, consistent with Question Type multi-select behavior.
+- Empty candidate results now use: `No questions match the selected filters.`

--- a/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_5_execution_record.md
+++ b/docs/exec-plans/current/epics/instructor_customizations/bank_selection_filters/phase_5_execution_record.md
@@ -1,0 +1,37 @@
+# Phase 5 Execution Record
+
+Date: 2026-06-30
+
+Ticket: `MER-5624`
+
+## Scope
+
+Closed the lightweight bank selection filters workflow with Clear All behavior and final preservation checks.
+
+## Implementation Summary
+
+- Added `Clear All` to the advanced filter bar with the existing `Icons.trash` icon.
+- Reset visibility to Show All, clear text search, clear Learning Objectives, and clear Question Type filters.
+- Reused the existing candidate filtering path so pagination and selected preview are recalculated consistently.
+- Kept unrelated visible checkbox selections intact when Clear All refreshes the currently visible candidate set.
+- Closed any open secondary filter dropdown when filters are cleared.
+
+## Verification
+
+Commands run:
+
+- `mix format lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+- `git diff --check`
+- `mix test test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs`
+
+Results:
+
+- LiveView tests passed.
+- Whitespace check passed.
+
+## Review Notes
+
+- Security: no new persistence, authorization, or client-provided trust boundary was introduced.
+- Performance: Clear All uses the same paged server-side candidate query path as other filter changes.
+- UI: Clear All is scoped to the advanced filter toolbar and uses the existing icon/token style pattern.
+- Compatibility: no dependency on `MER-5623` bulk actions was introduced.

--- a/lib/oli/activities/realizer/query/builder.ex
+++ b/lib/oli/activities/realizer/query/builder.ex
@@ -196,7 +196,7 @@ defmodule Oli.Activities.Realizer.Query.Builder do
     peripherals = Map.put(peripherals, :params, peripherals.params ++ [value])
 
     {[
-       "(to_tsvector(coalesce(title, '') || ' ' || coalesce(content::text, '')) @@ to_tsquery($#{param_index}))"
+       "((to_tsvector(coalesce(title, '')) || to_tsvector(content)) @@ to_tsquery($#{param_index}))"
      ], peripherals}
   end
 

--- a/lib/oli/activities/realizer/query/builder.ex
+++ b/lib/oli/activities/realizer/query/builder.ex
@@ -192,9 +192,12 @@ defmodule Oli.Activities.Realizer.Query.Builder do
   end
 
   defp build_where(%Expression{fact: :text, operator: _, value: value}, peripherals) do
+    param_index = length(peripherals.params) + 1
     peripherals = Map.put(peripherals, :params, peripherals.params ++ [value])
 
-    {["(to_tsvector(content) @@ to_tsquery($1))"], peripherals}
+    {[
+       "(to_tsvector(coalesce(title, '') || ' ' || coalesce(content::text, '')) @@ to_tsquery($#{param_index}))"
+     ], peripherals}
   end
 
   defp build_where(%Expression{fact: :type, operator: operator, value: value}, peripherals) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -1041,9 +1041,18 @@ defmodule Oli.Delivery.InstructorCustomizations do
   end
 
   defp candidate_filters_map(opts) do
-    {:ok, opts |> Keyword.get(:filters, %{}) |> Map.new()}
-  rescue
-    Protocol.UndefinedError -> {:error, {:invalid_candidate_filters, :filters}}
+    case Keyword.get(opts, :filters, %{}) do
+      filters when is_map(filters) -> {:ok, filters}
+      filters when is_list(filters) -> filters_from_pair_list(filters)
+      _filters -> {:error, {:invalid_candidate_filters, :filters}}
+    end
+  end
+
+  defp filters_from_pair_list(filters) do
+    case Enum.all?(filters, &match?({_key, _value}, &1)) do
+      true -> {:ok, Map.new(filters)}
+      false -> {:error, {:invalid_candidate_filters, :filters}}
+    end
   end
 
   defp normalize_candidate_visibility(filters) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -11,6 +11,7 @@ defmodule Oli.Delivery.InstructorCustomizations do
   alias Oli.Accounts
   alias Oli.Accounts.Author
   alias Oli.Accounts.User
+  alias Oli.Activities
   alias Oli.Activities.Realizer.Query.Paging
   alias Oli.Delivery.InstructorCustomizations.ActivityExclusion
   alias Oli.Delivery.InstructorCustomizations.PageExclusions
@@ -18,6 +19,7 @@ defmodule Oli.Delivery.InstructorCustomizations do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionResource
+  alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.Revision
   alias Oli.Repo
 
@@ -293,6 +295,42 @@ defmodule Oli.Delivery.InstructorCustomizations do
       {:error, {:too_many_candidates, result.totalCount}}
     else
       {:ok, result.rows}
+    end
+  end
+
+  @doc """
+   Returns filter option sets generated from every candidate in a resolved bank selection.
+  """
+  @spec list_bank_selection_candidate_filter_options(
+          %Section{},
+          %Revision{},
+          map(),
+          non_neg_integer()
+        ) :: {:ok, map()} | {:error, term()}
+  def list_bank_selection_candidate_filter_options(
+        %Section{} = section,
+        %Revision{} = page_revision,
+        selection,
+        total_count
+      )
+      when is_integer(total_count) and total_count >= 0 do
+    with {:ok, rows} <-
+           TargetResolver.list_candidate_filter_option_rows(
+             section,
+             page_revision,
+             selection,
+             total_count
+           ) do
+      objective_ids = rows |> Enum.flat_map(&candidate_objective_ids/1) |> Enum.uniq()
+
+      activity_type_ids =
+        rows |> Enum.map(& &1.activity_type_id) |> Enum.reject(&is_nil/1) |> Enum.uniq()
+
+      {:ok,
+       %{
+         learning_objectives: learning_objective_options(section, objective_ids),
+         activity_types: activity_type_options(activity_type_ids)
+       }}
     end
   end
 
@@ -1054,6 +1092,47 @@ defmodule Oli.Delivery.InstructorCustomizations do
 
   defp candidate_query_scope(%{visibility: :removed}, excluded_candidate_ids) do
     [activity_resource_ids: MapSet.to_list(excluded_candidate_ids)]
+  end
+
+  defp candidate_objective_ids(%{objectives: objectives}),
+    do: objective_ids_from_objectives(objectives)
+
+  defp candidate_objective_ids(_candidate), do: []
+
+  defp objective_ids_from_objectives(objectives) when is_map(objectives) do
+    objectives
+    |> Map.values()
+    |> List.flatten()
+    |> Enum.filter(&is_integer/1)
+  end
+
+  defp objective_ids_from_objectives(_objectives), do: []
+
+  defp learning_objective_options(_section, []), do: []
+
+  defp learning_objective_options(%Section{} = section, objective_ids) do
+    titles_by_id =
+      objective_ids
+      |> DeliveryResolver.objectives_by_resource_ids(section.slug)
+      |> Enum.reject(&is_nil/1)
+      |> Map.new(&{&1.resource_id, &1.title})
+
+    objective_ids
+    |> Enum.map(fn id -> %{id: id, title: Map.get(titles_by_id, id, "LO #{id}")} end)
+    |> Enum.sort_by(&String.downcase(&1.title))
+  end
+
+  defp activity_type_options([]), do: []
+
+  defp activity_type_options(activity_type_ids) do
+    titles_by_id =
+      Activities.list_activity_registrations()
+      |> Enum.filter(&(&1.id in activity_type_ids))
+      |> Map.new(&{&1.id, &1.title})
+
+    activity_type_ids
+    |> Enum.map(fn id -> %{id: id, title: Map.get(titles_by_id, id, "Question Type #{id}")} end)
+    |> Enum.sort_by(&String.downcase(&1.title))
   end
 
   defp summarize_bank_candidate(nil, _enabled?, _disable_allowed?), do: nil

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -1025,9 +1025,8 @@ defmodule Oli.Delivery.InstructorCustomizations do
   end
 
   defp normalize_candidate_filters(opts) do
-    filters = opts |> Keyword.get(:filters, %{}) |> Map.new()
-
-    with {:ok, visibility} <- normalize_candidate_visibility(filters),
+    with {:ok, filters} <- candidate_filters_map(opts),
+         {:ok, visibility} <- normalize_candidate_visibility(filters),
          {:ok, text_search} <- normalize_candidate_text_search(filters),
          {:ok, objective_ids} <- normalize_candidate_filter_ids(filters, :objective_ids),
          {:ok, activity_type_ids} <- normalize_candidate_filter_ids(filters, :activity_type_ids) do
@@ -1039,8 +1038,12 @@ defmodule Oli.Delivery.InstructorCustomizations do
          activity_type_ids: activity_type_ids
        }}
     end
+  end
+
+  defp candidate_filters_map(opts) do
+    {:ok, opts |> Keyword.get(:filters, %{}) |> Map.new()}
   rescue
-    _ -> {:error, {:invalid_candidate_filters, :filters}}
+    Protocol.UndefinedError -> {:error, {:invalid_candidate_filters, :filters}}
   end
 
   defp normalize_candidate_visibility(filters) do

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -26,6 +26,12 @@ defmodule Oli.Delivery.InstructorCustomizations do
   @default_candidate_limit 25
   @preview_summary_candidate_limit 500
 
+  @typep candidate_filter_option :: %{id: integer(), title: String.t()}
+  @typep candidate_filter_options :: %{
+           learning_objectives: [candidate_filter_option()],
+           activity_types: [candidate_filter_option()]
+         }
+
   @doc """
   Duplicates all activity exclusions from one section to another.
 
@@ -306,7 +312,7 @@ defmodule Oli.Delivery.InstructorCustomizations do
           %Revision{},
           map(),
           non_neg_integer()
-        ) :: {:ok, map()} | {:error, term()}
+        ) :: {:ok, candidate_filter_options()} | {:error, term()}
   def list_bank_selection_candidate_filter_options(
         %Section{} = section,
         %Revision{} = page_revision,

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -140,10 +140,17 @@ defmodule Oli.Delivery.InstructorCustomizations do
 
     with {:ok, paging} <- normalize_candidate_paging(opts),
          {:ok, filters} <- normalize_candidate_filters(opts),
+         exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id),
+         query_scope = candidate_query_scope(filters, exclusion_view.excluded_candidate_ids),
          {:ok, result} <-
-           TargetResolver.list_candidates(section, page_revision, selection, paging, filters) do
-      exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id)
-
+           TargetResolver.list_candidates(
+             section,
+             page_revision,
+             selection,
+             paging,
+             filters,
+             query_scope
+           ) do
       with {:ok, active_count} <-
              TargetResolver.count_active_candidates(
                section,
@@ -976,16 +983,28 @@ defmodule Oli.Delivery.InstructorCustomizations do
   defp normalize_candidate_filters(opts) do
     filters = opts |> Keyword.get(:filters, %{}) |> Map.new()
 
-    with {:ok, objective_ids} <- normalize_candidate_filter_ids(filters, :objective_ids),
+    with {:ok, visibility} <- normalize_candidate_visibility(filters),
+         {:ok, objective_ids} <- normalize_candidate_filter_ids(filters, :objective_ids),
          {:ok, activity_type_ids} <- normalize_candidate_filter_ids(filters, :activity_type_ids) do
       {:ok,
        %{
+         visibility: visibility,
          objective_ids: objective_ids,
          activity_type_ids: activity_type_ids
        }}
     end
   rescue
     _ -> {:error, {:invalid_candidate_filters, :filters}}
+  end
+
+  defp normalize_candidate_visibility(filters) do
+    case Map.get(filters, :visibility, Map.get(filters, "visibility", :all)) do
+      visibility when visibility in [:all, :available, :removed] -> {:ok, visibility}
+      "all" -> {:ok, :all}
+      "available" -> {:ok, :available}
+      "removed" -> {:ok, :removed}
+      _ -> {:error, {:invalid_candidate_filters, :visibility}}
+    end
   end
 
   defp normalize_candidate_filter_ids(filters, key) do
@@ -1016,6 +1035,16 @@ defmodule Oli.Delivery.InstructorCustomizations do
   end
 
   defp normalize_candidate_filter_id(_value), do: :error
+
+  defp candidate_query_scope(%{visibility: :all}, _excluded_candidate_ids), do: []
+
+  defp candidate_query_scope(%{visibility: :available}, excluded_candidate_ids) do
+    [blacklisted_ids: MapSet.to_list(excluded_candidate_ids)]
+  end
+
+  defp candidate_query_scope(%{visibility: :removed}, excluded_candidate_ids) do
+    [activity_resource_ids: MapSet.to_list(excluded_candidate_ids)]
+  end
 
   defp summarize_bank_candidate(nil, _enabled?, _disable_allowed?), do: nil
 

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -984,11 +984,13 @@ defmodule Oli.Delivery.InstructorCustomizations do
     filters = opts |> Keyword.get(:filters, %{}) |> Map.new()
 
     with {:ok, visibility} <- normalize_candidate_visibility(filters),
+         {:ok, text_search} <- normalize_candidate_text_search(filters),
          {:ok, objective_ids} <- normalize_candidate_filter_ids(filters, :objective_ids),
          {:ok, activity_type_ids} <- normalize_candidate_filter_ids(filters, :activity_type_ids) do
       {:ok,
        %{
          visibility: visibility,
+         text_search: text_search,
          objective_ids: objective_ids,
          activity_type_ids: activity_type_ids
        }}
@@ -1004,6 +1006,14 @@ defmodule Oli.Delivery.InstructorCustomizations do
       "available" -> {:ok, :available}
       "removed" -> {:ok, :removed}
       _ -> {:error, {:invalid_candidate_filters, :visibility}}
+    end
+  end
+
+  defp normalize_candidate_text_search(filters) do
+    case Map.get(filters, :text_search, Map.get(filters, "text_search", "")) do
+      nil -> {:ok, ""}
+      value when is_binary(value) -> {:ok, String.trim(value)}
+      _ -> {:error, {:invalid_candidate_filters, :text_search}}
     end
   end
 

--- a/lib/oli/delivery/instructor_customizations.ex
+++ b/lib/oli/delivery/instructor_customizations.ex
@@ -139,8 +139,9 @@ defmodule Oli.Delivery.InstructorCustomizations do
     page_resource_id = page_revision.resource_id
 
     with {:ok, paging} <- normalize_candidate_paging(opts),
+         {:ok, filters} <- normalize_candidate_filters(opts),
          {:ok, result} <-
-           TargetResolver.list_candidates(section, page_revision, selection, paging) do
+           TargetResolver.list_candidates(section, page_revision, selection, paging, filters) do
       exclusion_view = get_selection_exclusion_view(section, page_resource_id, selection_id)
 
       with {:ok, active_count} <-
@@ -971,6 +972,50 @@ defmodule Oli.Delivery.InstructorCustomizations do
         {:error, {:invalid_paging, :limit}}
     end
   end
+
+  defp normalize_candidate_filters(opts) do
+    filters = opts |> Keyword.get(:filters, %{}) |> Map.new()
+
+    with {:ok, objective_ids} <- normalize_candidate_filter_ids(filters, :objective_ids),
+         {:ok, activity_type_ids} <- normalize_candidate_filter_ids(filters, :activity_type_ids) do
+      {:ok,
+       %{
+         objective_ids: objective_ids,
+         activity_type_ids: activity_type_ids
+       }}
+    end
+  rescue
+    _ -> {:error, {:invalid_candidate_filters, :filters}}
+  end
+
+  defp normalize_candidate_filter_ids(filters, key) do
+    filters
+    |> Map.get(key, Map.get(filters, Atom.to_string(key), []))
+    |> List.wrap()
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case normalize_candidate_filter_id(value) do
+        {:ok, id} -> {:cont, {:ok, [id | acc]}}
+        :error -> {:halt, {:error, {:invalid_candidate_filters, key}}}
+      end
+    end)
+    |> case do
+      {:ok, ids} -> {:ok, ids |> Enum.reverse() |> Enum.uniq()}
+      error -> error
+    end
+  end
+
+  defp normalize_candidate_filter_id(value) when is_integer(value) and value > 0,
+    do: {:ok, value}
+
+  defp normalize_candidate_filter_id(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {id, ""} when id > 0 -> {:ok, id}
+      _ -> :error
+    end
+  end
+
+  defp normalize_candidate_filter_id(_value), do: :error
 
   defp summarize_bank_candidate(nil, _enabled?, _disable_allowed?), do: nil
 

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -182,7 +182,10 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
       page_revision,
       selection,
       MapSet.to_list(excluded_ids),
-      paging
+      paging,
+      nil,
+      :paged,
+      %{}
     )
   end
 
@@ -379,7 +382,9 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
                  selection,
                  [],
                  %Paging{offset: 0, limit: length(candidate_resource_ids)},
-                 candidate_resource_ids
+                 candidate_resource_ids,
+                 :paged,
+                 %{}
                ) do
           {:ok, MapSet.new(Enum.map(result.rows, & &1.resource_id))}
         end

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -9,6 +9,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   """
 
   alias Oli.Activities.Realizer.Logic
+  alias Oli.Activities.Realizer.Logic.Clause
+  alias Oli.Activities.Realizer.Logic.Expression
   alias Oli.Activities.Realizer.Query
   alias Oli.Activities.Realizer.Query.Batch
   alias Oli.Activities.Realizer.Query.Paging
@@ -134,7 +136,23 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t()) ::
           {:ok, map()} | {:error, term()}
   def list_candidates(%Section{} = section, page_revision, selection, %Paging{} = paging) do
-    execute_candidate_query(section, page_revision, selection, [], paging)
+    list_candidates(section, page_revision, selection, paging, %{})
+  end
+
+  @doc """
+  Lists current bank candidates matching the selection logic and additional filter criteria.
+  """
+  @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t(), map()) ::
+          {:ok, map()} | {:error, term()}
+  def list_candidates(
+        %Section{} = section,
+        page_revision,
+        selection,
+        %Paging{} = paging,
+        filters
+      )
+      when is_map(filters) do
+    execute_candidate_query(section, page_revision, selection, [], paging, nil, :paged, filters)
   end
 
   @doc """
@@ -209,7 +227,10 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
              page_revision,
              selection,
              MapSet.to_list(excluded_ids),
-             @count_query_paging
+             @count_query_paging,
+             nil,
+             :paged,
+             %{}
            ) do
       {:ok, result.totalCount}
     end
@@ -233,7 +254,10 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
              page_revision,
              selection,
              [],
-             %Paging{offset: 0, limit: max(total_count, 1)}
+             %Paging{offset: 0, limit: max(total_count, 1)},
+             nil,
+             :paged,
+             %{}
            ) do
       {:ok,
        result.rows
@@ -254,7 +278,8 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
              MapSet.to_list(excluded_ids),
              @sample_query_paging,
              nil,
-             :random
+             :random,
+             %{}
            ) do
       {:ok, List.first(result.rows)}
     end
@@ -276,7 +301,9 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
              selection,
              [],
              @count_query_paging,
-             [candidate_resource_id]
+             [candidate_resource_id],
+             :paged,
+             %{}
            ) do
       {:ok, result.rows != []}
     end
@@ -328,16 +355,18 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
          selection,
          blacklisted_ids,
          paging,
-         activity_resource_ids \\ nil,
-         query_type \\ :paged
+         activity_resource_ids,
+         query_type,
+         filters
        ) do
     with {:ok, %Logic{} = logic} <- parse_logic(selection),
+         %Logic{} = filtered_logic <- apply_candidate_filters(logic, filters),
          publication_id <-
            Publishing.get_publication_id_for_resource(section.slug, page_revision.resource_id),
          {:ok, result} <-
            execute_query(
              query_type,
-             logic,
+             filtered_logic,
              %Source{
                publication_id: publication_id,
                section_slug: section.slug,
@@ -393,5 +422,37 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
       {:error, "no values provided for expression"} -> {:ok, %Logic{conditions: nil}}
       error -> error
     end
+  end
+
+  defp apply_candidate_filters(%Logic{} = logic, filters) do
+    expressions =
+      []
+      |> maybe_add_objective_filter(Map.get(filters, :objective_ids, []))
+      |> maybe_add_activity_type_filter(Map.get(filters, :activity_type_ids, []))
+
+    case {logic.conditions, expressions} do
+      {_conditions, []} ->
+        logic
+
+      {nil, expressions} ->
+        %{logic | conditions: %Clause{operator: :all, children: expressions}}
+
+      {conditions, expressions} ->
+        %{logic | conditions: %Clause{operator: :all, children: [conditions | expressions]}}
+    end
+  end
+
+  defp maybe_add_objective_filter(expressions, []), do: expressions
+
+  defp maybe_add_objective_filter(expressions, objective_ids) do
+    expressions ++
+      [%Expression{fact: :objectives, operator: :contains, value: objective_ids}]
+  end
+
+  defp maybe_add_activity_type_filter(expressions, []), do: expressions
+
+  defp maybe_add_activity_type_filter(expressions, activity_type_ids) do
+    expressions ++
+      [%Expression{fact: :type, operator: :contains, value: activity_type_ids}]
   end
 end

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -453,6 +453,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   defp apply_candidate_filters(%Logic{} = logic, filters) do
     expressions =
       []
+      |> maybe_add_text_search_filter(Map.get(filters, :text_search, ""))
       |> maybe_add_objective_filter(Map.get(filters, :objective_ids, []))
       |> maybe_add_activity_type_filter(Map.get(filters, :activity_type_ids, []))
 
@@ -465,6 +466,17 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
       {conditions, expressions} ->
         %{logic | conditions: %Clause{operator: :all, children: [conditions | expressions]}}
+    end
+  end
+
+  defp maybe_add_text_search_filter(expressions, text_search) do
+    case text_search_query(text_search) do
+      "" ->
+        expressions
+
+      query ->
+        expressions ++
+          [%Expression{fact: :text, operator: :contains, value: query}]
     end
   end
 
@@ -481,4 +493,12 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
     expressions ++
       [%Expression{fact: :type, operator: :contains, value: activity_type_ids}]
   end
+
+  defp text_search_query(text_search) when is_binary(text_search) do
+    text_search
+    |> String.split(~r/[^\p{L}\p{N}_]+/u, trim: true)
+    |> Enum.join(" & ")
+  end
+
+  defp text_search_query(_text_search), do: ""
 end

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -136,23 +136,7 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t()) ::
           {:ok, map()} | {:error, term()}
   def list_candidates(%Section{} = section, page_revision, selection, %Paging{} = paging) do
-    list_candidates(section, page_revision, selection, paging, %{})
-  end
-
-  @doc """
-  Lists current bank candidates matching the selection logic and additional filter criteria.
-  """
-  @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t(), map()) ::
-          {:ok, map()} | {:error, term()}
-  def list_candidates(
-        %Section{} = section,
-        page_revision,
-        selection,
-        %Paging{} = paging,
-        filters
-      )
-      when is_map(filters) do
-    list_candidates(section, page_revision, selection, paging, filters, [])
+    list_candidates(section, page_revision, selection, paging, %{}, [])
   end
 
   @doc """

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -152,7 +152,33 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
         filters
       )
       when is_map(filters) do
-    execute_candidate_query(section, page_revision, selection, [], paging, nil, :paged, filters)
+    list_candidates(section, page_revision, selection, paging, filters, [])
+  end
+
+  @doc """
+  Lists current bank candidates with additional filter criteria and query scope options.
+  """
+  @spec list_candidates(%Section{}, %Revision{}, map(), Paging.t(), map(), keyword()) ::
+          {:ok, map()} | {:error, term()}
+  def list_candidates(
+        %Section{} = section,
+        page_revision,
+        selection,
+        %Paging{} = paging,
+        filters,
+        opts
+      )
+      when is_map(filters) and is_list(opts) do
+    execute_candidate_query(
+      section,
+      page_revision,
+      selection,
+      Keyword.get(opts, :blacklisted_ids, []),
+      paging,
+      Keyword.get(opts, :activity_resource_ids),
+      :paged,
+      filters
+    )
   end
 
   @doc """

--- a/lib/oli/delivery/instructor_customizations/target_resolver.ex
+++ b/lib/oli/delivery/instructor_customizations/target_resolver.ex
@@ -293,6 +293,33 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
   end
 
   @doc """
+  Lists all candidate rows needed to build filter option sets for a resolved selection target.
+  """
+  @spec list_candidate_filter_option_rows(%Section{}, %Revision{}, map(), non_neg_integer()) ::
+          {:ok, [%Revision{}]} | {:error, term()}
+  def list_candidate_filter_option_rows(
+        %Section{} = section,
+        page_revision,
+        selection,
+        total_count
+      )
+      when is_integer(total_count) and total_count >= 0 do
+    with {:ok, result} <-
+           execute_candidate_query(
+             section,
+             page_revision,
+             selection,
+             [],
+             %Paging{offset: 0, limit: max(total_count, 1)},
+             nil,
+             :paged,
+             %{}
+           ) do
+      {:ok, result.rows}
+    end
+  end
+
+  @doc """
   Returns one random active candidate matching the selection logic.
   """
   def sample_candidate(%Section{} = section, page_revision, selection, excluded_ids) do
@@ -482,9 +509,22 @@ defmodule Oli.Delivery.InstructorCustomizations.TargetResolver do
 
   defp maybe_add_objective_filter(expressions, []), do: expressions
 
+  defp maybe_add_objective_filter(expressions, [objective_id]) do
+    expressions ++
+      [%Expression{fact: :objectives, operator: :contains, value: [objective_id]}]
+  end
+
   defp maybe_add_objective_filter(expressions, objective_ids) do
     expressions ++
-      [%Expression{fact: :objectives, operator: :contains, value: objective_ids}]
+      [
+        %Clause{
+          operator: :any,
+          children:
+            Enum.map(objective_ids, fn objective_id ->
+              %Expression{fact: :objectives, operator: :contains, value: [objective_id]}
+            end)
+        }
+      ]
   end
 
   defp maybe_add_activity_type_filter(expressions, []), do: expressions

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -213,25 +213,19 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   end
 
   def handle_event("filter_candidates", params, socket) do
-    candidate_filters = candidate_filters_from_params(params)
+    candidate_filters = candidate_filters_from_params(params, socket.assigns.candidate_filters)
 
-    %{
-      section: section,
-      page_revision: page_revision,
-      selection: selection
-    } = socket.assigns
+    filter_candidates(socket, candidate_filters)
+  end
 
-    case load_candidates(section, page_revision, selection, filters: candidate_filters) do
-      {:ok, candidate_page} ->
-        {:noreply,
-         socket
-         |> assign(:candidate_filters, candidate_filters)
-         |> replace_candidate_page(candidate_page)}
+  def handle_event("set_candidate_visibility", %{"visibility" => visibility}, socket) do
+    candidate_filters =
+      %{
+        socket.assigns.candidate_filters
+        | visibility: candidate_visibility_from_param(visibility)
+      }
 
-      {:error, _reason} ->
-        {:noreply,
-         put_flash(socket, :error, "Unable to filter questions for this activity bank.")}
-    end
+    filter_candidates(socket, candidate_filters)
   end
 
   def handle_event("dismiss_invalid_remove_warning", _params, socket) do
@@ -357,6 +351,26 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       )
 
     {:reply, reply, socket}
+  end
+
+  defp filter_candidates(socket, candidate_filters) do
+    %{
+      section: section,
+      page_revision: page_revision,
+      selection: selection
+    } = socket.assigns
+
+    case load_candidates(section, page_revision, selection, filters: candidate_filters) do
+      {:ok, candidate_page} ->
+        {:noreply,
+         socket
+         |> assign(:candidate_filters, candidate_filters)
+         |> replace_candidate_page(candidate_page)}
+
+      {:error, _reason} ->
+        {:noreply,
+         put_flash(socket, :error, "Unable to filter questions for this activity bank.")}
+    end
   end
 
   defp validate_bank_candidate_target(socket, target) do
@@ -711,6 +725,35 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                 <% bulk_selection_state =
                   bulk_selection_view_state(@candidates, @checked_candidate_ids) %>
 
+                <div
+                  id="candidate-visibility-filters"
+                  class="mb-4 flex flex-wrap items-center gap-2"
+                  role="group"
+                  aria-label="Question visibility filter"
+                >
+                  <.candidate_visibility_button
+                    id="candidate-visibility-all"
+                    visibility="all"
+                    current_visibility={@candidate_filters.visibility}
+                  >
+                    Show All
+                  </.candidate_visibility_button>
+                  <.candidate_visibility_button
+                    id="candidate-visibility-available"
+                    visibility="available"
+                    current_visibility={@candidate_filters.visibility}
+                  >
+                    Available
+                  </.candidate_visibility_button>
+                  <.candidate_visibility_button
+                    id="candidate-visibility-removed"
+                    visibility="removed"
+                    current_visibility={@candidate_filters.visibility}
+                  >
+                    Removed
+                  </.candidate_visibility_button>
+                </div>
+
                 <div :if={bulk_selection_state.action} class="mb-4">
                   <button
                     id="bulk-selection-action-button"
@@ -758,6 +801,14 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                     </div>
 
                     <div class="flex flex-col h-[calc(100vh-300px)] overflow-scroll">
+                      <div
+                        :if={@candidates == []}
+                        id="candidate-list-empty-state"
+                        class="flex min-h-32 items-center justify-center border-b border-Table-table-border px-6 py-8 text-center text-sm text-Text-text-low"
+                      >
+                        No matching questions are currently available for this activity bank selection.
+                      </div>
+
                       <div
                         :for={candidate <- @candidates}
                         id={"candidate-row-#{candidate.activity_resource_id}"}
@@ -877,6 +928,40 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         </div>
       </div>
     </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :visibility, :string, required: true
+  attr :current_visibility, :atom, required: true
+  slot :inner_block, required: true
+
+  defp candidate_visibility_button(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :selected?,
+        assigns.current_visibility == candidate_visibility_from_param(assigns.visibility)
+      )
+
+    ~H"""
+    <button
+      id={@id}
+      type="button"
+      phx-click="set_candidate_visibility"
+      phx-value-visibility={@visibility}
+      aria-pressed={to_string(@selected?)}
+      class={[
+        "inline-flex min-h-10 items-center justify-center rounded-md border px-4 py-2 font-open-sans text-base font-semibold leading-6 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary",
+        if(@selected?,
+          do: "border-Text-text-button bg-Background-bg-primary text-Text-text-button",
+          else:
+            "border-Border-border-default bg-Background-bg-primary text-Text-text-high hover:bg-Surface-surface-secondary-hover"
+        )
+      ]}
+    >
+      {render_slot(@inner_block)}
+    </button>
     """
   end
 
@@ -1441,19 +1526,47 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   end
 
   defp default_candidate_filters do
-    %{activity_type_ids: [], objective_ids: []}
+    %{visibility: :all, activity_type_ids: [], objective_ids: []}
   end
 
-  defp candidate_filters_from_params(params) do
+  defp candidate_filters_from_params(params, current_filters) do
     %{
-      activity_type_ids: candidate_filter_ids_from_params(params, "activity_type_ids"),
-      objective_ids: candidate_filter_ids_from_params(params, "objective_ids")
+      visibility:
+        params
+        |> Map.get("visibility", current_filters.visibility)
+        |> candidate_visibility_from_param(),
+      activity_type_ids:
+        candidate_filter_ids_from_params(
+          params,
+          "activity_type_ids",
+          current_filters.activity_type_ids
+        ),
+      objective_ids:
+        candidate_filter_ids_from_params(params, "objective_ids", current_filters.objective_ids)
     }
   end
 
-  defp candidate_filter_ids_from_params(params, key) do
-    params
-    |> Map.get(key, [])
+  defp candidate_visibility_from_param(visibility)
+       when visibility in [:all, :available, :removed],
+       do: visibility
+
+  defp candidate_visibility_from_param("available"), do: :available
+  defp candidate_visibility_from_param("removed"), do: :removed
+  defp candidate_visibility_from_param(_visibility), do: :all
+
+  defp candidate_filter_ids_from_params(params, key, current_ids) do
+    value = Map.get(params, key)
+
+    if value do
+      current_ids
+    else
+      value
+      |> parse_candidate_filter_ids()
+    end
+  end
+
+  defp parse_candidate_filter_ids(value) do
+    value
     |> List.wrap()
     |> Enum.flat_map(fn value ->
       value

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -65,9 +65,6 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         criteria_presentation =
           ActivityBankSelectionCriteria.presentation(selection, section.slug)
 
-        candidate_surface_script_sources_by_activity_type_id =
-          candidate_surface_script_sources_by_activity_type_id()
-
         candidate_filters = default_candidate_filters()
 
         case load_candidates(section, revision, selection, filters: candidate_filters) do

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -241,6 +241,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     filter_candidates(socket, candidate_filters)
   end
 
+  def handle_event("clear_candidate_filters", _params, socket) do
+    filter_candidates(socket, default_candidate_filters())
+  end
+
   def handle_event("toggle_candidate_filter_dropdown", %{"filter_id" => filter_id}, socket) do
     open_candidate_filter_id =
       if socket.assigns.open_candidate_filter_id == filter_id, do: nil, else: filter_id
@@ -821,6 +825,15 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                     selected_ids={@candidate_filters.activity_type_ids}
                     open={@open_candidate_filter_id == "candidate-activity-type-filter"}
                   />
+
+                  <button
+                    id="candidate-clear-filters"
+                    type="button"
+                    phx-click="clear_candidate_filters"
+                    class="inline-flex h-[35px] items-center gap-1.5 px-2 font-open-sans text-sm font-normal leading-none text-Text-text-high transition hover:text-Text-text-button focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+                  >
+                    <Icons.trash class="h-4 w-4" /> Clear All Filters
+                  </button>
                 </div>
 
                 <div :if={bulk_selection_state.action} class="mb-4">

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -1763,10 +1763,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   defp parse_candidate_filter_ids(value) do
     value
     |> List.wrap()
-    |> Enum.flat_map(fn value ->
-      value
-      |> to_string()
-      |> String.split(",", trim: true)
+    |> Enum.flat_map(fn
+      value when is_binary(value) -> String.split(value, ",", trim: true)
+      value when is_integer(value) -> [Integer.to_string(value)]
+      _value -> []
     end)
     |> Enum.reduce([], fn value, acc ->
       case Integer.parse(value) do

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -20,6 +20,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   alias OliWeb.ManualGrading.RenderedActivity
 
   @candidate_row_limit 25
+  @candidate_text_search_max_length 120
   @type selection_mode :: :none | :available | :removed | :mixed
 
   def mount(
@@ -885,7 +886,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                         id="candidate-list-empty-state"
                         class="flex min-h-32 items-center justify-center border-b border-Table-table-border px-6 py-8 text-center text-sm text-Text-text-low"
                       >
-                        No questions match the selected filters.
+                        {candidate_empty_state_message(@candidate_filters)}
                       </div>
 
                       <div
@@ -997,7 +998,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                     <% end %>
                   <% else %>
                     <div class="rounded-lg border border-dashed border-Border-border-default bg-Surface-surface-secondary-hover px-6 py-12 text-center text-sm text-Text-text-low">
-                      No questions match the selected filters.
+                      {candidate_empty_state_message(@candidate_filters)}
                     </div>
                   <% end %>
                 </div>
@@ -1688,6 +1689,23 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     max(total_candidate_count - length(candidates), 0)
   end
 
+  defp candidate_empty_state_message(candidate_filters) do
+    if candidate_filters_active?(candidate_filters) do
+      "No questions match the selected filters."
+    else
+      "No matching questions are currently available for this activity bank selection."
+    end
+  end
+
+  defp candidate_filters_active?(%{
+         visibility: visibility,
+         text_search: text_search,
+         activity_type_ids: activity_type_ids,
+         objective_ids: objective_ids
+       }) do
+    visibility != :all or text_search != "" or activity_type_ids != [] or objective_ids != []
+  end
+
   defp default_candidate_filters do
     %{visibility: :all, text_search: "", activity_type_ids: [], objective_ids: []}
   end
@@ -1723,10 +1741,16 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
 
   defp candidate_text_search_from_params(params, current_text_search) do
     case Map.fetch(params, "text_search") do
-      {:ok, value} when is_binary(value) -> value
+      {:ok, value} when is_binary(value) -> normalize_candidate_text_search(value)
       {:ok, _value} -> ""
       :error -> current_text_search
     end
+  end
+
+  defp normalize_candidate_text_search(value) do
+    value
+    |> String.trim()
+    |> String.slice(0, @candidate_text_search_max_length)
   end
 
   defp candidate_filter_ids_from_params(params, key, current_ids) do

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -728,30 +728,54 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                 <div
                   id="candidate-visibility-filters"
                   class="mb-4 flex flex-wrap items-center gap-2"
-                  role="group"
-                  aria-label="Question visibility filter"
+                  aria-label="Question filters"
                 >
-                  <.candidate_visibility_button
-                    id="candidate-visibility-all"
-                    visibility="all"
-                    current_visibility={@candidate_filters.visibility}
+                  <div
+                    class="flex flex-wrap items-center gap-2"
+                    role="group"
+                    aria-label="Question visibility filter"
                   >
-                    Show All
-                  </.candidate_visibility_button>
-                  <.candidate_visibility_button
-                    id="candidate-visibility-available"
-                    visibility="available"
-                    current_visibility={@candidate_filters.visibility}
+                    <.candidate_visibility_button
+                      id="candidate-visibility-all"
+                      visibility="all"
+                      current_visibility={@candidate_filters.visibility}
+                    >
+                      Show All
+                    </.candidate_visibility_button>
+                    <.candidate_visibility_button
+                      id="candidate-visibility-available"
+                      visibility="available"
+                      current_visibility={@candidate_filters.visibility}
+                    >
+                      Available
+                    </.candidate_visibility_button>
+                    <.candidate_visibility_button
+                      id="candidate-visibility-removed"
+                      visibility="removed"
+                      current_visibility={@candidate_filters.visibility}
+                    >
+                      Removed
+                    </.candidate_visibility_button>
+                  </div>
+
+                  <form
+                    id="candidate-search-form"
+                    phx-change="filter_candidates"
+                    phx-submit="filter_candidates"
+                    class="flex h-[35px] w-full max-w-[224px] items-center gap-3 rounded-md border border-Specially-Tokens-Border-border-input bg-Specially-Tokens-Fill-fill-input px-2 py-1 shadow-[0px_2px_5px_0px_rgba(0,50,99,0.10)]"
                   >
-                    Available
-                  </.candidate_visibility_button>
-                  <.candidate_visibility_button
-                    id="candidate-visibility-removed"
-                    visibility="removed"
-                    current_visibility={@candidate_filters.visibility}
-                  >
-                    Removed
-                  </.candidate_visibility_button>
+                    <Icons.search class="h-5 w-5 shrink-0 text-Icon-icon-default" />
+                    <label for="candidate-search-input" class="sr-only">Search questions</label>
+                    <input
+                      id="candidate-search-input"
+                      type="search"
+                      name="text_search"
+                      value={@candidate_filters.text_search}
+                      phx-debounce="300"
+                      autocomplete="off"
+                      class="min-w-0 flex-1 border-none bg-transparent p-0 font-open-sans text-base font-normal leading-6 text-Text-text-high placeholder:text-Text-text-low focus:outline-none focus:ring-0"
+                    />
+                  </form>
                 </div>
 
                 <div :if={bulk_selection_state.action} class="mb-4">
@@ -1526,7 +1550,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   end
 
   defp default_candidate_filters do
-    %{visibility: :all, activity_type_ids: [], objective_ids: []}
+    %{visibility: :all, text_search: "", activity_type_ids: [], objective_ids: []}
   end
 
   defp candidate_filters_from_params(params, current_filters) do
@@ -1535,6 +1559,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         params
         |> Map.get("visibility", current_filters.visibility)
         |> candidate_visibility_from_param(),
+      text_search: candidate_text_search_from_params(params, current_filters.text_search),
       activity_type_ids:
         candidate_filter_ids_from_params(
           params,
@@ -1554,14 +1579,18 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   defp candidate_visibility_from_param("removed"), do: :removed
   defp candidate_visibility_from_param(_visibility), do: :all
 
-  defp candidate_filter_ids_from_params(params, key, current_ids) do
-    value = Map.get(params, key)
+  defp candidate_text_search_from_params(params, current_text_search) do
+    case Map.fetch(params, "text_search") do
+      {:ok, value} when is_binary(value) -> value
+      {:ok, _value} -> ""
+      :error -> current_text_search
+    end
+  end
 
-    if value do
-      current_ids
-    else
-      value
-      |> parse_candidate_filter_ids()
+  defp candidate_filter_ids_from_params(params, key, current_ids) do
+    case Map.fetch(params, key) do
+      {:ok, value} -> parse_candidate_filter_ids(value)
+      :error -> current_ids
     end
   end
 

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -72,6 +72,14 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
 
         case load_candidates(section, revision, selection, filters: candidate_filters) do
           {:ok, candidate_page} ->
+            candidate_filter_options =
+              load_candidate_filter_options(
+                section,
+                revision,
+                selection,
+                candidate_page.total_count
+              )
+
             preview_script_sources =
               candidate_surface_script_sources_for_selection(
                 section,
@@ -98,6 +106,8 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
                candidate_filters: candidate_filters,
+               candidate_filter_options: candidate_filter_options,
+               open_candidate_filter_id: nil,
                invalid_remove_warning: nil,
                candidate_preview_activity_types_map:
                  candidate_preview_dependencies.activity_types_map,
@@ -215,7 +225,10 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   def handle_event("filter_candidates", params, socket) do
     candidate_filters = candidate_filters_from_params(params, socket.assigns.candidate_filters)
 
-    filter_candidates(socket, candidate_filters)
+    open_candidate_filter_id =
+      Map.get(params, "_candidate_filter_id", socket.assigns.open_candidate_filter_id)
+
+    filter_candidates(socket, candidate_filters, open_candidate_filter_id)
   end
 
   def handle_event("set_candidate_visibility", %{"visibility" => visibility}, socket) do
@@ -226,6 +239,17 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       }
 
     filter_candidates(socket, candidate_filters)
+  end
+
+  def handle_event("toggle_candidate_filter_dropdown", %{"filter_id" => filter_id}, socket) do
+    open_candidate_filter_id =
+      if socket.assigns.open_candidate_filter_id == filter_id, do: nil, else: filter_id
+
+    {:noreply, assign(socket, :open_candidate_filter_id, open_candidate_filter_id)}
+  end
+
+  def handle_event("close_candidate_filter_dropdown", _params, socket) do
+    {:noreply, assign(socket, :open_candidate_filter_id, nil)}
   end
 
   def handle_event("dismiss_invalid_remove_warning", _params, socket) do
@@ -353,7 +377,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     {:reply, reply, socket}
   end
 
-  defp filter_candidates(socket, candidate_filters) do
+  defp filter_candidates(socket, candidate_filters, open_candidate_filter_id \\ nil) do
     %{
       section: section,
       page_revision: page_revision,
@@ -365,6 +389,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         {:noreply,
          socket
          |> assign(:candidate_filters, candidate_filters)
+         |> assign(:open_candidate_filter_id, open_candidate_filter_id)
          |> replace_candidate_page(candidate_page)}
 
       {:error, _reason} ->
@@ -727,37 +752,39 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
 
                 <div
                   id="candidate-visibility-filters"
-                  class="mb-4 flex flex-wrap items-center gap-2"
-                  aria-label="Question filters"
+                  class="mb-3 flex flex-wrap items-center gap-2"
+                  role="group"
+                  aria-label="Question visibility filter"
                 >
-                  <div
-                    class="flex flex-wrap items-center gap-2"
-                    role="group"
-                    aria-label="Question visibility filter"
+                  <.candidate_visibility_button
+                    id="candidate-visibility-all"
+                    visibility="all"
+                    current_visibility={@candidate_filters.visibility}
                   >
-                    <.candidate_visibility_button
-                      id="candidate-visibility-all"
-                      visibility="all"
-                      current_visibility={@candidate_filters.visibility}
-                    >
-                      Show All
-                    </.candidate_visibility_button>
-                    <.candidate_visibility_button
-                      id="candidate-visibility-available"
-                      visibility="available"
-                      current_visibility={@candidate_filters.visibility}
-                    >
-                      Available
-                    </.candidate_visibility_button>
-                    <.candidate_visibility_button
-                      id="candidate-visibility-removed"
-                      visibility="removed"
-                      current_visibility={@candidate_filters.visibility}
-                    >
-                      Removed
-                    </.candidate_visibility_button>
-                  </div>
+                    Show All
+                  </.candidate_visibility_button>
+                  <.candidate_visibility_button
+                    id="candidate-visibility-available"
+                    visibility="available"
+                    current_visibility={@candidate_filters.visibility}
+                  >
+                    Available
+                  </.candidate_visibility_button>
+                  <.candidate_visibility_button
+                    id="candidate-visibility-removed"
+                    visibility="removed"
+                    current_visibility={@candidate_filters.visibility}
+                  >
+                    Removed
+                  </.candidate_visibility_button>
+                </div>
 
+                <div
+                  id="candidate-advanced-filters"
+                  class="mb-4 inline-flex max-w-full flex-wrap items-center gap-2 bg-Surface-surface-primary p-2.5 shadow-[0px_2px_10px_0px_rgba(0,50,99,0.10)]"
+                  role="group"
+                  aria-label="Advanced question filters"
+                >
                   <form
                     id="candidate-search-form"
                     phx-change="filter_candidates"
@@ -776,6 +803,24 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                       class="min-w-0 flex-1 border-none bg-transparent p-0 font-open-sans text-base font-normal leading-6 text-Text-text-high placeholder:text-Text-text-low focus:outline-none focus:ring-0"
                     />
                   </form>
+
+                  <.candidate_multi_select_filter
+                    id="candidate-objective-filter"
+                    label="Learning Objectives"
+                    param_name="objective_ids"
+                    options={@candidate_filter_options.learning_objectives}
+                    selected_ids={@candidate_filters.objective_ids}
+                    open={@open_candidate_filter_id == "candidate-objective-filter"}
+                  />
+
+                  <.candidate_multi_select_filter
+                    id="candidate-activity-type-filter"
+                    label="Question Type"
+                    param_name="activity_type_ids"
+                    options={@candidate_filter_options.activity_types}
+                    selected_ids={@candidate_filters.activity_type_ids}
+                    open={@open_candidate_filter_id == "candidate-activity-type-filter"}
+                  />
                 </div>
 
                 <div :if={bulk_selection_state.action} class="mb-4">
@@ -830,7 +875,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                         id="candidate-list-empty-state"
                         class="flex min-h-32 items-center justify-center border-b border-Table-table-border px-6 py-8 text-center text-sm text-Text-text-low"
                       >
-                        No matching questions are currently available for this activity bank selection.
+                        No questions match the selected filters.
                       </div>
 
                       <div
@@ -942,7 +987,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                     <% end %>
                   <% else %>
                     <div class="rounded-lg border border-dashed border-Border-border-default bg-Surface-surface-secondary-hover px-6 py-12 text-center text-sm text-Text-text-low">
-                      No matching questions are currently available for this activity bank selection.
+                      No questions match the selected filters.
                     </div>
                   <% end %>
                 </div>
@@ -986,6 +1031,73 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     >
       {render_slot(@inner_block)}
     </button>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :label, :string, required: true
+  attr :param_name, :string, required: true
+  attr :options, :list, required: true
+  attr :selected_ids, :list, required: true
+  attr :open, :boolean, required: true
+
+  defp candidate_multi_select_filter(assigns) do
+    assigns =
+      assign(assigns,
+        label_text: candidate_filter_label(assigns.label, assigns.selected_ids)
+      )
+
+    ~H"""
+    <details
+      id={@id}
+      class="group relative"
+      open={@open}
+      phx-click-away="close_candidate_filter_dropdown"
+    >
+      <summary
+        id={"#{@id}-toggle"}
+        phx-click="toggle_candidate_filter_dropdown"
+        phx-value-filter_id={@id}
+        class="flex h-[35px] cursor-pointer list-none items-center justify-center gap-2.5 rounded-[3px] border border-Border-border-default bg-Surface-surface-primary px-2.5 font-open-sans text-base font-semibold leading-6 text-Text-text-high marker:hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary [&::-webkit-details-marker]:hidden"
+      >
+        <span class="max-w-[180px] truncate">{@label_text}</span>
+        <Icons.chevron_down
+          width="16"
+          height="16"
+          class="h-4 w-4 fill-Icon-icon-default transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <form
+        id={"#{@id}-form"}
+        phx-change="filter_candidates"
+        class="absolute left-0 top-[38px] z-[60] w-[220px] rounded-md border border-Specially-Tokens-Border-border-input bg-Specially-Tokens-Fill-fill-input px-3 py-2 shadow-[0px_2px_10px_0px_rgba(0,50,99,0.10)]"
+      >
+        <input type="hidden" name="_candidate_filter_id" value={@id} />
+        <input type="hidden" name={"#{@param_name}[]"} value="" />
+        <div
+          :if={@options == []}
+          id={"#{@id}-empty"}
+          class="py-1 font-open-sans text-sm font-normal leading-6 text-Text-text-low"
+        >
+          No options
+        </div>
+        <label
+          :for={option <- @options}
+          id={"#{@id}-option-#{option.id}"}
+          class="flex cursor-pointer items-center gap-1.5 py-1 font-open-sans text-sm font-normal leading-6 text-Text-text-high"
+        >
+          <input
+            id={"#{@id}-checkbox-#{option.id}"}
+            type="checkbox"
+            name={"#{@param_name}[]"}
+            value={option.id}
+            checked={option.id in @selected_ids}
+            class="h-4 w-4 rounded-none border-Border-border-bold text-Fill-Buttons-fill-primary focus:ring-Fill-Buttons-fill-primary"
+          />
+          <span class="min-w-0 truncate">{option.title}</span>
+        </label>
+      </form>
+    </details>
     """
   end
 
@@ -1102,6 +1214,23 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       selection,
       Keyword.put_new(opts, :limit, @candidate_row_limit)
     )
+  end
+
+  defp load_candidate_filter_options(
+         %Section{} = section,
+         %Revision{} = page_revision,
+         selection,
+         total_count
+       ) do
+    case InstructorCustomizations.list_bank_selection_candidate_filter_options(
+           section,
+           page_revision,
+           selection,
+           total_count
+         ) do
+      {:ok, options} -> options
+      {:error, _reason} -> %{learning_objectives: [], activity_types: []}
+    end
   end
 
   defp refresh_candidate_page(socket) do
@@ -1552,6 +1681,9 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   defp default_candidate_filters do
     %{visibility: :all, text_search: "", activity_type_ids: [], objective_ids: []}
   end
+
+  defp candidate_filter_label(label, []), do: label
+  defp candidate_filter_label(label, selected_ids), do: "#{label} (#{length(selected_ids)})"
 
   defp candidate_filters_from_params(params, current_filters) do
     %{

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -65,7 +65,12 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         criteria_presentation =
           ActivityBankSelectionCriteria.presentation(selection, section.slug)
 
-        case load_candidates(section, revision, selection) do
+        candidate_surface_script_sources_by_activity_type_id =
+          candidate_surface_script_sources_by_activity_type_id()
+
+        candidate_filters = default_candidate_filters()
+
+        case load_candidates(section, revision, selection, filters: candidate_filters) do
           {:ok, candidate_page} ->
             preview_script_sources =
               candidate_surface_script_sources_for_selection(
@@ -92,6 +97,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
                navigation_params: navigation_params,
                sidebar_expanded: sidebar_expanded,
                request_path: local_back_path(section.slug, revision.slug, navigation_params),
+               candidate_filters: candidate_filters,
                invalid_remove_warning: nil,
                candidate_preview_activity_types_map:
                  candidate_preview_dependencies.activity_types_map,
@@ -206,6 +212,28 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     end
   end
 
+  def handle_event("filter_candidates", params, socket) do
+    candidate_filters = candidate_filters_from_params(params)
+
+    %{
+      section: section,
+      page_revision: page_revision,
+      selection: selection
+    } = socket.assigns
+
+    case load_candidates(section, page_revision, selection, filters: candidate_filters) do
+      {:ok, candidate_page} ->
+        {:noreply,
+         socket
+         |> assign(:candidate_filters, candidate_filters)
+         |> replace_candidate_page(candidate_page)}
+
+      {:error, _reason} ->
+        {:noreply,
+         put_flash(socket, :error, "Unable to filter questions for this activity bank.")}
+    end
+  end
+
   def handle_event("dismiss_invalid_remove_warning", _params, socket) do
     socket =
       case socket.assigns.invalid_remove_warning do
@@ -265,10 +293,17 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       section: section,
       page_revision: page_revision,
       selection: selection,
+      candidate_filters: candidate_filters,
       candidate_offset: candidate_offset
     } = socket.assigns
 
-    case load_candidates(section, page_revision, selection, offset: candidate_offset) do
+    case load_candidates(
+           section,
+           page_revision,
+           selection,
+           offset: candidate_offset,
+           filters: candidate_filters
+         ) do
       {:ok, candidate_page} ->
         {:noreply, append_candidate_page(socket, candidate_page)}
 
@@ -951,7 +986,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
     )
   end
 
-  defp load_candidates(%Section{} = section, %Revision{} = page_revision, selection, opts \\ []) do
+  defp load_candidates(%Section{} = section, %Revision{} = page_revision, selection, opts) do
     InstructorCustomizations.list_bank_selection_candidates(
       section,
       page_revision,
@@ -969,7 +1004,8 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
              socket.assigns.section,
              socket.assigns.page_revision,
              socket.assigns.selection,
-             limit: visible_candidate_count
+             limit: visible_candidate_count,
+             filters: socket.assigns.candidate_filters
            ) do
       {:ok, replace_candidate_page(socket, candidate_page)}
     end
@@ -1402,6 +1438,36 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
 
   defp remaining_candidate_count(total_candidate_count, candidates) do
     max(total_candidate_count - length(candidates), 0)
+  end
+
+  defp default_candidate_filters do
+    %{activity_type_ids: [], objective_ids: []}
+  end
+
+  defp candidate_filters_from_params(params) do
+    %{
+      activity_type_ids: candidate_filter_ids_from_params(params, "activity_type_ids"),
+      objective_ids: candidate_filter_ids_from_params(params, "objective_ids")
+    }
+  end
+
+  defp candidate_filter_ids_from_params(params, key) do
+    params
+    |> Map.get(key, [])
+    |> List.wrap()
+    |> Enum.flat_map(fn value ->
+      value
+      |> to_string()
+      |> String.split(",", trim: true)
+    end)
+    |> Enum.reduce([], fn value, acc ->
+      case Integer.parse(value) do
+        {id, ""} when id > 0 -> [id | acc]
+        _ -> acc
+      end
+    end)
+    |> Enum.reverse()
+    |> Enum.uniq()
   end
 
   defp candidate_selected?(candidate, selected_candidate_id) do

--- a/test/oli/activities/realizer/query_execution_test.exs
+++ b/test/oli/activities/realizer/query_execution_test.exs
@@ -2,6 +2,7 @@ defmodule Oli.Activities.Query.ExecutorTest do
   use Oli.DataCase
 
   alias Oli.Activities.Realizer.Logic
+  alias Oli.Activities.Realizer.Logic.Clause
   alias Oli.Activities.Realizer.Logic.Expression
   alias Oli.Activities.Realizer.Query.Batch
   alias Oli.Activities.Realizer.Query.Builder
@@ -20,7 +21,7 @@ defmodule Oli.Activities.Query.ExecutorTest do
             scope: :banked,
             objectives: %{"1" => [1]},
             title: "1",
-            content: %{model: %{stem: "this is the question"}}
+            content: %{model: %{stem: "alpha question"}}
           },
           map.publication,
           map.project,
@@ -179,6 +180,45 @@ defmodule Oli.Activities.Query.ExecutorTest do
 
       paging = %Paging{limit: 1, offset: 0}
       logic = %Logic{conditions: %Expression{fact: :text, operator: :contains, value: "question"}}
+
+      {:ok, %Result{rowCount: 1, totalCount: 1}} =
+        Builder.build(logic, source, paging, :paged)
+        |> Executor.execute()
+    end
+
+    test "queries full text against activity titles", %{publication: publication} do
+      source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [],
+        section_slug: ""
+      }
+
+      paging = %Paging{limit: 1, offset: 0}
+      logic = %Logic{conditions: %Expression{fact: :text, operator: :contains, value: "1"}}
+
+      {:ok, %Result{rowCount: 1, totalCount: 1}} =
+        Builder.build(logic, source, paging, :paged)
+        |> Executor.execute()
+    end
+
+    test "queries for multiple full text expressions", %{publication: publication} do
+      source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [],
+        section_slug: ""
+      }
+
+      paging = %Paging{limit: 1, offset: 0}
+
+      logic = %Logic{
+        conditions: %Clause{
+          operator: :all,
+          children: [
+            %Expression{fact: :text, operator: :contains, value: "alpha"},
+            %Expression{fact: :text, operator: :contains, value: "question"}
+          ]
+        }
+      }
 
       {:ok, %Result{rowCount: 1, totalCount: 1}} =
         Builder.build(logic, source, paging, :paged)

--- a/test/oli/activities/realizer/query_execution_test.exs
+++ b/test/oli/activities/realizer/query_execution_test.exs
@@ -201,6 +201,21 @@ defmodule Oli.Activities.Query.ExecutorTest do
         |> Executor.execute()
     end
 
+    test "full text does not query json structural keys", %{publication: publication} do
+      source = %Source{
+        publication_id: publication.id,
+        blacklisted_activity_ids: [],
+        section_slug: ""
+      }
+
+      paging = %Paging{limit: 1, offset: 0}
+      logic = %Logic{conditions: %Expression{fact: :text, operator: :contains, value: "stem"}}
+
+      assert {:ok, %Result{rowCount: 0, totalCount: 0}} =
+               Builder.build(logic, source, paging, :paged)
+               |> Executor.execute()
+    end
+
     test "queries for multiple full text expressions", %{publication: publication} do
       source = %Source{
         publication_id: publication.id,

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -867,6 +867,14 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  "selection-1",
                  filters: %{text_search: 42}
                )
+
+      assert {:error, {:invalid_candidate_filters, :filters}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: 42
+               )
     end
 
     test "uses a standard default page size for candidate review", context do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -17,11 +17,27 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     project = insert(:project, authors: [author])
 
     embedded_activity = activity_revision("Embedded activity", :embedded)
+    objective_1 = objective_revision("Learning Objective 1")
+    objective_2 = objective_revision("Learning Objective 2")
 
     candidates = [
-      activity_revision("Candidate 1", :banked),
-      activity_revision("Candidate 2", :banked, "oli_multiple_choice", "Mitochondria content"),
-      activity_revision("Candidate 3", :banked, "oli_check_all_that_apply")
+      activity_revision("Candidate 1", :banked, "oli_multiple_choice", nil, [
+        objective_1.resource_id
+      ]),
+      activity_revision(
+        "Candidate 2",
+        :banked,
+        "oli_multiple_choice",
+        "Mitochondria content",
+        [objective_2.resource_id]
+      ),
+      activity_revision(
+        "Candidate 3",
+        :banked,
+        "oli_check_all_that_apply",
+        nil,
+        [objective_1.resource_id, objective_2.resource_id]
+      )
     ]
 
     page_revision =
@@ -52,7 +68,15 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
         content: %{}
       )
 
-    revisions = [root_revision, page_revision, adaptive_revision, embedded_activity | candidates]
+    revisions = [
+      root_revision,
+      page_revision,
+      adaptive_revision,
+      embedded_activity,
+      objective_1,
+      objective_2
+      | candidates
+    ]
 
     Enum.each(revisions, fn revision ->
       insert(:project_resource, project_id: project.id, resource_id: revision.resource_id)
@@ -85,6 +109,8 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
        page_revision: page_revision,
        adaptive_revision: adaptive_revision,
        embedded_activity: embedded_activity,
+       objective_1: objective_1,
+       objective_2: objective_2,
        candidates: candidates,
        instructor: instructor
      }}
@@ -749,6 +775,74 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
       refute candidate.enabled?
     end
 
+    test "generates filter options from all selection candidates including removed rows",
+         context do
+      [removed_candidate | _available_candidates] = context.candidates
+
+      assert {:ok, _view} =
+               InstructorCustomizations.exclude_bank_candidate(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 removed_candidate.resource_id,
+                 actor: context.instructor
+               )
+
+      assert {:ok, options} =
+               InstructorCustomizations.list_bank_selection_candidate_filter_options(
+                 context.section,
+                 context.page_revision,
+                 selection("selection-1", 2),
+                 3
+               )
+
+      assert Enum.map(options.learning_objectives, & &1.id) |> Enum.sort() ==
+               [context.objective_1.resource_id, context.objective_2.resource_id] |> Enum.sort()
+
+      assert Enum.map(options.learning_objectives, & &1.title) |> Enum.sort() ==
+               ["Learning Objective 1", "Learning Objective 2"]
+
+      activity_type_ids = Enum.map(options.activity_types, & &1.id)
+
+      assert Oli.Activities.get_registration_by_slug("oli_multiple_choice").id in activity_type_ids
+
+      assert Oli.Activities.get_registration_by_slug("oli_check_all_that_apply").id in activity_type_ids
+    end
+
+    test "combines objective and activity type candidate filters", context do
+      cata_registration = Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
+
+      assert {:ok, %{candidates: [candidate], total_count: 1}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{
+                   objective_ids: [context.objective_1.resource_id],
+                   activity_type_ids: [cata_registration.id]
+                 }
+               )
+
+      assert candidate.title == "Candidate 3"
+    end
+
+    test "matches any selected objective within the learning objective filter", context do
+      assert {:ok, %{candidates: candidates, total_count: 3}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{
+                   objective_ids: [
+                     context.objective_1.resource_id,
+                     context.objective_2.resource_id
+                   ]
+                 }
+               )
+
+      assert Enum.map(candidates, & &1.title) == ["Candidate 1", "Candidate 2", "Candidate 3"]
+    end
+
     test "rejects invalid candidate filters", context do
       assert {:error, {:invalid_candidate_filters, :activity_type_ids}} =
                InstructorCustomizations.list_bank_selection_candidates(
@@ -969,14 +1063,26 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
          title,
          scope,
          activity_slug \\ "oli_multiple_choice",
-         stem \\ nil
+         stem \\ nil,
+         objective_ids \\ []
        ) do
     insert(:revision,
       resource_type_id: ResourceType.id_for_activity(),
       activity_type_id: Oli.Activities.get_registration_by_slug(activity_slug).id,
       title: title,
       scope: scope,
-      content: %{"model" => %{"stem" => stem || title}}
+      content: %{"model" => %{"stem" => stem || title}},
+      objectives: %{"1" => objective_ids}
+    )
+  end
+
+  defp objective_revision(title) do
+    insert(:revision,
+      resource_type_id: ResourceType.id_for_objective(),
+      title: title,
+      scope: "embedded",
+      content: %{},
+      objectives: %{}
     )
   end
 

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -20,7 +20,7 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
 
     candidates = [
       activity_revision("Candidate 1", :banked),
-      activity_revision("Candidate 2", :banked),
+      activity_revision("Candidate 2", :banked, "oli_multiple_choice", "Mitochondria content"),
       activity_revision("Candidate 3", :banked, "oli_check_all_that_apply")
     ]
 
@@ -684,6 +684,71 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
       refute candidate.enabled?
     end
 
+    test "filters candidate listing by text search before paging", context do
+      assert {:ok, %{candidates: [candidate], total_count: 1, has_more?: false}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 limit: 1,
+                 filters: %{text_search: "mitochondria"}
+               )
+
+      assert candidate.title == "Candidate 2"
+
+      assert {:ok, %{candidates: [candidate], total_count: 1, has_more?: false}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{text_search: "Candidate 2"}
+               )
+
+      assert candidate.title == "Candidate 2"
+
+      assert {:ok, %{candidates: [candidate], total_count: 1, has_more?: false}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{"text_search" => "Candidate 3"}
+               )
+
+      assert candidate.title == "Candidate 3"
+    end
+
+    test "combines candidate text search with visibility filters", context do
+      [removed_candidate | _available_candidates] = context.candidates
+
+      assert {:ok, _view} =
+               InstructorCustomizations.exclude_bank_candidate(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 removed_candidate.resource_id,
+                 actor: context.instructor
+               )
+
+      assert {:ok, %{candidates: [], total_count: 0}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{visibility: :available, text_search: "Candidate 1"}
+               )
+
+      assert {:ok, %{candidates: [candidate], total_count: 1}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{visibility: :removed, text_search: "Candidate 1"}
+               )
+
+      assert candidate.activity_resource_id == removed_candidate.resource_id
+      refute candidate.enabled?
+    end
+
     test "rejects invalid candidate filters", context do
       assert {:error, {:invalid_candidate_filters, :activity_type_ids}} =
                InstructorCustomizations.list_bank_selection_candidates(
@@ -699,6 +764,14 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  context.page_revision.resource_id,
                  "selection-1",
                  filters: %{visibility: "hidden"}
+               )
+
+      assert {:error, {:invalid_candidate_filters, :text_search}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{text_search: 42}
                )
     end
 
@@ -892,13 +965,18 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     end
   end
 
-  defp activity_revision(title, scope, activity_slug \\ "oli_multiple_choice") do
+  defp activity_revision(
+         title,
+         scope,
+         activity_slug \\ "oli_multiple_choice",
+         stem \\ nil
+       ) do
     insert(:revision,
       resource_type_id: ResourceType.id_for_activity(),
       activity_type_id: Oli.Activities.get_registration_by_slug(activity_slug).id,
       title: title,
       scope: scope,
-      content: %{"model" => %{"stem" => title}}
+      content: %{"model" => %{"stem" => stem || title}}
     )
   end
 

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -875,6 +875,14 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  "selection-1",
                  filters: 42
                )
+
+      assert {:error, {:invalid_candidate_filters, :filters}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: [:bad_shape]
+               )
     end
 
     test "uses a standard default page size for candidate review", context do

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -648,6 +648,42 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
       assert candidate.title == "Candidate 3"
     end
 
+    test "filters candidate listing by visibility before paging", context do
+      [removed_candidate | available_candidates] = context.candidates
+
+      assert {:ok, _view} =
+               InstructorCustomizations.exclude_bank_candidate(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 removed_candidate.resource_id,
+                 actor: context.instructor
+               )
+
+      assert {:ok, %{candidates: [candidate], total_count: 2, has_more?: true}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 limit: 1,
+                 filters: %{visibility: :available}
+               )
+
+      assert candidate.activity_resource_id == hd(available_candidates).resource_id
+      assert candidate.enabled?
+
+      assert {:ok, %{candidates: [candidate], total_count: 1, has_more?: false}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{"visibility" => "removed"}
+               )
+
+      assert candidate.activity_resource_id == removed_candidate.resource_id
+      refute candidate.enabled?
+    end
+
     test "rejects invalid candidate filters", context do
       assert {:error, {:invalid_candidate_filters, :activity_type_ids}} =
                InstructorCustomizations.list_bank_selection_candidates(
@@ -655,6 +691,14 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
                  context.page_revision.resource_id,
                  "selection-1",
                  filters: %{activity_type_ids: ["bad"]}
+               )
+
+      assert {:error, {:invalid_candidate_filters, :visibility}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{visibility: "hidden"}
                )
     end
 

--- a/test/oli/delivery/instructor_customizations/write_api_test.exs
+++ b/test/oli/delivery/instructor_customizations/write_api_test.exs
@@ -17,7 +17,12 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     project = insert(:project, authors: [author])
 
     embedded_activity = activity_revision("Embedded activity", :embedded)
-    candidates = Enum.map(1..3, &activity_revision("Candidate #{&1}", :banked))
+
+    candidates = [
+      activity_revision("Candidate 1", :banked),
+      activity_revision("Candidate 2", :banked),
+      activity_revision("Candidate 3", :banked, "oli_check_all_that_apply")
+    ]
 
     page_revision =
       insert(:revision,
@@ -617,6 +622,42 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
       assert candidate.disable_allowed?
     end
 
+    test "filters candidate listing by activity type before paging", context do
+      mcq_registration = Oli.Activities.get_registration_by_slug("oli_multiple_choice")
+      cata_registration = Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
+
+      assert {:ok, %{candidates: [candidate], total_count: 2, has_more?: true}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 limit: 1,
+                 filters: %{activity_type_ids: [mcq_registration.id]}
+               )
+
+      assert candidate.title == "Candidate 1"
+
+      assert {:ok, %{candidates: [candidate], total_count: 1, has_more?: false}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{"activity_type_ids" => "#{cata_registration.id}"}
+               )
+
+      assert candidate.title == "Candidate 3"
+    end
+
+    test "rejects invalid candidate filters", context do
+      assert {:error, {:invalid_candidate_filters, :activity_type_ids}} =
+               InstructorCustomizations.list_bank_selection_candidates(
+                 context.section,
+                 context.page_revision.resource_id,
+                 "selection-1",
+                 filters: %{activity_type_ids: ["bad"]}
+               )
+    end
+
     test "uses a standard default page size for candidate review", context do
       assert {:ok, %{candidates: candidates, total_count: 3, has_more?: false, active_count: 3}} =
                InstructorCustomizations.list_bank_selection_candidates(
@@ -807,10 +848,10 @@ defmodule Oli.Delivery.InstructorCustomizations.WriteApiTest do
     end
   end
 
-  defp activity_revision(title, scope) do
+  defp activity_revision(title, scope, activity_slug \\ "oli_multiple_choice") do
     insert(:revision,
       resource_type_id: ResourceType.id_for_activity(),
-      activity_type_id: Oli.Activities.get_registration_by_slug("oli_multiple_choice").id,
+      activity_type_id: Oli.Activities.get_registration_by_slug(activity_slug).id,
       title: title,
       scope: scope,
       content: %{"model" => %{"stem" => title}}

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -198,7 +198,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       assert has_element?(
                view,
                "#candidate-list-empty-state",
-               "No matching questions are currently available for this activity bank selection."
+               "No questions match the selected filters."
              )
 
       refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
@@ -258,6 +258,73 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
              )
 
       assert has_element?(view, "div", "Showing 1 of 1 questions")
+    end
+
+    test "advanced filter bar renders below visibility filters and combines multi-select filters",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate,
+           objective_2: objective_2
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert has_element?(view, "#candidate-advanced-filters #candidate-search-form")
+      refute has_element?(view, "#candidate-visibility-filters #candidate-search-form")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objectives")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objective 1")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objective 2")
+      assert has_element?(view, "#candidate-activity-type-filter", "Question Type")
+
+      view
+      |> form("#candidate-objective-filter-form", %{
+        "_candidate_filter_id" => "candidate-objective-filter",
+        "objective_ids" => ["#{objective_2.resource_id}"]
+      })
+      |> render_change()
+
+      assert has_element?(view, "#candidate-objective-filter[open]")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objectives (1)")
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 15 of 15 questions")
+
+      view
+      |> element("#candidate-objective-filter-toggle")
+      |> render_click()
+
+      refute has_element?(view, "#candidate-objective-filter[open]")
+
+      cata_registration = Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
+
+      view
+      |> form("#candidate-activity-type-filter-form", %{
+        "_candidate_filter_id" => "candidate-activity-type-filter",
+        "activity_type_ids" => ["#{cata_registration.id}"]
+      })
+      |> render_change()
+
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objectives (1)")
+      assert has_element?(view, "#candidate-activity-type-filter[open]")
+      assert has_element?(view, "#candidate-activity-type-filter", "Question Type (1)")
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 15 of 15 questions")
+
+      view
+      |> form("#candidate-search-form", %{"text_search" => "does-not-match-any-question"})
+      |> render_change()
+
+      assert has_element?(
+               view,
+               "#candidate-list-empty-state",
+               "No questions match the selected filters."
+             )
+
+      assert has_element?(view, "div", "Showing 0 of 0 questions")
     end
 
     test "selected row stays selected after loading an additional candidate page", %{
@@ -897,16 +964,36 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
     ]
 
+    objective_1 =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Learning Objective 1",
+        scope: "embedded",
+        content: %{},
+        objectives: %{}
+      )
+
+    objective_2 =
+      insert(:revision,
+        resource_type_id: ResourceType.id_for_objective(),
+        title: "Learning Objective 2",
+        scope: "embedded",
+        content: %{},
+        objectives: %{}
+      )
+
     candidates =
       Enum.map(1..30, fn index ->
         activity_type = Enum.at(activity_types, rem(index - 1, length(activity_types)))
+        objective = if rem(index, 2) == 0, do: objective_2, else: objective_1
 
         insert(:revision,
           resource_type_id: ResourceType.id_for_activity(),
           activity_type_id: activity_type.id,
           title: "Candidate #{index}",
           scope: "banked",
-          content: %{"model" => %{"stem" => "Candidate #{index}"}}
+          content: %{"model" => %{"stem" => "Candidate #{index}"}},
+          objectives: %{"1" => [objective.resource_id]}
         )
       end)
 
@@ -936,7 +1023,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
         content: %{}
       )
 
-    revisions = [root_revision, page_revision | candidates]
+    revisions = [root_revision, page_revision, objective_1, objective_2 | candidates]
 
     Enum.each(revisions, fn revision ->
       insert(:project_resource, project_id: project.id, resource_id: revision.resource_id)
@@ -978,6 +1065,8 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
      user: user,
      section: section,
      page_revision: page_revision,
+     objective_1: objective_1,
+     objective_2: objective_2,
      candidates: candidates,
      first_candidate: hd(candidates),
      second_candidate: Enum.at(candidates, 1),

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -117,6 +117,96 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
              )
     end
 
+    test "visibility filter toggles show all, available, and removed candidates",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate,
+           user: user
+         } do
+      assert {:ok, _view} =
+               InstructorCustomizations.exclude_bank_candidate(
+                 section,
+                 page_revision.resource_id,
+                 "selection-1",
+                 first_candidate.resource_id,
+                 actor: user
+               )
+
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-visibility-available[aria-pressed=\"false\"]")
+      assert has_element?(view, "#candidate-visibility-removed[aria-pressed=\"false\"]")
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}", "Removed")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 25 of 30 questions")
+
+      view
+      |> element("#candidate-visibility-available")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"false\"]")
+      assert has_element?(view, "#candidate-visibility-available[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-visibility-removed[aria-pressed=\"false\"]")
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 25 of 29 questions")
+
+      view
+      |> element("#candidate-visibility-removed")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"false\"]")
+      assert has_element?(view, "#candidate-visibility-available[aria-pressed=\"false\"]")
+      assert has_element?(view, "#candidate-visibility-removed[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}", "Removed")
+      refute has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 1 of 1 questions")
+      refute has_element?(view, "#load-more-candidates")
+
+      view
+      |> element("#candidate-visibility-all")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}", "Removed")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 25 of 30 questions")
+    end
+
+    test "removed visibility filter renders an empty state when no removed candidates match",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      view
+      |> element("#candidate-visibility-removed")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-visibility-removed[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-list-empty-state")
+
+      assert has_element?(
+               view,
+               "#candidate-list-empty-state",
+               "No matching questions are currently available for this activity bank selection."
+             )
+
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 0 of 0 questions")
+      refute has_element?(view, "#load-more-candidates")
+      refute has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
+    end
+
     test "selected row stays selected after loading an additional candidate page", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -524,6 +524,30 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       refute has_element?(view, "#load-more-candidates")
     end
 
+    test "candidate filter event ignores malformed filter values without crashing",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("filter_candidates", %{
+        "activity_type_ids" => %{"bad" => "shape"},
+        "objective_ids" => [%{"also" => "bad"}]
+      })
+
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 25 of 30 questions")
+      assert has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
+    end
+
     test "candidate checkboxes keep same-state selection and header checkbox respects the current selection mode",
          %{
            conn: conn,

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -327,6 +327,72 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       assert has_element?(view, "div", "Showing 0 of 0 questions")
     end
 
+    test "clear all resets every candidate filter and preserves visible checkbox selections",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate,
+           objective_2: objective_2
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      view
+      |> element("#candidate-checkbox-#{second_candidate.resource_id}")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+
+      view
+      |> element("#candidate-visibility-available")
+      |> render_click()
+
+      view
+      |> form("#candidate-search-form", %{"text_search" => "Candidate 2"})
+      |> render_change()
+
+      view
+      |> form("#candidate-objective-filter-form", %{
+        "_candidate_filter_id" => "candidate-objective-filter",
+        "objective_ids" => ["#{objective_2.resource_id}"]
+      })
+      |> render_change()
+
+      cata_registration = Oli.Activities.get_registration_by_slug("oli_check_all_that_apply")
+
+      view
+      |> form("#candidate-activity-type-filter-form", %{
+        "_candidate_filter_id" => "candidate-activity-type-filter",
+        "activity_type_ids" => ["#{cata_registration.id}"]
+      })
+      |> render_change()
+
+      assert has_element?(view, "#candidate-visibility-available[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-search-input[value=\"Candidate 2\"]")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objectives (1)")
+      assert has_element?(view, "#candidate-activity-type-filter", "Question Type (1)")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 1 of 1 questions")
+
+      view
+      |> element("#candidate-clear-filters")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"true\"]")
+      assert has_element?(view, "#candidate-search-input[value=\"\"]")
+      assert has_element?(view, "#candidate-objective-filter", "Learning Objectives")
+      assert has_element?(view, "#candidate-activity-type-filter", "Question Type")
+      refute has_element?(view, "#candidate-objective-filter[open]")
+      refute has_element?(view, "#candidate-activity-type-filter[open]")
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      assert has_element?(view, "#candidate-checkbox-#{second_candidate.resource_id}[checked]")
+      assert has_element?(view, "div", "Showing 25 of 30 questions")
+    end
+
     test "selected row stays selected after loading an additional candidate page", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -207,6 +207,34 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       refute has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
     end
 
+    test "default empty candidate list renders neutral empty state", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      {:ok, view, _html} =
+        live(
+          conn,
+          PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-empty")
+        )
+
+      assert has_element?(view, "#candidate-visibility-all[aria-pressed=\"true\"]")
+
+      assert has_element?(
+               view,
+               "#candidate-list-empty-state",
+               "No matching questions are currently available for this activity bank selection."
+             )
+
+      refute has_element?(
+               view,
+               "#candidate-list-empty-state",
+               "No questions match the selected filters."
+             )
+
+      assert has_element?(view, "div", "Showing 0 of 0 questions")
+    end
+
     test "search filters candidates dynamically and is preserved after remove",
          %{
            conn: conn,
@@ -258,6 +286,30 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
              )
 
       assert has_element?(view, "div", "Showing 1 of 1 questions")
+    end
+
+    test "search input is trimmed and capped before filtering", %{
+      conn: conn,
+      section: section,
+      page_revision: page_revision
+    } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      capped_search = String.duplicate("x", 120)
+      long_search = "   #{capped_search}#{String.duplicate("x", 20)}   "
+
+      view
+      |> form("#candidate-search-form", %{"text_search" => long_search})
+      |> render_change()
+
+      assert has_element?(view, "#candidate-search-input[value=\"#{capped_search}\"]")
+
+      assert has_element?(
+               view,
+               "#candidate-list-empty-state",
+               "No questions match the selected filters."
+             )
     end
 
     test "advanced filter bar renders below visibility filters and combines multi-select filters",
@@ -1076,6 +1128,19 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
               "logic" => %{"conditions" => nil},
               "count" => 2,
               "pointsPerActivity" => 4
+            },
+            %{
+              "type" => "selection",
+              "id" => "selection-empty",
+              "logic" => %{
+                "conditions" => %{
+                  "fact" => "objectives",
+                  "operator" => "contains",
+                  "value" => [objective_2.resource_id + 1_000_000]
+                }
+              },
+              "count" => 1,
+              "pointsPerActivity" => 1
             }
           ]
         }

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -207,6 +207,59 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
       refute has_element?(view, "#selected-candidate-preview-#{first_candidate.resource_id}")
     end
 
+    test "search filters candidates dynamically and is preserved after remove",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           last_candidate: last_candidate
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      refute has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+
+      view
+      |> form("#candidate-search-form", %{"text_search" => "Candidate 30"})
+      |> render_change()
+
+      assert has_element?(view, "#candidate-search-input[value=\"Candidate 30\"]")
+      assert has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+      refute has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      assert has_element?(view, "div", "Showing 1 of 1 questions")
+      refute has_element?(view, "#load-more-candidates")
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{last_candidate.resource_id}"
+             )
+
+      payload = %{
+        "action" => "remove",
+        "target" => %{
+          "kind" => "bank_candidate",
+          "pageResourceId" => page_revision.resource_id,
+          "selectionId" => "selection-1",
+          "activityResourceId" => last_candidate.resource_id
+        }
+      }
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("toggle_preview_activity_customization", payload)
+
+      assert has_element?(view, "#candidate-search-input[value=\"Candidate 30\"]")
+
+      assert has_element?(
+               view,
+               "#candidate-row-#{last_candidate.resource_id}[data-candidate-enabled=\"false\"]",
+               "Removed"
+             )
+
+      assert has_element?(view, "div", "Showing 1 of 1 questions")
+    end
+
     test "selected row stays selected after loading an additional candidate page", %{
       conn: conn,
       section: section,

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -150,6 +150,52 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
              )
     end
 
+    test "candidate filter event resets paging and selected preview to the filtered result set",
+         %{
+           conn: conn,
+           section: section,
+           page_revision: page_revision,
+           first_candidate: first_candidate,
+           second_candidate: second_candidate,
+           last_candidate: last_candidate
+         } do
+      {:ok, view, _html} =
+        live(conn, PreviewRoutes.selection_path(section.slug, page_revision.slug, "selection-1"))
+
+      view
+      |> element("#load-more-candidates")
+      |> render_click()
+
+      assert has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+
+      view
+      |> element("#candidate-select-#{last_candidate.resource_id}")
+      |> render_click()
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{last_candidate.resource_id}"
+             )
+
+      mcq_registration = Oli.Activities.get_registration_by_slug("oli_multiple_choice")
+
+      view
+      |> element("#bank-selection-customization-bridge")
+      |> render_hook("filter_candidates", %{"activity_type_ids" => "#{mcq_registration.id}"})
+
+      assert has_element?(view, "#candidate-row-#{first_candidate.resource_id}")
+      refute has_element?(view, "#candidate-row-#{second_candidate.resource_id}")
+      refute has_element?(view, "#candidate-row-#{last_candidate.resource_id}")
+
+      assert has_element?(
+               view,
+               "#selected-candidate-preview-#{first_candidate.resource_id}"
+             )
+
+      assert has_element?(view, "div", "Showing 15 of 15 questions")
+      refute has_element?(view, "#load-more-candidates")
+    end
+
     test "candidate checkboxes keep same-state selection and header checkbox respects the current selection mode",
          %{
            conn: conn,


### PR DESCRIPTION
## Summary

Implements [MER-5624](https://eliterate.atlassian.net/browse/MER-5624).

This PR adds filtering support to the instructor Activity Bank Selection manager:

- Adds Show All / Available / Removed visibility filters.
- Adds server-side search across question title and content.
- Adds Learning Objective and Question Type multi-select filters.
- Adds Clear All Filters behavior.
- Keeps filtering server-side so results apply to the full candidate set, not only loaded rows.
- Preserves filter state across paging, preview selection, remove/restore actions, and checkbox interactions.
- Updates empty-state messaging for filtered results.

## Notes

- Learning Objective and Question Type multi-selects match any selected option within that filter family.
- Filter families combine with AND semantics.


https://github.com/user-attachments/assets/f7489245-929a-4238-8860-fcb8f4214ae0



[MER-5624]: https://eliterate.atlassian.net/browse/MER-5624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ