### PR TITLE
[ENHANCEMENT] [MER-5441] Automated multi-input delivery Playwright coverage

### DIFF
--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
@@ -1,0 +1,144 @@
+# Scenario: Seed a minimal published course for multi-input delivery automation.
+
+- project:
+    name: 'multi_input_delivery_project'
+    title: 'Multi Input Delivery Course ${RUN_ID}'
+    root:
+      children:
+        - page: 'Multi Input Practice'
+
+- create_activity:
+    project: 'multi_input_delivery_project'
+    title: 'Multi Input Question'
+    virtual_id: 'multi_input'
+    type: 'oli_multi_input'
+    content_format: 'json'
+    content:
+      activityType: 'oli_multi_input'
+      submitPerPart: false
+      choices: []
+      inputs:
+        - id: 'text_blank'
+          inputType: 'text'
+          partId: 'text_blank_part'
+        - id: 'numeric_blank'
+          inputType: 'numeric'
+          partId: 'numeric_blank_part'
+      stem:
+        id: 'multi_input_stem'
+        content:
+          - type: 'p'
+            children:
+              - text: 'Fill in both blanks: '
+              - type: 'input_ref'
+                id: 'text_blank'
+                children:
+                  - text: ''
+              - text: ' and '
+              - type: 'input_ref'
+                id: 'numeric_blank'
+                children:
+                  - text: ''
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ''
+        parts:
+          - id: 'text_blank_part'
+            scoringStrategy: 'best'
+            gradingApproach: 'automatic'
+            targets: ['text_blank']
+            responses:
+              - id: 'text_blank_correct'
+                rule: 'input contains {answer}'
+                score: 1
+                correct: true
+                feedback:
+                  id: 'text_blank_feedback_correct'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Correct text.'
+              - id: 'text_blank_incorrect'
+                rule: 'input like {.*}'
+                score: 0
+                correct: false
+                feedback:
+                  id: 'text_blank_feedback_incorrect'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Incorrect text.'
+            hints: []
+          - id: 'numeric_blank_part'
+            scoringStrategy: 'best'
+            gradingApproach: 'automatic'
+            targets: ['numeric_blank']
+            responses:
+              - id: 'numeric_blank_correct'
+                rule: 'input = {42}'
+                score: 1
+                correct: true
+                feedback:
+                  id: 'numeric_blank_feedback_correct'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Correct number.'
+              - id: 'numeric_blank_incorrect'
+                rule: 'input like {.*}'
+                score: 0
+                correct: false
+                feedback:
+                  id: 'numeric_blank_feedback_incorrect'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Incorrect number.'
+            hints: []
+
+- edit_page:
+    project: 'multi_input_delivery_project'
+    page: 'Multi Input Practice'
+    content: |
+      title: "Multi Input Practice"
+      graded: false
+      blocks:
+        - type: activity_reference
+          virtual_id: "multi_input"
+
+- publish:
+    to: 'multi_input_delivery_project'
+    description: 'Initial multi-input delivery publication'
+
+- section:
+    name: 'multi_input_delivery_section'
+    title: 'Multi Input Delivery Course ${RUN_ID}'
+    from: 'multi_input_delivery_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'multi_input_delivery_section_negative'
+    title: 'Multi Input Delivery Course ${RUN_ID} - Negative'
+    from: 'multi_input_delivery_project'
+    type: 'enrollable'
+    registration_open: true
+
+- user:
+    name: 'multi_input_delivery_student'
+    type: 'student'
+    email: 'multi-input-delivery-student${RUN_ID}@example.com'
+    given_name: 'Multi Input'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- enroll:
+    user: 'multi_input_delivery_student'
+    section: 'multi_input_delivery_section'
+    role: 'student'
+
+- enroll:
+    user: 'multi_input_delivery_student'
+    section: 'multi_input_delivery_section_negative'
+    role: 'student'

--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
@@ -16,7 +16,17 @@
     content:
       activityType: 'oli_multi_input'
       submitPerPart: false
-      choices: []
+      choices:
+        - id: 'choice_correct'
+          content:
+            - type: 'p'
+              children:
+                - text: 'Correct choice'
+        - id: 'choice_incorrect'
+          content:
+            - type: 'p'
+              children:
+                - text: 'Incorrect choice'
       inputs:
         - id: 'text_blank'
           inputType: 'text'
@@ -24,19 +34,28 @@
         - id: 'numeric_blank'
           inputType: 'numeric'
           partId: 'numeric_blank_part'
+        - id: 'dropdown_blank'
+          inputType: 'dropdown'
+          partId: 'dropdown_blank_part'
+          choiceIds: ['choice_correct', 'choice_incorrect']
       stem:
         id: 'multi_input_stem'
         content:
           - type: 'p'
             children:
-              - text: 'Fill in both blanks: '
+              - text: 'Fill in the blanks and select the matching choice: '
               - type: 'input_ref'
                 id: 'text_blank'
                 children:
                   - text: ''
-              - text: ' and '
+              - text: ', '
               - type: 'input_ref'
                 id: 'numeric_blank'
+                children:
+                  - text: ''
+              - text: ', and '
+              - type: 'input_ref'
+                id: 'dropdown_blank'
                 children:
                   - text: ''
       authoring:
@@ -93,6 +112,31 @@
                     - type: 'p'
                       children:
                         - text: 'Incorrect number.'
+            hints: []
+          - id: 'dropdown_blank_part'
+            scoringStrategy: 'best'
+            gradingApproach: 'automatic'
+            responses:
+              - id: 'dropdown_blank_correct'
+                rule: 'input like {choice_correct}'
+                score: 1
+                correct: true
+                feedback:
+                  id: 'dropdown_blank_feedback_correct'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Correct choice.'
+              - id: 'dropdown_blank_incorrect'
+                rule: 'input like {.*}'
+                score: 0
+                correct: false
+                feedback:
+                  id: 'dropdown_blank_feedback_incorrect'
+                  content:
+                    - type: 'p'
+                      children:
+                        - text: 'Incorrect choice.'
             hints: []
 
 - edit_page:

--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.scenario.yaml
@@ -47,7 +47,6 @@
           - id: 'text_blank_part'
             scoringStrategy: 'best'
             gradingApproach: 'automatic'
-            targets: ['text_blank']
             responses:
               - id: 'text_blank_correct'
                 rule: 'input contains {answer}'
@@ -73,7 +72,6 @@
           - id: 'numeric_blank_part'
             scoringStrategy: 'best'
             gradingApproach: 'automatic'
-            targets: ['numeric_blank']
             responses:
               - id: 'numeric_blank_correct'
                 rule: 'input = {42}'

--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
@@ -1,0 +1,101 @@
+import { expect } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import path from 'node:path';
+import {
+  configureStudentDeliveryRuntimeConfig,
+  openStudentDeliveryPractice,
+  seedStudentDeliveryScenario,
+} from './support';
+
+const runId = `-${Date.now()}`;
+const scenarioPath = path.resolve(__dirname, './multi-input-delivery.scenario.yaml');
+const activityTitle = 'Multi Input Practice';
+
+configureStudentDeliveryRuntimeConfig(runId, {
+  student: {
+    type: 'student',
+    role: 'Student',
+    emailPrefix: 'multi-input-delivery-student',
+    welcomeTitle: 'Hi, Multi Input',
+    name: 'Multi Input',
+    lastName: 'Student',
+  },
+  instructor: {
+    type: 'instructor',
+    role: 'Instructor',
+    emailPrefix: 'multi-input-delivery-instructor',
+    welcomeTitle: 'Instructor Dashboard',
+    header: 'Instructor Dashboard',
+  },
+  author: {
+    type: 'author',
+    role: 'Course Author',
+    emailPrefix: 'multi-input-delivery-author',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+  administrator: {
+    type: 'administrator',
+    role: 'Course Author',
+    emailPrefix: 'multi-input-delivery-admin',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+});
+
+let sections: { negative: string; positive: string };
+
+test.beforeAll(async ({ seedScenario }) => {
+  const outputs = await seedStudentDeliveryScenario(seedScenario, scenarioPath, runId);
+
+  sections = {
+    positive: outputs.sections?.multi_input_delivery_section ?? '',
+    negative: outputs.sections?.multi_input_delivery_section_negative ?? '',
+  };
+
+  expect(sections.positive).toBeTruthy();
+  expect(sections.negative).toBeTruthy();
+});
+
+test.describe('multi-input delivery', () => {
+  test('student can fill all blanks, submit, and see correct feedback', async ({
+    homeTask,
+    page,
+  }) => {
+    await openStudentDeliveryPractice(homeTask, page, sections.positive, activityTitle);
+    const activity = page.locator('.activity.multi-input-activity');
+    const inputs = activity.getByLabel('answer submission textbox');
+    const submitButton = page.getByRole('button', { name: 'submit', exact: true });
+
+    await expect(activity).toBeVisible();
+    await expect(inputs).toHaveCount(2);
+
+    await inputs.nth(0).fill('answer');
+    await inputs.nth(1).fill('42');
+
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.locator('.evaluation.feedback.correct')).toHaveCount(2);
+    await expect(page.getByLabel('result')).toHaveCount(2);
+  });
+
+  test('student filling an incorrect blank sees incorrect feedback', async ({ homeTask, page }) => {
+    await openStudentDeliveryPractice(homeTask, page, sections.negative, activityTitle);
+    const activity = page.locator('.activity.multi-input-activity');
+    const inputs = activity.getByLabel('answer submission textbox');
+    const submitButton = page.getByRole('button', { name: 'submit', exact: true });
+
+    await expect(activity).toBeVisible();
+    await expect(inputs).toHaveCount(2);
+
+    await inputs.nth(0).fill('wrong');
+    await inputs.nth(1).fill('7');
+
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    await expect(page.locator('.evaluation.feedback.incorrect')).toHaveCount(2);
+    await expect(page.locator('.evaluation.feedback.correct')).toHaveCount(0);
+  });
+});

--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
@@ -65,37 +65,43 @@ test.describe('multi-input delivery', () => {
     await openStudentDeliveryPractice(homeTask, page, sections.positive, activityTitle);
     const activity = page.locator('.activity.multi-input-activity');
     const inputs = activity.getByLabel('answer submission textbox');
+    const dropdown = activity.getByRole('combobox');
     const submitButton = page.getByRole('button', { name: 'submit', exact: true });
 
     await expect(activity).toBeVisible();
     await expect(inputs).toHaveCount(2);
+    await expect(dropdown).toBeVisible();
 
     await inputs.nth(0).fill('answer');
     await inputs.nth(1).fill('42');
+    await dropdown.selectOption('choice_correct');
 
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    await expect(page.locator('.evaluation.feedback.correct')).toHaveCount(2);
-    await expect(page.getByLabel('result')).toHaveCount(2);
+    await expect(page.locator('.evaluation.feedback.correct')).toHaveCount(3);
+    await expect(page.getByLabel('result')).toHaveCount(3);
   });
 
   test('student filling an incorrect blank sees incorrect feedback', async ({ homeTask, page }) => {
     await openStudentDeliveryPractice(homeTask, page, sections.negative, activityTitle);
     const activity = page.locator('.activity.multi-input-activity');
     const inputs = activity.getByLabel('answer submission textbox');
+    const dropdown = activity.getByRole('combobox');
     const submitButton = page.getByRole('button', { name: 'submit', exact: true });
 
     await expect(activity).toBeVisible();
     await expect(inputs).toHaveCount(2);
+    await expect(dropdown).toBeVisible();
 
     await inputs.nth(0).fill('wrong');
     await inputs.nth(1).fill('7');
+    await dropdown.selectOption('choice_incorrect');
 
     await expect(submitButton).toBeEnabled();
     await submitButton.click();
 
-    await expect(page.locator('.evaluation.feedback.incorrect')).toHaveCount(2);
+    await expect(page.locator('.evaluation.feedback.incorrect')).toHaveCount(3);
     await expect(page.locator('.evaluation.feedback.correct')).toHaveCount(0);
   });
 });

--- a/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/multi-input-delivery.spec.ts
@@ -66,7 +66,7 @@ test.describe('multi-input delivery', () => {
     const activity = page.locator('.activity.multi-input-activity');
     const inputs = activity.getByLabel('answer submission textbox');
     const dropdown = activity.getByRole('combobox');
-    const submitButton = page.getByRole('button', { name: 'submit', exact: true });
+    const submitButton = page.getByRole('button', { name: /^submit$/i });
 
     await expect(activity).toBeVisible();
     await expect(inputs).toHaveCount(2);
@@ -88,7 +88,7 @@ test.describe('multi-input delivery', () => {
     const activity = page.locator('.activity.multi-input-activity');
     const inputs = activity.getByLabel('answer submission textbox');
     const dropdown = activity.getByRole('combobox');
-    const submitButton = page.getByRole('button', { name: 'submit', exact: true });
+    const submitButton = page.getByRole('button', { name: /^submit$/i });
 
     await expect(activity).toBeVisible();
     await expect(inputs).toHaveCount(2);

--- a/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
+++ b/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
@@ -222,15 +222,14 @@
     content:
       activityType: "oli_multi_input"
       submitPerPart: false
-      multInputsPerPart: true
       choices: []
       inputs:
         - id: "1637853221"
           inputType: "text"
-          partId: "651271558"
+          partId: "text_part"
         - id: "2369651067"
           inputType: "numeric"
-          partId: "651271558"
+          partId: "numeric_part"
       stem:
         id: "multi_input_stem"
         content:
@@ -251,24 +250,44 @@
         transformations: []
         previewText: ""
         parts:
-          - id: "651271558"
+          - id: "text_part"
             scoringStrategy: "best"
             gradingApproach: "automatic"
-            targets: ["1637853221", "2369651067"]
+            targets: ["1637853221"]
             responses:
-              - id: "multi_input_correct"
-                rule: "input_ref_1637853221 contains {answer} && input_ref_2369651067 = {1}"
+              - id: "multi_input_text_correct"
+                rule: "input contains {answer}"
                 score: 1
                 correct: true
                 feedback:
-                  id: "multi_input_feedback_correct"
+                  id: "multi_input_text_feedback_correct"
                   content: []
-              - id: "multi_input_incorrect"
-                rule: "input_ref_1637853221 like {.*} && input_ref_2369651067 like {.*}"
+              - id: "multi_input_text_incorrect"
+                rule: "input like {.*}"
                 score: 0
                 correct: false
                 feedback:
-                  id: "multi_input_feedback_incorrect"
+                  id: "multi_input_text_feedback_incorrect"
+                  content: []
+            hints: []
+          - id: "numeric_part"
+            scoringStrategy: "best"
+            gradingApproach: "automatic"
+            targets: ["2369651067"]
+            responses:
+              - id: "multi_input_numeric_correct"
+                rule: "input = {1}"
+                score: 1
+                correct: true
+                feedback:
+                  id: "multi_input_numeric_feedback_correct"
+                  content: []
+              - id: "multi_input_numeric_incorrect"
+                rule: "input like {.*}"
+                score: 0
+                correct: false
+                feedback:
+                  id: "multi_input_numeric_feedback_incorrect"
                   content: []
             hints: []
 
@@ -406,7 +425,9 @@
     section: "basic_page_activity_section"
     page: "Mixed Practice"
     activity_virtual_id: "multi_input"
-    response: '{"1637853221":"answer","2369651067":"1"}'
+    response:
+      "1637853221": "answer"
+      "2369651067": "1"
 
 - assert:
     activity_attempt:
@@ -416,9 +437,8 @@
       activity_virtual_id: "multi_input"
       activity_lifecycle_state: "evaluated"
       part_lifecycle_state: "evaluated"
-      score: 1.0
-      out_of: 1.0
+      score: 2.0
+      out_of: 2.0
       part_score: 1.0
       part_out_of: 1.0
-      response: '{"1637853221":"answer","2369651067":"1"}'
       answerable: false

--- a/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
+++ b/test/scenarios/activities/basic_page_activity_submissions.scenario.yaml
@@ -253,7 +253,6 @@
           - id: "text_part"
             scoringStrategy: "best"
             gradingApproach: "automatic"
-            targets: ["1637853221"]
             responses:
               - id: "multi_input_text_correct"
                 rule: "input contains {answer}"
@@ -273,7 +272,6 @@
           - id: "numeric_part"
             scoringStrategy: "best"
             gradingApproach: "automatic"
-            targets: ["2369651067"]
             responses:
               - id: "multi_input_numeric_correct"
                 rule: "input = {1}"


### PR DESCRIPTION
## Summary

  Adds Playwright delivery coverage for plain multi-input activities (MER-5441).

  The new test seeds a deterministic student-delivery course with a plain `oli_multi_input` activity and verifies both:
  - a correct submission with two answered blanks shows correct feedback for both parts
  - an incorrect submission shows incorrect feedback without reporting correct feedback

  The implementation follows the pattern used by the existing CATA and ordering delivery tests, including a scenario-backed seed, two enrollable sections for positive/negative cases, and the shared student delivery helpers.

  ## Additional Cleanup
  
This PR takes opportunity to correct an existing backend scenario fixture unrelated to MER-5441:

  `test/scenarios/activities/basic_page_activity_submissions.scenario.yaml`

  That scenario had an `oli_multi_input` activity shaped like a legacy `oli_response_multi` activity, including multi-inputs-per-part style response rules. This worked for the limited test, but is not a correct model for other multi-input tests. Plain multi-input activities should instead model separate inputs as separate parts with simple per-part response rules. That scenario was changed to use a valid plain multi-input shape.

  ## Verification

  - Scenario YAML validation for the new Playwright scenario and corrected backend scenario
  - `mix test test/scenarios/activities/activities_test.exs`
  - `(cd assets/automation && npx eslint tests/torus/student_delivery/multi-input-delivery.spec.ts)`
  - `(cd assets/automation && npx prettier --check tests/torus/student_delivery/multi-input-delivery.spec.ts tests/torus/student_delivery/multi-input-
  delivery.scenario.yaml)`
  - `(cd assets/automation && npx playwright test tests/torus/student_delivery/multi-input-delivery.spec.ts --timeout=30000 --reporter=line)`
  
 Playwright tests run from assets/automation because playwright requires a newer version of nodejs than the one torus is pinned to; local .tool-versions file works for for asdf-managed installs to specify acceptable version.