### PR TITLE
[ENHANCEMENT] [MER-5416] Add workflow-based mixed page authoring coverage - PART 1/2

### DIFF
--- a/assets/automation/WORKFLOWS.md
+++ b/assets/automation/WORKFLOWS.md
@@ -1,0 +1,258 @@
+# Automation Workflows
+
+This document defines the v1 workflow contract for Playwright automation that alternates scenario-driven setup/assertions with browser-driven actions.
+
+## Purpose
+
+The workflow layer exists for cases where a single browser spec needs more than a one-time scenario seed. The primary pattern is:
+
+1. run one scenario to create deterministic state
+2. run one or more Playwright browser actions
+3. run one or more scenarios to validate the resulting state
+
+The first intended consumer was mixed-content authoring coverage, but the contract is reusable for later automation slices.
+
+## Relationship To Existing Fixtures
+
+The existing `seedScenario(...)` helper remains supported for tests that only need one scenario setup step.
+
+The workflow layer extends the fixture surface with a new helper, expected to be named `runWorkflow(...)`, rather than replacing `seedScenario(...)`.
+
+This keeps:
+
+- simple setup-only tests simple
+- workflow-driven tests explicit
+- backwards compatibility intact for existing specs
+
+## v1 Constraints
+
+The v1 workflow runner is intentionally narrow.
+
+Supported:
+
+- linear ordered execution
+- arbitrary number of steps
+- fail-fast behavior
+- serializable per-step outputs
+- step parameter interpolation from global params and prior outputs
+
+Not supported in v1:
+
+- branching
+- loops
+- parallel execution
+- top-level `hook` workflow steps
+- arbitrary shell commands
+- arbitrary Playwright spec-name execution by string
+
+If custom logic is needed in a scenario phase, use the existing `hook:` directive inside the scenario file rather than adding a top-level workflow hook step.
+
+## Step Types
+
+### `scenario`
+
+Executes a scenario YAML file through the existing internal scenario test endpoint.
+
+Shape:
+
+```yaml
+scenario:
+  file: 'setup.scenario.yaml'
+  params:
+    run_id: '${RUN_ID}'
+```
+
+### `playwright_action`
+
+Executes a named browser action from a local TypeScript action registry.
+
+Shape:
+
+```yaml
+playwright_action:
+  action: 'author_image_group'
+  params:
+    project_slug: '${setup.outputs.projects.authoring_project}'
+```
+
+The workflow contract deliberately refers to an action name, not an arbitrary Playwright spec or test string. This keeps the DSL stable even if file organization changes.
+
+## Workflow Shape
+
+Top-level shape:
+
+```yaml
+workflow:
+  - id: setup
+    scenario:
+      file: 'setup.scenario.yaml'
+
+  - id: author_image
+    playwright_action:
+      action: 'author_image_group'
+
+  - id: assert_preview
+    scenario:
+      file: 'assert_author_preview.scenario.yaml'
+```
+
+Rules:
+
+- `workflow` is an ordered list
+- each step must have an `id`
+- each step must declare exactly one step type
+- step ids must be unique within the workflow
+
+## Arbitrary Step Count
+
+`runWorkflow(...)` is not restricted to a fixed three-step shape such as `before -> browser -> after`.
+
+These are all valid design intents:
+
+- one step
+- three steps
+- fifteen steps
+
+Example:
+
+```yaml
+workflow:
+  - id: setup
+    scenario:
+      file: 'setup.scenario.yaml'
+
+  - id: author_inline
+    playwright_action:
+      action: 'author_inline_group'
+
+  - id: assert_inline
+    scenario:
+      file: 'assert_inline.scenario.yaml'
+
+  - id: author_table
+    playwright_action:
+      action: 'author_table_group'
+
+  - id: assert_table
+    scenario:
+      file: 'assert_table.scenario.yaml'
+```
+
+The only v1 restriction is that execution is linear and sequential.
+
+## Shared State And Outputs
+
+The runner owns a serializable workflow state made of:
+
+- global params
+- per-step outputs
+
+Conceptually:
+
+```ts
+type WorkflowState = {
+  params: Record<string, unknown>;
+  steps: Record<string, { outputs: Record<string, unknown> }>;
+};
+```
+
+Each step can emit small outputs that later steps consume.
+
+Examples:
+
+- scenario setup outputs:
+  - `projects.authoring_project`
+  - `sections.delivery_section`
+  - `users.author_email`
+- Playwright action outputs:
+  - `page_slug`
+  - `page_title`
+  - `variant`
+
+Avoid returning large or non-serializable payloads.
+
+## Interpolation
+
+Step params may reference:
+
+- workflow-global params
+- outputs from prior steps
+
+Examples:
+
+```yaml
+params:
+  run_id: '${RUN_ID}'
+  section_slug: '${setup.outputs.sections.delivery_section}'
+  page_slug: '${author_image.outputs.page_slug}'
+```
+
+Interpolation in v1 is intentionally simple:
+
+- placeholder substitution only
+- no computed expressions
+- no conditional logic
+
+Missing references are treated as configuration errors and should fail the workflow before step execution.
+
+## Failure Behavior
+
+The runner is fail-fast by default.
+
+If any step fails:
+
+- the workflow stops
+- later steps do not run
+- the error should report:
+  - workflow path or id
+  - step id
+  - step type
+  - resolved params where safe to print
+  - underlying scenario or browser error
+
+## Recommended Usage
+
+Use a workflow when:
+
+- a test needs more than a one-time scenario setup
+- browser actions must be followed by scenario-based assertions
+- state must move across several setup/mutate/assert phases
+
+Use `seedScenario(...)` directly when:
+
+- a test only needs deterministic setup before browser interaction
+- there is no scenario-based post-browser assertion phase
+
+## Example Mixed Content Pattern
+
+Representative shape:
+
+```yaml
+workflow:
+  - id: setup
+    scenario:
+      file: 'mixed_workflow/setup.scenario.yaml'
+
+  - id: author_codeblock
+    playwright_action:
+      action: 'author_codeblock_group'
+
+  - id: assert_codeblock
+    scenario:
+      file: 'mixed_workflow/assert_codeblock.scenario.yaml'
+
+  - id: author_image
+    playwright_action:
+      action: 'author_image_group'
+
+  - id: assert_image
+    scenario:
+      file: 'mixed_workflow/assert_image.scenario.yaml'
+```
+
+This proves:
+
+- repeated alternation between scenario and browser steps
+- arbitrary linear step count
+- reusable outputs between phases
+- browser-independent assertions after authoring mutations

--- a/assets/automation/src/core/fixture/my-fixture.ts
+++ b/assets/automation/src/core/fixture/my-fixture.ts
@@ -3,6 +3,8 @@ import { test as base } from '@playwright/test';
 import { Utils } from '@core/Utils';
 import { Verifier } from '@core/verify/Verifier';
 import { seedScenarioFromFile, SeedScenarioResponse } from '@core/seedScenario';
+import { runWorkflowFromFile } from '@core/workflow/runWorkflow';
+import { RunWorkflowOptions, WorkflowState } from '@core/workflow/types';
 import { AdministrationTask } from '@tasks/AdministrationTask';
 import { CurriculumTask } from '@tasks/CurriculumTask';
 import { HomeTask } from '@tasks/HomeTask';
@@ -19,7 +21,11 @@ type MyFixtures = {
   homeTask: HomeTask;
   projectTask: ProjectTask;
   studentTask: StudentTask;
-  seedScenario: (relativePath: string, params?: Record<string, unknown>) => Promise<SeedScenarioResponse>;
+  seedScenario: (
+    relativePath: string,
+    params?: Record<string, unknown>,
+  ) => Promise<SeedScenarioResponse>;
+  runWorkflow: (relativePath: string, options: RunWorkflowOptions) => Promise<WorkflowState>;
 };
 
 export const test = base.extend<MyFixtures>({
@@ -88,5 +94,30 @@ export const test = base.extend<MyFixtures>({
       await use(scenarioRunner);
     },
     { title: '🧪 Scenario Seeder' },
+  ],
+  runWorkflow: [
+    async (
+      { administrationTask, curriculumTask, homeTask, page, projectTask, request, studentTask },
+      use,
+      testInfo,
+    ) => {
+      const workflowRunner = async (relativePath: string, options: RunWorkflowOptions) => {
+        const workflowPath = path.resolve(path.dirname(testInfo.file), relativePath);
+
+        return runWorkflowFromFile(workflowPath, options, {
+          administrationTask,
+          curriculumTask,
+          homeTask,
+          page,
+          projectTask,
+          request,
+          studentTask,
+          testInfo,
+        });
+      };
+
+      await use(workflowRunner);
+    },
+    { title: '🔁 Workflow Runner' },
   ],
 });

--- a/assets/automation/src/core/workflow/interpolate.ts
+++ b/assets/automation/src/core/workflow/interpolate.ts
@@ -1,0 +1,126 @@
+import { WorkflowParams, WorkflowState, WorkflowValue } from '@core/workflow/types';
+
+const PLACEHOLDER_REGEX = /\$\{([^}]+)\}/g;
+
+export function interpolateWorkflowParams<T extends WorkflowValue>(
+  value: T,
+  state: WorkflowState,
+  stepId: string,
+): T {
+  if (typeof value === 'string') {
+    return interpolateString(value, state, stepId) as T;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => interpolateWorkflowParams(item, state, stepId)) as T;
+  }
+
+  if (value != null && typeof value === 'object') {
+    return Object.entries(value).reduce<Record<string, WorkflowValue>>(
+      (acc, [key, nestedValue]) => {
+        acc[key] = interpolateWorkflowParams(nestedValue as WorkflowValue, state, stepId);
+        return acc;
+      },
+      {},
+    ) as T;
+  }
+
+  return value;
+}
+
+function interpolateString(value: string, state: WorkflowState, stepId: string): WorkflowValue {
+  const matches = collectMatches(value);
+
+  if (matches.length === 0) {
+    return value;
+  }
+
+  if (matches.length === 1 && matches[0][0] === value) {
+    return resolveReference(matches[0][1], state, stepId);
+  }
+
+  return value.replace(PLACEHOLDER_REGEX, (_match, reference) => {
+    const resolved = resolveReference(reference, state, stepId);
+    return stringifyResolvedValue(reference, resolved, stepId);
+  });
+}
+
+function collectMatches(value: string) {
+  const matches: RegExpExecArray[] = [];
+  const pattern = new RegExp(PLACEHOLDER_REGEX.source, 'g');
+
+  let match = pattern.exec(value);
+
+  while (match) {
+    matches.push(match);
+    match = pattern.exec(value);
+  }
+
+  return matches;
+}
+
+function resolveReference(reference: string, state: WorkflowState, stepId: string): WorkflowValue {
+  const pathSegments = reference.split('.');
+
+  if (pathSegments.length === 0) {
+    throw new Error(`Workflow step "${stepId}" contains an empty interpolation reference`);
+  }
+
+  if (pathSegments[0] === 'params') {
+    return resolveFromObject(state.params, pathSegments.slice(1), reference, stepId);
+  }
+
+  if (pathSegments.length >= 2 && pathSegments[1] === 'outputs') {
+    const dependencyStepId = pathSegments[0];
+    const dependency = state.steps[dependencyStepId];
+
+    if (!dependency) {
+      throw new Error(
+        `Workflow step "${stepId}" references outputs from missing step "${dependencyStepId}"`,
+      );
+    }
+
+    return resolveFromObject(dependency.outputs, pathSegments.slice(2), reference, stepId);
+  }
+
+  return resolveFromObject(state.params, pathSegments, reference, stepId);
+}
+
+function resolveFromObject(
+  source: WorkflowParams,
+  pathSegments: string[],
+  reference: string,
+  stepId: string,
+): WorkflowValue {
+  let current: unknown = source;
+
+  for (const segment of pathSegments) {
+    if (
+      current == null ||
+      typeof current !== 'object' ||
+      !(segment in (current as Record<string, unknown>))
+    ) {
+      throw new Error(
+        `Workflow step "${stepId}" could not resolve interpolation reference "${reference}"`,
+      );
+    }
+
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  return current as WorkflowValue;
+}
+
+function stringifyResolvedValue(reference: string, value: WorkflowValue, stepId: string) {
+  if (value == null) {
+    return '';
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  throw new Error(
+    `Workflow step "${stepId}" resolved "${reference}" to a non-scalar value that cannot be embedded in a string`,
+  );
+}

--- a/assets/automation/src/core/workflow/loadWorkflow.ts
+++ b/assets/automation/src/core/workflow/loadWorkflow.ts
@@ -1,0 +1,59 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+import { WorkflowDefinition, WorkflowStepDefinition } from '@core/workflow/types';
+
+export function loadWorkflowFromFile(workflowFilePath: string): WorkflowDefinition {
+  const absolutePath = path.resolve(workflowFilePath);
+  const source = fs.readFileSync(absolutePath, 'utf8');
+  const parsed = yaml.load(source);
+
+  if (!isWorkflowDefinition(parsed)) {
+    throw new Error(`Workflow file "${absolutePath}" does not define a valid workflow`);
+  }
+
+  validateWorkflow(parsed.workflow, absolutePath);
+  return parsed;
+}
+
+function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    Array.isArray((value as WorkflowDefinition).workflow)
+  );
+}
+
+function validateWorkflow(workflow: WorkflowStepDefinition[], absolutePath: string) {
+  const seenStepIds = new Set<string>();
+
+  workflow.forEach((step, index) => {
+    if (!step.id) {
+      throw new Error(`Workflow file "${absolutePath}" is missing an id for step #${index + 1}`);
+    }
+
+    if (seenStepIds.has(step.id)) {
+      throw new Error(`Workflow file "${absolutePath}" contains duplicate step id "${step.id}"`);
+    }
+
+    seenStepIds.add(step.id);
+
+    const typeCount = Number(Boolean(step.scenario)) + Number(Boolean(step.playwright_action));
+
+    if (typeCount !== 1) {
+      throw new Error(
+        `Workflow step "${step.id}" in "${absolutePath}" must declare exactly one supported step type`,
+      );
+    }
+
+    if (step.scenario && !step.scenario.file) {
+      throw new Error(`Workflow step "${step.id}" in "${absolutePath}" is missing scenario.file`);
+    }
+
+    if (step.playwright_action && !step.playwright_action.action) {
+      throw new Error(
+        `Workflow step "${step.id}" in "${absolutePath}" is missing playwright_action.action`,
+      );
+    }
+  });
+}

--- a/assets/automation/src/core/workflow/runWorkflow.ts
+++ b/assets/automation/src/core/workflow/runWorkflow.ts
@@ -1,0 +1,88 @@
+import path from 'node:path';
+import { seedScenarioFromFile } from '@core/seedScenario';
+import { interpolateWorkflowParams } from '@core/workflow/interpolate';
+import { loadWorkflowFromFile } from '@core/workflow/loadWorkflow';
+import {
+  RunWorkflowOptions,
+  WorkflowActionContext,
+  WorkflowOutputs,
+  WorkflowState,
+} from '@core/workflow/types';
+import { getBaseUrl, getScenarioToken } from '@core/runtimeConfig';
+import { test } from '@playwright/test';
+
+export async function runWorkflowFromFile(
+  workflowFilePath: string,
+  options: RunWorkflowOptions,
+  context: Omit<WorkflowActionContext, 'seedScenario' | 'state'>,
+) {
+  const absoluteWorkflowPath = path.resolve(workflowFilePath);
+  const workflowDir = path.dirname(absoluteWorkflowPath);
+  const workflow = loadWorkflowFromFile(absoluteWorkflowPath);
+  const baseUrl = (context.testInfo.project.use.baseURL as string) || getBaseUrl();
+  const state: WorkflowState = {
+    params: options.params ?? {},
+    steps: {},
+  };
+
+  const seedScenario = async (relativePath: string, params: Record<string, unknown> = {}) => {
+    const scenarioPath = path.resolve(workflowDir, relativePath);
+
+    return seedScenarioFromFile(context.request, scenarioPath, params, baseUrl, getScenarioToken());
+  };
+
+  for (const step of workflow.workflow) {
+    if (step.scenario) {
+      const resolvedParams = interpolateWorkflowParams(step.scenario.params ?? {}, state, step.id);
+      const response =
+        await test.step(`workflow scenario: ${step.id} (${step.scenario.file})`, async () =>
+          seedScenario(step.scenario.file, resolvedParams));
+
+      state.steps[step.id] = {
+        id: step.id,
+        outputs: (response.outputs as WorkflowOutputs | undefined) ?? {},
+        summary: response.summary,
+        type: 'scenario',
+      };
+
+      continue;
+    }
+
+    if (step.playwright_action) {
+      const action = options.actions[step.playwright_action.action];
+
+      if (!action) {
+        throw new Error(
+          `Workflow step "${step.id}" references unknown Playwright action "${step.playwright_action.action}"`,
+        );
+      }
+
+      const resolvedParams = interpolateWorkflowParams(
+        step.playwright_action.params ?? {},
+        state,
+        step.id,
+      );
+
+      const actionOutputs =
+        await test.step(`workflow action: ${step.id} (${step.playwright_action.action})`, async () =>
+          action(
+            {
+              ...context,
+              seedScenario,
+              state,
+            },
+            resolvedParams,
+          ));
+
+      const outputs: WorkflowOutputs = typeof actionOutputs === 'undefined' ? {} : actionOutputs;
+
+      state.steps[step.id] = {
+        id: step.id,
+        outputs,
+        type: 'playwright_action',
+      };
+    }
+  }
+
+  return state;
+}

--- a/assets/automation/src/core/workflow/types.ts
+++ b/assets/automation/src/core/workflow/types.ts
@@ -1,0 +1,77 @@
+import { SeedScenarioResponse } from '@core/seedScenario';
+import { APIRequestContext, Page, TestInfo } from '@playwright/test';
+import { AdministrationTask } from '@tasks/AdministrationTask';
+import { CurriculumTask } from '@tasks/CurriculumTask';
+import { HomeTask } from '@tasks/HomeTask';
+import { ProjectTask } from '@tasks/ProjectTask';
+import { StudentTask } from '@tasks/StudentTask';
+
+export type WorkflowScalar = string | number | boolean | null;
+export type WorkflowValue =
+  | WorkflowScalar
+  | WorkflowValue[]
+  | { [key: string]: WorkflowValue | unknown }
+  | unknown;
+
+export type WorkflowParams = Record<string, WorkflowValue>;
+export type WorkflowOutputs = Record<string, WorkflowValue>;
+
+export type ScenarioWorkflowStep = {
+  file: string;
+  params?: WorkflowParams;
+};
+
+export type PlaywrightActionWorkflowStep = {
+  action: string;
+  params?: WorkflowParams;
+};
+
+export type WorkflowStepDefinition = {
+  id: string;
+  scenario?: ScenarioWorkflowStep;
+  playwright_action?: PlaywrightActionWorkflowStep;
+};
+
+export type WorkflowDefinition = {
+  workflow: WorkflowStepDefinition[];
+};
+
+export type WorkflowStepResult = {
+  id: string;
+  outputs: WorkflowOutputs;
+  summary?: Record<string, unknown>;
+  type: 'scenario' | 'playwright_action';
+};
+
+export type WorkflowState = {
+  params: WorkflowParams;
+  steps: Record<string, WorkflowStepResult>;
+};
+
+export type WorkflowActionContext = {
+  administrationTask: AdministrationTask;
+  curriculumTask: CurriculumTask;
+  homeTask: HomeTask;
+  page: Page;
+  projectTask: ProjectTask;
+  request: APIRequestContext;
+  seedScenario: (
+    relativePath: string,
+    params?: Record<string, unknown>,
+  ) => Promise<SeedScenarioResponse>;
+  state: WorkflowState;
+  studentTask: StudentTask;
+  testInfo: TestInfo;
+};
+
+export type WorkflowAction = (
+  context: WorkflowActionContext,
+  params: WorkflowParams,
+) => Promise<WorkflowOutputs | void>;
+
+export type WorkflowActionRegistry = Record<string, WorkflowAction>;
+
+export type RunWorkflowOptions = {
+  actions: WorkflowActionRegistry;
+  params?: WorkflowParams;
+};

--- a/assets/automation/src/core/workflow/types.ts
+++ b/assets/automation/src/core/workflow/types.ts
@@ -7,11 +7,11 @@ import { ProjectTask } from '@tasks/ProjectTask';
 import { StudentTask } from '@tasks/StudentTask';
 
 export type WorkflowScalar = string | number | boolean | null;
-export type WorkflowValue =
-  | WorkflowScalar
-  | WorkflowValue[]
-  | { [key: string]: WorkflowValue | unknown }
-  | unknown;
+export type WorkflowObject = {
+  [key: string]: WorkflowValue;
+};
+
+export type WorkflowValue = WorkflowScalar | WorkflowValue[] | WorkflowObject;
 
 export type WorkflowParams = Record<string, WorkflowValue>;
 export type WorkflowOutputs = Record<string, WorkflowValue>;

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -1,0 +1,73 @@
+import { test } from '@fixture/my-fixture';
+import { setRuntimeConfig } from '@core/runtimeConfig';
+import { TYPE_USER } from '@pom/types/type-user';
+import { mixedWorkflowActions } from './mixed_workflow/actions';
+
+const runId = `-${Date.now()}`;
+const baseUrl = 'http://localhost';
+const defaultPassword = 'changeme123456';
+
+setRuntimeConfig({
+  baseUrl,
+  scenarioToken: 'my-token',
+  loginData: {
+    student: {
+      type: TYPE_USER.student,
+      pageTitle: 'OLI Torus',
+      role: 'Student',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Hi, Jane',
+      email: `student${runId}@example.com`,
+      name: 'Jane',
+      last_name: 'Student',
+      pass: defaultPassword,
+    },
+    instructor: {
+      type: TYPE_USER.instructor,
+      pageTitle: 'OLI Torus',
+      role: 'Instructor',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Instructor Dashboard',
+      email: `instructor${runId}@example.com`,
+      pass: defaultPassword,
+      header: 'Instructor Dashboard',
+    },
+    author: {
+      type: TYPE_USER.author,
+      pageTitle: 'OLI Torus',
+      role: 'Course Author',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Course Author',
+      email: `author${runId}@example.com`,
+      pass: defaultPassword,
+      header: 'Course Author',
+    },
+    administrator: {
+      type: TYPE_USER.administrator,
+      pageTitle: 'OLI Torus',
+      role: 'Course Author',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Course Author',
+      email: `admin${runId}@example.com`,
+      pass: defaultPassword,
+      header: 'Course Author',
+    },
+  },
+});
+
+test.describe('mixed workflow', () => {
+  test.setTimeout(120_000);
+
+  test('seeds a draft page, authors two mixed-content changes in Playwright, and validates preview plus delivery after each publish', async ({
+    runWorkflow,
+  }) => {
+    await test.step('execute mixed workflow end-to-end', async () => {
+      await runWorkflow('./mixed_workflow/mixed-content.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: {
+          RUN_ID: runId,
+        },
+      });
+    });
+  });
+});

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -58,7 +58,7 @@ setRuntimeConfig({
 test.describe('mixed workflow', () => {
   test.setTimeout(120_000);
 
-  test('seeds a draft page, authors two mixed-content changes in Playwright, and validates preview plus delivery after each publish', async ({
+  test('publishes mixed page updates and validates preview plus delivery for code block and callout', async ({
     runWorkflow,
   }) => {
     await test.step('execute mixed workflow end-to-end', async () => {

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -1,0 +1,76 @@
+import { WorkflowActionRegistry } from '@core/workflow/types';
+import { expect, test } from '@playwright/test';
+import { TypeProgrammingLanguage } from '@pom/types/type-programming-language';
+
+const curriculumPath = (projectSlug: string) =>
+  `/workspaces/course_author/${encodeURIComponent(projectSlug)}/curriculum`;
+
+const editorPath = (projectSlug: string, revisionSlug: string) =>
+  `${curriculumPath(projectSlug)}/${encodeURIComponent(revisionSlug)}/edit`;
+
+const previewFlush = async (openPreview: () => Promise<{ close(): Promise<void> }>) => {
+  const preview = await openPreview();
+  await preview.close();
+};
+
+export const mixedWorkflowActions: WorkflowActionRegistry = {
+  async author_add_code_block({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const language = asString(params.language, 'language') as TypeProgrammingLanguage;
+    const code = asString(params.code, 'code');
+    const caption = asString(params.caption, 'caption');
+
+    await test.step('sign in as author and open the seeded page in the editor', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    });
+
+    await test.step('insert a code block and open preview to flush the draft change', async () => {
+      await curriculumTask.addCodeBlockToolbar(language, code, caption, false);
+      await previewFlush(() => curriculumTask.openPreview());
+      await expect(page).toHaveURL(new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`));
+    });
+
+    return {
+      caption,
+      code,
+      language,
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
+  async author_add_callout({ curriculumTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const calloutText = asString(params.callout_text, 'callout_text');
+
+    await test.step('re-open the page editor after the first publish cycle', async () => {
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    });
+
+    await test.step('insert a callout block from the editor toolbar and wait for it to render', async () => {
+      await curriculumTask.clickOnParagraphAndSelectContent('auto', 'Insert...', 'Callout');
+      await page.keyboard.type(calloutText);
+      await curriculumTask.waitChangeVisualize(calloutText);
+      await expect(page).toHaveURL(new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`));
+    });
+
+    return {
+      callout_text: calloutText,
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+};
+
+function asString(value: unknown, key: string) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Workflow action expected string param "${key}"`);
+  }
+
+  return value;
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -1,6 +1,8 @@
 import { WorkflowActionRegistry } from '@core/workflow/types';
-import { expect, test } from '@playwright/test';
+import { expect, Locator, Page, test } from '@playwright/test';
 import { TypeProgrammingLanguage } from '@pom/types/type-programming-language';
+
+const BASE_CONTENT_TEXT = 'Base content for mixed workflow coverage.';
 
 const curriculumPath = (projectSlug: string) =>
   `/workspaces/course_author/${encodeURIComponent(projectSlug)}/curriculum`;
@@ -50,7 +52,11 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     });
 
     await test.step('insert a callout block from the editor toolbar and wait for it to render', async () => {
-      await curriculumTask.clickOnParagraphAndSelectContent('auto', 'Insert...', 'Callout');
+      await focusBaseParagraphForBlockInsert(page);
+      await page.keyboard.press('Enter');
+      await expect(page.getByRole('button', { name: 'Insert...' })).toBeVisible();
+      await page.getByRole('button', { name: 'Insert...' }).click();
+      await page.getByRole('button', { name: 'Callout' }).click();
       await page.keyboard.type(calloutText);
       await curriculumTask.waitChangeVisualize(calloutText);
       await expect(page).toHaveURL(new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`));
@@ -73,4 +79,29 @@ function asString(value: unknown, key: string) {
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function focusBaseParagraphForBlockInsert(page: Page) {
+  const insertButton = page.getByRole('button', { name: 'Insert...' });
+  const focusTargets: Locator[] = [
+    page.locator('[data-slate-string="true"]').filter({ hasText: BASE_CONTENT_TEXT }).first(),
+    page.getByText(BASE_CONTENT_TEXT, { exact: true }).first(),
+    page.getByRole('paragraph').filter({ hasText: BASE_CONTENT_TEXT }).first(),
+  ];
+
+  for (const target of focusTargets) {
+    await target.click();
+    await page.keyboard.press('End');
+
+    const insertVisible = await insertButton
+      .waitFor({ state: 'visible', timeout: 1000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (insertVisible) {
+      return;
+    }
+  }
+
+  throw new Error('Could not focus the base paragraph strongly enough to expose the block insert toolbar');
 }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-callout.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-callout.scenario.yaml
@@ -1,0 +1,16 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_callout/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish callout workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_callout/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-codeblock.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-codeblock.scenario.yaml
@@ -1,0 +1,21 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_codeblock/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish code block workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- view_practice_page:
+    student: 'workflow_student'
+    section: 'workflow_delivery_section'
+    page: 'Mixed Workflow Page'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_codeblock/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.setup.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.setup.scenario.yaml
@@ -1,0 +1,51 @@
+- user:
+    name: 'workflow_author'
+    type: 'author'
+    email: 'author${RUN_ID}@example.com'
+    given_name: 'Playwright'
+    family_name: 'Author'
+    password: 'changeme123456'
+
+- user:
+    name: 'workflow_student'
+    type: 'student'
+    email: 'student${RUN_ID}@example.com'
+    given_name: 'Jane'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- project:
+    name: 'workflow_authoring_project'
+    title: 'Mixed Workflow ${RUN_ID}'
+    root:
+      children:
+        - page: 'Mixed Workflow Page'
+
+- edit_page:
+    project: 'workflow_authoring_project'
+    page: 'Mixed Workflow Page'
+    content: |
+      title: "Mixed Workflow Page"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Base content for mixed workflow coverage."
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Initial mixed workflow publication'
+
+- section:
+    name: 'workflow_delivery_section'
+    title: 'Mixed Workflow Section ${RUN_ID}'
+    from: 'workflow_authoring_project'
+    type: 'enrollable'
+    registration_open: true
+
+- enroll:
+    user: 'workflow_student'
+    section: 'workflow_delivery_section'
+    role: 'student'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.capture_workflow_page_revision_slug/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.workflow.yaml
@@ -1,0 +1,49 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_code_block_in_playwright
+    playwright_action:
+      action: 'author_add_code_block'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+        language: 'python'
+        caption: 'Mixed Workflow Code Block Caption'
+        code: 'print("mixed workflow code block")'
+
+  - id: assert_code_block_after_publish
+    scenario:
+      file: 'assert-codeblock.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_code_block_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_CODEBLOCK_CAPTION: '${author_code_block_in_playwright.outputs.caption}'
+        EXPECTED_CODEBLOCK_CODE: '${author_code_block_in_playwright.outputs.code}'
+
+  - id: author_callout_in_playwright
+    playwright_action:
+      action: 'author_add_callout'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+        callout_text: 'Mixed workflow callout text'
+
+  - id: assert_callout_after_publish
+    scenario:
+      file: 'assert-callout.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_callout_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_CALLOUT_TEXT: '${author_callout_in_playwright.outputs.callout_text}'

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md
@@ -1,0 +1,294 @@
+# MER-5416 Basic Page Publication Validation Approach
+
+Scope and reference artifacts:
+- Jira story: `MER-5416`
+- Epic plan source: `docs/exec-plans/current/epics/automated_testing/plan.md`
+- Existing authoring Playwright coverage:
+  - `assets/automation/tests/torus/course_authoring/course-authoring.spec.ts`
+  - `assets/automation/tests/torus/course_authoring/playwright_course_authoring.yaml`
+- Relevant scenario and preview precedents:
+  - `test/scenarios/features/instructor_preview_mixed_page_hardening.scenario.yaml`
+  - `test/scenarios/features/instructor_preview_hooks.ex`
+
+## Problem Statement
+`MER-5416` asks for expanded Playwright coverage of basic page authoring so it covers the items listed in the `MIXED` tab of the regression spreadsheet.
+
+The Jira description frames this as:
+
+1. `Oli.Scenario` bootstraps users, project, and page state.
+2. Playwright authors or edits the basic page content.
+3. The resulting content is validated as publication-ready.
+
+The latest Darren comment adds a stronger possible interpretation:
+
+1. `Oli.Scenario` bootstraps the world.
+2. Playwright performs the authoring step.
+3. A follow-up `Oli.Scenario` performs assertions against:
+   - authoring preview rendered content
+   - student delivery rendered content
+
+That interpretation is not yet reflected in the current automation infrastructure.
+
+## Working Interpretation
+For this ticket, the agreed meaning of the two assertion surfaces is:
+
+- `authoring preview assertions`
+  - validate the rendered output of the authored basic page through the authoring preview surface
+  - this is not instructor preview
+- `student delivery assertions`
+  - validate the rendered output of the same content after publish, section creation, and learner delivery
+
+This interpretation matters because the repository currently has stronger precedent for instructor preview assertions than for authoring preview assertions.
+
+## Current State In The Repo
+### What already exists
+- Playwright can seed scenario YAML worlds before a browser test via:
+  - `assets/automation/src/core/fixture/my-fixture.ts`
+  - `assets/automation/src/core/seedScenario.ts`
+  - `lib/oli_web/controllers/playwright_scenario_controller.ex`
+- Basic page authoring coverage already exists, but as broad authoring flows rather than a `MIXED`-tab-aligned validation matrix.
+- Scenario hooks can execute custom Elixir assertions during scenario execution.
+- Scenario directives already support learner-side attempt setup and answering flows such as:
+  - `view_practice_page`
+  - `visit_page`
+  - `answer_question`
+  - `hook`
+
+### What does not exist yet
+- No current mechanism runs a second scenario after Playwright modifies authored state.
+- No current Playwright fixture coordinates:
+  - scenario setup
+  - browser authoring mutation
+  - scenario-based post-authoring assertions
+- No current documented boundary was found for authoring-preview-specific assertions comparable to the existing instructor preview hook precedent.
+
+## Main Scope Question
+`MER-5416` appears to have two possible sizes.
+
+### Option A: Coverage-only ticket
+Deliver additional Playwright specs that:
+- seed the initial world with scenario YAML
+- author content in the browser
+- use browser-visible checks to validate the result
+
+This option stays within the current test infrastructure.
+
+### Option B: Coverage plus infrastructure ticket
+Deliver additional Playwright specs and also add infrastructure to support:
+- post-Playwright scenario execution
+- authoring preview assertions below the browser UI layer
+- student delivery assertions below the browser UI layer
+
+This option is materially larger because it introduces orchestration capability, not just more coverage.
+
+## Recommendation
+Treat `MER-5416` first as a dimensioning and slicing exercise, not immediately as a pure implementation ticket.
+
+Recommended next decision:
+
+1. Map the `MIXED` regression rows into concrete coverage groups.
+2. Split them into:
+   - rows that can be covered with the current Playwright stack
+   - rows that require post-authoring scenario assertions
+3. If most required rows fall into the first group, keep `MER-5416` as Option A.
+4. If key acceptance value depends on the second group, escalate to a formal plan and treat the infrastructure work explicitly.
+
+## Proposed Implementation Cut If We Keep The Ticket Small
+If the ticket remains Option A, implement it as:
+
+1. Add a dedicated `MER-5416` support scenario YAML for world bootstrap only.
+2. Add one or more Playwright specs aligned to `MIXED` row groupings.
+3. Reuse or extend basic page authoring POM helpers.
+4. Validate publication readiness through browser-level preview and delivery checks only where already practical.
+5. Document any missing authoring-preview or post-Playwright-scenario gaps as follow-up work.
+
+## Signals That The Ticket Should Escalate To A Formal Plan
+Escalate from `harness-work` to a fuller planning lane if any of these become required:
+
+- new scenario controller behavior to support multiple scenario phases
+- persistent state handoff from Playwright browser actions into scenario execution
+- new scenario directives or hooks specifically for authoring preview assertions
+- reusable infrastructure for asserting published delivery content outside Playwright after authoring mutations
+
+## Risks
+- The phrase `authoring preview assertions` can be misread as instructor preview if not fixed explicitly.
+- A coverage-only implementation may look complete while still missing the deeper post-authoring validation Darren described.
+- A single ticket that mixes matrix expansion with new automation orchestration may be too large for a lightweight work lane.
+
+## Immediate Next Step
+Use this document as the working support artifact for `MER-5416` while reviewing the `MIXED` tab row-by-row.
+
+The next concrete output should be a row-grouped coverage inventory that labels each regression item as:
+- `covered already`
+- `playwright only`
+- `needs post-playwright scenario support`
+
+That inventory now has a workflow-specific companion artifact in:
+- `docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md`
+
+The matrix is the source of truth for row-complete workflow planning against the external spreadsheet.
+
+## Initial Coverage Inventory From The Current Repo
+The external `MIXED` tab rows were not present in the Jira issue payload, so the first inventory pass is limited to the checked-in automation coverage.
+
+### Covered already
+The current `course_authoring` Playwright coverage already validates authoring preview for several authored content types on dedicated basic pages. The strongest precedent is the `Add one of each type of content to dedicated pages` group in `assets/automation/tests/torus/course_authoring/course-authoring.spec.ts`.
+
+Current preview-covered content types include:
+- cite
+- foreign text
+- image
+- formula
+- callout
+- popup
+- dialog
+- table
+- theorem
+- conjugation
+- description list
+- audio
+- video
+- YouTube
+- webpage embed
+- code block
+- figure
+- page link
+- definition
+
+There is also narrower existing coverage for:
+- modifying text content
+- changing text formatting
+- inserting an image into a basic page
+- publishing updates and confirming learner-visible page availability at a coarse level
+
+### Playwright only
+These are behaviors that the current suite appears structurally able to cover without new infrastructure, assuming they are part of the `MIXED` matrix:
+- additional basic page authored content insertions that can be validated through the existing author preview window
+- richer permutations of already-covered content types
+- save, reopen, and preview validation for authored content where browser-visible assertions are sufficient
+- grouped publication-ready checks that can be observed directly from authoring preview or learner delivery UI
+
+### Needs post-playwright scenario support
+These are the likely cases that cannot be considered solved by the current stack alone:
+- any requirement that explicitly needs scenario-driven assertions after Playwright has mutated the authored page
+- assertions against authoring preview through a non-browser raw-render boundary
+- assertions against student delivery through a non-browser raw-render boundary after the same Playwright authoring mutation
+- reusable orchestration of:
+  - scenario bootstrap
+  - Playwright authoring
+  - scenario assertion execution
+
+## Known Gap In This Inventory
+This initial inventory is coverage-oriented, not regression-row-complete.
+
+Until the `MIXED` spreadsheet tab is available as concrete row data, this document can only answer:
+- what the repo already covers
+- what the current infrastructure can probably absorb
+- what likely forces ticket escalation
+
+It cannot yet answer:
+- which exact regression rows are already satisfied
+- which exact regression rows are missing
+- which row groupings make the most sense for `MER-5416` spec slicing
+
+## `MIXED` Tab Inventory Snapshot
+The provided `MIXED` tab CSV currently contains 80 rows across these groups:
+
+- `CORE`: 1
+- `INLINE`: 15
+- `LIST`: 2
+- `TABLE`: 7
+- `IMAGE`: 5
+- `YOUTUBE`: 8
+- `VIDEO`: 6
+- `WEBPAGE`: 4
+- `CODEBLOCK`: 4
+- `FORMULA`: 1
+- `CALLOUT`: 1
+- `DEFINITION`: 1
+- `FIGURE`: 2
+- `DIALOG`: 11
+- `CONJUGATION`: 7
+- `DESCRIPTIONLIST`: 4
+- `THEOREM`: 1
+
+## Initial Group-Level Classification Against Current Coverage
+This is the first practical mapping between the checked-in Playwright coverage and the real `MIXED` inventory.
+
+### Likely covered already, fully or almost fully
+- `FORMULA`
+  - existing preview coverage adds and verifies formula content
+- `CALLOUT`
+  - existing preview coverage adds and verifies a block callout
+- `THEOREM`
+  - existing preview coverage adds and verifies theorem content
+- `WEBPAGE`
+  - current suite covers basic insertion and preview rendering
+  - settings/open-in-new-tab/copy-link flows are not yet confirmed, so this group is not truly complete
+
+### Partially covered by current Playwright coverage
+- `IMAGE`
+  - current suite inserts and previews an image
+  - missing: png/jpg replacement flow, caption, alt text, width, and likely delivery verification at row granularity
+- `YOUTUBE`
+  - current suite inserts and previews a YouTube embed
+  - missing: id-only insertion, caption edits, open/copy affordances, settings edits, alt text, delete/undo
+- `VIDEO`
+  - current suite inserts and previews video
+  - missing: extra track, caption track, poster image, size settings, delete/undo
+- `CODEBLOCK`
+  - current suite inserts a code block and verifies preview text
+  - missing: explicit language change, delete, undo, and row-level persisted/delivery checks
+- `DEFINITION`
+  - current suite covers simple definition creation
+  - missing: multiple definitions, translation, pronunciation, richer edit path
+- `FIGURE`
+  - current suite covers figure title
+  - missing: figure-internal content composition such as image and audio
+- `DIALOG`
+  - current suite covers only a very simple dialog happy path
+  - missing most of the 11-row dialog matrix: speakers, labels, lines, embedded content, toggle speaker, delete flows
+- `CONJUGATION`
+  - current suite covers initial insertion only
+  - missing the richer edit matrix
+- `DESCRIPTIONLIST`
+  - current suite covers initial insertion only
+  - missing richer editing flows
+- `TABLE`
+  - current suite covers simple table insertion with caption and cells
+  - missing structural table operations and style variants
+
+### Not meaningfully covered by current Playwright coverage
+- `CORE`
+  - editing lag check does not currently exist
+- `INLINE`
+  - current suite does not cover the inline-formatting matrix at all
+- `LIST`
+  - current suite only incidentally creates a list during a broad smoke flow; it does not cover bullet style or indent behavior
+
+## Practical Conclusion From The `MIXED` CSV
+`MER-5416` is not a small “fill a couple of holes” ticket if interpreted as full `MIXED`-tab coverage.
+
+The current suite already provides useful building blocks and a few direct matches, but most of the spreadsheet rows are still uncovered or only superficially represented.
+
+The highest-value insight from the CSV is:
+
+- the current repo has decent precedent for block-content insertion plus preview verification
+- the current repo has weak coverage for inline editing semantics, rich edit flows, and component settings matrices
+- the current repo has no built-in solution yet for Darren's proposed post-Playwright scenario assertion phase
+
+## Suggested Row Grouping For Implementation Slicing
+If `MER-5416` remains a single ticket, the rows should be grouped into a small number of implementation slices:
+
+1. `INLINE` + `LIST` + `CORE`
+2. `TABLE`
+3. `IMAGE` + `FIGURE`
+4. `YOUTUBE` + `VIDEO` + `WEBPAGE`
+5. `DIALOG` + `CONJUGATION` + `DESCRIPTIONLIST` + `DEFINITION`
+6. remaining singletons:
+   - `FORMULA`
+   - `CALLOUT`
+   - `THEOREM`
+   - `CODEBLOCK`
+
+This grouping aligns better with shared authoring widgets and helper opportunities than the raw spreadsheet order.

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/fdd.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/fdd.md
@@ -1,0 +1,245 @@
+# MER-5416 Automated Basic Page Authored Content - Functional Design Document
+
+## 1. Executive Summary
+`MER-5416` needs a reusable automation pattern that alternates scenario-driven state creation with browser-driven authoring and then returns to scenario-based assertions. The v1 design keeps orchestration on the Playwright/TypeScript side and treats `Oli.Scenarios` as the authoritative backend mechanism for setup and post-authoring assertions.
+
+The selected design introduces a linear workflow runner in `assets/automation` with two step types:
+- `scenario`
+- `playwright_action`
+
+This is the simplest design that satisfies `FR-001`, `FR-002`, `FR-003`, `FR-004`, `FR-005`, `FR-006`, `FR-007`, and `FR-008` while keeping the first PR focused on proving the pattern (`AC-001`, `AC-002`, `AC-003`, `AC-004`, `AC-005`, `AC-006`, `AC-007`, `AC-008`, `AC-009`).
+
+## 2. Requirements & Assumptions
+- Functional requirements:
+  - Provide a reusable two-phase automation pattern where Playwright can run after scenario setup and before a second scenario assertion phase (`FR-001`, `FR-002`, `AC-001`).
+  - Limit the first implementation slice to infrastructure plus one or two representative `MIXED` groups so the pattern is proven before the full matrix expands (`FR-003`, `AC-004`, `AC-005`).
+  - Reuse the existing authoring Playwright helpers and keep the resulting pattern durable for later grouped slices (`FR-004`, `FR-005`, `AC-006`, `AC-009`).
+  - Keep scenario-driven setup deterministic and validate authored state across persisted, preview, and delivery surfaces (`FR-006`, `FR-007`, `AC-002`, `AC-003`, `AC-008`).
+  - Document the infrastructure and follow-up grouping strategy explicitly (`FR-008`, `AC-009`).
+- Non-functional requirements:
+  - Existing scenario-seeded Playwright specs must remain compatible (`AC-006`).
+  - The first slice must preserve the author-preview interpretation and not drift into instructor-preview semantics (`AC-007`).
+  - The v1 pattern should be simple, linearly debuggable, and avoid speculative branching or distributed orchestration.
+- Assumptions:
+  - The first PR proves the pattern rather than maximizing `MIXED` row count.
+  - Post-Playwright assertions can be expressed through scenario YAML plus hooks or small scenario-surface extensions instead of a brand-new standalone assertion framework.
+  - A TypeScript-side runner is cheaper and lower-risk than making Elixir the orchestrator in v1 because Playwright already owns browser lifecycle, selectors, and debugging ergonomics.
+
+## 3. Repository Context Summary
+- What we know:
+  - Playwright scenario setup already exists through `assets/automation/src/core/fixture/my-fixture.ts`, `assets/automation/src/core/seedScenario.ts`, and `lib/oli_web/controllers/playwright_scenario_controller.ex`.
+  - The current backend contract executes one scenario YAML per request and returns structured outputs for projects, sections, products, users, and merged params.
+  - Existing course-authoring specs already exercise basic page editing and author preview, but they do not support a reusable `scenario -> browser -> scenario` alternation pattern.
+  - Torus's publication model requires learner delivery assertions to resolve through a published section context rather than mutable authoring state.
+  - The current `MIXED` matrix is much larger than current coverage, so grouped expansion after the first PR is required.
+- Unknowns to confirm:
+  - Whether author-preview assertions can be expressed entirely through hooks on existing preview routes or require a small scenario-surface addition.
+  - Which representative groups will provide the best signal in PR 1.
+  - Whether the existing `/test/scenario-yaml` route can remain unchanged and simply be called multiple times, or whether it needs a small response/params extension for better workflow outputs.
+
+## 4. Proposed Design
+### 4.1 Component Roles & Interactions
+- `Workflow runner` in `assets/automation/src/core/workflows/`
+  - Reads a workflow declaration.
+  - Executes steps sequentially.
+  - Maintains a serializable workflow state and step outputs.
+  - Is exposed to specs through a new fixture helper that extends `assets/automation/src/core/fixture/my-fixture.ts` rather than replacing `seedScenario(...)`.
+- `Scenario step adapter`
+  - Reuses the existing scenario execution endpoint.
+  - Loads YAML from disk and posts it with resolved params.
+  - Stores returned outputs under the step id.
+- `Playwright action step adapter`
+  - Resolves a named action from a local TypeScript action registry.
+  - Runs against the current Playwright test context, page, helpers, and POMs.
+  - Returns small serializable outputs for downstream steps.
+- `Action registry`
+  - Maps stable `playwright_action` names to implementations.
+  - Prevents the workflow DSL from naming arbitrary spec files or test cases.
+- `Scenario assertions`
+  - Stay in the existing `Oli.Scenarios` world.
+  - Use scenario directives and hooks for preview and delivery checks.
+- `Documentation`
+  - Durable infrastructure usage and DSL contract live in `assets/automation/WORKFLOWS.md`.
+
+### 4.2 State & Data Flow
+1. The Playwright spec loads a workflow declaration and runtime params such as `RUN_ID`.
+2. Step `scenario setup` executes and returns outputs such as section slug, project slug, user email, or named page identifiers.
+3. The runner stores those outputs under the step id.
+4. Step `playwright_action` interpolates params from prior step outputs, performs browser authoring, and returns compact outputs such as page title, page slug, or variant name.
+5. Step `scenario assert` interpolates params from prior step outputs and executes scenario-based preview or delivery assertions.
+6. The workflow fails fast on the first failing step and reports the failing step id, type, and error context.
+
+This satisfies the need for multi-step alternation without introducing branching, concurrency, or non-serializable shared state in v1. The runner is not restricted to a fixed three-step pattern; it accepts an arbitrary-length linear sequence of steps (`AC-001`, `AC-004`, `AC-006`).
+
+### 4.3 Lifecycle & Ownership
+- Workflow declaration ownership:
+  - test-local workflow files live beside the owning authoring specs or under a dedicated course-authoring workflow test directory.
+- Step execution ownership:
+  - TypeScript runner owns orchestration.
+  - Elixir remains the owner of scenario semantics and backend state creation/assertion behavior.
+- Fixture ownership:
+  - `my-fixture.ts` keeps `seedScenario(...)` for setup-only specs and gains `runWorkflow(...)` for workflow-driven specs.
+- Output ownership:
+  - each step owns its `outputs` map
+  - the runner owns interpolation and aggregation
+- Browser ownership:
+  - Playwright keeps ownership of browser/session/page lifecycle
+  - no Elixir-side browser orchestration is introduced in v1
+- Durable contract ownership:
+  - `assets/automation/WORKFLOWS.md` documents how to write and use workflows
+  - `mer-5416` work-item docs describe why this pattern exists and how it rolls out across PRs
+
+### 4.4 Alternatives Considered
+- `Elixir as orchestrator`
+  - rejected for v1
+  - reason: browser execution would have to become a subprocess or external worker concern, increasing complexity before the pattern is proven
+- `Top-level workflow steps for arbitrary hooks`
+  - rejected for v1
+  - reason: existing scenario `hook:` support already provides a custom assertion escape hatch inside scenario steps, so a second custom step type is unnecessary initially
+- `Workflow steps naming arbitrary Playwright tests/specs`
+  - rejected
+  - reason: naming arbitrary specs tightly couples the workflow DSL to Playwright file structure and reduces refactor safety; an action registry is the simpler adequate contract
+- `Single hard-coded before/after helpers instead of a workflow`
+  - rejected
+  - reason: it would solve only the first case and fail to satisfy the requirement for repeated alternation and grouped follow-up slices (`FR-001`, `FR-005`)
+
+## 5. Interfaces
+- Workflow declaration shape, v1:
+  - top-level `workflow` list
+  - arbitrary number of ordered steps
+  - each item must have:
+    - `id`
+    - exactly one step type:
+      - `scenario`
+      - `playwright_action`
+- Scenario step shape:
+  - `file`
+  - optional `params`
+- Playwright action step shape:
+  - `action`
+  - optional `params`
+- Workflow state shape:
+  - `params`: global workflow params
+  - `steps.<step_id>.outputs`: serializable per-step outputs
+- Interpolation:
+  - support global params and prior outputs using simple `${...}` placeholders
+  - no branching expressions or computed functions in v1
+- Playwright runner API:
+  - new helper exposed from the existing fixture surface, expected as `runWorkflow(...)`, that a spec can call with:
+    - workflow path
+    - runtime params
+    - Playwright fixture context
+- Backend scenario contract:
+  - continue using `/test/scenario-yaml`
+  - allow repeated calls within one Playwright test run
+
+Every acceptance criterion can map cleanly to these contracts: workflow orchestration (`AC-001`), preview and delivery assertion routing (`AC-002`, `AC-003`), first-slice reusability (`AC-004`, `AC-005`), compatibility (`AC-006`), author-preview semantic clarity (`AC-007`), end-to-end validation (`AC-008`), and durable grouped follow-up usage (`AC-009`).
+
+## 6. Data Model & Storage
+- No production domain tables or runtime data model changes are required for the workflow runner itself.
+- New workflow declarations are file-based test artifacts under `assets/automation/`.
+- New TypeScript interfaces define:
+  - workflow file schema
+  - workflow state
+  - scenario step result
+  - playwright action result
+- `assets/automation/WORKFLOWS.md` is part of the durable infrastructure contract and should be updated in the first implementation PR.
+- Scenario assertions may require additional scenario-level helper code or hook modules in `test/scenarios/` and `test/scenarios/features/`, but that is test infrastructure rather than production storage.
+
+## 7. Consistency & Transactions
+- Scenario setup and scenario assertion phases each execute atomically within their own request and scenario engine invocation.
+- The workflow runner does not attempt to create a cross-step distributed transaction.
+- Consistency boundary is:
+  - Playwright mutates state through normal authoring UI requests
+  - subsequent scenario steps observe the committed backend state produced by those requests
+- Fail-fast behavior prevents later assertions from running on top of already failed or incomplete browser mutations.
+
+## 8. Caching Strategy
+N/A
+
+The workflow runner should not introduce any new caches in v1. Each step should use current backend and browser behavior directly for correctness and debuggability.
+
+## 9. Performance & Scalability Posture
+- The v1 runner is intentionally linear and small-scale.
+- Browser-heavy coverage remains in release or targeted automation lanes, not the default fast path, which keeps the extra scenario phase operationally acceptable.
+- Reusing one Playwright test context across multiple sequential steps avoids spawning unnecessary browser sessions.
+- The first PR should keep the number of grouped cases intentionally low so feedback on runner shape arrives before broader expansion.
+
+## 10. Failure Modes & Resilience
+- Scenario step fails before browser step:
+  - workflow stops
+  - report setup error and scenario summary
+- Playwright action fails:
+  - workflow stops
+  - report action id, resolved params, and browser-side error
+- Post-Playwright scenario assertion fails:
+  - workflow stops
+  - report assertion-step failure distinctly from authoring-step failure
+- Interpolation references missing outputs:
+  - treat as runner configuration error
+  - fail before invoking the step
+- Existing scenario-seeded specs not using the new runner:
+  - remain unaffected because the new runner is additive and does not replace `seedScenario`
+
+## 11. Observability
+- Reuse existing scenario response summaries and errors from `PlaywrightScenarioController`.
+- Add runner-level step logging in TypeScript:
+  - workflow id/path
+  - step id
+  - step type
+  - start/end/failure status
+- Preserve browser-native debugging support:
+  - Playwright trace/screenshots when already enabled by test configuration
+- `assets/automation/WORKFLOWS.md` should document expected runner error surfaces so future contributors can debug missing outputs, step failures, and interpolation issues.
+
+## 12. Security & Privacy
+- Continue using the existing internal scenario token gate for backend scenario execution.
+- Do not introduce a new general-purpose endpoint for arbitrary code execution.
+- Step outputs must remain limited to the minimum identifiers needed for downstream test steps; avoid serializing unnecessary sensitive data.
+- No production-user privacy posture changes are introduced by this work item because all behavior remains inside the existing internal test infrastructure.
+
+## 13. Testing Strategy
+- Architecture validation:
+  - add targeted TypeScript tests for workflow parsing/interpolation if current automation infrastructure supports them cheaply
+- Backend validation:
+  - add targeted ExUnit or scenario tests for any new scenario hooks/directives used for author-preview or learner-delivery assertions
+- End-to-end validation:
+  - add the first workflow-driven Playwright specs for one or two representative `MIXED` groups
+  - prove `scenario -> playwright_action -> scenario` alternation works at least twice in one workflow
+- Regression validation:
+  - run the affected new workflow-driven specs
+  - run at least one existing scenario-seeded Playwright spec to confirm additive compatibility (`AC-006`)
+- Documentation validation:
+  - update `assets/automation/WORKFLOWS.md` in the first implementation PR (`AC-009`)
+
+## 14. Backwards Compatibility
+- Existing uses of `seedScenario` remain valid and unchanged (`AC-006`).
+- Existing course-authoring POMs and helper tasks remain the base layer; the new runner wraps them rather than replacing them (`FR-004`).
+- Workflow runner adoption is opt-in per spec, which keeps the first PR narrow and avoids mass migration pressure.
+
+## 15. Risks & Mitigations
+- Risk: workflow DSL grows too quickly into a mini-language.
+  - Mitigation: keep v1 to linear steps, two step types, simple interpolation, and no branching.
+- Risk: author-preview assertions secretly rely on instructor-preview routes.
+  - Mitigation: keep author-preview semantics explicit in workflow naming, scenario files, and acceptance tests (`AC-007`).
+- Risk: outputs become ad hoc and inconsistent across steps.
+  - Mitigation: define a small serializable output contract and document it in `assets/automation/WORKFLOWS.md`.
+- Risk: first PR chooses groups that are too trivial to prove the pattern.
+  - Mitigation: choose one or two representative groups with enough settings/edit/persist/render depth to validate the full loop (`AC-004`, `AC-008`).
+
+## 16. Open Questions & Follow-ups
+- Which groups should PR 1 use to maximize signal with manageable complexity?
+- Does author preview need a small new scenario surface, or can hooks against existing preview boundaries fully cover it?
+- Should follow-up PR planning live in `plan.md` as one grouped rollout or as explicit per-group phases?
+- Follow-up: produce `plan.md` with PR-by-PR slices once this FDD is accepted.
+
+## 17. References
+- `docs/exec-plans/current/epics/automated_testing/mer-5416/prd.md`
+- `docs/exec-plans/current/epics/automated_testing/mer-5416/requirements.yml`
+- `docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md`
+- `docs/exec-plans/current/epics/automated_testing/plan.md`
+- `lib/oli_web/controllers/playwright_scenario_controller.ex`
+- `assets/automation/src/core/fixture/my-fixture.ts`
+- `assets/automation/src/core/seedScenario.ts`
+- `assets/automation/tests/torus/course_authoring/course-authoring.spec.ts`
+- `docs/design-docs/publication-model.md`

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
@@ -1,0 +1,220 @@
+# MER-5416 Mixed Workflow Coverage Matrix
+
+This matrix is the row-complete workflow coverage inventory for the external `MIXED` spreadsheet tab.
+
+It exists to answer three questions durably:
+
+1. which spreadsheet rows are already covered by workflow-driven automation
+2. which rows are still planned but not yet covered
+3. which follow-up slice owns each remaining row
+
+## Status Legend
+
+- `covered`
+  - a workflow-driven test in `assets/automation/tests/torus/course_authoring` already covers the row behavior end to end
+- `planned`
+  - the row is in scope for workflow migration but not yet implemented
+- `needs-triage`
+  - the row needs a narrower implementation decision before it can be assigned cleanly to a slice
+
+## Slice Inventory
+
+These slices are coverage batches, not implementation phases.
+
+- `Initial Slice`
+  - corresponds to the first implementation PR after the workflow infrastructure is ready
+- `Follow-up Slice`
+  - corresponds to later grouped coverage PRs
+- `Initial Slice`
+  - workflow foundation plus representative `CODEBLOCK` and `CALLOUT` coverage
+- `Follow-up Slice 2`
+  - `CORE` + `INLINE` + `LIST`
+- `Follow-up Slice 3`
+  - `TABLE`
+- `Follow-up Slice 4`
+  - `IMAGE` + `FIGURE`
+- `Follow-up Slice 5`
+  - `YOUTUBE` + `VIDEO` + `WEBPAGE`
+- `Follow-up Slice 6`
+  - `DIALOG` + `CONJUGATION`
+- `Follow-up Slice 7`
+  - `DEFINITION` + `DESCRIPTIONLIST` + `THEOREM` + `FORMULA`
+- `Follow-up Slice 8`
+  - remaining `CODEBLOCK` lifecycle rows such as delete and undo
+
+## Coverage Rules
+
+- Every spreadsheet row must appear exactly once in this document.
+- Every row must have a non-empty `Workflow Status`.
+- Every row that is not `covered` must have a non-empty `Target Slice`.
+- When a workflow test lands, update both:
+  - `Workflow Status`
+  - `Workflow Test / Notes`
+- This matrix is considered complete when all 80 spreadsheet rows are represented, even if some remain `planned`.
+
+## Matrix
+
+### `CORE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `CORE-A` | Type in a couple of sentences. Verify there is no editing lag | `planned` | `Follow-up Slice 2` | Fold into the core text-editing workflow slice. |
+
+### `INLINE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `INLINE-C` | Apply bold | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-D` | Apply italic | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-E` | Apply code | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-F` | Create hyperlink to another page in the course | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
+| `INLINE-G` | Create hyperlink to an external site | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
+| `INLINE-I` | Apply underline | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-J` | Apply strikethrough | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-K` | Apply subscript | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-L` | Apply superscript | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-M` | Apply term | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
+| `INLINE-N` | Apply foreign. Select a language | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
+| `INLINE-O` | Apply popup content | `planned` | `Follow-up Slice 2` | Inline popup workflow family. |
+| `INLINE-R` | Apply inline callout | `planned` | `Follow-up Slice 2` | Distinct from block callout in `CALLOUT-A`. |
+| `INLINE-S` | Change text to be a heading | `planned` | `Follow-up Slice 2` | Block-format workflow family. |
+| `INLINE-T` | Change text direction | `planned` | `Follow-up Slice 2` | Directionality workflow family. |
+
+### `LIST`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `LIST-C` | Customize the bullet style of one of the lists | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
+| `LIST-D` | Indent one of the list items | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
+
+### `TABLE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `TABLE-B` | Add a column | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-C` | Add a row | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-D` | Toggle a cell to be a header | `planned` | `Follow-up Slice 3` | Table semantics workflow family. |
+| `TABLE-E` | Merge the contents of two cells | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-F` | Change the alignment of one cell | `planned` | `Follow-up Slice 3` | Table formatting workflow family. |
+| `TABLE-G` | Create a second table with four rows and set row style set to Alternating | `planned` | `Follow-up Slice 3` | Table style workflow family. |
+| `TABLE-H` | Create a third table with border style set to Hidden | `planned` | `Follow-up Slice 3` | Table style workflow family. |
+
+### `IMAGE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `IMAGE-B` | Insert a block image. In media manager, upload both a PNG and JPG image. Select the PNG | `planned` | `Follow-up Slice 4` | Media insertion workflow family. |
+| `IMAGE-C` | Change the image to the JPG | `planned` | `Follow-up Slice 4` | Media replacement workflow family. |
+| `IMAGE-D` | Enter a caption | `planned` | `Follow-up Slice 4` | Image caption workflow family. |
+| `IMAGE-E` | Using image settings, specify alternate text | `planned` | `Follow-up Slice 4` | Accessibility workflow family. |
+| `IMAGE-F` | Using image settings, define a custom width | `planned` | `Follow-up Slice 4` | Media settings workflow family. |
+
+### `YOUTUBE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `YOUTUBE-B` | Insert YouTube video using only the YouTube video id | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
+| `YOUTUBE-C` | Edit the caption of the YouTube video | `planned` | `Follow-up Slice 5` | Embed caption workflow family. |
+| `YOUTUBE-D` | Click to open the YouTube video in full screen in new tab | `planned` | `Follow-up Slice 5` | New-tab behavior may remain browser-only within the workflow. |
+| `YOUTUBE-E` | Click to copy the YouTube video URL to the clipboard | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
+| `YOUTUBE-F` | Using settings menu, change the video to a new id | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
+| `YOUTUBE-G` | Using settings menu, set the alternative text for YouTube video | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
+| `YOUTUBE-H` | Delete a YouTube video | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
+| `YOUTUBE-I` | Undo the deletion (Ctrl-z) | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
+
+### `CODEBLOCK`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `CODEBLOCK-B` | Change language to Python | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` code block phase. |
+| `CODEBLOCK-C` | Edit source of CodeBlock to insert a few lines of actual, formatted Python code | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` code block phase. |
+| `CODEBLOCK-D` | Delete the CodeBlock | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
+| `CODEBLOCK-E` | Undo the deletion (ctrl-z) | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
+
+### `VIDEO`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `VIDEO-B` | Add additional video track via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-C` | Add caption track via Settings dialog | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
+| `VIDEO-D` | Set poster image via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-E` | Set size of the video via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-F` | Delete the video | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
+| `VIDEO-G` | Undo the deletion (ctrl-z) | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
+
+### `WEBPAGE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `WEBPAGE-A` | Insert webpage (iframe) | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
+| `WEBPAGE-B` | Click to open in new tab | `planned` | `Follow-up Slice 5` | New-tab browser behavior plus persist/delivery validation. |
+| `WEBPAGE-C` | Click to copy URL | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
+| `WEBPAGE-D` | Using settings dialog, change the URL | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
+
+### `FORMULA`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `FORMULA-B` | Insert block formula, change type to Latex, and enter valid Latex | `planned` | `Follow-up Slice 7` | Block math workflow family. |
+
+### `CALLOUT`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `CALLOUT-A` | Insert block callout, enter text | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` callout phase. |
+
+### `DEFINITION`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `DEFINITION-B` | Click edit and change the term, add multiple definitions, a translation and a pronunciation | `planned` | `Follow-up Slice 7` | Definition editing workflow family. |
+
+### `FIGURE`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `FIGURE-B` | Edit Figure title | `planned` | `Follow-up Slice 4` | Figure settings workflow family. |
+| `FIGURE-C` | Insert other block content within Figure content | `planned` | `Follow-up Slice 4` | Nested-content workflow family. |
+
+### `DIALOG`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `DIALOG-B` | Edit dialog title | `planned` | `Follow-up Slice 6` | Dialog editing workflow family. |
+| `DIALOG-C` | Add a speaker | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-D` | Associate an image with a speaker | `planned` | `Follow-up Slice 6` | Dialog media workflow family. |
+| `DIALOG-E` | Delete a speaker | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-F` | Edit a speaker label | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-G` | Add a dialog line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-H` | Edit the text within speaker line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-I` | Add content element within speaker line | `planned` | `Follow-up Slice 6` | Dialog nested-content workflow family. |
+| `DIALOG-J` | Toggle the speaker associated with a line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-K` | Add a second line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-L` | Delete line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+
+### `CONJUGATION`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `CONJUGATION-B` | Edit title | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-C` | Edit verb | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-D` | Edit pronunciation | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-E` | Edit conjugation table headers (singular, plural) | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-F` | Edit conjugate content | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-G` | Edit conjugate pronouns | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-H` | Associate audio clip with conjugate | `planned` | `Follow-up Slice 6` | Conjugation media workflow family. |
+
+### `DESCRIPTIONLIST`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `DESCRIPTIONLIST-B` | Edit Description List title | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
+| `DESCRIPTIONLIST-C` | Edit default term and description | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
+| `DESCRIPTIONLIST-D` | Add term | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
+| `DESCRIPTIONLIST-E` | Add multiple definitions | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
+
+### `THEOREM`
+
+| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- |
+| `THEOREM-B` | Edit title, statement, proof | `planned` | `Follow-up Slice 7` | Theorem editing workflow family. |

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/plan.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/plan.md
@@ -1,0 +1,177 @@
+# MER-5416 Automated Basic Page Authored Content - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/epics/automated_testing/mer-5416/prd.md`
+- FDD: `docs/exec-plans/current/epics/automated_testing/mer-5416/fdd.md`
+- Requirements: `docs/exec-plans/current/epics/automated_testing/mer-5416/requirements.yml`
+- Coverage inventory and grouping notes: `docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md`
+- Row-complete workflow coverage matrix: `docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md`
+
+## Scope
+Deliver `MER-5416` as a multi-PR work item that first establishes the reusable `scenario -> playwright_action -> scenario` automation pattern and then expands `MIXED`-tab coverage by grouped authoring behavior. The first implementation PR is intentionally limited to infrastructure plus one or two representative groups so the workflow pattern is proven before broader expansion.
+
+This plan covers:
+- the TypeScript-side workflow runner and step contracts
+- additive backend support needed for repeated scenario execution and post-Playwright assertions
+- authoring preview and learner delivery assertion support
+- grouped follow-up expansion across the remaining `MIXED` coverage families
+
+This plan does not attempt to deliver all 80 spreadsheet rows in one PR.
+
+Coverage naming note:
+- `Phase` in this document means an implementation stage.
+- `Slice` in `mixed_coverage_matrix.md` means a coverage batch of spreadsheet rows.
+- Slices are not intended to align 1:1 with phases.
+
+## Clarifications & Default Assumptions
+- `AC-001`, `AC-002`, and `AC-003` are owned primarily by the infrastructure-first PR.
+- `AC-004` and `AC-008` require one or two representative groups in the first PR; default assumption is to prefer groups with moderate complexity and strong settings/render signal.
+- `AC-005` means the first PR must stop after proving the pattern and documenting grouped follow-up slices rather than absorbing broad row count.
+- `AC-006` requires explicit regression verification against at least one existing scenario-seeded Playwright spec.
+- `AC-007` means author preview must remain semantically distinct from instructor preview in both docs and assertions.
+- `AC-009` requires durable documentation in `assets/automation/WORKFLOWS.md` during the first implementation PR.
+- `AC-010` requires a row-complete `MIXED` matrix that remains current through the initial PR and the immediate follow-up PR.
+- Default first-slice candidates are `IMAGE` plus `CODEBLOCK` unless deeper implementation reconnaissance finds a better pair.
+
+## Phase 1: Finalize Workflow Contracts
+- Goal: Lock the v1 workflow DSL, step contracts, output model, and first-slice group choice so implementation can proceed without reopening the architecture. Supports `AC-004`, `AC-005`, `AC-007`, and `AC-009`.
+- Tasks:
+  - [ ] Confirm the v1 workflow declaration shape:
+    - `scenario`
+    - `playwright_action`
+  - [ ] Confirm the workflow state contract for global params and per-step outputs.
+  - [ ] Confirm interpolation rules and failure behavior for missing references.
+  - [ ] Choose the first one or two representative `MIXED` groups for PR 1.
+  - [ ] Confirm that top-level `hook` steps are out of scope for v1 and that custom assertion logic stays inside scenario steps.
+  - [ ] Create the row-complete `MIXED` workflow coverage matrix and assign every spreadsheet row to a target slice (`AC-010`).
+- Testing Tasks:
+  - [ ] Reconcile the chosen PR 1 groups against the `MIXED` CSV inventory and current repo coverage.
+  - Command(s): `rg -n "MIXED|IMAGE|CODEBLOCK|TABLE|INLINE" docs/exec-plans/current/epics/automated_testing assets/automation/tests/torus/course_authoring`
+- Definition of Done:
+  - v1 step types, outputs, interpolation, and first-slice groups are explicitly fixed for implementation.
+  - Author-preview semantics are unambiguous for PR 1 (`AC-007`).
+  - The matrix contains all 80 spreadsheet rows with non-empty workflow status and target slice fields (`AC-010`).
+- Gate:
+  - Gate A: implementation starts only after the first-slice groups and contracts are stable enough to avoid workflow-shape churn.
+- Dependencies:
+  - PRD and FDD complete.
+- Parallelizable Work:
+  - Lightweight scenario-surface reconnaissance for author-preview assertions can proceed in parallel with final group selection.
+
+## Phase 2: Build The Workflow Runner And Additive Scenario Support
+- Goal: Implement the reusable orchestration foundation for repeated scenario execution around Playwright authoring. Supports `AC-001`, `AC-006`, and `AC-009`.
+- Tasks:
+  - [ ] Add the workflow runner under `assets/automation/src/core/` with:
+    - workflow parsing
+    - sequential step execution
+    - serializable workflow state
+    - arbitrary-length linear step support
+  - [ ] Add a scenario step adapter that reuses the existing scenario execution endpoint for repeated calls.
+  - [ ] Add a Playwright action registry and action-step adapter.
+  - [ ] Extend `assets/automation/src/core/fixture/my-fixture.ts` with a new `runWorkflow(...)` helper while preserving `seedScenario(...)`.
+  - [ ] Keep the new runner additive so current `seedScenario` consumers remain unchanged (`AC-006`).
+  - [ ] Add or adjust scenario endpoint/response support only if needed to improve repeated-step outputs or params handling.
+  - [ ] Document the infrastructure contract in `assets/automation/WORKFLOWS.md` (`AC-009`).
+- Testing Tasks:
+  - [ ] Add targeted tests for workflow parsing/interpolation if cheap in the current automation stack.
+  - [ ] Run at least one existing scenario-seeded Playwright spec to prove additive compatibility (`AC-006`).
+  - Command(s): `cd assets/automation && npx playwright test tests/torus/course_authoring/course-authoring.spec.ts --grep "Content:"`
+- Definition of Done:
+  - The runner can execute at least `scenario -> playwright_action` successfully.
+  - Existing non-workflow scenario-seeded specs still run unchanged (`AC-006`).
+  - `assets/automation/WORKFLOWS.md` exists or is updated with the v1 contract (`AC-009`).
+- Gate:
+  - Gate B: no first-slice group coverage starts until the runner and additive compatibility are proven.
+- Dependencies:
+  - Phase 1 complete.
+- Parallelizable Work:
+  - Backend scenario assertion helpers can be prototyped in parallel as long as they do not require workflow-shape changes.
+
+## Phase 3: Add Post-Playwright Author Preview And Learner Delivery Assertions
+- Goal: Prove the second scenario phase can validate preview and delivery after browser mutations. Supports `AC-001`, `AC-002`, `AC-003`, and `AC-007`.
+- Tasks:
+  - [ ] Implement the scenario-based post-Playwright assertion path for author preview.
+  - [ ] Implement the scenario-based post-Playwright assertion path for learner delivery in a published section context.
+  - [ ] Add or refine scenario hooks/directives only if current scenario surfaces cannot express the required assertions cleanly.
+  - [ ] Keep preview assertions aligned to author preview and not instructor preview (`AC-007`).
+  - [ ] Ensure workflow outputs from browser steps can feed the scenario assertion phase.
+- Testing Tasks:
+  - [ ] Add targeted scenario tests for any new assertion helpers, hooks, or directives.
+  - [ ] Prove one workflow can execute `scenario -> playwright_action -> scenario`.
+  - Command(s): `mix test test/scenarios/features` 
+- Definition of Done:
+  - Author preview can be asserted without manual browser inspection (`AC-002`).
+  - Learner delivery can be asserted without manual browser inspection (`AC-003`).
+  - Workflow alternation works across both pre- and post-browser scenario phases (`AC-001`).
+- Gate:
+  - Gate C: representative group implementation may proceed only after both assertion surfaces are technically viable.
+- Dependencies:
+  - Phase 2 complete.
+- Parallelizable Work:
+  - Separate assertion helpers for preview and delivery can be built in parallel if they consume the same workflow outputs.
+
+## Phase 4: Deliver PR 1 With Representative `MIXED` Groups
+- Goal: Use the new pattern to automate one or two representative `MIXED` groups end to end. Supports `AC-004`, `AC-005`, `AC-008`, and `AC-009`.
+- Tasks:
+  - [ ] Create setup scenario(s) for the chosen representative groups.
+  - [ ] Implement Playwright actions for the chosen representative groups using existing authoring helpers where possible.
+  - [ ] Implement post-Playwright scenario assertion files for persisted state, author preview, and learner delivery as required by the chosen rows (`AC-008`).
+  - [ ] Keep the first PR bounded to the selected groups only (`AC-005`).
+  - [ ] Update the work-item docs to record which groups remain for follow-up slices (`AC-009`).
+  - [ ] Update the matrix so all PR 1 rows move from `planned` to `covered` with concrete workflow test references (`AC-010`).
+- Testing Tasks:
+  - [ ] Run the new workflow-driven Playwright specs for the representative groups.
+  - [ ] Re-run at least one unaffected existing scenario-seeded authoring spec (`AC-006`).
+  - Command(s): `cd assets/automation && npx playwright test tests/torus/course_authoring`
+- Definition of Done:
+  - One or two representative groups are automated end to end using the new pattern (`AC-004`).
+  - Those groups validate persisted authoring state, preview rendering, and learner delivery rendering where applicable (`AC-008`).
+  - The PR clearly documents that remaining groups are follow-up work (`AC-005`, `AC-009`).
+  - The matrix reflects the exact PR 1 covered rows and leaves no undocumented spreadsheet rows (`AC-010`).
+- Gate:
+  - Gate D: PR 1 is ready only when the new pattern has been exercised by real `MIXED` coverage rather than infrastructure-only smoke checks.
+- Dependencies:
+  - Phase 3 complete.
+- Parallelizable Work:
+  - If two representative groups are chosen, their authored-content actions and assertion files can be implemented in parallel once the runner and assertion surfaces are stable.
+
+## Phase 5: Expand Coverage Across Remaining Grouped Slices
+- Goal: Cover the remaining `MIXED` groups in follow-up PRs using the proven workflow pattern. Supports `AC-005` and `AC-009`, while extending the reusable value of `AC-001` through `AC-008`.
+- Tasks:
+  - [ ] Plan follow-up PRs by grouped authoring behavior instead of spreadsheet row order:
+    - `INLINE + LIST + CORE`
+    - `TABLE`
+    - `IMAGE + FIGURE` if not chosen in PR 1
+    - `YOUTUBE + VIDEO + WEBPAGE`
+    - `DIALOG + CONJUGATION + DESCRIPTIONLIST + DEFINITION`
+    - remaining singletons as appropriate
+  - [ ] Reuse the workflow runner, action registry, and scenario assertion pattern for each slice.
+  - [ ] Extend `assets/automation/WORKFLOWS.md` only when the contract itself changes, not for every new row family.
+  - [ ] Keep residual uncovered rows visible in work-item docs until the matrix is exhausted.
+  - [ ] Keep `mixed_coverage_matrix.md` current as each follow-up slice lands, starting with the immediate follow-up PR after Slice 1 (`AC-010`).
+- Testing Tasks:
+  - [ ] Run targeted Playwright coverage per grouped PR.
+  - [ ] Run targeted scenario tests when new hooks/directives are added for later groups.
+  - Command(s): `cd assets/automation && npx playwright test tests/torus/course_authoring`
+- Definition of Done:
+  - Follow-up PRs are organized around shared authoring behavior and helper reuse (`AC-009`).
+  - No follow-up PR re-litigates the workflow contract unless a real gap is discovered.
+  - The matrix remains row-complete and current after each follow-up slice, with the immediate next PR expected to preserve that invariant (`AC-010`).
+- Gate:
+  - Gate E: later groups may merge only if they use the established pattern rather than introducing a second automation style.
+- Dependencies:
+  - Phase 4 complete.
+- Parallelizable Work:
+  - Later grouped PRs can proceed in parallel after PR 1 merges if they do not change the workflow contract itself.
+
+## Parallelization Notes
+- Phases 2 and 3 have limited safe overlap, but assertion-surface work should not force changes to the step contract after Phase 1 closes.
+- Within Phase 4, two representative groups can be split across contributors if they share the same workflow runner base.
+- Phase 5 follow-up slices are the main parallelization opportunity once the pattern is proven and documented.
+
+## Phase Gate Summary
+- Gate A: workflow v1 contract and first-slice groups are fixed.
+- Gate B: additive runner infrastructure works and existing scenario-seeded specs remain compatible. Covers `AC-006` and `AC-009`.
+- Gate C: post-Playwright preview and delivery assertion phases are viable. Covers `AC-001`, `AC-002`, `AC-003`, and `AC-007`.
+- Gate D: PR 1 proves the full pattern on one or two representative `MIXED` groups. Covers `AC-004`, `AC-005`, and `AC-008`.
+- Gate E: grouped follow-up PRs expand coverage using the established pattern rather than inventing a parallel style. Covers `AC-009`.

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/prd.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/prd.md
@@ -1,0 +1,125 @@
+# MER-5416 Automated Basic Page Authored Content - Product Requirements Document
+
+## 1. Overview
+`MER-5416` expands automated basic page authoring coverage so Torus can validate publication-ready authored content against the regression spreadsheet's `MIXED` tab. The work item must also establish a reusable automation pattern for scenario-driven setup, Playwright authoring mutations, and post-Playwright scenario assertions against authoring preview and learner delivery.
+
+The first implementation slice should be delivered as an infrastructure-first PR that proves the new pattern on one or two representative `MIXED` groups. Remaining groups should follow in additional PRs using the same pattern.
+
+## 2. Background & Problem Statement
+Lane 2 of the automated testing epic targets basic page authoring because manual release validation still depends heavily on browser-driven authoring checks. Torus already has some Playwright coverage for basic page authoring, but that coverage is broad and shallow compared to the 80-row `MIXED` matrix used in manual regression.
+
+The Jira story and Darren's comment add an additional requirement beyond “more browser specs”: the system should support a three-stage flow where `Oli.Scenarios` bootstraps the authored world, Playwright mutates the page through the authoring UI, and a second scenario-based phase validates the resulting authored content through authoring preview and learner delivery.
+
+The current repository does not yet provide a reusable `post-Playwright scenario` execution pattern. Without that infrastructure, the team would either stop at browser-visible checks or create one-off assertions that do not scale across the rest of the `MIXED` matrix.
+
+## 3. Goals & Non-Goals
+### Goals
+- Establish a reusable automation pattern for `scenario setup -> Playwright authoring -> post-Playwright scenario assertions`.
+- Support scenario-based assertions for authoring preview rendering and student delivery rendering after Playwright mutates authored content.
+- Use the first PR to prove the pattern on one or two representative `MIXED` groups.
+- Keep subsequent coverage expansion organized by grouped authoring behavior rather than spreadsheet row order.
+- Reuse the existing authoring Playwright fixture, POMs, and scenario seeding infrastructure wherever possible.
+- Keep all test worlds self-seeded and deterministic, with no dependency on pre-existing external state.
+
+### Non-Goals
+- The first PR is not expected to cover all 80 `MIXED` rows.
+- Adaptive authoring and adaptive delivery are out of scope.
+- Instructor preview is not the target preview surface for this work item.
+- This work item does not attempt to replace all browser assertions with scenario-only coverage; Playwright remains part of the pattern.
+- This PRD does not prescribe the exact contents of every follow-up PR beyond grouped coverage boundaries.
+
+## 4. Users & Use Cases
+- QA and release engineering: Need automated evidence that authored basic page content is persisted and rendered correctly without a full manual pass across the `MIXED` matrix.
+- Course authors: Need confidence that common basic page authoring operations produce correct preview and learner-facing results after publication.
+- Engineering teams working on authoring regressions: Need a reusable infrastructure pattern so new matrix rows can be automated without inventing a fresh orchestration flow each time.
+- Future Playwright contributors: Need shared helpers and a stable two-phase scenario pattern rather than ad hoc one-off test wiring.
+
+## 5. UX / UI Requirements
+- Browser automation must operate through the existing course authoring UI entry points for basic page editing.
+- The system must support validating the authoring preview surface as the preview authority for this work item.
+- The system must support validating learner delivery rendering in a published section context after authoring changes are made.
+- Follow-up coverage should group similar authoring behaviors together so helper reuse is practical and test failures remain diagnosable.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+- Reliability: The new test pattern must be deterministic enough for repeated automation use and must avoid reliance on manually pre-created state.
+- Compatibility: Existing Playwright specs that only use scenario seeding must continue to work without adopting the new post-Playwright phase.
+- Maintainability: The first slice must prefer shared fixture and helper extension over one-off orchestration embedded in a single spec.
+- Performance: The additional scenario phase should be scoped narrowly enough to keep the first slice practical to run as targeted browser automation.
+- Security: Scenario execution must continue to use the existing authorized internal test boundary; no new public runtime path should be introduced for production use.
+- Accessibility: No new end-user UI is being introduced, but preview and delivery assertions should prefer semantic selectors or rendered-state checks where practical.
+
+## 9. Data, Interfaces & Dependencies
+- Depends on the existing Playwright scenario seed endpoint in `lib/oli_web/controllers/playwright_scenario_controller.ex`.
+- Depends on the existing Playwright fixture and request helper in:
+  - `assets/automation/src/core/fixture/my-fixture.ts`
+  - `assets/automation/src/core/seedScenario.ts`
+- Depends on existing basic page authoring helpers in:
+  - `assets/automation/src/systems/torus/tasks/CurriculumTask.ts`
+  - `assets/automation/src/systems/torus/pom/page/BasicPracticePagePO.ts`
+  - `assets/automation/src/systems/torus/pom/page/PagePreviewPO.ts`
+- May require new scenario directives, hooks, or orchestration support to:
+  - execute a scenario after Playwright mutations
+  - perform authoring preview assertions
+  - perform learner delivery assertions
+- Uses the `MIXED` spreadsheet tab as the coverage source of truth for grouped follow-up slices.
+
+## 10. Repository & Platform Considerations
+- The repository testing strategy prefers scenarios first, LiveView where appropriate, and Playwright only where browser behavior matters. This work item is explicitly a browser-critical authoring lane, but should still keep setup and deep assertions close to the scenario boundary.
+- The Torus frontend is a mixed Phoenix, LiveView, and targeted browser-app system. The tests must extend the existing authoring surface rather than inventing a separate harness.
+- Scenario infrastructure is already a first-class integration-testing mechanism in this repository, so any post-Playwright assertion phase should fit the existing `Oli.Scenarios` model rather than bypass it.
+- The work item naturally belongs under `docs/exec-plans/current/epics/automated_testing/`, and follow-up slices should remain traceable to `MER-5416` rather than becoming disconnected one-off browser specs.
+
+## 11. Feature Flagging, Rollout & Migration
+No feature flags present in this work item
+
+The rollout strategy is phased delivery by PR:
+- PR 1 introduces the infrastructure pattern plus one or two representative `MIXED` groups.
+- Later PRs extend coverage across the remaining grouped `MIXED` slices using the same pattern.
+
+No production feature rollout or data migration is expected beyond any internal test infrastructure changes required by the implementation.
+
+## 12. Telemetry & Success Metrics
+- Success is measured first by the existence of a reusable post-Playwright scenario pattern that can be consumed by later `MER-5416` slices.
+- Success is measured second by replacing manual validation for at least one or two representative `MIXED` groups with deterministic automated evidence.
+- Operational visibility should rely on existing logging and scenario execution feedback so failures in the second scenario phase are diagnosable.
+- A successful outcome for the full work item is that the remaining `MIXED` groups become straightforward coverage additions rather than new infrastructure projects.
+
+## 13. Risks & Mitigations
+- Risk: The team conflates authoring preview with instructor preview. Mitigation: keep author preview explicit in test helpers, requirements, and scenario assertions.
+- Risk: The first PR becomes too large by trying to absorb the full matrix. Mitigation: require the first PR to stop after infrastructure plus one or two representative groups.
+- Risk: New scenario orchestration breaks existing scenario-seeded Playwright tests. Mitigation: keep the new phase additive and backwards compatible with current fixture usage.
+- Risk: The initial representative groups are too simple and fail to prove the pattern. Mitigation: choose one or two groups with enough settings and rendering richness to exercise persisted, preview, and delivery surfaces.
+- Risk: Later groups drift into a parallel style. Mitigation: require reuse of the initial fixture and helper extensions in follow-up slices.
+
+## 14. Open Questions & Assumptions
+### Open Questions
+- Which one or two `MIXED` groups should be the first slice: a lower-complexity pair such as `IMAGE` and `CODEBLOCK`, or another pair with better infrastructure signal?
+- Should the second scenario phase be implemented as a new endpoint action, a fixture-level helper, or an extension of the existing scenario execution contract?
+- Do authoring preview assertions need new scenario directives, or can they be expressed through hooks against existing preview routes and render boundaries?
+
+### Assumptions
+- `MER-5416` is now a multi-PR work item, not a single small enhancement.
+- The first PR's primary success condition is proving the reusable pattern, not maximizing row count.
+- The `MIXED` spreadsheet tab is the authoritative coverage backlog for follow-up slices.
+- Full coverage expansion will be grouped by shared authoring behavior such as `INLINE`, `TABLE`, or media/embed families.
+
+## 15. QA Plan
+- Automated validation:
+  - validate the new work item's `requirements.yml` and `prd.md` through the harness validation scripts
+  - add targeted Playwright coverage for the initial representative `MIXED` groups
+  - add scenario validation and execution coverage for any new post-Playwright scenario mechanism
+  - verify existing scenario-seeded Playwright specs remain green or unaffected
+- Manual validation:
+  - inspect the first slice's authoring preview and learner delivery behavior only as a sanity check during development
+  - confirm the grouped follow-up plan matches the `MIXED` CSV inventory and does not silently drop uncovered rows
+
+## 16. Definition of Done
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/requirements.yml
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/requirements.yml
@@ -1,0 +1,101 @@
+work_item: mer-5416
+requirements:
+- title: Support a two-phase automation pattern for basic page authoring tests
+  status: proposed
+  id: FR-001
+- title: Enable post-Playwright scenario assertions for authoring preview and student
+    delivery
+  status: proposed
+  id: FR-002
+- title: Keep the first delivery slice limited to infrastructure plus representative
+    `MIXED` groups
+  status: proposed
+  id: FR-003
+- title: Reuse and extend the existing course authoring Playwright helpers instead
+    of creating a parallel style
+  status: proposed
+  id: FR-004
+- title: Organize `MIXED` coverage into grouped follow-up slices after the initial
+    infrastructure PR
+  status: proposed
+  id: FR-005
+- title: Preserve deterministic scenario-driven setup and avoid external pre-seeded
+    state
+  status: proposed
+  id: FR-006
+- title: Validate authored content across persisted state, authoring preview, and
+    learner delivery
+  status: proposed
+  id: FR-007
+- title: Document remaining `MIXED` groups and follow-up slices explicitly after the
+    first PR
+  status: proposed
+  id: FR-008
+- title: Maintain a row-complete workflow coverage matrix for every `MIXED` spreadsheet
+    row
+  status: proposed
+  id: FR-009
+acceptance_criteria:
+- title: The Playwright automation stack can seed a project and page with scenario
+    YAML, perform authoring mutations in the browser, and then execute a second scenario-based
+    assertion phase against the same authored state
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-001
+- title: The post-Playwright assertion phase can evaluate authoring preview rendering
+    for the authored page without requiring manual browser inspection
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-002
+- title: The post-Playwright assertion phase can evaluate learner delivery rendering
+    for the published page in a section context without requiring manual browser inspection
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-003
+- title: The initial implementation PR covers one or two representative `MIXED` groups
+    end to end using the new pattern and proves the pattern is reusable
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-004
+- title: The initial implementation PR does not attempt to absorb full `MIXED`-tab
+    coverage into one batch and instead leaves an explicit grouped follow-up plan
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-005
+- title: Existing Playwright scenario seeding behavior remains compatible for current
+    authoring and student delivery specs that do not use the new post-Playwright phase
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-006
+- title: The first slice preserves the agreed interpretation that authoring preview
+    assertions target author preview, not instructor preview
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-007
+- title: The selected initial groups are validated across persisted authoring state,
+    preview rendering, and learner delivery rendering when those surfaces are in scope
+    for the row group
+  status: proposed
+  verification_method: automated
+  proofs: []
+  id: AC-008
+- title: The work item documents the remaining `MIXED` groups in follow-up slices
+    organized by shared authoring behavior rather than spreadsheet row order
+  status: proposed
+  verification_method: doc
+  proofs: []
+  id: AC-009
+- title: The work item includes a row-complete matrix that maps all 80 `MIXED` spreadsheet
+    rows to workflow coverage status and target follow-up slice, and that matrix
+    is kept current through the initial PR and its immediate follow-up PR
+  status: proposed
+  verification_method: doc
+  proofs: []
+  id: AC-010

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/requirements_bulk.yml
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/requirements_bulk.yml
@@ -1,0 +1,54 @@
+requirements:
+  - title: Support a two-phase automation pattern for basic page authoring tests
+    status: proposed
+  - title: Enable post-Playwright scenario assertions for authoring preview and student delivery
+    status: proposed
+  - title: Keep the first delivery slice limited to infrastructure plus representative `MIXED` groups
+    status: proposed
+  - title: Reuse and extend the existing course authoring Playwright helpers instead of creating a parallel style
+    status: proposed
+  - title: Organize `MIXED` coverage into grouped follow-up slices after the initial infrastructure PR
+    status: proposed
+  - title: Preserve deterministic scenario-driven setup and avoid external pre-seeded state
+    status: proposed
+  - title: Validate authored content across persisted state, authoring preview, and learner delivery
+    status: proposed
+  - title: Document remaining `MIXED` groups and follow-up slices explicitly after the first PR
+    status: proposed
+acceptance_criteria:
+  - title: The Playwright automation stack can seed a project and page with scenario YAML, perform authoring mutations in the browser, and then execute a second scenario-based assertion phase against the same authored state
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The post-Playwright assertion phase can evaluate authoring preview rendering for the authored page without requiring manual browser inspection
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The post-Playwright assertion phase can evaluate learner delivery rendering for the published page in a section context without requiring manual browser inspection
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The initial implementation PR covers one or two representative `MIXED` groups end to end using the new pattern and proves the pattern is reusable
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The initial implementation PR does not attempt to absorb full `MIXED`-tab coverage into one batch and instead leaves an explicit grouped follow-up plan
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: Existing Playwright scenario seeding behavior remains compatible for current authoring and student delivery specs that do not use the new post-Playwright phase
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The first slice preserves the agreed interpretation that authoring preview assertions target author preview, not instructor preview
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The selected initial groups are validated across persisted authoring state, preview rendering, and learner delivery rendering when those surfaces are in scope for the row group
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - title: The work item documents the remaining `MIXED` groups in follow-up slices organized by shared authoring behavior rather than spreadsheet row order
+    status: proposed
+    verification_method: doc
+    proofs: []

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -1,0 +1,254 @@
+defmodule Oli.Scenarios.Features.MixedContentHooks do
+  import ExUnit.Assertions
+  import Phoenix.ConnTest, only: [get: 2, html_response: 2]
+
+  alias Oli.Accounts
+  alias Oli.Accounts.{Author, User}
+  alias Oli.Authoring.Course
+  alias Oli.Delivery.Sections
+  alias Oli.Publishing.{AuthoringResolver, DeliveryResolver}
+  alias Oli.Repo
+  alias Oli.Scenarios.DirectiveTypes.ExecutionState
+  alias Oli.Scenarios.Types.BuiltProject
+  alias OliWeb.Router.Helpers, as: Routes
+
+  @endpoint OliWeb.Endpoint
+
+  @project_name "workflow_authoring_project"
+  @section_name "workflow_delivery_section"
+  @page_title "Mixed Workflow Page"
+  @author_name "workflow_author"
+  @student_name "workflow_student"
+
+  def bind_workflow_context(%ExecutionState{} = state) do
+    author = fetch_author_from_params!(state)
+    student = fetch_student_from_params!(state)
+    project = fetch_project_from_params!(state)
+    section = fetch_section_from_params!(state)
+    revision = fetch_revision_from_params!(state, project.slug)
+
+    built_project = %BuiltProject{
+      project: project,
+      rev_by_title: %{@page_title => revision}
+    }
+
+    %{
+      state
+      | current_author: author,
+        projects: Map.put(state.projects, @project_name, built_project),
+        sections: Map.put(state.sections, @section_name, section),
+        users:
+          state.users
+          |> Map.put(@author_name, author)
+          |> Map.put(@student_name, student),
+        params: Map.put(state.params || %{}, "workflow_page_revision_slug", revision.slug)
+    }
+  end
+
+  def capture_workflow_page_revision_slug(%ExecutionState{} = state) do
+    revision = fetch_page_revision!(state)
+    %{state | params: Map.put(state.params || %{}, "workflow_page_revision_slug", revision.slug)}
+  end
+
+  def assert_author_preview_codeblock(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    text = html_text(html)
+
+    assert_contains(text, state.params["EXPECTED_CODEBLOCK_CAPTION"])
+    assert_contains(text, state.params["EXPECTED_CODEBLOCK_CODE"])
+
+    state
+  end
+
+  def assert_student_delivery_codeblock(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+
+    assert nested_contains?(content, state.params["EXPECTED_CODEBLOCK_CAPTION"])
+    assert nested_contains?(content, state.params["EXPECTED_CODEBLOCK_CODE"])
+
+    state
+  end
+
+  def assert_author_preview_reachable(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    assert_contains(html_text(html), "Preview Mode")
+    state
+  end
+
+  def assert_delivery_revision_reachable(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    assert is_map(content)
+    state
+  end
+
+  def assert_author_preview_callout(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    text = html_text(html)
+
+    assert_contains(text, state.params["EXPECTED_CALLOUT_TEXT"])
+
+    state
+  end
+
+  def assert_student_delivery_callout(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+
+    assert nested_contains?(content, state.params["EXPECTED_CALLOUT_TEXT"])
+
+    state
+  end
+
+  defp author_preview_html(%ExecutionState{} = state) do
+    author = fetch_user!(state, @author_name)
+    built_project = fetch_project!(state)
+    revision = fetch_page_revision!(state)
+
+    build_conn_as_author(author)
+    |> get(Routes.resource_path(@endpoint, :preview, built_project.project.slug, revision.slug))
+    |> html_response(200)
+  end
+
+  defp delivered_revision_content(%ExecutionState{} = state) do
+    section = fetch_section!(state)
+    revision = fetch_page_revision!(state)
+
+    case DeliveryResolver.from_resource_id(section.slug, revision.resource_id) do
+      nil ->
+        raise "Delivery revision for resource #{revision.resource_id} not found in section #{section.slug}"
+
+      delivered_revision ->
+        delivered_revision.content
+    end
+  end
+
+  defp fetch_project!(%ExecutionState{} = state) do
+    case Map.get(state.projects, @project_name) do
+      nil -> raise "Project #{@project_name} not found in scenario state"
+      built_project -> built_project
+    end
+  end
+
+  defp fetch_section!(%ExecutionState{} = state) do
+    case Map.get(state.sections, @section_name) do
+      nil -> raise "Section #{@section_name} not found in scenario state"
+      section -> section
+    end
+  end
+
+  defp fetch_user!(%ExecutionState{} = state, name) do
+    case Map.get(state.users, name) do
+      nil -> raise "User #{name} not found in scenario state"
+      user -> user
+    end
+  end
+
+  defp fetch_page_revision!(%ExecutionState{} = state) do
+    built_project = fetch_project!(state)
+
+    case Map.get(built_project.rev_by_title, @page_title) do
+      nil -> raise "Page #{@page_title} not found in built project"
+      revision -> revision
+    end
+  end
+
+  defp fetch_author_from_params!(%ExecutionState{} = state) do
+    email = required_param!(state, "AUTHOR_EMAIL")
+
+    case Accounts.get_author_by_email(email) do
+      %Author{} = author -> author
+      _ -> raise "Author with email #{email} not found"
+    end
+  end
+
+  defp fetch_student_from_params!(%ExecutionState{} = state) do
+    email = required_param!(state, "STUDENT_EMAIL")
+
+    case Repo.get_by(User, email: email) do
+      %User{} = user -> user
+      _ -> raise "User with email #{email} not found"
+    end
+  end
+
+  defp fetch_project_from_params!(%ExecutionState{} = state) do
+    slug = required_param!(state, "PROJECT_SLUG")
+
+    case Course.get_project_by_slug(slug) do
+      nil -> raise "Project with slug #{slug} not found"
+      project -> project
+    end
+  end
+
+  defp fetch_section_from_params!(%ExecutionState{} = state) do
+    slug = required_param!(state, "SECTION_SLUG")
+
+    case Sections.get_section_by(slug: slug) do
+      nil -> raise "Section with slug #{slug} not found"
+      section -> section
+    end
+  end
+
+  defp fetch_revision_from_params!(%ExecutionState{} = state, project_slug) do
+    revision_slug = required_param!(state, "PAGE_REVISION_SLUG")
+
+    case AuthoringResolver.from_revision_slug(project_slug, revision_slug) do
+      nil -> raise "Revision with slug #{revision_slug} not found for project #{project_slug}"
+      revision -> revision
+    end
+  end
+
+  defp assert_contains(html, expected) when is_binary(expected) and expected != "" do
+    assert html =~ expected
+  end
+
+  defp assert_contains(_html, expected) do
+    raise "Expected non-empty string assertion value, got: #{inspect(expected)}"
+  end
+
+  defp required_param!(%ExecutionState{} = state, key) do
+    case Map.get(state.params || %{}, key) do
+      value when is_binary(value) and value != "" ->
+        value
+
+      value ->
+        raise "Expected scenario param #{key} to be a non-empty string, got: #{inspect(value)}"
+    end
+  end
+
+  defp html_text(html) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.text(sep: " ")
+  end
+
+  defp build_conn_as_author(author) do
+    token = Accounts.generate_author_session_token(author)
+
+    Phoenix.ConnTest.build_conn()
+    |> Phoenix.ConnTest.init_test_session(%{})
+    |> Plug.Conn.put_session(:author_token, token)
+    |> Plug.Conn.put_session(:current_author_id, author.id)
+  end
+
+  defp nested_contains?(value, expected) when is_binary(expected) and expected != "" do
+    case value do
+      text when is_binary(text) ->
+        String.contains?(text, expected)
+
+      ^expected ->
+        true
+
+      list when is_list(list) ->
+        Enum.any?(list, &nested_contains?(&1, expected))
+
+      map when is_map(map) ->
+        map
+        |> Map.values()
+        |> Enum.any?(&nested_contains?(&1, expected))
+
+      _ ->
+        false
+    end
+  end
+
+  defp nested_contains?(_value, _expected), do: false
+end

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -1,4 +1,9 @@
 defmodule Oli.Scenarios.Features.MixedContentHooks do
+  @moduledoc """
+  Scenario hooks that rebuild mixed-workflow context and assert author preview
+  plus published delivery content after Playwright authoring steps.
+  """
+
   import ExUnit.Assertions
   import Phoenix.ConnTest, only: [get: 2, html_response: 2]
 
@@ -20,6 +25,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
   @author_name "workflow_author"
   @student_name "workflow_student"
 
+  @doc """
+  Rebuilds the scenario execution state from workflow params after a Playwright step.
+  """
   def bind_workflow_context(%ExecutionState{} = state) do
     author = fetch_author_from_params!(state)
     student = fetch_student_from_params!(state)
@@ -45,11 +53,17 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     }
   end
 
+  @doc """
+  Captures the authored page revision slug into scenario params for later workflow steps.
+  """
   def capture_workflow_page_revision_slug(%ExecutionState{} = state) do
     revision = fetch_page_revision!(state)
     %{state | params: Map.put(state.params || %{}, "workflow_page_revision_slug", revision.slug)}
   end
 
+  @doc """
+  Asserts that the author preview renders the expected code block content.
+  """
   def assert_author_preview_codeblock(%ExecutionState{} = state) do
     html = author_preview_html(state)
     text = html_text(html)
@@ -60,6 +74,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that the published delivery revision contains the expected code block content.
+  """
   def assert_student_delivery_codeblock(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
 
@@ -69,18 +86,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
-  def assert_author_preview_reachable(%ExecutionState{} = state) do
-    html = author_preview_html(state)
-    assert_contains(html_text(html), "Preview Mode")
-    state
-  end
-
-  def assert_delivery_revision_reachable(%ExecutionState{} = state) do
-    content = delivered_revision_content(state)
-    assert is_map(content)
-    state
-  end
-
+  @doc """
+  Asserts that the author preview renders the expected callout content.
+  """
   def assert_author_preview_callout(%ExecutionState{} = state) do
     html = author_preview_html(state)
     text = html_text(html)
@@ -90,6 +98,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that the published delivery revision contains the expected callout content.
+  """
   def assert_student_delivery_callout(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
 

--- a/test/oli_web/components/delivery/learning_objectives/student_proficiency_list_test.exs
+++ b/test/oli_web/components/delivery/learning_objectives/student_proficiency_list_test.exs
@@ -4,7 +4,6 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.StudentProficiencyListTe
   import LiveComponentTests
   import Phoenix.LiveViewTest
 
-  alias LiveComponentTests.Driver
   alias OliWeb.Components.Delivery.LearningObjectives.StudentProficiencyList
 
   describe "StudentProficiencyList component" do


### PR DESCRIPTION
## Jira

https://eliterate.atlassian.net/browse/MER-5416

## Summary

- add a reusable workflow runner for automation that alternates scenario setup/assertions with Playwright actions
- document the workflow contract and add a row-complete mixed coverage matrix for the `MIXED` spreadsheet tab
- add initial mixed workflow coverage for code block and callout, including author preview and published delivery assertions
- keep this PR intentionally limited to the foundational workflow infrastructure plus the first representative mixed-content slice

## Implementation Notes

- `runWorkflow(...)` is additive and does not replace `seedScenario(...)`
- this PR is foundational: it extends the automation stack to support multi-step scenario/playwright workflows
- the first coverage slice is intentionally limited to `CODEBLOCK` and `CALLOUT`
- the remaining rows tracked in `mixed_coverage_matrix.md` are expected to land in follow-up PRs
- the goal is to avoid one oversized PR and prove the workflow pattern before expanding across the rest of the matrix
- mixed workflow assertions rebuild context in Elixir hooks and validate both author preview and published delivery content

## Validation

- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- `npx playwright test tests/torus/course_authoring/mixed-workflow.spec.ts --reporter=line`
- `mix test`
