### PR TITLE
[BUG FIX] [MER-5768] Fix deleted LO attachments and sub-objective delete feedback

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -3,10 +3,10 @@ on: pull_request
 
 permissions:
   contents: read
-  pull-requests: write     # for PR comments/reviews
-  issues: write            # label add (if used)
-  checks: write            # if using the Checks API
-  statuses: write          # allow setting commit status
+  pull-requests: write # for PR comments/reviews
+  issues: write # label add (if used)
+  checks: write # if using the Checks API
+  statuses: write # allow setting commit status
 
 jobs:
   run:
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
-      - run: npm i -D danger js-yaml micromatch typescript ts-node
+      - run: npm i -D danger js-yaml micromatch typescript@5.9.3 ts-node
       - run: npx danger ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/oli/authoring/editing/objective_editor.ex
+++ b/lib/oli/authoring/editing/objective_editor.ex
@@ -282,25 +282,28 @@ defmodule Oli.Authoring.Editing.ObjectiveEditor do
   defp detach_from_page(objective_id, page_slug, project_slug, author) do
     case PageEditor.acquire_lock(project_slug, page_slug, author.email) do
       {:acquired} ->
-        # We need to create the context so that we get a client-side view of the
-        # current objectives as slugs and not as ids
-        {:ok, %{objectives: objectives}} =
-          PageEditor.create_context(project_slug, page_slug, author)
+        case PageEditor.create_context(project_slug, page_slug, author) do
+          # We need to create the context so that we get a client-side view of the
+          # current objectives as slugs and not as ids.
+          {:ok, %{objectives: objectives}} ->
+            update = %{
+              "objectives" => %{
+                "attached" =>
+                  Enum.filter(Map.get(objectives, "attached"), fn s -> s != objective_id end)
+              }
+            }
 
-        # Construct the update that will filter out the objective
-        update = %{
-          "objectives" => %{
-            "attached" =>
-              Enum.filter(Map.get(objectives, "attached"), fn s -> s != objective_id end)
-          }
-        }
+            result =
+              case PageEditor.edit(project_slug, page_slug, author.email, update) do
+                {:ok, _} -> true
+                _ -> false
+              end
 
-        case PageEditor.edit(project_slug, page_slug, author.email, update) do
-          {:ok, _} ->
             PageEditor.release_lock(project_slug, page_slug, author.email)
-            true
+            result
 
           _ ->
+            PageEditor.release_lock(project_slug, page_slug, author.email)
             false
         end
 

--- a/lib/oli/publishing.ex
+++ b/lib/oli/publishing.ex
@@ -1429,15 +1429,17 @@ defmodule Oli.Publishing do
     WHERE
       revisions.id IN (SELECT revision_id
       FROM published_resources
-       WHERE publication_id = #{publication_id})
+       WHERE publication_id = $1)
        AND (
-         (revisions.resource_type_id = #{activity_id} AND revisions.objectives->part @> '[#{resource_id}]')
+         (revisions.resource_type_id = $2 AND revisions.objectives->part @> jsonb_build_array($3::bigint))
          OR
-         (revisions.resource_type_id = #{page_id} AND revisions.objectives->'attached' @> '[#{resource_id}]')
+         (revisions.resource_type_id = $4 AND revisions.objectives->'attached' @> jsonb_build_array($3::bigint))
        )
+       AND revisions.deleted IS FALSE
     """
 
-    {:ok, %{rows: results}} = Ecto.Adapters.SQL.query(Oli.Repo, sql, [])
+    {:ok, %{rows: results}} =
+      Ecto.Adapters.SQL.query(Oli.Repo, sql, [publication_id, activity_id, resource_id, page_id])
 
     results
     |> Enum.map(fn [scope, id, resource_id, title, slug, part] ->
@@ -1486,6 +1488,7 @@ defmodule Oli.Publishing do
           WHERE publication_id = $1)
         AND
           (revision.resource_type_id = $2 OR revision.resource_type_id = $3)
+        AND revision.deleted IS FALSE
         AND jsonb_array_length(revision.objectives->part) > 0;
     """
 

--- a/lib/oli_web/live/objectives/form_modal.ex
+++ b/lib/oli_web/live/objectives/form_modal.ex
@@ -39,12 +39,12 @@ defmodule OliWeb.ObjectivesLive.FormModal do
                   />
                 </div>
 
-                <button
-                  class="form-button btn btn-md btn-primary btn-block w-auto float-right mt-4"
-                  type="submit"
-                >
-                  {button_text(@action)}
-                </button>
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                  <button type="button" class="btn btn-link" phx-click="hide_modal">Cancel</button>
+                  <button class="form-button btn btn-md btn-primary btn-block w-auto" type="submit">
+                    {button_text(@action)}
+                  </button>
+                </div>
               </.form>
             </div>
           </div>

--- a/lib/oli_web/live/workspaces/course_author/objectives/form_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/form_modal.ex
@@ -39,12 +39,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.FormModal do
                   />
                 </div>
 
-                <button
-                  class="form-button btn btn-md btn-primary btn-block w-auto float-right mt-4"
-                  type="submit"
-                >
-                  {button_text(@action)}
-                </button>
+                <div class="d-flex justify-content-end gap-2 mt-4">
+                  <button type="button" class="btn btn-link" phx-click="hide_modal">Cancel</button>
+                  <button class="form-button btn btn-md btn-primary btn-block w-auto" type="submit">
+                    {button_text(@action)}
+                  </button>
+                </div>
               </.form>
             </div>
           </div>

--- a/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
@@ -97,6 +97,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
                           phx-click="display_sub_objective_delete_modal"
                           phx-value-slug={sub_objective.slug}
                           phx-value-parent_slug={item.slug}
+                          phx-value-title={sub_objective.title}
                         >
                           <i class="fas fa-trash-alt fa-lg"></i> Delete
                         </.button>

--- a/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
@@ -10,7 +10,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
   attr(:revision_history_link, :boolean, required: true)
   attr(:rows, :list, required: true)
   attr(:selected, :string, required: true)
-  attr(:pending_delete_slug, :string, default: nil)
+  attr(:pending_delete_slugs, :any, default: MapSet.new())
 
   def render(assigns) do
     ~H"""
@@ -65,22 +65,22 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
                       :if={!is_nil(sub_objective)}
                       class={[
                         "list-group-item p-2 d-flex align-items-center group/item",
-                        sub_objective.slug == @pending_delete_slug && "opacity-50"
+                        MapSet.member?(@pending_delete_slugs, sub_objective.slug) && "opacity-50"
                       ]}
                     >
                       <div class={[
                         "py-1.5 w-75",
-                        sub_objective.slug == @pending_delete_slug && "line-through"
+                        MapSet.member?(@pending_delete_slugs, sub_objective.slug) && "line-through"
                       ]}>
                         {sub_objective.title}
                       </div>
                       <.loader
-                        :if={sub_objective.slug == @pending_delete_slug}
+                        :if={MapSet.member?(@pending_delete_slugs, sub_objective.slug)}
                         class="ml-2"
                         icon_class="text-secondary"
                       />
                       <div
-                        :if={sub_objective.slug != @pending_delete_slug}
+                        :if={!MapSet.member?(@pending_delete_slugs, sub_objective.slug)}
                         class="ml-2 invisible group-hover/item:visible"
                       >
                         <.button

--- a/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/listing.ex
@@ -10,6 +10,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
   attr(:revision_history_link, :boolean, required: true)
   attr(:rows, :list, required: true)
   attr(:selected, :string, required: true)
+  attr(:pending_delete_slug, :string, default: nil)
 
   def render(assigns) do
     ~H"""
@@ -60,9 +61,28 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
                 <div class="font-bold">Sub-Objectives</div>
                 <ul class="list-group list-group-flush">
                   <%= for sub_objective <- item.children do %>
-                    <li :if={!is_nil(sub_objective)} class="list-group-item p-2 d-flex group/item">
-                      <div class="py-1.5 w-75">{sub_objective.title}</div>
-                      <div class="ml-2 invisible group-hover/item:visible">
+                    <li
+                      :if={!is_nil(sub_objective)}
+                      class={[
+                        "list-group-item p-2 d-flex align-items-center group/item",
+                        sub_objective.slug == @pending_delete_slug && "opacity-50"
+                      ]}
+                    >
+                      <div class={[
+                        "py-1.5 w-75",
+                        sub_objective.slug == @pending_delete_slug && "line-through"
+                      ]}>
+                        {sub_objective.title}
+                      </div>
+                      <.loader
+                        :if={sub_objective.slug == @pending_delete_slug}
+                        class="ml-2"
+                        icon_class="text-secondary"
+                      />
+                      <div
+                        :if={sub_objective.slug != @pending_delete_slug}
+                        class="ml-2 invisible group-hover/item:visible"
+                      >
                         <.button
                           variant={:tertiary}
                           size={:xs}
@@ -74,7 +94,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.Objectives.Listing do
                         <.button
                           variant={:danger}
                           size={:xs}
-                          phx-click="delete"
+                          phx-click="display_sub_objective_delete_modal"
                           phx-value-slug={sub_objective.slug}
                           phx-value-parent_slug={item.slug}
                         >

--- a/lib/oli_web/live/workspaces/course_author/objectives/sub_objective_delete_modal.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives/sub_objective_delete_modal.ex
@@ -1,0 +1,46 @@
+defmodule OliWeb.Workspaces.CourseAuthor.Objectives.SubObjectiveDeleteModal do
+  use OliWeb, :html
+
+  attr(:id, :string, required: true)
+  attr(:parent_slug, :string, required: true)
+  attr(:slug, :string, required: true)
+  attr(:title, :string, required: true)
+
+  def render(assigns) do
+    ~H"""
+    <div
+      class="modal fade show"
+      id={@id}
+      tabindex="-1"
+      role="dialog"
+      aria-hidden="true"
+      phx-hook="ModalLaunch"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Delete Sub-Objective</h5>
+            <button type="button" class="btn-close" phx-click="hide_modal" aria-label="Close">
+            </button>
+          </div>
+          <div class="modal-body">
+            Are you sure you want to delete <strong>{@title}</strong>?
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-link" phx-click="hide_modal">Cancel</button>
+            <button
+              phx-click="delete_sub_objective"
+              phx-value-slug={@slug}
+              phx-value-parent_slug={@parent_slug}
+              phx-key="enter"
+              class="btn btn-danger"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -53,7 +53,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
        all_objectives: all_objectives,
        all_children: all_children,
        objective_attachments: [],
-       pending_sub_objective_delete_slug: nil,
+       pending_sub_objective_delete_slugs: MapSet.new(),
        query: "",
        selected: "",
        offset: 0,
@@ -107,7 +107,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
           }
           rows={@table_model.rows}
           selected={@selected}
-          pending_delete_slug={@pending_sub_objective_delete_slug}
+          pending_delete_slugs={@pending_sub_objective_delete_slugs}
           project_slug={@project.slug}
         />
       </Table.render>
@@ -190,8 +190,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
        table_model: table_model,
        total_count: length(objectives),
        all_objectives: all_objectives,
-       all_children: all_children,
-       pending_sub_objective_delete_slug: nil
+       all_children: all_children
      )
      |> hide_modal(modal_assigns: nil)
      |> push_patch(to: live_path(socket, socket.assigns.params))}
@@ -460,26 +459,27 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     socket = clear_flash(socket)
     %{project: %{slug: project_slug}, author: %{email: author_email}} = socket.assigns
 
-    case socket.assigns.pending_sub_objective_delete_slug do
-      nil ->
-        socket =
-          socket
-          |> assign(pending_sub_objective_delete_slug: slug)
-          |> hide_modal(modal_assigns: nil)
-          |> start_async({:delete_sub_objective, slug}, fn ->
-            project = Course.get_project_by_slug(project_slug)
-            author = Accounts.get_author_by_email(author_email)
+    if MapSet.member?(socket.assigns.pending_sub_objective_delete_slugs, slug) do
+      {:noreply,
+       socket
+       |> hide_modal(modal_assigns: nil)
+       |> put_flash(:error, "That sub-objective is already being deleted")}
+    else
+      socket =
+        socket
+        |> assign(
+          pending_sub_objective_delete_slugs:
+            MapSet.put(socket.assigns.pending_sub_objective_delete_slugs, slug)
+        )
+        |> hide_modal(modal_assigns: nil)
+        |> start_async({:delete_sub_objective, slug}, fn ->
+          project = Course.get_project_by_slug(project_slug)
+          author = Accounts.get_author_by_email(author_email)
 
-            delete_objective_result(slug, parent_slug, project, author)
-          end)
+          delete_objective_result(slug, parent_slug, project, author)
+        end)
 
-        {:noreply, socket}
-
-      _pending_slug ->
-        {:noreply,
-         socket
-         |> hide_modal(modal_assigns: nil)
-         |> put_flash(:error, "A sub-objective is already being deleted")}
+      {:noreply, socket}
     end
   end
 
@@ -574,7 +574,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
 
   @impl Phoenix.LiveView
   def handle_async({:delete_sub_objective, slug}, result, socket) do
-    if socket.assigns.pending_sub_objective_delete_slug == slug do
+    if MapSet.member?(socket.assigns.pending_sub_objective_delete_slugs, slug) do
       flash_type =
         case result do
           {:ok, flash_type} ->
@@ -590,6 +590,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
           :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
           :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
         end
+
+      socket =
+        assign(socket,
+          pending_sub_objective_delete_slugs:
+            MapSet.delete(socket.assigns.pending_sub_objective_delete_slugs, slug)
+        )
 
       return_updated_data(socket.assigns.project, flash_fn, socket)
     else

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -6,6 +6,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
   use OliWeb.Common.SortableTable.TableHandlers
   use OliWeb.Common.Modal
 
+  require Logger
+
   alias Oli.Accounts
   alias Oli.Authoring.Editing.ObjectiveEditor
   alias Oli.Publishing
@@ -22,6 +24,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     Listing,
     SelectExistingSubModal,
     SelectionsModal,
+    SubObjectiveDeleteModal,
     TableModel
   }
 
@@ -49,6 +52,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
        all_objectives: all_objectives,
        all_children: all_children,
        objective_attachments: [],
+       pending_sub_objective_delete_slug: nil,
        query: "",
        selected: "",
        offset: 0,
@@ -102,6 +106,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
           }
           rows={@table_model.rows}
           selected={@selected}
+          pending_delete_slug={@pending_sub_objective_delete_slug}
           project_slug={@project.slug}
         />
       </Table.render>
@@ -184,7 +189,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
        table_model: table_model,
        total_count: length(objectives),
        all_objectives: all_objectives,
-       all_children: all_children
+       all_children: all_children,
+       pending_sub_objective_delete_slug: nil
      )
      |> hide_modal(modal_assigns: nil)
      |> push_patch(to: live_path(socket, socket.assigns.params))}
@@ -410,11 +416,105 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     end
   end
 
+  def handle_event(
+        "display_sub_objective_delete_modal",
+        %{"slug" => slug, "parent_slug" => parent_slug},
+        socket
+      ) do
+    socket = clear_flash(socket)
+
+    %{project: project} = socket.assigns
+    %{title: title} = AuthoringResolver.from_revision_slug(project.slug, slug)
+
+    modal_assigns = %{
+      id: "delete_sub_objective_modal",
+      slug: slug,
+      parent_slug: parent_slug,
+      title: title
+    }
+
+    modal = fn assigns ->
+      ~H"""
+      <SubObjectiveDeleteModal.render {@modal_assigns} />
+      """
+    end
+
+    {:noreply, show_modal(socket, modal, modal_assigns: modal_assigns)}
+  end
+
   def handle_event("delete", %{"slug" => slug} = params, socket) do
     socket = clear_flash(socket)
 
     parent_slug = Map.get(params, "parent_slug", "")
     %{project: project, author: author, objectives: objectives} = socket.assigns
+
+    flash_fn = delete_objective(slug, parent_slug, project, author, objectives)
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  def handle_event(
+        "delete_sub_objective",
+        %{"slug" => slug, "parent_slug" => parent_slug},
+        socket
+      ) do
+    socket = clear_flash(socket)
+    %{project: project, author: author, objectives: objectives} = socket.assigns
+    pid = self()
+
+    Task.start(fn ->
+      flash_type =
+        try do
+          delete_objective_result(slug, parent_slug, project, author, objectives)
+        rescue
+          e ->
+            Logger.error(Exception.format(:error, e, __STACKTRACE__))
+            :error
+        end
+
+      send(pid, {:finish_sub_objective_delete, flash_type})
+    end)
+
+    {:noreply,
+     socket
+     |> assign(pending_sub_objective_delete_slug: slug)
+     |> hide_modal(modal_assigns: nil)}
+  end
+
+  def handle_event(
+        "add_existing_sub",
+        %{"slug" => slug, "parent_slug" => parent_slug} = _params,
+        socket
+      ) do
+    socket = clear_flash(socket)
+
+    %{project: project, author: author} = socket.assigns
+
+    flash_fn =
+      case ObjectiveEditor.add_new_parent_for_sub_objective(
+             slug,
+             parent_slug,
+             project.slug,
+             author
+           ) do
+        {:ok, _revision} ->
+          fn socket -> put_flash(socket, :info, "Sub-objective successfully added") end
+
+        {:error, _} ->
+          fn socket -> put_flash(socket, :error, "Could not add sub-objective") end
+      end
+
+    return_updated_data(project, flash_fn, socket)
+  end
+
+  defp delete_objective(slug, parent_slug, project, author, objectives) do
+    case delete_objective_result(slug, parent_slug, project, author, objectives) do
+      :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
+      :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
+    end
+  end
+
+  defp delete_objective_result(slug, parent_slug, project, author, objectives) do
     %{resource_id: resource_id} = AuthoringResolver.from_revision_slug(project.slug, slug)
 
     ObjectiveEditor.detach_objective(resource_id, project, author)
@@ -453,45 +553,23 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
         end
       end
 
-    flash_fn =
-      case delete_fn.() do
-        {:ok, _} ->
-          fn socket -> put_flash(socket, :info, "Objective successfully removed") end
-
-        {:error, _error} ->
-          fn socket -> put_flash(socket, :error, "Could not remove objective") end
-      end
-
-    return_updated_data(project, flash_fn, socket)
-  end
-
-  def handle_event(
-        "add_existing_sub",
-        %{"slug" => slug, "parent_slug" => parent_slug} = _params,
-        socket
-      ) do
-    socket = clear_flash(socket)
-
-    %{project: project, author: author} = socket.assigns
-
-    flash_fn =
-      case ObjectiveEditor.add_new_parent_for_sub_objective(
-             slug,
-             parent_slug,
-             project.slug,
-             author
-           ) do
-        {:ok, _revision} ->
-          fn socket -> put_flash(socket, :info, "Sub-objective successfully added") end
-
-        {:error, _} ->
-          fn socket -> put_flash(socket, :error, "Could not add sub-objective") end
-      end
-
-    return_updated_data(project, flash_fn, socket)
+    case delete_fn.() do
+      {:ok, _} -> :ok
+      {:error, _error} -> :error
+    end
   end
 
   @impl Phoenix.LiveView
+  def handle_info({:finish_sub_objective_delete, flash_type}, socket) do
+    flash_fn =
+      case flash_type do
+        :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
+        :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
+      end
+
+    return_updated_data(socket.assigns.project, flash_fn, socket)
+  end
+
   def handle_info({:finish_attachments, {objectives_attachments, flash_fn}}, socket) do
     page_id = ResourceType.id_for_page()
     activity_id = ResourceType.id_for_activity()

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -9,6 +9,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
   require Logger
 
   alias Oli.Accounts
+  alias Oli.Authoring.Course
   alias Oli.Authoring.Editing.ObjectiveEditor
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
@@ -418,13 +419,11 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
 
   def handle_event(
         "display_sub_objective_delete_modal",
-        %{"slug" => slug, "parent_slug" => parent_slug},
+        %{"slug" => slug, "parent_slug" => parent_slug} = params,
         socket
       ) do
     socket = clear_flash(socket)
-
-    %{project: project} = socket.assigns
-    %{title: title} = AuthoringResolver.from_revision_slug(project.slug, slug)
+    title = Map.get(params, "title", "this sub-objective")
 
     modal_assigns = %{
       id: "delete_sub_objective_modal",
@@ -446,9 +445,9 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     socket = clear_flash(socket)
 
     parent_slug = Map.get(params, "parent_slug", "")
-    %{project: project, author: author, objectives: objectives} = socket.assigns
+    %{project: project, author: author} = socket.assigns
 
-    flash_fn = delete_objective(slug, parent_slug, project, author, objectives)
+    flash_fn = delete_objective(slug, parent_slug, project, author)
 
     return_updated_data(project, flash_fn, socket)
   end
@@ -459,26 +458,29 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
         socket
       ) do
     socket = clear_flash(socket)
-    %{project: project, author: author, objectives: objectives} = socket.assigns
-    pid = self()
+    %{project: %{slug: project_slug}, author: %{email: author_email}} = socket.assigns
 
-    Task.start(fn ->
-      flash_type =
-        try do
-          delete_objective_result(slug, parent_slug, project, author, objectives)
-        rescue
-          e ->
-            Logger.error(Exception.format(:error, e, __STACKTRACE__))
-            :error
-        end
+    case socket.assigns.pending_sub_objective_delete_slug do
+      nil ->
+        socket =
+          socket
+          |> assign(pending_sub_objective_delete_slug: slug)
+          |> hide_modal(modal_assigns: nil)
+          |> start_async({:delete_sub_objective, slug}, fn ->
+            project = Course.get_project_by_slug(project_slug)
+            author = Accounts.get_author_by_email(author_email)
 
-      send(pid, {:finish_sub_objective_delete, flash_type})
-    end)
+            delete_objective_result(slug, parent_slug, project, author)
+          end)
 
-    {:noreply,
-     socket
-     |> assign(pending_sub_objective_delete_slug: slug)
-     |> hide_modal(modal_assigns: nil)}
+        {:noreply, socket}
+
+      _pending_slug ->
+        {:noreply,
+         socket
+         |> hide_modal(modal_assigns: nil)
+         |> put_flash(:error, "A sub-objective is already being deleted")}
+    end
   end
 
   def handle_event(
@@ -507,25 +509,30 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     return_updated_data(project, flash_fn, socket)
   end
 
-  defp delete_objective(slug, parent_slug, project, author, objectives) do
-    case delete_objective_result(slug, parent_slug, project, author, objectives) do
+  defp delete_objective(slug, parent_slug, project, author) do
+    case delete_objective_result(slug, parent_slug, project, author) do
       :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
       :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
     end
   end
 
-  defp delete_objective_result(slug, parent_slug, project, author, objectives) do
+  defp delete_objective_result(slug, parent_slug, project, author) do
     %{resource_id: resource_id} = AuthoringResolver.from_revision_slug(project.slug, slug)
 
     ObjectiveEditor.detach_objective(resource_id, project, author)
 
+    objectives =
+      project
+      |> ObjectiveEditor.fetch_objective_mappings()
+      |> Enum.map(& &1.revision)
+
     {parents, parent_to_detach_slug} =
       Enum.reduce(objectives, {[], ""}, fn objective, {parents, parent_to_detach_slug} ->
-        case Enum.find(objective.children, fn child -> !is_nil(child) && child.slug == slug end) do
-          nil ->
+        case Enum.member?(objective.children, resource_id) do
+          false ->
             {parents, parent_to_detach_slug}
 
-          _ ->
+          true ->
             if objective.slug == parent_slug,
               do: {[objective | parents], objective.slug},
               else: {[objective | parents], parent_to_detach_slug}
@@ -539,17 +546,23 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
             slug,
             author,
             project,
-            AuthoringResolver.from_revision_slug(project.slug, parent_to_detach_slug)
+            parent_objective(project, parent_to_detach_slug)
           )
         end
       else
         fn ->
-          ObjectiveEditor.remove_sub_objective_from_parent(
-            slug,
-            author,
-            project,
-            AuthoringResolver.from_revision_slug(project.slug, parent_to_detach_slug)
-          )
+          case parent_objective(project, parent_to_detach_slug) do
+            nil ->
+              {:error, :not_found}
+
+            parent_objective ->
+              ObjectiveEditor.remove_sub_objective_from_parent(
+                slug,
+                author,
+                project,
+                parent_objective
+              )
+          end
         end
       end
 
@@ -560,16 +573,36 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_info({:finish_sub_objective_delete, flash_type}, socket) do
-    flash_fn =
-      case flash_type do
-        :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
-        :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
-      end
+  def handle_async({:delete_sub_objective, slug}, result, socket) do
+    if socket.assigns.pending_sub_objective_delete_slug == slug do
+      flash_type =
+        case result do
+          {:ok, flash_type} ->
+            flash_type
 
-    return_updated_data(socket.assigns.project, flash_fn, socket)
+          {:exit, reason} ->
+            Logger.error("Sub-objective deletion failed: #{inspect(reason)}")
+            :error
+        end
+
+      flash_fn =
+        case flash_type do
+          :ok -> fn socket -> put_flash(socket, :info, "Objective successfully removed") end
+          :error -> fn socket -> put_flash(socket, :error, "Could not remove objective") end
+        end
+
+      return_updated_data(socket.assigns.project, flash_fn, socket)
+    else
+      {:noreply, socket}
+    end
   end
 
+  defp parent_objective(_project, ""), do: nil
+
+  defp parent_objective(project, slug),
+    do: AuthoringResolver.from_revision_slug(project.slug, slug)
+
+  @impl Phoenix.LiveView
   def handle_info({:finish_attachments, {objectives_attachments, flash_fn}}, socket) do
     page_id = ResourceType.id_for_page()
     activity_id = ResourceType.id_for_activity()

--- a/test/oli/editing/objective_editor_test.exs
+++ b/test/oli/editing/objective_editor_test.exs
@@ -2,6 +2,7 @@ defmodule Oli.Authoring.Editing.ObjectiveEditorTest do
   use Oli.DataCase
 
   alias Oli.Authoring.Editing.{ActivityEditor, ObjectiveEditor, PageEditor}
+  alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
   alias Oli.Resources.Revision
 
@@ -117,6 +118,35 @@ defmodule Oli.Authoring.Editing.ObjectiveEditorTest do
         AuthoringResolver.from_resource_id(project.slug, updated_revision.resource_id)
 
       assert updated_page.objectives == %{"attached" => []}
+    end
+
+    test "detach_objective/3 skips stale deleted page attachments", %{
+      author: author,
+      project: project,
+      revision1: revision
+    } do
+      {:ok, %{revision: objective}} =
+        ObjectiveEditor.add_new(%{title: "Test Objective"}, author, project)
+
+      objectives = %{"attached" => [objective.resource_id]}
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+
+      {:ok, _updated_revision} =
+        PageEditor.edit(project.slug, revision.slug, author.email, %{"objectives" => objectives})
+
+      PageEditor.release_lock(project.slug, revision.slug, author.email)
+
+      PageEditor.acquire_lock(project.slug, revision.slug, author.email)
+
+      assert {:ok, _} =
+               PageEditor.edit(project.slug, revision.slug, author.email, %{deleted: true})
+
+      PageEditor.release_lock(project.slug, revision.slug, author.email)
+
+      assert [] = ObjectiveEditor.detach_objective(objective.resource_id, project, author)
+
+      publication = Publishing.project_working_publication(project.slug)
+      assert [] = Publishing.retrieve_lock_info([revision.resource_id], publication.id)
     end
 
     test "detach_objective/3 does not remove when locked", %{

--- a/test/oli/publishing_test.exs
+++ b/test/oli/publishing_test.exs
@@ -445,20 +445,28 @@ defmodule Oli.PublishingTest do
 
       assert {:ok, _} = PageEditor.edit(project.slug, revision.slug, author.email, update)
 
+      PageEditor.acquire_lock(project.slug, activity3.slug, author.email)
+
+      assert {:ok, _} =
+               PageEditor.edit(project.slug, activity3.slug, author.email, %{deleted: true})
+
+      PageEditor.release_lock(project.slug, activity3.slug, author.email)
+
       results = Publishing.find_objective_attachments(obj1.resource_id, publication.id)
 
-      assert length(results) == 5
+      assert length(results) == 4
 
       # activity 2 should appear twice since it has the objective attached in multiple parts
       assert Enum.filter(results, fn r -> r.resource_id == activity2.resource_id end) |> length ==
                2
 
-      # the next two have it in only one part
+      # the next activity has it in only one part
       assert Enum.filter(results, fn r -> r.resource_id == activity1.resource_id end) |> length ==
                1
 
+      # this activity has the objective attached but is deleted
       assert Enum.filter(results, fn r -> r.resource_id == activity3.resource_id end) |> length ==
-               1
+               0
 
       # this activity does not have this objective attached at all
       assert Enum.filter(results, fn r -> r.resource_id == activity4.resource_id end) |> length ==
@@ -547,6 +555,25 @@ defmodule Oli.PublishingTest do
       }
 
       assert {:ok, _} = PageEditor.edit(project.slug, revision.slug, author.email, update)
+
+      {:ok, %{revision: deleted_page}} =
+        Course.create_and_attach_resource(project, %{
+          objectives: %{"attached" => [obj1.resource_id]},
+          children: [],
+          content: %{},
+          title: "deleted page",
+          resource_type_id: ResourceType.id_for_page(),
+          author_id: author.id
+        })
+
+      Publishing.upsert_published_resource(publication, deleted_page)
+
+      PageEditor.acquire_lock(project.slug, deleted_page.slug, author.email)
+
+      assert {:ok, _} =
+               PageEditor.edit(project.slug, deleted_page.slug, author.email, %{deleted: true})
+
+      PageEditor.release_lock(project.slug, deleted_page.slug, author.email)
 
       results = Publishing.find_attached_objectives(publication.id)
 

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -691,10 +691,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
       |> element("button[phx-click='delete_sub_objective'][phx-value-slug=#{sub_obj.slug}]")
       |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj.slug})
 
-      assert view
-             |> element(~s{div[role="alert"].alert-info})
-             |> render() =~
-               "Objective successfully removed"
+      assert has_element?(view, ".collapse .line-through", "#{sub_obj.title}")
+      assert has_element?(view, ".collapse .spinner-border")
+
+      wait_until(fn ->
+        has_element?(view, ~s{div[role="alert"].alert-info}, "Objective successfully removed")
+      end)
 
       assert 1 ==
                project
@@ -741,10 +743,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
       )
       |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj_a.slug})
 
-      assert view
-             |> element(~s{div[role="alert"].alert-info})
-             |> render() =~
-               "Objective successfully removed"
+      assert has_element?(view, "##{obj_a.slug} .line-through", "#{sub_obj.title}")
+      assert has_element?(view, "##{obj_a.slug} .spinner-border")
+
+      wait_until(fn ->
+        has_element?(view, ~s{div[role="alert"].alert-info}, "Objective successfully removed")
+      end)
 
       assert 3 ==
                project

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -679,7 +679,16 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
       assert has_element?(view, ".collapse", "#{sub_obj.title}")
 
       view
-      |> element("button[phx-click='delete'][phx-value-slug=#{sub_obj.slug}]")
+      |> element(
+        "button[phx-click='display_sub_objective_delete_modal'][phx-value-slug=#{sub_obj.slug}]"
+      )
+      |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj.slug})
+
+      assert has_element?(view, "#delete_sub_objective_modal", "Delete Sub-Objective")
+      assert has_element?(view, "#delete_sub_objective_modal", "#{sub_obj.title}")
+
+      view
+      |> element("button[phx-click='delete_sub_objective'][phx-value-slug=#{sub_obj.slug}]")
       |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj.slug})
 
       assert view
@@ -720,7 +729,15 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
 
       view
       |> element(
-        "button[phx-click='delete'][phx-value-slug=#{sub_obj.slug}][phx-value-parent_slug=#{obj_a.slug}]"
+        "button[phx-click='display_sub_objective_delete_modal'][phx-value-slug=#{sub_obj.slug}][phx-value-parent_slug=#{obj_a.slug}]"
+      )
+      |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj_a.slug})
+
+      assert has_element?(view, "#delete_sub_objective_modal", "Delete Sub-Objective")
+
+      view
+      |> element(
+        "button[phx-click='delete_sub_objective'][phx-value-slug=#{sub_obj.slug}][phx-value-parent_slug=#{obj_a.slug}]"
       )
       |> render_click(%{"slug" => sub_obj.slug, "parent_slug" => obj_a.slug})
 


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5768

This is a follow-on fix to the previous attempt to resolve cases where certain sub-LOs could not be deleted. The issue is not easy to reproduce with a fresh course or with export/import, because project export filters out deleted revisions. Affected courses need stale objective attachment data on deleted page or activity revisions, so the LO editor still thinks the objective is referenced by resources that are no longer editable. The observed crash path was triggered by a deleted page revision: detachment acquired a page lock, then failed when the page editor rejected the deleted revision as not found.

## Summary

- Filter deleted page and activity revisions out of authoring learning-objective attachment queries.
- Harden objective detachment so stale deleted page contexts are skipped without crashing or leaving acquired locks behind.
- Add a sub-objective delete confirmation flow with pending row feedback while deletion completes.
- Add a cancel action to objective create/edit modals.

<img width="4120" height="2458" alt="2026-07-09 11 57 28" src="https://github.com/user-attachments/assets/555997ed-8d04-4071-85e4-7c1c25511742" />


## Validation

- `mix format`
- `mix compile`
- `mix test test/oli/publishing_test.exs test/oli/editing/objective_editor_test.exs`
- `mix test test/oli_web/live/workspaces/course_author/objectives_live_test.exs`

The fix was tested manually and verified using the production Real Chem projects exhibiting the issue.