### PR TITLE
[BUG FIX] [MER-4525] [MER-5724] Ensure activity authoring UI non-editable in read-only contexts

### DIFF
--- a/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
+++ b/assets/src/components/activities/check_all_that_apply/CheckAllThatApplyAuthoring.tsx
@@ -134,6 +134,7 @@ const CheckAllThatApply = () => {
     projectSlug: projectSlug,
   });
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <ControlledTabs isInstructorPreview={isInstructorPreview}>
@@ -174,7 +175,7 @@ const CheckAllThatApply = () => {
           onSelect={(id) => dispatch(CATAActions.toggleChoiceCorrectness(id))}
           isEvaluated={false}
           context={writerContext}
-          disabled={isInstructorPreview}
+          disabled={readOnly}
           multiSelect
         />
         <SimpleFeedback partId={model.authoring.parts[0].id} />
@@ -194,7 +195,7 @@ const CheckAllThatApply = () => {
           addTargetedResponse={() => dispatch(CATAActions.addTargetedFeedback())}
           unselectedIcon={<Checkbox.Unchecked />}
           selectedIcon={<Checkbox.Checked />}
-          disabled={isInstructorPreview}
+          disabled={readOnly}
           multiSelect
         />
       </TabbedNavigation.Tab>

--- a/assets/src/components/activities/common/authoring/RemoveButton.tsx
+++ b/assets/src/components/activities/common/authoring/RemoveButton.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAuthoringElementContext } from 'components/activities/AuthoringElementProvider';
 import { AuthoringButton } from 'components/activities/common/authoring/AuthoringButton';
+import { classNames } from 'utils/classNames';
 
 type Props = {
   onClick: () => void;
@@ -10,17 +11,26 @@ type Props = {
   mode?: 'authoring' | 'instructor_preview';
 };
 
-export const RemoveButton: React.FC<Props> = (props) => (
-  <AuthoringButton
-    ariaLabel="Remove"
-    editMode={props.editMode}
-    mode={props.mode}
-    action={props.onClick}
-    className="text-body-color dark:text-body-color-dark hover:text-red-500"
-  >
-    <i className="fa-solid fa-xmark fa-xl"></i>
-  </AuthoringButton>
-);
+export const RemoveButton: React.FC<Props> = (props) => {
+  const isDisabled = !props.editMode || props.mode === 'instructor_preview';
+
+  return (
+    <AuthoringButton
+      ariaLabel="Remove"
+      editMode={props.editMode}
+      mode={props.mode}
+      action={props.onClick}
+      className={classNames(
+        'text-body-color dark:text-body-color-dark',
+        !isDisabled && 'hover:text-red-500',
+        props.className,
+      )}
+      style={props.style}
+    >
+      <i className="fa-solid fa-xmark fa-xl"></i>
+    </AuthoringButton>
+  );
+};
 
 export const RemoveButtonConnected: React.FC<Omit<Props, 'editMode' | 'mode'>> = (props) => {
   const { editMode, mode } = useAuthoringElementContext();

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.modules.scss
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.modules.scss
@@ -12,9 +12,3 @@
 .addChoiceContainer {
   padding-left: 32px;
 }
-
-.readOnlySimpleTextChoice {
-  &:focus {
-    box-shadow: none;
-  }
-}

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.modules.scss
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.modules.scss
@@ -12,3 +12,9 @@
 .addChoiceContainer {
   padding-left: 32px;
 }
+
+.readOnlySimpleTextChoice {
+  &:focus {
+    box-shadow: none;
+  }
+}

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
@@ -77,7 +77,10 @@ export const Choices: React.FC<Props> = ({
                         {renderChoiceIcon(icon, choice, index)}
                         {simpleText ? (
                           <input
-                            className="form-control border-none"
+                            className={classNames(
+                              'form-control border-none',
+                              readOnly && styles.readOnlySimpleTextChoice,
+                            )}
                             placeholder="Answer choice"
                             value={toSimpleText(choice.content)}
                             readOnly={readOnly}

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
@@ -47,6 +47,7 @@ export const Choices: React.FC<Props> = ({
 }) => {
   const { projectSlug, editMode, mode } = useAuthoringElementContext();
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <>
@@ -66,26 +67,33 @@ export const Choices: React.FC<Props> = ({
                     className="mb-4"
                     item={choice}
                     color={colorMap?.get(choice.id)}
+                    isDragDisabled={readOnly}
                   >
                     {(choice, index) => (
                       <>
-                        {!isInstructorPreview && <Draggable.DragIndicator />}
+                        {!isInstructorPreview && (
+                          <Draggable.DragIndicator isDragDisabled={readOnly} />
+                        )}
                         {renderChoiceIcon(icon, choice, index)}
                         {simpleText ? (
                           <input
                             className="form-control border-none"
                             placeholder="Answer choice"
                             value={toSimpleText(choice.content)}
-                            onChange={(e) => onEdit(choice.id, makeContent(e.target.value).content)}
+                            readOnly={readOnly}
+                            style={{ cursor: readOnly ? 'default' : 'text' }}
+                            onChange={(e) => {
+                              if (!readOnly) onEdit(choice.id, makeContent(e.target.value).content);
+                            }}
                           />
                         ) : (
                           <SlateOrMarkdownEditor
                             style={{
                               flexGrow: 1,
-                              cursor: isInstructorPreview ? 'default' : 'text',
+                              cursor: readOnly ? 'default' : 'text',
                               backgroundColor: colorMap?.get(choice.id),
                             }}
-                            editMode={editMode && !isInstructorPreview}
+                            editMode={!readOnly}
                             editorType={choice.editor || DEFAULT_EDITOR}
                             placeholder="Answer choice"
                             content={choice.content}

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
@@ -84,7 +84,11 @@ export const Choices: React.FC<Props> = ({
                             placeholder="Answer choice"
                             value={toSimpleText(choice.content)}
                             readOnly={readOnly}
+                            tabIndex={readOnly ? -1 : undefined}
                             style={{ cursor: readOnly ? 'default' : 'text' }}
+                            onMouseDown={(e) => {
+                              if (readOnly) e.preventDefault();
+                            }}
                             onChange={(e) => {
                               if (!readOnly) onEdit(choice.id, makeContent(e.target.value).content);
                             }}

--- a/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
+++ b/assets/src/components/activities/common/choices/authoring/ChoicesAuthoring.tsx
@@ -77,18 +77,11 @@ export const Choices: React.FC<Props> = ({
                         {renderChoiceIcon(icon, choice, index)}
                         {simpleText ? (
                           <input
-                            className={classNames(
-                              'form-control border-none',
-                              readOnly && styles.readOnlySimpleTextChoice,
-                            )}
+                            className="form-control border-none"
                             placeholder="Answer choice"
                             value={toSimpleText(choice.content)}
                             readOnly={readOnly}
-                            tabIndex={readOnly ? -1 : undefined}
                             style={{ cursor: readOnly ? 'default' : 'text' }}
-                            onMouseDown={(e) => {
-                              if (readOnly) e.preventDefault();
-                            }}
                             onChange={(e) => {
                               if (!readOnly) onEdit(choice.id, makeContent(e.target.value).content);
                             }}

--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -40,6 +40,10 @@ export const ChoicesDelivery: React.FC<Props> = ({
 }) => {
   const choiceRefs = useRef<(HTMLDivElement | null)[]>([]);
   const isSelected = (choiceId: ChoiceId) => !!selected.find((s) => s === choiceId);
+  const renderIcon = (icon: React.ReactNode) =>
+    React.isValidElement<{ disabled?: boolean }>(icon)
+      ? React.cloneElement(icon, { disabled: disabled || icon.props.disabled })
+      : icon;
 
   // Track which choice is currently focusable (roving tabindex)
   // Initialize to selected index, or 0 if nothing selected
@@ -165,7 +169,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
           <div className={styles.choicesChoiceWrapper} dir={choice.textDirection}>
             <div className={styles.choicesChoiceLabel}>
               <div className="d-flex align-items-center col">
-                {isSelected(choice.id) ? selectedIcon : unselectedIcon}
+                {renderIcon(isSelected(choice.id) ? selectedIcon : unselectedIcon)}
                 <div className={classNames('content', styles.choicesChoiceContent)}>
                   <HtmlContentModelRenderer
                     content={choice.content}

--- a/assets/src/components/activities/common/explanation/ExplanationAuthoring.tsx
+++ b/assets/src/components/activities/common/explanation/ExplanationAuthoring.tsx
@@ -16,7 +16,9 @@ interface Props {
   partId: string;
 }
 export const Explanation: React.FC<Props> = (props) => {
-  const { dispatch, model, projectSlug } = useAuthoringElementContext<HasParts>();
+  const { dispatch, editMode, mode, model, projectSlug } = useAuthoringElementContext<HasParts>();
+  const isInstructorPreview = mode === 'instructor_preview';
+
   return (
     <SlateOrMarkdownEditor
       placeholder="Explanation"
@@ -25,7 +27,7 @@ export const Explanation: React.FC<Props> = (props) => {
       onEditorTypeChange={(editor: EditorType) =>
         dispatch(setExplanationEditor(props.partId, editor))
       }
-      editMode={true}
+      editMode={editMode && !isInstructorPreview}
       editorType={getExplanationEditor(model, props.partId)}
       allowBlockElements={true}
       projectSlug={projectSlug}

--- a/assets/src/components/activities/common/hints/authoring/HintCard.tsx
+++ b/assets/src/components/activities/common/hints/authoring/HintCard.tsx
@@ -14,6 +14,7 @@ export const HintCard: React.FC<{
   updateOneEditor: (id: ID, editor: EditorType) => void;
   updateOneTextDirection: (id: ID, textDirection: string) => void;
   projectSlug: string;
+  editMode: boolean;
 }> = ({
   title,
   placeholder,
@@ -22,6 +23,7 @@ export const HintCard: React.FC<{
   updateOneEditor,
   updateOneTextDirection,
   projectSlug,
+  editMode,
 }) => {
   return (
     <Card.Card>
@@ -31,7 +33,7 @@ export const HintCard: React.FC<{
           placeholder={placeholder}
           content={hint?.content || []}
           onEdit={(content) => updateOne(hint.id, content)}
-          editMode={true}
+          editMode={editMode}
           editorType={hint.editor || DEFAULT_EDITOR}
           onEditorTypeChange={(editor) => updateOneEditor(hint.id, editor)}
           allowBlockElements={true}

--- a/assets/src/components/activities/common/hints/authoring/HintsAuthoring.tsx
+++ b/assets/src/components/activities/common/hints/authoring/HintsAuthoring.tsx
@@ -20,6 +20,7 @@ interface HintsAuthoringProps {
   deerInHeadlightsHint: Hint;
   cognitiveHints: Hint[];
   bottomOutHint: Hint;
+  editMode: boolean;
 }
 export const HintsAuthoring: React.FC<HintsAuthoringProps> = ({
   deerInHeadlightsHint,
@@ -30,6 +31,7 @@ export const HintsAuthoring: React.FC<HintsAuthoringProps> = ({
   removeOne,
   updateOneEditor,
   updateOneTextDirection,
+  editMode,
 }) => {
   const { projectSlug } = useAuthoringElementContext();
   return (
@@ -40,6 +42,7 @@ export const HintsAuthoring: React.FC<HintsAuthoringProps> = ({
         updateOneEditor={updateOneEditor}
         updateOneTextDirection={updateOneTextDirection}
         projectSlug={projectSlug}
+        editMode={editMode}
       />
       <CognitiveHints
         hints={cognitiveHints}
@@ -49,6 +52,7 @@ export const HintsAuthoring: React.FC<HintsAuthoringProps> = ({
         updateOneTextDirection={updateOneTextDirection}
         updateOneEditor={updateOneEditor}
         projectSlug={projectSlug}
+        editMode={editMode}
       />
       <BottomOutHint
         hint={bottomOutHint}
@@ -56,6 +60,7 @@ export const HintsAuthoring: React.FC<HintsAuthoringProps> = ({
         updateOneEditor={updateOneEditor}
         updateOneTextDirection={updateOneTextDirection}
         projectSlug={projectSlug}
+        editMode={editMode}
       />
     </>
   );
@@ -67,6 +72,7 @@ interface HintProps {
   updateOne: (id: ID, content: RichText) => void;
   updateOneEditor: (id: ID, editor: EditorType) => void;
   updateOneTextDirection: (id: ID, textDirection: TextDirection) => void;
+  editMode: boolean;
 }
 const DeerInHeadlightsHint: React.FC<HintProps> = ({
   hint,
@@ -74,6 +80,7 @@ const DeerInHeadlightsHint: React.FC<HintProps> = ({
   updateOneEditor,
   updateOneTextDirection,
   projectSlug,
+  editMode,
 }) => (
   <HintCard
     title={<>{'"Deer in headlights" hint'}</>}
@@ -83,6 +90,7 @@ const DeerInHeadlightsHint: React.FC<HintProps> = ({
     updateOneEditor={updateOneEditor}
     updateOneTextDirection={updateOneTextDirection}
     projectSlug={projectSlug}
+    editMode={editMode}
   />
 );
 
@@ -96,6 +104,7 @@ interface CognitiveProps {
   title?: React.ReactNode;
   placeholder?: string;
   projectSlug: string;
+  editMode: boolean;
 }
 export const CognitiveHints: React.FC<CognitiveProps> = ({
   hints,
@@ -107,6 +116,7 @@ export const CognitiveHints: React.FC<CognitiveProps> = ({
   placeholder,
   projectSlug,
   updateOneEditor,
+  editMode,
 }) => (
   <Card.Card>
     <Card.Title>{title || '"Cognitive" hints'}</Card.Title>
@@ -120,7 +130,7 @@ export const CognitiveHints: React.FC<CognitiveProps> = ({
             content={hint.content}
             onEdit={(content) => updateOne(hint.id, content)}
             onEditorTypeChange={(editor) => updateOneEditor(hint.id, editor)}
-            editMode={true}
+            editMode={editMode}
             editorType={hint.editor || DEFAULT_EDITOR}
             allowBlockElements={true}
             projectSlug={projectSlug}
@@ -149,6 +159,7 @@ const BottomOutHint: React.FC<HintProps> = ({
   projectSlug,
   updateOneEditor,
   updateOneTextDirection,
+  editMode,
 }) => (
   <HintCard
     title={<>{'"Bottom out" hint'}</>}
@@ -158,5 +169,6 @@ const BottomOutHint: React.FC<HintProps> = ({
     updateOneTextDirection={updateOneTextDirection}
     projectSlug={projectSlug}
     updateOneEditor={updateOneEditor}
+    editMode={editMode}
   />
 );

--- a/assets/src/components/activities/common/hints/authoring/HintsAuthoringConnected.tsx
+++ b/assets/src/components/activities/common/hints/authoring/HintsAuthoringConnected.tsx
@@ -8,7 +8,9 @@ interface Props {
   partId: string;
 }
 export const Hints: React.FC<Props> = (props) => {
-  const { dispatch, model } = useAuthoringElementContext<HasParts>();
+  const { dispatch, editMode, mode, model } = useAuthoringElementContext<HasParts>();
+  const isInstructorPreview = mode === 'instructor_preview';
+
   return (
     <HintsAuthoring
       addOne={() => dispatch(HintUtils.addCognitiveHint(makeHint(''), props.partId))}
@@ -21,6 +23,7 @@ export const Hints: React.FC<Props> = (props) => {
       deerInHeadlightsHint={HintUtils.getDeerInHeadlightsHint(model, props.partId)}
       cognitiveHints={HintUtils.getCognitiveHints(model, props.partId)}
       bottomOutHint={HintUtils.getBottomOutHint(model, props.partId)}
+      editMode={editMode && !isInstructorPreview}
     />
   );
 };

--- a/assets/src/components/activities/common/responses/FeedbackCard.tsx
+++ b/assets/src/components/activities/common/responses/FeedbackCard.tsx
@@ -16,7 +16,6 @@ export const FeedbackCard: React.FC<{
   updateTextDirection: (textDirection: TextDirection) => void;
   placeholder?: string;
   children: any;
-  editMode?: boolean;
 }> = ({
   title,
   feedback,
@@ -25,11 +24,10 @@ export const FeedbackCard: React.FC<{
   children,
   updateEditor,
   updateTextDirection,
-  editMode,
 }) => {
   const { editMode: contextEditMode, mode, projectSlug } = useAuthoringElementContext();
   const isInstructorPreview = mode === 'instructor_preview';
-  const effectiveEditMode = editMode ?? (contextEditMode && !isInstructorPreview);
+  const editMode = contextEditMode && !isInstructorPreview;
 
   return (
     <Card.Card>
@@ -40,7 +38,7 @@ export const FeedbackCard: React.FC<{
           content={feedback.content}
           onEdit={(content) => update(feedback.id, content)}
           onEditorTypeChange={updateEditor}
-          editMode={effectiveEditMode}
+          editMode={editMode}
           editorType={feedback.editor || DEFAULT_EDITOR}
           allowBlockElements={true}
           projectSlug={projectSlug}

--- a/assets/src/components/activities/common/responses/FeedbackCard.tsx
+++ b/assets/src/components/activities/common/responses/FeedbackCard.tsx
@@ -25,9 +25,12 @@ export const FeedbackCard: React.FC<{
   children,
   updateEditor,
   updateTextDirection,
-  editMode = true,
+  editMode,
 }) => {
-  const { projectSlug } = useAuthoringElementContext();
+  const { editMode: contextEditMode, mode, projectSlug } = useAuthoringElementContext();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const effectiveEditMode = editMode ?? (contextEditMode && !isInstructorPreview);
+
   return (
     <Card.Card>
       <Card.Title>{title}</Card.Title>
@@ -37,7 +40,7 @@ export const FeedbackCard: React.FC<{
           content={feedback.content}
           onEdit={(content) => update(feedback.id, content)}
           onEditorTypeChange={updateEditor}
-          editMode={editMode}
+          editMode={effectiveEditMode}
           editorType={feedback.editor || DEFAULT_EDITOR}
           allowBlockElements={true}
           projectSlug={projectSlug}

--- a/assets/src/components/activities/common/responses/FeedbackCard.tsx
+++ b/assets/src/components/activities/common/responses/FeedbackCard.tsx
@@ -16,15 +16,7 @@ export const FeedbackCard: React.FC<{
   updateTextDirection: (textDirection: TextDirection) => void;
   placeholder?: string;
   children: any;
-}> = ({
-  title,
-  feedback,
-  update,
-  placeholder,
-  children,
-  updateEditor,
-  updateTextDirection,
-}) => {
+}> = ({ title, feedback, update, placeholder, children, updateEditor, updateTextDirection }) => {
   const { editMode: contextEditMode, mode, projectSlug } = useAuthoringElementContext();
   const isInstructorPreview = mode === 'instructor_preview';
   const editMode = contextEditMode && !isInstructorPreview;

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -21,13 +21,12 @@ interface Props {
   removeResponse: (responseId: ID) => void;
   updateScore?: (responseId: ID, score: number) => void;
   customScoring?: boolean;
-  editMode?: boolean;
 }
 
 export const ResponseCard: React.FC<Props> = (props) => {
   const { editMode: contextEditMode, mode, projectSlug } = useAuthoringElementContext();
   const isInstructorPreview = mode === 'instructor_preview';
-  const editMode = props.editMode ?? (contextEditMode && !isInstructorPreview);
+  const editMode = contextEditMode && !isInstructorPreview;
 
   const onEditorTypeChange = (editor: EditorType) =>
     props.updateFeedbackEditor!(props.response.id, editor);

--- a/assets/src/components/activities/common/responses/ResponseCard.tsx
+++ b/assets/src/components/activities/common/responses/ResponseCard.tsx
@@ -25,8 +25,9 @@ interface Props {
 }
 
 export const ResponseCard: React.FC<Props> = (props) => {
-  const { projectSlug } = useAuthoringElementContext();
-  const editMode = props.editMode ?? true;
+  const { editMode: contextEditMode, mode, projectSlug } = useAuthoringElementContext();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const editMode = props.editMode ?? (contextEditMode && !isInstructorPreview);
 
   const onEditorTypeChange = (editor: EditorType) =>
     props.updateFeedbackEditor!(props.response.id, editor);

--- a/assets/src/components/activities/common/responses/SimpleFeedback.tsx
+++ b/assets/src/components/activities/common/responses/SimpleFeedback.tsx
@@ -45,7 +45,6 @@ export const SimpleFeedback: React.FC<Props> = ({ partId }) => {
         update={(_id, content) => updateFeedback(correctResponse.id, content as RichText)}
         updateEditor={(editor) => updateFeedbackEditor(correctResponse.id, editor)}
         placeholder="Encourage students or explain why the answer is correct"
-        editMode={editMode && !isInstructorPreview}
       >
         {authoringContext.contentBreaksExist ? (
           <ShowPage
@@ -65,7 +64,6 @@ export const SimpleFeedback: React.FC<Props> = ({ partId }) => {
           updateTextDirection(incorrectResponse.id, textDirection)
         }
         placeholder="Enter catch-all feedback for incorrect answers"
-        editMode={editMode && !isInstructorPreview}
       >
         {authoringContext.contentBreaksExist ? (
           <ShowPage

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -107,7 +107,6 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
           removeResponse={hook.removeFeedback}
           updateFeedbackTextDirection={hook.updateFeedbackTextDirection}
           customScoring={customScoring}
-          editMode={responseEditMode}
         >
           <ChoicesDelivery
             unselectedIcon={props.unselectedIcon}

--- a/assets/src/components/activities/common/responses/TargetedFeedback.tsx
+++ b/assets/src/components/activities/common/responses/TargetedFeedback.tsx
@@ -117,7 +117,7 @@ export const TargetedFeedback: React.FC<Props> = (props) => {
             onSelect={(id) => props.toggleChoice(id, mapping)}
             isEvaluated={false}
             context={writerContext}
-            disabled={props.disabled}
+            disabled={props.disabled || !responseEditMode}
             multiSelect={props.multiSelect}
           />
 

--- a/assets/src/components/activities/custom_dnd/HintsEditor.tsx
+++ b/assets/src/components/activities/custom_dnd/HintsEditor.tsx
@@ -9,11 +9,14 @@ interface Props {
   partId: string;
 }
 export const HintsEditor: React.FC<Props> = (props) => {
-  const { model, dispatch, projectSlug } = useAuthoringElementContext<CustomDnDSchema>();
+  const { model, dispatch, editMode, mode, projectSlug } =
+    useAuthoringElementContext<CustomDnDSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
 
   return (
     <CognitiveHints
       key={props.partId}
+      editMode={editMode && !isInstructorPreview}
       hints={Hints.byPart(model, props.partId)}
       updateOne={(id, content) => dispatch(Hints.setContent(id, content as RichText))}
       updateOneEditor={(id, editor) => dispatch(Hints.setEditor(id, editor))}

--- a/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
+++ b/assets/src/components/activities/image_coding/ImageCodingAuthoring.tsx
@@ -24,18 +24,16 @@ import { ImageCodeEditor } from './sections/ImageCodeEditor';
 import { lastPart } from './utils';
 
 const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
-  const {
-    dispatch,
-    model,
-    mode: _mode,
-    onRequestMedia,
-  } = useAuthoringElementContext<ImageCodingModelSchema>();
+  const { dispatch, editMode, model, mode, onRequestMedia } =
+    useAuthoringElementContext<ImageCodingModelSchema>();
 
   const { projectSlug } = props;
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   const sharedProps = {
     model: props.model,
-    editMode: props.editMode,
+    editMode: !readOnly,
     projectSlug,
     onRequestMedia,
   };
@@ -111,7 +109,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
 
         <p>Image problems: Solution Code {!usesImage() ? '-- add image to enable' : ''}</p>
         <ImageCodeEditor
-          disabled={!usesImage()}
+          disabled={readOnly || !usesImage()}
           value={model.solutionCode}
           onChange={(newValue: string) => dispatch(ICActions.editSolutionCode(newValue))}
         />
@@ -121,7 +119,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <input
             type="number"
             value={model.tolerance}
-            disabled={!usesImage()}
+            disabled={readOnly || !usesImage()}
             onChange={(e: any) => dispatch(ICActions.editTolerance(e.target.value))}
           />
           &nbsp;(Average per-pixel error allowed.)
@@ -134,7 +132,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           <input
             type="text"
             value={model.regex}
-            disabled={usesImage()}
+            disabled={readOnly || usesImage()}
             onChange={(e: any) => dispatch(ICActions.editRegex(e.target.value))}
           />
           &nbsp;Pattern for correct text output
@@ -161,11 +159,19 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
             </li>
           ))}
         </ul>
-        <button className="btn btn-primary mt-2" onClick={addImage} disabled={usesSpreadsheet()}>
+        <button
+          className="btn btn-primary mt-2"
+          onClick={addImage}
+          disabled={readOnly || usesSpreadsheet()}
+        >
           Add Image...
         </button>
         &nbsp;&nbsp;&nbsp;
-        <button className="btn btn-primary mt-2" onClick={addSpreadsheet} disabled={usesImage()}>
+        <button
+          className="btn btn-primary mt-2"
+          onClick={addSpreadsheet}
+          disabled={readOnly || usesImage()}
+        >
           Add Spreadsheet...
         </button>
       </div>
@@ -173,7 +179,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
 
       <Heading title="Starter Code" id="starter-code" />
       <ImageCodeEditor
-        disabled={false}
+        disabled={readOnly}
         value={model.starterCode}
         onChange={(newValue: string) => dispatch(ICActions.editStarterCode(newValue))}
       />
@@ -186,6 +192,7 @@ const ImageCoding = (props: AuthoringElementProps<ImageCodingModelSchema>) => {
           id="example-toggle"
           aria-label="Checkbox for example"
           checked={model.isExample}
+          disabled={readOnly}
           onChange={(e: any) => dispatch(ICActions.editIsExample(e.target.checked))}
         />
         <label className="form-check-label" htmlFor="example-toggle">

--- a/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
@@ -33,7 +33,7 @@ import { RectangleEditor } from './Sections/RectangleEditor';
 import { ImageHotspotActions } from './actions';
 import { Hotspot, ImageHotspotModelSchema, getShape, makeHotspot, shapeType } from './schema';
 
-const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => {
+export const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => {
   const { dispatch, editMode, model, mode, projectSlug, authoringContext } =
     useAuthoringElementContext<ImageHotspotModelSchema>();
 
@@ -188,17 +188,14 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
                           id={hotspot.id}
                           label={hotspotNumeral(model, hotspot.id)}
                           selected={hotspot.id === selectedHotspot}
+                          readOnly={readOnly}
                           boundingClientRect={
                             imgRef.current
                               ? Maybe.just(imgRef.current.getBoundingClientRect())
                               : Maybe.nothing()
                           }
                           coords={Immutable.List(hotspot.coords)}
-                          onSelect={(id) => {
-                            if (!readOnly) {
-                              setSelectedHotspot(id);
-                            }
-                          }}
+                          onSelect={setSelectedHotspot}
                           onEdit={(coords) => {
                             if (!readOnly) {
                               onEditCoords(hotspot.id, coords);

--- a/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
+++ b/assets/src/components/activities/image_hotspot/ImageHotspotAuthoring.tsx
@@ -34,7 +34,7 @@ import { ImageHotspotActions } from './actions';
 import { Hotspot, ImageHotspotModelSchema, getShape, makeHotspot, shapeType } from './schema';
 
 const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => {
-  const { dispatch, model, mode, projectSlug, authoringContext } =
+  const { dispatch, editMode, model, mode, projectSlug, authoringContext } =
     useAuthoringElementContext<ImageHotspotModelSchema>();
 
   const selectedPartId = model.authoring.parts[0].id;
@@ -42,6 +42,7 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
     projectSlug: projectSlug,
   });
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   const [selectedHotspot, setSelectedHotspot] = useState<string | null>(null);
   const [addPolyMode, setAddPolyMode] = useState<boolean>(false);
@@ -193,15 +194,27 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
                               : Maybe.nothing()
                           }
                           coords={Immutable.List(hotspot.coords)}
-                          onSelect={setSelectedHotspot}
-                          onEdit={(coords) => onEditCoords(hotspot.id, coords)}
+                          onSelect={(id) => {
+                            if (!readOnly) {
+                              setSelectedHotspot(id);
+                            }
+                          }}
+                          onEdit={(coords) => {
+                            if (!readOnly) {
+                              onEditCoords(hotspot.id, coords);
+                            }
+                          }}
                         />
                       );
                     }
                   })}
                   {addPolyMode && (
                     <PolygonAdder
-                      onEdit={onAddPoly}
+                      onEdit={(coords) => {
+                        if (!readOnly) {
+                          onAddPoly(coords);
+                        }
+                      }}
                       boundingClientRect={imgRef.current!.getBoundingClientRect()}
                     />
                   )}
@@ -213,21 +226,29 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
                 <p>{addPolyMsg}</p>
               </div>
             )}
-            <button className="btn btn-primary mt-2" onClick={setImageURL}>
+            <button className="btn btn-primary mt-2" onClick={setImageURL} disabled={readOnly}>
               Choose Image
             </button>
             &nbsp; &nbsp;
-            <button className="btn btn-primary mt-2" disabled={!model.imageURL} onClick={addCircle}>
+            <button
+              className="btn btn-primary mt-2"
+              disabled={readOnly || !model.imageURL}
+              onClick={addCircle}
+            >
               Add Circle
             </button>
             &nbsp;&nbsp;
-            <button className="btn btn-primary mt-2" disabled={!model.imageURL} onClick={addRect}>
+            <button
+              className="btn btn-primary mt-2"
+              disabled={readOnly || !model.imageURL}
+              onClick={addRect}
+            >
               Add Rectangle
             </button>
             &nbsp;&nbsp;
             <button
               className="btn btn-primary mt-2"
-              disabled={!model.imageURL || addPolyMode}
+              disabled={readOnly || !model.imageURL || addPolyMode}
               onClick={beginAddPolyMode}
             >
               Add Polygon
@@ -236,7 +257,7 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
             <button
               className="btn btn-primary mt-2"
               onClick={(e) => removeHotspot(selectedHotspot!)}
-              disabled={!selectedHotspot || model.choices.length <= 1}
+              disabled={readOnly || !selectedHotspot || model.choices.length <= 1}
             >
               Remove
             </button>
@@ -249,6 +270,7 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
               id="multiple-toggle"
               aria-label="Checkbox for multiple selection"
               checked={model.multiple}
+              disabled={readOnly}
               onChange={(e: any) =>
                 dispatch(ImageHotspotActions.setMultipleSelection(e.target.checked))
               }
@@ -278,6 +300,7 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
             }
             isEvaluated={false}
             context={writerContext}
+            disabled={readOnly}
             multiSelect={model.multiple}
           />
           <SimpleFeedback partId={selectedPartId} />
@@ -289,6 +312,7 @@ const ImageHotspot = (props: AuthoringElementProps<ImageHotspotModelSchema>) => 
             addTargetedResponse={() => dispatch(MCActions.addTargetedFeedback(selectedPartId))}
             unselectedIcon={<Radio.Unchecked />}
             selectedIcon={<Radio.Checked />}
+            disabled={readOnly}
           />
         </TabbedNavigation.Tab>
 

--- a/assets/src/components/activities/image_hotspot/Sections/CircleEditor.tsx
+++ b/assets/src/components/activities/image_hotspot/Sections/CircleEditor.tsx
@@ -18,6 +18,7 @@ export interface CircleEditorProps {
   label: string;
   coords: Immutable.List<number>;
   selected: boolean;
+  readOnly?: boolean;
   boundingClientRect: Maybe<DOMRect>;
   onSelect: (id: string) => void;
   onEdit: (coords: Immutable.List<number>) => void;
@@ -218,7 +219,7 @@ export class CircleEditor extends React.PureComponent<CircleEditorProps, CircleE
   }
 
   render() {
-    const { id, label, coords, selected } = this.props;
+    const { id, label, coords, selected, readOnly } = this.props;
     const { newCoords } = this.state;
     const renderCoords = newCoords.valueOr(coords);
 
@@ -228,7 +229,9 @@ export class CircleEditor extends React.PureComponent<CircleEditorProps, CircleE
           className={`shapeEditor ${selected ? 'shape-selected' : ''}`}
           onMouseDown={(e) => {
             this.onSelect(id, e);
-            this.beginMove(e);
+            if (!readOnly) {
+              this.beginMove(e);
+            }
           }}
           onMouseUp={(e) => this.endMove(e)}
           {...mapCoordsToCircleProps(renderCoords)}
@@ -236,7 +239,7 @@ export class CircleEditor extends React.PureComponent<CircleEditorProps, CircleE
         <text className="shape-label" x={renderCoords.get(0)! - 7} y={renderCoords.get(1)! + 7}>
           {label}
         </text>
-        {selected && this.renderResizeHandles(renderCoords)}
+        {selected && !readOnly && this.renderResizeHandles(renderCoords)}
       </React.Fragment>
     );
   }

--- a/assets/src/components/activities/image_hotspot/Sections/PolygonEditor.tsx
+++ b/assets/src/components/activities/image_hotspot/Sections/PolygonEditor.tsx
@@ -25,6 +25,7 @@ export interface PolygonEditorProps {
   label: string;
   coords: Immutable.List<number>;
   selected: boolean;
+  readOnly?: boolean;
   boundingClientRect: Maybe<DOMRect>;
   onSelect: (id: string) => void;
   onEdit: (coords: Immutable.List<number>) => void;
@@ -239,7 +240,7 @@ export class PolygonEditor extends React.PureComponent<PolygonEditorProps, Polyg
   }
 
   render() {
-    const { id, label, coords, selected } = this.props;
+    const { id, label, coords, selected, readOnly } = this.props;
     const { newCoords } = this.state;
     const renderCoords = newCoords.valueOr(coords);
 
@@ -252,7 +253,9 @@ export class PolygonEditor extends React.PureComponent<PolygonEditorProps, Polyg
           className={`shapeEditor ${selected ? 'shape-selected' : ''}`}
           onMouseDown={(e) => {
             this.onSelect(id, e);
-            this.beginMove(e);
+            if (!readOnly) {
+              this.beginMove(e);
+            }
           }}
           onMouseUp={(e) => this.endMove(e)}
           {...mapCoordsToPolygonProps(renderCoords)}
@@ -260,7 +263,7 @@ export class PolygonEditor extends React.PureComponent<PolygonEditorProps, Polyg
         <text className="shape-label" x={centeroid.x - 7} y={centeroid.y + 7}>
           {label}
         </text>
-        {selected && this.renderResizeHandles(renderCoords)}
+        {selected && !readOnly && this.renderResizeHandles(renderCoords)}
       </React.Fragment>
     );
   }

--- a/assets/src/components/activities/image_hotspot/Sections/RectangleEditor.tsx
+++ b/assets/src/components/activities/image_hotspot/Sections/RectangleEditor.tsx
@@ -19,6 +19,7 @@ export interface RectangleEditorProps {
   label: string;
   coords: Immutable.List<number>;
   selected: boolean;
+  readOnly?: boolean;
   boundingClientRect: Maybe<DOMRect>;
   onSelect: (id: string) => void;
   onEdit: (coords: Immutable.List<number>) => void;
@@ -304,7 +305,7 @@ export class RectangleEditor extends React.PureComponent<
   }
 
   render() {
-    const { id, label, coords, selected } = this.props;
+    const { id, label, coords, selected, readOnly } = this.props;
     const { newCoords } = this.state;
     const renderCoords = newCoords.valueOr(coords);
 
@@ -314,7 +315,9 @@ export class RectangleEditor extends React.PureComponent<
           className={`shapeEditor ${selected ? 'shape-selected' : ''}`}
           onMouseDown={(e) => {
             this.onSelect(id, e);
-            this.beginMove(e);
+            if (!readOnly) {
+              this.beginMove(e);
+            }
           }}
           onMouseUp={(e) => this.endMove(e)}
           {...mapCoordsToRectProps(renderCoords)}
@@ -330,7 +333,7 @@ export class RectangleEditor extends React.PureComponent<
         >
           {label}
         </text>
-        {selected && this.renderResizeHandles(renderCoords)}
+        {selected && !readOnly && this.renderResizeHandles(renderCoords)}
       </React.Fragment>
     );
   }

--- a/assets/src/components/activities/likert/LikertAuthoring.tsx
+++ b/assets/src/components/activities/likert/LikertAuthoring.tsx
@@ -91,6 +91,7 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
     projectSlug: projectSlug,
   });
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   // const transformedData = {
   //   values: model.choices
@@ -232,6 +233,7 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
                 id="descending-toggle"
                 aria-label="Checkbox for descending order"
                 checked={model.orderDescending}
+                disabled={readOnly}
                 onChange={(e: any) => dispatch(LikertActions.setOrderDescending(e.target.checked))}
               />
               <label className="form-check-label" htmlFor="descending-toggle">
@@ -267,7 +269,7 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
             onSelect={(id) => dispatch(MCActions.toggleChoiceCorrectness(id, selectedPartId))}
             isEvaluated={false}
             context={writerContext}
-            disabled={isInstructorPreview}
+            disabled={readOnly}
           />
           <SimpleFeedback partId={selectedPartId} />
           <ActivityScoring partId={model.authoring.parts[0].id} />
@@ -281,7 +283,7 @@ const Likert = (props: AuthoringElementProps<LikertModelSchema>) => {
             }
             unselectedIcon={<Radio.Unchecked />}
             selectedIcon={<Radio.Checked />}
-            disabled={isInstructorPreview}
+            disabled={readOnly}
           />
         </TabbedNavigation.Tab>
 

--- a/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
+++ b/assets/src/components/activities/lti_external_tool/LTIExternalToolAuthoring.tsx
@@ -16,8 +16,9 @@ import { LTIExternalToolSchema } from './schema';
 const store = configureStore();
 
 const LTIExternalTool: React.FC = () => {
-  const { model, projectSlug, authoringContext, activityId, onEdit } =
+  const { model, editMode, mode, projectSlug, authoringContext, activityId, onEdit } =
     useAuthoringElementContext<LTIExternalToolSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
 
   const activityIdStr = activityId ? `${activityId}` : undefined;
 
@@ -62,7 +63,7 @@ const LTIExternalTool: React.FC = () => {
                 id={`open-in-new-tab-${activityIdStr}`}
                 value={model.openInNewTab}
                 onChange={(value) => onEdit({ ...model, openInNewTab: value })}
-                editMode={true}
+                editMode={editMode && !isInstructorPreview}
               />
             </div>
             <div className="text-gray-500 my-4">

--- a/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/AnswerKeyTab.tsx
@@ -81,8 +81,10 @@ interface Props {
   input: MultiInput;
 }
 export const AnswerKeyTab: React.FC<Props> = (props) => {
-  const { model, dispatch, authoringContext, editMode, projectSlug } =
+  const { model, dispatch, authoringContext, editMode, mode, projectSlug } =
     useAuthoringElementContext<MultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
   const correctResponse =
     props.input.inputType === 'dropdown'
       ? undefined
@@ -117,6 +119,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           onSelect={(id) => dispatch(MCActions.toggleChoiceCorrectness(id, props.input.partId))}
           isEvaluated={false}
           context={defaultWriterContext({ projectSlug: projectSlug })}
+          disabled={readOnly}
         />
 
         <SimpleFeedback partId={props.input.partId} />
@@ -139,6 +142,7 @@ export const AnswerKeyTab: React.FC<Props> = (props) => {
           }
           unselectedIcon={<Radio.Unchecked />}
           selectedIcon={<Radio.Checked />}
+          disabled={readOnly}
         />
       </>
     );

--- a/assets/src/components/activities/multi_input/sections/HintsTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/HintsTab.tsx
@@ -11,11 +11,14 @@ interface Props {
   index: number;
 }
 export const HintsTab: React.FC<Props> = (props) => {
-  const { model, dispatch, projectSlug } = useAuthoringElementContext<MultiInputSchema>();
+  const { model, dispatch, editMode, mode, projectSlug } =
+    useAuthoringElementContext<MultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
 
   return (
     <CognitiveHints
       projectSlug={projectSlug}
+      editMode={editMode && !isInstructorPreview}
       key={props.input.id}
       hints={Hints.byPart(model, props.input.partId)}
       updateOne={(id, content) => dispatch(Hints.setContent(id, content as RichText))}

--- a/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
+++ b/assets/src/components/activities/multi_input/sections/QuestionTab.tsx
@@ -123,7 +123,9 @@ interface InputSizeEditorProps {
 }
 
 const InputSizeEditor: React.FC<InputSizeEditorProps> = ({ input }) => {
-  const { dispatch } = useAuthoringElementContext<MultiInputSchema>();
+  const { dispatch, editMode, mode } = useAuthoringElementContext<MultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <div className="inline-flex items-baseline mb-2">
@@ -131,6 +133,7 @@ const InputSizeEditor: React.FC<InputSizeEditorProps> = ({ input }) => {
       <select
         className="flex-shrink-0 border py-1 px-1.5 border-neutral-300 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white ml-2"
         value={input.size || 'medium'}
+        disabled={readOnly}
         onChange={({ target: { value } }) => {
           dispatch(MultiInputActions.setInputSize(input.id, value as MultiInputSize));
         }}

--- a/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
+++ b/assets/src/components/activities/multiple_choice/MultipleChoiceAuthoring.tsx
@@ -117,6 +117,7 @@ const MultipleChoice: React.FC = () => {
     projectSlug: projectSlug,
   });
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <>
@@ -164,7 +165,7 @@ const MultipleChoice: React.FC = () => {
             }
             isEvaluated={false}
             context={writerContext}
-            disabled={isInstructorPreview}
+            disabled={readOnly}
           />
           <SimpleFeedback partId={model.authoring.parts[0].id} />
           <ActivityScoring partId={model.authoring.parts[0].id} />
@@ -178,7 +179,7 @@ const MultipleChoice: React.FC = () => {
             }
             unselectedIcon={<Radio.Unchecked />}
             selectedIcon={<Radio.Checked />}
-            disabled={isInstructorPreview}
+            disabled={readOnly}
           />
         </TabbedNavigation.Tab>
 

--- a/assets/src/components/activities/ordering/OrderingAuthoring.tsx
+++ b/assets/src/components/activities/ordering/OrderingAuthoring.tsx
@@ -115,6 +115,7 @@ export const Ordering: React.FC = () => {
     useAuthoringElementContext<OrderingSchema>();
   const writerContext = defaultWriterContext({ projectSlug: projectSlug });
   const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   const choices = model.choices.reduce((m: any, c) => {
     m[c.id] = c;
@@ -146,6 +147,7 @@ export const Ordering: React.FC = () => {
           choices={getCorrectChoiceIds(model).map((id) => choices[id])}
           colorMap={model.choiceColors ? new Map(model.choiceColors) : undefined}
           setChoices={(choices) => dispatch(Actions.setCorrectChoices(choices))}
+          disabled={readOnly}
         />
         <SimpleFeedback partId={model.authoring.parts[0].id} />
         <ActivityScoring partId={model.authoring.parts[0].id} />

--- a/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
+++ b/assets/src/components/activities/ordering/sections/ResponseChoices.tsx
@@ -19,7 +19,15 @@ export const ResponseChoices: React.FC<Props> = ({
   writerContext: { projectSlug },
 }) => {
   return (
-    <Draggable.Column displayOutline items={choices} setItems={setChoices}>
+    <Draggable.Column
+      displayOutline
+      items={choices}
+      setItems={(choices) => {
+        if (!disabled) {
+          setChoices(choices);
+        }
+      }}
+    >
       {choices.map((choice, index) => (
         <Draggable.Item
           isDragDisabled={disabled ?? false}

--- a/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
+++ b/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
@@ -43,7 +43,6 @@ export const TargetedFeedback: React.FC = () => {
           removeResponse={(id) => dispatch(ResponseActions.removeTargetedFeedback(id))}
           updateScore={(id, score) => dispatch(ResponseActions.editResponseScore(id, score))}
           customScoring={customScoring}
-          editMode={responseEditMode}
           key={mapping.response.id}
         >
           <ResponseChoices

--- a/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
+++ b/assets/src/components/activities/ordering/sections/TargetedFeedback.tsx
@@ -13,10 +13,12 @@ import { getTargetedResponseMappings, hasCustomScoring } from 'data/activities/m
 import { defaultWriterContext } from 'data/content/writers/context';
 
 export const TargetedFeedback: React.FC = () => {
-  const { model, dispatch, authoringContext, editMode, projectSlug } =
+  const { model, dispatch, authoringContext, editMode, mode, projectSlug } =
     useAuthoringElementContext<OrderingSchema>();
   const writerContext = defaultWriterContext({ projectSlug });
   const customScoring = hasCustomScoring(model);
+  const isInstructorPreview = mode === 'instructor_preview';
+  const responseEditMode = editMode && !isInstructorPreview;
 
   return (
     <>
@@ -41,6 +43,7 @@ export const TargetedFeedback: React.FC = () => {
           removeResponse={(id) => dispatch(ResponseActions.removeTargetedFeedback(id))}
           updateScore={(id, score) => dispatch(ResponseActions.editResponseScore(id, score))}
           customScoring={customScoring}
+          editMode={responseEditMode}
           key={mapping.response.id}
         >
           <ResponseChoices
@@ -54,10 +57,11 @@ export const TargetedFeedback: React.FC = () => {
                 ),
               )
             }
+            disabled={!responseEditMode}
           />
           {authoringContext.contentBreaksExist ? (
             <ShowPage
-              editMode={editMode}
+              editMode={responseEditMode}
               index={mapping.response.showPage}
               onChange={(showPage: any) =>
                 dispatch(ResponseActions.editShowPage(mapping.response.id, showPage))

--- a/assets/src/components/activities/response_multi/sections/HintsTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/HintsTab.tsx
@@ -12,11 +12,14 @@ interface Props {
   index: number;
 }
 export const HintsTab: React.FC<Props> = (props) => {
-  const { model, dispatch, projectSlug } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const { model, dispatch, editMode, mode, projectSlug } =
+    useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
 
   return (
     <CognitiveHints
       projectSlug={projectSlug}
+      editMode={editMode && !isInstructorPreview}
       key={props.input.id}
       hints={Hints.byPart(model, props.input.partId)}
       updateOne={(id, content) => dispatch(Hints.setContent(id, content as RichText))}

--- a/assets/src/components/activities/response_multi/sections/QuestionTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/QuestionTab.tsx
@@ -76,7 +76,9 @@ interface InputSizeEditorProps {
 }
 
 const InputSizeEditor: React.FC<InputSizeEditorProps> = ({ input }) => {
-  const { dispatch } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const { dispatch, editMode, mode } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <div className="inline-flex items-baseline mb-2">
@@ -84,6 +86,7 @@ const InputSizeEditor: React.FC<InputSizeEditorProps> = ({ input }) => {
       <select
         className="flex-shrink-0 border py-1 px-1.5 border-neutral-300 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white ml-2"
         value={input.size || 'medium'}
+        disabled={readOnly}
         onChange={({ target: { value } }) => {
           dispatch(ResponseMultiInputActions.setInputSize(input.id, value as MultiInputSize));
         }}
@@ -101,7 +104,9 @@ interface MoveInputIntoPartProps {
   parts: Part[];
 }
 const MoveInputIntoPart: React.FC<MoveInputIntoPartProps> = ({ input, parts }) => {
-  const { dispatch } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const { dispatch, editMode, mode } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   return (
     <div className="inline-flex items-baseline mb-2">
@@ -112,6 +117,7 @@ const MoveInputIntoPart: React.FC<MoveInputIntoPartProps> = ({ input, parts }) =
         className="flex-shrink-0 border py-1 px-1.5 border-neutral-300 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white ml-2"
         value={undefined}
         defaultValue={undefined}
+        disabled={readOnly}
         onChange={({ target: { value } }) => {
           if (value !== input.partId) {
             dispatch(ResponseMultiInputActions.moveInputToPart(input.id, value));

--- a/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/ResponseTab.tsx
@@ -31,8 +31,10 @@ interface Props {
 }
 export const ResponseTab: React.FC<Props> = (props) => {
   const { response } = props;
-  const { model, dispatch, authoringContext, editMode } =
+  const { model, dispatch, authoringContext, editMode, mode } =
     useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const responseEditMode = editMode && !isInstructorPreview;
   const [matchStyle, setMatchStyle] = useState<MatchStyle>(
     response.matchStyle ? response.matchStyle : 'all',
   );
@@ -142,6 +144,7 @@ export const ResponseTab: React.FC<Props> = (props) => {
           name={'matchStyleOptions' + response.id}
           id={'matchStyleRadio1' + response.id}
           value="all"
+          disabled={!responseEditMode}
         />
         <label className="form-check-label" htmlFor={'matchStyleRadio1' + response.id}>
           all
@@ -156,6 +159,7 @@ export const ResponseTab: React.FC<Props> = (props) => {
           name={'matchStyleOptions' + response.id}
           id={'matchStyleRadio2' + response.id}
           value="any"
+          disabled={!responseEditMode}
         />
         <label className="form-check-label" htmlFor={'matchStyleRadio2' + response.id}>
           any
@@ -170,6 +174,7 @@ export const ResponseTab: React.FC<Props> = (props) => {
           name={'matchStyleOptions' + response.id}
           id={'matchStyleRadio3' + response.id}
           value="none"
+          disabled={!responseEditMode}
         />
         <label className="form-check-label" htmlFor={'matchStyleRadio3' + response.id}>
           none
@@ -192,7 +197,7 @@ export const ResponseTab: React.FC<Props> = (props) => {
       >
         {authoringContext.contentBreaksExist ? (
           <ShowPage
-            editMode={editMode}
+            editMode={responseEditMode}
             index={response.showPage}
             onChange={(v) => updateShowPage(response.id, v)}
           />
@@ -216,7 +221,11 @@ export const ResponseTab: React.FC<Props> = (props) => {
           />
         ) : (
           /* We are using custom scoring, so prompt for a score instead of correct/incorrect */
-          <ScoreInput score={props.response.score} onChange={onScoreChange} editMode={true}>
+          <ScoreInput
+            score={props.response.score}
+            onChange={onScoreChange}
+            editMode={responseEditMode}
+          >
             Score:
           </ScoreInput>
         )}
@@ -246,7 +255,7 @@ export const ResponseTab: React.FC<Props> = (props) => {
         >
           {authoringContext.contentBreaksExist ? (
             <ShowPage
-              editMode={editMode}
+              editMode={responseEditMode}
               index={response.showPage}
               onChange={(v) => updateShowPage(response.id, v)}
             />
@@ -262,9 +271,16 @@ interface AddRuleProps {
   response: Response;
 }
 const AddRule: React.FC<AddRuleProps> = ({ inputs, response }) => {
-  const { model, dispatch } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const { model, dispatch, editMode, mode } =
+    useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   const addRule = (inputId: string) => {
+    if (readOnly) {
+      return;
+    }
+
     const input: MultiInput | undefined = inputs.find((i) => i.id === inputId);
     if (input) {
       let choiceId: string | undefined;
@@ -297,6 +313,7 @@ const AddRule: React.FC<AddRuleProps> = ({ inputs, response }) => {
       <select
         className="flex-shrink-0 border py-1 px-1.5 border-neutral-300 rounded w-full disabled:bg-neutral-100 disabled:text-neutral-600 dark:bg-neutral-800 dark:border-neutral-700 dark:text-white ml-2"
         value={undefined}
+        disabled={readOnly}
         onChange={({ target: { value } }) => {
           addRule(value);
         }}

--- a/assets/src/components/activities/response_multi/sections/RulesTab.tsx
+++ b/assets/src/components/activities/response_multi/sections/RulesTab.tsx
@@ -20,7 +20,10 @@ interface Props {
   editRule: (id: ResponseId, inputId: string, rule: string) => void;
 }
 export const RulesTab: React.FC<Props> = (props) => {
-  const { model, projectSlug, dispatch } = useAuthoringElementContext<ResponseMultiInputSchema>();
+  const { model, projectSlug, dispatch, editMode, mode } =
+    useAuthoringElementContext<ResponseMultiInputSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
 
   const removeInputFromResponse = () => {
     dispatch(ResponseMultiInputActions.removeInputFromResponse(props.input.id, props.response.id));
@@ -53,6 +56,7 @@ export const RulesTab: React.FC<Props> = (props) => {
             isEvaluated={false}
             context={defaultWriterContext({ projectSlug: projectSlug })}
             multiSelect={orRule}
+            disabled={readOnly}
           />
         )}
         <div className="choicesAuthoring__removeButtonContainer">

--- a/assets/src/components/activities/vlab/sections/VlabConfigTab.tsx
+++ b/assets/src/components/activities/vlab/sections/VlabConfigTab.tsx
@@ -13,7 +13,9 @@ interface Props {
 }
 
 export const VlabConfigTab: React.FC<Props> = (props) => {
-  const { model, dispatch, editMode } = useAuthoringElementContext<VlabSchema>();
+  const { model, dispatch, editMode, mode } = useAuthoringElementContext<VlabSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
   const assignmentList = [
     'default',
     'chemvlab/IV/IV_dilute_saline/',
@@ -82,6 +84,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 name={'assignmentSource_' + model.stem.id}
                 value="builtIn"
                 checked={model.assignmentSource === 'builtIn'}
+                disabled={readOnly}
                 onChange={() => dispatch(VlabActions.setAssignmentSource('builtIn'))}
               />
               Choose Assignment from Built-in List
@@ -95,6 +98,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 name={'assignmentSource_' + model.stem.id}
                 value="fromJSON"
                 checked={model.assignmentSource === 'fromJSON'}
+                disabled={readOnly}
                 onChange={() => dispatch(VlabActions.setAssignmentSource('fromJSON'))}
               />
               Create Assignment from Custom JSON
@@ -106,6 +110,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 <select
                   className="custom-select mr-2 form-control form-control-sm"
                   value={model.assignmentPath}
+                  disabled={readOnly}
                   onChange={(e) => dispatch(VlabActions.setAssignmentPath(e.target.value))}
                 >
                   {assignmentList.map((assignment, i) => (
@@ -124,7 +129,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.configuration}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editConfiguration(s))}
                 />
@@ -135,7 +140,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.assignment}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editAssignment(s))}
                 />
@@ -146,7 +151,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.reactions}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editReactions(s))}
                 />
@@ -157,7 +162,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.solutions}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editSolutions(s))}
                 />
@@ -168,7 +173,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.species}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editSpecies(s))}
                 />
@@ -179,7 +184,7 @@ export const VlabConfigTab: React.FC<Props> = (props) => {
                 </div>
                 <WrappedMonaco
                   model={model.spectra}
-                  editMode={editMode}
+                  editMode={!readOnly}
                   language="javascript"
                   onEdit={(s) => dispatch(VlabActions.editSpectra(s))}
                 />

--- a/assets/src/components/activities/vlab/sections/VlabParameterSelector.tsx
+++ b/assets/src/components/activities/vlab/sections/VlabParameterSelector.tsx
@@ -11,7 +11,9 @@ interface Props {
 const paramList = ['volume', 'temp', 'pH', 'moles', 'mass', 'molarity', 'concentration'];
 
 export const VlabParameterSelector: React.FC<Props> = (props) => {
-  const { model, dispatch } = useAuthoringElementContext<VlabSchema>();
+  const { model, dispatch, editMode, mode } = useAuthoringElementContext<VlabSchema>();
+  const isInstructorPreview = mode === 'instructor_preview';
+  const readOnly = !editMode || isInstructorPreview;
   return (
     <>
       <div>
@@ -30,6 +32,7 @@ export const VlabParameterSelector: React.FC<Props> = (props) => {
                 name={'vlparam_' + model.stem.id}
                 value={param}
                 checked={param === props.input.parameter}
+                disabled={readOnly}
                 onChange={() => dispatch(VlabActions.setVlabParameter(props.input.id, param))}
               />
               {friendlyVlabParameter(param as any)}
@@ -44,6 +47,7 @@ export const VlabParameterSelector: React.FC<Props> = (props) => {
             name="speciesID"
             value={props.input.species}
             disabled={
+              readOnly ||
               props.input.parameter === 'volume' ||
               props.input.parameter === 'temp' ||
               props.input.parameter === 'pH'

--- a/assets/src/components/activity/InlineActivityEditor.modules.scss
+++ b/assets/src/components/activity/InlineActivityEditor.modules.scss
@@ -13,6 +13,13 @@
 
     &.disabled {
       background: var(--color-gray-100);
+
+      :global(.formula),
+      :global(.formula-inline),
+      :global(.resize-selection-box-handle),
+      :global(.resize-selection-box-border) {
+        cursor: default !important;
+      }
     }
   }
   .toolbar {

--- a/assets/src/components/common/DraggableColumn.tsx
+++ b/assets/src/components/common/DraggableColumn.tsx
@@ -68,7 +68,9 @@ const Item: React.FC<ItemProps> = ({
           )}
           style={{ ...getStyle(provided.draggableProps.style, snapshot), backgroundColor: color }}
           aria-label={itemAriaLabel || 'Item ' + index}
-          onKeyDown={(e: any) => reorderByKey(e, index, items, item, setItems)}
+          onKeyDown={(e: any) => {
+            if (!isDragDisabled) reorderByKey(e, index, items, item, setItems);
+          }}
         >
           {children(item, index)}
         </div>

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -80,6 +80,25 @@ export const validateEditorContentValue = (value: any): Descendant[] => {
   return value;
 };
 
+const readOnlyInteractiveSelector = [
+  'button',
+  'input',
+  'select',
+  'textarea',
+  '[role="button"]',
+  '.formula',
+  '.formula-inline',
+  '.resize-selection-box-handle',
+  '.resize-selection-box-border',
+].join(',');
+
+const shouldSuppressReadOnlyInteraction = (target: EventTarget | null) => {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.closest('audio, video')) return false;
+
+  return target.closest(readOnlyInteractiveSelector) !== null;
+};
+
 export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => {
   const editor = useMemo(() => {
     if (props.editorOverride) {
@@ -145,6 +164,13 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
     }
   };
 
+  const suppressReadOnlyInteraction = (e: React.SyntheticEvent<HTMLDivElement>) => {
+    if (props.editMode || !shouldSuppressReadOnlyInteraction(e.target)) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
   return (
     <React.Fragment>
       <Slate
@@ -180,6 +206,8 @@ export const Editor: React.FC<EditorProps> = React.memo((props: EditorProps) => 
           onFocus={props.onFocus || emptyOnFocus}
           onBlur={props.onBlur}
           onPaste={onPaste}
+          onMouseDownCapture={suppressReadOnlyInteraction}
+          onClickCapture={suppressReadOnlyInteraction}
         />
       </Slate>
     </React.Fragment>

--- a/assets/src/components/editing/editor/Editor.tsx
+++ b/assets/src/components/editing/editor/Editor.tsx
@@ -93,7 +93,7 @@ const readOnlyInteractiveSelector = [
 ].join(',');
 
 const shouldSuppressReadOnlyInteraction = (target: EventTarget | null) => {
-  if (!(target instanceof HTMLElement)) return false;
+  if (!(target instanceof Element)) return false;
   if (target.closest('audio, video')) return false;
 
   return target.closest(readOnlyInteractiveSelector) !== null;

--- a/assets/src/components/editing/elements/formula/FormulaEditor.tsx
+++ b/assets/src/components/editing/elements/formula/FormulaEditor.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { useSlate } from 'slate-react';
 import { EditorProps } from 'components/editing/elements/interfaces';
-import { useEditModelCallback } from 'components/editing/elements/utils';
+import { getEditMode, useEditModelCallback } from 'components/editing/elements/utils';
 import * as ContentModel from 'data/content/model/elements/types';
 import { modalActions } from '../../../../actions/modal';
 import { Formula } from '../../../common/Formula';
@@ -8,6 +9,8 @@ import { FormulaModal } from './FormulaModal';
 
 interface Props extends EditorProps<ContentModel.FormulaBlock | ContentModel.FormulaInline> {}
 export const FormulaEditor = (props: Props) => {
+  const editor = useSlate();
+  const editMode = getEditMode(editor);
   const onEdit = useEditModelCallback(props.model);
 
   if (props.model.src === undefined)
@@ -23,7 +26,7 @@ export const FormulaEditor = (props: Props) => {
   }
 
   const onFormulaClick = () => {
-    console.log('onFormulaClick');
+    if (!editMode) return;
 
     window.oliDispatch(
       modalActions.display(
@@ -45,8 +48,8 @@ export const FormulaEditor = (props: Props) => {
 
       <Formula
         id={props.model.id}
-        onClick={onFormulaClick}
-        style={{ cursor: 'pointer' }}
+        onClick={editMode ? onFormulaClick : undefined}
+        style={editMode ? { cursor: 'pointer' } : undefined}
         type={props.model.legacyBlockRendered ? 'formula' : props.model.type}
         subtype={props.model.subtype}
         src={props.model.src}

--- a/assets/src/components/editing/toolbar/HoverContainer.tsx
+++ b/assets/src/components/editing/toolbar/HoverContainer.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren, ReactNode, useCallback, useEffect, useState }
 import { Popover, PopoverAlign, PopoverPosition } from 'react-tiny-popover';
 import { Editor } from 'slate';
 import { ReactEditor, useSlate } from 'slate-react';
+import { getEditMode } from 'components/editing/elements/utils';
 import { useMousedown } from 'components/misc/resizable/useMousedown';
 import { positionRect } from 'data/content/utils';
 
@@ -21,7 +22,8 @@ export const HoverContainer = (props: PropsWithChildren<Props>) => {
 
   const mousedown = useMousedown();
   const [position, setPosition] = useState(offscreenRect);
-  const isOpen = typeof props.isOpen === 'function' ? props.isOpen(editor) : props.isOpen;
+  const requestedOpen = typeof props.isOpen === 'function' ? props.isOpen(editor) : props.isOpen;
+  const isOpen = getEditMode(editor) && requestedOpen;
 
   useEffect(() => {
     if (!isOpen) setPosition(offscreenRect);

--- a/assets/src/components/editing/toolbar/Toolbar.tsx
+++ b/assets/src/components/editing/toolbar/Toolbar.tsx
@@ -1,4 +1,6 @@
 import React, { PropsWithChildren } from 'react';
+import { useSlate } from 'slate-react';
+import { getEditMode } from 'components/editing/elements/utils';
 import { ToolbarContext, ToolbarContextT } from 'components/editing/toolbar/hooks/useToolbar';
 import { CommandContext } from '../elements/commands/interfaces';
 import styles from './Toolbar.modules.scss';
@@ -8,6 +10,7 @@ interface Props {
   fixed?: boolean;
 }
 export const Toolbar = (props: PropsWithChildren<Props>) => {
+  const editor = useSlate();
   const [submenu, setSubmenu] = React.useState<React.MutableRefObject<HTMLButtonElement> | null>(
     null,
   );
@@ -23,6 +26,8 @@ export const Toolbar = (props: PropsWithChildren<Props>) => {
   );
 
   const cssClasses = props.fixed ? `${styles.toolbar} ${styles.fixedToolbar}` : styles.toolbar;
+
+  if (!getEditMode(editor)) return null;
 
   return (
     <ToolbarContext.Provider value={context}>

--- a/assets/test/activities/choices_delivery_test.tsx
+++ b/assets/test/activities/choices_delivery_test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
+import { makeChoice } from 'components/activities/types';
+import { Radio } from 'components/misc/icons/radio/Radio';
+import { defaultWriterContext } from 'data/content/writers/context';
+
+describe('ChoicesDelivery', () => {
+  it('keeps disabled radio icons inert', () => {
+    const onSelect = jest.fn();
+
+    const { container } = render(
+      <ChoicesDelivery
+        choices={[makeChoice('Choice A', 'choice-a')]}
+        selected={[]}
+        context={defaultWriterContext({ projectSlug: 'project' })}
+        onSelect={onSelect}
+        isEvaluated={false}
+        unselectedIcon={<Radio.Unchecked />}
+        selectedIcon={<Radio.Checked />}
+        disabled
+      />,
+    );
+
+    const radioIcon = container.querySelector('input[type="radio"]') as HTMLInputElement;
+    const choice = container.querySelector('[aria-label="choice 1"]') as HTMLElement;
+
+    expect(radioIcon).toBeDisabled();
+
+    fireEvent.click(choice);
+
+    expect(radioIcon).not.toBeChecked();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('preserves disabled state from caller-provided icons', () => {
+    const { container } = render(
+      <ChoicesDelivery
+        choices={[makeChoice('Choice A', 'choice-a')]}
+        selected={[]}
+        context={defaultWriterContext({ projectSlug: 'project' })}
+        onSelect={jest.fn()}
+        isEvaluated={true}
+        unselectedIcon={<Radio.Unchecked disabled />}
+        selectedIcon={<Radio.Checked />}
+      />,
+    );
+
+    expect(container.querySelector('input[type="radio"]')).toBeDisabled();
+  });
+});

--- a/assets/test/activities/readonly_authoring_test.tsx
+++ b/assets/test/activities/readonly_authoring_test.tsx
@@ -212,6 +212,7 @@ describe('readonly activity authoring components', () => {
     );
 
     expect(screen.getAllByPlaceholderText('Answer choice')[0]).toHaveAttribute('readonly');
+    expect(screen.getAllByPlaceholderText('Answer choice')[0]).toHaveAttribute('tabindex', '-1');
     expect(screen.getAllByRole('button', { name: 'Remove' })[0]).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add choice' })).toBeDisabled();
 

--- a/assets/test/activities/readonly_authoring_test.tsx
+++ b/assets/test/activities/readonly_authoring_test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { AuthoringElementProvider } from 'components/activities/AuthoringElementProvider';
+import { Explanation } from 'components/activities/common/explanation/ExplanationAuthoring';
+import { Hints } from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
+import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
+import { TargetedFeedback } from 'components/activities/common/responses/TargetedFeedback';
+import { Dropdown } from 'components/activities/multi_input/schema';
+import { AnswerKeyTab } from 'components/activities/multi_input/sections/AnswerKeyTab';
+import { ResponseTab } from 'components/activities/response_multi/sections/ResponseTab';
+import {
+  ChoiceIdsToResponseId,
+  HasChoices,
+  HasParts,
+  makeChoice,
+  makeHint,
+  makePart,
+  makeResponse,
+  makeStem,
+} from 'components/activities/types';
+import { Responses } from 'data/activities/model/responses';
+import { defaultAuthoringElementProps } from '../utils/activity_mocks';
+
+jest.mock('components/editing/SlateOrMarkdownEditor', () => ({
+  SlateOrMarkdownEditor: ({ editMode, placeholder, onEdit }: any) => (
+    <textarea
+      aria-label={placeholder || 'rich-text-editor'}
+      data-edit-mode={String(editMode)}
+      disabled={!editMode}
+      onChange={(e) => onEdit?.([{ type: 'p', children: [{ text: e.target.value }] }])}
+    />
+  ),
+}));
+
+jest.mock('components/activities/common/choices/delivery/ChoicesDelivery', () => ({
+  ChoicesDelivery: ({ choices, disabled, onSelect, selected = [] }: any) => (
+    <div data-testid="choices-delivery" data-disabled={String(!!disabled)}>
+      {choices.map((choice: any) => (
+        <button
+          key={choice.id}
+          type="button"
+          disabled={!!disabled}
+          aria-pressed={selected.includes(choice.id)}
+          onClick={() => onSelect?.(choice.id)}
+        >
+          {choice.id}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const partId = 'part-1';
+const correctResponseId = 'correct-response-1';
+const targetedResponseId = 'targeted-response-1';
+const choiceA = makeChoice('Choice A', 'choice-a');
+const choiceB = makeChoice('Choice B', 'choice-b');
+const correctResponse = {
+  ...makeResponse('input like {choice-a}', 1, 'correct feedback', true),
+  id: correctResponseId,
+};
+const targetedResponse = {
+  ...makeResponse('input like {choice-b}', 0, 'targeted feedback'),
+  id: targetedResponseId,
+};
+
+const baseModel = (): HasParts &
+  HasChoices & { authoring: { targeted: ChoiceIdsToResponseId[] } } =>
+  ({
+    stem: makeStem('Question stem'),
+    choices: [choiceA, choiceB],
+    authoring: {
+      parts: [
+        {
+          ...makePart(
+            [correctResponse, targetedResponse],
+            [makeHint('first'), makeHint('second'), makeHint('third')],
+            partId,
+          ),
+          explanation: {
+            id: 'explanation-1',
+            content: [{ type: 'p', children: [{ text: 'Explanation' }] }],
+          },
+        },
+      ],
+      targeted: [[[choiceB.id], targetedResponseId]],
+      transformations: [],
+      previewText: '',
+    },
+  } as any);
+
+const renderWithAuthoringContext = (
+  children: React.ReactNode,
+  {
+    model = baseModel(),
+    editMode = false,
+    mode = 'authoring' as 'authoring' | 'instructor_preview',
+  } = {},
+) => {
+  const props = {
+    ...defaultAuthoringElementProps<any>(model as any),
+    editMode,
+    mode,
+    authoringContext: { contentBreaksExist: false },
+  };
+
+  return render(<AuthoringElementProvider {...props}>{children}</AuthoringElementProvider>);
+};
+
+describe('readonly activity authoring components', () => {
+  it('renders fallback explanation and hints as read-only when editMode is false', () => {
+    renderWithAuthoringContext(
+      <>
+        <Explanation partId={partId} />
+        <Hints partId={partId} />
+      </>,
+    );
+
+    expect(screen.getByLabelText('Explanation')).toBeDisabled();
+    expect(screen.getByLabelText('Explanation')).toHaveAttribute('data-edit-mode', 'false');
+    expect(
+      screen.getByLabelText('Restate the question for students who are confused by the prompt'),
+    ).toBeDisabled();
+    expect(screen.getAllByLabelText('Explain how to solve the problem')[0]).toBeDisabled();
+  });
+
+  it('defaults response feedback cards to the authoring context read-only state', () => {
+    const updateFeedback = jest.fn();
+
+    renderWithAuthoringContext(
+      <ResponseCard
+        title="Targeted feedback"
+        response={targetedResponse}
+        updateFeedbackTextDirection={jest.fn()}
+        updateFeedbackEditor={jest.fn()}
+        updateFeedback={updateFeedback}
+        updateCorrectness={jest.fn()}
+        removeResponse={jest.fn()}
+      />,
+    );
+
+    const editor = screen.getByLabelText(
+      'Explain why the student might have arrived at this answer',
+    );
+    expect(editor).toBeDisabled();
+    expect(editor).toHaveAttribute('data-edit-mode', 'false');
+  });
+
+  it('disables targeted choice feedback in locked common choice activities', () => {
+    const toggleChoice = jest.fn();
+
+    renderWithAuthoringContext(
+      <TargetedFeedback
+        choices={[choiceA, choiceB]}
+        partId={partId}
+        toggleChoice={toggleChoice}
+        addTargetedResponse={jest.fn()}
+        selectedIcon={<span />}
+        unselectedIcon={<span />}
+      />,
+    );
+
+    expect(screen.getByTestId('choices-delivery')).toHaveAttribute('data-disabled', 'true');
+    fireEvent.click(screen.getByRole('button', { name: choiceB.id }));
+    expect(toggleChoice).not.toHaveBeenCalled();
+  });
+
+  it('disables multi-input dropdown answer key choices in locked authoring', () => {
+    const model = {
+      ...baseModel(),
+      inputs: [
+        {
+          id: 'input-1',
+          inputType: 'dropdown',
+          partId,
+          choiceIds: [choiceA.id, choiceB.id],
+        } as Dropdown,
+      ],
+      authoring: {
+        ...baseModel().authoring,
+        parts: [makePart(Responses.forMultipleChoice(choiceA.id), [makeHint('')], partId)],
+        targeted: [],
+      },
+    };
+
+    renderWithAuthoringContext(<AnswerKeyTab input={model.inputs[0]} />, { model });
+
+    expect(screen.getByTestId('choices-delivery')).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('disables ResponseMulti rule controls in instructor preview fallback', () => {
+    const dropdownInput: Dropdown = {
+      id: 'input-1',
+      inputType: 'dropdown',
+      partId,
+      choiceIds: [choiceA.id, choiceB.id],
+    };
+    const model = {
+      ...baseModel(),
+      inputs: [dropdownInput],
+      authoring: {
+        ...baseModel().authoring,
+        parts: [
+          {
+            ...makePart([targetedResponse], [makeHint('')], partId, [dropdownInput.id]),
+            targets: [dropdownInput.id],
+          },
+        ],
+      },
+    };
+
+    renderWithAuthoringContext(
+      <ResponseTab
+        title="Correct Answer"
+        response={{
+          ...targetedResponse,
+          rule: `input_ref_${dropdownInput.id} match {${choiceA.id}}`,
+        }}
+        partId={partId}
+        removeResponse={jest.fn()}
+        updateCorrectness={jest.fn()}
+      />,
+      { model, mode: 'instructor_preview' },
+    );
+
+    expect(screen.getByLabelText('all')).toBeDisabled();
+    expect(screen.getByTestId('choices-delivery')).toHaveAttribute('data-disabled', 'true');
+  });
+});

--- a/assets/test/activities/readonly_authoring_test.tsx
+++ b/assets/test/activities/readonly_authoring_test.tsx
@@ -212,7 +212,6 @@ describe('readonly activity authoring components', () => {
     );
 
     expect(screen.getAllByPlaceholderText('Answer choice')[0]).toHaveAttribute('readonly');
-    expect(screen.getAllByPlaceholderText('Answer choice')[0]).toHaveAttribute('tabindex', '-1');
     expect(screen.getAllByRole('button', { name: 'Remove' })[0]).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add choice' })).toBeDisabled();
 

--- a/assets/test/activities/readonly_authoring_test.tsx
+++ b/assets/test/activities/readonly_authoring_test.tsx
@@ -7,6 +7,7 @@ import { Explanation } from 'components/activities/common/explanation/Explanatio
 import { Hints } from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
 import { TargetedFeedback } from 'components/activities/common/responses/TargetedFeedback';
+import { ImageHotspot } from 'components/activities/image_hotspot/ImageHotspotAuthoring';
 import { Dropdown } from 'components/activities/multi_input/schema';
 import { AnswerKeyTab } from 'components/activities/multi_input/sections/AnswerKeyTab';
 import { ResponseTab } from 'components/activities/response_multi/sections/ResponseTab';
@@ -50,6 +51,10 @@ jest.mock('components/activities/common/choices/delivery/ChoicesDelivery', () =>
       ))}
     </div>
   ),
+}));
+
+jest.mock('components/activities/common/responses/SimpleFeedback', () => ({
+  SimpleFeedback: () => <div data-testid="simple-feedback" />,
 }));
 
 const partId = 'part-1';
@@ -272,5 +277,32 @@ describe('readonly activity authoring components', () => {
 
     expect(screen.getByLabelText('all')).toBeDisabled();
     expect(screen.getByTestId('choices-delivery')).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('allows image hotspots to be selected for inspection in locked authoring', () => {
+    const model = {
+      ...baseModel(),
+      imageURL: 'https://example.com/hotspot.png',
+      width: 300,
+      height: 200,
+      multiple: false,
+      choices: [
+        {
+          ...choiceA,
+          coords: [50, 50, 25],
+        },
+      ],
+    };
+    const props = defaultAuthoringElementProps<any>(model as any);
+    const { container } = renderWithAuthoringContext(<ImageHotspot {...props} />, { model });
+
+    const hotspot = container.querySelector('circle.shapeEditor');
+    expect(hotspot).not.toBeNull();
+    expect(hotspot).not.toHaveClass('shape-selected');
+
+    fireEvent.mouseDown(hotspot!);
+
+    expect(hotspot).toHaveClass('shape-selected');
+    expect(container.querySelector('.shape-handle')).not.toBeInTheDocument();
   });
 });

--- a/assets/test/activities/readonly_authoring_test.tsx
+++ b/assets/test/activities/readonly_authoring_test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { AuthoringElementProvider } from 'components/activities/AuthoringElementProvider';
+import { Choices as ChoicesAuthoring } from 'components/activities/common/choices/authoring/ChoicesAuthoring';
 import { Explanation } from 'components/activities/common/explanation/ExplanationAuthoring';
 import { Hints } from 'components/activities/common/hints/authoring/HintsAuthoringConnected';
 import { ResponseCard } from 'components/activities/common/responses/ResponseCard';
@@ -187,6 +188,51 @@ describe('readonly activity authoring components', () => {
     renderWithAuthoringContext(<AnswerKeyTab input={model.inputs[0]} />, { model });
 
     expect(screen.getByTestId('choices-delivery')).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('disables simple text choice authoring in locked authoring', () => {
+    const onEdit = jest.fn();
+    const setAll = jest.fn();
+
+    renderWithAuthoringContext(
+      <ChoicesAuthoring
+        icon={(_choice, index) => <span>{index + 1}.</span>}
+        choices={[choiceA, choiceB]}
+        addOne={jest.fn()}
+        setAll={setAll}
+        onEdit={onEdit}
+        onRemove={jest.fn()}
+        simpleText
+      />,
+    );
+
+    expect(screen.getAllByPlaceholderText('Answer choice')[0]).toHaveAttribute('readonly');
+    expect(screen.getAllByRole('button', { name: 'Remove' })[0]).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add choice' })).toBeDisabled();
+
+    fireEvent.change(screen.getAllByPlaceholderText('Answer choice')[0], {
+      target: { value: 'edited' },
+    });
+
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(setAll).not.toHaveBeenCalled();
+  });
+
+  it('disables rich text choice authoring in locked authoring', () => {
+    renderWithAuthoringContext(
+      <ChoicesAuthoring
+        choices={[choiceA, choiceB]}
+        addOne={jest.fn()}
+        setAll={jest.fn()}
+        onEdit={jest.fn()}
+        onRemove={jest.fn()}
+      />,
+    );
+
+    expect(screen.getAllByLabelText('Answer choice')[0]).toBeDisabled();
+    expect(screen.getAllByLabelText('Answer choice')[0]).toHaveAttribute('data-edit-mode', 'false');
+    expect(screen.getAllByRole('button', { name: 'Remove' })[0]).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add choice' })).toBeDisabled();
   });
 
   it('disables ResponseMulti rule controls in instructor preview fallback', () => {

--- a/assets/test/components/editing/readonly_slate_elements_test.tsx
+++ b/assets/test/components/editing/readonly_slate_elements_test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { createEditor, Descendant } from 'slate';
+import { Descendant, createEditor } from 'slate';
 import { Editable, Slate, withReact } from 'slate-react';
 import { Editor } from 'components/editing/editor/Editor';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
@@ -11,11 +11,7 @@ const mockFormulaClick = jest.fn();
 jest.mock('components/editing/editor/modelEditorDispatch', () => ({
   editorFor: (element: any, props: any) => (
     <span {...props.attributes}>
-      <span
-        className={element.className}
-        data-testid={element.testId}
-        onClick={mockFormulaClick}
-      >
+      <span className={element.className} data-testid={element.testId} onClick={mockFormulaClick}>
         {props.children}
       </span>
     </span>

--- a/assets/test/components/editing/readonly_slate_elements_test.tsx
+++ b/assets/test/components/editing/readonly_slate_elements_test.tsx
@@ -7,15 +7,31 @@ import { Editor } from 'components/editing/editor/Editor';
 import { Toolbar } from 'components/editing/toolbar/Toolbar';
 
 const mockFormulaClick = jest.fn();
+const mockControlClick = jest.fn();
 
 jest.mock('components/editing/editor/modelEditorDispatch', () => ({
-  editorFor: (element: any, props: any) => (
-    <span {...props.attributes}>
-      <span className={element.className} data-testid={element.testId} onClick={mockFormulaClick}>
-        {props.children}
+  editorFor: (element: any, props: any) => {
+    if (element.type === 'button_control') {
+      return (
+        <span {...props.attributes}>
+          <button type="button" onClick={mockControlClick}>
+            <svg data-testid="button-icon">
+              <circle cx="5" cy="5" r="5" />
+            </svg>
+            {props.children}
+          </button>
+        </span>
+      );
+    }
+
+    return (
+      <span {...props.attributes}>
+        <span className={element.className} data-testid={element.testId} onClick={mockFormulaClick}>
+          {props.children}
+        </span>
       </span>
-    </span>
-  ),
+    );
+  },
   markFor: (_mark: string, children: React.ReactNode) => children,
 }));
 
@@ -39,6 +55,7 @@ const renderReadOnlySlate = (children: React.ReactNode) => {
 describe('read-only slate editor elements', () => {
   beforeEach(() => {
     mockFormulaClick.mockClear();
+    mockControlClick.mockClear();
   });
 
   it('does not render slate toolbars while the editor is read-only', () => {
@@ -73,5 +90,27 @@ describe('read-only slate editor elements', () => {
     fireEvent.click(screen.getByTestId('formula'));
 
     expect(mockFormulaClick).not.toHaveBeenCalled();
+  });
+
+  it('suppresses svg descendant clicks inside read-only authoring controls', () => {
+    render(
+      <Editor
+        commandContext={commandContext}
+        editMode={false}
+        onEdit={jest.fn()}
+        toolbarInsertDescs={[]}
+        value={[
+          {
+            type: 'button_control',
+            children: [{ text: '' }],
+          } as any,
+        ]}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('button-icon'));
+    fireEvent.click(screen.getByTestId('button-icon'));
+
+    expect(mockControlClick).not.toHaveBeenCalled();
   });
 });

--- a/assets/test/components/editing/readonly_slate_elements_test.tsx
+++ b/assets/test/components/editing/readonly_slate_elements_test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createEditor, Descendant } from 'slate';
+import { Editable, Slate, withReact } from 'slate-react';
+import { Editor } from 'components/editing/editor/Editor';
+import { Toolbar } from 'components/editing/toolbar/Toolbar';
+
+const mockFormulaClick = jest.fn();
+
+jest.mock('components/editing/editor/modelEditorDispatch', () => ({
+  editorFor: (element: any, props: any) => (
+    <span {...props.attributes}>
+      <span
+        className={element.className}
+        data-testid={element.testId}
+        onClick={mockFormulaClick}
+      >
+        {props.children}
+      </span>
+    </span>
+  ),
+  markFor: (_mark: string, children: React.ReactNode) => children,
+}));
+
+const commandContext = { projectSlug: 'project' } as any;
+
+const renderReadOnlySlate = (children: React.ReactNode) => {
+  const editor = withReact(createEditor());
+  const value: Descendant[] = [{ type: 'p', children: [{ text: '' }] } as any];
+
+  return render(
+    <Slate editor={editor} initialValue={value} onChange={jest.fn()}>
+      <Editable
+        readOnly={true}
+        renderElement={(props) => <p {...props.attributes}>{props.children}</p>}
+      />
+      {children}
+    </Slate>,
+  );
+};
+
+describe('read-only slate editor elements', () => {
+  beforeEach(() => {
+    mockFormulaClick.mockClear();
+  });
+
+  it('does not render slate toolbars while the editor is read-only', () => {
+    renderReadOnlySlate(
+      <Toolbar context={commandContext}>
+        <span data-testid="toolbar-action">Action</span>
+      </Toolbar>,
+    );
+
+    expect(screen.queryByTestId('toolbar-action')).not.toBeInTheDocument();
+  });
+
+  it('suppresses authoring clicks inside a read-only editor', () => {
+    render(
+      <Editor
+        commandContext={commandContext}
+        editMode={false}
+        onEdit={jest.fn()}
+        toolbarInsertDescs={[]}
+        value={[
+          {
+            type: 'formula',
+            className: 'formula',
+            testId: 'formula',
+            children: [{ text: 'x^2' }],
+          } as any,
+        ]}
+      />,
+    );
+
+    fireEvent.mouseDown(screen.getByTestId('formula'));
+    fireEvent.click(screen.getByTestId('formula'));
+
+    expect(mockFormulaClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes activity authoring UI that remained editable when rendered with `editMode=false`.

This showed up in two places:

- **Activity Bank locked mode**, where locked activities should render as read-only. [MER-4525]
- **Instructor Preview,** where activities without custom preview components (e.g. SingleResponse) fall back to using authoring components, similarly exposing edit affordances where should render read-only. [MER-5724], which notes Hints and Explanation tabs showing in a SingleResponse, though there are other possible instances.

The fix covers two distinct kinds of editability:

- React activity authoring controls that were not receiving or honoring `editMode=false`.
- Slate-embedded authoring affordances, where settings/edit modals could be reached through hover toolbars or direct clicks on embedded elements such as images, popups, links, formulas.

## Details

- Propagates and honors `editMode` across common activity authoring surfaces, including stems, hints, explanations, answer keys, response/feedback editors, targeted feedback, and activity-specific controls.
- Keeps existing activity-specific conditions intact, including Image Coding's distinction between image-evaluated and regex-evaluated problems, while also applying read-only state.
- Adds centralized Slate read-only protection:
  - `HoverContainer` does not open authoring popovers when Slate is read-only.
  - `Toolbar` renders nothing when Slate is read-only.
  - The Slate `Editor` suppresses read-only clicks/mousedowns on authoring controls such as buttons, form controls, formula spans, and resize handles.
- Allows native audio/video playback controls to remain interactive in read-only Slate, since playback is not an authoring edit.
- Preserves locked Activity Bank visual parity for choice authoring where practical: drag handles and delete/add controls remain visible but disabled, rather than disappearing.
- Prevents disabled answer-key radio/checkbox icons from visually toggling when clicked.
- Disables formula click affordances/cursor styling in read-only Slate.
- Adds keyboard reorder protection for disabled draggable choice/order controls.
- Adds targeted regression coverage for read-only authoring controls and disabled answer-key choice controls.

## Verification

- `yarn test test/activities/readonly_authoring_test.tsx --runInBand`
- `yarn test test/components/editing/readonly_slate_elements_test.tsx test/activities/readonly_authoring_test.tsx --runInBand`
- `yarn test test/activities/choices_delivery_test.tsx test/activities/readonly_authoring_test.tsx --runInBand`
  - `yarn check-types`

## Sample Demo


https://github.com/user-attachments/assets/2569f967-5461-4e8e-be94-152c607fab68





[MER-4525]: https://eliterate.atlassian.net/browse/MER-4525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-5724]: https://eliterate.atlassian.net/browse/MER-5724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ