### PR TITLE
[ENHANCEMENT] [MER-5495] Add scenario coverage for course discussions

### DIFF
--- a/lib/oli/scenarios/directive_parser.ex
+++ b/lib/oli/scenarios/directive_parser.ex
@@ -33,6 +33,9 @@ defmodule Oli.Scenarios.DirectiveParser do
     AnswerQuestionDirective,
     CertificateDirective,
     DiscussionPostDirective,
+    DiscussionConfigDirective,
+    DiscussionModerationDirective,
+    DiscussionDeleteDirective,
     ClassNoteDirective,
     CompleteScoredPageDirective,
     FinalizeAttemptDirective,
@@ -287,6 +290,7 @@ defmodule Oli.Scenarios.DirectiveParser do
       "activity_customization",
       "page_objectives",
       "activity_objectives",
+      "discussion",
       "assertions"
     ]
 
@@ -308,6 +312,7 @@ defmodule Oli.Scenarios.DirectiveParser do
           page_objectives: parse_page_objectives_assertion(assert_data["page_objectives"]),
           activity_objectives:
             parse_activity_objectives_assertion(assert_data["activity_objectives"]),
+          discussion: parse_discussion_assertion(assert_data["discussion"]),
           assertions: assert_data["assertions"]
         }
 
@@ -338,6 +343,7 @@ defmodule Oli.Scenarios.DirectiveParser do
            "activity_customization",
            "page_objectives",
            "activity_objectives",
+           "discussion",
            "assertions"
          ]}
       else
@@ -357,6 +363,7 @@ defmodule Oli.Scenarios.DirectiveParser do
            "activity_customization",
            "page_objectives",
            "activity_objectives",
+           "discussion",
            "assertions"
          ]}
       end
@@ -380,6 +387,7 @@ defmodule Oli.Scenarios.DirectiveParser do
           page_objectives: parse_page_objectives_assertion(assert_data["page_objectives"]),
           activity_objectives:
             parse_activity_objectives_assertion(assert_data["activity_objectives"]),
+          discussion: parse_discussion_assertion(assert_data["discussion"]),
           assertions: assert_data["assertions"]
         }
 
@@ -717,8 +725,34 @@ defmodule Oli.Scenarios.DirectiveParser do
     end
   end
 
+  defp parse_directive(%{"discussion_config" => discussion_config_data}) do
+    allowed_attrs = ["section", "enabled", "auto_accept", "anonymous_posting"]
+
+    case DirectiveValidator.validate_attributes(
+           allowed_attrs,
+           discussion_config_data,
+           "discussion_config"
+         ) do
+      :ok ->
+        %DiscussionConfigDirective{
+          section: discussion_config_data["section"],
+          enabled: parse_optional_boolean(discussion_config_data["enabled"], "enabled"),
+          auto_accept:
+            parse_optional_boolean(discussion_config_data["auto_accept"], "auto_accept"),
+          anonymous_posting:
+            parse_optional_boolean(
+              discussion_config_data["anonymous_posting"],
+              "anonymous_posting"
+            )
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
   defp parse_directive(%{"discussion_post" => discussion_post_data}) do
-    allowed_attrs = ["student", "section", "body"]
+    allowed_attrs = ["name", "student", "section", "body", "reply_to", "anonymous"]
 
     case DirectiveValidator.validate_attributes(
            allowed_attrs,
@@ -727,9 +761,51 @@ defmodule Oli.Scenarios.DirectiveParser do
          ) do
       :ok ->
         %DiscussionPostDirective{
+          name: discussion_post_data["name"],
           student: discussion_post_data["student"],
           section: discussion_post_data["section"],
-          body: discussion_post_data["body"]
+          body: discussion_post_data["body"],
+          reply_to: discussion_post_data["reply_to"],
+          anonymous: parse_boolean(discussion_post_data["anonymous"], false, "anonymous")
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
+  defp parse_directive(%{"discussion_moderation" => discussion_moderation_data}) do
+    allowed_attrs = ["post", "instructor", "action"]
+
+    case DirectiveValidator.validate_attributes(
+           allowed_attrs,
+           discussion_moderation_data,
+           "discussion_moderation"
+         ) do
+      :ok ->
+        %DiscussionModerationDirective{
+          post: discussion_moderation_data["post"],
+          instructor: discussion_moderation_data["instructor"],
+          action: parse_discussion_moderation_action(discussion_moderation_data["action"])
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
+  defp parse_directive(%{"discussion_delete" => discussion_delete_data}) do
+    allowed_attrs = ["post", "actor"]
+
+    case DirectiveValidator.validate_attributes(
+           allowed_attrs,
+           discussion_delete_data,
+           "discussion_delete"
+         ) do
+      :ok ->
+        %DiscussionDeleteDirective{
+          post: discussion_delete_data["post"],
+          actor: discussion_delete_data["actor"]
         }
 
       {:error, msg} ->
@@ -949,13 +1025,21 @@ defmodule Oli.Scenarios.DirectiveParser do
          "answer_question",
          "finalize_attempt",
          "student_exception",
+         "certificate",
+         "discussion_config",
+         "discussion_post",
+         "discussion_moderation",
+         "discussion_delete",
+         "class_note",
+         "complete_scored_page",
+         "certificate_action",
          "use",
          "collaborator",
          "media",
          "bibliography",
          "hook"
        ] do
-      raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, instructor_customization, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, use, collaborator, media, bibliography, hook"
+      raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, instructor_customization, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, certificate, discussion_config, discussion_post, discussion_moderation, discussion_delete, class_note, complete_scored_page, certificate_action, use, collaborator, media, bibliography, hook"
     else
       # This shouldn't happen as specific handlers above should match first
       raise "Internal error: unhandled directive '#{key}'"
@@ -994,7 +1078,10 @@ defmodule Oli.Scenarios.DirectiveParser do
              "finalize_attempt",
              "student_exception",
              "certificate",
+             "discussion_config",
              "discussion_post",
+             "discussion_moderation",
+             "discussion_delete",
              "class_note",
              "complete_scored_page",
              "certificate_action",
@@ -1009,7 +1096,7 @@ defmodule Oli.Scenarios.DirectiveParser do
         [parse_directive(%{key => value})]
 
       {key, _value} ->
-        raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, instructor_customization, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, certificate, discussion_post, class_note, complete_scored_page, certificate_action, use, collaborator, media, bibliography, hook"
+        raise "Unrecognized directive: '#{key}'. Valid directives are: project, clone, section, product, remix, manipulate, publish, assert, verify, user, enroll, institution, update, customize, create_activity, activity_bank, instructor_customization, edit_page, view_practice_page, visit_page, start_attempt, gate, time, wait, answer_question, finalize_attempt, student_exception, certificate, discussion_config, discussion_post, discussion_moderation, discussion_delete, class_note, complete_scored_page, certificate_action, use, collaborator, media, bibliography, hook"
     end)
   end
 
@@ -1274,6 +1361,29 @@ defmodule Oli.Scenarios.DirectiveParser do
           admin_title2: data["admin_title2"],
           admin_name3: data["admin_name3"],
           admin_title3: data["admin_title3"]
+        }
+
+      {:error, msg} ->
+        raise msg
+    end
+  end
+
+  defp parse_discussion_assertion(nil), do: nil
+
+  defp parse_discussion_assertion(data) when is_map(data) do
+    case DirectiveValidator.validate_assertion_attributes(:discussion, data) do
+      :ok ->
+        %{
+          section: data["section"],
+          post: data["post"],
+          student: data["student"],
+          visible: parse_optional_boolean(data["visible"], "visible"),
+          status: parse_optional_post_status(data["status"]),
+          contains_discussions:
+            parse_optional_boolean(data["contains_discussions"], "contains_discussions"),
+          auto_accept: parse_optional_boolean(data["auto_accept"], "auto_accept"),
+          anonymous_posting:
+            parse_optional_boolean(data["anonymous_posting"], "anonymous_posting")
         }
 
       {:error, msg} ->
@@ -1889,6 +1999,29 @@ defmodule Oli.Scenarios.DirectiveParser do
       "approve" -> :approve
       "deny" -> :deny
       other -> raise "Invalid certificate action '#{other}'. Expected approve or deny"
+    end
+  end
+
+  defp parse_discussion_moderation_action(nil),
+    do: raise("discussion_moderation requires an action")
+
+  defp parse_discussion_moderation_action(value) when is_binary(value) do
+    case String.downcase(String.trim(value)) do
+      "approve" -> :approve
+      "reject" -> :reject
+      other -> raise "Invalid discussion_moderation action '#{other}'. Expected approve or reject"
+    end
+  end
+
+  defp parse_optional_post_status(nil), do: nil
+
+  defp parse_optional_post_status(value) when is_binary(value) do
+    case String.downcase(String.trim(value)) do
+      "submitted" -> :submitted
+      "approved" -> :approved
+      "deleted" -> :deleted
+      "archived" -> :archived
+      other -> raise "Invalid discussion post status '#{other}'"
     end
   end
 

--- a/lib/oli/scenarios/directive_types.ex
+++ b/lib/oli/scenarios/directive_types.ex
@@ -84,6 +84,7 @@ defmodule Oli.Scenarios.DirectiveTypes do
       :activity_customization,
       :page_objectives,
       :activity_objectives,
+      :discussion,
       :assertions
     ]
   end
@@ -281,11 +282,44 @@ defmodule Oli.Scenarios.DirectiveTypes do
   defmodule DiscussionPostDirective do
     @moduledoc """
     Creates a discussion post for a student in a section.
+    name: optional scenario-local name for referencing the post later
     student: scenario user name
     section: scenario section name
     body: discussion post body
+    reply_to: optional scenario-local parent post name
+    anonymous: whether to create the post anonymously
     """
-    defstruct [:student, :section, :body]
+    defstruct [:name, :student, :section, :body, :reply_to, :anonymous]
+  end
+
+  defmodule DiscussionConfigDirective do
+    @moduledoc """
+    Configures course discussions on a section.
+    section: scenario section name
+    enabled: whether course discussions are enabled
+    auto_accept: whether posts are visible without approval
+    anonymous_posting: whether anonymous posting is enabled
+    """
+    defstruct [:section, :enabled, :auto_accept, :anonymous_posting]
+  end
+
+  defmodule DiscussionModerationDirective do
+    @moduledoc """
+    Applies instructor moderation to a named discussion post.
+    post: scenario-local post name
+    instructor: scenario user name
+    action: approve or reject
+    """
+    defstruct [:post, :instructor, :action]
+  end
+
+  defmodule DiscussionDeleteDirective do
+    @moduledoc """
+    Deletes a named discussion post as a scenario user.
+    post: scenario-local post name
+    actor: scenario user name
+    """
+    defstruct [:post, :actor]
   end
 
   defmodule ClassNoteDirective do
@@ -371,6 +405,8 @@ defmodule Oli.Scenarios.DirectiveTypes do
               finalized_attempts: %{},
               # {user_name, section_name, page_title, activity_virtual_id} -> evaluation result
               activity_evaluations: %{},
+              # name -> Discussion post
+              discussion_posts: %{},
               # gate name -> GatingCondition
               gates: %{},
               # scenario-local current time

--- a/lib/oli/scenarios/directive_validator.ex
+++ b/lib/oli/scenarios/directive_validator.ex
@@ -106,6 +106,18 @@ defmodule Oli.Scenarios.DirectiveValidator do
             "admin_title3"
           ]
 
+        :discussion ->
+          [
+            "section",
+            "post",
+            "student",
+            "visible",
+            "status",
+            "contains_discussions",
+            "auto_accept",
+            "anonymous_posting"
+          ]
+
         :gating ->
           [
             "gate",

--- a/lib/oli/scenarios/directives/assert/discussion_assertion.ex
+++ b/lib/oli/scenarios/directives/assert/discussion_assertion.ex
@@ -56,6 +56,7 @@ defmodule Oli.Scenarios.Directives.Assert.DiscussionAssertion do
           discussion_data.anonymous_posting,
           "anonymous_posting"
         ),
+        check_post_scope(section, post),
         compare_field(post && post.status, discussion_data.status, "status"),
         check_visibility(section, student, post, discussion_data.visible)
       ]
@@ -84,6 +85,18 @@ defmodule Oli.Scenarios.Directives.Assert.DiscussionAssertion do
     if actual == expected,
       do: :ok,
       else: "expected #{label}=#{inspect(expected)}, got #{inspect(actual)}"
+  end
+
+  defp check_post_scope(_section, nil), do: :ok
+
+  defp check_post_scope(section, post) do
+    root_resource_id = section.root_section_resource && section.root_section_resource.resource_id
+
+    if post.section_id == section.id and post.resource_id == root_resource_id do
+      :ok
+    else
+      "post does not belong to section '#{section.slug}'"
+    end
   end
 
   defp check_visibility(_section, _student, _post, nil), do: :ok

--- a/lib/oli/scenarios/directives/assert/discussion_assertion.ex
+++ b/lib/oli/scenarios/directives/assert/discussion_assertion.ex
@@ -1,0 +1,121 @@
+defmodule Oli.Scenarios.Directives.Assert.DiscussionAssertion do
+  @moduledoc """
+  Handles assertions for course discussion configuration and named posts.
+  """
+
+  alias Oli.Repo
+  alias Oli.Resources.Collaboration
+  alias Oli.Scenarios.DirectiveTypes.{AssertDirective, VerificationResult}
+  alias Oli.Scenarios.Directives.Assert.Helpers
+  alias Oli.Scenarios.Engine
+
+  def assert(%AssertDirective{discussion: discussion_data}, state)
+      when is_map(discussion_data) do
+    with {:ok, section} <- Helpers.get_section(state, discussion_data.section),
+         {:ok, student} <- maybe_get_student(state, discussion_data.student),
+         {:ok, post} <- maybe_get_post(state, discussion_data.post),
+         verification_result <- verify(section, student, post, discussion_data) do
+      {:ok, state, verification_result}
+    else
+      {:error, reason} ->
+        {:error, "Failed to assert discussion: #{reason}"}
+    end
+  end
+
+  def assert(%AssertDirective{discussion: nil}, state), do: {:ok, state, nil}
+
+  defp maybe_get_student(_state, nil), do: {:ok, nil}
+  defp maybe_get_student(state, student_name), do: Helpers.get_user(state, student_name)
+
+  defp maybe_get_post(_state, nil), do: {:ok, nil}
+
+  defp maybe_get_post(state, post_name) do
+    case Engine.get_discussion_post(state, post_name) do
+      nil -> {:error, "Discussion post '#{post_name}' not found"}
+      post -> {:ok, Collaboration.get_post_by(%{id: post.id}) || post}
+    end
+  end
+
+  defp verify(section, student, post, discussion_data) do
+    section = Repo.preload(section, :root_section_resource)
+    config = section.root_section_resource && section.root_section_resource.collab_space_config
+
+    checks =
+      [
+        compare_field(
+          section.contains_discussions,
+          discussion_data.contains_discussions,
+          "contains_discussions"
+        ),
+        compare_field(config && config.auto_accept, discussion_data.auto_accept, "auto_accept"),
+        compare_field(
+          config && config.anonymous_posting,
+          discussion_data.anonymous_posting,
+          "anonymous_posting"
+        ),
+        compare_field(post && post.status, discussion_data.status, "status"),
+        check_visibility(section, student, post, discussion_data.visible)
+      ]
+      |> Enum.reject(&(&1 == :ok))
+
+    case checks do
+      [] ->
+        %VerificationResult{
+          to: discussion_data.section,
+          passed: true,
+          message: "Discussion assertion passed for '#{discussion_data.section}'"
+        }
+
+      failures ->
+        %VerificationResult{
+          to: discussion_data.section,
+          passed: false,
+          message: Enum.join(failures, "; ")
+        }
+    end
+  end
+
+  defp compare_field(_actual, nil, _label), do: :ok
+
+  defp compare_field(actual, expected, label) do
+    if actual == expected,
+      do: :ok,
+      else: "expected #{label}=#{inspect(expected)}, got #{inspect(actual)}"
+  end
+
+  defp check_visibility(_section, _student, _post, nil), do: :ok
+
+  defp check_visibility(_section, nil, _post, _expected) do
+    "student is required when asserting discussion visibility"
+  end
+
+  defp check_visibility(_section, _student, nil, _expected) do
+    "post is required when asserting discussion visibility"
+  end
+
+  defp check_visibility(section, student, post, expected) do
+    visible? =
+      section.root_section_resource.resource_id
+      |> list_visible_posts(section, student)
+      |> Enum.any?(&(&1.id == post.id))
+
+    if visible? == expected,
+      do: :ok,
+      else: "expected visible=#{inspect(expected)}, got #{inspect(visible?)}"
+  end
+
+  defp list_visible_posts(root_resource_id, section, student) do
+    {posts, _more?} =
+      Collaboration.list_root_posts_for_section(
+        student.id,
+        section.id,
+        root_resource_id,
+        100,
+        0,
+        "date",
+        :asc
+      )
+
+    posts
+  end
+end

--- a/lib/oli/scenarios/directives/assert/discussion_assertion.ex
+++ b/lib/oli/scenarios/directives/assert/discussion_assertion.ex
@@ -3,8 +3,11 @@ defmodule Oli.Scenarios.Directives.Assert.DiscussionAssertion do
   Handles assertions for course discussion configuration and named posts.
   """
 
+  import Ecto.Query, warn: false
+
   alias Oli.Repo
   alias Oli.Resources.Collaboration
+  alias Oli.Resources.Collaboration.Post
   alias Oli.Scenarios.DirectiveTypes.{AssertDirective, VerificationResult}
   alias Oli.Scenarios.Directives.Assert.Helpers
   alias Oli.Scenarios.Engine
@@ -96,26 +99,23 @@ defmodule Oli.Scenarios.Directives.Assert.DiscussionAssertion do
   defp check_visibility(section, student, post, expected) do
     visible? =
       section.root_section_resource.resource_id
-      |> list_visible_posts(section, student)
-      |> Enum.any?(&(&1.id == post.id))
+      |> visible_post?(section, student, post)
 
     if visible? == expected,
       do: :ok,
       else: "expected visible=#{inspect(expected)}, got #{inspect(visible?)}"
   end
 
-  defp list_visible_posts(root_resource_id, section, student) do
-    {posts, _more?} =
-      Collaboration.list_root_posts_for_section(
-        student.id,
-        section.id,
-        root_resource_id,
-        100,
-        0,
-        "date",
-        :asc
-      )
-
-    posts
+  defp visible_post?(root_resource_id, section, student, post) do
+    Repo.exists?(
+      from p in Post,
+        where:
+          p.id == ^post.id and
+            p.section_id == ^section.id and
+            p.resource_id == ^root_resource_id and
+            p.visibility == :public and
+            (p.status in [:approved, :archived, :deleted] or
+               (p.status == :submitted and p.user_id == ^student.id))
+    )
   end
 end

--- a/lib/oli/scenarios/directives/assert_handler.ex
+++ b/lib/oli/scenarios/directives/assert_handler.ex
@@ -19,6 +19,7 @@ defmodule Oli.Scenarios.Directives.AssertHandler do
     ActivityCustomizationAssertion,
     PageObjectivesAssertion,
     ActivityObjectivesAssertion,
+    DiscussionAssertion,
     GeneralAssertion
   }
 
@@ -64,6 +65,9 @@ defmodule Oli.Scenarios.Directives.AssertHandler do
 
       directive.activity_objectives != nil ->
         ActivityObjectivesAssertion.assert(directive, state)
+
+      directive.discussion != nil ->
+        DiscussionAssertion.assert(directive, state)
 
       directive.progress != nil ->
         ProgressAssertion.assert(directive, state)

--- a/lib/oli/scenarios/directives/discussion_config_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_config_handler.ex
@@ -1,0 +1,88 @@
+defmodule Oli.Scenarios.Directives.DiscussionConfigHandler do
+  @moduledoc """
+  Configures course discussions on a scenario section.
+  """
+
+  alias Oli.Delivery.Sections
+  alias Oli.Repo
+  alias Oli.Scenarios.DirectiveTypes.{DiscussionConfigDirective, ExecutionState}
+  alias Oli.Scenarios.Engine
+
+  def handle(
+        %DiscussionConfigDirective{
+          section: section_name,
+          enabled: enabled,
+          auto_accept: auto_accept,
+          anonymous_posting: anonymous_posting
+        },
+        %ExecutionState{} = state
+      ) do
+    with {:ok, section} <- fetch_section(state, section_name),
+         {:ok, root_section_resource} <- fetch_root_section_resource(section),
+         attrs <-
+           config_attrs(
+             root_section_resource.collab_space_config,
+             enabled,
+             auto_accept,
+             anonymous_posting
+           ),
+         {:ok, _updated_root_section_resource} <-
+           Sections.update_section_resource(root_section_resource, %{collab_space_config: attrs}),
+         {:ok, updated_section} <-
+           maybe_update_contains_discussions(section, enabled) do
+      {:ok, put_section_or_product(state, section_name, updated_section)}
+    else
+      {:error, reason} ->
+        {:error, "Failed to configure discussions: #{inspect(reason)}"}
+    end
+  end
+
+  defp fetch_section(state, name) do
+    case Engine.get_section(state, name) || Engine.get_product(state, name) do
+      nil -> {:error, "Section '#{name}' not found"}
+      section -> {:ok, section}
+    end
+  end
+
+  defp fetch_root_section_resource(section) do
+    section = Repo.preload(section, :root_section_resource)
+
+    case section.root_section_resource do
+      nil -> {:error, "Root section resource not found for section '#{section.slug}'"}
+      root_section_resource -> {:ok, root_section_resource}
+    end
+  end
+
+  defp config_attrs(config, enabled, auto_accept, anonymous_posting) do
+    config
+    |> config_to_map()
+    |> maybe_put(:status, status(enabled))
+    |> maybe_put(:auto_accept, auto_accept)
+    |> maybe_put(:anonymous_posting, anonymous_posting)
+  end
+
+  defp status(nil), do: nil
+  defp status(true), do: :enabled
+  defp status(false), do: :disabled
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp config_to_map(nil), do: %{}
+  defp config_to_map(%{__struct__: _} = config), do: Map.from_struct(config)
+  defp config_to_map(config) when is_map(config), do: config
+
+  defp maybe_update_contains_discussions(section, nil), do: {:ok, section}
+
+  defp maybe_update_contains_discussions(section, enabled) do
+    Sections.update_section(section, %{contains_discussions: enabled})
+  end
+
+  defp put_section_or_product(state, name, updated_section) do
+    if Engine.get_product(state, name) do
+      Engine.put_product(state, name, updated_section)
+    else
+      Engine.put_section(state, name, updated_section)
+    end
+  end
+end

--- a/lib/oli/scenarios/directives/discussion_delete_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_delete_handler.ex
@@ -1,0 +1,45 @@
+defmodule Oli.Scenarios.Directives.DiscussionDeleteHandler do
+  @moduledoc """
+  Deletes named discussion posts through the collaboration authorization path.
+  """
+
+  alias Oli.Repo
+  alias Oli.Resources.Collaboration
+  alias Oli.Scenarios.DirectiveTypes.{DiscussionDeleteDirective, ExecutionState}
+  alias Oli.Scenarios.Engine
+
+  def handle(
+        %DiscussionDeleteDirective{post: post_name, actor: actor_name},
+        %ExecutionState{} = state
+      ) do
+    with {:ok, actor} <- fetch_user(state, actor_name),
+         {:ok, post} <- fetch_post(state, post_name),
+         {count, nil} when count > 0 <- Collaboration.soft_delete_post(post.id, actor),
+         updated_post <- Collaboration.get_post_by(%{id: post.id}) |> Repo.preload(:user) do
+      {:ok, Engine.put_discussion_post(state, post_name, updated_post)}
+    else
+      {:error, reason} ->
+        {:error, "Failed to delete discussion post: #{inspect(reason)}"}
+
+      other ->
+        {:error, "Failed to delete discussion post: #{inspect(other)}"}
+    end
+  end
+
+  defp fetch_user(state, name) do
+    case Engine.get_user(state, name) do
+      nil -> {:error, "User '#{name}' not found"}
+      user -> {:ok, user}
+    end
+  end
+
+  defp fetch_post(state, name) do
+    case Engine.get_discussion_post(state, name) do
+      nil ->
+        {:error, "Discussion post '#{name}' not found"}
+
+      post ->
+        {:ok, Collaboration.get_post_by(%{id: post.id}) || post}
+    end
+  end
+end

--- a/lib/oli/scenarios/directives/discussion_delete_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_delete_handler.ex
@@ -3,6 +3,7 @@ defmodule Oli.Scenarios.Directives.DiscussionDeleteHandler do
   Deletes named discussion posts through the collaboration authorization path.
   """
 
+  alias Oli.Delivery.Sections
   alias Oli.Repo
   alias Oli.Resources.Collaboration
   alias Oli.Scenarios.DirectiveTypes.{DiscussionDeleteDirective, ExecutionState}
@@ -14,6 +15,7 @@ defmodule Oli.Scenarios.Directives.DiscussionDeleteHandler do
       ) do
     with {:ok, actor} <- fetch_user(state, actor_name),
          {:ok, post} <- fetch_post(state, post_name),
+         :ok <- authorize_delete(actor, post),
          {count, nil} when count > 0 <- Collaboration.soft_delete_post(post.id, actor),
          updated_post <- Collaboration.get_post_by(%{id: post.id}) |> Repo.preload(:user) do
       {:ok, Engine.put_discussion_post(state, post_name, updated_post)}
@@ -30,6 +32,21 @@ defmodule Oli.Scenarios.Directives.DiscussionDeleteHandler do
     case Engine.get_user(state, name) do
       nil -> {:error, "User '#{name}' not found"}
       user -> {:ok, user}
+    end
+  end
+
+  defp authorize_delete(actor, post) do
+    post = Repo.preload(post, :section)
+
+    cond do
+      post.user_id == actor.id ->
+        :ok
+
+      post.section && Sections.is_instructor?(actor, post.section.slug) ->
+        :ok
+
+      true ->
+        {:error, "User '#{actor.email}' is not authorized to delete this discussion post"}
     end
   end
 

--- a/lib/oli/scenarios/directives/discussion_moderation_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_moderation_handler.ex
@@ -4,6 +4,7 @@ defmodule Oli.Scenarios.Directives.DiscussionModerationHandler do
   """
 
   alias Oli.Repo
+  alias Oli.Delivery.Sections
   alias Oli.Resources.Collaboration
   alias Oli.Scenarios.DirectiveTypes.{DiscussionModerationDirective, ExecutionState}
   alias Oli.Scenarios.Engine
@@ -16,8 +17,9 @@ defmodule Oli.Scenarios.Directives.DiscussionModerationHandler do
         },
         %ExecutionState{} = state
       ) do
-    with {:ok, _instructor} <- fetch_user(state, instructor_name),
+    with {:ok, instructor} <- fetch_user(state, instructor_name),
          {:ok, post} <- fetch_post(state, post_name),
+         :ok <- authorize_moderation(instructor, post),
          {:ok, updated_post} <- moderate(post, action) do
       {:ok, Engine.put_discussion_post(state, post_name, updated_post)}
     else
@@ -30,6 +32,16 @@ defmodule Oli.Scenarios.Directives.DiscussionModerationHandler do
     case Engine.get_user(state, name) do
       nil -> {:error, "User '#{name}' not found"}
       user -> {:ok, user}
+    end
+  end
+
+  defp authorize_moderation(instructor, post) do
+    post = Repo.preload(post, :section)
+
+    if post.section && Sections.is_instructor?(instructor, post.section.slug) do
+      :ok
+    else
+      {:error, "User '#{instructor.email}' is not authorized to moderate this discussion post"}
     end
   end
 

--- a/lib/oli/scenarios/directives/discussion_moderation_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_moderation_handler.ex
@@ -1,0 +1,59 @@
+defmodule Oli.Scenarios.Directives.DiscussionModerationHandler do
+  @moduledoc """
+  Applies instructor moderation to named discussion posts.
+  """
+
+  alias Oli.Repo
+  alias Oli.Resources.Collaboration
+  alias Oli.Scenarios.DirectiveTypes.{DiscussionModerationDirective, ExecutionState}
+  alias Oli.Scenarios.Engine
+
+  def handle(
+        %DiscussionModerationDirective{
+          post: post_name,
+          instructor: instructor_name,
+          action: action
+        },
+        %ExecutionState{} = state
+      ) do
+    with {:ok, _instructor} <- fetch_user(state, instructor_name),
+         {:ok, post} <- fetch_post(state, post_name),
+         {:ok, updated_post} <- moderate(post, action) do
+      {:ok, Engine.put_discussion_post(state, post_name, updated_post)}
+    else
+      {:error, reason} ->
+        {:error, "Failed to moderate discussion post: #{inspect(reason)}"}
+    end
+  end
+
+  defp fetch_user(state, name) do
+    case Engine.get_user(state, name) do
+      nil -> {:error, "User '#{name}' not found"}
+      user -> {:ok, user}
+    end
+  end
+
+  defp fetch_post(state, name) do
+    case Engine.get_discussion_post(state, name) do
+      nil ->
+        {:error, "Discussion post '#{name}' not found"}
+
+      post ->
+        {:ok, Collaboration.get_post_by(%{id: post.id}) || post}
+    end
+  end
+
+  defp moderate(post, :approve) do
+    Collaboration.update_post(post, %{status: :approved})
+  end
+
+  defp moderate(post, :reject) do
+    case Collaboration.delete_posts(post) do
+      {count, nil} when count > 0 ->
+        {:ok, Collaboration.get_post_by(%{id: post.id}) |> Repo.preload(:user)}
+
+      other ->
+        {:error, other}
+    end
+  end
+end

--- a/lib/oli/scenarios/directives/discussion_post_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_post_handler.ex
@@ -45,26 +45,38 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
   defp post_attrs(student, section, root_section_resource, parent_post, body, anonymous) do
     config = root_section_resource.collab_space_config
 
-    if anonymous && !anonymous_posting_enabled?(config) do
-      {:error, "Anonymous posting is not enabled for section '#{section.slug}'"}
-    else
-      auto_accept = is_nil(config) or Map.get(config, :auto_accept, true)
+    cond do
+      !discussions_enabled?(section, config) ->
+        {:error, "Discussions are not enabled for section '#{section.slug}'"}
 
-      attrs =
-        %{
-          user_id: student.id,
-          section_id: section.id,
-          resource_id: root_section_resource.resource_id,
-          status: if(auto_accept, do: :approved, else: :submitted),
-          visibility: :public,
-          anonymous: anonymous,
-          content: %PostContent{message: body}
-        }
-        |> maybe_put_parent(parent_post)
+      anonymous && !anonymous_posting_enabled?(config) ->
+        {:error, "Anonymous posting is not enabled for section '#{section.slug}'"}
 
-      {:ok, attrs}
+      true ->
+        auto_accept = auto_accept_enabled?(config)
+
+        attrs =
+          %{
+            user_id: student.id,
+            section_id: section.id,
+            resource_id: root_section_resource.resource_id,
+            status: if(auto_accept, do: :approved, else: :submitted),
+            visibility: :public,
+            anonymous: anonymous,
+            content: %PostContent{message: body}
+          }
+          |> maybe_put_parent(parent_post)
+
+        {:ok, attrs}
     end
   end
+
+  defp discussions_enabled?(section, config) do
+    (section.contains_discussions == true and config) && Map.get(config, :status) == :enabled
+  end
+
+  defp auto_accept_enabled?(nil), do: true
+  defp auto_accept_enabled?(config), do: Map.get(config, :auto_accept) != false
 
   defp anonymous_posting_enabled?(nil), do: false
   defp anonymous_posting_enabled?(config), do: Map.get(config, :anonymous_posting, false)

--- a/lib/oli/scenarios/directives/discussion_post_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_post_handler.ex
@@ -26,7 +26,7 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
          {:ok, section} <- fetch_section(state, section_name),
          {:ok, root_section_resource} <- fetch_root_section_resource(section),
          {:ok, parent_post} <- fetch_parent_post(state, reply_to),
-         attrs <-
+         {:ok, attrs} <-
            post_attrs(student, section, root_section_resource, parent_post, body, anonymous),
          {:ok, post} <-
            CertificationEligibility.create_post_and_verify_qualification(
@@ -43,19 +43,30 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
 
   defp post_attrs(student, section, root_section_resource, parent_post, body, anonymous) do
     config = root_section_resource.collab_space_config
-    auto_accept = is_nil(config) or Map.get(config, :auto_accept, true)
 
-    %{
-      user_id: student.id,
-      section_id: section.id,
-      resource_id: root_section_resource.resource_id,
-      status: if(auto_accept, do: :approved, else: :submitted),
-      visibility: :public,
-      anonymous: anonymous,
-      content: %PostContent{message: body}
-    }
-    |> maybe_put_parent(parent_post)
+    if anonymous && !anonymous_posting_enabled?(config) do
+      {:error, "Anonymous posting is not enabled for section '#{section.slug}'"}
+    else
+      auto_accept = is_nil(config) or Map.get(config, :auto_accept, true)
+
+      attrs =
+        %{
+          user_id: student.id,
+          section_id: section.id,
+          resource_id: root_section_resource.resource_id,
+          status: if(auto_accept, do: :approved, else: :submitted),
+          visibility: :public,
+          anonymous: anonymous,
+          content: %PostContent{message: body}
+        }
+        |> maybe_put_parent(parent_post)
+
+      {:ok, attrs}
+    end
   end
+
+  defp anonymous_posting_enabled?(nil), do: false
+  defp anonymous_posting_enabled?(config), do: Map.get(config, :anonymous_posting, false)
 
   defp maybe_put_parent(attrs, nil), do: attrs
 

--- a/lib/oli/scenarios/directives/discussion_post_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_post_handler.ex
@@ -26,6 +26,7 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
          {:ok, section} <- fetch_section(state, section_name),
          {:ok, root_section_resource} <- fetch_root_section_resource(section),
          {:ok, parent_post} <- fetch_parent_post(state, reply_to),
+         :ok <- validate_parent_post(parent_post, section, root_section_resource),
          {:ok, attrs} <-
            post_attrs(student, section, root_section_resource, parent_post, body, anonymous),
          {:ok, post} <-
@@ -67,6 +68,17 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
 
   defp anonymous_posting_enabled?(nil), do: false
   defp anonymous_posting_enabled?(config), do: Map.get(config, :anonymous_posting, false)
+
+  defp validate_parent_post(nil, _section, _root_section_resource), do: :ok
+
+  defp validate_parent_post(parent_post, section, root_section_resource) do
+    if parent_post.section_id == section.id and
+         parent_post.resource_id == root_section_resource.resource_id do
+      :ok
+    else
+      {:error, "Parent discussion post does not belong to section '#{section.slug}'"}
+    end
+  end
 
   defp maybe_put_parent(attrs, nil), do: attrs
 

--- a/lib/oli/scenarios/directives/discussion_post_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_post_handler.ex
@@ -5,11 +5,13 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
 
   alias Oli.CertificationEligibility
   alias Oli.Delivery.GrantedCertificates
+  alias Oli.Delivery.Sections
   alias Oli.Repo
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.PostContent
   alias Oli.Scenarios.DirectiveTypes.{DiscussionPostDirective, ExecutionState}
   alias Oli.Scenarios.Engine
+  alias Lti_1p3.Roles.ContextRoles
 
   def handle(
         %DiscussionPostDirective{
@@ -24,6 +26,7 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
       ) do
     with {:ok, student} <- fetch_user(state, student_name),
          {:ok, section} <- fetch_section(state, section_name),
+         :ok <- validate_student_enrollment(student, section),
          {:ok, root_section_resource} <- fetch_root_section_resource(section),
          {:ok, parent_post} <- fetch_parent_post(state, reply_to),
          :ok <- validate_parent_post(parent_post, section, root_section_resource),
@@ -80,6 +83,24 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
 
   defp anonymous_posting_enabled?(nil), do: false
   defp anonymous_posting_enabled?(config), do: Map.get(config, :anonymous_posting, false)
+
+  defp validate_student_enrollment(student, section) do
+    learner_role_id = ContextRoles.get_role(:context_learner).id
+
+    case Sections.get_enrollment(section.slug, student.id) do
+      nil ->
+        {:error, "Student '#{student.email}' is not enrolled in section '#{section.slug}'"}
+
+      enrollment ->
+        enrollment = Repo.preload(enrollment, :context_roles)
+
+        if Enum.any?(enrollment.context_roles, &(&1.id == learner_role_id)) do
+          :ok
+        else
+          {:error, "Student '#{student.email}' is not enrolled in section '#{section.slug}'"}
+        end
+    end
+  end
 
   defp validate_parent_post(nil, _section, _root_section_resource), do: :ok
 

--- a/lib/oli/scenarios/directives/discussion_post_handler.ex
+++ b/lib/oli/scenarios/directives/discussion_post_handler.ex
@@ -5,33 +5,68 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
 
   alias Oli.CertificationEligibility
   alias Oli.Delivery.GrantedCertificates
+  alias Oli.Repo
+  alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.PostContent
   alias Oli.Scenarios.DirectiveTypes.{DiscussionPostDirective, ExecutionState}
   alias Oli.Scenarios.Engine
 
   def handle(
-        %DiscussionPostDirective{student: student_name, section: section_name, body: body},
+        %DiscussionPostDirective{
+          name: post_name,
+          student: student_name,
+          section: section_name,
+          body: body,
+          reply_to: reply_to,
+          anonymous: anonymous
+        },
         %ExecutionState{} = state
       ) do
     with {:ok, student} <- fetch_user(state, student_name),
          {:ok, section} <- fetch_section(state, section_name),
-         {:ok, _post} <-
+         {:ok, root_section_resource} <- fetch_root_section_resource(section),
+         {:ok, parent_post} <- fetch_parent_post(state, reply_to),
+         attrs <-
+           post_attrs(student, section, root_section_resource, parent_post, body, anonymous),
+         {:ok, post} <-
            CertificationEligibility.create_post_and_verify_qualification(
-             %{
-               user_id: student.id,
-               section_id: section.id,
-               visibility: :public,
-               content: %PostContent{message: body}
-             },
+             attrs,
              true
            ) do
       GrantedCertificates.has_qualified(student.id, section.id)
-      {:ok, state}
+      {:ok, maybe_store_post(state, post_name, post)}
     else
       {:error, reason} ->
         {:error, "Failed to create discussion post: #{inspect(reason)}"}
     end
   end
+
+  defp post_attrs(student, section, root_section_resource, parent_post, body, anonymous) do
+    config = root_section_resource.collab_space_config
+    auto_accept = is_nil(config) or Map.get(config, :auto_accept, true)
+
+    %{
+      user_id: student.id,
+      section_id: section.id,
+      resource_id: root_section_resource.resource_id,
+      status: if(auto_accept, do: :approved, else: :submitted),
+      visibility: :public,
+      anonymous: anonymous,
+      content: %PostContent{message: body}
+    }
+    |> maybe_put_parent(parent_post)
+  end
+
+  defp maybe_put_parent(attrs, nil), do: attrs
+
+  defp maybe_put_parent(attrs, parent_post) do
+    attrs
+    |> Map.put(:parent_post_id, parent_post.id)
+    |> Map.put(:thread_root_id, parent_post.thread_root_id || parent_post.id)
+  end
+
+  defp maybe_store_post(state, nil, _post), do: state
+  defp maybe_store_post(state, name, post), do: Engine.put_discussion_post(state, name, post)
 
   defp fetch_user(state, name) do
     case Engine.get_user(state, name) do
@@ -44,6 +79,27 @@ defmodule Oli.Scenarios.Directives.DiscussionPostHandler do
     case Engine.get_section(state, name) do
       nil -> {:error, "Section '#{name}' not found"}
       section -> {:ok, section}
+    end
+  end
+
+  defp fetch_root_section_resource(section) do
+    section = Repo.preload(section, :root_section_resource)
+
+    case section.root_section_resource do
+      nil -> {:error, "Root section resource not found for section '#{section.slug}'"}
+      root_section_resource -> {:ok, root_section_resource}
+    end
+  end
+
+  defp fetch_parent_post(_state, nil), do: {:ok, nil}
+
+  defp fetch_parent_post(state, name) do
+    case Engine.get_discussion_post(state, name) do
+      nil ->
+        {:error, "Discussion post '#{name}' not found"}
+
+      post ->
+        {:ok, Collaboration.get_post_by(%{id: post.id}) || post}
     end
   end
 end

--- a/lib/oli/scenarios/engine.ex
+++ b/lib/oli/scenarios/engine.ex
@@ -34,6 +34,9 @@ defmodule Oli.Scenarios.Engine do
     AnswerQuestionDirective,
     CertificateDirective,
     DiscussionPostDirective,
+    DiscussionConfigDirective,
+    DiscussionModerationDirective,
+    DiscussionDeleteDirective,
     ClassNoteDirective,
     CompleteScoredPageDirective,
     FinalizeAttemptDirective,
@@ -74,6 +77,9 @@ defmodule Oli.Scenarios.Engine do
     AnswerQuestionHandler,
     CertificateHandler,
     DiscussionPostHandler,
+    DiscussionConfigHandler,
+    DiscussionModerationHandler,
+    DiscussionDeleteHandler,
     ClassNoteHandler,
     CompleteScoredPageHandler,
     FinalizeAttemptHandler,
@@ -158,6 +164,7 @@ defmodule Oli.Scenarios.Engine do
           page_attempts: %{},
           finalized_attempts: %{},
           activity_evaluations: %{},
+          discussion_posts: %{},
           gates: %{},
           scenario_time: nil,
           params: opts[:params] || %{},
@@ -333,6 +340,18 @@ defmodule Oli.Scenarios.Engine do
     DiscussionPostHandler.handle(directive, state)
   end
 
+  def execute_directive(%DiscussionConfigDirective{} = directive, state) do
+    DiscussionConfigHandler.handle(directive, state)
+  end
+
+  def execute_directive(%DiscussionModerationDirective{} = directive, state) do
+    DiscussionModerationHandler.handle(directive, state)
+  end
+
+  def execute_directive(%DiscussionDeleteDirective{} = directive, state) do
+    DiscussionDeleteHandler.handle(directive, state)
+  end
+
   def execute_directive(%ClassNoteDirective{} = directive, state) do
     ClassNoteHandler.handle(directive, state)
   end
@@ -443,6 +462,20 @@ defmodule Oli.Scenarios.Engine do
   """
   def put_user(state, name, user) do
     %{state | users: Map.put(state.users, name, user)}
+  end
+
+  @doc """
+  Gets a named discussion post from the state.
+  """
+  def get_discussion_post(state, name) do
+    Map.get(state.discussion_posts, name)
+  end
+
+  @doc """
+  Upserts a discussion post by name into the state.
+  """
+  def put_discussion_post(state, name, post) do
+    %{state | discussion_posts: Map.put(state.discussion_posts, name, post)}
   end
 
   @doc """

--- a/priv/schemas/v0-1-0/scenario.schema.json
+++ b/priv/schemas/v0-1-0/scenario.schema.json
@@ -256,6 +256,24 @@
         "admin_title3": { "type": "string" }
       }
     },
+    "discussionAssertion": {
+      "type": "object",
+      "required": ["section"],
+      "additionalProperties": false,
+      "properties": {
+        "section": { "type": "string" },
+        "post": { "type": "string" },
+        "student": { "type": "string" },
+        "visible": { "$ref": "#/definitions/booleanLike" },
+        "status": {
+          "type": "string",
+          "enum": ["submitted", "approved", "deleted", "archived"]
+        },
+        "contains_discussions": { "$ref": "#/definitions/booleanLike" },
+        "auto_accept": { "$ref": "#/definitions/booleanLike" },
+        "anonymous_posting": { "$ref": "#/definitions/booleanLike" }
+      }
+    },
     "gatingAssertion": {
       "type": "object",
       "additionalProperties": false,
@@ -471,6 +489,7 @@
         "activity_customization": { "$ref": "#/definitions/activityCustomizationAssertion" },
         "page_objectives": { "$ref": "#/definitions/pageObjectivesAssertion" },
         "activity_objectives": { "$ref": "#/definitions/activityObjectivesAssertion" },
+        "discussion": { "$ref": "#/definitions/discussionAssertion" },
         "assertions": {}
       }
     },
@@ -492,6 +511,7 @@
         "activity_customization": { "$ref": "#/definitions/activityCustomizationAssertion" },
         "page_objectives": { "$ref": "#/definitions/pageObjectivesAssertion" },
         "activity_objectives": { "$ref": "#/definitions/activityObjectivesAssertion" },
+        "discussion": { "$ref": "#/definitions/discussionAssertion" },
         "assertions": {}
       }
     },
@@ -1642,6 +1662,24 @@
         },
         {
           "type": "object",
+          "required": ["discussion_config"],
+          "additionalProperties": false,
+          "properties": {
+            "discussion_config": {
+              "type": "object",
+              "required": ["section"],
+              "additionalProperties": false,
+              "properties": {
+                "section": { "type": "string" },
+                "enabled": { "$ref": "#/definitions/booleanLike" },
+                "auto_accept": { "$ref": "#/definitions/booleanLike" },
+                "anonymous_posting": { "$ref": "#/definitions/booleanLike" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
           "required": ["discussion_post"],
           "additionalProperties": false,
           "properties": {
@@ -1650,9 +1688,48 @@
               "required": ["student", "section", "body"],
               "additionalProperties": false,
               "properties": {
+                "name": { "type": "string" },
                 "student": { "type": "string" },
                 "section": { "type": "string" },
-                "body": { "type": "string" }
+                "body": { "type": "string" },
+                "reply_to": { "type": "string" },
+                "anonymous": { "$ref": "#/definitions/booleanLike" }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["discussion_moderation"],
+          "additionalProperties": false,
+          "properties": {
+            "discussion_moderation": {
+              "type": "object",
+              "required": ["post", "instructor", "action"],
+              "additionalProperties": false,
+              "properties": {
+                "post": { "type": "string" },
+                "instructor": { "type": "string" },
+                "action": {
+                  "type": "string",
+                  "enum": ["approve", "reject"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["discussion_delete"],
+          "additionalProperties": false,
+          "properties": {
+            "discussion_delete": {
+              "type": "object",
+              "required": ["post", "actor"],
+              "additionalProperties": false,
+              "properties": {
+                "post": { "type": "string" },
+                "actor": { "type": "string" }
               }
             }
           }

--- a/test/oli/scenarios/certificate_directives_test.exs
+++ b/test/oli/scenarios/certificate_directives_test.exs
@@ -40,6 +40,10 @@ defmodule Oli.Scenarios.CertificateDirectivesTest do
         from: "certificate_product"
         title: "Certificate Section"
 
+    - discussion_config:
+        section: "certificate_section"
+        enabled: true
+
     - user:
         name: "instructor_1"
         type: "instructor"

--- a/test/oli/scenarios/certificate_directives_test.exs
+++ b/test/oli/scenarios/certificate_directives_test.exs
@@ -54,6 +54,10 @@ defmodule Oli.Scenarios.CertificateDirectivesTest do
         type: "student"
         email: "student_1@test.edu"
 
+    - enroll:
+        user: "student_1"
+        section: "certificate_section"
+
     - assert:
         certificate:
           section: "certificate_section"

--- a/test/oli/scenarios/discussion_directives_test.exs
+++ b/test/oli/scenarios/discussion_directives_test.exs
@@ -97,6 +97,47 @@ defmodule Oli.Scenarios.DiscussionDirectivesTest do
       assert error =~ "Discussions are not enabled"
     end
 
+    test "rejects posts by students who are not enrolled in the section" do
+      yaml = """
+      - project:
+          name: "unenrolled_discussion_course"
+          title: "Unenrolled Discussion Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "unenrolled_discussion_product"
+          title: "Unenrolled Discussion Product"
+          from: "unenrolled_discussion_course"
+
+      - discussion_config:
+          section: "unenrolled_discussion_product"
+          enabled: true
+
+      - section:
+          name: "unenrolled_discussion_section"
+          title: "Unenrolled Discussion Section"
+          from: "unenrolled_discussion_product"
+
+      - user:
+          name: "unenrolled_discussion_student"
+          type: "student"
+          email: "unenrolled_discussion_student@test.edu"
+
+      - discussion_post:
+          name: "unenrolled_discussion_post"
+          student: "unenrolled_discussion_student"
+          section: "unenrolled_discussion_section"
+          body: "This post should be rejected."
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "is not enrolled in section"
+    end
+
     test "defaults posts to approved when auto accept is not configured" do
       yaml = """
       - project:
@@ -210,6 +251,69 @@ defmodule Oli.Scenarios.DiscussionDirectivesTest do
 
       assert [{_, error}] = result.errors
       assert error =~ "Parent discussion post does not belong to section"
+    end
+  end
+
+  describe "discussion assertions" do
+    test "fail when a named post belongs to another section even without visibility asserted" do
+      yaml = """
+      - project:
+          name: "assert_post_scope_course"
+          title: "Assert Post Scope Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "assert_post_scope_product"
+          title: "Assert Post Scope Product"
+          from: "assert_post_scope_course"
+
+      - discussion_config:
+          section: "assert_post_scope_product"
+          enabled: true
+
+      - section:
+          name: "assert_first_section"
+          title: "Assert First Section"
+          from: "assert_post_scope_product"
+
+      - section:
+          name: "assert_second_section"
+          title: "Assert Second Section"
+          from: "assert_post_scope_product"
+
+      - user:
+          name: "assert_post_scope_student"
+          type: "student"
+          email: "assert_post_scope_student@test.edu"
+
+      - enroll:
+          user: "assert_post_scope_student"
+          section: "assert_first_section"
+
+      - enroll:
+          user: "assert_post_scope_student"
+          section: "assert_second_section"
+
+      - discussion_post:
+          name: "first_section_status_post"
+          student: "assert_post_scope_student"
+          section: "assert_first_section"
+          body: "This post belongs to the first section."
+
+      - assert:
+          discussion:
+            section: "assert_second_section"
+            post: "first_section_status_post"
+            status: "approved"
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert result.errors == []
+      assert [%{passed: false, message: message}] = result.verifications
+      assert message =~ "post does not belong to section"
     end
   end
 

--- a/test/oli/scenarios/discussion_directives_test.exs
+++ b/test/oli/scenarios/discussion_directives_test.exs
@@ -51,6 +51,68 @@ defmodule Oli.Scenarios.DiscussionDirectivesTest do
       assert [{_, error}] = result.errors
       assert error =~ "Anonymous posting is not enabled"
     end
+
+    test "rejects replies to posts from another section" do
+      yaml = """
+      - project:
+          name: "cross_section_reply_course"
+          title: "Cross Section Reply Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "cross_section_reply_product"
+          title: "Cross Section Reply Product"
+          from: "cross_section_reply_course"
+
+      - discussion_config:
+          section: "cross_section_reply_product"
+          enabled: true
+          auto_accept: true
+
+      - section:
+          name: "first_discussion_section"
+          title: "First Discussion Section"
+          from: "cross_section_reply_product"
+
+      - section:
+          name: "second_discussion_section"
+          title: "Second Discussion Section"
+          from: "cross_section_reply_product"
+
+      - user:
+          name: "cross_section_student"
+          type: "student"
+          email: "cross_section_student@test.edu"
+
+      - enroll:
+          user: "cross_section_student"
+          section: "first_discussion_section"
+
+      - enroll:
+          user: "cross_section_student"
+          section: "second_discussion_section"
+
+      - discussion_post:
+          name: "first_section_post"
+          student: "cross_section_student"
+          section: "first_discussion_section"
+          body: "This post belongs to the first section."
+
+      - discussion_post:
+          name: "cross_section_reply"
+          student: "cross_section_student"
+          section: "second_discussion_section"
+          reply_to: "first_section_post"
+          body: "This reply should be rejected."
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "Parent discussion post does not belong to section"
+    end
   end
 
   describe "discussion_moderation" do

--- a/test/oli/scenarios/discussion_directives_test.exs
+++ b/test/oli/scenarios/discussion_directives_test.exs
@@ -1,0 +1,117 @@
+defmodule Oli.Scenarios.DiscussionDirectivesTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios.DirectiveParser
+  alias Oli.Scenarios.Engine
+
+  describe "discussion_post" do
+    test "rejects anonymous posts when anonymous posting is disabled" do
+      yaml = """
+      - project:
+          name: "anonymous_disabled_course"
+          title: "Anonymous Disabled Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "anonymous_disabled_product"
+          title: "Anonymous Disabled Product"
+          from: "anonymous_disabled_course"
+
+      - discussion_config:
+          section: "anonymous_disabled_product"
+          enabled: true
+          anonymous_posting: false
+
+      - section:
+          name: "anonymous_disabled_section"
+          title: "Anonymous Disabled Section"
+          from: "anonymous_disabled_product"
+
+      - user:
+          name: "anonymous_student"
+          type: "student"
+          email: "anonymous_student@test.edu"
+
+      - enroll:
+          user: "anonymous_student"
+          section: "anonymous_disabled_section"
+
+      - discussion_post:
+          name: "anonymous_post"
+          student: "anonymous_student"
+          section: "anonymous_disabled_section"
+          anonymous: true
+          body: "This anonymous post should be rejected."
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "Anonymous posting is not enabled"
+    end
+  end
+
+  describe "discussion_moderation" do
+    test "rejects moderation by a user without an instructor role in the section" do
+      yaml = """
+      - project:
+          name: "moderation_auth_course"
+          title: "Moderation Auth Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "moderation_auth_product"
+          title: "Moderation Auth Product"
+          from: "moderation_auth_course"
+
+      - discussion_config:
+          section: "moderation_auth_product"
+          enabled: true
+          auto_accept: false
+
+      - section:
+          name: "moderation_auth_section"
+          title: "Moderation Auth Section"
+          from: "moderation_auth_product"
+
+      - user:
+          name: "post_author"
+          type: "student"
+          email: "post_author@test.edu"
+
+      - user:
+          name: "student_moderator"
+          type: "student"
+          email: "student_moderator@test.edu"
+
+      - enroll:
+          user: "post_author"
+          section: "moderation_auth_section"
+
+      - enroll:
+          user: "student_moderator"
+          section: "moderation_auth_section"
+
+      - discussion_post:
+          name: "pending_post"
+          student: "post_author"
+          section: "moderation_auth_section"
+          body: "This post needs a real moderator."
+
+      - discussion_moderation:
+          post: "pending_post"
+          instructor: "student_moderator"
+          action: "approve"
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "not authorized to moderate"
+    end
+  end
+end

--- a/test/oli/scenarios/discussion_directives_test.exs
+++ b/test/oli/scenarios/discussion_directives_test.exs
@@ -52,6 +52,104 @@ defmodule Oli.Scenarios.DiscussionDirectivesTest do
       assert error =~ "Anonymous posting is not enabled"
     end
 
+    test "rejects posts when discussions are disabled" do
+      yaml = """
+      - project:
+          name: "disabled_discussion_course"
+          title: "Disabled Discussion Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "disabled_discussion_product"
+          title: "Disabled Discussion Product"
+          from: "disabled_discussion_course"
+
+      - discussion_config:
+          section: "disabled_discussion_product"
+          enabled: false
+
+      - section:
+          name: "disabled_discussion_section"
+          title: "Disabled Discussion Section"
+          from: "disabled_discussion_product"
+
+      - user:
+          name: "disabled_discussion_student"
+          type: "student"
+          email: "disabled_discussion_student@test.edu"
+
+      - enroll:
+          user: "disabled_discussion_student"
+          section: "disabled_discussion_section"
+
+      - discussion_post:
+          name: "disabled_discussion_post"
+          student: "disabled_discussion_student"
+          section: "disabled_discussion_section"
+          body: "This post should be rejected."
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "Discussions are not enabled"
+    end
+
+    test "defaults posts to approved when auto accept is not configured" do
+      yaml = """
+      - project:
+          name: "auto_accept_default_course"
+          title: "Auto Accept Default Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "auto_accept_default_product"
+          title: "Auto Accept Default Product"
+          from: "auto_accept_default_course"
+
+      - discussion_config:
+          section: "auto_accept_default_product"
+          enabled: true
+
+      - section:
+          name: "auto_accept_default_section"
+          title: "Auto Accept Default Section"
+          from: "auto_accept_default_product"
+
+      - user:
+          name: "auto_accept_default_student"
+          type: "student"
+          email: "auto_accept_default_student@test.edu"
+
+      - enroll:
+          user: "auto_accept_default_student"
+          section: "auto_accept_default_section"
+
+      - discussion_post:
+          name: "auto_accept_default_post"
+          student: "auto_accept_default_student"
+          section: "auto_accept_default_section"
+          body: "This post should be auto-approved."
+
+      - assert:
+          discussion:
+            section: "auto_accept_default_section"
+            post: "auto_accept_default_post"
+            student: "auto_accept_default_student"
+            status: "approved"
+            visible: true
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert result.errors == []
+      assert Enum.all?(result.verifications, & &1.passed)
+    end
+
     test "rejects replies to posts from another section" do
       yaml = """
       - project:
@@ -174,6 +272,66 @@ defmodule Oli.Scenarios.DiscussionDirectivesTest do
 
       assert [{_, error}] = result.errors
       assert error =~ "not authorized to moderate"
+    end
+  end
+
+  describe "discussion_delete" do
+    test "rejects deletion by a user who is neither the post owner nor section instructor" do
+      yaml = """
+      - project:
+          name: "delete_auth_course"
+          title: "Delete Auth Course"
+          root:
+            children:
+              - page: "Welcome"
+
+      - product:
+          name: "delete_auth_product"
+          title: "Delete Auth Product"
+          from: "delete_auth_course"
+
+      - discussion_config:
+          section: "delete_auth_product"
+          enabled: true
+
+      - section:
+          name: "delete_auth_section"
+          title: "Delete Auth Section"
+          from: "delete_auth_product"
+
+      - user:
+          name: "delete_post_owner"
+          type: "student"
+          email: "delete_post_owner@test.edu"
+
+      - user:
+          name: "delete_other_student"
+          type: "student"
+          email: "delete_other_student@test.edu"
+
+      - enroll:
+          user: "delete_post_owner"
+          section: "delete_auth_section"
+
+      - enroll:
+          user: "delete_other_student"
+          section: "delete_auth_section"
+
+      - discussion_post:
+          name: "owned_post"
+          student: "delete_post_owner"
+          section: "delete_auth_section"
+          body: "Only the owner or instructor can delete this."
+
+      - discussion_delete:
+          post: "owned_post"
+          actor: "delete_other_student"
+      """
+
+      result = yaml |> DirectiveParser.parse_yaml!() |> Engine.execute()
+
+      assert [{_, error}] = result.errors
+      assert error =~ "not authorized to delete"
     end
   end
 end

--- a/test/scenarios/certificates/student_progress_pending_and_approval.scenario.yaml
+++ b/test/scenarios/certificates/student_progress_pending_and_approval.scenario.yaml
@@ -39,6 +39,10 @@
     title: "Certificate Progress Section"
     from: "certificate_progress_product"
 
+- discussion_config:
+    section: "certificate_progress_section"
+    enabled: true
+
 - user:
     name: "certificate_instructor"
     type: "instructor"

--- a/test/scenarios/discussions/course_discussions.scenario.yaml
+++ b/test/scenarios/discussions/course_discussions.scenario.yaml
@@ -72,6 +72,21 @@
       status: "approved"
       visible: true
 
+- discussion_post:
+    name: "auto_accepted_reply"
+    student: "student_b"
+    section: "discussion_section"
+    reply_to: "auto_accepted_post"
+    body: "This reply is visible immediately."
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "auto_accepted_reply"
+      student: "student_a"
+      status: "approved"
+      visible: true
+
 - discussion_delete:
     post: "auto_accepted_post"
     actor: "student_a"

--- a/test/scenarios/discussions/course_discussions.scenario.yaml
+++ b/test/scenarios/discussions/course_discussions.scenario.yaml
@@ -1,0 +1,166 @@
+# Course discussion participation and moderation workflows.
+
+- project:
+    name: "discussion_course"
+    title: "Discussion Course"
+    root:
+      children:
+        - page: "Welcome"
+
+- product:
+    name: "discussion_product"
+    title: "Discussion Product"
+    from: "discussion_course"
+
+- discussion_config:
+    section: "discussion_product"
+    enabled: true
+    auto_accept: true
+    anonymous_posting: false
+
+- section:
+    name: "discussion_section"
+    title: "Discussion Section"
+    from: "discussion_product"
+
+- user:
+    name: "discussion_instructor"
+    type: "instructor"
+    email: "discussion_instructor@test.edu"
+
+- user:
+    name: "student_a"
+    type: "student"
+    email: "student_a@test.edu"
+
+- user:
+    name: "student_b"
+    type: "student"
+    email: "student_b@test.edu"
+
+- enroll:
+    user: "discussion_instructor"
+    section: "discussion_section"
+    role: "instructor"
+
+- enroll:
+    user: "student_a"
+    section: "discussion_section"
+
+- enroll:
+    user: "student_b"
+    section: "discussion_section"
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      contains_discussions: true
+      auto_accept: true
+      anonymous_posting: false
+
+- discussion_post:
+    name: "auto_accepted_post"
+    student: "student_a"
+    section: "discussion_section"
+    body: "This post is visible immediately."
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "auto_accepted_post"
+      student: "student_b"
+      status: "approved"
+      visible: true
+
+- discussion_delete:
+    post: "auto_accepted_post"
+    actor: "student_a"
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "auto_accepted_post"
+      status: "deleted"
+
+- discussion_config:
+    section: "discussion_section"
+    enabled: true
+    auto_accept: false
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      contains_discussions: true
+      auto_accept: false
+
+- discussion_post:
+    name: "pending_post"
+    student: "student_a"
+    section: "discussion_section"
+    body: "This post needs approval."
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "pending_post"
+      student: "student_a"
+      status: "submitted"
+      visible: true
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "pending_post"
+      student: "student_b"
+      visible: false
+
+- discussion_moderation:
+    post: "pending_post"
+    instructor: "discussion_instructor"
+    action: "approve"
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "pending_post"
+      student: "student_b"
+      status: "approved"
+      visible: true
+
+- discussion_post:
+    name: "rejected_post"
+    student: "student_a"
+    section: "discussion_section"
+    body: "This post will be rejected."
+
+- discussion_moderation:
+    post: "rejected_post"
+    instructor: "discussion_instructor"
+    action: "reject"
+
+- assert:
+    discussion:
+      section: "discussion_section"
+      post: "rejected_post"
+      student: "student_b"
+      status: "deleted"
+      visible: true
+
+- product:
+    name: "discussion_disabled_product"
+    title: "Discussion Disabled Product"
+    from: "discussion_course"
+
+- discussion_config:
+    section: "discussion_disabled_product"
+    enabled: false
+
+- section:
+    name: "discussion_disabled_section"
+    title: "Discussion Disabled Section"
+    from: "discussion_disabled_product"
+
+- assert:
+    discussion:
+      section: "discussion_disabled_section"
+      contains_discussions: false

--- a/test/scenarios/discussions/discussions_test.exs
+++ b/test/scenarios/discussions/discussions_test.exs
@@ -1,0 +1,33 @@
+defmodule Oli.Scenarios.DiscussionsTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios
+  alias Oli.Scenarios.RuntimeOpts
+
+  @scenario_dir Path.dirname(__ENV__.file)
+
+  for path <- Path.wildcard(Path.join(@scenario_dir, "*.scenario.yaml")) |> Enum.sort() do
+    name =
+      path
+      |> Path.basename(".scenario.yaml")
+      |> String.replace("_", " ")
+
+    @scenario_path path
+    test "scenario: #{name}" do
+      assert :ok = Scenarios.validate_file(@scenario_path)
+
+      result =
+        Scenarios.execute_file(
+          @scenario_path,
+          RuntimeOpts.build()
+        )
+
+      assert result.errors == []
+
+      failed_verifications =
+        Enum.filter(result.verifications, fn verification -> !verification.passed end)
+
+      assert failed_verifications == []
+    end
+  end
+end

--- a/test/support/scenarios/docs/student_simulation.md
+++ b/test/support/scenarios/docs/student_simulation.md
@@ -261,19 +261,103 @@ directives:
 
 ## discussion_post
 
-Creates a learner discussion post in a section and then evaluates certificate qualification synchronously.
+Creates a learner course discussion post in a section. Scenario execution also processes certificate eligibility synchronously, preserving the deterministic side effect that production normally enqueues when certificate checks are required.
 
 ### Parameters
+- `name`: Scenario-local post name for later moderation, deletion, or assertions
 - `student`: Name of the student user (required)
 - `section`: Name of the section (required)
 - `body`: Post body text (required)
+- `reply_to`: Scenario-local parent post name when creating a reply
+- `anonymous`: Whether to create the post anonymously
 
 ### Example
 ```yaml
 - discussion_post:
+    name: "alice_intro"
     student: "alice"
     section: "my_section"
     body: "My discussion contribution"
+```
+
+---
+
+## discussion_config
+
+Configures course discussions on a section or product blueprint by updating the root section resource collaboration config and the section `contains_discussions` flag.
+
+### Parameters
+- `section`: Scenario name of the section or product (required)
+- `enabled`: Whether Course Discussions are enabled
+- `auto_accept`: Whether posts are visible without instructor approval
+- `anonymous_posting`: Whether anonymous posting is enabled
+
+### Example
+```yaml
+- discussion_config:
+    section: "my_product"
+    enabled: true
+    auto_accept: false
+```
+
+---
+
+## discussion_moderation
+
+Applies instructor moderation to a named discussion post.
+
+### Parameters
+- `post`: Scenario-local post name (required)
+- `instructor`: Scenario user name for the instructor (required)
+- `action`: `approve` or `reject` (required)
+
+### Example
+```yaml
+- discussion_moderation:
+    post: "alice_intro"
+    instructor: "instructor_1"
+    action: "approve"
+```
+
+---
+
+## discussion_delete
+
+Deletes a named discussion post through the collaboration authorization path.
+
+### Parameters
+- `post`: Scenario-local post name (required)
+- `actor`: Scenario user name for the deleting user (required)
+
+### Example
+```yaml
+- discussion_delete:
+    post: "alice_intro"
+    actor: "alice"
+```
+
+---
+
+## discussion assertions
+
+Use `assert.discussion` to verify course discussion configuration, named post status, and student-visible discussion listings.
+
+### Supported checks
+- `contains_discussions`
+- `auto_accept`
+- `anonymous_posting`
+- named post `status`: `submitted`, `approved`, `deleted`, or `archived`
+- named post `visible` for a specific student
+
+### Example
+```yaml
+- assert:
+    discussion:
+      section: "my_section"
+      post: "alice_intro"
+      student: "bob"
+      status: "approved"
+      visible: true
 ```
 
 ---


### PR DESCRIPTION
## Summary

  Adds scenario-level coverage for Course Discussion participation and moderation workflows for [MER-5495](https://eliterate.atlassian.net/browse/MER-5495).

  This extends `Oli.Scenarios` with reusable discussion primitives:

  - `discussion_config`
  - named `discussion_post`
  - `discussion_moderation`
  - `discussion_delete`
  - `assert.discussion`

  The new scenario covers:

  - Course Discussion enabled/disabled inheritance from product to section
  - student post creation
  - visibility to another student
  - student deletion
  - pending posts when auto-accept is disabled
  - instructor approval
  - instructor rejection/deleted state

  Existing certificate scenario behavior is preserved: `discussion_post` still synchronously processes certificate eligibility side effects.

  ## Why Scenario Coverage

  The manual regression tests describe end-to-end user workflows, but the behavior under test is primarily application state and LiveView/server event behavior, not browser-specific rendering or external integration.

  Per the automated testing plan, the preferred hierarchy is:

  1. Scenario tests for integrated application workflows
  2. LiveView tests where UI event wiring needs direct coverage
  3. Playwright only when browser behavior or cross-system behavior is essential

  For this work, scenario tests are sufficient because they exercise the real Torus application paths for section discussion
  configuration, post creation, moderation, deletion, visibility, and persistence without relying on brittle browser automation. No Canvas/LTI flow, browser-only interaction, or client-heavy behavior is required for the covered acceptance cases.

  ## Validation

  - `mix compile`
  - `MIX_ENV=test mix test test/scenarios/discussions/discussions_test.exs test/scenarios/certificates/certificates_test.exs test/oli/
  scenarios/certificate_directives_test.exs test/oli/scenarios/certificate_parser_test.exs test/scenarios/validation/
  invalid_attributes_test.exs test/scenarios/validation/schema_validation_test.exs`



[MER-5495]: https://eliterate.atlassian.net/browse/MER-5495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ