### PR TITLE
[BUG FIX] [MER-5766] Restore manual grading for adaptive CAPI iframes

### DIFF
--- a/assets/src/apps/authoring/components/PropertyEditor/schemas/part.ts
+++ b/assets/src/apps/authoring/components/PropertyEditor/schemas/part.ts
@@ -15,8 +15,23 @@ export const adaptiveScorablePartTypes = new Set([
   'janus-fill-blanks',
 ]);
 
+// Stateful, non-auto-scored parts that can still be flagged for manual grading.
+// These are NOT auto-scored adaptive inputs (so they do not receive adaptive feedback
+// defaults and do not contribute an automatic screen score), but authors need to be able
+// to mark them as requiring manual grading (e.g. an embedded report inside an iframe).
+export const manualGradablePartTypes = new Set(['janus-capi-iframe']);
+
 export const isAdaptiveScorablePartType = (type?: string | null) =>
   !!type && adaptiveScorablePartTypes.has(type);
+
+export const isManualGradablePartType = (type?: string | null) =>
+  !!type && manualGradablePartTypes.has(type);
+
+// Whether the Scoring section (Requires Manual Grading, and optionally Max Score) should be
+// shown for a given part type. Auto-scored adaptive inputs show the full section; manual-only
+// parts show just the Requires Manual Grading toggle (see applyScoringSchemaVisibility).
+export const showsScoringSection = (type?: string | null) =>
+  isAdaptiveScorablePartType(type) || isManualGradablePartType(type);
 
 const partSchema: JSONSchema7 = {
   type: 'object',
@@ -310,6 +325,12 @@ export const transformModelToSchema = (model: any) => {
       requiresManualGrading: !!requiresManualGrading,
       maxScore: parseNumString(maxScore) || 1,
     };
+  } else if (isManualGradablePartType(type)) {
+    // Manual-only parts expose just the Requires Manual Grading toggle; the max score for the
+    // screen is authored at the screen level, so no part-level Max Score is surfaced here.
+    result.Scoring = {
+      requiresManualGrading: !!requiresManualGrading,
+    };
   }
 
   /* console.log('PART [transformModelToSchema]', { model, result }); */
@@ -338,6 +359,8 @@ export const transformSchemaToModel = (schema: any) => {
   if (isAdaptiveScorablePartType(type)) {
     result.custom.requiresManualGrading = Scoring?.requiresManualGrading;
     result.custom.maxScore = Scoring?.maxScore;
+  } else if (isManualGradablePartType(type)) {
+    result.custom.requiresManualGrading = Scoring?.requiresManualGrading;
   }
 
   if (palette) {
@@ -369,6 +392,76 @@ export const removeScoringFromSchema = (schema: JSONSchema7): JSONSchema7 => {
 export const removeScoringFromUiSchema = (uiSchema: Record<string, any>) => {
   const { Scoring: _scoring, ...remainingUiSchema } = uiSchema;
   return remainingUiSchema;
+};
+
+// Produces a Scoring section that only exposes the Requires Manual Grading toggle, dropping the
+// Max Score field (used for manual-only parts such as iframes where max score is authored at the
+// screen level).
+const removeMaxScoreFromScoringSchema = (schema: JSONSchema7): JSONSchema7 => {
+  const properties = (schema.properties || {}) as Record<string, any>;
+  const scoring = properties.Scoring;
+
+  if (!scoring || typeof scoring !== 'object' || !scoring.properties) {
+    return schema;
+  }
+
+  const { maxScore: _maxScore, ...remainingScoringProperties } = scoring.properties;
+
+  return {
+    ...schema,
+    properties: {
+      ...properties,
+      Scoring: {
+        ...scoring,
+        properties: remainingScoringProperties,
+      },
+    },
+  };
+};
+
+const removeMaxScoreFromScoringUiSchema = (uiSchema: Record<string, any>) => {
+  const scoring = uiSchema.Scoring;
+
+  if (!scoring || typeof scoring !== 'object') {
+    return uiSchema;
+  }
+
+  const { maxScore: _maxScore, ...remainingScoringUiSchema } = scoring;
+
+  return {
+    ...uiSchema,
+    Scoring: remainingScoringUiSchema,
+  };
+};
+
+// Centralizes how the Scoring section is shown per part type:
+// - auto-scored adaptive inputs: full Scoring section (Requires Manual Grading + Max Score)
+// - manual-only parts (e.g. iframe): Requires Manual Grading only
+// - everything else: no Scoring section
+export const applyScoringSchemaVisibility = (
+  schema: JSONSchema7,
+  type?: string | null,
+): JSONSchema7 => {
+  if (isAdaptiveScorablePartType(type)) {
+    return schema;
+  }
+  if (isManualGradablePartType(type)) {
+    return removeMaxScoreFromScoringSchema(schema);
+  }
+  return removeScoringFromSchema(schema);
+};
+
+export const applyScoringUiSchemaVisibility = (
+  uiSchema: Record<string, any>,
+  type?: string | null,
+) => {
+  if (isAdaptiveScorablePartType(type)) {
+    return uiSchema;
+  }
+  if (isManualGradablePartType(type)) {
+    return removeMaxScoreFromScoringUiSchema(uiSchema);
+  }
+  return removeScoringFromUiSchema(uiSchema);
 };
 
 export default partSchema;

--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -24,10 +24,10 @@ import PropertyEditor from '../PropertyEditor/PropertyEditor';
 import AccordionTemplate from '../PropertyEditor/custom/AccordionTemplate';
 import CompJsonEditor from '../PropertyEditor/custom/CompJsonEditor';
 import partSchema, {
+  applyScoringSchemaVisibility,
+  applyScoringUiSchemaVisibility,
   isAdaptiveScorablePartType,
   partUiSchema,
-  removeScoringFromSchema,
-  removeScoringFromUiSchema,
   responsivePartSchema,
   responsivePartUiSchema,
   simplifiedPartSchema,
@@ -100,15 +100,9 @@ const getSimplifiedComponentSchema = (
   allowTriggers: boolean,
 ): JSONSchema7 => {
   const tagName = instance ? String(instance.tagName).toLowerCase() : '';
-  const showScoring = isAdaptiveScorablePartType(tagName);
-  const responsiveBaseSchema = showScoring
-    ? simplifiedResponsivePartSchema
-    : removeScoringFromSchema(simplifiedResponsivePartSchema);
   const baseSchema = responsiveLayout
-    ? responsiveBaseSchema
-    : showScoring
-    ? simplifiedPartSchema
-    : removeScoringFromSchema(simplifiedPartSchema);
+    ? applyScoringSchemaVisibility(simplifiedResponsivePartSchema, tagName)
+    : applyScoringSchemaVisibility(simplifiedPartSchema, tagName);
 
   if (instance && instance.getSchema) {
     const customPartSchema = instance.getSchema('simple', { allowAiTriggers: allowTriggers });
@@ -143,12 +137,11 @@ const getExpertComponentSchema = (
 ): JSONSchema7 => {
   const tagName = instance ? String(instance.tagName).toLowerCase() : '';
   const baseSchema = responsiveLayout ? responsivePartSchema : partSchema;
-  const showScoring = isAdaptiveScorablePartType(tagName);
-  const filteredBaseSchema = showScoring ? baseSchema : removeScoringFromSchema(baseSchema);
+  const filteredBaseSchema = applyScoringSchemaVisibility(baseSchema, tagName);
 
   if (instance && instance.getSchema) {
     const customPartSchema = instance.getSchema('expert', { allowAiTriggers: allowTriggers });
-    const simplePartSchema = showScoring
+    const simplePartSchema = isAdaptiveScorablePartType(tagName)
       ? instance.getSchema('simple', { allowAiTriggers: allowTriggers })
       : null;
 
@@ -212,14 +205,9 @@ const getSimplifiedComponentUISchema = (instance: any, responsiveLayout: boolean
   const tagName = instance ? String(instance.tagName).toLowerCase() : '';
   const title = simplifiedLabels[tagName] || 'Component Options';
   const componentDescription = simplifiedDescriptionLabels[tagName] || '';
-  const responsiveBaseUiSchema = isAdaptiveScorablePartType(tagName)
-    ? simplifiedResponsivePartUiSchema
-    : removeScoringFromUiSchema(simplifiedResponsivePartUiSchema);
   const baseUiSchema = responsiveLayout
-    ? responsiveBaseUiSchema
-    : isAdaptiveScorablePartType(tagName)
-    ? simplifiedPartUiSchema
-    : removeScoringFromUiSchema(simplifiedPartUiSchema);
+    ? applyScoringUiSchemaVisibility(simplifiedResponsivePartUiSchema, tagName)
+    : applyScoringUiSchemaVisibility(simplifiedPartUiSchema, tagName);
   if (instance && instance.getUiSchema) {
     const customPartUiSchema = instance.getUiSchema('simple');
     const newUiSchema = {
@@ -239,9 +227,7 @@ const getExpertComponentUISchema = (instance: any, responsiveLayout: boolean) =>
   // ui schema
   const tagName = instance ? String(instance.tagName).toLowerCase() : '';
   const componentUiSchema = responsiveLayout ? responsivePartUiSchema : partUiSchema;
-  const baseUiSchema = isAdaptiveScorablePartType(tagName)
-    ? componentUiSchema
-    : removeScoringFromUiSchema(componentUiSchema);
+  const baseUiSchema = applyScoringUiSchemaVisibility(componentUiSchema, tagName);
   if (instance && instance.getUiSchema) {
     const customPartUiSchema = instance.getUiSchema('expert');
     const simplePartUiSchema =

--- a/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
+++ b/assets/src/components/activities/adaptive/components/authoring/ScreenAuthor.tsx
@@ -12,10 +12,9 @@ import ConfigurationModal from 'apps/authoring/components/EditingCanvas/Configur
 import PropertyEditor from 'apps/authoring/components/PropertyEditor/PropertyEditor';
 import CustomFieldTemplate from 'apps/authoring/components/PropertyEditor/custom/CustomFieldTemplate';
 import partSchema, {
-  isAdaptiveScorablePartType,
+  applyScoringSchemaVisibility,
+  applyScoringUiSchemaVisibility,
   partUiSchema,
-  removeScoringFromSchema,
-  removeScoringFromUiSchema,
   transformModelToSchema as transformPartModelToSchema,
   transformSchemaToModel as transformPartSchemaToModel,
 } from 'apps/authoring/components/PropertyEditor/schemas/part';
@@ -236,9 +235,8 @@ const ScreenAuthor: React.FC<ScreenAuthorProps> = ({
         const PartClass = customElements.get(part.type);
         if (PartClass) {
           const partInstance = new PartClass() as any;
-          const showScoring = isAdaptiveScorablePartType(part.type);
-          const baseSchema = showScoring ? partSchema : removeScoringFromSchema(partSchema);
-          const baseUiSchema = showScoring ? partUiSchema : removeScoringFromUiSchema(partUiSchema);
+          const baseSchema = applyScoringSchemaVisibility(partSchema, part.type);
+          const baseUiSchema = applyScoringUiSchemaVisibility(partUiSchema, part.type);
 
           if (partInstance.getSchema) {
             const customPartSchema = partInstance.getSchema(undefined, {

--- a/assets/test/advanced_authoring/adaptive_scorable_part_types_test.ts
+++ b/assets/test/advanced_authoring/adaptive_scorable_part_types_test.ts
@@ -3,7 +3,14 @@ import {
   hasSimpleAuthorQuestionPart,
   questionComponents,
 } from '../../src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav';
-import { adaptiveScorablePartTypes } from '../../src/apps/authoring/components/PropertyEditor/schemas/part';
+import {
+  adaptiveScorablePartTypes,
+  isAdaptiveScorablePartType,
+  isManualGradablePartType,
+  showsScoringSection,
+  transformModelToSchema,
+  transformSchemaToModel,
+} from '../../src/apps/authoring/components/PropertyEditor/schemas/part';
 
 const normalizeAdaptivePartSlug = (slug: string) => slug.replace(/_/g, '-');
 
@@ -23,6 +30,15 @@ describe('adaptive scorable part types', () => {
   it('includes scored non-primary response types and excludes display-only parts', () => {
     expect(adaptiveScorablePartTypes.has('janus-fill-blanks')).toBe(true);
     expect(adaptiveScorablePartTypes.has('janus-formula')).toBe(false);
+  });
+
+  it('treats the capi iframe as manually gradable but not auto-scorable', () => {
+    expect(isManualGradablePartType('janus-capi-iframe')).toBe(true);
+    expect(isAdaptiveScorablePartType('janus-capi-iframe')).toBe(false);
+    expect(showsScoringSection('janus-capi-iframe')).toBe(true);
+    // auto-scored inputs are still shown, and non-gradable display parts are not
+    expect(showsScoringSection('janus-mcq')).toBe(true);
+    expect(showsScoringSection('janus-text-flow')).toBe(false);
   });
 
   it('does not treat display-only parts as blocking the first simple-author question component', () => {
@@ -45,5 +61,39 @@ describe('adaptive scorable part types', () => {
         },
       }),
     ).toBe(true);
+  });
+
+  describe('manual-only part scoring transforms (capi iframe)', () => {
+    const buildIframeModel = () => ({
+      id: 'iframe-1',
+      type: 'janus-capi-iframe',
+      custom: {
+        x: 0,
+        y: 0,
+        z: 0,
+        width: 400,
+        height: 400,
+        requiresManualGrading: true,
+      },
+    });
+
+    it('surfaces only the Requires Manual Grading toggle and injects no feedback defaults', () => {
+      const schema = transformModelToSchema(buildIframeModel());
+
+      expect(schema.Scoring).toEqual({ requiresManualGrading: true });
+      expect(schema.Scoring.maxScore).toBeUndefined();
+      expect(schema.custom.correctFeedback).toBeUndefined();
+      expect(schema.custom.incorrectFeedback).toBeUndefined();
+    });
+
+    it('round-trips requiresManualGrading without forcing a maxScore or feedback defaults', () => {
+      const schema = transformModelToSchema(buildIframeModel());
+      const model = transformSchemaToModel(schema);
+
+      expect(model.custom.requiresManualGrading).toBe(true);
+      expect(model.custom.maxScore).toBeUndefined();
+      expect(model.custom.correctFeedback).toBeUndefined();
+      expect(model.custom.incorrectFeedback).toBeUndefined();
+    });
   });
 });

--- a/lib/oli/activities/adaptive_parts.ex
+++ b/lib/oli/activities/adaptive_parts.ex
@@ -276,10 +276,19 @@ defmodule Oli.Activities.AdaptiveParts do
   end
 
   def persisted_part_grading_approach(content, part) when is_map(content) and is_map(part) do
-    if rule_scored_part?(content, part) and not scorable_part?(part) do
-      :automatic
-    else
-      grading_approach(part)
+    cond do
+      # An explicit manual-grading flag always wins, even when the part is referenced by a
+      # scoring rule (e.g. an iframe whose value is checked in a trap-state condition).
+      # Otherwise authors could never manually grade a part that also drives adaptive rule
+      # logic, since being rule-referenced would silently force it back to automatic.
+      grading_approach(part) == :manual ->
+        :manual
+
+      rule_scored_part?(content, part) and not scorable_part?(part) ->
+        :automatic
+
+      true ->
+        grading_approach(part)
     end
   end
 

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -500,19 +500,30 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
           )
 
         if scoringContext.isManuallyGraded do
-          with :ok <-
-                 maybe_persist_mixed_adaptive_automatic_parts(
-                   section_slug,
-                   activity_attempt_guid,
-                   client_evaluations,
-                   datashop_session_id,
-                   part_attempts
-                 ),
-               :ok <- submit_pending_manual_adaptive_attempts(activity_attempt_guid) do
-            {:ok, decodedResults}
+          # Only finalize this submission when the rules engine fires a correct result. On a
+          # correct result we persist the automatic parts (without rolling up the activity) and
+          # submit the pending manual parts for grading. On an incorrect result we leave ALL part
+          # attempts active (both automatic and manual) so the student can retry with a clean
+          # slate. Persisting automatic parts early would mark them :evaluated, and
+          # `filter_already_evaluated` would then prevent them from ever being re-scored on a later
+          # correct retry, leaving stale automatic scores in the finalized attempt.
+          if adaptive_result_correct?(decodedResults, activity_score, activity_out_of) do
+            with :ok <-
+                   maybe_persist_mixed_adaptive_automatic_parts(
+                     section_slug,
+                     activity_attempt_guid,
+                     client_evaluations,
+                     datashop_session_id,
+                     part_attempts
+                   ),
+                 :ok <- submit_pending_manual_adaptive_attempts(activity_attempt_guid) do
+              {:ok, decodedResults}
+            else
+              {:error, err} ->
+                {:error, err}
+            end
           else
-            {:error, err} ->
-              {:error, err}
+            {:ok, decodedResults}
           end
         else
           Logger.debug("Adaptive activity score: #{activity_score}")
@@ -631,6 +642,20 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
           {:ok, _results} -> :ok
           {:error, err} -> {:error, err}
         end
+    end
+  end
+
+  # Determine whether a manually graded adaptive screen submission should be captured for
+  # grading. Prefer the rules engine's own `correct` flag, falling back to comparing the
+  # computed screen score against the screen out_of.
+  defp adaptive_result_correct?(decoded_results, activity_score, activity_out_of) do
+    case Map.get(decoded_results, "correct") do
+      correct when is_boolean(correct) ->
+        correct
+
+      _ ->
+        is_number(activity_out_of) and activity_out_of > 0 and is_number(activity_score) and
+          activity_score >= activity_out_of
     end
   end
 

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -515,6 +515,81 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
     end
   end
 
+  # Adaptive stateful non-scorable parts (e.g. a manually graded janus-capi-iframe) do not carry a
+  # meaningful part-level `out_of`; their score is authored at the screen level via
+  # `custom.maxScore`. The authoring sync persists a bogus default `outOf` of 1 for them (there is
+  # no per-part Max Score field), so without this override the instructor would grade out of 1
+  # instead of the screen's max score. We therefore assign the screen max score to those manual
+  # part attempts, splitting it evenly when more than one such part exists so they still sum to the
+  # screen max.
+  #
+  # Scorable adaptive inputs (e.g. janus-multi-line-text) DO expose a per-part Max Score whose
+  # authored value is persisted to `outOf`, so we leave their `out_of` untouched to respect the
+  # author-configured per-part maximum.
+  defp apply_adaptive_manual_out_of(
+         parts_map,
+         model,
+         %{activity_type_id: activity_type_id} = activity_attempt,
+         part_attempts
+       ) do
+    with true <- AdaptiveParts.adaptive_activity?(%{activity_type_id: activity_type_id}),
+         screen_max when is_number(screen_max) and screen_max > 0 <-
+           adaptive_screen_max_score(model) do
+      content = activity_attempt.revision.content
+
+      manual_part_ids =
+        part_attempts
+        |> Enum.filter(fn pa -> pa.grading_approach == :manual end)
+        |> Enum.map(& &1.part_id)
+        |> Enum.uniq()
+        |> Enum.filter(&Map.has_key?(parts_map, &1))
+        |> Enum.filter(fn part_id ->
+          case AdaptiveParts.part_definition(content, part_id) do
+            nil -> false
+            part -> not AdaptiveParts.scorable_part?(part)
+          end
+        end)
+
+      case manual_part_ids do
+        [] ->
+          parts_map
+
+        ids ->
+          per_part = screen_max / length(ids)
+
+          Enum.reduce(ids, parts_map, fn part_id, acc ->
+            Map.update!(acc, part_id, fn %Part{} = part -> %{part | out_of: per_part} end)
+          end)
+      end
+    else
+      _ -> parts_map
+    end
+  end
+
+  defp apply_adaptive_manual_out_of(parts_map, _model, _activity_attempt, _part_attempts),
+    do: parts_map
+
+  defp adaptive_screen_max_score(%Oli.Activities.Model{delivery: delivery}) when is_map(delivery) do
+    delivery
+    |> Map.get("custom", %{})
+    |> Map.get("maxScore")
+    |> normalize_number()
+  end
+
+  defp adaptive_screen_max_score(_), do: nil
+
+  defp normalize_number(value) when is_integer(value), do: value * 1.0
+  defp normalize_number(value) when is_float(value), do: value
+
+  defp normalize_number(value) when is_binary(value) do
+    case Float.parse(value) do
+      {parsed, ""} -> parsed
+      _ -> nil
+    end
+  end
+
+  defp normalize_number(_), do: nil
+
   @spec patch_with(Phoenix.LiveView.Socket.t(), map) :: {:noreply, Phoenix.LiveView.Socket.t()}
   def patch_with(socket, changes) do
     {:noreply,
@@ -585,7 +660,12 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
         OliWeb.ManualGrading.Rendering.render(rendering_context, :instructor_preview)
 
       {:ok, model} = Oli.Activities.Model.parse(activity_attempt.revision.content)
-      parts_map = Enum.reduce(model.parts, %{}, fn p, m -> Map.put(m, p.id, p) end)
+
+      parts_map =
+        model.parts
+        |> Enum.reduce(%{}, fn p, m -> Map.put(m, p.id, p) end)
+        |> apply_adaptive_manual_out_of(model, activity_attempt, part_attempts)
+
       selected_part_attempt = List.first(part_attempts)
 
       [

--- a/lib/oli_web/live/manual_grading/manual_grading_view.ex
+++ b/lib/oli_web/live/manual_grading/manual_grading_view.ex
@@ -569,7 +569,8 @@ defmodule OliWeb.ManualGrading.ManualGradingView do
   defp apply_adaptive_manual_out_of(parts_map, _model, _activity_attempt, _part_attempts),
     do: parts_map
 
-  defp adaptive_screen_max_score(%Oli.Activities.Model{delivery: delivery}) when is_map(delivery) do
+  defp adaptive_screen_max_score(%Oli.Activities.Model{delivery: delivery})
+       when is_map(delivery) do
     delivery
     |> Map.get("custom", %{})
     |> Map.get("maxScore")

--- a/test/oli/activities/adaptive_parts_test.exs
+++ b/test/oli/activities/adaptive_parts_test.exs
@@ -189,6 +189,80 @@ defmodule Oli.Activities.AdaptivePartsTest do
            ) == :manual
   end
 
+  test "treats an iframe flagged for manual grading in partsLayout as manually gradeable" do
+    content = %{
+      "partsLayout" => [
+        %{
+          "id" => "janus_capi_iframe-1",
+          "type" => "janus-capi-iframe",
+          "custom" => %{"requiresManualGrading" => true}
+        }
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "janus_capi_iframe-1", "type" => "janus-capi-iframe"}
+        ]
+      }
+    }
+
+    part = AdaptiveParts.part_definition(content, "janus_capi_iframe-1")
+
+    assert AdaptiveParts.stateful_non_scorable_part_type?("janus-capi-iframe")
+    assert AdaptiveParts.persisted_part?(content, "janus_capi_iframe-1")
+    assert AdaptiveParts.persisted_part_grading_approach(content, part) == :manual
+
+    assert AdaptiveParts.manual_gradeable_part_ids(content) ==
+             MapSet.new(["janus_capi_iframe-1"])
+  end
+
+  test "keeps an explicitly manual iframe manual even when referenced by a scoring rule" do
+    # Mirrors the real MER-5766 regression: the iframe carries requiresManualGrading in
+    # partsLayout, has stale gradingApproach "automatic" in authoring.parts, and is also
+    # referenced by a trap-state rule condition. The rule reference must not silently
+    # downgrade the part back to automatic.
+    content = %{
+      "partsLayout" => [
+        %{
+          "id" => "janus_capi_iframe-1",
+          "type" => "janus-capi-iframe",
+          "custom" => %{"requiresManualGrading" => true}
+        }
+      ],
+      "authoring" => %{
+        "parts" => [
+          %{
+            "id" => "janus_capi_iframe-1",
+            "type" => "janus-capi-iframe",
+            "gradingApproach" => "automatic"
+          }
+        ],
+        "rules" => [
+          %{
+            "id" => "r.correct",
+            "disabled" => false,
+            "conditions" => %{
+              "all" => [
+                %{
+                  "fact" => "stage.janus_capi_iframe-1.reportComplete",
+                  "operator" => "equal",
+                  "value" => "true"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+
+    part = AdaptiveParts.part_definition(content, "janus_capi_iframe-1")
+
+    assert AdaptiveParts.rule_scored_part?(content, "janus_capi_iframe-1")
+    assert AdaptiveParts.persisted_part_grading_approach(content, part) == :manual
+
+    assert AdaptiveParts.manual_gradeable_part_ids(content) ==
+             MapSet.new(["janus_capi_iframe-1"])
+  end
+
   test "ignores missing ids when collecting persisted-only stateful parts" do
     content = %{
       "partsLayout" => [

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -957,6 +957,141 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_essay.out_of == nil
     end
 
+    test "does not submit manual adaptive attempts when the rules engine result is incorrect" do
+      user = insert(:user)
+      section = insert(:section)
+
+      activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 2, "maxAttempt" => 1},
+          "partsLayout" => [
+            %{
+              "id" => "dropdown_1",
+              "type" => "janus-dropdown",
+              "custom" => %{
+                "correctAnswer" => 2,
+                "optionLabels" => ["Option 1", "Option 2"],
+                "correctFeedback" => "Auto correct",
+                "incorrectFeedback" => "Auto incorrect"
+              }
+            },
+            %{
+              "id" => "essay_1",
+              "type" => "janus-multi-line-text",
+              "custom" => %{
+                "correctFeedback" => "Manual correct",
+                "incorrectFeedback" => "Manual incorrect"
+              }
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [],
+            "variablesRequiredForEvaluation" => [
+              "stage.dropdown_1.selectedIndex",
+              "stage.essay_1.text"
+            ],
+            "parts" => [
+              %{
+                "id" => "dropdown_1",
+                "type" => "janus-dropdown",
+                "gradingApproach" => "automatic"
+              },
+              %{
+                "id" => "essay_1",
+                "type" => "janus-multi-line-text",
+                "gradingApproach" => "manual"
+              }
+            ],
+            # Only a default "wrong" rule fires, so the screen evaluates as incorrect.
+            "rules" => [
+              %{
+                "id" => "r.wrong",
+                "name" => "wrong",
+                "disabled" => false,
+                "default" => true,
+                "correct" => false,
+                "conditions" => %{"all" => []},
+                "event" => %{
+                  "type" => "r.wrong",
+                  "params" => %{"actions" => []}
+                }
+              }
+            ]
+          }
+        })
+
+      setup =
+        setup_adaptive_activity_attempt(user, section, activity_revision, [
+          "dropdown_1",
+          "essay_1"
+        ])
+
+      [dropdown_attempt, essay_attempt] =
+        setup.part_attempts
+        |> Enum.sort_by(& &1.part_id)
+
+      assert {:ok, essay_attempt} =
+               Core.update_part_attempt(essay_attempt, %{grading_approach: :manual})
+
+      part_inputs = [
+        %{
+          attempt_guid: dropdown_attempt.attempt_guid,
+          input: %StudentInput{
+            input: %{
+              "selectedIndex" => %{"path" => "stage.dropdown_1.selectedIndex", "value" => 1},
+              "selectedItem" => %{
+                "path" => "stage.dropdown_1.selectedItem",
+                "value" => "Option 1"
+              },
+              "value" => %{"path" => "stage.dropdown_1.value", "value" => "Option 1"}
+            }
+          },
+          timestamp: DateTime.utc_now()
+        },
+        %{
+          attempt_guid: essay_attempt.attempt_guid,
+          input: %StudentInput{
+            input: %{
+              "text" => %{"path" => "stage.essay_1.text", "value" => "Work in progress"}
+            }
+          },
+          timestamp: DateTime.utc_now()
+        }
+      ]
+
+      assert {:ok, _result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 setup.activity_attempt.attempt_guid,
+                 part_inputs,
+                 nil
+               )
+
+      updated_attempt =
+        Core.get_activity_attempt_by(attempt_guid: setup.activity_attempt.attempt_guid)
+
+      # The activity is not finalized so the student can retry.
+      assert updated_attempt.lifecycle_state == :active
+
+      updated_part_attempts =
+        Core.get_latest_part_attempts(setup.activity_attempt.attempt_guid)
+        |> Enum.sort_by(& &1.part_id)
+
+      [updated_dropdown, updated_essay] = updated_part_attempts
+
+      # On an incorrect result ALL part attempts remain active so the student can retry with a
+      # clean slate. Persisting the automatic parts early would mark them :evaluated and they could
+      # never be re-scored on a later correct retry, leaving stale automatic scores.
+      assert updated_dropdown.grading_approach == :automatic
+      assert updated_dropdown.lifecycle_state == :active
+
+      # The manual part remains active and is not submitted for grading.
+      assert updated_essay.grading_approach == :manual
+      assert updated_essay.lifecycle_state == :active
+      assert updated_essay.score == nil
+      assert updated_essay.out_of == nil
+    end
+
     test "uses a single-input scorable rule to set part score, out_of, and feedback" do
       user = insert(:user)
       section = insert(:section)


### PR DESCRIPTION
## Summary

Fixes MER-5766: manually scored `janus-capi-iframe` attempts were not appearing in the
Instructor manual grading queue and were grading out of 1 instead of the screen max.

- Re-expose **Requires Manual Grading** for `janus-capi-iframe` in Advanced Author
  (without treating it as an auto-scored adaptive input)
- Honor an explicit manual-grading flag even when the iframe is referenced by a
  scoring/trap-state rule (`persisted_part_grading_approach`)
- Submit manual adaptive attempts to the grading queue only when the rules engine
  returns a correct result, so students can retry on incorrect
- On incorrect, leave all part attempts active (do not persist automatic parts early)
  to avoid stale scores on retry
- Backfill instructor **Out Of** from the screen `maxScore` for manual non-scorable
  adaptive parts (iframe) at grading time

Screen `maxScore` remains the single source of truth for iframe scoring; authors do not set a separate part-level max.

## Test plan
I have done testing for each component in Advanced Author and confirmed that there is no regression. The fix also works as expected. 

That being said, QA testing on hotfixes needs to be diligent as well. Each component needs to be tested to ensure functionality, and the iframe component needs to be tested extensively with various URLs linked in the iframe. 

## Automated tests

- `assets/test/advanced_authoring/adaptive_scorable_part_types_test.ts`
- `test/oli/activities/adaptive_parts_test.exs`
- `test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs`