### PR TITLE
[ENHANCEMENT] [MER-5492] Add enrollment transfer workflow coverage

### DIFF
--- a/assets/automation/tests/torus/instructor/transfer-enrollment.scenario.yaml
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.scenario.yaml
@@ -1,0 +1,78 @@
+# Scenario: Seed a course setup that exercises instructor-managed enrollment transfer.
+
+- project:
+    name: 'transfer_enrollment_project'
+    title: 'Enrollment Transfer Course ${RUN_ID}'
+    root:
+      children:
+        - page: 'Enrollment Transfer Lesson'
+
+- edit_page:
+    project: 'transfer_enrollment_project'
+    page: 'Enrollment Transfer Lesson'
+    content: |
+      title: "Enrollment Transfer Lesson"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Enrollment transfer scenario content."
+
+- publish:
+    to: 'transfer_enrollment_project'
+    description: 'Initial enrollment transfer course publication'
+
+- section:
+    name: 'transfer_enrollment_source_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Source'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'transfer_enrollment_target_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Target'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- user:
+    name: 'transfer_enrollment_source_student'
+    type: 'student'
+    email: 'transfer-enrollment-source-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Source'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_target_student'
+    type: 'student'
+    email: 'transfer-enrollment-target-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Target'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_admin'
+    type: 'author'
+    system_role: 'system_admin'
+    email: 'transfer-enrollment-admin${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Admin'
+    password: 'changeme123456'
+
+- enroll:
+    user: 'transfer_enrollment_source_student'
+    section: 'transfer_enrollment_source_section'
+    role: 'student'
+
+- enroll:
+    user: 'transfer_enrollment_target_student'
+    section: 'transfer_enrollment_target_section'
+    role: 'student'
+
+- complete_scored_page:
+    student: 'transfer_enrollment_source_student'
+    section: 'transfer_enrollment_source_section'
+    page: 'Enrollment Transfer Lesson'
+    score: 1
+    out_of: 1

--- a/assets/automation/tests/torus/instructor/transfer-enrollment.scenario.yaml
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.scenario.yaml
@@ -35,6 +35,69 @@
     type: 'enrollable'
     registration_open: true
 
+- section:
+    name: 'transfer_enrollment_empty_target_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Empty Target'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'transfer_enrollment_cancel_source_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Cancel Source'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'transfer_enrollment_cancel_target_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Cancel Target'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'transfer_enrollment_overwrite_source_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Overwrite Source'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- section:
+    name: 'transfer_enrollment_overwrite_target_section'
+    title: 'Enrollment Transfer Course ${RUN_ID} - Overwrite Target'
+    from: 'transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
+- project:
+    name: 'isolated_transfer_enrollment_project'
+    title: 'Isolated Enrollment Transfer Course ${RUN_ID}'
+    root:
+      children:
+        - page: 'Isolated Enrollment Transfer Lesson'
+
+- edit_page:
+    project: 'isolated_transfer_enrollment_project'
+    page: 'Isolated Enrollment Transfer Lesson'
+    content: |
+      title: "Isolated Enrollment Transfer Lesson"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Isolated enrollment transfer scenario content."
+
+- publish:
+    to: 'isolated_transfer_enrollment_project'
+    description: 'Initial isolated enrollment transfer course publication'
+
+- section:
+    name: 'isolated_transfer_enrollment_source_section'
+    title: 'Isolated Enrollment Transfer Course ${RUN_ID} - Source'
+    from: 'isolated_transfer_enrollment_project'
+    type: 'enrollable'
+    registration_open: true
+
 - user:
     name: 'transfer_enrollment_source_student'
     type: 'student'
@@ -52,12 +115,60 @@
     password: 'changeme123456'
 
 - user:
+    name: 'transfer_enrollment_overwrite_source_student'
+    type: 'student'
+    email: 'transfer-enrollment-overwrite-source-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Overwrite Source'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_cancel_source_student'
+    type: 'student'
+    email: 'transfer-enrollment-cancel-source-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Cancel Source'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_cancel_target_student'
+    type: 'student'
+    email: 'transfer-enrollment-cancel-target-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Cancel Target'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_overwrite_target_student'
+    type: 'student'
+    email: 'transfer-enrollment-overwrite-target-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Overwrite Target'
+    password: 'changeme123456'
+
+- user:
+    name: 'transfer_enrollment_instructor'
+    type: 'instructor'
+    email: 'transfer-enrollment-instructor${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Instructor'
+    password: 'changeme123456'
+
+- user:
     name: 'transfer_enrollment_admin'
     type: 'author'
     system_role: 'system_admin'
     email: 'transfer-enrollment-admin${RUN_ID}@example.com'
     given_name: 'Transfer'
     family_name: 'Admin'
+    password: 'changeme123456'
+
+- user:
+    name: 'isolated_transfer_enrollment_student'
+    type: 'student'
+    email: 'isolated-transfer-enrollment-student${RUN_ID}@example.com'
+    given_name: 'Transfer'
+    family_name: 'Solo'
     password: 'changeme123456'
 
 - enroll:
@@ -70,9 +181,60 @@
     section: 'transfer_enrollment_target_section'
     role: 'student'
 
+- enroll:
+    user: 'transfer_enrollment_overwrite_source_student'
+    section: 'transfer_enrollment_overwrite_source_section'
+    role: 'student'
+
+- enroll:
+    user: 'transfer_enrollment_cancel_source_student'
+    section: 'transfer_enrollment_cancel_source_section'
+    role: 'student'
+
+- enroll:
+    user: 'transfer_enrollment_cancel_target_student'
+    section: 'transfer_enrollment_cancel_target_section'
+    role: 'student'
+
+- enroll:
+    user: 'transfer_enrollment_overwrite_target_student'
+    section: 'transfer_enrollment_overwrite_target_section'
+    role: 'student'
+
+- enroll:
+    user: 'transfer_enrollment_instructor'
+    section: 'transfer_enrollment_source_section'
+    role: 'instructor'
+
+- enroll:
+    user: 'isolated_transfer_enrollment_student'
+    section: 'isolated_transfer_enrollment_source_section'
+    role: 'student'
+
 - complete_scored_page:
     student: 'transfer_enrollment_source_student'
     section: 'transfer_enrollment_source_section'
     page: 'Enrollment Transfer Lesson'
     score: 1
+    out_of: 1
+
+- complete_scored_page:
+    student: 'transfer_enrollment_overwrite_source_student'
+    section: 'transfer_enrollment_overwrite_source_section'
+    page: 'Enrollment Transfer Lesson'
+    score: 1
+    out_of: 1
+
+- complete_scored_page:
+    student: 'transfer_enrollment_cancel_source_student'
+    section: 'transfer_enrollment_cancel_source_section'
+    page: 'Enrollment Transfer Lesson'
+    score: 1
+    out_of: 1
+
+- complete_scored_page:
+    student: 'transfer_enrollment_overwrite_target_student'
+    section: 'transfer_enrollment_overwrite_target_section'
+    page: 'Enrollment Transfer Lesson'
+    score: 0
     out_of: 1

--- a/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
@@ -9,8 +9,25 @@ import {
 
 const runId = `-${Date.now()}`;
 const scenarioPath = path.resolve(__dirname, './transfer-enrollment.scenario.yaml');
-const transferEnrollmentMessage =
-  "This will transfer this student's enrollment, and all their current progress, to the selected course section.";
+const transferMessages = {
+  description:
+    "This will transfer this student's enrollment, and all their current progress, to the selected course section. If this student is already enrolled in the selected course section, that progress will be lost.",
+  emptySections: 'There are no other sections to transfer this student to.',
+  emptyStudents: 'There are no other students to transfer this student to.',
+  success: 'Enrollment successfully transfered',
+} as const;
+
+type SectionSlugs = {
+  source: string;
+  target: string;
+  cancelSource: string;
+  cancelTarget: string;
+  overwriteSource: string;
+  overwriteTarget: string;
+  isolatedSource: string;
+};
+
+let sectionSlugs!: SectionSlugs;
 
 configureStudentDeliveryRuntimeConfig(runId, {
   student: {
@@ -44,17 +61,47 @@ configureStudentDeliveryRuntimeConfig(runId, {
   },
 });
 
-let sourceSectionSlug = '';
-let targetSectionSlug = '';
-
 test.beforeAll(async ({ seedScenario }) => {
-  const outputs = await seedStudentDeliveryScenario(seedScenario, scenarioPath, runId);
+  const { sections = {} } = await seedStudentDeliveryScenario(seedScenario, scenarioPath, runId);
 
-  sourceSectionSlug = outputs.sections?.transfer_enrollment_source_section ?? '';
-  targetSectionSlug = outputs.sections?.transfer_enrollment_target_section ?? '';
+  sectionSlugs = {
+    source: sections.transfer_enrollment_source_section ?? '',
+    target: sections.transfer_enrollment_target_section ?? '',
+    cancelSource: sections.transfer_enrollment_cancel_source_section ?? '',
+    cancelTarget: sections.transfer_enrollment_cancel_target_section ?? '',
+    overwriteSource: sections.transfer_enrollment_overwrite_source_section ?? '',
+    overwriteTarget: sections.transfer_enrollment_overwrite_target_section ?? '',
+    isolatedSource: sections.isolated_transfer_enrollment_source_section ?? '',
+  };
 
-  expect(sourceSectionSlug).toBeTruthy();
-  expect(targetSectionSlug).toBeTruthy();
+  expect(
+    sectionSlugs.source,
+    'Missing scenario output for transfer_enrollment_source_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.target,
+    'Missing scenario output for transfer_enrollment_target_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.cancelSource,
+    'Missing scenario output for transfer_enrollment_cancel_source_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.cancelTarget,
+    'Missing scenario output for transfer_enrollment_cancel_target_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.overwriteSource,
+    'Missing scenario output for transfer_enrollment_overwrite_source_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.overwriteTarget,
+    'Missing scenario output for transfer_enrollment_overwrite_target_section',
+  ).toBeTruthy();
+  expect(
+    sectionSlugs.isolatedSource,
+    'Missing scenario output for isolated_transfer_enrollment_source_section',
+  ).toBeTruthy();
 });
 
 test.describe('enrollment transfer', () => {
@@ -62,49 +109,179 @@ test.describe('enrollment transfer', () => {
     homeTask,
     page,
   }) => {
+    const { source, target } = sectionSlugs;
+
     await homeTask.login('administrator');
 
     // Baseline: the target student exists and still has no score before the transfer.
-    await openStudentActionsFromInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
+    await openStudentActionsFromInstructorStudents(page, target, 'Target, Transfer');
     await expectStudentMetric(page, 'course completion', '0%');
+    await expectStudentMetric(page, 'average score', '-');
 
     // Open the source student actions and launch the transfer modal.
-    await openStudentActionsFromInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
-    await page.getByRole('button', { name: 'Transfer Enrollment', exact: true }).click();
-    await expect(page.locator('#transfer_enrollment_modal_backdrop')).toBeVisible();
-    await expect(page.locator('#transfer_enrollment_modal')).toContainText(transferEnrollmentMessage);
+    await openTransferEnrollmentModal(page, source, 'Source, Transfer');
 
     // Pick the destination section and student, then confirm the transfer.
-    await selectTransferModalRow(page, `Enrollment Transfer Course ${runId} - Target`);
+    await selectTransferModalRow(page, transferSectionTitle('Target'));
     await selectTransferModalRow(page, 'Transfer Target');
 
     await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'Confirm', exact: true }).click();
 
-    await expect(page.locator('#live_flash_container')).toContainText(
-      'Enrollment successfully transfered',
-    );
+    await expect(page.locator('#live_flash_container')).toContainText(transferMessages.success);
 
     // Verify both sections now reflect the expected post-transfer state.
-    await expectStudentListedInInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
-    await expectStudentListedInInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
+    await findSectionStudentLink(page, target, 'Target, Transfer');
+    await findSectionStudentLink(page, source, 'Source, Transfer');
 
     // Destination keeps the transferred score, source keeps the enrollment shell.
-    await openStudentActionsFromInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
+    await openStudentActionsFromInstructorStudents(page, target, 'Target, Transfer');
     await expectStudentMetric(page, 'course completion', '0%');
     await expectStudentMetric(page, 'average score', '100%');
 
-    await openStudentActionsFromInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
+    await openStudentActionsFromInstructorStudents(page, source, 'Source, Transfer');
     await expectStudentMetric(page, 'average score', '-');
+  });
+
+  test('admin overwrites existing target progress when transferring enrollment', async ({
+    homeTask,
+    page,
+  }) => {
+    const { overwriteSource, overwriteTarget } = sectionSlugs;
+
+    await homeTask.login('administrator');
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      overwriteTarget,
+      'Overwrite Target, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '0%');
+
+    await openTransferEnrollmentModal(
+      page,
+      overwriteSource,
+      'Overwrite Source, Transfer',
+    );
+    await selectTransferModalRow(page, transferSectionTitle('Overwrite Target'));
+    await selectTransferModalRow(page, 'Transfer Overwrite Target');
+    await expect(page.locator('#transfer_enrollment_modal')).toContainText(
+      'Transfer Overwrite Target',
+    );
+
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click();
+    await expect(page.locator('#live_flash_container')).toContainText(transferMessages.success);
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      overwriteTarget,
+      'Overwrite Target, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '100%');
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      overwriteSource,
+      'Overwrite Source, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '-');
+  });
+
+  test('admin can close transfer enrollment after making selections without changing learner data', async ({
+    homeTask,
+    page,
+  }) => {
+    const { cancelSource, cancelTarget } = sectionSlugs;
+
+    await homeTask.login('administrator');
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      cancelSource,
+      'Cancel Source, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '100%');
+
+    await openTransferEnrollmentModal(page, cancelSource, 'Cancel Source, Transfer');
+    await selectTransferModalRow(page, transferSectionTitle('Cancel Target'));
+    await selectTransferModalRow(page, 'Transfer Cancel Target');
+    await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toBeVisible();
+
+    await page.locator('#transfer_enrollment_modal_backdrop button[phx-click="close"]').click();
+    await expect(page.locator('#transfer_enrollment_modal_backdrop')).toHaveCount(0);
+    await expect(page.getByText(transferMessages.success)).toHaveCount(0);
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      cancelSource,
+      'Cancel Source, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '100%');
+
+    await openStudentActionsFromInstructorStudents(
+      page,
+      cancelTarget,
+      'Cancel Target, Transfer',
+    );
+    await expectStudentMetric(page, 'average score', '-');
+  });
+
+  test('admin sees a no-sections message when no eligible transfer sections exist', async ({
+    homeTask,
+    page,
+  }) => {
+    await homeTask.login('administrator');
+    await openTransferEnrollmentModal(page, sectionSlugs.isolatedSource, 'Solo, Transfer');
+
+    await expect(page.locator('#transfer_enrollment_modal')).toContainText(
+      transferMessages.emptySections,
+    );
+    await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toHaveCount(0);
+  });
+
+  test('admin sees a no-students message when the selected section has no transfer candidates', async ({
+    homeTask,
+    page,
+  }) => {
+    await homeTask.login('administrator');
+    await openTransferEnrollmentModal(page, sectionSlugs.source, 'Source, Transfer');
+
+    await selectTransferModalRow(page, transferSectionTitle('Empty Target'));
+    await expect(page.locator('#transfer_enrollment_modal')).toContainText(
+      transferMessages.emptyStudents,
+    );
+    await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toHaveCount(0);
+  });
+
+  test('non-admin instructor does not see the transfer enrollment action', async ({
+    homeTask,
+    page,
+  }) => {
+    await homeTask.login('instructor');
+    await openStudentActionsFromInstructorStudents(page, sectionSlugs.source, 'Source, Transfer');
+
+    await expect(page.locator('#transfer_enrollment')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Transfer Enrollment', exact: true })).toHaveCount(
+      0,
+    );
   });
 });
 
+// Opens the actions page for a student and launches the transfer enrollment modal.
+async function openTransferEnrollmentModal(page: Page, sectionSlug: string, studentName: string) {
+  await openStudentActionsFromInstructorStudents(page, sectionSlug, studentName);
+  await page.getByRole('button', { name: 'Transfer Enrollment', exact: true }).click();
+  await expect(page.locator('#transfer_enrollment_modal_backdrop')).toBeVisible();
+  await expect(page.locator('#transfer_enrollment_modal')).toContainText(transferMessages.description);
+}
+
+// Navigates from the instructor student list to the selected student's actions page.
 async function openStudentActionsFromInstructorStudents(
   page: Page,
   sectionSlug: string,
   studentName: string,
 ) {
-  const studentLink = await findStudentLinkInInstructorStudents(page, sectionSlug, studentName);
+  const studentLink = await findSectionStudentLink(page, sectionSlug, studentName);
   const href = await studentLink.getAttribute('href');
 
   if (!href) {
@@ -119,20 +296,8 @@ async function openStudentActionsFromInstructorStudents(
   await expect(page.locator('#student_actions')).toBeVisible();
 }
 
-async function expectStudentListedInInstructorStudents(
-  page: Page,
-  sectionSlug: string,
-  studentName: string,
-) {
-  // This list is the simplest way to confirm the enrollment still exists in the section.
-  await findStudentLinkInInstructorStudents(page, sectionSlug, studentName);
-}
-
-async function findStudentLinkInInstructorStudents(
-  page: Page,
-  sectionSlug: string,
-  studentName: string,
-) {
+// Opens the instructor student list for a section and returns the student's dashboard link.
+async function findSectionStudentLink(page: Page, sectionSlug: string, studentName: string) {
   await page.goto(`/sections/${sectionSlug}/instructor_dashboard/overview/students`, {
     waitUntil: 'load',
   });
@@ -147,6 +312,7 @@ async function findStudentLinkInInstructorStudents(
   return studentLink;
 }
 
+// Selects a row in the transfer modal's current table step by visible text.
 async function selectTransferModalRow(page: Page, text: string) {
   const row = page.locator('#transfer_enrollment_modal tbody tr').filter({ hasText: text }).first();
 
@@ -154,6 +320,7 @@ async function selectTransferModalRow(page: Page, text: string) {
   await row.click();
 }
 
+// Asserts the displayed metric value inside the student details card.
 async function expectStudentMetric(
   page: Page,
   label: 'average score' | 'course completion',
@@ -166,3 +333,6 @@ async function expectStudentMetric(
 
   await expect(metric).toContainText(value);
 }
+
+// Builds the visible section title used in the transfer selection table.
+const transferSectionTitle = (label: string) => `Enrollment Transfer Course ${runId} - ${label}`;

--- a/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
@@ -1,7 +1,11 @@
 import { expect, type Page } from '@playwright/test';
 import { test } from '@fixture/my-fixture';
 import path from 'node:path';
-import { configureStudentDeliveryRuntimeConfig, seedStudentDeliveryScenario } from '../student_delivery/support';
+import {
+  configureStudentDeliveryRuntimeConfig,
+  seedStudentDeliveryScenario,
+  waitForMainLiveView,
+} from '../student_delivery/support';
 
 const runId = `-${Date.now()}`;
 const scenarioPath = path.resolve(__dirname, './transfer-enrollment.scenario.yaml');
@@ -100,17 +104,7 @@ async function openStudentActionsFromInstructorStudents(
   sectionSlug: string,
   studentName: string,
 ) {
-  await page.goto(`/sections/${sectionSlug}/instructor_dashboard/overview/students`, {
-    waitUntil: 'load',
-  });
-  await expect(page.locator('#students_table')).toBeVisible();
-
-  const studentLink = page
-    .locator('#students_table')
-    .getByRole('link', { name: studentName, exact: true })
-    .first();
-  await expect(studentLink).toBeVisible();
-
+  const studentLink = await findStudentLinkInInstructorStudents(page, sectionSlug, studentName);
   const href = await studentLink.getAttribute('href');
 
   if (!href) {
@@ -125,19 +119,20 @@ async function openStudentActionsFromInstructorStudents(
   await expect(page.locator('#student_actions')).toBeVisible();
 }
 
-async function selectTransferModalRow(page: Page, text: string) {
-  const row = page.locator('#transfer_enrollment_modal tbody tr').filter({ hasText: text }).first();
-
-  await expect(row).toBeVisible();
-  await row.click();
-}
-
 async function expectStudentListedInInstructorStudents(
   page: Page,
   sectionSlug: string,
   studentName: string,
 ) {
   // This list is the simplest way to confirm the enrollment still exists in the section.
+  await findStudentLinkInInstructorStudents(page, sectionSlug, studentName);
+}
+
+async function findStudentLinkInInstructorStudents(
+  page: Page,
+  sectionSlug: string,
+  studentName: string,
+) {
   await page.goto(`/sections/${sectionSlug}/instructor_dashboard/overview/students`, {
     waitUntil: 'load',
   });
@@ -147,8 +142,16 @@ async function expectStudentListedInInstructorStudents(
     .locator('#students_table')
     .getByRole('link', { name: studentName, exact: true })
     .first();
+  await expect(studentLink).toBeVisible();
 
-  await expect(studentLink).toHaveCount(1);
+  return studentLink;
+}
+
+async function selectTransferModalRow(page: Page, text: string) {
+  const row = page.locator('#transfer_enrollment_modal tbody tr').filter({ hasText: text }).first();
+
+  await expect(row).toBeVisible();
+  await row.click();
 }
 
 async function expectStudentMetric(
@@ -162,12 +165,4 @@ async function expectStudentMetric(
     .locator('xpath=following-sibling::span');
 
   await expect(metric).toContainText(value);
-}
-
-async function waitForMainLiveView(page: Page) {
-  await page.waitForFunction(
-    () => document.querySelector('[data-phx-main]')?.classList.contains('phx-connected'),
-    undefined,
-    { timeout: 15_000 },
-  );
 }

--- a/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
@@ -14,7 +14,7 @@ const transferMessages = {
     "This will transfer this student's enrollment, and all their current progress, to the selected course section. If this student is already enrolled in the selected course section, that progress will be lost.",
   emptySections: 'There are no other sections to transfer this student to.',
   emptyStudents: 'There are no other students to transfer this student to.',
-  success: 'Enrollment successfully transfered',
+  success: 'Enrollment successfully transferred',
 } as const;
 
 type SectionSlugs = {

--- a/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
+++ b/assets/automation/tests/torus/instructor/transfer-enrollment.spec.ts
@@ -1,0 +1,173 @@
+import { expect, type Page } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import path from 'node:path';
+import { configureStudentDeliveryRuntimeConfig, seedStudentDeliveryScenario } from '../student_delivery/support';
+
+const runId = `-${Date.now()}`;
+const scenarioPath = path.resolve(__dirname, './transfer-enrollment.scenario.yaml');
+const transferEnrollmentMessage =
+  "This will transfer this student's enrollment, and all their current progress, to the selected course section.";
+
+configureStudentDeliveryRuntimeConfig(runId, {
+  student: {
+    type: 'student',
+    role: 'Student',
+    emailPrefix: 'transfer-enrollment-student',
+    welcomeTitle: 'Hi, Transfer',
+    name: 'Transfer',
+    lastName: 'Student',
+  },
+  instructor: {
+    type: 'instructor',
+    role: 'Instructor',
+    emailPrefix: 'transfer-enrollment-instructor',
+    welcomeTitle: 'Instructor Dashboard',
+    header: 'Instructor Dashboard',
+  },
+  author: {
+    type: 'author',
+    role: 'Course Author',
+    emailPrefix: 'transfer-enrollment-author',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+  administrator: {
+    type: 'administrator',
+    role: 'Course Author',
+    emailPrefix: 'transfer-enrollment-admin',
+    welcomeTitle: 'Course Author',
+    header: 'Course Author',
+  },
+});
+
+let sourceSectionSlug = '';
+let targetSectionSlug = '';
+
+test.beforeAll(async ({ seedScenario }) => {
+  const outputs = await seedStudentDeliveryScenario(seedScenario, scenarioPath, runId);
+
+  sourceSectionSlug = outputs.sections?.transfer_enrollment_source_section ?? '';
+  targetSectionSlug = outputs.sections?.transfer_enrollment_target_section ?? '';
+
+  expect(sourceSectionSlug).toBeTruthy();
+  expect(targetSectionSlug).toBeTruthy();
+});
+
+test.describe('enrollment transfer', () => {
+  test('admin can transfer enrollment data between sections and preserve learner score', async ({
+    homeTask,
+    page,
+  }) => {
+    await homeTask.login('administrator');
+
+    // Baseline: the target student exists and still has no score before the transfer.
+    await openStudentActionsFromInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
+    await expectStudentMetric(page, 'course completion', '0%');
+
+    // Open the source student actions and launch the transfer modal.
+    await openStudentActionsFromInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
+    await page.getByRole('button', { name: 'Transfer Enrollment', exact: true }).click();
+    await expect(page.locator('#transfer_enrollment_modal_backdrop')).toBeVisible();
+    await expect(page.locator('#transfer_enrollment_modal')).toContainText(transferEnrollmentMessage);
+
+    // Pick the destination section and student, then confirm the transfer.
+    await selectTransferModalRow(page, `Enrollment Transfer Course ${runId} - Target`);
+    await selectTransferModalRow(page, 'Transfer Target');
+
+    await expect(page.getByRole('button', { name: 'Confirm', exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click();
+
+    await expect(page.locator('#live_flash_container')).toContainText(
+      'Enrollment successfully transfered',
+    );
+
+    // Verify both sections now reflect the expected post-transfer state.
+    await expectStudentListedInInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
+    await expectStudentListedInInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
+
+    // Destination keeps the transferred score, source keeps the enrollment shell.
+    await openStudentActionsFromInstructorStudents(page, targetSectionSlug, 'Target, Transfer');
+    await expectStudentMetric(page, 'course completion', '0%');
+    await expectStudentMetric(page, 'average score', '100%');
+
+    await openStudentActionsFromInstructorStudents(page, sourceSectionSlug, 'Source, Transfer');
+    await expectStudentMetric(page, 'average score', '-');
+  });
+});
+
+async function openStudentActionsFromInstructorStudents(
+  page: Page,
+  sectionSlug: string,
+  studentName: string,
+) {
+  await page.goto(`/sections/${sectionSlug}/instructor_dashboard/overview/students`, {
+    waitUntil: 'load',
+  });
+  await expect(page.locator('#students_table')).toBeVisible();
+
+  const studentLink = page
+    .locator('#students_table')
+    .getByRole('link', { name: studentName, exact: true })
+    .first();
+  await expect(studentLink).toBeVisible();
+
+  const href = await studentLink.getAttribute('href');
+
+  if (!href) {
+    throw new Error(`Could not read student dashboard link for ${studentName}`);
+  }
+
+  const studentActionsUrl = new URL(href, page.url());
+  studentActionsUrl.pathname = studentActionsUrl.pathname.replace(/\/content$/, '/actions');
+
+  await page.goto(studentActionsUrl.toString(), { waitUntil: 'load' });
+  await waitForMainLiveView(page);
+  await expect(page.locator('#student_actions')).toBeVisible();
+}
+
+async function selectTransferModalRow(page: Page, text: string) {
+  const row = page.locator('#transfer_enrollment_modal tbody tr').filter({ hasText: text }).first();
+
+  await expect(row).toBeVisible();
+  await row.click();
+}
+
+async function expectStudentListedInInstructorStudents(
+  page: Page,
+  sectionSlug: string,
+  studentName: string,
+) {
+  // This list is the simplest way to confirm the enrollment still exists in the section.
+  await page.goto(`/sections/${sectionSlug}/instructor_dashboard/overview/students`, {
+    waitUntil: 'load',
+  });
+  await expect(page.locator('#students_table')).toBeVisible();
+
+  const studentLink = page
+    .locator('#students_table')
+    .getByRole('link', { name: studentName, exact: true })
+    .first();
+
+  await expect(studentLink).toHaveCount(1);
+}
+
+async function expectStudentMetric(
+  page: Page,
+  label: 'average score' | 'course completion',
+  value: string,
+) {
+  const metric = page
+    .locator('#student_details_card h4')
+    .filter({ hasText: label })
+    .locator('xpath=following-sibling::span');
+
+  await expect(metric).toContainText(value);
+}
+
+async function waitForMainLiveView(page: Page) {
+  await page.waitForFunction(
+    () => document.querySelector('[data-phx-main]')?.classList.contains('phx-connected'),
+    undefined,
+    { timeout: 15_000 },
+  );
+}

--- a/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/sayg-saved-work-notice.spec.ts
@@ -2,7 +2,11 @@ import { expect, type Page } from '@playwright/test';
 import { test } from '@fixture/my-fixture';
 import { MenuDropdownCO } from '@pom/home/MenuDropdownCO';
 import path from 'node:path';
-import { configureStudentDeliveryRuntimeConfig, seedStudentDeliveryScenario } from './support';
+import {
+  configureStudentDeliveryRuntimeConfig,
+  seedStudentDeliveryScenario,
+  waitForMainLiveView,
+} from './support';
 
 const runId = `-${Date.now()}`;
 const scenarioPath = path.resolve(__dirname, './sayg-saved-work-notice.scenario.yaml');
@@ -220,14 +224,6 @@ async function revealBottomNavigation(page: Page) {
 
   await expect(bottomBarWrapper).toBeAttached();
   await bottomBarWrapper.hover();
-}
-
-async function waitForMainLiveView(page: Page) {
-  await page.waitForFunction(
-    () => document.querySelector('[data-phx-main]')?.classList.contains('phx-connected'),
-    undefined,
-    { timeout: 15_000 },
-  );
 }
 
 async function enterCourseIfNeeded(page: Page) {

--- a/assets/automation/tests/torus/student_delivery/support.ts
+++ b/assets/automation/tests/torus/student_delivery/support.ts
@@ -98,6 +98,14 @@ export async function openStudentDeliveryPractice(
   await expect(page.getByText(activityTitle).first()).toBeVisible();
 }
 
+export async function waitForMainLiveView(page: Page) {
+  await page.waitForFunction(
+    () => document.querySelector('[data-phx-main]')?.classList.contains('phx-connected'),
+    undefined,
+    { timeout: 15_000 },
+  );
+}
+
 function learnPath(sectionSlug: string) {
   return `/sections/${sectionSlug}/learn?sidebar_expanded=true&selected_view=outline`;
 }

--- a/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
+++ b/lib/oli_web/components/delivery/actions/transfer_enrollment.ex
@@ -304,7 +304,7 @@ defmodule OliWeb.Delivery.Actions.TransferEnrollment do
            target_student.id
          ) do
       {:ok, _} ->
-        send(self(), {:put_flash, :info, "Enrollment successfully transfered"})
+        send(self(), {:put_flash, :info, "Enrollment successfully transferred"})
         {:noreply, socket}
 
       {:error, _} ->

--- a/test/oli_web/live/delivery/student_dashboard/components/actions_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/actions_tab_test.exs
@@ -519,7 +519,7 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.ActionsTabTest do
       |> render_click("finish_transfer_enrollment")
 
       # shows success message
-      assert has_element?(view, "div.alert.alert-info", "Enrollment successfully transfered")
+      assert has_element?(view, "div.alert.alert-info", "Enrollment successfully transferred")
     end
 
     test "shows text if there are no sections to transfer data", %{conn: conn, user_1: user_1} do


### PR DESCRIPTION
[MER-5492](https://eliterate.atlassian.net/browse/MER-5492)

## Summary

This PR adds Playwright automation coverage for the instructor-side Enrollment Transfer workflow.

### Changes

- Covers the enrollment transfer happy path.
- Adds overwrite, cancellation, no eligible sections, no transferable students, and non-admin instructor visibility cases.
- Expands the scenario with independent datasets per case.
- Reduces duplication in the spec through reusable helpers.

### Tests

- npm run pw -- tests/torus/instructor/transfer-enrollment.spec.ts

[MER-5492]: https://eliterate.atlassian.net/browse/MER-5492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ