### PR TITLE
[ENHANCEMENT] [MER-5489] Add automated coverage for student dashboard, assignments, and schedule views

### DIFF
--- a/assets/automation/tests/torus/student_delivery/student-dashboard-coverage.scenario.yaml
+++ b/assets/automation/tests/torus/student_delivery/student-dashboard-coverage.scenario.yaml
@@ -1,0 +1,66 @@
+# Scenario: Seed a minimal published course for student dashboard, assignments, and schedule coverage.
+
+- project:
+    name: 'student_dashboard_coverage_project'
+    title: 'MER-5489 Student Dashboard Coverage ${RUN_ID}'
+    root:
+      children:
+        - page: 'Coverage Page'
+
+- edit_page:
+    project: 'student_dashboard_coverage_project'
+    page: 'Coverage Page'
+    content: |
+      title: "Coverage Page"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Coverage content"
+
+- publish:
+    to: 'student_dashboard_coverage_project'
+    description: 'Initial student dashboard coverage publication'
+
+- section:
+    name: 'student_dashboard_coverage_section'
+    title: 'MER-5489 Student Dashboard Coverage ${RUN_ID}'
+    from: 'student_dashboard_coverage_project'
+    type: 'enrollable'
+    open_and_free: true
+    registration_open: true
+    start_date: '2026-04-16T00:00:00Z'
+
+- user:
+    name: 'student_dashboard_coverage_student'
+    type: 'student'
+    email: 'student-dashboard-coverage-student${RUN_ID}@example.com'
+    given_name: 'Coverage'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
+    name: 'student_dashboard_coverage_instructor'
+    type: 'instructor'
+    email: 'student-dashboard-coverage-instructor${RUN_ID}@example.com'
+    given_name: 'Coverage'
+    family_name: 'Instructor'
+    password: 'changeme123456'
+
+- enroll:
+    user: 'student_dashboard_coverage_student'
+    section: 'student_dashboard_coverage_section'
+    role: 'student'
+
+- enroll:
+    user: 'student_dashboard_coverage_instructor'
+    section: 'student_dashboard_coverage_section'
+    role: 'instructor'
+
+- manipulate:
+    to: 'student_dashboard_coverage_section'
+    ops:
+      - revise:
+          target: 'Coverage Page'
+          set:
+            scheduling_type: '@atom(due_by)'
+            end_date: '2026-11-11T23:59:59Z'

--- a/assets/automation/tests/torus/student_delivery/student-dashboard-coverage.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/student-dashboard-coverage.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import path from 'node:path';
+import { configureStudentDeliveryRuntimeConfig, seedStudentDeliveryScenario } from './support';
+
+const runId = `-${Date.now()}`;
+const scenarioPath = path.resolve(__dirname, './student-dashboard-coverage.scenario.yaml');
+const sectionTitle = `MER-5489 Student Dashboard Coverage ${runId}`;
+
+configureStudentDeliveryRuntimeConfig(runId, {
+  student: {
+    type: 'student',
+    role: 'Student',
+    emailPrefix: 'student-dashboard-coverage-student',
+    welcomeTitle: 'Hi, Coverage',
+    name: 'Coverage',
+    lastName: 'Student',
+  },
+  instructor: {
+    type: 'instructor',
+    role: 'Instructor',
+    emailPrefix: 'student-dashboard-coverage-instructor',
+    welcomeTitle: 'Instructor Dashboard',
+    header: 'Instructor Dashboard',
+  },
+  author: {
+    type: 'author',
+    role: 'Course Author',
+    emailPrefix: 'student-dashboard-coverage-author',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+  administrator: {
+    type: 'administrator',
+    role: 'Course Author',
+    emailPrefix: 'student-dashboard-coverage-admin',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+});
+
+let sectionSlug = '';
+
+test.beforeAll(async ({ seedScenario }) => {
+  const outputs = await seedStudentDeliveryScenario(seedScenario, scenarioPath, runId);
+
+  sectionSlug = outputs.sections?.student_dashboard_coverage_section ?? '';
+  expect(sectionSlug).toBeTruthy();
+});
+
+test.describe('student dashboard, assignments, and schedule coverage', () => {
+  test.beforeEach(async ({ homeTask }) => {
+    await homeTask.login('student');
+  });
+
+  test('student dashboard lets the student find and open the course', async ({
+    page,
+    studentTask,
+  }) => {
+    await expect(page.getByRole('heading', { name: 'Courses available' })).toBeVisible();
+    await studentTask.searchProject(sectionTitle);
+    await expect(page.locator('#home-assignments')).toBeVisible();
+  });
+
+  test('assignments view loads for the course', async ({ page, studentTask }) => {
+    await studentTask.searchProject(sectionTitle);
+
+    await page.goto(assignmentsPath(sectionSlug), { waitUntil: 'load' });
+    await expect(page).toHaveURL(assignmentsPath(sectionSlug));
+    await expect(page.getByRole('heading', { name: 'Assignments' })).toBeVisible();
+  });
+
+  test('schedule view loads for the course', async ({ page, studentTask }) => {
+    await studentTask.searchProject(sectionTitle);
+
+    await page.goto(schedulePath(sectionSlug), { waitUntil: 'load' });
+    await expect(page).toHaveURL(schedulePath(sectionSlug));
+    await expect(page.getByRole('heading', { name: 'Course Schedule' })).toBeVisible();
+    await expect(page.locator('#schedule-view')).toBeVisible();
+  });
+});
+
+function assignmentsPath(sectionSlug: string) {
+  return `/sections/${sectionSlug}/assignments?sidebar_expanded=true`;
+}
+
+function schedulePath(sectionSlug: string) {
+  return `/sections/${sectionSlug}/student_schedule?sidebar_expanded=true`;
+}


### PR DESCRIPTION
[MER-5489](https://eliterate.atlassian.net/browse/MER-5489)

## Summary

Added end-to-end coverage for the student flow from the dashboard into the course, plus Assignments and Course Schedule page checks.

### Changes

- Added a new seed scenario for a minimal published course with an enrollable section and due_by content.

- Added a Playwright spec with 3 tests:
  - open the course from the student dashboard
  - load Assignments
  - load Course Schedule

- Reused studentTask.searchProject(...) to avoid duplicating the dashboard navigation flow.

### Tests

- npm run pw -- tests/torus/student_delivery/student-dashboard-coverage.spec.ts
- Result: 3 passed

[MER-5489]: https://eliterate.atlassian.net/browse/MER-5489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ