### PR TITLE
[CHORE] [MER-0000] Pin Danger TypeScript version

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
-      - run: npm i -D danger js-yaml micromatch typescript ts-node
+      - run: npm i -D danger js-yaml micromatch typescript@5.9.3 ts-node
       - run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
 ## Summary

  Pins the TypeScript version used by the Danger workflow to `5.9.3`.

  ## Problem

  Danger is currently failing in CI before it can execute our `dangerfile.ts` rules:

  ```text
  TypeError: ts.getDefaultCompilerOptions is not a function
      at typescriptify (.../node_modules/danger/distribution/runner/runners/utils/transpiler.js)
```

  The workflow installs Danger dependencies with unpinned versions on every run:

  `npm i -D danger js-yaml micromatch typescript ts-node`

  That allows npm to resolve a newer TypeScript version whose package/API shape is incompatible with Danger’s TypeScript transpiler. The crash happens while Danger is loading/transpiling our `dangerfile.ts`, before our repo-specific Danger logic runs.

  ## Fix

  Pin typescript to a known compatible 5.x version:

  `npm i -D danger js-yaml micromatch typescript@5.9.3 ts-node`

  `ts.getDefaultCompilerOptions` is present in TypeScript 5.9.3, so this restores the API expected by Danger’s transpiler while keeping the change minimal.

  ## Notes

  This is a CI infrastructure fix. It is unrelated to any specific application code change.

