### PR TITLE
[BUG FIX] [MER-5500] Fix Playwright payment session token transport

### DIFF
--- a/assets/automation/tests/torus/student_payment/support.spec.ts
+++ b/assets/automation/tests/torus/student_payment/support.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { setRuntimeConfig } from '@core/runtimeConfig';
+import { logInAsScenarioUser } from './support';
+
+test.describe('student payment support', () => {
+  test('logInAsScenarioUser authenticates with header and not query params', async ({ page }) => {
+    const baseUrl = 'http://localhost';
+    const email = 'student@example.com';
+    const requestPath = '/sections/demo-section';
+
+    setRuntimeConfig({
+      baseUrl,
+      scenarioToken: 'scenario-secret',
+    });
+
+    let capturedHeader: string | undefined;
+    let capturedTokenParam: string | null = null;
+    let capturedEmailParam: string | null = null;
+    let capturedRequestPathParam: string | null = null;
+
+    await page.route(`${baseUrl}/test/log_in_user**`, async (route) => {
+      const request = route.request();
+      const url = new URL(request.url());
+
+      capturedHeader = request.headers()['x-playwright-scenario-token'];
+      capturedTokenParam = url.searchParams.get('token');
+      capturedEmailParam = url.searchParams.get('email');
+      capturedRequestPathParam = url.searchParams.get('request_path');
+
+      await route.fulfill({
+        status: 302,
+        headers: {
+          location: `${baseUrl}${requestPath}`,
+        },
+      });
+    });
+
+    await page.route(`${baseUrl}${requestPath}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<html><body>ok</body></html>',
+      });
+    });
+
+    await logInAsScenarioUser(page, email, requestPath);
+
+    expect(capturedHeader).toBe('scenario-secret');
+    expect(capturedTokenParam).toBeNull();
+    expect(capturedEmailParam).toBe(email);
+    expect(capturedRequestPathParam).toBe(requestPath);
+  });
+});

--- a/assets/automation/tests/torus/student_payment/support.ts
+++ b/assets/automation/tests/torus/student_payment/support.ts
@@ -78,14 +78,22 @@ export async function logInAsScenarioUser(
   expectedPath = requestPath,
 ) {
   const baseUrl = getBaseUrl();
+  const scenarioToken = getScenarioToken();
   const loginUrl = new URL('/test/log_in_user', baseUrl);
 
-  loginUrl.searchParams.set('token', getScenarioToken());
   loginUrl.searchParams.set('email', email);
   loginUrl.searchParams.set('request_path', requestPath);
 
-  await page.goto(loginUrl.toString(), { waitUntil: 'load' });
-  await expect(page).toHaveURL(new RegExp(escapeRegExp(expectedPath)));
+  await page.context().setExtraHTTPHeaders({
+    'x-playwright-scenario-token': scenarioToken,
+  });
+
+  try {
+    await page.goto(loginUrl.toString(), { waitUntil: 'load' });
+    await expect(page).toHaveURL(new RegExp(escapeRegExp(expectedPath)));
+  } finally {
+    await page.context().setExtraHTTPHeaders({});
+  }
 }
 
 export async function postJsonInBrowser<T>(

--- a/assets/automation/tests/torus/student_payment/support.ts
+++ b/assets/automation/tests/torus/student_payment/support.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test';
+import { expect, type Page, type Route } from '@playwright/test';
 import { type SeedScenarioResponse } from '@core/seedScenario';
 import { getBaseUrl, getScenarioToken } from '@core/runtimeConfig';
 
@@ -83,17 +83,10 @@ export async function logInAsScenarioUser(
 
   loginUrl.searchParams.set('email', email);
   loginUrl.searchParams.set('request_path', requestPath);
-
-  await page.context().setExtraHTTPHeaders({
-    'x-playwright-scenario-token': scenarioToken,
-  });
-
-  try {
+  await withScenarioTokenOnLoginRequest(page, loginUrl, scenarioToken, async () => {
     await page.goto(loginUrl.toString(), { waitUntil: 'load' });
     await expect(page).toHaveURL(new RegExp(escapeRegExp(expectedPath)));
-  } finally {
-    await page.context().setExtraHTTPHeaders({});
-  }
+  });
 }
 
 export async function postJsonInBrowser<T>(
@@ -156,6 +149,31 @@ export async function submitPaymentCode(page: Page, code: string) {
   });
 
   await page.getByRole('button', { name: 'Submit' }).click();
+}
+
+async function withScenarioTokenOnLoginRequest(
+  page: Page,
+  loginUrl: URL,
+  scenarioToken: string,
+  action: () => Promise<void>,
+) {
+  const loginUrlPattern = `${loginUrl.toString()}**`;
+  const addScenarioTokenToLoginRequest = async (route: Route) => {
+    await route.fallback({
+      headers: {
+        ...route.request().headers(),
+        'x-playwright-scenario-token': scenarioToken,
+      },
+    });
+  };
+
+  await page.route(loginUrlPattern, addScenarioTokenToLoginRequest);
+
+  try {
+    await action();
+  } finally {
+    await page.unroute(loginUrlPattern, addScenarioTokenToLoginRequest);
+  }
 }
 
 function escapeRegExp(value: string) {


### PR DESCRIPTION
## Jira
https://eliterate.atlassian.net/browse/MER-5500

## Summary
- fix the Playwright student payment login helper to send the scenario token in the `x-playwright-scenario-token` header
- add a focused Playwright regression spec for the helper contract
- keep the backend contract unchanged

## Bug Origin
The regression was introduced in the AI review commit:
https://github.com/Simon-Initiative/oli-torus/commit/f88908e8552eae6e02489741e96038a47e5df524

That change hardened the backend session helper to accept the scenario token only from the `x-playwright-scenario-token` header, but the Playwright payment helper still sent the token in the query string. As a result, payment smoke tests could stop at `/test/log_in_user` instead of reaching the seeded section.

## Fix
- update the Playwright helper to send the token via header instead of query params
- add a regression spec that verifies the header is present and the `token` query param is absent

## Validation
- `cd assets/automation && npx playwright test tests/torus/student_payment/support.spec.ts`
- `cd assets/automation && npx playwright test tests/torus/student_payment/payment-unlock.spec.ts --grep "learner unlocks a paid section with a payment code"`
- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`

## Image
<img width="620" height="564" alt="image" src="https://github.com/user-attachments/assets/28782585-e7bc-4dc1-b531-059e59aad60d" />



