### PR TITLE
[BUG FIX] [MER-5725] Fix various issues with deleted pages and learning objectives

### DIFF
--- a/lib/oli/analytics/summary/browse_insights.ex
+++ b/lib/oli/analytics/summary/browse_insights.ex
@@ -133,14 +133,25 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
          %Sorting{} = sorting,
          options
        ) do
-    total_count = get_total_count(query, options)
+    case objective_resource_type?(options) do
+      true ->
+        query
+        |> add_non_activity_select(0, options)
+        |> add_non_activity_order_by(sorting, options)
+        |> Repo.all()
+        |> filter_deleted_objectives()
+        |> apply_paging(%Paging{limit: limit, offset: offset})
 
-    query
-    |> add_non_activity_select(total_count, options)
-    |> add_non_activity_order_by(sorting, options)
-    |> limit(^limit)
-    |> offset(^offset)
-    |> Repo.all()
+      false ->
+        total_count = get_total_count(query, options)
+
+        query
+        |> add_non_activity_select(total_count, options)
+        |> add_non_activity_order_by(sorting, options)
+        |> limit(^limit)
+        |> offset(^offset)
+        |> Repo.all()
+    end
   end
 
   defp add_activity_row_select(query, adaptive_activity_type_id) do
@@ -281,6 +292,7 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           id: s.id,
           total_count: fragment("?::int", ^total_count),
           title: rev.title,
+          deleted: rev.deleted,
           resource_id: s.resource_id,
           slug: rev.slug,
           part_id: s.part_id,
@@ -314,6 +326,7 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           s.resource_id,
           s.part_id,
           rev.title,
+          rev.deleted,
           rev.slug,
           rev.activity_type_id
         ])
@@ -322,6 +335,7 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
           total_count: fragment("?::int", ^total_count),
           resource_id: s.resource_id,
           title: rev.title,
+          deleted: rev.deleted,
           slug: rev.slug,
           part_id: s.part_id,
           activity_type_id: rev.activity_type_id,
@@ -488,5 +502,19 @@ defmodule Oli.Analytics.Summary.BrowseInsights do
       [] -> query
       _section_ids -> query |> group_by([s, _, _, _], [s.resource_id, s.part_id])
     end
+  end
+
+  defp objective_resource_type?(%BrowseInsightsOptions{resource_type_id: resource_type_id}) do
+    resource_type_id == ResourceType.get_id_by_type("objective")
+  end
+
+  defp filter_deleted_objectives(rows), do: Enum.reject(rows, & &1.deleted)
+
+  defp apply_paging(rows, %Paging{limit: limit, offset: offset}) do
+    total_count = length(rows)
+
+    rows
+    |> Enum.slice(offset, limit)
+    |> Enum.map(&Map.put(&1, :total_count, total_count))
   end
 end

--- a/lib/oli/authoring/editing/objective_editor.ex
+++ b/lib/oli/authoring/editing/objective_editor.ex
@@ -250,14 +250,14 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
         # whose parent page is locked
         Enum.filter(activities, fn %{scope: scope} -> scope == "embedded" end)
         |> Enum.filter(fn %{resource_id: resource_id} ->
-          !Map.has_key?(locked_by, Map.get(parent_pages, resource_id).id)
+          case Map.get(parent_pages, resource_id) do
+            nil -> false
+            %{id: page_id} -> !Map.has_key?(locked_by, page_id)
+          end
         end)
         |> Enum.each(fn activity ->
-          page =
-            AuthoringResolver.from_resource_id(
-              project.slug,
-              Map.get(parent_pages, activity.resource_id).id
-            )
+          %{id: page_id} = Map.fetch!(parent_pages, activity.resource_id)
+          page = AuthoringResolver.from_resource_id(project.slug, page_id)
 
           detach_from_activity(objective_id, page, activity, project.slug, author)
         end)

--- a/lib/oli/authoring/editing/objective_editor.ex
+++ b/lib/oli/authoring/editing/objective_editor.ex
@@ -249,17 +249,19 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
         # detach from all non-locked embedded activities. Locked activities are those activities
         # whose parent page is locked
         Enum.filter(activities, fn %{scope: scope} -> scope == "embedded" end)
-        |> Enum.filter(fn %{resource_id: resource_id} ->
+        |> Enum.each(fn %{resource_id: resource_id} = activity ->
           case Map.get(parent_pages, resource_id) do
-            nil -> false
-            %{id: page_id} -> !Map.has_key?(locked_by, page_id)
-          end
-        end)
-        |> Enum.each(fn activity ->
-          %{id: page_id} = Map.fetch!(parent_pages, activity.resource_id)
-          page = AuthoringResolver.from_resource_id(project.slug, page_id)
+            nil ->
+              if !Map.has_key?(locked_banked_activities, resource_id) do
+                detach_from_banked_activity(objective_id, activity, project.slug, author)
+              end
 
-          detach_from_activity(objective_id, page, activity, project.slug, author)
+            %{id: page_id} ->
+              if !Map.has_key?(locked_by, page_id) do
+                page = AuthoringResolver.from_resource_id(project.slug, page_id)
+                detach_from_activity(objective_id, page, activity, project.slug, author)
+              end
+          end
         end)
 
         # detach from all non-locked banked activities. Locked banked activities are those activities
@@ -427,7 +429,7 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
           end)
 
         locked_banked_activities =
-          case Enum.filter(distinct_activities, fn a -> a.scope == "banked" end) do
+          case directly_locked_activities(distinct_activities, parent_pages) do
             [] ->
               %{}
 
@@ -473,6 +475,19 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
       end)
 
     deduped
+  end
+
+  defp directly_locked_activities(activities, parent_pages) do
+    Enum.filter(activities, fn
+      %{scope: "banked"} ->
+        true
+
+      %{scope: "embedded", resource_id: resource_id} ->
+        !Map.has_key?(parent_pages, resource_id)
+
+      _ ->
+        false
+    end)
   end
 
   # For the pages that directly attach an objective, and the pages that

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -119,7 +119,8 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
             Sections.get_objectives_and_subobjectives(socket.assigns.section,
               exclude_sub_objectives: false,
               include_related_activities_count: true
-            ),
+            )
+            |> filter_root_contained_objectives(),
           navigator_items:
             Oli.Delivery.Sections.SectionResourceDepot.containers(socket.assigns.section.id,
               numbering_level: {:in, [1, 2]}
@@ -1686,4 +1687,31 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   end
 
   defp parse_dashboard_section_split(_split), do: :error
+
+  defp filter_root_contained_objectives(objectives) do
+    root_contained_ids =
+      objectives
+      |> Enum.filter(&root_contained_objective?/1)
+      |> Enum.map(& &1.resource_id)
+      |> MapSet.new()
+
+    parent_ids_for_root_contained_subobjectives =
+      objectives
+      |> Enum.filter(fn objective ->
+        not is_nil(objective.subobjective) and
+          MapSet.member?(root_contained_ids, objective.resource_id)
+      end)
+      |> Enum.map(& &1.objective_resource_id)
+      |> MapSet.new()
+
+    Enum.filter(objectives, fn objective ->
+      MapSet.member?(root_contained_ids, objective.resource_id) or
+        (is_nil(objective.subobjective) and
+           MapSet.member?(parent_ids_for_root_contained_subobjectives, objective.resource_id))
+    end)
+  end
+
+  defp root_contained_objective?(objective) do
+    nil in List.wrap(Map.get(objective, :container_ids))
+  end
 end

--- a/test/oli/analytics/summary/browse_insights_test.exs
+++ b/test/oli/analytics/summary/browse_insights_test.exs
@@ -158,6 +158,31 @@ defmodule Oli.Analytics.Summary.BrowseInsightsTest do
       assert Enum.at(results, 1).title == "B"
       assert Enum.at(results, 2).title == "C"
     end
+
+    test "filters deleted objectives after fetching insights", %{
+      project: project,
+      o2: o2
+    } do
+      objective_type_id = Oli.Resources.ResourceType.get_id_by_type("objective")
+
+      from(r in Oli.Resources.Revision, where: r.resource_id == ^o2.resource.id)
+      |> Repo.update_all(set: [deleted: true])
+
+      results =
+        BrowseInsights.browse_insights(
+          %Oli.Repo.Paging{limit: 4, offset: 0},
+          %Oli.Repo.Sorting{direction: :asc, field: :title},
+          %Oli.Analytics.Summary.BrowseInsightsOptions{
+            project_id: project.id,
+            section_ids: [],
+            resource_type_id: objective_type_id
+          }
+        )
+
+      assert Enum.map(results, & &1.title) == ["A", "C"]
+      assert Enum.all?(results, &(&1.total_count == 2))
+      refute Enum.any?(results, & &1.deleted)
+    end
   end
 
   describe "browse insights query, specific section_ids" do

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -120,6 +120,51 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       assert has_element?(view, "h6", "There are no objectives to show")
     end
 
+    test "does not show objectives that are not root-contained", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      project: project,
+      obj_revision_1: obj_revision_1
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.update_section(section, %{v25_migration: :not_started})
+
+      stale_objective_resource = insert(:resource)
+
+      stale_objective_revision =
+        insert(:revision, %{
+          resource: stale_objective_resource,
+          objectives: %{},
+          resource_type_id: Oli.Resources.ResourceType.id_for_objective(),
+          children: [],
+          content: %{},
+          deleted: false,
+          slug: "old_dnu_objective",
+          title: "OLD DNU Objective"
+        })
+
+      stale_section_resource =
+        insert(:section_resource, %{
+          section: section,
+          project: project,
+          resource_id: stale_objective_resource.id,
+          revision_id: stale_objective_revision.id,
+          resource_type_id: Oli.Resources.ResourceType.id_for_objective(),
+          title: stale_objective_revision.title,
+          slug: stale_objective_revision.slug,
+          children: []
+        })
+
+      Oli.Delivery.Sections.SectionResourceDepot.update_section_resource(stale_section_resource)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      assert has_element?(view, "#objectives-table")
+      assert has_element?(view, "span", obj_revision_1.title)
+      refute has_element?(view, "span", stale_objective_revision.title)
+    end
+
     test "applies searching", %{
       conn: conn,
       instructor: instructor,

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -6,6 +6,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
   import Phoenix.LiveViewTest
 
   alias Oli.Authoring.Editing.ObjectiveEditor
+  alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.ResourceType
 
   defp live_view_route(project_slug, params \\ %{}),
@@ -132,12 +133,19 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
 
     insert(:project_resource, %{project_id: project.id, resource_id: activity_resource.id})
 
-    insert(:published_resource, %{
-      author: hd(project.authors),
-      publication: publication,
-      resource: activity_resource,
-      revision: activity_revision
-    })
+    published_resource =
+      insert(:published_resource, %{
+        author: hd(project.authors),
+        publication: publication,
+        resource: activity_resource,
+        revision: activity_revision
+      })
+
+    {:ok, _} =
+      Oli.Publishing.update_published_resource(published_resource, %{
+        locked_by_id: nil,
+        lock_updated_at: nil
+      })
 
     {:ok, activity_revision}
   end
@@ -466,7 +474,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
     } do
       {:ok, obj} = create_objective(project, publication, "obj_a", "Objective A")
 
-      {:ok, _activity} =
+      {:ok, activity} =
         create_embedded_activity_with_objective(
           project,
           publication,
@@ -494,6 +502,13 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
              |> element(~s{div[role="alert"].alert-info})
              |> render() =~
                "Objective successfully removed"
+
+      updated_activity = AuthoringResolver.from_resource_id(project.slug, activity.resource_id)
+
+      refute updated_activity.objectives
+             |> Map.values()
+             |> List.flatten()
+             |> Enum.member?(obj.resource_id)
     end
 
     test "add existing sub objective", %{conn: conn, project: project, publication: publication} do

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -109,6 +109,39 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
     {:ok, page_revision}
   end
 
+  defp create_embedded_activity_with_objective(
+         project,
+         publication,
+         objective_id,
+         slug
+       ) do
+    activity_resource = insert(:resource)
+
+    activity_revision =
+      insert(:revision, %{
+        resource: activity_resource,
+        objectives: %{"1" => [objective_id]},
+        resource_type_id: ResourceType.id_for_activity(),
+        children: [],
+        content: %{},
+        deleted: false,
+        title: "Activity",
+        slug: slug,
+        scope: :embedded
+      })
+
+    insert(:project_resource, %{project_id: project.id, resource_id: activity_resource.id})
+
+    insert(:published_resource, %{
+      author: hd(project.authors),
+      publication: publication,
+      resource: activity_resource,
+      revision: activity_revision
+    })
+
+    {:ok, activity_revision}
+  end
+
   describe "user cannot access when is not logged in" do
     setup [:create_project]
 
@@ -424,6 +457,43 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
 
       assert_receive {:finish_attachments, {_attachments, _flash_fn}}
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "remove objective with orphaned embedded activity attachment", %{
+      conn: conn,
+      project: project,
+      publication: publication
+    } do
+      {:ok, obj} = create_objective(project, publication, "obj_a", "Objective A")
+
+      {:ok, _activity} =
+        create_embedded_activity_with_objective(
+          project,
+          publication,
+          obj.resource_id,
+          "orphaned_activity"
+        )
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      view
+      |> element("button[phx-click='set_selected'][phx-value-slug=#{obj.slug}]")
+      |> render_click(%{"slug" => obj.slug})
+
+      view
+      |> element("button[phx-click='display_delete_modal'][phx-value-slug=#{obj.slug}]")
+      |> render_click(%{"slug" => obj.slug})
+
+      assert has_element?(view, "#delete_objective_modal", "Delete Objective")
+
+      view
+      |> element("button[phx-click='delete'][phx-value-slug=#{obj.slug}]")
+      |> render_click(%{"slug" => obj.slug, "parent_slug" => ""})
+
+      assert view
+             |> element(~s{div[role="alert"].alert-info})
+             |> render() =~
+               "Objective successfully removed"
     end
 
     test "add existing sub objective", %{conn: conn, project: project, publication: publication} do


### PR DESCRIPTION
This PR fixes three distinct problems:

**1. The Instructor Dashboard was continuing to show learning objectives that were no longer reachable from the course content.** 

This was easy to reproduce:

1. As an author, create an objective, place an activity on a page in the course project and attach that objective to that activity. 
2. Publish the project, apply the update to a course section and then as a student, answer the question.
3. Verify that in the Instructor Dashboard that you see results for that objective.
4. Then as an author, remove that page from the course.  Publish and apply the update to the section.
5. As instructor, look again at Instructor Dashboard "Learning Objectives" tab and see that the table still shows that objective. 

The fix here was to post-process the list of learning objectives and filter out any LOs that are no longer "reachable" from the course content.  With this fix in place, the LO no longer displays in step 5 above. 


**2. The "By Objective" option in the Authoring Insights view was showing results for all objectives, included those marked as deleted.** 

To reproduce:

1. Publish a course project with a learning objective attached to an activity. 
2. As a student, answer the question.
3. As author, in "Insights" view, verify you see data for that LO when you use "By Objective" option.
4. As author, delete the host page, and then Remove the objective from the Objectives editor.
5. As author, from "Insights" view, use "By Objective" option and you will still see that LO listed.

Fix was to only show non deleted objectives. 


**3. The "Remove" learning objective feature would crash if attempting to detach the learning objective from an "orphaned" activity.** 

 To reproduce this issue:

1. Create a page with an activity, attach an LO to that activity.
2. From Curriculum view, delete that page from the course. 
3. From the "Objectives" view, attempt to "Remove" that LO. 
4. You should see a modal dialog appear indicating that the LO is still attached to that Activity.
5. Click "Ok" to proceed (to detach the LO and delete).  

Without this fix the removal fails due to a BadMapError.  With this fix, the detachment succeeds and the LO is removed. 
