### PR TITLE
[BUG FIX] [MER-5776] Fix authoring UI and fraction choice labels

### DIFF
--- a/assets/src/components/activities/short_answer/sections/InputEntry.tsx
+++ b/assets/src/components/activities/short_answer/sections/InputEntry.tsx
@@ -669,7 +669,11 @@ export const InputEntry: React.FC<InputProps> = ({
               onChange={onEditNumericTolerance}
             />
           )}
-          <PrecisionInput input={numericState.input} onEditInput={onEditNumericInput} />
+          <PrecisionInput
+            input={numericState.input}
+            onEditInput={onEditNumericInput}
+            valueInputKind={numericValueInputKind}
+          />
           {activeQuestionType === 'number_with_units' && unitMismatchTargetControl}
         </div>
       </div>

--- a/assets/src/components/activities/short_answer/sections/InputEntry.tsx
+++ b/assets/src/components/activities/short_answer/sections/InputEntry.tsx
@@ -203,6 +203,10 @@ const isNumericQuestion = (inputType: InputType, questionType: ShortAnswerQuesti
 const usesNumericAnswerControls = (inputType: InputType, questionType: ShortAnswerQuestionType) =>
   isNumericQuestion(inputType, questionType) || questionType === 'number_with_units';
 
+const numericValueInputKindForQuestionType = (
+  questionType: ShortAnswerQuestionType,
+): 'number' | 'quantity' => (questionType === 'number_with_units' ? 'quantity' : 'number');
+
 const isLatexQuestion = (inputType: InputType, questionType: ShortAnswerQuestionType) =>
   inputType === 'math' || questionType === 'latex_direct';
 
@@ -605,6 +609,7 @@ export const InputEntry: React.FC<InputProps> = ({
   };
 
   const showsNumericAnswerControls = usesNumericAnswerControls(inputType, activeQuestionType);
+  const numericValueInputKind = numericValueInputKindForQuestionType(activeQuestionType);
   const unitMismatchTargetControl =
     allowUnitMismatchTarget && isUnitQuestionType(activeQuestionType) ? (
       <div className="mt-2 rounded border border-gray-200 bg-gray-50 p-3 text-body-color dark:border-gray-700 dark:bg-gray-800 dark:text-body-color-dark">
@@ -645,9 +650,17 @@ export const InputEntry: React.FC<InputProps> = ({
               ))}
             </select>
             {numericState.input.kind === InputKind.Numeric ? (
-              <SimpleNumericInput input={numericState.input} onEditInput={onEditNumericInput} />
+              <SimpleNumericInput
+                input={numericState.input}
+                onEditInput={onEditNumericInput}
+                valueInputKind={numericValueInputKind}
+              />
             ) : (
-              <RangeNumericInput input={numericState.input} onEditInput={onEditNumericInput} />
+              <RangeNumericInput
+                input={numericState.input}
+                onEditInput={onEditNumericInput}
+                valueInputKind={numericValueInputKind}
+              />
             )}
           </div>
           {numericState.kind === 'tol' && (
@@ -677,8 +690,8 @@ export const InputEntry: React.FC<InputProps> = ({
           onChange={onSelectFractionMatchMode}
           aria-label="Fraction match type"
         >
-          <option value="exact">Match this answer exactly</option>
-          <option value="equivalent">Match equivalent fractions</option>
+          <option value="exact">Require a simplified fraction</option>
+          <option value="equivalent">Accept any equivalent fraction</option>
         </select>
       </div>
     ) : null;

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -183,6 +183,7 @@ export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({
             className="custom-select mr-1"
             disabled={!editMode}
             style={{ width: 400 }}
+            aria-label="Range boundary inclusion"
             value={inclusiveOrExclusiveValue(input.inclusive)}
             onChange={({ target: { value } }) => {
               onEditInput({ ...input, inclusive: isInclusive(value) });
@@ -244,6 +245,7 @@ export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({
           className="custom-select mr-1"
           disabled={!editMode}
           style={{ width: 400 }}
+          aria-label="Range boundary inclusion"
           value={inclusiveOrExclusiveValue(input.inclusive)}
           onChange={({ target: { value } }) => {
             onEditInput({ ...input, inclusive: isInclusive(value) });

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -1,5 +1,6 @@
 import React, { createRef, useState } from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
+import { MathExpressionInput } from 'components/activities/common/math_expression';
 import { InfoTip } from 'components/misc/InfoTip';
 import {
   InputKind,
@@ -14,6 +15,8 @@ import { classNames } from 'utils/classNames';
 import guid from 'utils/guid';
 import { isValidNumber } from 'utils/number';
 import { disableScrollWheelChange } from '../utils';
+
+export type NumericValueInputKind = 'number' | 'quantity';
 
 // here we defined a "editable number" variant data type that contains information
 // about the number that is being edited. for example, a number input being edited
@@ -63,13 +66,34 @@ const editableNumberFromVNum = (vnum: numberOrVar): EditableNumber =>
 export interface SimpleNumericInputProps extends InputProps {
   input: InputNumeric;
   onEditInput: (input: InputNumeric) => void;
+  valueInputKind?: NumericValueInputKind;
 }
 
-export const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({ input, onEditInput }) => {
+export const SimpleNumericInput: React.FC<SimpleNumericInputProps> = ({
+  input,
+  onEditInput,
+  valueInputKind = 'number',
+}) => {
   const { editMode } = useAuthoringElementContext();
   const numericInputRef = createRef<HTMLInputElement>();
   const [editableNumber, setEditableNumber] = useState(editableNumberFromVNum(input.value));
   const editableNumberInvalid = editableNumber.kind === EditableNumberKind.Invalid;
+
+  if (valueInputKind === 'quantity') {
+    return (
+      <MathExpressionInput
+        disabled={!editMode}
+        layout="authoring"
+        previewMode="below_input"
+        validationKind="quantity"
+        ariaLabel="Correct answer"
+        placeholder="Correct answer"
+        value={String(input.value)}
+        onChange={(value) => onEditInput({ ...input, value })}
+      />
+    );
+  }
+
   return (
     <div>
       <input
@@ -109,9 +133,14 @@ const isInclusive = (value: string): boolean => value === 'inclusive';
 export interface RangeNumericInputProps extends InputProps {
   input: InputRange;
   onEditInput: (input: InputRange) => void;
+  valueInputKind?: NumericValueInputKind;
 }
 
-export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onEditInput }) => {
+export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({
+  input,
+  onEditInput,
+  valueInputKind = 'number',
+}) => {
   const { editMode } = useAuthoringElementContext();
   const lowerBoundInputRef = createRef<HTMLInputElement>();
   const upperBoundInputRef = createRef<HTMLInputElement>();
@@ -123,6 +152,50 @@ export const RangeNumericInput: React.FC<RangeNumericInputProps> = ({ input, onE
   );
   const lowerBoundInvalid = editableLowerBound.kind === EditableNumberKind.Invalid;
   const upperBoundInvalid = editableUpperBound.kind === EditableNumberKind.Invalid;
+
+  if (valueInputKind === 'quantity') {
+    return (
+      <div className="d-flex flex-column">
+        <div className="d-md-flex flex-md-row align-items-center gap-2">
+          <MathExpressionInput
+            disabled={!editMode}
+            layout="authoring"
+            previewMode="below_input"
+            validationKind="quantity"
+            ariaLabel="Lower bound"
+            placeholder="Lower bound"
+            value={String(input.lowerBound)}
+            onChange={(lowerBound) => onEditInput({ ...input, lowerBound })}
+          />
+          <div className="mx-1">and</div>
+          <MathExpressionInput
+            disabled={!editMode}
+            layout="authoring"
+            previewMode="below_input"
+            validationKind="quantity"
+            ariaLabel="Upper bound"
+            placeholder="Upper bound"
+            value={String(input.upperBound)}
+            onChange={(upperBound) => onEditInput({ ...input, upperBound })}
+          />
+          <select
+            className="custom-select mr-1"
+            disabled={!editMode}
+            style={{ width: 400 }}
+            value={inclusiveOrExclusiveValue(input.inclusive)}
+            onChange={({ target: { value } }) => {
+              onEditInput({ ...input, inclusive: isInclusive(value) });
+            }}
+            name="range-inclusive-exclusive"
+          >
+            <option value="inclusive">Inclusive</option>
+            <option value="exclusive">Exclusive</option>
+          </select>
+          <InfoTip title="Inclusive will include the boundaries in the range. Exclusive does not include boundaries." />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="d-flex flex-column">

--- a/assets/src/components/activities/short_answer/sections/NumericInput.tsx
+++ b/assets/src/components/activities/short_answer/sections/NumericInput.tsx
@@ -1,4 +1,5 @@
 import React, { createRef, useState } from 'react';
+import { quantityValueSource } from 'gleam/torusExpression';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { MathExpressionInput } from 'components/activities/common/math_expression';
 import { InfoTip } from 'components/misc/InfoTip';
@@ -332,23 +333,39 @@ const DIGITS: Record<string, boolean> = {
   '9': true,
 };
 const isDigit = (c: string): boolean => DIGITS[c];
-const numberOfDigits = (value: numberOrVar) => value.toString().split('').filter(isDigit).length;
+const numberOfDigits = (value: numberOrVar, valueInputKind: NumericValueInputKind) => {
+  const source = value.toString();
+  const numericSource = valueInputKind === 'quantity' ? quantityValueSource(source) : source;
 
-const inferPrecision = (input: InputNumeric | InputRange) => {
+  return numericSource.split('').filter(isDigit).length;
+};
+
+const inferPrecision = (
+  input: InputNumeric | InputRange,
+  valueInputKind: NumericValueInputKind,
+) => {
   switch (input.kind) {
     case InputKind.Numeric:
-      return numberOfDigits(input.value);
+      return numberOfDigits(input.value, valueInputKind);
     case InputKind.Range:
-      return Math.min(numberOfDigits(input.lowerBound), numberOfDigits(input.upperBound));
+      return Math.min(
+        numberOfDigits(input.lowerBound, valueInputKind),
+        numberOfDigits(input.upperBound, valueInputKind),
+      );
   }
 };
 
 export interface PrecisionInputProps {
   input: InputNumeric | InputRange;
   onEditInput: (input: InputNumeric | InputRange) => void;
+  valueInputKind?: NumericValueInputKind;
 }
 
-export const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInput }) => {
+export const PrecisionInput: React.FC<PrecisionInputProps> = ({
+  input,
+  onEditInput,
+  valueInputKind = 'number',
+}) => {
   const { editMode } = useAuthoringElementContext();
   const numericInputRef = createRef<HTMLInputElement>();
   const [precision, setPrecision] = useState(precisionFromNumberOrUndefined(input.precision));
@@ -362,7 +379,10 @@ export const PrecisionInput: React.FC<PrecisionInputProps> = ({ input, onEditInp
       setPrecision({ kind: PrecisionKind.None });
       onEditInput({ ...input, precision: undefined });
     } else {
-      const p = { kind: PrecisionKind.WithPrecision, value: inferPrecision(input) };
+      const p = {
+        kind: PrecisionKind.WithPrecision,
+        value: inferPrecision(input, valueInputKind),
+      };
       setPrecision(p);
       onEditInput({ ...input, precision: p.value });
     }

--- a/assets/src/data/activities/model/match_conversion.ts
+++ b/assets/src/data/activities/model/match_conversion.ts
@@ -181,7 +181,7 @@ export const numericInputFromMatchConfig = (
       return {
         kind: InputKind.Numeric,
         operator: matchOperator === 'equal' ? 'eq' : 'neq',
-        value: numericExpectedValue(math.expected),
+        value: math.mode === 'unit_aware' ? math.expected : numericExpectedValue(math.expected),
         precision,
       };
     case 'greater_than':

--- a/assets/src/gleam/torusExpression.ts
+++ b/assets/src/gleam/torusExpression.ts
@@ -55,6 +55,11 @@ export type MathExpressionPreviewResult =
   | { status: 'invalid'; debug: string }
   | { status: 'unknown'; debug: string };
 
+type ParsedQuantity = {
+  value: { span: { end: number } };
+  unit: unknown;
+};
+
 export function validateMathExpressionSyntax(
   expression: string,
   kind: MathExpressionSyntaxKind,
@@ -87,6 +92,14 @@ export function previewMathExpressionSyntax(
   }
 
   return kind === 'quantity' ? previewQuantityExpression(trimmed) : previewPlainExpression(trimmed);
+}
+
+export function quantityValueSource(source: string): string {
+  const result = parse_quantity_or_expression(source);
+
+  if (!isOk(result) || !isParsedQuantity(result[0])) return source;
+
+  return source.slice(0, result[0].value.span.end);
 }
 
 function previewPlainExpression(expression: string): MathExpressionPreviewResult {
@@ -144,5 +157,22 @@ function isError(result: unknown): result is { 0: any; isOk: () => false } {
     result !== null &&
     typeof (result as { isOk?: unknown }).isOk === 'function' &&
     !(result as { isOk: () => boolean }).isOk()
+  );
+}
+
+function isParsedQuantity(value: unknown): value is ParsedQuantity {
+  if (typeof value !== 'object' || value === null || !('unit' in value) || !('value' in value)) {
+    return false;
+  }
+
+  const parsedValue = (value as { value: unknown }).value;
+
+  return (
+    typeof parsedValue === 'object' &&
+    parsedValue !== null &&
+    'span' in parsedValue &&
+    typeof (parsedValue as { span: unknown }).span === 'object' &&
+    (parsedValue as { span: { end?: unknown } }).span !== null &&
+    typeof (parsedValue as { span: { end?: unknown } }).span.end === 'number'
   );
 }

--- a/assets/test/gleam/torus_expression_test.ts
+++ b/assets/test/gleam/torus_expression_test.ts
@@ -1,4 +1,4 @@
-import { previewMathExpressionSyntax } from 'gleam/torusExpression';
+import { previewMathExpressionSyntax, quantityValueSource } from 'gleam/torusExpression';
 import type { MathExpressionSyntaxKind } from 'gleam/torusExpression';
 import { parsed_quantity_to_latex, parsed_to_latex } from 'gleam_build/oli/math/latex.mjs';
 import { parse } from 'gleam_build/oli/math/parser.mjs';
@@ -128,5 +128,26 @@ describe('torusExpression preview adapter', () => {
 
     expect(quantity.parse_quantity_or_expression).toHaveBeenCalledWith('9.8 m/s^2');
     expect(parser.parse).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['9.8 m/s^2', 3, '9.8'],
+    ['(12 + 3) J/(mol*K)', 8, '(12 + 3)'],
+  ])('returns only the value source for quantity %s', (source, end, expected) => {
+    quantity.parse_quantity_or_expression.mockReturnValue(
+      ok({ value: { span: { end } }, unit: 'parsed-unit' }),
+    );
+
+    expect(quantityValueSource(source)).toBe(expected);
+    expect(quantity.parse_quantity_or_expression).toHaveBeenCalledWith(source);
+  });
+
+  it.each([
+    [ok({ value: { span: { end: 3 } } }), '9.8'],
+    [error('invalid quantity'), '9.8m/s^2'],
+  ])('preserves the source when the parser result is not a quantity', (result, source) => {
+    quantity.parse_quantity_or_expression.mockReturnValue(result);
+
+    expect(quantityValueSource(source)).toBe(source);
   });
 });

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -318,4 +318,34 @@ describe('multi input question - default (with text input)', () => {
     const answerEditors = screen.getAllByLabelText('Correct answer');
     expect(answerEditors).toHaveLength(2);
   });
+
+  it('uses quantity editors in answer key and targeted feedback for number with units', () => {
+    const freshModel = defaultModel();
+    const originalInput = freshModel.inputs[0] as FillInTheBlank;
+    let mathModel = dispatch(
+      freshModel,
+      MultiInputActions.setQuestionType(originalInput.id, 'number_with_units'),
+    );
+    const mathInput = mathModel.inputs[0] as FillInTheBlank;
+    mathModel = dispatch(mathModel, addTargetedFeedbackFillInTheBlank(mathInput));
+    const authoringModel = JSON.parse(JSON.stringify(mathModel)) as MultiInputSchema;
+    const authoringInput = authoringModel.inputs[0] as FillInTheBlank;
+
+    render(
+      <Provider store={configureStore()}>
+        <AuthoringElementProvider
+          {...defaultAuthoringElementProps<MultiInputSchema>(authoringModel)}
+        >
+          <AnswerKeyTab input={authoringInput} />
+        </AuthoringElementProvider>
+      </Provider>,
+    );
+
+    expect(screen.getAllByRole('button', { name: 'Math expression syntax help' })).toHaveLength(2);
+
+    const answerEditors = screen.getAllByLabelText('Correct answer');
+    fireEvent.change(answerEditors[0], { target: { value: '1.2 m/s^2' } });
+
+    expect(answerEditors[0]).toHaveValue('1.2 m/s^2');
+  });
 });

--- a/assets/test/multi_input/multi_input_authoring_test.tsx
+++ b/assets/test/multi_input/multi_input_authoring_test.tsx
@@ -319,7 +319,7 @@ describe('multi input question - default (with text input)', () => {
     expect(answerEditors).toHaveLength(2);
   });
 
-  it('uses quantity editors in answer key and targeted feedback for number with units', () => {
+  it('authors unit-targeted feedback end to end for number with units', () => {
     const freshModel = defaultModel();
     const originalInput = freshModel.inputs[0] as FillInTheBlank;
     let mathModel = dispatch(
@@ -347,5 +347,35 @@ describe('multi input question - default (with text input)', () => {
     fireEvent.change(answerEditors[0], { target: { value: '1.2 m/s^2' } });
 
     expect(answerEditors[0]).toHaveValue('1.2 m/s^2');
+
+    const unitMatchType = screen.getByLabelText('Unit feedback match type');
+    expect(screen.getByRole('option', { name: 'Wrong unit' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Missing unit' })).toBeInTheDocument();
+
+    fireEvent.change(unitMatchType, { target: { value: 'missing_unit' } });
+
+    let targetedMatchConfig = authoringModel.authoring.parts[0].responses[1].matchConfig;
+    expect(
+      targetedMatchConfig?.type === 'math_expression' && targetedMatchConfig.math,
+    ).toMatchObject({
+      mode: 'unit_aware',
+      matchMissingUnit: true,
+    });
+    expect(
+      targetedMatchConfig?.type === 'math_expression' && targetedMatchConfig.math,
+    ).not.toHaveProperty('matchWrongUnits');
+
+    fireEvent.change(unitMatchType, { target: { value: 'wrong_units' } });
+
+    targetedMatchConfig = authoringModel.authoring.parts[0].responses[1].matchConfig;
+    expect(
+      targetedMatchConfig?.type === 'math_expression' && targetedMatchConfig.math,
+    ).toMatchObject({
+      mode: 'unit_aware',
+      matchWrongUnits: true,
+    });
+    expect(
+      targetedMatchConfig?.type === 'math_expression' && targetedMatchConfig.math,
+    ).not.toHaveProperty('matchMissingUnit');
   });
 });

--- a/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
+++ b/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { act } from 'react-dom/test-utils';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { quantityValueSource } from 'gleam/torusExpression';
 import { AuthoringElementProvider } from 'components/activities/AuthoringElementProvider';
 import { ShortAnswerActions } from 'components/activities/short_answer/actions';
 import { InputEntry } from 'components/activities/short_answer/sections/InputEntry';
@@ -17,6 +18,7 @@ import { dispatch } from 'utils/test_utils';
 import { defaultAuthoringElementProps } from '../utils/activity_mocks';
 
 jest.mock('gleam/torusExpression', () => ({
+  quantityValueSource: jest.fn((source: string) => source.replace(/\s+[A-Za-zµÅΩ].*$/, '')),
   previewMathExpressionSyntax: jest.fn((expression: string, kind: 'expression' | 'quantity') =>
     expression.includes('bad')
       ? { status: 'invalid', debug: 'invalid expression' }
@@ -27,6 +29,8 @@ jest.mock('gleam/torusExpression', () => ({
         },
   ),
 }));
+
+const quantityValueSourceMock = quantityValueSource as jest.Mock;
 
 jest.mock('components/misc/InfoTip', () => ({
   InfoTip: () => null,
@@ -41,6 +45,7 @@ describe('short answer math expression authoring', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    quantityValueSourceMock.mockClear();
     restoreMathJax = window.MathJax;
     window.MathJax = {
       startup: { promise: Promise.resolve() },
@@ -50,6 +55,7 @@ describe('short answer math expression authoring', () => {
 
   afterEach(() => {
     window.MathJax = restoreMathJax;
+    jest.clearAllTimers();
     jest.useRealTimers();
   });
 
@@ -372,6 +378,43 @@ describe('short answer math expression authoring', () => {
     expect(onEditResponseMatchConfig).toHaveBeenCalled();
   });
 
+  it('preserves numeric significant-figure inference for number questions', () => {
+    const model = dispatch(defaultModel(), ShortAnswerActions.setQuestionType('numeric', '1'));
+    const response = makeMatchConfigResponse(
+      MatchConfigs.numeric({ operator: 'equal', expected: '12.30' }),
+      0,
+    );
+    const onEditResponseMatchConfig = jest.fn();
+
+    render(
+      <AuthoringElementProvider {...defaultAuthoringElementProps(model)}>
+        <InputEntry
+          inputType={model.inputType}
+          questionType={shortAnswerQuestionType(model)}
+          mathExpressionConfig={shortAnswerMathExpressionConfig(model)}
+          response={response}
+          onEditResponseRule={jest.fn()}
+          onEditResponseMatchConfig={onEditResponseMatchConfig}
+        />
+      </AuthoringElementProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Significant Figures' }));
+
+    expect(screen.getByRole('spinbutton', { name: 'Significant Figures' })).toHaveValue(4);
+    expect(quantityValueSourceMock).not.toHaveBeenCalled();
+    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
+      response.id,
+      expect.objectContaining({
+        type: 'math_expression',
+        math: expect.objectContaining({
+          mode: 'numeric',
+          precision: { type: 'significant_figures', count: 4 },
+        }),
+      }),
+    );
+  });
+
   it('uses quantity validation while preserving numeric comparison controls for number_with_units', () => {
     const model = dispatch(
       defaultModel(),
@@ -398,6 +441,21 @@ describe('short answer math expression authoring', () => {
     expect(screen.getByLabelText('Correct answer')).toHaveValue('9.8 m/s^2');
     expect(screen.getByLabelText('Unit feedback match type')).toBeInTheDocument();
 
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Significant Figures' }));
+
+    expect(screen.getByRole('spinbutton', { name: 'Significant Figures' })).toHaveValue(2);
+    expect(quantityValueSourceMock).toHaveBeenCalledWith('9.8 m/s^2');
+    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
+      response.id,
+      expect.objectContaining({
+        type: 'math_expression',
+        math: expect.objectContaining({
+          mode: 'unit_aware',
+          precision: { type: 'significant_figures', count: 2 },
+        }),
+      }),
+    );
+
     fireEvent.change(screen.getByLabelText('Correct answer'), {
       target: { value: '10 km/hr' },
     });
@@ -421,10 +479,10 @@ describe('short answer math expression authoring', () => {
       ShortAnswerActions.setQuestionType('number_with_units', '1'),
     );
     const response = makeMatchConfigResponse(
-      MatchConfigs.unitAware('1 m/s', undefined, {
+      MatchConfigs.unitAware('1.2 m/s^2', undefined, {
         operator: 'between',
-        lower: '1 m/s',
-        upper: '2 m/s',
+        lower: '1.2 m/s^2',
+        upper: '34.5 km/hr^10',
         bounds: 'inclusive',
       }),
       0,
@@ -445,8 +503,24 @@ describe('short answer math expression authoring', () => {
     );
 
     expect(screen.getAllByRole('button', { name: 'Math expression syntax help' })).toHaveLength(2);
-    expect(screen.getByLabelText('Lower bound')).toHaveValue('1 m/s');
-    expect(screen.getByLabelText('Upper bound')).toHaveValue('2 m/s');
+    expect(screen.getByLabelText('Lower bound')).toHaveValue('1.2 m/s^2');
+    expect(screen.getByLabelText('Upper bound')).toHaveValue('34.5 km/hr^10');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Significant Figures' }));
+
+    expect(screen.getByRole('spinbutton', { name: 'Significant Figures' })).toHaveValue(2);
+    expect(quantityValueSourceMock).toHaveBeenNthCalledWith(1, '1.2 m/s^2');
+    expect(quantityValueSourceMock).toHaveBeenNthCalledWith(2, '34.5 km/hr^10');
+    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
+      response.id,
+      expect.objectContaining({
+        type: 'math_expression',
+        math: expect.objectContaining({
+          mode: 'unit_aware',
+          precision: { type: 'significant_figures', count: 2 },
+        }),
+      }),
+    );
 
     fireEvent.change(screen.getByLabelText('Upper bound'), {
       target: { value: '3 km/hr' },
@@ -459,7 +533,7 @@ describe('short answer math expression authoring', () => {
         math: expect.objectContaining({
           mode: 'unit_aware',
           operator: 'between',
-          lower: '1 m/s',
+          lower: '1.2 m/s^2',
           upper: '3 km/hr',
         }),
       }),

--- a/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
+++ b/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
@@ -283,7 +283,7 @@ describe('short answer math expression authoring', () => {
     expect(screen.getByRole('option', { name: 'Missing unit' })).toBeInTheDocument();
   });
 
-  it('stores wrong-unit and missing-unit targeted feedback match modes', () => {
+  it('stores mutually exclusive unit-targeted feedback modes for number with units', () => {
     const model = dispatch(
       defaultModel(),
       ShortAnswerActions.setQuestionType('number_with_units', '1'),
@@ -305,35 +305,41 @@ describe('short answer math expression authoring', () => {
       </AuthoringElementProvider>,
     );
 
+    expect(screen.getByRole('option', { name: 'Wrong unit' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Missing unit' })).toBeInTheDocument();
+
     fireEvent.change(screen.getByLabelText('Unit feedback match type'), {
       target: { value: 'missing_unit' },
     });
 
-    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
-      response.id,
-      expect.objectContaining({
-        type: 'math_expression',
-        math: expect.objectContaining({
-          mode: 'unit_aware',
-          matchMissingUnit: true,
-        }),
-      }),
-    );
+    let savedMatchConfig =
+      onEditResponseMatchConfig.mock.calls[onEditResponseMatchConfig.mock.calls.length - 1][1];
+    expect(savedMatchConfig.math).toMatchObject({
+      mode: 'unit_aware',
+      matchMissingUnit: true,
+    });
+    expect(savedMatchConfig.math).not.toHaveProperty('matchWrongUnits');
 
     fireEvent.change(screen.getByLabelText('Unit feedback match type'), {
       target: { value: 'wrong_units' },
     });
 
-    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
-      response.id,
-      expect.objectContaining({
-        type: 'math_expression',
-        math: expect.objectContaining({
-          mode: 'unit_aware',
-          matchWrongUnits: true,
-        }),
-      }),
-    );
+    savedMatchConfig =
+      onEditResponseMatchConfig.mock.calls[onEditResponseMatchConfig.mock.calls.length - 1][1];
+    expect(savedMatchConfig.math).toMatchObject({
+      mode: 'unit_aware',
+      matchWrongUnits: true,
+    });
+    expect(savedMatchConfig.math).not.toHaveProperty('matchMissingUnit');
+
+    fireEvent.change(screen.getByLabelText('Unit feedback match type'), {
+      target: { value: 'none' },
+    });
+
+    savedMatchConfig =
+      onEditResponseMatchConfig.mock.calls[onEditResponseMatchConfig.mock.calls.length - 1][1];
+    expect(savedMatchConfig.math).not.toHaveProperty('matchWrongUnits');
+    expect(savedMatchConfig.math).not.toHaveProperty('matchMissingUnit');
   });
 
   it('uses shared math expression help for fraction answer editors', () => {

--- a/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
+++ b/assets/test/short_answer/short_answer_math_expression_authoring_test.tsx
@@ -28,6 +28,10 @@ jest.mock('gleam/torusExpression', () => ({
   ),
 }));
 
+jest.mock('components/misc/InfoTip', () => ({
+  InfoTip: () => null,
+}));
+
 // @ac "AC-024" Answer-key expected-answer editors expose validation and help.
 // @ac "AC-025" Targeted feedback editors expose validation and help.
 // @ac "AC-026" Candidate/test expression coverage is satisfied by the shared editor path when present.
@@ -362,7 +366,7 @@ describe('short answer math expression authoring', () => {
     expect(onEditResponseMatchConfig).toHaveBeenCalled();
   });
 
-  it('uses numeric answer controls for number_with_units answer editors', () => {
+  it('uses quantity validation while preserving numeric comparison controls for number_with_units', () => {
     const model = dispatch(
       defaultModel(),
       ShortAnswerActions.setQuestionType('number_with_units', '1'),
@@ -384,13 +388,12 @@ describe('short answer math expression authoring', () => {
       </AuthoringElementProvider>,
     );
 
-    expect(
-      screen.queryByRole('button', { name: 'Math expression syntax help' }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Math expression syntax help' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Correct answer')).toHaveValue('9.8 m/s^2');
     expect(screen.getByLabelText('Unit feedback match type')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Correct answer'), {
-      target: { value: '10' },
+      target: { value: '10 km/hr' },
     });
 
     expect(onEditResponseMatchConfig).toHaveBeenCalledWith(
@@ -399,8 +402,59 @@ describe('short answer math expression authoring', () => {
         type: 'math_expression',
         math: expect.objectContaining({
           mode: 'unit_aware',
-          expected: '10',
+          expected: '10 km/hr',
           operator: 'equal',
+        }),
+      }),
+    );
+  });
+
+  it('uses quantity validation for number_with_units range bounds', () => {
+    const model = dispatch(
+      defaultModel(),
+      ShortAnswerActions.setQuestionType('number_with_units', '1'),
+    );
+    const response = makeMatchConfigResponse(
+      MatchConfigs.unitAware('1 m/s', undefined, {
+        operator: 'between',
+        lower: '1 m/s',
+        upper: '2 m/s',
+        bounds: 'inclusive',
+      }),
+      0,
+    );
+    const onEditResponseMatchConfig = jest.fn();
+
+    render(
+      <AuthoringElementProvider {...defaultAuthoringElementProps(model)}>
+        <InputEntry
+          inputType={model.inputType}
+          questionType={shortAnswerQuestionType(model)}
+          mathExpressionConfig={shortAnswerMathExpressionConfig(model)}
+          response={response}
+          onEditResponseRule={jest.fn()}
+          onEditResponseMatchConfig={onEditResponseMatchConfig}
+        />
+      </AuthoringElementProvider>,
+    );
+
+    expect(screen.getAllByRole('button', { name: 'Math expression syntax help' })).toHaveLength(2);
+    expect(screen.getByLabelText('Lower bound')).toHaveValue('1 m/s');
+    expect(screen.getByLabelText('Upper bound')).toHaveValue('2 m/s');
+
+    fireEvent.change(screen.getByLabelText('Upper bound'), {
+      target: { value: '3 km/hr' },
+    });
+
+    expect(onEditResponseMatchConfig).toHaveBeenLastCalledWith(
+      response.id,
+      expect.objectContaining({
+        type: 'math_expression',
+        math: expect.objectContaining({
+          mode: 'unit_aware',
+          operator: 'between',
+          lower: '1 m/s',
+          upper: '3 km/hr',
         }),
       }),
     );

--- a/gleam/src/math/equality/numeric.gleam
+++ b/gleam/src/math/equality/numeric.gleam
@@ -4,6 +4,8 @@ import gleam/list
 import gleam/string
 import math/equality/types
 
+const tolerance_boundary_relative_epsilon = 0.000000000001
+
 /// Evaluate the standard/basic page numeric comparison family. This is kept out
 /// of the expression parser because Number inputs historically accept scalar
 /// numeric answers, not full math expressions with variables or operators.
@@ -381,15 +383,35 @@ fn values_equal(
   case tolerance {
     types.NoTolerance -> submitted_value == expected_value
     types.AbsoluteTolerance(value) ->
-      absolute_difference(submitted_value, expected_value) <=. value
+      within_tolerance_window(
+        absolute_difference(submitted_value, expected_value),
+        value,
+      )
     types.RelativeTolerance(value) ->
-      absolute_difference(submitted_value, expected_value)
-      <=. relative_window(submitted_value, expected_value, value)
+      within_tolerance_window(
+        absolute_difference(submitted_value, expected_value),
+        relative_window(submitted_value, expected_value, value),
+      )
     types.AbsoluteOrRelativeTolerance(absolute, relative) ->
-      absolute_difference(submitted_value, expected_value) <=. absolute
-      || absolute_difference(submitted_value, expected_value)
-      <=. relative_window(submitted_value, expected_value, relative)
+      within_tolerance_window(
+        absolute_difference(submitted_value, expected_value),
+        absolute,
+      )
+      || within_tolerance_window(
+        absolute_difference(submitted_value, expected_value),
+        relative_window(submitted_value, expected_value, relative),
+      )
   }
+}
+
+/// Decimal authoring values such as `1.5 +/- 0.1` can parse to binary floats
+/// where an exact boundary lands a few ULPs outside the authored tolerance.
+/// Keep authored positive tolerance windows inclusive without changing exact
+/// no-tolerance comparisons.
+fn within_tolerance_window(difference: Float, window: Float) -> Bool {
+  difference <=. window
+  || window >. 0.0
+  && difference <=. window +. window *. tolerance_boundary_relative_epsilon
 }
 
 /// Use the tolerance diagnostic only when a tolerance was part of the author

--- a/gleam/src/math/match/evaluate.gleam
+++ b/gleam/src/math/match/evaluate.gleam
@@ -465,10 +465,8 @@ fn evaluate_unit_numeric_aware(
   case reference_unit(config) {
     Error(error) -> types.MatchInvalidConfig(error: error)
     Ok(reference_unit) -> {
-      case
-        numeric.scale_comparison_values(spec, reference_unit.scale_to_canonical)
-      {
-        Error(error) -> types.MatchInvalidConfig(error: equality_error(error))
+      case normalize_authored_unit_numeric_spec(spec, config, reference_unit) {
+        Error(error) -> types.MatchInvalidConfig(error: error)
         Ok(canonical_spec) ->
           evaluate_unit_numeric_submission(
             canonical_spec,
@@ -480,6 +478,223 @@ fn evaluate_unit_numeric_aware(
           )
       }
     }
+  }
+}
+
+/// Numeric unit-aware comparisons historically stored scalar operands in the
+/// reference unit. Quantity editors now preserve authored units, so normalize
+/// each operand before the shared numeric evaluator applies its comparison.
+fn normalize_authored_unit_numeric_spec(
+  spec: equality_types.NumericSpec,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(equality_types.NumericSpec, types.MatchConfigError) {
+  case
+    normalize_authored_unit_numeric_comparison(
+      spec.comparison,
+      config,
+      reference_unit,
+    )
+  {
+    Error(error) -> Error(error)
+    Ok(comparison) ->
+      Ok(equality_types.NumericSpec(
+        comparison: comparison,
+        tolerance: spec.tolerance,
+        representation: spec.representation,
+        precision: spec.precision,
+      ))
+  }
+}
+
+fn normalize_authored_unit_numeric_comparison(
+  comparison: equality_types.NumericComparison,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(equality_types.NumericComparison, types.MatchConfigError) {
+  case comparison {
+    equality_types.Equal(expected) ->
+      normalize_authored_unit_numeric_input(
+        expected,
+        "expected",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.Equal)
+
+    equality_types.NotEqual(expected) ->
+      normalize_authored_unit_numeric_input(
+        expected,
+        "expected",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.NotEqual)
+
+    equality_types.GreaterThan(threshold) ->
+      normalize_authored_unit_numeric_input(
+        threshold,
+        "threshold",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.GreaterThan)
+
+    equality_types.GreaterThanOrEqual(threshold) ->
+      normalize_authored_unit_numeric_input(
+        threshold,
+        "threshold",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.GreaterThanOrEqual)
+
+    equality_types.LessThan(threshold) ->
+      normalize_authored_unit_numeric_input(
+        threshold,
+        "threshold",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.LessThan)
+
+    equality_types.LessThanOrEqual(threshold) ->
+      normalize_authored_unit_numeric_input(
+        threshold,
+        "threshold",
+        config,
+        reference_unit,
+      )
+      |> result.map(equality_types.LessThanOrEqual)
+
+    equality_types.Between(lower, upper, bounds) ->
+      normalize_authored_unit_numeric_range(
+        lower,
+        upper,
+        bounds,
+        equality_types.Between,
+        config,
+        reference_unit,
+      )
+
+    equality_types.NotBetween(lower, upper, bounds) ->
+      normalize_authored_unit_numeric_range(
+        lower,
+        upper,
+        bounds,
+        equality_types.NotBetween,
+        config,
+        reference_unit,
+      )
+  }
+}
+
+fn normalize_authored_unit_numeric_range(
+  lower: equality_types.NumericInput,
+  upper: equality_types.NumericInput,
+  bounds: equality_types.RangeBounds,
+  constructor: fn(
+    equality_types.NumericInput,
+    equality_types.NumericInput,
+    equality_types.RangeBounds,
+  ) -> equality_types.NumericComparison,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(equality_types.NumericComparison, types.MatchConfigError) {
+  case
+    normalize_authored_unit_numeric_input(
+      lower,
+      "lower",
+      config,
+      reference_unit,
+    ),
+    normalize_authored_unit_numeric_input(
+      upper,
+      "upper",
+      config,
+      reference_unit,
+    )
+  {
+    Ok(lower), Ok(upper) -> Ok(constructor(lower, upper, bounds))
+    Error(error), _ | _, Error(error) -> Error(error)
+  }
+}
+
+fn normalize_authored_unit_numeric_input(
+  input: equality_types.NumericInput,
+  field: String,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+  let equality_types.NumericInput(raw: raw) = input
+
+  case quantity.parse_quantity_or_expression(raw) {
+    Ok(unit_types.ParsedExpression(_)) ->
+      normalize_authored_scalar(raw, field, reference_unit.scale_to_canonical)
+
+    Ok(unit_types.ParsedQuantity(_, unit)) ->
+      normalize_authored_quantity(raw, unit, field, config, reference_unit)
+
+    Error(_) ->
+      Error(types.InvalidField(
+        field: "math." <> field,
+        reason: "expected a scalar number or quantity",
+      ))
+  }
+}
+
+fn normalize_authored_scalar(
+  raw: String,
+  field: String,
+  scale: Float,
+) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+  case numeric.parse_scalar(raw) {
+    Ok(value) ->
+      Ok(equality_types.NumericInput(raw: float.to_string(value *. scale)))
+    Error(Nil) ->
+      Error(types.InvalidField(
+        field: "math." <> field,
+        reason: "expected a scalar number or quantity",
+      ))
+  }
+}
+
+fn normalize_authored_quantity(
+  raw: String,
+  unit: unit_types.UnitExpr,
+  field: String,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+  case
+    numeric.parse_scalar(submitted_numeric_value_source(raw)),
+    unit_normalize.normalize_unit(unit)
+  {
+    Ok(value), Ok(normalized_unit) ->
+      case config.mode {
+        unit_types.IgnoreUnits ->
+          Ok(equality_types.NumericInput(raw: float.to_string(value)))
+        unit_types.RequireUnits ->
+          case same_dimensions(normalized_unit, reference_unit) {
+            True ->
+              Ok(
+                equality_types.NumericInput(raw: float.to_string(
+                  value *. normalized_unit.scale_to_canonical,
+                )),
+              )
+            False ->
+              Error(types.InvalidField(
+                field: "math." <> field,
+                reason: "quantity unit is incompatible with the configured reference unit",
+              ))
+          }
+      }
+
+    _, _ ->
+      Error(types.InvalidField(
+        field: "math." <> field,
+        reason: "expected a scalar quantity with a supported unit",
+      ))
   }
 }
 

--- a/gleam/src/math/match/evaluate.gleam
+++ b/gleam/src/math/match/evaluate.gleam
@@ -29,6 +29,13 @@ type SubmittedUnitStatus {
   SubmittedMissingUnit
 }
 
+type NormalizedAuthoredNumericInput {
+  NormalizedAuthoredNumericInput(
+    raw: equality_types.NumericInput,
+    canonical: equality_types.NumericInput,
+  )
+}
+
 /// Validate only the root contract invariant owned by the match-config layer.
 pub fn validate_config(
   config: types.MatchConfig,
@@ -467,8 +474,9 @@ fn evaluate_unit_numeric_aware(
     Ok(reference_unit) -> {
       case normalize_authored_unit_numeric_spec(spec, config, reference_unit) {
         Error(error) -> types.MatchInvalidConfig(error: error)
-        Ok(canonical_spec) ->
+        Ok(#(raw_spec, canonical_spec)) ->
           evaluate_unit_numeric_submission(
+            raw_spec,
             canonical_spec,
             submitted,
             config,
@@ -481,14 +489,17 @@ fn evaluate_unit_numeric_aware(
   }
 }
 
-/// Numeric unit-aware comparisons historically stored scalar operands in the
-/// reference unit. Quantity editors now preserve authored units, so normalize
-/// each operand before the shared numeric evaluator applies its comparison.
+/// Scalarize each authored operand twice: once at its authored magnitude for
+/// targeted unit-error responses, and once in canonical units for normal
+/// unit-aware comparisons.
 fn normalize_authored_unit_numeric_spec(
   spec: equality_types.NumericSpec,
   config: unit_types.UnitConfig,
   reference_unit: unit_types.NormalUnit,
-) -> Result(equality_types.NumericSpec, types.MatchConfigError) {
+) -> Result(
+  #(equality_types.NumericSpec, equality_types.NumericSpec),
+  types.MatchConfigError,
+) {
   case
     normalize_authored_unit_numeric_comparison(
       spec.comparison,
@@ -497,12 +508,20 @@ fn normalize_authored_unit_numeric_spec(
     )
   {
     Error(error) -> Error(error)
-    Ok(comparison) ->
-      Ok(equality_types.NumericSpec(
-        comparison: comparison,
-        tolerance: spec.tolerance,
-        representation: spec.representation,
-        precision: spec.precision,
+    Ok(#(raw_comparison, canonical_comparison)) ->
+      Ok(#(
+        equality_types.NumericSpec(
+          comparison: raw_comparison,
+          tolerance: spec.tolerance,
+          representation: spec.representation,
+          precision: spec.precision,
+        ),
+        equality_types.NumericSpec(
+          comparison: canonical_comparison,
+          tolerance: spec.tolerance,
+          representation: spec.representation,
+          precision: spec.precision,
+        ),
       ))
   }
 }
@@ -511,61 +530,64 @@ fn normalize_authored_unit_numeric_comparison(
   comparison: equality_types.NumericComparison,
   config: unit_types.UnitConfig,
   reference_unit: unit_types.NormalUnit,
-) -> Result(equality_types.NumericComparison, types.MatchConfigError) {
+) -> Result(
+  #(equality_types.NumericComparison, equality_types.NumericComparison),
+  types.MatchConfigError,
+) {
   case comparison {
     equality_types.Equal(expected) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         expected,
         "expected",
+        equality_types.Equal,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.Equal)
 
     equality_types.NotEqual(expected) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         expected,
         "expected",
+        equality_types.NotEqual,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.NotEqual)
 
     equality_types.GreaterThan(threshold) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         threshold,
         "threshold",
+        equality_types.GreaterThan,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.GreaterThan)
 
     equality_types.GreaterThanOrEqual(threshold) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         threshold,
         "threshold",
+        equality_types.GreaterThanOrEqual,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.GreaterThanOrEqual)
 
     equality_types.LessThan(threshold) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         threshold,
         "threshold",
+        equality_types.LessThan,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.LessThan)
 
     equality_types.LessThanOrEqual(threshold) ->
-      normalize_authored_unit_numeric_input(
+      normalize_authored_unit_numeric_operand(
         threshold,
         "threshold",
+        equality_types.LessThanOrEqual,
         config,
         reference_unit,
       )
-      |> result.map(equality_types.LessThanOrEqual)
 
     equality_types.Between(lower, upper, bounds) ->
       normalize_authored_unit_numeric_range(
@@ -589,6 +611,24 @@ fn normalize_authored_unit_numeric_comparison(
   }
 }
 
+fn normalize_authored_unit_numeric_operand(
+  input: equality_types.NumericInput,
+  field: String,
+  constructor: fn(equality_types.NumericInput) ->
+    equality_types.NumericComparison,
+  config: unit_types.UnitConfig,
+  reference_unit: unit_types.NormalUnit,
+) -> Result(
+  #(equality_types.NumericComparison, equality_types.NumericComparison),
+  types.MatchConfigError,
+) {
+  normalize_authored_unit_numeric_input(input, field, config, reference_unit)
+  |> result.map(fn(normalized) {
+    let NormalizedAuthoredNumericInput(raw, canonical) = normalized
+    #(constructor(raw), constructor(canonical))
+  })
+}
+
 fn normalize_authored_unit_numeric_range(
   lower: equality_types.NumericInput,
   upper: equality_types.NumericInput,
@@ -600,7 +640,10 @@ fn normalize_authored_unit_numeric_range(
   ) -> equality_types.NumericComparison,
   config: unit_types.UnitConfig,
   reference_unit: unit_types.NormalUnit,
-) -> Result(equality_types.NumericComparison, types.MatchConfigError) {
+) -> Result(
+  #(equality_types.NumericComparison, equality_types.NumericComparison),
+  types.MatchConfigError,
+) {
   case
     normalize_authored_unit_numeric_input(
       lower,
@@ -615,7 +658,13 @@ fn normalize_authored_unit_numeric_range(
       reference_unit,
     )
   {
-    Ok(lower), Ok(upper) -> Ok(constructor(lower, upper, bounds))
+    Ok(NormalizedAuthoredNumericInput(raw_lower, canonical_lower)),
+      Ok(NormalizedAuthoredNumericInput(raw_upper, canonical_upper))
+    ->
+      Ok(#(
+        constructor(raw_lower, raw_upper, bounds),
+        constructor(canonical_lower, canonical_upper, bounds),
+      ))
     Error(error), _ | _, Error(error) -> Error(error)
   }
 }
@@ -625,7 +674,7 @@ fn normalize_authored_unit_numeric_input(
   field: String,
   config: unit_types.UnitConfig,
   reference_unit: unit_types.NormalUnit,
-) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+) -> Result(NormalizedAuthoredNumericInput, types.MatchConfigError) {
   let equality_types.NumericInput(raw: raw) = input
 
   case quantity.parse_quantity_or_expression(raw) {
@@ -647,10 +696,15 @@ fn normalize_authored_scalar(
   raw: String,
   field: String,
   scale: Float,
-) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+) -> Result(NormalizedAuthoredNumericInput, types.MatchConfigError) {
   case numeric.parse_scalar(raw) {
     Ok(value) ->
-      Ok(equality_types.NumericInput(raw: float.to_string(value *. scale)))
+      Ok(NormalizedAuthoredNumericInput(
+        raw: equality_types.NumericInput(raw: float.to_string(value)),
+        canonical: equality_types.NumericInput(raw: float.to_string(
+          value *. scale,
+        )),
+      ))
     Error(Nil) ->
       Error(types.InvalidField(
         field: "math." <> field,
@@ -665,7 +719,7 @@ fn normalize_authored_quantity(
   field: String,
   config: unit_types.UnitConfig,
   reference_unit: unit_types.NormalUnit,
-) -> Result(equality_types.NumericInput, types.MatchConfigError) {
+) -> Result(NormalizedAuthoredNumericInput, types.MatchConfigError) {
   case
     numeric.parse_scalar(submitted_numeric_value_source(raw)),
     unit_normalize.normalize_unit(unit)
@@ -673,15 +727,19 @@ fn normalize_authored_quantity(
     Ok(value), Ok(normalized_unit) ->
       case config.mode {
         unit_types.IgnoreUnits ->
-          Ok(equality_types.NumericInput(raw: float.to_string(value)))
+          Ok(NormalizedAuthoredNumericInput(
+            raw: equality_types.NumericInput(raw: float.to_string(value)),
+            canonical: equality_types.NumericInput(raw: float.to_string(value)),
+          ))
         unit_types.RequireUnits ->
           case same_dimensions(normalized_unit, reference_unit) {
             True ->
-              Ok(
-                equality_types.NumericInput(raw: float.to_string(
+              Ok(NormalizedAuthoredNumericInput(
+                raw: equality_types.NumericInput(raw: float.to_string(value)),
+                canonical: equality_types.NumericInput(raw: float.to_string(
                   value *. normalized_unit.scale_to_canonical,
                 )),
-              )
+              ))
             False ->
               Error(types.InvalidField(
                 field: "math." <> field,
@@ -699,6 +757,7 @@ fn normalize_authored_quantity(
 }
 
 fn evaluate_unit_numeric_submission(
+  raw_spec: equality_types.NumericSpec,
   canonical_spec: equality_types.NumericSpec,
   submitted: String,
   config: unit_types.UnitConfig,
@@ -712,9 +771,9 @@ fn evaluate_unit_numeric_submission(
       case match_missing_unit, match_wrong_units, status {
         True, _, SubmittedMissingUnit ->
           evaluate_unit_numeric_value_target(
-            canonical_spec,
+            raw_spec,
             raw_value,
-            value *. reference_unit.scale_to_canonical,
+            value,
             types.UnitMissingMatched,
             types.UnitMissingNotMatched,
           )
@@ -727,9 +786,9 @@ fn evaluate_unit_numeric_submission(
 
         False, True, SubmittedWrongUnit ->
           evaluate_unit_numeric_value_target(
-            canonical_spec,
+            raw_spec,
             raw_value,
-            value *. reference_unit.scale_to_canonical,
+            value,
             types.UnitWrongMatched,
             types.UnitWrongNotMatched,
           )
@@ -759,16 +818,16 @@ fn evaluate_unit_numeric_submission(
 }
 
 fn evaluate_unit_numeric_value_target(
-  canonical_spec: equality_types.NumericSpec,
+  raw_spec: equality_types.NumericSpec,
   raw_value: String,
-  canonical_value: Float,
+  value: Float,
   matched_diagnostic: types.MatchDiagnostic,
   not_matched_diagnostic: types.MatchDiagnostic,
 ) -> types.MatchResult {
   evaluate_unit_numeric_value(
-    canonical_spec,
+    raw_spec,
     raw_value,
-    canonical_value,
+    value,
     matched_diagnostic,
     not_matched_diagnostic,
   )

--- a/gleam/test/math_equality_numeric_test.gleam
+++ b/gleam/test/math_equality_numeric_test.gleam
@@ -138,6 +138,39 @@ pub fn absolute_tolerance_supports_boundary_inside_and_outside_values_test() {
     ])
 }
 
+pub fn decimal_absolute_tolerance_includes_authored_boundaries_test() {
+  let tolerance = types.AbsoluteTolerance(value: 0.1)
+
+  assert evaluate_with_options(
+      types.Equal(types.numeric_input("1.5")),
+      tolerance,
+      types.AnyRepresentation,
+      types.NoPrecision,
+      "1.4",
+    )
+    == matched()
+
+  assert evaluate_with_options(
+      types.Equal(types.numeric_input("1.5")),
+      tolerance,
+      types.AnyRepresentation,
+      types.NoPrecision,
+      "1.6",
+    )
+    == matched()
+
+  assert evaluate_with_options(
+      types.Equal(types.numeric_input("1.5")),
+      tolerance,
+      types.AnyRepresentation,
+      types.NoPrecision,
+      "1.399",
+    )
+    == types.EqualityNotMatched(diagnostics: [
+      types.NumericToleranceMismatch,
+    ])
+}
+
 pub fn relative_tolerance_uses_larger_magnitude_and_near_zero_behavior_test() {
   let tolerance = types.RelativeTolerance(value: 0.1)
 

--- a/gleam/test/math_match_test.gleam
+++ b/gleam/test/math_match_test.gleam
@@ -178,6 +178,23 @@ pub fn unit_aware_numeric_config_evaluates_equal_with_number_tolerance_test() {
     ])
 }
 
+pub fn unit_aware_numeric_config_evaluates_quantity_authored_expected_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"1 m/s\",\"operator\":\"equal\",\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "1 m/s")
+    == types.MatchMatched(diagnostics: [types.ConfigAccepted, types.UnitMatched])
+  assert torus_math.evaluate_match(config, "3.6 km/hr")
+    == types.MatchMatched(diagnostics: [types.ConfigAccepted, types.UnitMatched])
+  assert torus_math.evaluate_match(config, "1 km/hr")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitNotMatched,
+    ])
+}
+
 pub fn unit_aware_numeric_config_evaluates_ordered_comparisons_test() {
   let source =
     "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"greater_than\",\"threshold\":\"10\",\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"

--- a/gleam/test/math_match_test.gleam
+++ b/gleam/test/math_match_test.gleam
@@ -248,6 +248,24 @@ pub fn unit_aware_numeric_config_targets_wrong_units_by_raw_value_test() {
     ])
 }
 
+pub fn unit_aware_numeric_config_targets_wrong_units_by_non_reference_authored_magnitude_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"3.6 km/hr\",\"operator\":\"equal\",\"matchWrongUnits\":true,\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "3.6 cm/s")
+    == types.MatchMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitWrongMatched,
+    ])
+  assert torus_math.evaluate_match(config, "1 cm/s")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitWrongNotMatched,
+    ])
+}
+
 pub fn unit_aware_numeric_config_targets_missing_units_by_raw_value_test() {
   let source =
     "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"10\",\"operator\":\"greater_than\",\"threshold\":\"10\",\"matchMissingUnit\":true,\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\"]}}}"
@@ -265,6 +283,24 @@ pub fn unit_aware_numeric_config_targets_missing_units_by_raw_value_test() {
       types.UnitMissingNotMatched,
     ])
   assert torus_math.evaluate_match(config, "11 m/s")
+    == types.MatchNotMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitMissingNotMatched,
+    ])
+}
+
+pub fn unit_aware_numeric_config_targets_missing_units_by_non_reference_authored_magnitude_test() {
+  let source =
+    "{\"version\":1,\"type\":\"math_expression\",\"math\":{\"mode\":\"unit_aware\",\"expected\":\"3.6 km/hr\",\"operator\":\"equal\",\"matchMissingUnit\":true,\"unitPolicy\":{\"type\":\"convertible_units\",\"units\":[\"m/s\",\"km/hr\"]}}}"
+
+  let assert Ok(config) = torus_math.decode_match_config(source)
+
+  assert torus_math.evaluate_match(config, "3.6")
+    == types.MatchMatched(diagnostics: [
+      types.ConfigAccepted,
+      types.UnitMissingMatched,
+    ])
+  assert torus_math.evaluate_match(config, "1")
     == types.MatchNotMatched(diagnostics: [
       types.ConfigAccepted,
       types.UnitMissingNotMatched,

--- a/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
+++ b/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
@@ -200,6 +200,11 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
             tolerance: absolute_tolerance(0.5),
             feedback: "single-tolerance-absolute"
           ),
+          correct("1.5", 2,
+            subtype: "numeric",
+            tolerance: absolute_tolerance(0.1),
+            feedback: "single-tolerance-boundary"
+          ),
           correct("100", 2,
             subtype: "numeric",
             tolerance: relative_tolerance(0.1),
@@ -215,6 +220,8 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
         cases: [
           solves("10", score: 2, out_of: 2, feedback: "single-tolerance-none"),
           solves("20.4", score: 2, out_of: 2, feedback: "single-tolerance-absolute"),
+          solves("1.4", score: 2, out_of: 2, feedback: "single-tolerance-boundary"),
+          solves("1.6", score: 2, out_of: 2, feedback: "single-tolerance-boundary"),
           solves("109", score: 2, out_of: 2, feedback: "single-tolerance-relative"),
           solves("1000.8",
             score: 2,
@@ -358,6 +365,13 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
             score: 2,
             feedback: "multi-tolerance-absolute"
           ),
+          input("tol_boundary",
+            subtype: "numeric",
+            answer: "1.5",
+            tolerance: absolute_tolerance(0.1),
+            score: 2,
+            feedback: "multi-tolerance-boundary"
+          ),
           input("tol_relative",
             subtype: "numeric",
             answer: "100",
@@ -378,14 +392,34 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
             %{
               "tol_none" => "10",
               "tol_absolute" => "20.4",
+              "tol_boundary" => "1.4",
               "tol_relative" => "109",
               "tol_absolute_or_relative" => "1000.8"
             },
-            score: 8,
-            out_of: 8,
+            score: 10,
+            out_of: 10,
             parts: [
               part("tol_none", 2, "multi-tolerance-none"),
               part("tol_absolute", 2, "multi-tolerance-absolute"),
+              part("tol_boundary", 2, "multi-tolerance-boundary"),
+              part("tol_relative", 2, "multi-tolerance-relative"),
+              part("tol_absolute_or_relative", 2, "multi-tolerance-absolute-or-relative")
+            ]
+          ),
+          solves(
+            %{
+              "tol_none" => "10",
+              "tol_absolute" => "20.4",
+              "tol_boundary" => "1.6",
+              "tol_relative" => "109",
+              "tol_absolute_or_relative" => "1000.8"
+            },
+            score: 10,
+            out_of: 10,
+            parts: [
+              part("tol_none", 2, "multi-tolerance-none"),
+              part("tol_absolute", 2, "multi-tolerance-absolute"),
+              part("tol_boundary", 2, "multi-tolerance-boundary"),
               part("tol_relative", 2, "multi-tolerance-relative"),
               part("tol_absolute_or_relative", 2, "multi-tolerance-absolute-or-relative")
             ]
@@ -394,14 +428,16 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
             %{
               "tol_none" => "10.1",
               "tol_absolute" => "20.6",
+              "tol_boundary" => "1.399",
               "tol_relative" => "112",
               "tol_absolute_or_relative" => "1001.1"
             },
             score: 0,
-            out_of: 8,
+            out_of: 10,
             parts: [
               part("tol_none", 0, "incorrect", 2),
               part("tol_absolute", 0, "incorrect", 2),
+              part("tol_boundary", 0, "incorrect", 2),
               part("tol_relative", 0, "incorrect", 2),
               part("tol_absolute_or_relative", 0, "incorrect", 2)
             ]

--- a/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
+++ b/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
@@ -62,6 +62,41 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
           misses("9 cm/s", out_of: 2)
         ]
       ),
+      single("single number with units targets non-reference authored magnitudes",
+        subtype: "number_with_units",
+        unit_policy: convertible_units(["m/s", "km/hr"]),
+        responses: [
+          correct("1 m/s", 2, feedback: "correct"),
+          targeted("3.6 km/hr", 1.5,
+            subtype: "number_with_units",
+            operator: "equal",
+            wrong_units: true,
+            feedback: "non-reference-wrong-units"
+          ),
+          targeted("3.6 km/hr", 1,
+            subtype: "number_with_units",
+            operator: "equal",
+            missing_unit: true,
+            feedback: "non-reference-missing-unit"
+          ),
+          incorrect()
+        ],
+        cases: [
+          solves("1 m/s", score: 2, out_of: 2, feedback: "correct"),
+          solves("3.6 cm/s",
+            score: 1.5,
+            out_of: 2,
+            feedback: "non-reference-wrong-units"
+          ),
+          solves("3.6",
+            score: 1,
+            out_of: 2,
+            feedback: "non-reference-missing-unit"
+          ),
+          misses("1 cm/s", out_of: 2),
+          misses("1", out_of: 2)
+        ]
+      ),
       single("single number with units numeric tolerance",
         subtype: "number_with_units",
         unit_policy: convertible_units(["m/s", "km/hr"]),

--- a/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
+++ b/test/oli/delivery/math_expression_activity_attempt_matrix_test.exs
@@ -79,6 +79,23 @@ defmodule Oli.Delivery.MathExpressionActivityAttemptMatrixTest do
           misses("37.08 km/hr", out_of: 2)
         ]
       ),
+      single("single number with units quantity-authored equality",
+        subtype: "number_with_units",
+        unit_policy: convertible_units(["m/s", "km/hr"]),
+        responses: [
+          correct("1 m/s", 2,
+            subtype: "number_with_units",
+            operator: "equal",
+            feedback: "unit-quantity-equality"
+          ),
+          incorrect()
+        ],
+        cases: [
+          solves("1 m/s", score: 2, out_of: 2, feedback: "unit-quantity-equality"),
+          solves("3.6 km/hr", score: 2, out_of: 2, feedback: "unit-quantity-equality"),
+          misses("1 km/hr", out_of: 2)
+        ]
+      ),
       single("single number with units numeric greater-than and unit targets",
         subtype: "number_with_units",
         unit_policy: convertible_units(["m/s"]),


### PR DESCRIPTION
This PR fixes a couple of issues found during the "Math Expression Playtest" session last week.

1. The "Number with Units" option was using the wrong input type, which made it impossible to enter values that actually contain units. 
2. The "Fraction" input type was using incorrect labels for the "match exactly / equivalent" options, which led to misleading results. 