### PR TITLE
[ENHANCEMENT] [MER-5463] Scenario based automated schedule testing 

### DIFF
--- a/test/scenarios/delivery/scheduling/scheduling_test.exs
+++ b/test/scenarios/delivery/scheduling/scheduling_test.exs
@@ -1,0 +1,45 @@
+defmodule Oli.Scenarios.Delivery.SchedulingTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios
+  alias Oli.Scenarios.RuntimeOpts
+  alias Oli.Scenarios.ScenarioRunner
+
+  @scenario_dir Path.dirname(__ENV__.file)
+
+  @scenarios ScenarioRunner.discover_scenarios(@scenario_dir,
+               pattern: "*.yaml",
+               exclude: ["setup.yaml"],
+               include_metadata: true
+             )
+
+  for {name, path, metadata} <- @scenarios do
+    name = String.replace(name, "_", " ")
+
+    for tag <- metadata.tags do
+      @tag String.to_atom(tag)
+    end
+
+    if metadata.timeout_ms do
+      @tag timeout: metadata.timeout_ms
+    end
+
+    @scenario_path path
+    test "scenario: #{name}" do
+      assert :ok = Scenarios.validate_file(@scenario_path)
+
+      result =
+        Scenarios.execute_file(
+          @scenario_path,
+          RuntimeOpts.build()
+        )
+
+      assert result.errors == []
+
+      failed_verifications =
+        Enum.filter(result.verifications, fn verification -> !verification.passed end)
+
+      assert failed_verifications == []
+    end
+  end
+end

--- a/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
+++ b/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
@@ -1,0 +1,87 @@
+scenario:
+  tags:
+    - scheduling
+  reason: "Exercises section schedule creation, learner-facing due date terms, and late submission behavior."
+
+directives:
+  - use:
+      file: "setup.yaml"
+
+  - manipulate:
+      to: "scheduling_section"
+      ops:
+        - revise:
+            target: "Scheduled Quiz"
+            set:
+              start_date: "2040-12-23T21:00:00Z"
+              max_attempts: 3
+              time_limit: 0
+
+  - assert:
+      prologue:
+        section: "scheduling_section"
+        student: "student_1"
+        page: "Scheduled Quiz"
+        allow_attempt: false
+        show_blocking_gates: false
+        attempts_taken: 0
+        max_attempts: 3
+        attempts_summary: "Attempts 0/3"
+        next_attempt_ordinal: "1st"
+        attempt_message: "This assessment is not yet available. It will be available on December 23, 2040 9:00 PM UTC"
+
+  - manipulate:
+      to: "scheduling_section"
+      ops:
+        - revise:
+            target: "Scheduled Quiz"
+            set:
+              start_date: "2024-12-22T21:00:00Z"
+              end_date: "2024-12-23T21:00:00Z"
+              max_attempts: 3
+              time_limit: 0
+              late_policy: "@atom(allow_late_start_and_late_submit)"
+
+  - assert:
+      prologue:
+        section: "scheduling_section"
+        student: "student_1"
+        page: "Scheduled Quiz"
+        allow_attempt: true
+        show_blocking_gates: false
+        attempts_taken: 0
+        max_attempts: 3
+        attempts_summary: "Attempts 0/3"
+        next_attempt_ordinal: "1st"
+        attempt_message: "You have 3 attempts remaining out of 3 total attempts."
+        terms:
+          page_due_terms: "This assignment was available on Sun Dec 22, 2024 at 9:00pm. and was due on Mon Dec 23, 2024 by 9:00pm."
+          page_scoring_terms: "For this assignment, your score will be determined by your best attempt."
+          page_submit_term: "If you submit after the due date, it will be marked late."
+
+  - visit_page:
+      student: "student_1"
+      section: "scheduling_section"
+      page: "Scheduled Quiz"
+
+  - answer_question:
+      student: "student_1"
+      section: "scheduling_section"
+      page: "Scheduled Quiz"
+      activity_virtual_id: "scheduled_quiz_q1"
+      response: "b"
+
+  - finalize_attempt:
+      student: "student_1"
+      section: "scheduling_section"
+      page: "Scheduled Quiz"
+
+  - assert:
+      gradebook:
+        instructor: "instructor_1"
+        section: "scheduling_section"
+        student: "student_1"
+        page: "Scheduled Quiz"
+        score: 1.0
+        out_of: 1.0
+        was_late: true

--- a/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
+++ b/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
@@ -82,6 +82,7 @@ directives:
       section: "scheduling_section"
       page: "Scheduled Quiz"
 
+  # This verifies persisted gradebook data, not access through the instructor gradebook UI.
   - assert:
       gradebook:
         instructor: "instructor_1"

--- a/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
+++ b/test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml
@@ -30,6 +30,12 @@ directives:
         next_attempt_ordinal: "1st"
         attempt_message: "This assessment is not yet available. It will be available on December 23, 2040 9:00 PM UTC"
 
+  - start_attempt:
+      student: "student_1"
+      section: "scheduling_section"
+      page: "Scheduled Quiz"
+      expect: "before_start_date"
+
   - manipulate:
       to: "scheduling_section"
       ops:

--- a/test/scenarios/delivery/scheduling/setup.yaml
+++ b/test/scenarios/delivery/scheduling/setup.yaml
@@ -47,6 +47,11 @@
     email: "scheduling_student@test.edu"
 
 - enroll:
+    user: "instructor_1"
+    section: "scheduling_section"
+    role: "instructor"
+
+- enroll:
     user: "student_1"
     section: "scheduling_section"
     role: "student"

--- a/test/scenarios/delivery/scheduling/setup.yaml
+++ b/test/scenarios/delivery/scheduling/setup.yaml
@@ -1,0 +1,52 @@
+# Shared setup for delivery scheduling scenarios.
+
+- project:
+    name: "scheduling_source"
+    title: "Scheduling Source Project"
+    root:
+      children:
+        - page: "Scheduled Quiz"
+
+- edit_page:
+    project: "scheduling_source"
+    page: "Scheduled Quiz"
+    content: |
+      title: "Scheduled Quiz"
+      graded: true
+      blocks:
+        - type: activity
+          virtual_id: "scheduled_quiz_q1"
+          activity:
+            type: oli_multiple_choice
+            stem_md: "What is 3 + 3?"
+            choices:
+              - id: "a"
+                body_md: "5"
+                score: 0
+              - id: "b"
+                body_md: "6"
+                score: 1
+
+- publish:
+    to: "scheduling_source"
+    description: "Initial scheduled quiz page"
+
+- section:
+    name: "scheduling_section"
+    title: "Scheduling Section"
+    from: "scheduling_source"
+
+- user:
+    name: "instructor_1"
+    type: "instructor"
+    email: "scheduling_instructor@test.edu"
+
+- user:
+    name: "student_1"
+    type: "student"
+    email: "scheduling_student@test.edu"
+
+- enroll:
+    user: "student_1"
+    section: "scheduling_section"
+    role: "student"


### PR DESCRIPTION
## Summary

Implements MER-5463 by adding scenario coverage for section schedule creation and due-date behavior in delivery.

This PR adds a scheduling scenario that verifies:
- learner access is blocked before a future `start_date`
- learner-facing attempt messaging reflects availability and max attempts
- due-date/scoring/submission terms render for an available-but-past-due assessment
- late submissions are accepted under the configured late policy
- the instructor gradebook records the submitted attempt as late

## Changes

- Adds `test/scenarios/delivery/scheduling/scheduling_test.exs` to discover and run scheduling scenario YAML files.
- Adds `test/scenarios/delivery/scheduling/setup.yaml` with shared project, section, quiz, instructor, student, and enrollment setup.
- Adds `test/scenarios/delivery/scheduling/section_schedule_due_date_behavior.scenario.yaml` covering schedule mutation, prologue assertions, learner attempt flow, finalization, and
gradebook late-status verification.

## Jira

MER-5463

## Testing

```bash
mix test test/scenarios/delivery/scheduling/scheduling_test.exs