### PR TITLE
[BUG FIX] [MER-5625] Preserve preview customization UI state across updates (rework)

### DIFF
--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { PreviewContext } from 'components/activities/types';
+import { usePreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
 import { LearningObjectiveList } from './LearningObjectiveList';
 import { PreviewDetailsToggle } from './PreviewDetailsToggle';
 import { PreviewHeader } from './PreviewHeader';
@@ -13,41 +14,6 @@ interface Props {
   detailsHeader?: React.ReactNode;
   defaultExpanded?: boolean;
 }
-
-const normalizePreviewActions = (actions: PreviewContext['actions']) =>
-  (actions ?? []).map((action) => ({
-    ...action,
-    disabled: typeof action.disabled === 'boolean' ? action.disabled : false,
-  }));
-
-const matchesCustomizationTarget = (
-  expectedTarget: PreviewContext['customizationTarget'],
-  replyTarget?: Partial<PreviewContext['customizationTarget']>,
-) => {
-  if (!replyTarget || replyTarget.kind !== expectedTarget.kind) {
-    return false;
-  }
-
-  if (replyTarget.pageResourceId !== expectedTarget.pageResourceId) {
-    return false;
-  }
-
-  if (
-    Object.prototype.hasOwnProperty.call(expectedTarget, 'selectionId') &&
-    expectedTarget.selectionId !== replyTarget.selectionId
-  ) {
-    return false;
-  }
-
-  if (
-    Object.prototype.hasOwnProperty.call(expectedTarget, 'activityResourceId') &&
-    expectedTarget.activityResourceId !== replyTarget.activityResourceId
-  ) {
-    return false;
-  }
-
-  return true;
-};
 
 const TrashActionIcon: React.FC<{ className?: string }> = ({ className = 'h-4 w-4' }) => (
   <svg
@@ -137,10 +103,21 @@ export const ActivityPreviewCard: React.FC<Props> = ({
 }) => {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [activeTabId, setActiveTabId] = React.useState(detailTabs[0]?.id ?? '');
-  const [actions, setActions] = React.useState(normalizePreviewActions(previewContext.actions));
-  const [visualState, setVisualState] = React.useState(previewContext.visualState ?? 'default');
-  const [statusPill, setStatusPill] = React.useState(previewContext.statusPill);
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const { state, begin } = usePreviewCustomizationState(previewContext.customizationTarget, {
+    disposition:
+      previewContext.actions?.[0]?.kind === 'restore' || previewContext.visualState === 'removed'
+        ? 'removed'
+        : 'included',
+    canToggle: !previewContext.actions?.[0]?.disabled,
+  });
+  const action = state.disposition === 'removed' ? 'restore' : 'remove';
+  const showRemovedTreatment =
+    state.disposition === 'removed' && previewContext.customizationTarget.kind !== 'bank_candidate';
+  const visualState = showRemovedTreatment ? 'removed' : 'default';
+  const statusPill = showRemovedTreatment
+    ? { kind: 'removed' as const, label: 'Removed' }
+    : undefined;
+  const isSubmitting = state.pendingAction !== null;
   const detailsRegionId = React.useMemo(
     () => `${previewContext.activityHtmlId}-preview-details`,
     [previewContext.activityHtmlId],
@@ -149,18 +126,6 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     visualState === 'removed'
       ? 'relative h-full bg-Surface-surface-secondary-muted before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger'
       : '';
-
-  React.useEffect(() => {
-    setActions(normalizePreviewActions(previewContext.actions));
-    setVisualState(previewContext.visualState ?? 'default');
-    setStatusPill(previewContext.statusPill);
-    setIsSubmitting(false);
-  }, [
-    previewContext.activityResourceId,
-    previewContext.actions,
-    previewContext.visualState,
-    previewContext.statusPill,
-  ]);
 
   React.useEffect(() => {
     if (detailTabs.length === 0) {
@@ -174,81 +139,33 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     }
   }, [activeTabId, detailTabs]);
 
-  React.useEffect(() => {
-    const handleCustomizationReply = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-
-      const replyTarget =
-        detail?.target ??
-        (detail
-          ? {
-              kind: previewContext.customizationTarget.kind,
-              pageResourceId:
-                detail.pageResourceId ?? previewContext.customizationTarget.pageResourceId,
-              activityResourceId: detail.activityResourceId,
-              selectionId: detail.selectionId,
-            }
-          : undefined);
-
-      if (!matchesCustomizationTarget(previewContext.customizationTarget, replyTarget)) {
-        return;
-      }
-
-      setIsSubmitting(false);
-
-      if (detail.ok && Array.isArray(detail.actions)) {
-        setActions(normalizePreviewActions(detail.actions));
-      }
-
-      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'visualState')) {
-        setVisualState(detail.visualState ?? 'default');
-      }
-
-      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'statusPill')) {
-        setStatusPill(detail.statusPill ?? undefined);
-      }
-    };
-
-    window.addEventListener('oli:preview-customization:reply', handleCustomizationReply);
-
-    return () => {
-      window.removeEventListener('oli:preview-customization:reply', handleCustomizationReply);
-    };
-  }, [previewContext.customizationTarget]);
-
   const headerActions =
-    previewContext.canCustomize && actions.length > 0 ? (
+    previewContext.canCustomize && (previewContext.actions?.length ?? 0) > 0 ? (
       <div className="flex flex-wrap items-center gap-2">
-        {actions.map((action) => (
-          <button
-            key={action.kind}
-            type="button"
-            disabled={action.disabled || isSubmitting}
-            className={actionButtonClasses(action.kind, action.disabled || isSubmitting)}
-            onClick={() => {
-              if (action.disabled || isSubmitting) {
-                return;
-              }
+        <button
+          type="button"
+          disabled={!state.canToggle || isSubmitting}
+          aria-busy={isSubmitting}
+          className={actionButtonClasses(action, !state.canToggle || isSubmitting)}
+          onClick={() => {
+            if (!state.canToggle || isSubmitting) {
+              return;
+            }
 
-              // Keep preview components presentational: emit a typed intent and let the enclosing
-              // LiveView decide how "remove" or "restore" maps to section/page mutations. The
-              // reply updates only local customization state, avoiding a remount so existing
-              // component UI state remains intact.
-              setIsSubmitting(true);
-              window.dispatchEvent(
-                new CustomEvent('oli:preview-customization', {
-                  detail: {
-                    action: action.kind,
-                    target: previewContext.customizationTarget,
-                  },
-                }),
-              );
-            }}
-          >
-            {action.kind === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-            {isSubmitting ? 'Updating...' : action.label}
-          </button>
-        ))}
+            begin(action);
+            window.dispatchEvent(
+              new CustomEvent('oli:preview-customization', {
+                detail: {
+                  action,
+                  target: previewContext.customizationTarget,
+                },
+              }),
+            );
+          }}
+        >
+          {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+          {isSubmitting ? 'Updating...' : action === 'remove' ? 'Remove' : 'Restore'}
+        </button>
       </div>
     ) : null;
 

--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { PreviewContext } from 'components/activities/types';
-import { usePreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
+import {
+  getPreviewCustomizationCopy,
+  usePreviewCustomizationState,
+} from 'components/instructor_preview/preview_customization_store';
 import { LearningObjectiveList } from './LearningObjectiveList';
 import { PreviewDetailsToggle } from './PreviewDetailsToggle';
 import { PreviewHeader } from './PreviewHeader';
@@ -103,7 +106,7 @@ export const ActivityPreviewCard: React.FC<Props> = ({
 }) => {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [activeTabId, setActiveTabId] = React.useState(detailTabs[0]?.id ?? '');
-  const { state, copy, begin } = usePreviewCustomizationState(previewContext.customizationTarget, {
+  const { state, begin } = usePreviewCustomizationState(previewContext.customizationTarget, {
     disposition:
       previewContext.actions?.[0]?.kind === 'restore' || previewContext.visualState === 'removed'
         ? 'removed'
@@ -118,6 +121,10 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     ? { kind: 'removed' as const, label: 'Removed' }
     : undefined;
   const isSubmitting = state.pendingAction !== null;
+  const actionCopy =
+    previewContext.canCustomize && (previewContext.actions?.length ?? 0) > 0
+      ? getPreviewCustomizationCopy()
+      : null;
   const detailsRegionId = React.useMemo(
     () => `${previewContext.activityHtmlId}-preview-details`,
     [previewContext.activityHtmlId],
@@ -139,35 +146,34 @@ export const ActivityPreviewCard: React.FC<Props> = ({
     }
   }, [activeTabId, detailTabs]);
 
-  const headerActions =
-    previewContext.canCustomize && (previewContext.actions?.length ?? 0) > 0 ? (
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          disabled={!state.canToggle || isSubmitting}
-          aria-busy={isSubmitting}
-          className={actionButtonClasses(action, !state.canToggle || isSubmitting)}
-          onClick={() => {
-            if (!state.canToggle || isSubmitting) {
-              return;
-            }
+  const headerActions = actionCopy ? (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        disabled={!state.canToggle || isSubmitting}
+        aria-busy={isSubmitting}
+        className={actionButtonClasses(action, !state.canToggle || isSubmitting)}
+        onClick={() => {
+          if (!state.canToggle || isSubmitting) {
+            return;
+          }
 
-            begin(action);
-            window.dispatchEvent(
-              new CustomEvent('oli:preview-customization', {
-                detail: {
-                  action,
-                  target: previewContext.customizationTarget,
-                },
-              }),
-            );
-          }}
-        >
-          {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-          {isSubmitting ? copy.pending : copy[action]}
-        </button>
-      </div>
-    ) : null;
+          begin(action);
+          window.dispatchEvent(
+            new CustomEvent('oli:preview-customization', {
+              detail: {
+                action,
+                target: previewContext.customizationTarget,
+              },
+            }),
+          );
+        }}
+      >
+        {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+        {isSubmitting ? actionCopy.pending : actionCopy[action]}
+      </button>
+    </div>
+  ) : null;
 
   return (
     <article className={`p-6 ${cardClasses}`}>

--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -103,7 +103,7 @@ export const ActivityPreviewCard: React.FC<Props> = ({
 }) => {
   const [expanded, setExpanded] = React.useState(defaultExpanded);
   const [activeTabId, setActiveTabId] = React.useState(detailTabs[0]?.id ?? '');
-  const { state, begin } = usePreviewCustomizationState(previewContext.customizationTarget, {
+  const { state, copy, begin } = usePreviewCustomizationState(previewContext.customizationTarget, {
     disposition:
       previewContext.actions?.[0]?.kind === 'restore' || previewContext.visualState === 'removed'
         ? 'removed'
@@ -164,7 +164,7 @@ export const ActivityPreviewCard: React.FC<Props> = ({
           }}
         >
           {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-          {isSubmitting ? 'Updating...' : action === 'remove' ? 'Remove' : 'Restore'}
+          {isSubmitting ? copy.pending : copy[action]}
         </button>
       </div>
     ) : null;

--- a/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
+++ b/assets/src/components/activities/common/preview/ActivityPreviewCard.tsx
@@ -117,14 +117,14 @@ export const ActivityPreviewCard: React.FC<Props> = ({
   const showRemovedTreatment =
     state.disposition === 'removed' && previewContext.customizationTarget.kind !== 'bank_candidate';
   const visualState = showRemovedTreatment ? 'removed' : 'default';
-  const statusPill = showRemovedTreatment
-    ? { kind: 'removed' as const, label: 'Removed' }
-    : undefined;
-  const isSubmitting = state.pendingAction !== null;
   const actionCopy =
     previewContext.canCustomize && (previewContext.actions?.length ?? 0) > 0
       ? getPreviewCustomizationCopy()
       : null;
+  const statusPill = showRemovedTreatment
+    ? { kind: 'removed' as const, label: (actionCopy ?? getPreviewCustomizationCopy()).removed }
+    : undefined;
+  const isSubmitting = state.pendingAction !== null;
   const detailsRegionId = React.useMemo(
     () => `${previewContext.activityHtmlId}-preview-details`,
     [previewContext.activityHtmlId],

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -287,12 +287,20 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
   ) : null;
 
   const cardClasses =
-    visualState === 'removed'
-      ? 'relative bg-Surface-surface-secondary-muted before:absolute before:inset-y-0 before:left-0 before:w-[6px] before:bg-Border-border-danger'
-      : 'bg-Surface-surface-primary';
+    visualState === 'removed' ? 'bg-Surface-surface-secondary-muted' : 'bg-Surface-surface-primary';
 
   return (
-    <article className={`p-[25px] font-open-sans ${cardClasses}`}>
+    <article
+      className={`relative p-[25px] font-open-sans ${cardClasses}`}
+      data-preview-visual-state={visualState}
+    >
+      {visualState === 'removed' ? (
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 w-[6px] bg-Border-border-danger"
+          data-preview-removed-rail
+        />
+      ) : null}
       <div className="flex flex-col gap-[18px]">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex min-w-0 flex-col">

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { PreviewHeader } from 'components/activities/common/preview/PreviewHeader';
 import { PreviewAction, PreviewStatusPill, PreviewVisualState } from 'components/activities/types';
+import { usePreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
 import { ArrowRight } from 'components/misc/icons/Icons';
 
 interface CustomizationTarget {
@@ -125,15 +126,6 @@ const pluralize = (count: number, singular: string, plural: string) =>
 
 const labelTextClasses = 'font-open-sans text-[14px] font-bold leading-4 text-Text-text-high';
 
-const matchesCustomizationTarget = (
-  expectedTarget: CustomizationTarget,
-  replyTarget?: Partial<CustomizationTarget>,
-) =>
-  !!replyTarget &&
-  replyTarget.kind === expectedTarget.kind &&
-  replyTarget.pageResourceId === expectedTarget.pageResourceId &&
-  replyTarget.selectionId === expectedTarget.selectionId;
-
 const SampleActivityPreview: React.FC<{
   sample?: SampleActivity | null;
   visualState: PreviewVisualState;
@@ -201,78 +193,46 @@ const SampleActivityPreview: React.FC<{
 };
 
 export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
-  const [actions, setActions] = React.useState(payload.actions ?? []);
-  const [visualState, setVisualState] = React.useState(payload.visualState ?? 'default');
-  const [statusPill, setStatusPill] = React.useState(payload.statusPill ?? undefined);
-  const [availableCount, setAvailableCount] = React.useState(payload.availableCount);
-  const [isSubmitting, setIsSubmitting] = React.useState(false);
-
-  React.useEffect(() => {
-    setActions(payload.actions ?? []);
-    setVisualState(payload.visualState ?? 'default');
-    setStatusPill(payload.statusPill ?? undefined);
-    setAvailableCount(payload.availableCount);
-  }, [payload]);
-
-  React.useEffect(() => {
-    const handleCustomizationReply = (event: Event) => {
-      const detail = (event as CustomEvent).detail;
-
-      if (!matchesCustomizationTarget(payload.customizationTarget, detail?.target)) {
-        return;
-      }
-
-      setIsSubmitting(false);
-
-      if (detail.ok && Array.isArray(detail.actions)) {
-        setActions(detail.actions);
-      }
-
-      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'visualState')) {
-        setVisualState(detail.visualState ?? 'default');
-      }
-
-      if (detail.ok && Object.prototype.hasOwnProperty.call(detail, 'statusPill')) {
-        setStatusPill(detail.statusPill ?? undefined);
-      }
-
-      if (detail.ok && typeof detail.availableCount === 'number') {
-        setAvailableCount(detail.availableCount);
-      }
-    };
-
-    window.addEventListener('oli:preview-customization:reply', handleCustomizationReply);
-
-    return () => {
-      window.removeEventListener('oli:preview-customization:reply', handleCustomizationReply);
-    };
-  }, [payload.customizationTarget]);
+  const { state, begin } = usePreviewCustomizationState(payload.customizationTarget, {
+    disposition:
+      payload.actions?.[0]?.kind === 'restore' || payload.visualState === 'removed'
+        ? 'removed'
+        : 'included',
+    canToggle: !payload.actions?.[0]?.disabled,
+    availableCount: payload.availableCount,
+  });
+  const action = state.disposition === 'removed' ? 'restore' : 'remove';
+  const visualState = state.disposition === 'removed' ? 'removed' : 'default';
+  const availableCount = state.availableCount ?? payload.availableCount;
+  const isSubmitting = state.pendingAction !== null;
 
   const headerActions =
-    payload.canCustomize && actions.length > 0 ? (
+    payload.canCustomize && (payload.actions?.length ?? 0) > 0 ? (
       <div className="flex flex-wrap items-center gap-2">
-        {actions.map((action) => (
-          <button
-            key={action.kind}
-            type="button"
-            disabled={isSubmitting}
-            className={actionButtonClasses(action.kind)}
-            onClick={() => {
-              setIsSubmitting(true);
-              window.dispatchEvent(
-                new CustomEvent('oli:preview-customization', {
-                  detail: {
-                    action: action.kind,
-                    target: payload.customizationTarget,
-                  },
-                }),
-              );
-            }}
-          >
-            {action.kind === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-            {isSubmitting ? 'Updating...' : action.label}
-          </button>
-        ))}
+        <button
+          type="button"
+          disabled={!state.canToggle || isSubmitting}
+          aria-busy={isSubmitting}
+          className={actionButtonClasses(action)}
+          onClick={() => {
+            if (!state.canToggle || isSubmitting) {
+              return;
+            }
+
+            begin(action);
+            window.dispatchEvent(
+              new CustomEvent('oli:preview-customization', {
+                detail: {
+                  action,
+                  target: payload.customizationTarget,
+                },
+              }),
+            );
+          }}
+        >
+          {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+          {isSubmitting ? 'Updating...' : action === 'remove' ? 'Remove' : 'Restore'}
+        </button>
       </div>
     ) : null;
 
@@ -312,9 +272,9 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
               >
                 {payload.title}
               </div>
-              {statusPill ? (
+              {state.disposition === 'removed' ? (
                 <span className="inline-flex items-center rounded-full border border-Border-border-danger bg-Fill-fill-danger px-3 py-1 pr-4 font-open-sans text-[16px] font-bold leading-4 text-Text-text-danger">
-                  {statusPill.label}
+                  Removed
                 </span>
               ) : null}
             </div>

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -212,6 +212,8 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
     payload.canCustomize && (payload.actions?.length ?? 0) > 0
       ? getPreviewCustomizationCopy()
       : null;
+  const removedCopy =
+    state.disposition === 'removed' ? actionCopy ?? getPreviewCustomizationCopy() : null;
 
   const headerActions = actionCopy ? (
     <div className="flex flex-wrap items-center gap-2">
@@ -278,9 +280,9 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
               >
                 {payload.title}
               </div>
-              {state.disposition === 'removed' ? (
+              {removedCopy ? (
                 <span className="inline-flex items-center rounded-full border border-Border-border-danger bg-Fill-fill-danger px-3 py-1 pr-4 font-open-sans text-[16px] font-bold leading-4 text-Text-text-danger">
-                  Removed
+                  {removedCopy.removed}
                 </span>
               ) : null}
             </div>

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -193,7 +193,7 @@ const SampleActivityPreview: React.FC<{
 };
 
 export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
-  const { state, begin } = usePreviewCustomizationState(payload.customizationTarget, {
+  const { state, copy, begin } = usePreviewCustomizationState(payload.customizationTarget, {
     disposition:
       payload.actions?.[0]?.kind === 'restore' || payload.visualState === 'removed'
         ? 'removed'
@@ -231,7 +231,7 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
           }}
         >
           {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-          {isSubmitting ? 'Updating...' : action === 'remove' ? 'Remove' : 'Restore'}
+          {isSubmitting ? copy.pending : copy[action]}
         </button>
       </div>
     ) : null;

--- a/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
+++ b/assets/src/components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { PreviewHeader } from 'components/activities/common/preview/PreviewHeader';
 import { PreviewAction, PreviewStatusPill, PreviewVisualState } from 'components/activities/types';
-import { usePreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
+import {
+  getPreviewCustomizationCopy,
+  usePreviewCustomizationState,
+} from 'components/instructor_preview/preview_customization_store';
 import { ArrowRight } from 'components/misc/icons/Icons';
 
 interface CustomizationTarget {
@@ -193,7 +196,7 @@ const SampleActivityPreview: React.FC<{
 };
 
 export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
-  const { state, copy, begin } = usePreviewCustomizationState(payload.customizationTarget, {
+  const { state, begin } = usePreviewCustomizationState(payload.customizationTarget, {
     disposition:
       payload.actions?.[0]?.kind === 'restore' || payload.visualState === 'removed'
         ? 'removed'
@@ -205,36 +208,39 @@ export const ActivityBankSelectionPreview: React.FC<Props> = ({ payload }) => {
   const visualState = state.disposition === 'removed' ? 'removed' : 'default';
   const availableCount = state.availableCount ?? payload.availableCount;
   const isSubmitting = state.pendingAction !== null;
+  const actionCopy =
+    payload.canCustomize && (payload.actions?.length ?? 0) > 0
+      ? getPreviewCustomizationCopy()
+      : null;
 
-  const headerActions =
-    payload.canCustomize && (payload.actions?.length ?? 0) > 0 ? (
-      <div className="flex flex-wrap items-center gap-2">
-        <button
-          type="button"
-          disabled={!state.canToggle || isSubmitting}
-          aria-busy={isSubmitting}
-          className={actionButtonClasses(action)}
-          onClick={() => {
-            if (!state.canToggle || isSubmitting) {
-              return;
-            }
+  const headerActions = actionCopy ? (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        disabled={!state.canToggle || isSubmitting}
+        aria-busy={isSubmitting}
+        className={actionButtonClasses(action)}
+        onClick={() => {
+          if (!state.canToggle || isSubmitting) {
+            return;
+          }
 
-            begin(action);
-            window.dispatchEvent(
-              new CustomEvent('oli:preview-customization', {
-                detail: {
-                  action,
-                  target: payload.customizationTarget,
-                },
-              }),
-            );
-          }}
-        >
-          {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
-          {isSubmitting ? copy.pending : copy[action]}
-        </button>
-      </div>
-    ) : null;
+          begin(action);
+          window.dispatchEvent(
+            new CustomEvent('oli:preview-customization', {
+              detail: {
+                action,
+                target: payload.customizationTarget,
+              },
+            }),
+          );
+        }}
+      >
+        {action === 'remove' ? <TrashActionIcon /> : <RestoreActionIcon />}
+        {isSubmitting ? actionCopy.pending : actionCopy[action]}
+      </button>
+    </div>
+  ) : null;
 
   const manageQuestionsAction = payload.manageQuestionsUrl ? (
     <a

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -284,7 +284,6 @@ export const usePreviewCustomizationState = (
 
   return {
     state,
-    copy: getPreviewCustomizationCopy(),
     begin: (action: PreviewCustomizationAction) => store.begin(target, action),
   };
 };

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -1,0 +1,257 @@
+import React from 'react';
+import { PreviewCustomizationTarget } from 'components/activities/types';
+
+export type PreviewCustomizationDisposition = 'included' | 'removed';
+export type PreviewCustomizationAction = 'remove' | 'restore';
+
+export interface PreviewCustomizationState {
+  disposition: PreviewCustomizationDisposition;
+  pendingAction: PreviewCustomizationAction | null;
+  canToggle: boolean;
+  availableCount?: number;
+}
+
+export interface PreviewCustomizationInitialState {
+  disposition: PreviewCustomizationDisposition;
+  canToggle?: boolean;
+  availableCount?: number;
+}
+
+export interface PreviewCustomizationReply {
+  ok?: boolean;
+  target?: PreviewCustomizationTarget;
+  disposition?: PreviewCustomizationDisposition;
+  visualState?: 'default' | 'removed' | null;
+  actions?: unknown;
+  availableCount?: number;
+}
+
+type Listener = () => void;
+
+const pageStoreProperty = '__oliInstructorPreviewCustomizationStore';
+const fallbackStoresProperty = '__oliInstructorPreviewCustomizationFallbackStores';
+
+type PageStoreHost = HTMLElement & {
+  [pageStoreProperty]?: PreviewCustomizationStore;
+};
+
+type GlobalWithFallbackStores = typeof globalThis & {
+  [fallbackStoresProperty]?: Map<number, PreviewCustomizationStore>;
+};
+
+export const previewCustomizationTargetKey = (target: PreviewCustomizationTarget) =>
+  [
+    target.kind,
+    target.pageResourceId,
+    target.selectionId ?? '',
+    target.activityResourceId ?? '',
+  ].join(':');
+
+export class PreviewCustomizationStore {
+  readonly pageResourceId: number;
+
+  private readonly entries = new Map<string, PreviewCustomizationState>();
+  private readonly listeners = new Map<string, Set<Listener>>();
+
+  constructor(pageResourceId: number) {
+    this.pageResourceId = pageResourceId;
+  }
+
+  initialize(
+    target: PreviewCustomizationTarget,
+    initialState: PreviewCustomizationInitialState,
+  ): PreviewCustomizationState {
+    const key = previewCustomizationTargetKey(target);
+    const existing = this.entries.get(key);
+
+    if (existing) {
+      return existing;
+    }
+
+    const state = {
+      ...initialState,
+      canToggle: initialState.canToggle ?? true,
+      pendingAction: null,
+    };
+    this.entries.set(key, state);
+    return state;
+  }
+
+  get(target: PreviewCustomizationTarget): PreviewCustomizationState | undefined {
+    return this.entries.get(previewCustomizationTargetKey(target));
+  }
+
+  subscribe(target: PreviewCustomizationTarget, listener: Listener): () => void {
+    const key = previewCustomizationTargetKey(target);
+    const targetListeners = this.listeners.get(key) ?? new Set<Listener>();
+    targetListeners.add(listener);
+    this.listeners.set(key, targetListeners);
+
+    return () => {
+      targetListeners.delete(listener);
+
+      if (targetListeners.size === 0) {
+        this.listeners.delete(key);
+      }
+    };
+  }
+
+  begin(target: PreviewCustomizationTarget, action: PreviewCustomizationAction) {
+    this.update(target, (state) => ({ ...state, pendingAction: action }));
+  }
+
+  applyReply(target: PreviewCustomizationTarget, reply: PreviewCustomizationReply) {
+    this.update(target, (state) => {
+      if (!reply.ok) {
+        return { ...state, pendingAction: null };
+      }
+
+      const replyAction = firstReplyAction(reply.actions);
+      const dispositionFromAction =
+        replyAction?.kind === 'restore'
+          ? 'removed'
+          : replyAction?.kind === 'remove'
+          ? 'included'
+          : undefined;
+      const dispositionFromPendingAction =
+        state.pendingAction === 'remove'
+          ? 'removed'
+          : state.pendingAction === 'restore'
+          ? 'included'
+          : undefined;
+      const disposition =
+        reply.disposition ??
+        dispositionFromAction ??
+        dispositionFromPendingAction ??
+        (reply.visualState === 'removed' ? 'removed' : state.disposition);
+
+      return {
+        ...state,
+        disposition,
+        pendingAction: null,
+        canToggle:
+          typeof replyAction?.disabled === 'boolean' ? !replyAction.disabled : state.canToggle,
+        availableCount:
+          typeof reply.availableCount === 'number' ? reply.availableCount : state.availableCount,
+      };
+    });
+  }
+
+  private update(
+    target: PreviewCustomizationTarget,
+    updater: (state: PreviewCustomizationState) => PreviewCustomizationState,
+  ) {
+    const key = previewCustomizationTargetKey(target);
+    const current = this.entries.get(key);
+
+    if (!current) {
+      return;
+    }
+
+    const next = updater(current);
+    this.entries.set(key, next);
+    this.listeners.get(key)?.forEach((listener) => listener());
+  }
+}
+
+const firstReplyAction = (
+  actions: unknown,
+): { kind: PreviewCustomizationAction; disabled?: boolean } | undefined => {
+  if (!Array.isArray(actions)) {
+    return undefined;
+  }
+
+  const action = actions[0];
+
+  if (
+    !action ||
+    typeof action !== 'object' ||
+    (action.kind !== 'remove' && action.kind !== 'restore')
+  ) {
+    return undefined;
+  }
+
+  return {
+    kind: action.kind,
+    disabled: typeof action.disabled === 'boolean' ? action.disabled : undefined,
+  };
+};
+
+const pageStoreHost = (): PageStoreHost | null =>
+  typeof document === 'undefined'
+    ? null
+    : (document.getElementById('instructor-preview-lesson') as PageStoreHost | null);
+
+const fallbackStores = (): Map<number, PreviewCustomizationStore> => {
+  const global = globalThis as GlobalWithFallbackStores;
+  global[fallbackStoresProperty] ??= new Map<number, PreviewCustomizationStore>();
+  return global[fallbackStoresProperty] as Map<number, PreviewCustomizationStore>;
+};
+
+export const getPreviewCustomizationStore = (pageResourceId: number) => {
+  const host = pageStoreHost();
+
+  if (host) {
+    const existing = host[pageStoreProperty];
+
+    if (existing?.pageResourceId === pageResourceId) {
+      return existing;
+    }
+
+    const store = new PreviewCustomizationStore(pageResourceId);
+    host[pageStoreProperty] = store;
+    return store;
+  }
+
+  const stores = fallbackStores();
+  const existing = stores.get(pageResourceId);
+
+  if (existing) {
+    return existing;
+  }
+
+  const store = new PreviewCustomizationStore(pageResourceId);
+  stores.set(pageResourceId, store);
+  return store;
+};
+
+export const clearPreviewCustomizationStore = (pageResourceId: number) => {
+  const host = pageStoreHost();
+
+  if (host?.[pageStoreProperty]?.pageResourceId === pageResourceId) {
+    delete host[pageStoreProperty];
+  }
+
+  fallbackStores().delete(pageResourceId);
+};
+
+export const clearFallbackPreviewCustomizationStore = (pageResourceId: number) => {
+  fallbackStores().delete(pageResourceId);
+};
+
+export const usePreviewCustomizationState = (
+  target: PreviewCustomizationTarget,
+  initialState: PreviewCustomizationInitialState,
+) => {
+  const store = getPreviewCustomizationStore(target.pageResourceId);
+  const targetKey = previewCustomizationTargetKey(target);
+  const [state, setState] = React.useState(() => store.initialize(target, initialState));
+
+  React.useEffect(() => {
+    const current = store.initialize(target, initialState);
+    setState(current);
+
+    return store.subscribe(target, () => {
+      const next = store.get(target);
+
+      if (next) {
+        setState(next);
+      }
+    });
+  }, [store, targetKey]);
+
+  return {
+    state,
+    begin: (action: PreviewCustomizationAction) => store.begin(target, action),
+  };
+};

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -85,6 +85,7 @@ export class PreviewCustomizationStore {
   readonly pageResourceId: number;
 
   private readonly entries = new Map<string, PreviewCustomizationState>();
+  private readonly lastServerStates = new Map<string, PreviewCustomizationInitialState>();
   private readonly listeners = new Map<string, Set<Listener>>();
 
   constructor(pageResourceId: number) {
@@ -97,16 +98,45 @@ export class PreviewCustomizationStore {
   ): PreviewCustomizationState {
     const key = previewCustomizationTargetKey(target);
     const existing = this.entries.get(key);
+    const normalizedInitialState = {
+      ...initialState,
+      canToggle: initialState.canToggle ?? true,
+    };
 
     if (existing) {
-      return existing;
+      const previousInitialState = this.lastServerStates.get(key);
+
+      if (existing.pendingAction || !previousInitialState) {
+        return existing;
+      }
+
+      const state = {
+        ...existing,
+        disposition:
+          normalizedInitialState.disposition !== previousInitialState.disposition
+            ? normalizedInitialState.disposition
+            : existing.disposition,
+        canToggle:
+          normalizedInitialState.canToggle !== previousInitialState.canToggle
+            ? normalizedInitialState.canToggle
+            : existing.canToggle,
+        availableCount:
+          normalizedInitialState.availableCount !== previousInitialState.availableCount
+            ? normalizedInitialState.availableCount
+            : existing.availableCount,
+      };
+      // Reconcile only fields the server actually changed. An unchanged payload may be a stale
+      // LiveView rerender and must not overwrite newer state applied from an action reply.
+      this.lastServerStates.set(key, normalizedInitialState);
+      this.entries.set(key, state);
+      return state;
     }
 
     const state = {
-      ...initialState,
-      canToggle: initialState.canToggle ?? true,
+      ...normalizedInitialState,
       pendingAction: null,
     };
+    this.lastServerStates.set(key, normalizedInitialState);
     this.entries.set(key, state);
     return state;
   }
@@ -153,11 +183,18 @@ export class PreviewCustomizationStore {
           : state.pendingAction === 'restore'
           ? 'included'
           : undefined;
+      const dispositionFromVisualState =
+        reply.visualState === 'removed'
+          ? 'removed'
+          : reply.visualState === 'default'
+          ? 'included'
+          : undefined;
       const disposition =
         reply.disposition ??
         dispositionFromAction ??
         dispositionFromPendingAction ??
-        (reply.visualState === 'removed' ? 'removed' : state.disposition);
+        dispositionFromVisualState ??
+        state.disposition;
 
       return {
         ...state,
@@ -282,7 +319,13 @@ export const usePreviewCustomizationState = (
         setState(next);
       }
     });
-  }, [store, targetKey]);
+  }, [
+    store,
+    targetKey,
+    initialState.disposition,
+    initialState.canToggle,
+    initialState.availableCount,
+  ]);
 
   return {
     state,

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PreviewCustomizationTarget } from 'components/activities/types';
+import type { PreviewCustomizationTarget } from 'components/activities/types';
 
 export type PreviewCustomizationDisposition = 'included' | 'removed';
 export type PreviewCustomizationAction = 'remove' | 'restore';
@@ -35,6 +35,8 @@ export interface PreviewCustomizationReply {
 }
 
 type Listener = () => void;
+type ServerStateChanges = Partial<PreviewCustomizationInitialState>;
+type AuthoritativeReplyFields = Partial<Record<keyof PreviewCustomizationInitialState, boolean>>;
 
 const pageStoreProperty = '__oliInstructorPreviewCustomizationStore';
 const fallbackStoresProperty = '__oliInstructorPreviewCustomizationFallbackStores';
@@ -86,6 +88,7 @@ export class PreviewCustomizationStore {
 
   private readonly entries = new Map<string, PreviewCustomizationState>();
   private readonly lastServerStates = new Map<string, PreviewCustomizationInitialState>();
+  private readonly pendingServerChanges = new Map<string, ServerStateChanges>();
   private readonly listeners = new Map<string, Set<Listener>>();
 
   constructor(pageResourceId: number) {
@@ -106,28 +109,24 @@ export class PreviewCustomizationStore {
     if (existing) {
       const previousInitialState = this.lastServerStates.get(key);
 
-      if (existing.pendingAction || !previousInitialState) {
+      if (!previousInitialState) {
         return existing;
       }
 
-      const state = {
-        ...existing,
-        disposition:
-          normalizedInitialState.disposition !== previousInitialState.disposition
-            ? normalizedInitialState.disposition
-            : existing.disposition,
-        canToggle:
-          normalizedInitialState.canToggle !== previousInitialState.canToggle
-            ? normalizedInitialState.canToggle
-            : existing.canToggle,
-        availableCount:
-          normalizedInitialState.availableCount !== previousInitialState.availableCount
-            ? normalizedInitialState.availableCount
-            : existing.availableCount,
-      };
+      const changes = serverStateChanges(previousInitialState, normalizedInitialState);
       // Reconcile only fields the server actually changed. An unchanged payload may be a stale
       // LiveView rerender and must not overwrite newer state applied from an action reply.
       this.lastServerStates.set(key, normalizedInitialState);
+
+      if (existing.pendingAction) {
+        this.pendingServerChanges.set(key, {
+          ...this.pendingServerChanges.get(key),
+          ...changes,
+        });
+        return existing;
+      }
+
+      const state = reconcileServerState(existing, changes);
       this.entries.set(key, state);
       return state;
     }
@@ -165,9 +164,13 @@ export class PreviewCustomizationStore {
   }
 
   applyReply(target: PreviewCustomizationTarget, reply: PreviewCustomizationReply) {
+    const key = previewCustomizationTargetKey(target);
+    const pendingServerChanges = this.pendingServerChanges.get(key);
+    this.pendingServerChanges.delete(key);
+
     this.update(target, (state) => {
       if (!reply.ok) {
-        return { ...state, pendingAction: null };
+        return reconcileServerState({ ...state, pendingAction: null }, pendingServerChanges);
       }
 
       const replyAction = firstReplyAction(reply.actions);
@@ -196,7 +199,7 @@ export class PreviewCustomizationStore {
         dispositionFromVisualState ??
         state.disposition;
 
-      return {
+      const next = {
         ...state,
         disposition,
         pendingAction: null,
@@ -205,6 +208,17 @@ export class PreviewCustomizationStore {
         availableCount:
           typeof reply.availableCount === 'number' ? reply.availableCount : state.availableCount,
       };
+
+      return reconcileServerState(next, pendingServerChanges, {
+        disposition:
+          reply.disposition !== undefined ||
+          replyAction !== undefined ||
+          state.pendingAction !== null ||
+          reply.visualState === 'removed' ||
+          reply.visualState === 'default',
+        canToggle: typeof replyAction?.disabled === 'boolean',
+        availableCount: typeof reply.availableCount === 'number',
+      });
     });
   }
 
@@ -224,6 +238,43 @@ export class PreviewCustomizationStore {
     this.listeners.get(key)?.forEach((listener) => listener());
   }
 }
+
+const serverStateChanges = (
+  previous: PreviewCustomizationInitialState,
+  next: PreviewCustomizationInitialState,
+): ServerStateChanges => ({
+  ...(next.disposition !== previous.disposition ? { disposition: next.disposition } : {}),
+  ...(next.canToggle !== previous.canToggle ? { canToggle: next.canToggle } : {}),
+  ...(next.availableCount !== previous.availableCount
+    ? { availableCount: next.availableCount }
+    : {}),
+});
+
+const reconcileServerState = (
+  state: PreviewCustomizationState,
+  changes?: ServerStateChanges,
+  authoritativeReplyFields: AuthoritativeReplyFields = {},
+): PreviewCustomizationState => {
+  if (!changes) {
+    return state;
+  }
+
+  return {
+    ...state,
+    disposition:
+      !authoritativeReplyFields.disposition && changes.disposition !== undefined
+        ? changes.disposition
+        : state.disposition,
+    canToggle:
+      !authoritativeReplyFields.canToggle && changes.canToggle !== undefined
+        ? changes.canToggle
+        : state.canToggle,
+    availableCount:
+      !authoritativeReplyFields.availableCount && 'availableCount' in changes
+        ? changes.availableCount
+        : state.availableCount,
+  };
+};
 
 const firstReplyAction = (
   actions: unknown,

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -6,6 +6,7 @@ export type PreviewCustomizationAction = 'remove' | 'restore';
 
 export interface PreviewCustomizationCopy {
   remove: string;
+  removed: string;
   restore: string;
   pending: string;
   pendingAnnouncement: string;
@@ -69,6 +70,7 @@ export const getPreviewCustomizationCopy = (): PreviewCustomizationCopy => {
 
   if (
     typeof copy.remove !== 'string' ||
+    typeof copy.removed !== 'string' ||
     typeof copy.restore !== 'string' ||
     typeof copy.pending !== 'string' ||
     typeof copy.pendingAnnouncement !== 'string'

--- a/assets/src/components/instructor_preview/preview_customization_store.ts
+++ b/assets/src/components/instructor_preview/preview_customization_store.ts
@@ -4,6 +4,13 @@ import { PreviewCustomizationTarget } from 'components/activities/types';
 export type PreviewCustomizationDisposition = 'included' | 'removed';
 export type PreviewCustomizationAction = 'remove' | 'restore';
 
+export interface PreviewCustomizationCopy {
+  remove: string;
+  restore: string;
+  pending: string;
+  pendingAnnouncement: string;
+}
+
 export interface PreviewCustomizationState {
   disposition: PreviewCustomizationDisposition;
   pendingAction: PreviewCustomizationAction | null;
@@ -30,6 +37,7 @@ type Listener = () => void;
 
 const pageStoreProperty = '__oliInstructorPreviewCustomizationStore';
 const fallbackStoresProperty = '__oliInstructorPreviewCustomizationFallbackStores';
+const copyAttribute = 'data-preview-customization-copy';
 
 type PageStoreHost = HTMLElement & {
   [pageStoreProperty]?: PreviewCustomizationStore;
@@ -46,6 +54,30 @@ export const previewCustomizationTargetKey = (target: PreviewCustomizationTarget
     target.selectionId ?? '',
     target.activityResourceId ?? '',
   ].join(':');
+
+export const getPreviewCustomizationCopy = (): PreviewCustomizationCopy => {
+  const encodedCopy =
+    typeof document === 'undefined'
+      ? undefined
+      : document.querySelector<HTMLElement>(`[${copyAttribute}]`)?.getAttribute(copyAttribute);
+
+  if (!encodedCopy) {
+    throw new Error('Instructor preview customization copy is missing from the page');
+  }
+
+  const copy = JSON.parse(encodedCopy) as Partial<PreviewCustomizationCopy>;
+
+  if (
+    typeof copy.remove !== 'string' ||
+    typeof copy.restore !== 'string' ||
+    typeof copy.pending !== 'string' ||
+    typeof copy.pendingAnnouncement !== 'string'
+  ) {
+    throw new Error('Instructor preview customization copy is invalid');
+  }
+
+  return copy as PreviewCustomizationCopy;
+};
 
 export class PreviewCustomizationStore {
   readonly pageResourceId: number;
@@ -252,6 +284,7 @@ export const usePreviewCustomizationState = (
 
   return {
     state,
+    copy: getPreviewCustomizationCopy(),
     begin: (action: PreviewCustomizationAction) => store.begin(target, action),
   };
 };

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -1,4 +1,8 @@
-import type { PreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
+import type { PreviewCustomizationTarget } from 'components/activities/types';
+import type {
+  PreviewCustomizationReply,
+  PreviewCustomizationState,
+} from 'components/instructor_preview/preview_customization_store';
 import {
   clearFallbackPreviewCustomizationStore,
   getPreviewCustomizationCopy,
@@ -10,9 +14,9 @@ type InstructorPreviewCustomizationHook = {
   pushEvent: (
     event: string,
     payload: Record<string, unknown>,
-    callback?: (reply: Record<string, unknown>) => void,
+    callback?: (reply: unknown) => void,
   ) => void;
-  handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
+  handleEvent: (event: string, callback: (payload: unknown) => void) => void;
   handlePreviewCustomization?: (event: Event) => void;
   handleFallbackPreviewCustomizationClick?: (event: Event) => void;
   previewCustomizationPageIds?: Set<number>;
@@ -23,6 +27,73 @@ const validActions = new Set(['remove', 'restore']);
 
 const isNumber = (value: unknown): value is number => typeof value === 'number';
 const isString = (value: unknown): value is string => typeof value === 'string';
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object';
+
+const isValidCustomizationTarget = (value: unknown): value is PreviewCustomizationTarget => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  if (!isString(value.kind) || !validTargetKinds.has(value.kind)) {
+    return false;
+  }
+
+  if (!isNumber(value.pageResourceId)) {
+    return false;
+  }
+
+  if (value.activityResourceId !== undefined && !isNumber(value.activityResourceId)) {
+    return false;
+  }
+
+  if (value.selectionId !== undefined && !isString(value.selectionId)) {
+    return false;
+  }
+
+  switch (value.kind) {
+    case 'embedded_activity':
+      return isNumber(value.activityResourceId);
+
+    case 'bank_selection':
+      return isString(value.selectionId);
+
+    case 'bank_candidate':
+      return isString(value.selectionId) && isNumber(value.activityResourceId);
+
+    default:
+      return false;
+  }
+};
+
+const isValidCustomizationReply = (value: unknown): value is PreviewCustomizationReply => {
+  if (!isRecord(value) || typeof value.ok !== 'boolean') {
+    return false;
+  }
+
+  if (value.target !== undefined && !isValidCustomizationTarget(value.target)) {
+    return false;
+  }
+
+  if (
+    value.disposition !== undefined &&
+    value.disposition !== 'included' &&
+    value.disposition !== 'removed'
+  ) {
+    return false;
+  }
+
+  if (
+    value.visualState !== undefined &&
+    value.visualState !== null &&
+    value.visualState !== 'default' &&
+    value.visualState !== 'removed'
+  ) {
+    return false;
+  }
+
+  return value.availableCount === undefined || isNumber(value.availableCount);
+};
 
 const isValidCustomizationDetail = (
   detail: unknown,
@@ -35,45 +106,15 @@ const isValidCustomizationDetail = (
     selectionId?: string;
   };
 } => {
-  if (!detail || typeof detail !== 'object') {
+  if (!isRecord(detail)) {
     return false;
   }
 
-  const candidate = detail as Record<string, unknown>;
-  const target =
-    candidate.target && typeof candidate.target === 'object'
-      ? (candidate.target as Record<string, unknown>)
-      : null;
-
-  if (!target) {
+  if (!isString(detail.action) || !validActions.has(detail.action)) {
     return false;
   }
 
-  if (!isString(candidate.action) || !validActions.has(candidate.action)) {
-    return false;
-  }
-
-  if (!isString(target.kind) || !validTargetKinds.has(target.kind)) {
-    return false;
-  }
-
-  if (!isNumber(target.pageResourceId)) {
-    return false;
-  }
-
-  switch (target.kind) {
-    case 'embedded_activity':
-      return isNumber(target.activityResourceId);
-
-    case 'bank_selection':
-      return isString(target.selectionId);
-
-    case 'bank_candidate':
-      return isString(target.selectionId) && isNumber(target.activityResourceId);
-
-    default:
-      return false;
-  }
+  return isValidCustomizationTarget(detail.target);
 };
 
 export const InstructorPreviewCustomization = {
@@ -219,13 +260,8 @@ export const InstructorPreviewCustomization = {
     };
 
     const applyCustomizationReply = (
-      target: {
-        kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
-        pageResourceId: number;
-        activityResourceId?: number;
-        selectionId?: string;
-      },
-      reply: Record<string, unknown>,
+      target: PreviewCustomizationTarget,
+      reply: PreviewCustomizationReply,
     ) => {
       clearPendingAnnouncement();
       const store = storeForPage(target.pageResourceId);
@@ -236,28 +272,33 @@ export const InstructorPreviewCustomization = {
         updateFallbackPreviewCard(target, state);
       }
     };
+    const recoverFromInvalidReply = (detail: {
+      action: 'remove' | 'restore';
+      target: PreviewCustomizationTarget;
+    }) => {
+      const failedReply = { ...detail, ok: false };
+      applyCustomizationReply(detail.target, failedReply);
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: failedReply,
+        }),
+      );
+    };
 
     // Preview activities are custom elements hydrated by React, but the mutation authority stays
     // in LiveView. This hook is the bridge from browser-side preview actions back to the socket.
     this.handleEvent('preview_customization_reply', (reply) => {
+      if (!isValidCustomizationReply(reply) || !reply.target) {
+        return;
+      }
+
       window.dispatchEvent(
         new CustomEvent('oli:preview-customization:reply', {
           detail: reply,
         }),
       );
 
-      const target = reply.target as
-        | {
-            kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
-            pageResourceId: number;
-            activityResourceId?: number;
-            selectionId?: string;
-          }
-        | undefined;
-
-      if (target) {
-        applyCustomizationReply(target, reply);
-      }
+      applyCustomizationReply(reply.target, reply);
     });
 
     this.handlePreviewCustomization = (event: Event) => {
@@ -272,9 +313,14 @@ export const InstructorPreviewCustomization = {
       // The pushEvent callback carries the per-component reply while the same handle_event can
       // still update normal LiveView assigns for the rest of the page.
       this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
+        if (!isValidCustomizationReply(reply)) {
+          recoverFromInvalidReply(detail);
+          return;
+        }
+
         const mergedReply = {
-          ...detail,
           ...reply,
+          ...detail,
         };
         applyCustomizationReply(detail.target, mergedReply);
         window.dispatchEvent(
@@ -304,12 +350,7 @@ export const InstructorPreviewCustomization = {
         return;
       }
 
-      let target: {
-        kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
-        pageResourceId: number;
-        activityResourceId?: number;
-        selectionId?: string;
-      };
+      let target: unknown;
 
       try {
         target = JSON.parse(encodedTarget);
@@ -331,15 +372,20 @@ export const InstructorPreviewCustomization = {
 
       announcePendingUpdate();
 
-      const store = storeForPage(target.pageResourceId);
-      store.initialize(target, {
+      const store = storeForPage(detail.target.pageResourceId);
+      store.initialize(detail.target, {
         disposition: detail.action === 'restore' ? 'removed' : 'included',
       });
-      store.begin(target, detail.action);
+      store.begin(detail.target, detail.action);
 
       this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
-        const mergedReply = { ...detail, ...reply };
-        applyCustomizationReply(target, mergedReply);
+        if (!isValidCustomizationReply(reply)) {
+          recoverFromInvalidReply(detail);
+          return;
+        }
+
+        const mergedReply = { ...reply, ...detail };
+        applyCustomizationReply(detail.target, mergedReply);
 
         window.dispatchEvent(
           new CustomEvent('oli:preview-customization:reply', {

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -200,12 +200,17 @@ export const InstructorPreviewCustomization = {
         const titleRow = wrapper.querySelector<HTMLElement>('[data-preview-title-row]');
         const existingPill = wrapper.querySelector<HTMLElement>('[data-preview-status-pill]');
         if (showRemovedTreatment) {
-          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">Removed</span>`;
-
           if (existingPill) {
-            existingPill.outerHTML = pillMarkup;
+            existingPill.textContent = copy.removed;
           } else if (titleRow) {
-            titleRow.insertAdjacentHTML('beforeend', pillMarkup);
+            titleRow.insertAdjacentHTML(
+              'beforeend',
+              '<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]"></span>',
+            );
+            const insertedPill = titleRow.querySelector<HTMLElement>('[data-preview-status-pill]');
+            if (insertedPill) {
+              insertedPill.textContent = copy.removed;
+            }
           }
         } else if (existingPill) {
           existingPill.remove();

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -1,5 +1,5 @@
+import type { PreviewCustomizationState } from 'components/instructor_preview/preview_customization_store';
 import {
-  PreviewCustomizationState,
   clearFallbackPreviewCustomizationStore,
   getPreviewCustomizationCopy,
   getPreviewCustomizationStore,

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -1,11 +1,12 @@
-import type { PreviewAction } from 'components/activities/types';
 import {
   PreviewCustomizationState,
   clearFallbackPreviewCustomizationStore,
+  getPreviewCustomizationCopy,
   getPreviewCustomizationStore,
 } from 'components/instructor_preview/preview_customization_store';
 
 type InstructorPreviewCustomizationHook = {
+  el: HTMLElement;
   pushEvent: (
     event: string,
     payload: Record<string, unknown>,
@@ -78,6 +79,18 @@ const isValidCustomizationDetail = (
 export const InstructorPreviewCustomization = {
   mounted(this: InstructorPreviewCustomizationHook) {
     this.previewCustomizationPageIds = new Set<number>();
+    const copy = getPreviewCustomizationCopy();
+    const statusRegion = this.el.querySelector<HTMLElement>('[data-preview-customization-status]');
+    const announcePendingUpdate = () => {
+      if (statusRegion) {
+        statusRegion.textContent = copy.pendingAnnouncement;
+      }
+    };
+    const clearPendingAnnouncement = () => {
+      if (statusRegion) {
+        statusRegion.textContent = '';
+      }
+    };
     const storeForPage = (pageResourceId: number) => {
       this.previewCustomizationPageIds?.add(pageResourceId);
       return getPreviewCustomizationStore(pageResourceId);
@@ -165,27 +178,24 @@ export const InstructorPreviewCustomization = {
                 isAuthoringFallback ? ' instructor-preview-authoring-fallback' : ''
               }`;
 
-        const action: PreviewAction =
-          state.disposition === 'removed'
-            ? { kind: 'restore', label: 'Restore' }
-            : { kind: 'remove', label: 'Remove' };
+        const action = state.disposition === 'removed' ? 'restore' : 'remove';
         const disabled = !state.canToggle || state.pendingAction !== null;
         const isPending = state.pendingAction !== null;
-        button.dataset.previewCustomizationAction = action.kind;
+        button.dataset.previewCustomizationAction = action;
         button.disabled = disabled;
         button.setAttribute('aria-busy', String(isPending));
-        button.className = previewActionButtonClass(action.kind, disabled);
+        button.className = previewActionButtonClass(action, disabled);
+
+        button.innerHTML = `${
+          action === 'remove'
+            ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+            : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+        }<span data-preview-customization-label></span>`;
 
         const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
         if (label) {
-          label.textContent = isPending ? 'Updating...' : action.label;
+          label.textContent = isPending ? copy.pending : copy[action];
         }
-
-        button.innerHTML = `${
-          action.kind === 'remove'
-            ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
-            : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
-        }<span data-preview-customization-label>${isPending ? 'Updating...' : action.label}</span>`;
 
         const titleRow = wrapper.querySelector<HTMLElement>('[data-preview-title-row]');
         const existingPill = wrapper.querySelector<HTMLElement>('[data-preview-status-pill]');
@@ -212,6 +222,7 @@ export const InstructorPreviewCustomization = {
       },
       reply: Record<string, unknown>,
     ) => {
+      clearPendingAnnouncement();
       const store = storeForPage(target.pageResourceId);
       store.applyReply(target, reply);
       const state = store.get(target);
@@ -250,6 +261,8 @@ export const InstructorPreviewCustomization = {
       if (!isValidCustomizationDetail(detail)) {
         return;
       }
+
+      announcePendingUpdate();
 
       // The pushEvent callback carries the per-component reply while the same handle_event can
       // still update normal LiveView assigns for the rest of the page.
@@ -308,8 +321,10 @@ export const InstructorPreviewCustomization = {
       button.disabled = true;
       const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
       if (label) {
-        label.textContent = 'Updating...';
+        label.textContent = copy.pending;
       }
+
+      announcePendingUpdate();
 
       const store = storeForPage(target.pageResourceId);
       store.initialize(target, {

--- a/assets/src/hooks/instructor_preview_customization.ts
+++ b/assets/src/hooks/instructor_preview_customization.ts
@@ -1,4 +1,9 @@
 import type { PreviewAction } from 'components/activities/types';
+import {
+  PreviewCustomizationState,
+  clearFallbackPreviewCustomizationStore,
+  getPreviewCustomizationStore,
+} from 'components/instructor_preview/preview_customization_store';
 
 type InstructorPreviewCustomizationHook = {
   pushEvent: (
@@ -9,6 +14,7 @@ type InstructorPreviewCustomizationHook = {
   handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
   handlePreviewCustomization?: (event: Event) => void;
   handleFallbackPreviewCustomizationClick?: (event: Event) => void;
+  previewCustomizationPageIds?: Set<number>;
 };
 
 const validTargetKinds = new Set(['embedded_activity', 'bank_selection', 'bank_candidate']);
@@ -16,7 +22,6 @@ const validActions = new Set(['remove', 'restore']);
 
 const isNumber = (value: unknown): value is number => typeof value === 'number';
 const isString = (value: unknown): value is string => typeof value === 'string';
-const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean';
 
 const isValidCustomizationDetail = (
   detail: unknown,
@@ -72,6 +77,12 @@ const isValidCustomizationDetail = (
 
 export const InstructorPreviewCustomization = {
   mounted(this: InstructorPreviewCustomizationHook) {
+    this.previewCustomizationPageIds = new Set<number>();
+    const storeForPage = (pageResourceId: number) => {
+      this.previewCustomizationPageIds?.add(pageResourceId);
+      return getPreviewCustomizationStore(pageResourceId);
+    };
+
     const previewActionButtonClass = (kind: 'remove' | 'restore', disabled: boolean) => {
       const shared =
         'inline-flex items-center gap-2 rounded-[6px] border bg-Surface-surface-primary px-4 py-2 font-open-sans text-[14px] font-semibold leading-4 tracking-normal shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none';
@@ -83,27 +94,6 @@ export const InstructorPreviewCustomization = {
       return kind === 'remove'
         ? `${shared} border-Border-border-danger text-Specially-Tokens-Text-text-button-pill-muted hover:bg-[rgba(255,64,64,0.08)] dark:border-Border-border-danger dark:text-[#FFB5B7] dark:hover:bg-[rgba(255,64,64,0.18)] focus-visible:outline-Border-border-danger`
         : `${shared} bg-transparent border-[#8AB8E5] text-Text-text-button hover:bg-[#EEF6FF] hover:text-Text-text-button-hover dark:bg-transparent dark:border-[#4C82B8] dark:text-[#9FD0FF] dark:hover:bg-[#16395C] dark:hover:text-[#D7ECFF] focus-visible:outline-[#8AB8E5]`;
-    };
-
-    const normalizeReplyAction = (action: unknown): PreviewAction | null => {
-      if (!action || typeof action !== 'object') {
-        return null;
-      }
-
-      const candidate = action as Record<string, unknown>;
-
-      if (
-        (candidate.kind !== 'remove' && candidate.kind !== 'restore') ||
-        !isString(candidate.label)
-      ) {
-        return null;
-      }
-
-      return {
-        kind: candidate.kind,
-        label: candidate.label,
-        disabled: isBoolean(candidate.disabled) ? candidate.disabled : false,
-      };
     };
 
     // Some activity types still fall back to the authoring element during instructor preview.
@@ -118,12 +108,8 @@ export const InstructorPreviewCustomization = {
         activityResourceId?: number;
         selectionId?: string;
       },
-      reply: Record<string, unknown>,
+      state: PreviewCustomizationState,
     ) => {
-      if (!reply.ok) {
-        return;
-      }
-
       const wrappers = document.querySelectorAll<HTMLElement>(
         '.instructor-preview-activity-wrapper',
       );
@@ -163,7 +149,9 @@ export const InstructorPreviewCustomization = {
           return;
         }
 
-        const visualState = reply.visualState === 'removed' ? 'removed' : 'default';
+        const showRemovedTreatment =
+          state.disposition === 'removed' && target.kind !== 'bank_candidate';
+        const visualState = showRemovedTreatment ? 'removed' : 'default';
         const isAuthoringFallback = wrapper.classList.contains(
           'instructor-preview-authoring-fallback',
         );
@@ -177,38 +165,32 @@ export const InstructorPreviewCustomization = {
                 isAuthoringFallback ? ' instructor-preview-authoring-fallback' : ''
               }`;
 
-        if (Array.isArray(reply.actions) && reply.actions.length > 0) {
-          const action = normalizeReplyAction(reply.actions[0]);
+        const action: PreviewAction =
+          state.disposition === 'removed'
+            ? { kind: 'restore', label: 'Restore' }
+            : { kind: 'remove', label: 'Remove' };
+        const disabled = !state.canToggle || state.pendingAction !== null;
+        const isPending = state.pendingAction !== null;
+        button.dataset.previewCustomizationAction = action.kind;
+        button.disabled = disabled;
+        button.setAttribute('aria-busy', String(isPending));
+        button.className = previewActionButtonClass(action.kind, disabled);
 
-          if (action) {
-            const disabled = action.disabled ?? false;
-            button.dataset.previewCustomizationAction = action.kind;
-            button.disabled = disabled;
-            button.className = previewActionButtonClass(action.kind, disabled);
-
-            const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
-            if (label) {
-              label.textContent = action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore');
-            }
-
-            button.innerHTML = `${
-              action.kind === 'remove'
-                ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
-                : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
-            }<span data-preview-customization-label>${
-              action.label ?? (action.kind === 'remove' ? 'Remove' : 'Restore')
-            }</span>`;
-          }
+        const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
+        if (label) {
+          label.textContent = isPending ? 'Updating...' : action.label;
         }
+
+        button.innerHTML = `${
+          action.kind === 'remove'
+            ? '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6H5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M19 6V20C19 20.5304 18.7893 21.0391 18.4142 21.4142C18.0391 21.7893 17.5304 22 17 22H7C6.46957 22 5.96086 21.7893 5.58579 21.4142C5.21071 21.0391 5 20.5304 5 20V6M8 6V4C8 3.46957 8.21071 2.96086 8.58579 2.58579C8.96086 2.21071 9.46957 2 10 2H14C14.5304 2 15.0391 2.21071 15.4142 2.58579C15.7893 2.96086 16 3.46957 16 4V6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M10 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M14 11V17" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+            : '<svg aria-hidden="true" class="h-4 w-4" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3.33301 9.16667C3.33301 12.3883 5.94468 15 9.16634 15C12.388 15 14.9997 12.3883 14.9997 9.16667C14.9997 5.94501 12.388 3.33334 9.16634 3.33334C7.24384 3.33334 5.53848 4.2628 4.47595 5.69884" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path><path d="M5.00033 1.66666L5.00033 5.83332L9.16699 5.83332" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path></svg>'
+        }<span data-preview-customization-label>${isPending ? 'Updating...' : action.label}</span>`;
 
         const titleRow = wrapper.querySelector<HTMLElement>('[data-preview-title-row]');
         const existingPill = wrapper.querySelector<HTMLElement>('[data-preview-status-pill]');
-        const statusPill = reply.statusPill as { kind?: string; label?: string } | null | undefined;
-
-        if (statusPill?.kind === 'removed') {
-          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">${
-            statusPill.label ?? 'Removed'
-          }</span>`;
+        if (showRemovedTreatment) {
+          const pillMarkup = `<span data-preview-status-pill class="inline-flex items-center rounded-full border border-Border-border-danger bg-[rgba(255,64,64,0.08)] px-4 py-1 font-open-sans text-[14px] font-semibold leading-4 tracking-normal text-[#C91414] dark:bg-[rgba(255,64,64,0.16)] dark:text-[#FFB5B7]">Removed</span>`;
 
           if (existingPill) {
             existingPill.outerHTML = pillMarkup;
@@ -219,6 +201,24 @@ export const InstructorPreviewCustomization = {
           existingPill.remove();
         }
       });
+    };
+
+    const applyCustomizationReply = (
+      target: {
+        kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
+        pageResourceId: number;
+        activityResourceId?: number;
+        selectionId?: string;
+      },
+      reply: Record<string, unknown>,
+    ) => {
+      const store = storeForPage(target.pageResourceId);
+      store.applyReply(target, reply);
+      const state = store.get(target);
+
+      if (state) {
+        updateFallbackPreviewCard(target, state);
+      }
     };
 
     // Preview activities are custom elements hydrated by React, but the mutation authority stays
@@ -240,7 +240,7 @@ export const InstructorPreviewCustomization = {
         | undefined;
 
       if (target) {
-        updateFallbackPreviewCard(target, reply);
+        applyCustomizationReply(target, reply);
       }
     });
 
@@ -254,16 +254,16 @@ export const InstructorPreviewCustomization = {
       // The pushEvent callback carries the per-component reply while the same handle_event can
       // still update normal LiveView assigns for the rest of the page.
       this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
+        const mergedReply = {
+          ...detail,
+          ...reply,
+        };
+        applyCustomizationReply(detail.target, mergedReply);
         window.dispatchEvent(
           new CustomEvent('oli:preview-customization:reply', {
-            detail: {
-              ...detail,
-              ...reply,
-            },
+            detail: mergedReply,
           }),
         );
-
-        updateFallbackPreviewCard(detail.target, reply);
       });
     };
 
@@ -307,53 +307,27 @@ export const InstructorPreviewCustomization = {
 
       button.disabled = true;
       const label = button.querySelector<HTMLElement>('[data-preview-customization-label]');
-      const previousLabel = label?.textContent ?? '';
-
       if (label) {
         label.textContent = 'Updating...';
       }
 
-      this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
-        button.disabled = false;
+      const store = storeForPage(target.pageResourceId);
+      store.initialize(target, {
+        disposition: detail.action === 'restore' ? 'removed' : 'included',
+      });
+      store.begin(target, detail.action);
 
-        if (!reply.ok && label) {
-          label.textContent = previousLabel;
-        }
+      this.pushEvent('toggle_preview_activity_customization', detail, (reply) => {
+        const mergedReply = { ...detail, ...reply };
+        applyCustomizationReply(target, mergedReply);
 
         window.dispatchEvent(
           new CustomEvent('oli:preview-customization:reply', {
-            detail: {
-              ...detail,
-              ...reply,
-            },
+            detail: mergedReply,
           }),
         );
-
-        updateFallbackPreviewCard(detail.target, reply);
       });
     };
-
-    this.handleEvent?.('preview_customization_reply', (reply) => {
-      const target =
-        reply.target && typeof reply.target === 'object'
-          ? (reply.target as {
-              kind: 'embedded_activity' | 'bank_selection' | 'bank_candidate';
-              pageResourceId: number;
-              activityResourceId?: number;
-              selectionId?: string;
-            })
-          : null;
-
-      window.dispatchEvent(
-        new CustomEvent('oli:preview-customization:reply', {
-          detail: reply,
-        }),
-      );
-
-      if (target) {
-        updateFallbackPreviewCard(target, reply);
-      }
-    });
 
     window.addEventListener('oli:preview-customization', this.handlePreviewCustomization);
     window.addEventListener('click', this.handleFallbackPreviewCustomizationClick as EventListener);
@@ -370,5 +344,7 @@ export const InstructorPreviewCustomization = {
         this.handleFallbackPreviewCustomizationClick as EventListener,
       );
     }
+
+    this.previewCustomizationPageIds?.forEach(clearFallbackPreviewCustomizationStore);
   },
 };

--- a/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
+++ b/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
@@ -12,6 +12,7 @@ import {
 
 const customizationCopy = {
   remove: 'Remove',
+  removed: 'Removed',
   restore: 'Restore',
   pending: 'Updating...',
   pendingAnnouncement: 'Updating activity customization.',
@@ -81,6 +82,7 @@ describe('ActivityBankSelectionPreview', () => {
     const copyHost = document.querySelector<HTMLElement>('[data-preview-customization-copy]');
     copyHost!.dataset.previewCustomizationCopy = JSON.stringify({
       remove: 'Exclude question',
+      removed: 'Excluded question',
       restore: 'Include question',
       pending: 'Saving...',
       pendingAnnouncement: 'Saving question customization.',
@@ -104,6 +106,7 @@ describe('ActivityBankSelectionPreview', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Include question' })).toBeInTheDocument();
+    expect(screen.getByText('Excluded question')).toBeInTheDocument();
   });
 
   test('restoring one selection removes only that card removed-state rail', () => {

--- a/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
+++ b/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import {
   ActivityBankSelectionPreview,
   ActivityBankSelectionPreviewPayload,
@@ -9,6 +9,19 @@ import {
   clearPreviewCustomizationStore,
   getPreviewCustomizationStore,
 } from 'components/instructor_preview/preview_customization_store';
+
+const customizationCopy = {
+  remove: 'Remove',
+  restore: 'Restore',
+  pending: 'Updating...',
+  pendingAnnouncement: 'Updating activity customization.',
+};
+
+const installCustomizationCopy = () => {
+  const host = document.createElement('div');
+  host.dataset.previewCustomizationCopy = JSON.stringify(customizationCopy);
+  document.body.appendChild(host);
+};
 
 const includedSelection = (selectionId: string): ActivityBankSelectionPreviewPayload => ({
   id: selectionId,
@@ -53,8 +66,45 @@ const dispatchReply = (selectionId: string, visualState: 'default' | 'removed') 
 };
 
 describe('ActivityBankSelectionPreview', () => {
-  beforeEach(() => clearPreviewCustomizationStore(10));
-  afterEach(() => clearPreviewCustomizationStore(10));
+  beforeEach(() => {
+    clearPreviewCustomizationStore(10);
+    installCustomizationCopy();
+  });
+  afterEach(() => {
+    clearPreviewCustomizationStore(10);
+    document
+      .querySelectorAll('[data-preview-customization-copy]')
+      .forEach((element) => element.remove());
+  });
+
+  test('uses the server-provided page copy for every action state', () => {
+    const copyHost = document.querySelector<HTMLElement>('[data-preview-customization-copy]');
+    copyHost!.dataset.previewCustomizationCopy = JSON.stringify({
+      remove: 'Exclude question',
+      restore: 'Include question',
+      pending: 'Saving...',
+      pendingAnnouncement: 'Saving question customization.',
+    });
+
+    render(<ActivityBankSelectionPreview payload={includedSelection('first')} />);
+
+    const target = includedSelection('first').customizationTarget;
+    expect(screen.getByRole('button', { name: 'Exclude question' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude question' }));
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeInTheDocument();
+
+    act(() => {
+      getPreviewCustomizationStore(10).applyReply(target, {
+        ok: true,
+        target,
+        visualState: 'removed',
+        actions: [{ kind: 'restore', label: 'This payload label is not rendered' }],
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Include question' })).toBeInTheDocument();
+  });
 
   test('restoring one selection removes only that card removed-state rail', () => {
     const initialSelections = ['first', 'second', 'third'].map(includedSelection);

--- a/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
+++ b/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
@@ -4,18 +4,23 @@ import {
   ActivityBankSelectionPreview,
   ActivityBankSelectionPreviewPayload,
 } from 'components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview';
+import 'components/instructor_preview/activity_bank_selection_preview/preview-entry';
+import {
+  clearPreviewCustomizationStore,
+  getPreviewCustomizationStore,
+} from 'components/instructor_preview/preview_customization_store';
 
-const removedSelection = (selectionId: string): ActivityBankSelectionPreviewPayload => ({
+const includedSelection = (selectionId: string): ActivityBankSelectionPreviewPayload => ({
   id: selectionId,
   title: `Bank selection ${selectionId}`,
   selectedCount: 1,
-  availableCount: 0,
+  availableCount: 4,
   pointsPerActivity: 1,
   sampleActivity: null,
   canCustomize: true,
-  actions: [{ kind: 'restore', label: 'Restore' }],
-  visualState: 'removed',
-  statusPill: { kind: 'removed', label: 'Removed' },
+  actions: [{ kind: 'remove', label: 'Remove' }],
+  visualState: 'default',
+  statusPill: null,
   customizationTarget: {
     kind: 'bank_selection',
     pageResourceId: 10,
@@ -26,43 +31,124 @@ const removedSelection = (selectionId: string): ActivityBankSelectionPreviewPayl
 const cardFor = (selectionId: string) =>
   screen.getByText(`Bank selection ${selectionId}`).closest('article') as HTMLElement;
 
+const dispatchReply = (selectionId: string, visualState: 'default' | 'removed') => {
+  const removed = visualState === 'removed';
+
+  act(() => {
+    const target = {
+      kind: 'bank_selection' as const,
+      pageResourceId: 10,
+      selectionId,
+    };
+    getPreviewCustomizationStore(10).applyReply(target, {
+      ok: true,
+      target,
+      visualState,
+      actions: [
+        removed ? { kind: 'restore', label: 'Restore' } : { kind: 'remove', label: 'Remove' },
+      ],
+      availableCount: removed ? 0 : 4,
+    });
+  });
+};
+
 describe('ActivityBankSelectionPreview', () => {
+  beforeEach(() => clearPreviewCustomizationStore(10));
+  afterEach(() => clearPreviewCustomizationStore(10));
+
   test('restoring one selection removes only that card removed-state rail', () => {
-    render(
+    const initialSelections = ['first', 'second', 'third'].map(includedSelection);
+    const { rerender } = render(
       <>
-        <ActivityBankSelectionPreview payload={removedSelection('first')} />
-        <ActivityBankSelectionPreview payload={removedSelection('second')} />
-        <ActivityBankSelectionPreview payload={removedSelection('last')} />
+        {initialSelections.map((selection) => (
+          <ActivityBankSelectionPreview key={selection.id} payload={selection} />
+        ))}
       </>,
     );
 
+    dispatchReply('first', 'removed');
+    dispatchReply('second', 'removed');
+    dispatchReply('third', 'removed');
+
     expect(cardFor('first')).toHaveAttribute('data-preview-visual-state', 'removed');
     expect(cardFor('second')).toHaveAttribute('data-preview-visual-state', 'removed');
-    expect(cardFor('last')).toHaveAttribute('data-preview-visual-state', 'removed');
+    expect(cardFor('third')).toHaveAttribute('data-preview-visual-state', 'removed');
     expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
     expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
-    expect(cardFor('last').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('third').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
 
-    act(() => {
-      window.dispatchEvent(
-        new CustomEvent('oli:preview-customization:reply', {
-          detail: {
-            ok: true,
-            target: {
-              kind: 'bank_selection',
-              pageResourceId: 10,
-              selectionId: 'last',
-            },
-            visualState: 'default',
-            statusPill: null,
-            actions: [{ kind: 'remove', label: 'Remove' }],
-          },
-        }),
-      );
+    rerender(
+      <>
+        {initialSelections.map((selection) => (
+          <ActivityBankSelectionPreview
+            key={selection.id}
+            payload={{
+              ...selection,
+              customizationTarget: { ...selection.customizationTarget },
+            }}
+          />
+        ))}
+      </>,
+    );
+
+    expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('third').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('first').querySelector('button')).toHaveTextContent('Restore');
+    expect(cardFor('second').querySelector('button')).toHaveTextContent('Restore');
+    expect(cardFor('third').querySelector('button')).toHaveTextContent('Restore');
+
+    dispatchReply('third', 'default');
+
+    expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('third').querySelector('[data-preview-removed-rail]')).not.toBeInTheDocument();
+    expect(cardFor('first').querySelector('button')).toHaveTextContent('Restore');
+    expect(cardFor('second').querySelector('button')).toHaveTextContent('Restore');
+    expect(cardFor('third').querySelector('button')).toHaveTextContent('Remove');
+  });
+
+  test('preserves selection state through payload updates and transient reconnects', async () => {
+    const hosts = ['first', 'second', 'third'].map((selectionId) => {
+      const host = document.createElement('oli-activity-bank-selection-preview') as HTMLElement & {
+        render: () => void;
+      };
+
+      host.setAttribute('payload', JSON.stringify(includedSelection(selectionId)));
+      document.body.appendChild(host);
+
+      return host;
     });
 
-    expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
-    expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
-    expect(cardFor('last').querySelector('[data-preview-removed-rail]')).not.toBeInTheDocument();
+    dispatchReply('first', 'removed');
+    dispatchReply('second', 'removed');
+    dispatchReply('third', 'removed');
+
+    hosts.forEach((host, index) => {
+      const regeneratedPayload = {
+        ...includedSelection(['first', 'second', 'third'][index]),
+        selectedCount: 2,
+      };
+
+      host.setAttribute('payload', JSON.stringify(regeneratedPayload));
+    });
+    hosts.forEach((host) => {
+      host.remove();
+      document.body.appendChild(host);
+    });
+    hosts.forEach((host) => host.render());
+
+    dispatchReply('third', 'default');
+
+    expect(hosts[0].querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(hosts[1].querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(hosts[2].querySelector('[data-preview-removed-rail]')).not.toBeInTheDocument();
+    expect(hosts[0].querySelector('button')).toHaveTextContent('Restore');
+    expect(hosts[1].querySelector('button')).toHaveTextContent('Restore');
+    expect(hosts[2].querySelector('button')).toHaveTextContent('Remove');
+    hosts.forEach((host) => expect(host).toHaveTextContent('Selects: 2 questions'));
+
+    hosts.forEach((host) => host.remove());
+    await act(async () => Promise.resolve());
   });
 });

--- a/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
+++ b/assets/test/activities/preview/activity_bank_selection_preview_test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import {
+  ActivityBankSelectionPreview,
+  ActivityBankSelectionPreviewPayload,
+} from 'components/instructor_preview/activity_bank_selection_preview/ActivityBankSelectionPreview';
+
+const removedSelection = (selectionId: string): ActivityBankSelectionPreviewPayload => ({
+  id: selectionId,
+  title: `Bank selection ${selectionId}`,
+  selectedCount: 1,
+  availableCount: 0,
+  pointsPerActivity: 1,
+  sampleActivity: null,
+  canCustomize: true,
+  actions: [{ kind: 'restore', label: 'Restore' }],
+  visualState: 'removed',
+  statusPill: { kind: 'removed', label: 'Removed' },
+  customizationTarget: {
+    kind: 'bank_selection',
+    pageResourceId: 10,
+    selectionId,
+  },
+});
+
+const cardFor = (selectionId: string) =>
+  screen.getByText(`Bank selection ${selectionId}`).closest('article') as HTMLElement;
+
+describe('ActivityBankSelectionPreview', () => {
+  test('restoring one selection removes only that card removed-state rail', () => {
+    render(
+      <>
+        <ActivityBankSelectionPreview payload={removedSelection('first')} />
+        <ActivityBankSelectionPreview payload={removedSelection('second')} />
+        <ActivityBankSelectionPreview payload={removedSelection('last')} />
+      </>,
+    );
+
+    expect(cardFor('first')).toHaveAttribute('data-preview-visual-state', 'removed');
+    expect(cardFor('second')).toHaveAttribute('data-preview-visual-state', 'removed');
+    expect(cardFor('last')).toHaveAttribute('data-preview-visual-state', 'removed');
+    expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('last').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('oli:preview-customization:reply', {
+          detail: {
+            ok: true,
+            target: {
+              kind: 'bank_selection',
+              pageResourceId: 10,
+              selectionId: 'last',
+            },
+            visualState: 'default',
+            statusPill: null,
+            actions: [{ kind: 'remove', label: 'Remove' }],
+          },
+        }),
+      );
+    });
+
+    expect(cardFor('first').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('second').querySelector('[data-preview-removed-rail]')).toBeInTheDocument();
+    expect(cardFor('last').querySelector('[data-preview-removed-rail]')).not.toBeInTheDocument();
+  });
+});

--- a/assets/test/activities/preview/preview_customization_store_test.ts
+++ b/assets/test/activities/preview/preview_customization_store_test.ts
@@ -1,0 +1,65 @@
+import { PreviewCustomizationTarget } from 'components/activities/types';
+import { PreviewCustomizationStore } from 'components/instructor_preview/preview_customization_store';
+
+const target: PreviewCustomizationTarget = {
+  kind: 'bank_selection',
+  pageResourceId: 10,
+  selectionId: 'selection-1',
+};
+
+describe('PreviewCustomizationStore', () => {
+  test('reconciles changed server state without overwriting reply state with stale inputs', () => {
+    const store = new PreviewCustomizationStore(10);
+    const includedState = {
+      disposition: 'included' as const,
+      canToggle: true,
+      availableCount: 4,
+    };
+
+    store.initialize(target, includedState);
+    store.applyReply(target, {
+      ok: true,
+      visualState: 'removed',
+      availableCount: 3,
+    });
+
+    expect(store.initialize(target, includedState)).toMatchObject({
+      disposition: 'removed',
+      canToggle: true,
+      availableCount: 3,
+    });
+
+    expect(
+      store.initialize(target, {
+        disposition: 'removed',
+        canToggle: false,
+        availableCount: 2,
+      }),
+    ).toMatchObject({
+      disposition: 'removed',
+      canToggle: false,
+      availableCount: 2,
+    });
+
+    expect(
+      store.initialize(target, {
+        disposition: 'included',
+        canToggle: true,
+        availableCount: 4,
+      }),
+    ).toMatchObject({
+      disposition: 'included',
+      canToggle: true,
+      availableCount: 4,
+    });
+  });
+
+  test('maps an explicit default visual state to included', () => {
+    const store = new PreviewCustomizationStore(10);
+
+    store.initialize(target, { disposition: 'removed' });
+    store.applyReply(target, { ok: true, visualState: 'default' });
+
+    expect(store.get(target)?.disposition).toBe('included');
+  });
+});

--- a/assets/test/activities/preview/preview_customization_store_test.ts
+++ b/assets/test/activities/preview/preview_customization_store_test.ts
@@ -1,4 +1,4 @@
-import { PreviewCustomizationTarget } from 'components/activities/types';
+import type { PreviewCustomizationTarget } from 'components/activities/types';
 import { PreviewCustomizationStore } from 'components/instructor_preview/preview_customization_store';
 
 const target: PreviewCustomizationTarget = {
@@ -61,5 +61,60 @@ describe('PreviewCustomizationStore', () => {
     store.applyReply(target, { ok: true, visualState: 'default' });
 
     expect(store.get(target)?.disposition).toBe('included');
+  });
+
+  test('reconciles server updates received while an action is pending', () => {
+    const store = new PreviewCustomizationStore(10);
+
+    store.initialize(target, {
+      disposition: 'included',
+      canToggle: true,
+      availableCount: 4,
+    });
+    store.begin(target, 'remove');
+
+    store.initialize(target, {
+      disposition: 'included',
+      canToggle: false,
+      availableCount: 2,
+    });
+    store.applyReply(target, { ok: true, visualState: 'removed' });
+
+    expect(store.get(target)).toMatchObject({
+      disposition: 'removed',
+      pendingAction: null,
+      canToggle: false,
+      availableCount: 2,
+    });
+  });
+
+  test('prefers authoritative reply fields over queued server updates', () => {
+    const store = new PreviewCustomizationStore(10);
+
+    store.initialize(target, {
+      disposition: 'included',
+      canToggle: true,
+      availableCount: 4,
+    });
+    store.begin(target, 'remove');
+
+    store.initialize(target, {
+      disposition: 'included',
+      canToggle: false,
+      availableCount: 2,
+    });
+    store.applyReply(target, {
+      ok: true,
+      visualState: 'removed',
+      actions: [{ kind: 'restore', disabled: false }],
+      availableCount: 3,
+    });
+
+    expect(store.get(target)).toMatchObject({
+      disposition: 'removed',
+      pendingAction: null,
+      canToggle: true,
+      availableCount: 3,
+    });
   });
 });

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -414,7 +414,7 @@ describe('PreviewElementProvider', () => {
 });
 
 describe('InstructorPreviewCustomization fallback preview wiring', () => {
-  test('updates a server-rendered authoring fallback card after a successful reply', () => {
+  test('recovers from a malformed callback before updating an authoring fallback', () => {
     document.body.innerHTML = `
       <div data-preview-customization-copy='${JSON.stringify({
         ...customizationCopy,
@@ -451,13 +451,9 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       </div>
     `;
 
-    let customizationReply: ((reply: Record<string, unknown>) => void) | undefined;
+    let customizationReply: ((reply: unknown) => void) | undefined;
     const pushEvent = jest.fn(
-      (
-        _event: string,
-        _payload: Record<string, unknown>,
-        callback?: (reply: Record<string, unknown>) => void,
-      ) => {
+      (_event: string, _payload: Record<string, unknown>, callback?: (reply: unknown) => void) => {
         customizationReply = callback;
       },
     );
@@ -474,9 +470,9 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       pushEvent: (
         event: string,
         payload: Record<string, unknown>,
-        callback?: (reply: Record<string, unknown>) => void,
+        callback?: (reply: unknown) => void,
       ) => void;
-      handleEvent: (event: string, callback: (payload: Record<string, unknown>) => void) => void;
+      handleEvent: (event: string, callback: (payload: unknown) => void) => void;
       handlePreviewCustomization?: (event: Event) => void;
       handleFallbackPreviewCustomizationClick?: (event: Event) => void;
     } = {
@@ -505,6 +501,13 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       expect.any(Function),
     );
 
+    act(() => customizationReply?.({ ok: 'yes', visualState: 'removed' }));
+
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Remove' })).toHaveAttribute('aria-busy', 'false');
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
     act(() => customizationReply?.(successfulReply));
 
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
@@ -522,7 +525,7 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     document.body.innerHTML = '';
   });
 
-  test('keeps removed bank-candidate fallbacks visually default and labels bulk-disabled actions', () => {
+  test('ignores malformed broadcasts and keeps bank-candidate fallback behavior', () => {
     document.body.innerHTML = `
       <div data-preview-customization-copy='${JSON.stringify(customizationCopy)}'>
         <span role="status" aria-live="polite" aria-atomic="true" data-preview-customization-status></span>
@@ -541,11 +544,7 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     `;
 
     const pushEvent = jest.fn(
-      (
-        _event: string,
-        _payload: Record<string, unknown>,
-        callback?: (reply: Record<string, unknown>) => void,
-      ) => {
+      (_event: string, _payload: Record<string, unknown>, callback?: (reply: unknown) => void) => {
         callback?.({
           ok: true,
           visualState: 'default',
@@ -571,7 +570,22 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     expect(wrapper).not.toHaveClass('instructor-preview-removed', 'before:bg-Border-border-danger');
     expect(screen.queryByText('Removed')).not.toBeInTheDocument();
 
-    const serverReply = handleEvent.mock.calls[0][1] as (reply: Record<string, unknown>) => void;
+    const serverReply = handleEvent.mock.calls[0][1] as (reply: unknown) => void;
+    act(() => {
+      serverReply({
+        ok: 'yes',
+        target: {
+          kind: 'bank_candidate',
+          pageResourceId: 10,
+          selectionId: 'selection-1',
+          activityResourceId: 200,
+        },
+        actions: [{ kind: 'remove', label: 'Remove' }],
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeEnabled();
+
     act(() => {
       serverReply({
         ok: true,

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -16,6 +16,7 @@ import { InstructorPreviewCustomization } from 'hooks/instructor_preview_customi
 
 const customizationCopy = {
   remove: 'Remove',
+  removed: 'Removed',
   restore: 'Restore',
   pending: 'Updating...',
   pendingAnnouncement: 'Updating activity customization.',
@@ -136,6 +137,7 @@ describe('ActivityPreviewCard', () => {
     const copyHost = document.querySelector<HTMLElement>('[data-preview-customization-copy]');
     copyHost!.dataset.previewCustomizationCopy = JSON.stringify({
       remove: 'Exclude activity',
+      removed: 'Excluded activity',
       restore: 'Include activity',
       pending: 'Saving...',
       pendingAnnouncement: 'Saving activity customization.',
@@ -170,7 +172,7 @@ describe('ActivityPreviewCard', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Include activity' })).toBeInTheDocument();
-    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('Excluded activity')).toBeInTheDocument();
   });
 
   test('preserves each embedded activity removal through stale preview-context rerenders', () => {
@@ -414,7 +416,10 @@ describe('PreviewElementProvider', () => {
 describe('InstructorPreviewCustomization fallback preview wiring', () => {
   test('updates a server-rendered authoring fallback card after a successful reply', () => {
     document.body.innerHTML = `
-      <div data-preview-customization-copy='${JSON.stringify(customizationCopy)}'>
+      <div data-preview-customization-copy='${JSON.stringify({
+        ...customizationCopy,
+        removed: 'Excluded fallback activity',
+      })}'>
         <span role="status" aria-live="polite" aria-atomic="true" data-preview-customization-status></span>
       </div>
       <div class="instructor-preview-activity-wrapper instructor-preview-authoring-fallback instructor-preview-default mb-6 rounded-lg border border-Border-border-default overflow-hidden p-6 bg-Surface-surface-primary">
@@ -503,7 +508,7 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     act(() => customizationReply?.(successfulReply));
 
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
-    expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByText('Excluded fallback activity')).toBeInTheDocument();
     expect(screen.getByRole('status')).toBeEmptyDOMElement();
     expect(document.querySelector('.instructor-preview-activity-wrapper')).toHaveClass(
       'instructor-preview-authoring-fallback',

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -14,6 +14,22 @@ import {
 } from 'components/instructor_preview/preview_customization_store';
 import { InstructorPreviewCustomization } from 'hooks/instructor_preview_customization';
 
+const customizationCopy = {
+  remove: 'Remove',
+  restore: 'Restore',
+  pending: 'Updating...',
+  pendingAnnouncement: 'Updating activity customization.',
+};
+
+const installCustomizationBridge = () => {
+  const host = document.createElement('div');
+  host.dataset.previewCustomizationCopy = JSON.stringify(customizationCopy);
+  host.innerHTML =
+    '<span role="status" aria-live="polite" aria-atomic="true" data-preview-customization-status></span>';
+  document.body.appendChild(host);
+  return host;
+};
+
 const previewContext: PreviewContext = {
   sectionSlug: 'section-1',
   pageResourceId: 10,
@@ -37,8 +53,16 @@ const previewContext: PreviewContext = {
 };
 
 describe('ActivityPreviewCard', () => {
-  beforeEach(() => clearPreviewCustomizationStore(10));
-  afterEach(() => clearPreviewCustomizationStore(10));
+  beforeEach(() => {
+    clearPreviewCustomizationStore(10);
+    installCustomizationBridge();
+  });
+  afterEach(() => {
+    clearPreviewCustomizationStore(10);
+    document
+      .querySelectorAll('[data-preview-customization-copy]')
+      .forEach((element) => element.remove());
+  });
 
   test('toggles details and switches tabs with keyboard navigation', () => {
     render(
@@ -109,6 +133,13 @@ describe('ActivityPreviewCard', () => {
   });
 
   test('updates action label from remove to restore after LiveView reply without remounting', () => {
+    const copyHost = document.querySelector<HTMLElement>('[data-preview-customization-copy]');
+    copyHost!.dataset.previewCustomizationCopy = JSON.stringify({
+      remove: 'Exclude activity',
+      restore: 'Include activity',
+      pending: 'Saving...',
+      pendingAnnouncement: 'Saving activity customization.',
+    });
     const actionableContext = {
       ...previewContext,
       actions: [{ kind: 'remove' as const, label: 'Remove' }],
@@ -120,9 +151,9 @@ describe('ActivityPreviewCard', () => {
       </ActivityPreviewCard>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude activity' }));
 
-    expect(screen.getByRole('button', { name: 'Updating...' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Saving...' })).toBeInTheDocument();
 
     act(() => {
       const target = {
@@ -134,11 +165,11 @@ describe('ActivityPreviewCard', () => {
         ok: true,
         target,
         visualState: 'removed',
-        actions: [{ kind: 'restore', label: 'Restore' }],
+        actions: [{ kind: 'restore', label: 'This payload label is not rendered' }],
       });
     });
 
-    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Include activity' })).toBeInTheDocument();
     expect(screen.getByText('Removed')).toBeInTheDocument();
   });
 
@@ -383,6 +414,9 @@ describe('PreviewElementProvider', () => {
 describe('InstructorPreviewCustomization fallback preview wiring', () => {
   test('updates a server-rendered authoring fallback card after a successful reply', () => {
     document.body.innerHTML = `
+      <div data-preview-customization-copy='${JSON.stringify(customizationCopy)}'>
+        <span role="status" aria-live="polite" aria-atomic="true" data-preview-customization-status></span>
+      </div>
       <div class="instructor-preview-activity-wrapper instructor-preview-authoring-fallback instructor-preview-default mb-6 rounded-lg border border-Border-border-default overflow-hidden p-6 bg-Surface-surface-primary">
         <header class="mb-4 flex flex-col gap-3">
           <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
@@ -412,22 +446,26 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       </div>
     `;
 
+    let customizationReply: ((reply: Record<string, unknown>) => void) | undefined;
     const pushEvent = jest.fn(
       (
         _event: string,
         _payload: Record<string, unknown>,
         callback?: (reply: Record<string, unknown>) => void,
       ) => {
-        callback?.({
-          ok: true,
-          actions: [{ kind: 'restore', label: 'Restore' }],
-          visualState: 'removed',
-          statusPill: { kind: 'removed', label: 'Removed' },
-        });
+        customizationReply = callback;
       },
     );
 
+    const successfulReply = {
+      ok: true,
+      actions: [{ kind: 'restore', label: 'Restore' }],
+      visualState: 'removed',
+      statusPill: { kind: 'removed', label: 'Removed' },
+    };
+
     const hook: {
+      el: HTMLElement;
       pushEvent: (
         event: string,
         payload: Record<string, unknown>,
@@ -437,6 +475,7 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       handlePreviewCustomization?: (event: Event) => void;
       handleFallbackPreviewCustomizationClick?: (event: Event) => void;
     } = {
+      el: document.querySelector('[data-preview-customization-copy]') as HTMLElement,
       pushEvent,
       handleEvent: jest.fn(),
     };
@@ -444,6 +483,9 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     InstructorPreviewCustomization.mounted.call(hook);
 
     fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(screen.getByRole('button', { name: 'Updating...' })).toBeDisabled();
+    expect(screen.getByRole('status')).toHaveTextContent('Updating activity customization.');
 
     expect(pushEvent).toHaveBeenCalledWith(
       'toggle_preview_activity_customization',
@@ -458,8 +500,11 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       expect.any(Function),
     );
 
+    act(() => customizationReply?.(successfulReply));
+
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
     expect(screen.getByText('Removed')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toBeEmptyDOMElement();
     expect(document.querySelector('.instructor-preview-activity-wrapper')).toHaveClass(
       'instructor-preview-authoring-fallback',
       'instructor-preview-removed',
@@ -474,6 +519,9 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
 
   test('keeps removed bank-candidate fallbacks visually default and labels bulk-disabled actions', () => {
     document.body.innerHTML = `
+      <div data-preview-customization-copy='${JSON.stringify(customizationCopy)}'>
+        <span role="status" aria-live="polite" aria-atomic="true" data-preview-customization-status></span>
+      </div>
       <div class="instructor-preview-activity-wrapper instructor-preview-authoring-fallback instructor-preview-default">
         <div data-preview-title-row="200"><h3>Fallback Candidate</h3></div>
         <button
@@ -502,6 +550,7 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
     );
     const handleEvent = jest.fn();
     const hook = {
+      el: document.querySelector('[data-preview-customization-copy]') as HTMLElement,
       pushEvent,
       handleEvent,
       handlePreviewCustomization: undefined as ((event: Event) => void) | undefined,

--- a/assets/test/activities/preview/preview_foundation_test.tsx
+++ b/assets/test/activities/preview/preview_foundation_test.tsx
@@ -8,6 +8,10 @@ import {
 import { ActivityPreviewCard } from 'components/activities/common/preview/ActivityPreviewCard';
 import { ReadonlyPanel } from 'components/activities/common/preview/ReadonlyPanel';
 import { ActivityModelSchema, PreviewContext } from 'components/activities/types';
+import {
+  clearPreviewCustomizationStore,
+  getPreviewCustomizationStore,
+} from 'components/instructor_preview/preview_customization_store';
 import { InstructorPreviewCustomization } from 'hooks/instructor_preview_customization';
 
 const previewContext: PreviewContext = {
@@ -33,6 +37,9 @@ const previewContext: PreviewContext = {
 };
 
 describe('ActivityPreviewCard', () => {
+  beforeEach(() => clearPreviewCustomizationStore(10));
+  afterEach(() => clearPreviewCustomizationStore(10));
+
   test('toggles details and switches tabs with keyboard navigation', () => {
     render(
       <ActivityPreviewCard
@@ -118,26 +125,102 @@ describe('ActivityPreviewCard', () => {
     expect(screen.getByRole('button', { name: 'Updating...' })).toBeInTheDocument();
 
     act(() => {
-      window.dispatchEvent(
-        new CustomEvent('oli:preview-customization:reply', {
-          detail: {
-            ok: true,
-            target: {
-              kind: 'embedded_activity',
-              pageResourceId: 10,
-              activityResourceId: 100,
-            },
-            activityResourceId: 100,
-            visualState: 'removed',
-            statusPill: { kind: 'removed', label: 'Removed' },
-            actions: [{ kind: 'restore', label: 'Restore' }],
-          },
-        }),
-      );
+      const target = {
+        kind: 'embedded_activity' as const,
+        pageResourceId: 10,
+        activityResourceId: 100,
+      };
+      getPreviewCustomizationStore(10).applyReply(target, {
+        ok: true,
+        target,
+        visualState: 'removed',
+        actions: [{ kind: 'restore', label: 'Restore' }],
+      });
     });
 
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
     expect(screen.getByText('Removed')).toBeInTheDocument();
+  });
+
+  test('preserves each embedded activity removal through stale preview-context rerenders', () => {
+    const includedContext = (activityResourceId: number): PreviewContext => ({
+      ...previewContext,
+      activityResourceId,
+      activityHtmlId: `activity_${activityResourceId}`,
+      title: `Activity ${activityResourceId}`,
+      actions: [{ kind: 'remove', label: 'Remove' }],
+      visualState: 'default',
+      customizationTarget: {
+        kind: 'embedded_activity',
+        pageResourceId: 10,
+        activityResourceId,
+      },
+    });
+    const initialContexts = [includedContext(100), includedContext(200)];
+    const { rerender } = render(
+      <>
+        {initialContexts.map((context) => (
+          <ActivityPreviewCard key={context.activityResourceId} previewContext={context}>
+            <div>{`Question ${context.activityResourceId}`}</div>
+          </ActivityPreviewCard>
+        ))}
+      </>,
+    );
+
+    [100, 200].forEach((activityResourceId) => {
+      act(() => {
+        const target = {
+          kind: 'embedded_activity' as const,
+          pageResourceId: 10,
+          activityResourceId,
+        };
+        getPreviewCustomizationStore(10).applyReply(target, {
+          ok: true,
+          target,
+          visualState: 'removed',
+          actions: [{ kind: 'restore', label: 'Restore' }],
+        });
+      });
+    });
+
+    rerender(
+      <>
+        {initialContexts.map((context) => (
+          <ActivityPreviewCard
+            key={context.activityResourceId}
+            previewContext={{
+              ...context,
+              actions: [{ kind: 'remove', label: 'Remove' }],
+              customizationTarget: { ...context.customizationTarget },
+            }}
+          >
+            <div>{`Question ${context.activityResourceId}`}</div>
+          </ActivityPreviewCard>
+        ))}
+      </>,
+    );
+
+    act(() => {
+      const target = {
+        kind: 'embedded_activity' as const,
+        pageResourceId: 10,
+        activityResourceId: 200,
+      };
+      getPreviewCustomizationStore(10).applyReply(target, {
+        ok: true,
+        target,
+        visualState: 'default',
+        actions: [{ kind: 'remove', label: 'Remove' }],
+      });
+    });
+
+    const firstCard = screen.getByText('Question 100').closest('article') as HTMLElement;
+    const secondCard = screen.getByText('Question 200').closest('article') as HTMLElement;
+
+    expect(firstCard).toHaveClass('before:bg-Border-border-danger');
+    expect(firstCard).toHaveTextContent('Restore');
+    expect(secondCard).not.toHaveClass('before:bg-Border-border-danger');
+    expect(secondCard).toHaveTextContent('Remove');
   });
 
   test('matches replies for selection-based targets using the full customization target', () => {
@@ -157,28 +240,70 @@ describe('ActivityPreviewCard', () => {
       </ActivityPreviewCard>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove bank' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
 
     act(() => {
-      window.dispatchEvent(
-        new CustomEvent('oli:preview-customization:reply', {
-          detail: {
-            ok: true,
-            target: {
-              kind: 'bank_selection',
-              pageResourceId: 10,
-              selectionId: 'selection-1',
-            },
-            actions: [{ kind: 'restore', label: 'Restore' }],
-          },
-        }),
-      );
+      const target = {
+        kind: 'bank_selection' as const,
+        pageResourceId: 10,
+        selectionId: 'selection-1',
+      };
+      getPreviewCustomizationStore(10).applyReply(target, {
+        ok: true,
+        target,
+        visualState: 'removed',
+        actions: [{ kind: 'restore', label: 'Restore' }],
+      });
     });
 
     expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
   });
 
-  test('renders removed visual treatment only when the preview context asks for it', () => {
+  test('tracks bank-candidate disposition without applying removed-card treatment', () => {
+    const candidateTarget = {
+      kind: 'bank_candidate' as const,
+      pageResourceId: 10,
+      selectionId: 'selection-1',
+      activityResourceId: 100,
+    };
+    const candidateContext = {
+      ...previewContext,
+      actions: [{ kind: 'remove' as const, label: 'Remove' }],
+      customizationTarget: candidateTarget,
+    };
+
+    render(
+      <ActivityPreviewCard previewContext={candidateContext}>
+        <div>Candidate question</div>
+      </ActivityPreviewCard>,
+    );
+
+    act(() => {
+      getPreviewCustomizationStore(10).applyReply(candidateTarget, {
+        ok: true,
+        target: candidateTarget,
+        visualState: 'default',
+        actions: [{ kind: 'restore', label: 'Restore' }],
+      });
+    });
+
+    const card = screen.getByText('Candidate question').closest('article') as HTMLElement;
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(card).not.toHaveClass('before:bg-Border-border-danger');
+    expect(screen.queryByText('Removed')).not.toBeInTheDocument();
+
+    act(() => {
+      getPreviewCustomizationStore(10).applyReply(candidateTarget, {
+        ok: true,
+        target: candidateTarget,
+        actions: [{ kind: 'restore', label: 'Restore', disabled: true }],
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeDisabled();
+  });
+
+  test('derives removed visual treatment from semantic customization state', () => {
     const removedContext = {
       ...previewContext,
       actions: [{ kind: 'restore' as const, label: 'Restore' }],
@@ -209,6 +334,14 @@ describe('ActivityPreviewCard', () => {
         <div>Question body</div>
       </ActivityPreviewCard>,
     );
+
+    act(() => {
+      getPreviewCustomizationStore(10).applyReply(previewContext.customizationTarget, {
+        ok: true,
+        target: previewContext.customizationTarget,
+        disposition: 'included',
+      });
+    });
 
     expect(screen.queryByText('Removed')).not.toBeInTheDocument();
     expect(screen.getByText('Question body').closest('article')).not.toHaveClass('border-l-4');
@@ -334,6 +467,72 @@ describe('InstructorPreviewCustomization fallback preview wiring', () => {
       'before:w-[6px]',
       'before:bg-Border-border-danger',
     );
+
+    InstructorPreviewCustomization.destroyed.call(hook);
+    document.body.innerHTML = '';
+  });
+
+  test('keeps removed bank-candidate fallbacks visually default and labels bulk-disabled actions', () => {
+    document.body.innerHTML = `
+      <div class="instructor-preview-activity-wrapper instructor-preview-authoring-fallback instructor-preview-default">
+        <div data-preview-title-row="200"><h3>Fallback Candidate</h3></div>
+        <button
+          type="button"
+          data-preview-customization-action="remove"
+          data-preview-customization-target='{"kind":"bank_candidate","pageResourceId":10,"selectionId":"selection-1","activityResourceId":200}'
+          data-preview-customization-button
+        >
+          <span data-preview-customization-label>Remove</span>
+        </button>
+      </div>
+    `;
+
+    const pushEvent = jest.fn(
+      (
+        _event: string,
+        _payload: Record<string, unknown>,
+        callback?: (reply: Record<string, unknown>) => void,
+      ) => {
+        callback?.({
+          ok: true,
+          visualState: 'default',
+          actions: [{ kind: 'restore', label: 'Restore' }],
+        });
+      },
+    );
+    const handleEvent = jest.fn();
+    const hook = {
+      pushEvent,
+      handleEvent,
+      handlePreviewCustomization: undefined as ((event: Event) => void) | undefined,
+      handleFallbackPreviewCustomizationClick: undefined as ((event: Event) => void) | undefined,
+    };
+
+    InstructorPreviewCustomization.mounted.call(hook);
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    const wrapper = document.querySelector('.instructor-preview-activity-wrapper');
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeInTheDocument();
+    expect(wrapper).toHaveClass('instructor-preview-default');
+    expect(wrapper).not.toHaveClass('instructor-preview-removed', 'before:bg-Border-border-danger');
+    expect(screen.queryByText('Removed')).not.toBeInTheDocument();
+
+    const serverReply = handleEvent.mock.calls[0][1] as (reply: Record<string, unknown>) => void;
+    act(() => {
+      serverReply({
+        ok: true,
+        target: {
+          kind: 'bank_candidate',
+          pageResourceId: 10,
+          selectionId: 'selection-1',
+          activityResourceId: 200,
+        },
+        actions: [{ kind: 'restore', label: 'Restore', disabled: true }],
+      });
+    });
+
+    expect(screen.getByRole('button', { name: 'Restore' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Restore' })).toHaveAttribute('aria-busy', 'false');
 
     InstructorPreviewCustomization.destroyed.call(hook);
     document.body.innerHTML = '';

--- a/lib/oli/rendering/activity/preview_customization.ex
+++ b/lib/oli/rendering/activity/preview_customization.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Rendering.Activity.PreviewCustomization do
+  @moduledoc false
+
+  @copy %{
+    "remove" => "Remove",
+    "restore" => "Restore",
+    "pending" => "Updating...",
+    "pendingAnnouncement" => "Updating activity customization."
+  }
+
+  def copy, do: @copy
+
+  def action(kind, opts \\ []) when kind in ["remove", "restore"] do
+    %{kind: kind, label: Map.fetch!(@copy, kind)}
+    |> maybe_disable(Keyword.get(opts, :disabled))
+  end
+
+  defp maybe_disable(action, disabled) when is_boolean(disabled),
+    do: Map.put(action, :disabled, disabled)
+
+  defp maybe_disable(action, _disabled), do: action
+end

--- a/lib/oli/rendering/activity/preview_customization.ex
+++ b/lib/oli/rendering/activity/preview_customization.ex
@@ -3,6 +3,7 @@ defmodule Oli.Rendering.Activity.PreviewCustomization do
 
   @copy %{
     "remove" => "Remove",
+    "removed" => "Removed",
     "restore" => "Restore",
     "pending" => "Updating...",
     "pendingAnnouncement" => "Updating activity customization."
@@ -14,6 +15,9 @@ defmodule Oli.Rendering.Activity.PreviewCustomization do
     %{kind: kind, label: Map.fetch!(@copy, kind)}
     |> maybe_disable(Keyword.get(opts, :disabled))
   end
+
+  def removed_status_pill,
+    do: %{kind: "removed", label: Map.fetch!(@copy, "removed")}
 
   defp maybe_disable(action, disabled) when is_boolean(disabled),
     do: Map.put(action, :disabled, disabled)

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -138,7 +138,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
       canCustomize: true,
       actions: actions(selection_enabled?),
       visualState: if(selection_enabled?, do: "default", else: "removed"),
-      statusPill: if(selection_enabled?, do: nil, else: %{kind: "removed", label: "Removed"}),
+      statusPill:
+        if(selection_enabled?, do: nil, else: PreviewCustomization.removed_status_pill()),
       customizationTarget: %{
         kind: "bank_selection",
         pageResourceId: page_revision.resource_id,

--- a/lib/oli/rendering/content/activity_bank_selection_preview.ex
+++ b/lib/oli/rendering/content/activity_bank_selection_preview.ex
@@ -8,6 +8,7 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   alias Oli.Rendering.Content.ActivityBankSelectionCriteria
   alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.Context
+  alias Oli.Rendering.Activity.PreviewCustomization
   alias Oli.Resources.PageContent
 
   @script "instructor_preview_components.js"
@@ -319,8 +320,8 @@ defmodule Oli.Rendering.Content.ActivityBankSelectionPreview do
   defp select_count(%Selection{count: count}, _selection), do: count
   defp select_count(_parsed_selection, selection), do: Map.get(selection, "count", 0)
 
-  defp actions(true), do: [%{kind: "remove", label: "Remove"}]
-  defp actions(false), do: [%{kind: "restore", label: "Restore"}]
+  defp actions(true), do: [PreviewCustomization.action("remove")]
+  defp actions(false), do: [PreviewCustomization.action("restore")]
 
   defp manage_questions_url(section_slug, revision_slug, selection_id, navigation_params) do
     request_path =

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -19,6 +19,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
   alias Oli.Grading
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Rendering.Activity.ActivitySummary
+  alias Oli.Rendering.Activity.PreviewCustomization
   alias Oli.Rendering.Content.JumpNavigation
   alias Oli.Rendering.{Context, Page}
   alias Oli.Resources
@@ -1001,9 +1002,9 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
 
   defp preview_actions(exclusion_view, activity_resource_id) do
     if InstructorCustomizations.activity_enabled?(exclusion_view, activity_resource_id) do
-      [%{kind: "remove", label: "Remove"}]
+      [PreviewCustomization.action("remove")]
     else
-      [%{kind: "restore", label: "Restore"}]
+      [PreviewCustomization.action("restore")]
     end
   end
 

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -601,7 +601,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
                 activity_revision.resource_id
               ),
               do: nil,
-              else: %{kind: "removed", label: "Removed"}
+              else: PreviewCustomization.removed_status_pill()
             ),
           customization_target: %{
             kind: "embedded_activity",

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -649,6 +649,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
           role="status"
           aria-live="polite"
           aria-atomic="true"
+          phx-update="ignore"
           data-preview-customization-status
         >
         </span>

--- a/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
+++ b/lib/oli_web/live/delivery/instructor/bank_selection_manager_live.ex
@@ -7,6 +7,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
   alias Oli.Delivery.Sections.Section
   alias Oli.Publishing.DeliveryResolver, as: Resolver
   alias Oli.Rendering.Content.ActivityBankSelectionCriteria
+  alias Oli.Rendering.Activity.PreviewCustomization
   alias Oli.Resources.Revision
 
   alias OliWeb.Components.Delivery.ActivityBankSelectionCriteria,
@@ -532,8 +533,8 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
       statusPill: nil,
       actions:
         if(action == "remove",
-          do: [%{kind: "restore", label: "Restore"}],
-          else: [%{kind: "remove", label: "Remove"}]
+          do: [PreviewCustomization.action("restore")],
+          else: [PreviewCustomization.action("remove")]
         )
     }
   end
@@ -637,7 +638,21 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
         <.preview_flash_group flash={@flash} />
       </div>
 
-      <div id="bank-selection-customization-bridge" phx-hook="InstructorPreviewCustomization"></div>
+      <div
+        id="bank-selection-customization-bridge"
+        phx-hook="InstructorPreviewCustomization"
+        data-preview-customization-copy={Jason.encode!(PreviewCustomization.copy())}
+      >
+        <span
+          id="preview-customization-status"
+          class="sr-only"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-preview-customization-status
+        >
+        </span>
+      </div>
       <div
         id="bank-selection-preview-script-loader"
         phx-hook="LoadSurveyScripts"
@@ -1332,9 +1347,9 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLive do
 
   defp candidate_preview_actions(candidate, bulk_selection_active?) do
     if candidate.enabled? do
-      [%{kind: "remove", label: "Remove", disabled: bulk_selection_active?}]
+      [PreviewCustomization.action("remove", disabled: bulk_selection_active?)]
     else
-      [%{kind: "restore", label: "Restore", disabled: bulk_selection_active?}]
+      [PreviewCustomization.action("restore", disabled: bulk_selection_active?)]
     end
   end
 

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -11,6 +11,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   alias Oli.Resources.Collaboration
   alias Oli.Resources.Collaboration.CollabSpaceConfig
   alias Oli.Resources.Revision
+  alias Oli.Rendering.Activity.PreviewCustomization
   alias OliWeb.Components.Modal
   alias OliWeb.Delivery.Instructor.PreviewReturn
   alias OliWeb.Delivery.Student.Utils
@@ -73,8 +74,18 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     <div
       id="instructor-preview-lesson"
       data-preview-mode={@preview_mode}
+      data-preview-customization-copy={Jason.encode!(PreviewCustomization.copy())}
       phx-hook="InstructorPreviewCustomization"
     >
+      <span
+        id="preview-customization-status"
+        class="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-preview-customization-status
+      >
+      </span>
       <.scripts scripts={@scripts} user_token={assigns[:user_token]} />
 
       <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
@@ -149,8 +160,18 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
     <div
       id="instructor-preview-lesson"
       data-preview-mode={@preview_mode}
+      data-preview-customization-copy={Jason.encode!(PreviewCustomization.copy())}
       phx-hook="InstructorPreviewCustomization"
     >
+      <span
+        id="preview-customization-status"
+        class="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        data-preview-customization-status
+      >
+      </span>
       <.scripts scripts={@scripts} user_token={assigns[:user_token]} />
 
       <Layouts.instructor_preview_header return_context={@instructor_preview_return} />
@@ -1110,8 +1131,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   defp preview_status_pill("remove"), do: %{kind: "removed", label: "Removed"}
   defp preview_status_pill(_action), do: nil
 
-  defp preview_next_actions("remove"), do: [%{kind: "restore", label: "Restore"}]
-  defp preview_next_actions(_action), do: [%{kind: "remove", label: "Remove"}]
+  defp preview_next_actions("remove"), do: [PreviewCustomization.action("restore")]
+  defp preview_next_actions(_action), do: [PreviewCustomization.action("remove")]
 
   defp client_preview_customization_target(%{
          kind: :embedded_activity,

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -83,6 +83,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         role="status"
         aria-live="polite"
         aria-atomic="true"
+        phx-update="ignore"
         data-preview-customization-status
       >
       </span>
@@ -169,6 +170,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
         role="status"
         aria-live="polite"
         aria-atomic="true"
+        phx-update="ignore"
         data-preview-customization-status
       >
       </span>

--- a/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
+++ b/lib/oli_web/live/delivery/instructor/preview_lesson_live.ex
@@ -1128,7 +1128,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLive do
   defp preview_visual_state("remove"), do: "removed"
   defp preview_visual_state(_action), do: "default"
 
-  defp preview_status_pill("remove"), do: %{kind: "removed", label: "Removed"}
+  defp preview_status_pill("remove"), do: PreviewCustomization.removed_status_pill()
   defp preview_status_pill(_action), do: nil
 
   defp preview_next_actions("remove"), do: [PreviewCustomization.action("restore")]

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -64,7 +64,7 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
 
       assert has_element?(
                view,
-               "#bank-selection-customization-bridge [data-preview-customization-status][role='status'][aria-live='polite']"
+               "#bank-selection-customization-bridge [data-preview-customization-status][role='status'][aria-live='polite'][phx-update='ignore']"
              )
 
       assert has_element?(

--- a/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/bank_selection_manager_live_test.exs
@@ -59,6 +59,16 @@ defmodule OliWeb.Delivery.Instructor.BankSelectionManagerLiveTest do
 
       assert has_element?(
                view,
+               "#bank-selection-customization-bridge[data-preview-customization-copy]"
+             )
+
+      assert has_element?(
+               view,
+               "#bank-selection-customization-bridge [data-preview-customization-status][role='status'][aria-live='polite']"
+             )
+
+      assert has_element?(
+               view,
                "#selected-candidate-preview-#{first_candidate.resource_id}"
              )
 

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -45,7 +45,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert has_element?(
                view,
-               "#instructor-preview-lesson [data-preview-customization-status][role='status'][aria-live='polite']"
+               "#instructor-preview-lesson [data-preview-customization-status][role='status'][aria-live='polite'][phx-update='ignore']"
              )
     end
 

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -32,7 +32,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       section: section,
       page_revision: page_revision
     } do
-      {:ok, _view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+      {:ok, view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
 
       assert html =~ ~s|id="instructor-preview-header"|
       assert html =~ ~s|<main id="main"|
@@ -41,6 +41,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       assert html =~ "/js/oli_multiple_choice_preview.js"
       refute html =~ "/js/oli_multiple_choice_authoring.js"
       refute html =~ "Page Discussion"
+      assert has_element?(view, "#instructor-preview-lesson[data-preview-customization-copy]")
+
+      assert has_element?(
+               view,
+               "#instructor-preview-lesson [data-preview-customization-status][role='status'][aria-live='polite']"
+             )
     end
 
     test "renders learning objective coverage and overall available points", %{


### PR DESCRIPTION
 ## Issue

  MER-5625 made the learning-objective and available-points summaries update after instructors remove or restore questions. Those LiveView updates can transiently reconnect the custom elements rendering the assessment content. This was causing presentation errors due to use of stale state after sequences of actions like the following:

  1. Remove several activity-bank selections.
  2. Dismiss the success banner.
  3. Restore one selection.

  The other removed selections incorrectly appear included: their buttons change to Remove, and their Removed pill and red rail disappear. Reloading shows that persistence was correct; only the client presentation had been reset.

  ## Root cause

  Each bank-selection React root independently stored its remove/restore state. When LiveView updated the new counters, the custom elements could reconnect and render again using their original server payload.

  That payload represented the state when the page initially loaded. It did not contain removals performed since then. Re-rendering therefore reset every component to stale initial state, after which the restore response updated only the selected item.

  React-backed embedded activities used the same general local-state pattern and were vulnerable to the same failure.

  ## Why state management was reworked

  A narrow fix could prevent one custom element from unmounting or teach one component to ignore repeated props. That would fix the reported bank-selection sequence, but it would leave state ownership distributed across independent React roots and preserve the same vulnerability for embedded activities and other preview surfaces.

  The implementation instead introduces a small page-scoped semantic store shared by:

  - Activity-bank selections
  - Embedded activities
  - Bank candidates
  - Server-rendered activity fallbacks

  The store owns only semantic interaction state: included or removed, pending action, whether toggling is currently allowed, and the bank’s available count. Buttons, rails, pills, backgrounds, and accessibility attributes are derived from that state.

  Initial server payloads seed targets only once. LiveView replies update the store, while reconnecting components subscribe to the existing state instead of overwriting it with stale payloads. Reloading still reconstructs the store from authoritative persisted server state.

  This is broader than the minimum symptom fix, but it removes the shared failure mechanism and gives all remove/restore presentations one consistent source of truth.
  
  ## Regression coverage

  - Added a bank-selection test reproducing the failed sequence: remove multiple selections, rerender from stale initial payloads, restore one, and verify the others retain their Restore buttons, Removed state, and red rails.

  - Added a custom-element reconnect test confirming bank-selection state survives transient disconnect/reconnect cycles.
  - Added an equivalent embedded-activity test confirming multiple removals survive stale preview-context rerenders and restoring one activity does not reset another.

  - Added coverage for bank-candidate and server-rendered fallback variants, including their distinct visual and disabled-state behavior.

  The relevant tests are in:

  - `assets/test/activities/preview/activity_bank_selection_preview_test.tsx`
  - `assets/test/activities/preview/preview_foundation_test.tsx`

  The embedded-activity regression test is named:

  `preserves each embedded activity removal through stale preview-context rerenders`

  ## Verification

  - 25 instructor-preview Jest tests pass.
  - TypeScript, ESLint, and Prettier checks pass.
  - The reported browser sequence passes, and a subsequent reload confirms the same persisted state.
  
  ## Demo Video

https://github.com/user-attachments/assets/50a2e210-1193-4fc8-aa2a-2353bf4d9ced

