### PR TITLE
[ENHANCEMENT] [MER-5422] Add Playwright coverage for Simple Author adaptive branching

### DIFF
--- a/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
+++ b/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
@@ -71,7 +71,7 @@ export class StudentCoursePO {
 
     const courseUrl = this.courseUrlFromWelcome();
     if (courseUrl) {
-      await this.page.goto(courseUrl, { waitUntil: 'domcontentloaded', timeout: 15000 });
+      await this.page.goto(courseUrl, { waitUntil: 'domcontentloaded' });
       await this.waitForCourseHome(15000);
     }
   }

--- a/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
+++ b/assets/automation/src/systems/torus/pom/course/StudentCoursePO.ts
@@ -71,8 +71,7 @@ export class StudentCoursePO {
 
     const courseUrl = this.courseUrlFromWelcome();
     if (courseUrl) {
-      await this.page.goto(courseUrl);
-      await this.page.waitForLoadState('domcontentloaded');
+      await this.page.goto(courseUrl, { waitUntil: 'domcontentloaded', timeout: 15000 });
       await this.waitForCourseHome(15000);
     }
   }

--- a/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
+++ b/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
@@ -194,6 +194,8 @@ export class BasicPracticePagePO {
     await this.replaceFirstFlowchartRule('Correct', 'Correct Terminal');
     await this.selectFlowchartScreenByTitle('Routing Question');
     await this.addFlowchartRuleToNewScreen('Any Incorrect', 'Incorrect Terminal');
+    await this.selectFlowchartScreenByTitle('Routing Question');
+    await this.replaceLastFlowchartRule('Any Incorrect', 'Incorrect Terminal');
 
     await expect(this.flowchartNodes).toHaveCount(3, { timeout: 30000 });
     await expect(this.flowchartScreenTitle('Routing Question')).toBeVisible();
@@ -322,6 +324,19 @@ export class BasicPracticePagePO {
     const pathEditor = this.flowchartSidebar
       .locator('.path-editor-incomplete, .path-editor-completed')
       .first();
+    await this.completeFlowchartRule(pathEditor, rule, destinationTitle);
+  }
+
+  private async replaceLastFlowchartRule(rule: string, destinationTitle: string) {
+    const path = this.flowchartSidebar
+      .locator('.path-editor-incomplete, .path-editor-completed')
+      .last();
+    await path.waitFor({ state: 'visible', timeout: 10000 });
+    await path.click();
+
+    const pathEditor = this.flowchartSidebar
+      .locator('.path-editor-incomplete, .path-editor-completed')
+      .last();
     await this.completeFlowchartRule(pathEditor, rule, destinationTitle);
   }
 

--- a/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
+++ b/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
@@ -83,7 +83,7 @@ export class BasicPracticePagePO {
     this.simpleAuthorMultipleChoiceButton = this.simpleAuthorToolbar
       .locator('.toolbar-column')
       .filter({ hasText: 'Question Components' })
-      .locator('button.component-button')
+      .locator('button.component-button[data-component="janus_mcq"]')
       .first();
     this.simpleAuthorMultipleChoicePart = page.locator(
       'janus-mcq, [data-part-id^="janus_mcq-"], [data-part-id^="janus-mcq-"]',
@@ -163,6 +163,36 @@ export class BasicPracticePagePO {
 
     await expect(this.adaptiveReadOnlyInput).not.toBeChecked({ timeout: 10000 });
     await this.assertAdvancedAuthorEditable();
+  }
+
+  async ensureSimpleAuthorReady() {
+    await this.completeSimpleAuthorOnboardingIfPresent();
+
+    const hasToggle = (await this.adaptiveReadOnlyInput.count().catch(() => 0)) > 0;
+    if (hasToggle && (await this.adaptiveReadOnlyInput.isChecked().catch(() => false))) {
+      await expect(this.adaptiveReadOnlyInput).toBeEnabled({ timeout: 30000 });
+
+      await this.page.evaluate(() => {
+        const input = document.querySelector<HTMLInputElement>('input[name="adaptive_read_only"]');
+
+        if (input?.checked) {
+          input.click();
+        }
+      });
+
+      await expect(this.adaptiveReadOnlyInput).not.toBeChecked({ timeout: 10000 });
+    }
+
+    await this.adaptiveAuthorToolbar.first().waitFor({ state: 'visible', timeout: 30000 });
+    await expect(
+      this.advancedAuthorFlowchartMode,
+      'Simple Author flowchart mode should load.',
+    ).toBeVisible({
+      timeout: 30000,
+    });
+    await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
+      timeout: 30000,
+    });
   }
 
   private async assertAdvancedAuthorEditable() {

--- a/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
+++ b/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
@@ -115,10 +115,7 @@ export class BasicPracticePagePO {
       .catch(() => false);
 
     if (simpleAuthorToolbarVisible) {
-      await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
-        timeout: 30000,
-      });
-      await expect(this.simpleAuthorMultipleChoiceButton).toBeEnabled({ timeout: 30000 });
+      await this.waitForSimpleAuthorMultipleChoiceToolbarReady();
       await this.addSimpleAuthorMultipleChoicePart();
       return;
     }
@@ -210,10 +207,7 @@ export class BasicPracticePagePO {
 
     await this.selectFlowchartScreenByTitle('Welcome Screen');
     await this.switchToAdvancedAuthorScreenPanelMode();
-    await this.clickAdvancedAuthorMultipleChoiceButton();
-    await this.simpleAuthorMultipleChoicePart
-      .first()
-      .waitFor({ state: 'attached', timeout: 30000 });
+    await this.ensureSimpleAuthorMultipleChoicePart();
     await this.setSimpleAuthorScreenMaxAttempts('1');
     await this.waitForChangesSaved().catch(() => void 0);
 
@@ -284,6 +278,8 @@ export class BasicPracticePagePO {
   }
 
   private async addSimpleAuthorMultipleChoicePart() {
+    await this.waitForSimpleAuthorMultipleChoiceToolbarReady();
+
     for (let attempt = 0; attempt < 10; attempt += 1) {
       await this.simpleAuthorMultipleChoiceButton.click();
 
@@ -299,6 +295,24 @@ export class BasicPracticePagePO {
     }
 
     await this.simpleAuthorMultipleChoicePart.first().waitFor({ state: 'attached', timeout: 1000 });
+  }
+
+  private async ensureSimpleAuthorMultipleChoicePart() {
+    const hasPart = (await this.simpleAuthorMultipleChoicePart.count().catch(() => 0)) > 0;
+    if (hasPart) return;
+
+    await this.clickAdvancedAuthorMultipleChoiceButton();
+    await this.simpleAuthorMultipleChoicePart
+      .first()
+      .waitFor({ state: 'attached', timeout: 30000 });
+  }
+
+  private async waitForSimpleAuthorMultipleChoiceToolbarReady() {
+    await this.simpleAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
+    await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
+      timeout: 30000,
+    });
+    await expect(this.simpleAuthorMultipleChoiceButton).toBeEnabled({ timeout: 30000 });
   }
 
   private async setSimpleAuthorScreenMaxAttempts(maxAttempts: string) {

--- a/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
+++ b/assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts
@@ -25,6 +25,14 @@ export class BasicPracticePagePO {
   private readonly pageTitleSaveButton: Locator;
   private readonly adaptiveReadOnlyInput: Locator;
   private readonly advancedAuthorToolbar: Locator;
+  private readonly adaptiveAuthorToolbar: Locator;
+  private readonly simpleAuthorToolbar: Locator;
+  private readonly simpleAuthorMultipleChoiceButton: Locator;
+  private readonly simpleAuthorMultipleChoicePart: Locator;
+  private readonly advancedAuthorScreenPanelMode: Locator;
+  private readonly advancedAuthorFlowchartMode: Locator;
+  private readonly flowchartNodes: Locator;
+  private readonly flowchartSidebar: Locator;
   private readonly captionAudio: Locator;
   private readonly figure: Locator;
   private readonly textbox: Locator;
@@ -61,6 +69,35 @@ export class BasicPracticePagePO {
       '#adaptive_read_only_toggle input[name="adaptive_read_only"]',
     );
     this.advancedAuthorToolbar = page.locator('#advanced-authoring nav.aa-header-nav');
+    this.adaptiveAuthorToolbar = page.locator(
+      [
+        '#advanced-authoring nav.aa-header-nav',
+        '#advanced-authoring .component-toolbar',
+        '#advanced-authoring .top-toolbar',
+        '#advanced-authoring .sidebar-header',
+        '.flowchart-editor .top-toolbar',
+        '.flowchart-editor .sidebar-header',
+      ].join(', '),
+    );
+    this.simpleAuthorToolbar = page.locator('#advanced-authoring .component-toolbar');
+    this.simpleAuthorMultipleChoiceButton = this.simpleAuthorToolbar
+      .locator('.toolbar-column')
+      .filter({ hasText: 'Question Components' })
+      .locator('button.component-button')
+      .first();
+    this.simpleAuthorMultipleChoicePart = page.locator(
+      'janus-mcq, [data-part-id^="janus_mcq-"], [data-part-id^="janus-mcq-"]',
+    );
+    this.advancedAuthorScreenPanelMode = page
+      .locator('#advanced-authoring .sidebar-header, .flowchart-editor .sidebar-header')
+      .filter({ hasText: 'Screen Panel' })
+      .first();
+    this.advancedAuthorFlowchartMode = page
+      .locator('#advanced-authoring .sidebar-header, .flowchart-editor .sidebar-header')
+      .filter({ hasText: 'Flowchart' })
+      .first();
+    this.flowchartNodes = page.locator('.flowchart-node');
+    this.flowchartSidebar = page.locator('.flowchart-sidebar');
     this.captionAudio = page.getByRole('paragraph').filter({ hasText: 'Caption (optional)' });
     this.figure = this.page.getByRole('figure', { name: 'Figure Title' });
     this.textbox = this.figure.getByRole('textbox');
@@ -72,6 +109,20 @@ export class BasicPracticePagePO {
   }
 
   async clickAdvancedAuthorMultipleChoiceButton() {
+    const simpleAuthorToolbarVisible = await this.simpleAuthorToolbar
+      .waitFor({ state: 'visible', timeout: 1000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (simpleAuthorToolbarVisible) {
+      await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
+        timeout: 30000,
+      });
+      await expect(this.simpleAuthorMultipleChoiceButton).toBeEnabled({ timeout: 30000 });
+      await this.addSimpleAuthorMultipleChoicePart();
+      return;
+    }
+
     await this.advancedAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
     await this.page.waitForFunction(() => customElements.get('janus-mcq') != null, undefined, {
       timeout: 30000,
@@ -118,7 +169,234 @@ export class BasicPracticePagePO {
     await expect(this.editTitleButton, 'Advanced authoring should be editable.').toBeEnabled({
       timeout: 15000,
     });
-    await this.advancedAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
+    await this.adaptiveAuthorToolbar.first().waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  async buildSimpleAdvancedAuthorMcqBranchingLesson() {
+    await this.waitForAdvancedAuthorFlowchartReady();
+
+    await this.selectFlowchartScreenByTitle('End of Lesson');
+    await this.renameSelectedFlowchartScreen('Correct Terminal');
+
+    await this.selectFlowchartScreenByTitle('Welcome Screen');
+    await this.switchToAdvancedAuthorScreenPanelMode();
+    await this.clickAdvancedAuthorMultipleChoiceButton();
+    await this.simpleAuthorMultipleChoicePart
+      .first()
+      .waitFor({ state: 'attached', timeout: 30000 });
+    await this.setSimpleAuthorScreenMaxAttempts('1');
+    await this.waitForChangesSaved().catch(() => void 0);
+
+    await this.switchToAdvancedAuthorFlowchartMode();
+    await this.selectFlowchartScreenByTitle('Welcome Screen');
+    await this.renameSelectedFlowchartScreen('Routing Question');
+
+    await this.replaceFirstFlowchartRule('Correct', 'Correct Terminal');
+    await this.selectFlowchartScreenByTitle('Routing Question');
+    await this.addFlowchartRuleToNewScreen('Any Incorrect', 'Incorrect Terminal');
+
+    await expect(this.flowchartNodes).toHaveCount(3, { timeout: 30000 });
+    await expect(this.flowchartScreenTitle('Routing Question')).toBeVisible();
+    await expect(this.flowchartScreenTitle('Correct Terminal')).toBeVisible();
+    await expect(this.flowchartScreenTitle('Incorrect Terminal')).toBeVisible();
+    await this.waitForChangesSaved().catch(() => void 0);
+
+    return {
+      question: 'Routing Question',
+      correct: 'Correct Terminal',
+      incorrect: 'Incorrect Terminal',
+      screenCount: await this.flowchartNodes.count(),
+    };
+  }
+
+  async waitForAdvancedAuthorFlowchartReady() {
+    await this.completeSimpleAuthorOnboardingIfPresent();
+
+    await expect(
+      this.advancedAuthorFlowchartMode,
+      'Simple Author flowchart mode should load.',
+    ).toBeVisible({
+      timeout: 30000,
+    });
+    await this.advancedAuthorFlowchartMode.click();
+    await this.flowchartNodes.first().waitFor({ state: 'visible', timeout: 30000 });
+    await expect(this.flowchartScreenTitle('Welcome Screen')).toBeVisible({ timeout: 30000 });
+    await expect(this.flowchartScreenTitle('End of Lesson')).toBeVisible({ timeout: 30000 });
+  }
+
+  private async completeSimpleAuthorOnboardingIfPresent() {
+    const wizard = this.page.locator('.onboard-wizard');
+
+    const wizardVisible = await wizard
+      .waitFor({ state: 'visible', timeout: 3000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!wizardVisible) return;
+
+    for (let stepIndex = 0; stepIndex < 3; stepIndex += 1) {
+      const nextButton = wizard.getByRole('button', { name: /^Next$/ }).last();
+      await expect(nextButton).toBeEnabled({ timeout: 10000 });
+      await nextButton.click();
+    }
+  }
+
+  private async switchToAdvancedAuthorScreenPanelMode() {
+    await this.advancedAuthorScreenPanelMode.click();
+    await this.simpleAuthorToolbar.waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  private async switchToAdvancedAuthorFlowchartMode() {
+    await this.advancedAuthorFlowchartMode.click();
+    await this.flowchartNodes.first().waitFor({ state: 'visible', timeout: 30000 });
+  }
+
+  private async addSimpleAuthorMultipleChoicePart() {
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      await this.simpleAuthorMultipleChoiceButton.click();
+
+      const partAdded = await this.simpleAuthorMultipleChoicePart
+        .first()
+        .waitFor({ state: 'attached', timeout: 3000 })
+        .then(() => true)
+        .catch(() => false);
+
+      if (partAdded) return;
+
+      await this.page.waitForTimeout(250);
+    }
+
+    await this.simpleAuthorMultipleChoicePart.first().waitFor({ state: 'attached', timeout: 1000 });
+  }
+
+  private async setSimpleAuthorScreenMaxAttempts(maxAttempts: string) {
+    const maxAttemptsField = this.page
+      .locator('xpath=//*[normalize-space(.)="Max Attempts"]/following::select[1]')
+      .first();
+    await expect(maxAttemptsField).toBeVisible({ timeout: 10000 });
+    await maxAttemptsField.selectOption(maxAttempts);
+    await expect(maxAttemptsField).toHaveValue(maxAttempts, { timeout: 10000 });
+  }
+
+  private flowchartScreenTitle(title: string) {
+    return this.page
+      .locator('.flowchart-node .title-text')
+      .filter({ hasText: new RegExp(`^${this.escapeRegExp(title)}$`) })
+      .first();
+  }
+
+  private async selectFlowchartScreenByTitle(title: string) {
+    const screen = this.flowchartNodes.filter({ hasText: title }).first();
+    await screen.locator('.node-box').click({ position: { x: 8, y: 8 } });
+    await expect(this.flowchartSidebar).toContainText(title, { timeout: 10000 });
+  }
+
+  private async renameSelectedFlowchartScreen(title: string) {
+    const screenTitle = this.flowchartSidebar.locator('.screen-title').first();
+    await screenTitle.click();
+    const input = screenTitle.locator('input');
+    await input.fill(title);
+    await input.press('Enter');
+
+    const inputStillVisible = await input
+      .waitFor({ state: 'visible', timeout: 500 })
+      .then(() => true)
+      .catch(() => false);
+    if (inputStillVisible) {
+      await input.evaluate((element) => (element as HTMLElement).blur());
+    }
+
+    await expect(this.flowchartSidebar.locator('.screen-title')).toContainText(title, {
+      timeout: 10000,
+    });
+    await expect(this.flowchartScreenTitle(title)).toBeVisible({ timeout: 30000 });
+  }
+
+  private async replaceFirstFlowchartRule(rule: string, destinationTitle: string) {
+    const path = this.flowchartSidebar
+      .locator('.path-editor-incomplete, .path-editor-completed')
+      .first();
+    await path.waitFor({ state: 'visible', timeout: 10000 });
+    await path.click();
+
+    const pathEditor = this.flowchartSidebar
+      .locator('.path-editor-incomplete, .path-editor-completed')
+      .first();
+    await this.completeFlowchartRule(pathEditor, rule, destinationTitle);
+  }
+
+  private async addFlowchartRuleToNewScreen(rule: string, destinationTitle: string) {
+    const existingTitles = await this.flowchartNodeTitles();
+    const existingNodeCount = await this.flowchartNodes.count();
+
+    await this.flowchartSidebar.getByRole('button', { name: 'Add Rule' }).click();
+
+    const pathEditor = this.flowchartSidebar
+      .locator('.path-editor-incomplete, .path-editor-completed')
+      .last();
+    await pathEditor.waitFor({ state: 'visible', timeout: 10000 });
+
+    await this.completeFlowchartRule(pathEditor, rule, '-- Create new screen --');
+    await expect(this.flowchartNodes).toHaveCount(existingNodeCount + 1, { timeout: 30000 });
+
+    const newScreenTitle = await this.waitForNewFlowchartNodeTitle(existingTitles);
+    await this.renameNewestFlowchartScreen(newScreenTitle, destinationTitle);
+  }
+
+  private async completeFlowchartRule(pathEditor: Locator, rule: string, destinationTitle: string) {
+    const pathType = pathEditor.locator('select').first();
+    await expect(pathType).toBeVisible({ timeout: 10000 });
+    await pathType.selectOption({ label: rule });
+
+    const destination = pathEditor.locator('.destination-section select').first();
+    await expect(destination).toBeVisible({ timeout: 10000 });
+    await destination.selectOption({ label: destinationTitle });
+
+    await pathEditor.getByRole('button', { name: 'Done' }).click();
+  }
+
+  private async renameNewestFlowchartScreen(currentTitle: string, newTitle: string) {
+    await expect(this.flowchartScreenTitle(currentTitle)).toBeVisible({ timeout: 30000 });
+    const screenTitle = this.flowchartScreenTitle(currentTitle);
+    await screenTitle
+      .locator(
+        'xpath=ancestor::div[contains(concat(" ", normalize-space(@class), " "), " flowchart-node ")]',
+      )
+      .locator('.node-box')
+      .click({ position: { x: 8, y: 8 } });
+    await this.renameSelectedFlowchartScreen(newTitle);
+  }
+
+  private async flowchartNodeTitles() {
+    return (await this.page.locator('.flowchart-node .title-text').allTextContents()).map((title) =>
+      title.trim(),
+    );
+  }
+
+  private async waitForNewFlowchartNodeTitle(existingTitles: string[]) {
+    const existingCounts = existingTitles.reduce<Record<string, number>>((counts, title) => {
+      counts[title] = (counts[title] ?? 0) + 1;
+      return counts;
+    }, {});
+
+    for (let attempt = 0; attempt < 60; attempt += 1) {
+      const seen = { ...existingCounts };
+      const newTitle = (await this.flowchartNodeTitles()).find((title) => {
+        if (!seen[title]) return true;
+        seen[title] -= 1;
+        return false;
+      });
+
+      if (newTitle) return newTitle;
+
+      await this.page.waitForTimeout(500);
+    }
+
+    throw new Error('New flowchart screen title was not found.');
+  }
+
+  private escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
   async renameTitle(titlePage: string) {

--- a/assets/automation/src/systems/torus/pom/project/CurriculumPO.ts
+++ b/assets/automation/src/systems/torus/pom/project/CurriculumPO.ts
@@ -7,6 +7,7 @@ export type Index = 'first' | 'last' | number;
 export class CurriculumPO {
   private readonly contentCenter: Locator;
   private readonly practiceButton: Locator;
+  private readonly adaptiveSimplePracticeButton: Locator;
   private readonly adaptivePracticeButton: Locator;
   private readonly scoredButton: Locator;
   private readonly editPageLink: Locator;
@@ -19,6 +20,9 @@ export class CurriculumPO {
   constructor(private readonly page: Page) {
     this.contentCenter = page.locator('#content > div.container.mx-auto.p-8');
     this.practiceButton = page.getByRole('button', { name: 'Practice' });
+    this.adaptiveSimplePracticeButton = page.getByRole('button', {
+      name: 'Practice (Simple Author)',
+    });
     this.adaptivePracticeButton = page.getByRole('button', { name: 'Practice (Advanced Author)' });
     this.scoredButton = page.getByRole('button', { name: 'Scored' }).first();
     this.createUnitButton = page.getByRole('button', { name: 'Create a Unit' });
@@ -49,6 +53,15 @@ export class CurriculumPO {
 
   async clickAdaptivePracticeButton() {
     await this.adaptivePracticeButton.click();
+    return this.waitForAdaptivePageOrVerify('New Advanced Author Page');
+  }
+
+  async clickAdaptiveSimplePracticeButton() {
+    await this.adaptiveSimplePracticeButton.click();
+    return this.waitForAdaptivePageOrVerify('New Simple Author Page');
+  }
+
+  private async waitForAdaptivePageOrVerify(title: string) {
     const editorTitleBar = this.page.locator('div.TitleBar');
 
     try {
@@ -61,7 +74,7 @@ export class CurriculumPO {
       // fall through to the curriculum entry verification below
     }
 
-    await this.verifyPage('New Advanced Author Page', 'Edit Page', 'last');
+    await this.verifyPage(title, 'Edit Page', 'last');
     return false;
   }
 

--- a/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
+++ b/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
@@ -32,7 +32,13 @@ import { QuestionLikertCO } from '@pom/activities/QuestionLikertCO';
 import { step } from '@core/decoration/step';
 import { QuestionImageHotspot } from '@pom/activities/QuestionImageHotspot';
 
-type PageType = 'basic-practice' | 'basic-scored' | 'adaptive-practice' | 'unit' | 'module';
+type PageType =
+  | 'basic-practice'
+  | 'basic-scored'
+  | 'adaptive-practice'
+  | 'adaptive-simple-practice'
+  | 'unit'
+  | 'module';
 
 export class CurriculumTask {
   private readonly basicPP: BasicPracticePagePO;
@@ -142,6 +148,9 @@ export class CurriculumTask {
       case 'adaptive-practice':
         openedEditor = await this.curriculum.clickAdaptivePracticeButton();
         break;
+      case 'adaptive-simple-practice':
+        openedEditor = await this.curriculum.clickAdaptiveSimplePracticeButton();
+        break;
       case 'unit':
         await this.curriculum.clickCreateUnitButton();
         break;
@@ -167,6 +176,12 @@ export class CurriculumTask {
   @step('Create an adaptive page in Advanced Author')
   async createAdaptivePageInAdvancedAuthor(stayInEditor = false) {
     await this.addPage('adaptive-practice', true);
+    await this.enterPage(
+      'adaptive-practice',
+      this.defaultPageName('adaptive-practice'),
+      'Edit Page',
+      'last',
+    );
     await this.basicPP.ensureAdvancedAuthorEditable();
     await this.basicPP.waitForChangesSaved().catch(() => void 0);
     if (!stayInEditor) {
@@ -175,9 +190,32 @@ export class CurriculumTask {
     }
   }
 
+  @step('Create an adaptive page in Simple Author')
+  async createAdaptivePageInSimpleAuthor(stayInEditor = false) {
+    await this.addPage('adaptive-simple-practice', true);
+    await this.enterPage(
+      'adaptive-simple-practice',
+      this.defaultPageName('adaptive-simple-practice'),
+      'Edit Page',
+      'last',
+    );
+    await this.basicPP.ensureAdvancedAuthorEditable();
+    await this.basicPP.waitForAdvancedAuthorFlowchartReady();
+    await this.basicPP.waitForChangesSaved().catch(() => void 0);
+    if (!stayInEditor) {
+      await this.returnToCurriculum();
+      await this.curriculum.expectPageVisible('New Simple Author Page');
+    }
+  }
+
   @step('Enter a page from the project. Type: {type}')
   async enterPage(type: PageType, namePage: string, link: string, index: Index) {
-    if (type === 'basic-practice' || type === 'basic-scored' || type === 'adaptive-practice') {
+    if (
+      type === 'basic-practice' ||
+      type === 'basic-scored' ||
+      type === 'adaptive-practice' ||
+      type === 'adaptive-simple-practice'
+    ) {
       if (await this.curriculum.pageEditorIsOpen(500)) return;
       await this.curriculum.clickEditPageLink(namePage, link, index);
     }
@@ -197,6 +235,8 @@ export class CurriculumTask {
         return 'New Assessment';
       case 'adaptive-practice':
         return 'New Advanced Author Page';
+      case 'adaptive-simple-practice':
+        return 'New Simple Author Page';
       case 'unit':
         return 'Unit 1: Unit';
       case 'module':
@@ -599,6 +639,11 @@ export class CurriculumTask {
     );
     await expect(this.page.locator('janus-mcq').first()).toBeVisible({ timeout: 30000 });
     await this.basicPP.waitForChangesSaved().catch(() => void 0);
+  }
+
+  @step('Build a simple Advanced Author MCQ branching lesson')
+  async buildSimpleAdvancedAuthorMcqBranchingLesson() {
+    return this.basicPP.buildSimpleAdvancedAuthorMcqBranchingLesson();
   }
 
   @step("Add activities with questions '{editorTitle}', '{activityType}' and '{questionText}'")

--- a/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
+++ b/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
@@ -162,6 +162,8 @@ export class CurriculumTask {
     if (openedEditor && !stayInEditor) {
       await this.returnToCurriculum();
     }
+
+    return openedEditor;
   }
 
   @step('Add a page to the project. Type: {type}, Title: {titlePage}')
@@ -175,13 +177,15 @@ export class CurriculumTask {
 
   @step('Create an adaptive page in Advanced Author')
   async createAdaptivePageInAdvancedAuthor(stayInEditor = false) {
-    await this.addPage('adaptive-practice', true);
-    await this.enterPage(
-      'adaptive-practice',
-      this.defaultPageName('adaptive-practice'),
-      'Edit Page',
-      'last',
-    );
+    const openedEditor = await this.addPage('adaptive-practice', true);
+    if (!openedEditor) {
+      await this.enterPage(
+        'adaptive-practice',
+        this.defaultPageName('adaptive-practice'),
+        'Edit Page',
+        'last',
+      );
+    }
     await this.basicPP.ensureAdvancedAuthorEditable();
     await this.basicPP.waitForChangesSaved().catch(() => void 0);
     if (!stayInEditor) {
@@ -192,13 +196,15 @@ export class CurriculumTask {
 
   @step('Create an adaptive page in Simple Author')
   async createAdaptivePageInSimpleAuthor(stayInEditor = false) {
-    await this.addPage('adaptive-simple-practice', true);
-    await this.enterPage(
-      'adaptive-simple-practice',
-      this.defaultPageName('adaptive-simple-practice'),
-      'Edit Page',
-      'last',
-    );
+    const openedEditor = await this.addPage('adaptive-simple-practice', true);
+    if (!openedEditor) {
+      await this.enterPage(
+        'adaptive-simple-practice',
+        this.defaultPageName('adaptive-simple-practice'),
+        'Edit Page',
+        'last',
+      );
+    }
     await this.basicPP.ensureAdvancedAuthorEditable();
     await this.basicPP.waitForAdvancedAuthorFlowchartReady();
     await this.basicPP.waitForChangesSaved().catch(() => void 0);

--- a/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
+++ b/assets/automation/src/systems/torus/tasks/CurriculumTask.ts
@@ -205,7 +205,7 @@ export class CurriculumTask {
         'last',
       );
     }
-    await this.basicPP.ensureAdvancedAuthorEditable();
+    await this.basicPP.ensureSimpleAuthorReady();
     await this.basicPP.waitForAdvancedAuthorFlowchartReady();
     await this.basicPP.waitForChangesSaved().catch(() => void 0);
     if (!stayInEditor) {

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -1,6 +1,6 @@
 import { setRuntimeConfig } from '@core/runtimeConfig';
 import { test } from '@fixture/my-fixture';
-import { Browser, BrowserContext, Page, expect } from '@playwright/test';
+import { BrowserContext, Page, expect } from '@playwright/test';
 import { StudentCoursePO } from '@pom/course/StudentCoursePO';
 import { TYPE_USER } from '@pom/types/type-user';
 import { CurriculumTask } from '@tasks/CurriculumTask';
@@ -76,15 +76,17 @@ test.beforeAll(async ({ seedScenario }) => {
   });
 });
 
-test('Author creates an adaptive page with MCQ and student resolves it', async ({ browser }) => {
+test('Author creates an adaptive page with MCQ and student resolves it', async ({
+  browser,
+  page,
+}) => {
   test.setTimeout(180_000);
   setRuntimeConfig({ loginData: loginData() });
 
-  const authorContext = await browser.newContext();
   const studentContext = await browser.newContext();
 
   try {
-    const authorPage = await authorContext.newPage();
+    const authorPage = page;
     const studentPage = await studentContext.newPage();
 
     const authorHomeTask = new HomeTask(authorPage);
@@ -123,77 +125,54 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
     await expect(studentPage.getByRole('radio', { name: 'Option 2' })).not.toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 3' })).not.toBeChecked();
   } finally {
-    await closeContexts(studentContext, authorContext);
+    await closeContexts(studentContext);
   }
 });
 
 test.describe.serial('simple MCQ branching adaptive lesson', () => {
-  test('author creates and publishes the lesson', async ({ browser }) => {
+  test('author creates and publishes the lesson', async ({ page }) => {
     test.setTimeout(180_000);
 
-    await buildAndPublishBranchingLesson(browser);
+    await buildAndPublishBranchingLesson(page);
   });
 
-  test('student follows the correct route', async ({ browser }) => {
+  test('student follows the correct route', async ({ page }) => {
     test.setTimeout(120_000);
 
-    const context = await browser.newContext();
-
-    try {
-      const page = await context.newPage();
-
-      await openPublishedBranchingLesson(page, correctStudentEmail, 'Jane');
-      await answerMcqAndExpectTerminal(page, 'Option 1', 'Correct Terminal');
-    } finally {
-      await closeContexts(context);
-    }
+    await openPublishedBranchingLesson(page, correctStudentEmail, 'Jane');
+    await answerMcqAndExpectTerminal(page, 'Option 1', 'Correct Terminal');
   });
 
-  test('student follows the incorrect route', async ({ browser }) => {
+  test('student follows the incorrect route', async ({ page }) => {
     test.setTimeout(120_000);
 
-    const context = await browser.newContext();
-
-    try {
-      const page = await context.newPage();
-
-      await openPublishedBranchingLesson(page, incorrectStudentEmail, 'Jamie');
-      await answerMcqAndExpectTerminal(page, 'Option 2', 'Incorrect Terminal');
-    } finally {
-      await closeContexts(context);
-    }
+    await openPublishedBranchingLesson(page, incorrectStudentEmail, 'Jamie');
+    await answerMcqAndExpectTerminal(page, 'Option 2', 'Incorrect Terminal');
   });
 });
 
-async function buildAndPublishBranchingLesson(browser: Browser) {
-  const authorContext = await browser.newContext();
+async function buildAndPublishBranchingLesson(page: Page) {
+  const authorHomeTask = new HomeTask(page);
+  const authorProjectTask = new ProjectTask(page);
+  const authorCurriculumTask = new CurriculumTask(page);
 
-  try {
-    const authorPage = await authorContext.newPage();
-    const authorHomeTask = new HomeTask(authorPage);
-    const authorProjectTask = new ProjectTask(authorPage);
-    const authorCurriculumTask = new CurriculumTask(authorPage);
+  // Author flow: create the adaptive page and build the three-screen MCQ branching lesson.
+  await authorHomeTask.goToSite(baseUrl);
+  await authorHomeTask.login('author');
+  await authorProjectTask.searchAndEnterProject(branchingProjectName);
+  await authorHomeTask.enterToCurriculum();
+  await authorCurriculumTask.createAdaptivePageInSimpleAuthor(true);
+  const lesson = await authorCurriculumTask.buildSimpleAdvancedAuthorMcqBranchingLesson();
+  expect(lesson).toMatchObject({
+    question: 'Routing Question',
+    correct: 'Correct Terminal',
+    incorrect: 'Incorrect Terminal',
+    screenCount: 3,
+  });
 
-    // Author flow: create the adaptive page and build the three-screen MCQ branching lesson.
-    await authorHomeTask.goToSite(baseUrl);
-    await authorHomeTask.login('author');
-    await authorProjectTask.searchAndEnterProject(branchingProjectName);
-    await authorHomeTask.enterToCurriculum();
-    await authorCurriculumTask.createAdaptivePageInSimpleAuthor(true);
-    const lesson = await authorCurriculumTask.buildSimpleAdvancedAuthorMcqBranchingLesson();
-    expect(lesson).toMatchObject({
-      question: 'Routing Question',
-      correct: 'Correct Terminal',
-      incorrect: 'Incorrect Terminal',
-      screenCount: 3,
-    });
-
-    // Publish the authored page so it becomes available to learners.
-    await authorHomeTask.enterToPublish();
-    await authorProjectTask.publishProject();
-  } finally {
-    await closeContexts(authorContext);
-  }
+  // Publish the authored page so it becomes available to learners.
+  await authorHomeTask.enterToPublish();
+  await authorProjectTask.publishProject();
 }
 
 async function closeContexts(...contexts: BrowserContext[]) {

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -1,67 +1,73 @@
-import { expect } from '@playwright/test';
-import { test } from '@fixture/my-fixture';
 import { setRuntimeConfig } from '@core/runtimeConfig';
+import { test } from '@fixture/my-fixture';
+import { Browser, BrowserContext, Page, expect } from '@playwright/test';
+import { StudentCoursePO } from '@pom/course/StudentCoursePO';
+import { TYPE_USER } from '@pom/types/type-user';
+import { CurriculumTask } from '@tasks/CurriculumTask';
 import { HomeTask } from '@tasks/HomeTask';
 import { ProjectTask } from '@tasks/ProjectTask';
-import { CurriculumTask } from '@tasks/CurriculumTask';
 import { StudentTask } from '@tasks/StudentTask';
-import { TYPE_USER } from '@pom/types/type-user';
-import { StudentCoursePO } from '@pom/course/StudentCoursePO';
 
 const runId = `-${Date.now()}`;
 const baseUrl = 'http://localhost';
 const defaultPassword = 'changeme123456';
 const adminPassword = 'changeme123456';
 const projectName = `TQA-19-automation${runId}`;
-const adaptivePageTitle = 'New Advanced Author Page';
+const branchingProjectName = `TQA-19-automation-branching${runId}`;
+const advancedAuthorPageTitle = 'New Advanced Author Page';
+const simpleAuthorPageTitle = 'New Simple Author Page';
 const scenarioPath = `${__dirname}/playwright_adaptive_authoring.yaml`;
+const correctStudentEmail = `student${runId}@example.com`;
+const incorrectStudentEmail = `student_incorrect${runId}@example.com`;
+
+const loginData = (studentEmail = correctStudentEmail, studentName = 'Jane') => ({
+  student: {
+    type: TYPE_USER.student,
+    pageTitle: 'OLI Torus',
+    role: 'Student',
+    welcomeText: 'Welcome to OLI Torus',
+    welcomeTitle: `Hi, ${studentName}`,
+    email: studentEmail,
+    name: studentName,
+    last_name: 'Student',
+    pass: defaultPassword,
+  },
+  instructor: {
+    type: TYPE_USER.instructor,
+    pageTitle: 'OLI Torus',
+    role: 'Instructor',
+    welcomeText: 'Welcome to OLI Torus',
+    welcomeTitle: 'Instructor Dashboard',
+    email: `instructor${runId}@example.com`,
+    pass: defaultPassword,
+    header: 'Instructor Dashboard',
+  },
+  author: {
+    type: TYPE_USER.author,
+    pageTitle: 'OLI Torus',
+    role: 'Course Author',
+    welcomeText: 'Welcome to OLI Torus',
+    welcomeTitle: 'Course Author',
+    email: `author${runId}@example.com`,
+    pass: defaultPassword,
+    header: 'Course Author',
+  },
+  administrator: {
+    type: TYPE_USER.administrator,
+    pageTitle: 'OLI Torus',
+    role: 'Course Author',
+    welcomeText: 'Welcome to OLI Torus',
+    welcomeTitle: 'Course Author',
+    email: `admin${runId}@example.com`,
+    pass: adminPassword,
+    header: 'Course Author',
+  },
+});
 
 setRuntimeConfig({
   baseUrl,
   scenarioToken: 'my-token',
-  loginData: {
-    student: {
-      type: TYPE_USER.student,
-      pageTitle: 'OLI Torus',
-      role: 'Student',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Hi, Jane',
-      email: `student${runId}@example.com`,
-      name: 'Jane',
-      last_name: 'Student',
-      pass: defaultPassword,
-    },
-    instructor: {
-      type: TYPE_USER.instructor,
-      pageTitle: 'OLI Torus',
-      role: 'Instructor',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Instructor Dashboard',
-      email: `instructor${runId}@example.com`,
-      pass: defaultPassword,
-      header: 'Instructor Dashboard',
-    },
-    author: {
-      type: TYPE_USER.author,
-      pageTitle: 'OLI Torus',
-      role: 'Course Author',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Course Author',
-      email: `author${runId}@example.com`,
-      pass: defaultPassword,
-      header: 'Course Author',
-    },
-    administrator: {
-      type: TYPE_USER.administrator,
-      pageTitle: 'OLI Torus',
-      role: 'Course Author',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Course Author',
-      email: `admin${runId}@example.com`,
-      pass: adminPassword,
-      header: 'Course Author',
-    },
-  },
+  loginData: loginData(),
 });
 
 test.beforeAll(async ({ seedScenario }) => {
@@ -72,6 +78,8 @@ test.beforeAll(async ({ seedScenario }) => {
 
 test('Author creates an adaptive page with MCQ and student resolves it', async ({ browser }) => {
   test.setTimeout(180_000);
+  setRuntimeConfig({ loginData: loginData() });
+
   const authorContext = await browser.newContext();
   const studentContext = await browser.newContext();
 
@@ -104,8 +112,8 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
     await studentHomeTask.login('student');
     await studentTask.searchProject(projectName);
     await studentHomeTask.enterToLearn();
-    await studentTask.validateResource([adaptivePageTitle]);
-    await studentCourse.openPage(adaptivePageTitle);
+    await studentTask.validateResource([advancedAuthorPageTitle]);
+    await studentCourse.openPage(advancedAuthorPageTitle);
 
     // Validate that the MCQ is rendered and can be answered.
     await expect(studentPage.locator('janus-mcq').first()).toBeVisible();
@@ -115,7 +123,154 @@ test('Author creates an adaptive page with MCQ and student resolves it', async (
     await expect(studentPage.getByRole('radio', { name: 'Option 2' })).not.toBeChecked();
     await expect(studentPage.getByRole('radio', { name: 'Option 3' })).not.toBeChecked();
   } finally {
-    await studentContext.close();
-    await authorContext.close();
+    await closeContexts(studentContext, authorContext);
   }
 });
+
+test.describe.serial('simple MCQ branching adaptive lesson', () => {
+  test('author creates and publishes the lesson', async ({ browser }) => {
+    test.setTimeout(180_000);
+
+    await buildAndPublishBranchingLesson(browser);
+  });
+
+  test('student follows the correct route', async ({ browser }) => {
+    test.setTimeout(120_000);
+
+    const context = await browser.newContext();
+
+    try {
+      const page = await context.newPage();
+
+      await openPublishedBranchingLesson(page, correctStudentEmail, 'Jane');
+      await answerMcqAndExpectTerminal(page, 'Option 1', 'Correct Terminal');
+    } finally {
+      await closeContexts(context);
+    }
+  });
+
+  test('student follows the incorrect route', async ({ browser }) => {
+    test.setTimeout(120_000);
+
+    const context = await browser.newContext();
+
+    try {
+      const page = await context.newPage();
+
+      await openPublishedBranchingLesson(page, incorrectStudentEmail, 'Jamie');
+      await answerMcqAndExpectTerminal(page, 'Option 2', 'Incorrect Terminal');
+    } finally {
+      await closeContexts(context);
+    }
+  });
+});
+
+async function buildAndPublishBranchingLesson(browser: Browser) {
+  const authorContext = await browser.newContext();
+
+  try {
+    const authorPage = await authorContext.newPage();
+    const authorHomeTask = new HomeTask(authorPage);
+    const authorProjectTask = new ProjectTask(authorPage);
+    const authorCurriculumTask = new CurriculumTask(authorPage);
+
+    // Author flow: create the adaptive page and build the three-screen MCQ branching lesson.
+    await authorHomeTask.goToSite(baseUrl);
+    await authorHomeTask.login('author');
+    await authorProjectTask.searchAndEnterProject(branchingProjectName);
+    await authorHomeTask.enterToCurriculum();
+    await authorCurriculumTask.createAdaptivePageInSimpleAuthor(true);
+    const lesson = await authorCurriculumTask.buildSimpleAdvancedAuthorMcqBranchingLesson();
+    expect(lesson).toMatchObject({
+      question: 'Routing Question',
+      correct: 'Correct Terminal',
+      incorrect: 'Incorrect Terminal',
+      screenCount: 3,
+    });
+
+    // Publish the authored page so it becomes available to learners.
+    await authorHomeTask.enterToPublish();
+    await authorProjectTask.publishProject();
+  } finally {
+    await closeContexts(authorContext);
+  }
+}
+
+async function closeContexts(...contexts: BrowserContext[]) {
+  await Promise.allSettled(contexts.map((context) => context.close()));
+}
+
+async function openPublishedBranchingLesson(page: Page, studentEmail: string, studentName: string) {
+  setRuntimeConfig({ loginData: loginData(studentEmail, studentName) });
+
+  const studentHomeTask = new HomeTask(page);
+  const studentTask = new StudentTask(page);
+  const studentCourse = new StudentCoursePO(page);
+
+  await studentHomeTask.goToSite(baseUrl);
+  await studentHomeTask.login('student');
+  await studentTask.searchProject(branchingProjectName);
+  await studentHomeTask.enterToLearn();
+  await studentTask.validateResource([simpleAuthorPageTitle]);
+  await studentCourse.openPage(simpleAuthorPageTitle);
+  await expect(page.locator('janus-mcq').first()).toBeVisible({ timeout: 30000 });
+  await showLessonHistory(page);
+  await expect(
+    page.getByLabel('Lesson history', { exact: true }).getByText('Routing Question', {
+      exact: true,
+    }),
+  ).toBeVisible({ timeout: 30000 });
+  await hideLessonHistory(page);
+}
+
+async function answerMcqAndExpectTerminal(page: Page, optionName: string, terminalText: string) {
+  const terminal = page.getByLabel('Lesson history', { exact: true }).getByText(terminalText, {
+    exact: true,
+  });
+  const mcq = page.locator('janus-mcq').first();
+  const option = mcq.getByRole('radio', { name: optionName, exact: true });
+  const optionLabel = mcq.getByText(optionName, { exact: true });
+
+  await expect(mcq).toBeVisible({ timeout: 30000 });
+  await expect(option).toBeVisible();
+  await optionLabel.click();
+  await expect(option).toBeChecked();
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    if (await terminal.isVisible().catch(() => false)) return;
+
+    const nextButton = page.getByRole('button', { name: /^Next$/ }).last();
+    await expect(nextButton).toBeEnabled({ timeout: 10000 });
+    await nextButton.click();
+    await showLessonHistory(page);
+    await terminal.waitFor({ state: 'visible', timeout: 5000 }).catch(() => undefined);
+    if (await terminal.isVisible().catch(() => false)) return;
+
+    await hideLessonHistory(page);
+  }
+
+  await showLessonHistory(page);
+  await expect(terminal).toBeVisible();
+}
+
+async function showLessonHistory(page: Page) {
+  const historyPanel = page.getByLabel('Lesson history', { exact: true });
+
+  if (await historyPanel.isVisible().catch(() => false)) return;
+
+  const showHistoryButton = page.getByRole('button', { name: 'Show lesson history' });
+  await expect(showHistoryButton).toBeVisible({ timeout: 10000 });
+  await showHistoryButton.click();
+  await expect(historyPanel).toBeVisible({ timeout: 10000 });
+}
+
+async function hideLessonHistory(page: Page) {
+  const historyPanel = page.getByLabel('Lesson history', { exact: true });
+
+  if (!(await historyPanel.isVisible().catch(() => false))) return;
+
+  const hideHistoryButton = page.getByRole('button', { name: 'Minimize lesson history' });
+  await expect(hideHistoryButton).toBeVisible({ timeout: 10000 });
+  await hideHistoryButton.click();
+  await expect(historyPanel).not.toBeVisible({ timeout: 10000 });
+}

--- a/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/adaptive-authoring.spec.ts
@@ -233,8 +233,19 @@ async function answerMcqAndExpectTerminal(page: Page, optionName: string, termin
 
   await expect(mcq).toBeVisible({ timeout: 30000 });
   await expect(option).toBeVisible();
+  const selectionSave = page
+    .waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        response.url().includes('/activity_attempt/') &&
+        response.url().endsWith('/active'),
+      { timeout: 10000 },
+    )
+    .catch(() => undefined);
+
   await optionLabel.click();
   await expect(option).toBeChecked();
+  await selectionSave;
 
   for (let attempt = 0; attempt < 4; attempt += 1) {
     if (await terminal.isVisible().catch(() => false)) return;

--- a/assets/automation/tests/torus/course_authoring/playwright_adaptive_authoring.yaml
+++ b/assets/automation/tests/torus/course_authoring/playwright_adaptive_authoring.yaml
@@ -20,6 +20,14 @@
     password: 'changeme123456'
 
 - user:
+    name: 'playwright_student_incorrect'
+    type: 'student'
+    email: 'student_incorrect${RUN_ID}@example.com'
+    given_name: 'Jamie'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
     name: 'playwright_author'
     type: 'author'
     email: 'author${RUN_ID}@example.com'
@@ -35,10 +43,24 @@
       children:
         - page: 'Page 1'
 
+- project:
+    name: 'TQA-19-automation-branching${RUN_ID}'
+    title: 'TQA-19-automation-branching${RUN_ID}'
+    visibility: global
+    root:
+      children:
+        - page: 'Page 1'
+
 - section:
     name: 'TQA-19-automation${RUN_ID}'
     title: 'TQA-19-automation${RUN_ID}'
     from: 'TQA-19-automation${RUN_ID}'
+    open_and_free: true
+
+- section:
+    name: 'TQA-19-automation-branching${RUN_ID}'
+    title: 'TQA-19-automation-branching${RUN_ID}'
+    from: 'TQA-19-automation-branching${RUN_ID}'
     open_and_free: true
 
 - enroll:
@@ -51,4 +73,28 @@
     user: 'playwright_student'
     email: 'student${RUN_ID}@example.com'
     section: 'TQA-19-automation${RUN_ID}'
+    role: student
+
+- enroll:
+    user: 'playwright_student_incorrect'
+    email: 'student_incorrect${RUN_ID}@example.com'
+    section: 'TQA-19-automation${RUN_ID}'
+    role: student
+
+- enroll:
+    user: 'playwright_instructor'
+    email: 'instructor${RUN_ID}@example.com'
+    section: 'TQA-19-automation-branching${RUN_ID}'
+    role: instructor
+
+- enroll:
+    user: 'playwright_student'
+    email: 'student${RUN_ID}@example.com'
+    section: 'TQA-19-automation-branching${RUN_ID}'
+    role: student
+
+- enroll:
+    user: 'playwright_student_incorrect'
+    email: 'student_incorrect${RUN_ID}@example.com'
+    section: 'TQA-19-automation-branching${RUN_ID}'
     role: student

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -93,6 +93,7 @@ const ToolbarOption: React.FC<{
       key={component}
       onClick={onClick}
       className="component-button"
+      data-component={component}
       disabled={disabled}
       ref={ref}
     >


### PR DESCRIPTION
- Adds automation support for creating Simple Author adaptive practice pages.
- Builds and publishes a three-screen Simple Author MCQ branching lesson:
  - Routing Question
  - Correct Terminal
  - Incorrect Terminal
- Verifies both correct and incorrect learner routes in delivery.
- Hardens adaptive authoring page objects for Simple Author flowchart/screen-panel mode, read-only toggling, MCQ insertion, screen renaming, and flowchart rule creation.
- Stabilizes student course entry by bounding welcome-page navigation to `domcontentloaded`.

See: https://eliterate.atlassian.net/browse/MER-5422