### PR TITLE
[BUG FIX] [MER-5767] Fix practice page progress after reset

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,10 +3,10 @@ on: pull_request
 
 permissions:
   contents: read
-  pull-requests: write     # for PR comments/reviews
-  issues: write            # label add (if used)
-  checks: write            # if using the Checks API
-  statuses: write          # allow setting commit status
+  pull-requests: write # for PR comments/reviews
+  issues: write # label add (if used)
+  checks: write # if using the Checks API
+  statuses: write # allow setting commit status
 
 jobs:
   run:
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
-      - run: npm i -D danger js-yaml micromatch typescript ts-node
+      - run: npm i -D danger js-yaml micromatch typescript@5.9.3 ts-node
       - run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1212,17 +1212,17 @@ defmodule Oli.Delivery.Metrics do
   @doc """
   For an activity attempt specified by an attempt guid, calculate and set in the corresponding resource access
   record, the percentage complete for the related page. This calculation only needs to be performed after the
-  evaluation of the first attempt for given activity.  This method should update exactly one record, the resource
+  evaluation of a scoreable attempt for given activity.  This method should update exactly one record, the resource
   access for the page that this activity attempt ultimately pertains to (through its parent resource attempt).
 
   Can return one of:
   {:ok, :updated} -> Progress calculated and set
-  {:ok, :noop} -> Nothing needed to be done, since the attempt number was greater than 1
+  {:ok, :noop} -> Nothing needed to be done, since the attempt was not scoreable
   {:error, :unexpected_update_count} -> 0 or more than 1 record would have been updated, rolled back
   {:error, e} -> An other error occurred, rolled back
   """
   def update_page_progress(activity_attempt_guid) when is_binary(activity_attempt_guid) do
-    if Core.is_scoreable_first_attempt?(activity_attempt_guid) do
+    if scoreable_activity_attempt?(activity_attempt_guid) do
       do_update(activity_attempt_guid)
     else
       {:ok, :noop}
@@ -1231,7 +1231,6 @@ defmodule Oli.Delivery.Metrics do
 
   def update_page_progress(%ActivityAttempt{
         scoreable: true,
-        attempt_number: 1,
         attempt_guid: attempt_guid
       }) do
     do_update(attempt_guid)
@@ -1241,9 +1240,42 @@ defmodule Oli.Delivery.Metrics do
     {:ok, :noop}
   end
 
+  defp scoreable_activity_attempt?(activity_attempt_guid) do
+    Repo.exists?(
+      from(aa in ActivityAttempt,
+        where: aa.attempt_guid == ^activity_attempt_guid and aa.scoreable == true
+      )
+    )
+  end
+
   defp do_update(activity_attempt_guid) do
     Oli.Repo.transaction(fn ->
       sql = """
+        WITH target AS (
+          SELECT
+            ra.resource_access_id,
+            ra.revision_id,
+            aa.resource_attempt_id
+          FROM activity_attempts AS aa
+          JOIN resource_attempts AS ra ON ra.id = aa.resource_attempt_id
+          WHERE aa.attempt_guid = $1
+          LIMIT 1
+        ),
+        latest_attempts AS (
+          SELECT DISTINCT ON (aa2.resource_id)
+            aa2.id,
+            aa2.lifecycle_state
+          FROM activity_attempts AS aa2
+          JOIN target ON target.resource_attempt_id = aa2.resource_attempt_id
+          WHERE aa2.scoreable = true
+          ORDER BY aa2.resource_id, aa2.id DESC
+        ),
+        counts AS (
+          SELECT
+            COUNT(id) FILTER (WHERE lifecycle_state = 'evaluated' OR lifecycle_state = 'submitted')::float AS completed_count,
+            COUNT(id)::float AS total_count
+          FROM latest_attempts
+        )
         UPDATE
           resource_accesses
         SET
@@ -1253,18 +1285,8 @@ defmodule Oli.Delivery.Metrics do
               (
                 SELECT
                   completed_count / (total_count * ((COALESCE(rev.full_progress_pct, 100) / 100.0)))
-                FROM (
-                  SELECT
-                    COUNT(aa2.id) FILTER (WHERE aa2.lifecycle_state = 'evaluated' OR aa2.lifecycle_state = 'submitted')::float AS completed_count,
-                    COUNT(aa2.id)::float AS total_count
-                  FROM activity_attempts AS aa
-                  JOIN resource_attempts AS ra ON ra.id = aa.resource_attempt_id
-                  JOIN revisions AS rev ON ra.revision_id = rev.id
-                  JOIN activity_attempts AS aa2 ON ra.id = aa2.resource_attempt_id
-                  WHERE aa.attempt_guid = $1 AND aa2.scoreable = true AND aa2.attempt_number = 1
-                ) AS counts,
-                revisions AS rev
-                WHERE rev.id = (SELECT ra.revision_id FROM resource_attempts ra JOIN activity_attempts aa ON ra.id = aa.resource_attempt_id WHERE aa.attempt_guid = $1 LIMIT 1)
+                FROM counts, target
+                JOIN revisions AS rev ON rev.id = target.revision_id
               ),
               resource_accesses.progress
             )
@@ -1272,15 +1294,10 @@ defmodule Oli.Delivery.Metrics do
           updated_at = NOW()
         WHERE
           id =
-            (SELECT
-              resource_attempts.resource_access_id
-            FROM resource_attempts
-            JOIN activity_attempts ON resource_attempts.id = activity_attempts.resource_attempt_id
-            WHERE activity_attempts.attempt_guid = $2
-            LIMIT 1);
+            (SELECT resource_access_id FROM target);
       """
 
-      case Ecto.Adapters.SQL.query(Oli.Repo, sql, [activity_attempt_guid, activity_attempt_guid]) do
+      case Ecto.Adapters.SQL.query(Oli.Repo, sql, [activity_attempt_guid]) do
         {:ok, %{num_rows: 1}} ->
           :updated
 

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1268,7 +1268,7 @@ defmodule Oli.Delivery.Metrics do
           FROM activity_attempts AS aa2
           JOIN target ON target.resource_attempt_id = aa2.resource_attempt_id
           WHERE aa2.scoreable = true
-          ORDER BY aa2.resource_id, aa2.id DESC
+          ORDER BY aa2.resource_id, aa2.attempt_number DESC, aa2.id DESC
         ),
         counts AS (
           SELECT

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -331,6 +331,42 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       assert_in_delta 1.0, ra.progress, 0.0001
     end
 
+    test "page level progress selects latest activity attempts by attempt number", map do
+      [p1, _, _] = map.mod1_pages
+
+      map =
+        map
+        |> Map.put(:our_page, %{revision: p1.revision, resource: p1.resource})
+        |> Seeder.create_resource_attempt(
+          %{attempt_number: 1, lifecycle_state: :active},
+          :this_user,
+          :our_page,
+          :attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
+          :activity_a,
+          :attempt1,
+          :activity_a_attempt2
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_a,
+          :attempt1,
+          :activity_a_attempt1
+        )
+
+      {:ok, _resource_access} =
+        ResourceAccess
+        |> Oli.Repo.get!(map.attempt1.resource_access_id)
+        |> Core.update_resource_access(%{progress: 0.0})
+
+      assert {:ok, :updated} = Metrics.update_page_progress(map.activity_a_attempt2.attempt_guid)
+
+      ra = Oli.Repo.get(ResourceAccess, map.attempt1.resource_access_id)
+      assert_in_delta 1.0, ra.progress, 0.0001
+    end
+
     test "progress_for_page/3 calculates correctly", %{
       mod1_pages: mod1_pages,
       this_user: this_user,

--- a/test/oli/delivery/metrics/progress_test.exs
+++ b/test/oli/delivery/metrics/progress_test.exs
@@ -263,9 +263,72 @@ defmodule Oli.Delivery.Metrics.ProgressTest do
       # because it can never go lower
       ra = Oli.Repo.get(ResourceAccess, map.attempt2.resource_access_id)
       assert_in_delta 0.75, ra.progress, 0.0001
+    end
 
-      # TODO: test the case where we submit all the 4 scorable activities
-      # and assert the progress is 1.0
+    test "page level progress uses reset activity attempts to reach completion", map do
+      [p1, _, _] = map.mod1_pages
+
+      map =
+        map
+        |> Map.put(:our_page, %{revision: p1.revision, resource: p1.resource})
+        |> Seeder.create_resource_attempt(
+          %{attempt_number: 1, lifecycle_state: :active},
+          :this_user,
+          :our_page,
+          :attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :evaluated, scoreable: true},
+          :activity_a,
+          :attempt1,
+          :activity_a_attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_b,
+          :attempt1,
+          :activity_b_attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_c,
+          :attempt1,
+          :activity_c_attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 1, lifecycle_state: :active, scoreable: true},
+          :activity_d,
+          :attempt1,
+          :activity_d_attempt1
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
+          :activity_b,
+          :attempt1,
+          :activity_b_attempt2
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
+          :activity_c,
+          :attempt1,
+          :activity_c_attempt2
+        )
+        |> Seeder.create_activity_attempt(
+          %{attempt_number: 2, lifecycle_state: :evaluated, scoreable: true},
+          :activity_d,
+          :attempt1,
+          :activity_d_attempt2
+        )
+
+      {:ok, _resource_access} =
+        ResourceAccess
+        |> Oli.Repo.get!(map.attempt1.resource_access_id)
+        |> Core.update_resource_access(%{progress: 0.25})
+
+      assert {:ok, :updated} = Metrics.update_page_progress(map.activity_d_attempt2.attempt_guid)
+
+      ra = Oli.Repo.get(ResourceAccess, map.attempt1.resource_access_id)
+      assert_in_delta 1.0, ra.progress, 0.0001
     end
 
     test "progress_for_page/3 calculates correctly", %{


### PR DESCRIPTION
## Summary

Fixes MER-5767 by allowing practice/ungraded page progress to be recomputed from reset activity attempts. Previously, page progress updates only ran for the first scoreable activity attempt, so a learner who reset a partially completed practice page could complete the visible reset attempts while the page stayed stuck below 100%.

## Query Change Details

`Oli.Delivery.Metrics.update_page_progress/1` now treats any scoreable activity attempt as eligible to trigger progress recomputation, instead of only scoreable attempts where `attempt_number = 1`. This is necessary because reset activity attempts normally have a higher attempt number.

The SQL update in `lib/oli/delivery/metrics.ex` was reworked into CTEs:

- `target` resolves the current activity attempt guid to its parent page attempt, revision, and `resource_access` row. This keeps the update scoped to exactly one learner/page access record.
- `latest_attempts` selects the latest scoreable attempt for each activity resource on that same page attempt using `SELECT DISTINCT ON (aa2.resource_id)` ordered by `aa2.id DESC`. This replaces the old `aa2.attempt_number = 1` filter, which excluded reset attempts.
- `counts` computes completion using only those latest scoreable attempts: submitted or evaluated attempts count as complete, and all latest scoreable attempts count toward the denominator.

The final `UPDATE resource_accesses` still preserves the existing monotonic behavior with `GREATEST(calculated_progress, resource_accesses.progress)` and caps progress with `LEAST(1.0, ...)`, so recomputation can repair stuck progress but will not reduce already-complete progress.

## Tests

- Added regression coverage for a partially completed page where reset attempts complete the remaining scoreable activities and page progress reaches `1.0`.

## Verification

- `mix format lib/oli/delivery/metrics.ex test/oli/delivery/metrics/progress_test.exs`
- `mix test test/oli/delivery/metrics/progress_test.exs`
- `git diff --check`

## Risk

Low to moderate. The update remains scoped to a single `resource_access` row, but progress recomputation now runs for scoreable reset attempts and evaluates latest attempts per activity resource rather than first attempts only.