### PR TITLE
[BUG FIX] [MER-5780] Add accessible titles and descriptions to adaptive iframes

### DIFF
--- a/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
@@ -9,12 +9,13 @@ import { clone, parseBoolean } from 'utils/common';
 import { CapiVariable } from '../../../adaptivity/capi';
 import CapiVariablePicker from './CapiVariablePicker';
 import { JanusCAPIRequestTypes } from './JanusCAPIRequestTypes';
-import { CapiIframeModel } from './schema';
+import { CapiIframeModel, resolveIframeTitle } from './schema';
 import { resolveAdaptiveIframeSource } from './sourceResolver';
 
 const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (props) => {
   const { model, configuremode, onConfigure, onCancelConfigure, onSaveConfigure } = props;
   const { z, width, height, src, configData } = model;
+  const iframeTitle = resolveIframeTitle(model.description);
   const id: string = props.id;
   const [simFrame, setSimFrame] = useState<HTMLIFrameElement>();
   const messageListener = useRef<any>(null);
@@ -390,6 +391,7 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
         {configClicked ? (
           <iframe
             ref={frameRef}
+            title={iframeTitle}
             style={{ height: '100%', width: '100%' }}
             data-janus-type={tagName}
             src={resolvedSrc}
@@ -417,6 +419,7 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
                     }
                     <iframe
                       ref={frameRef}
+                      title={iframeTitle}
                       style={{ display: 'none', height: '100%', width: '100%' }}
                       data-janus-type={tagName}
                       scrolling={props.type?.toLowerCase() === 'janus-capi-iframe' ? 'no' : ''}

--- a/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/CapiIframeAuthor.tsx
@@ -9,14 +9,16 @@ import { clone, parseBoolean } from 'utils/common';
 import { CapiVariable } from '../../../adaptivity/capi';
 import CapiVariablePicker from './CapiVariablePicker';
 import { JanusCAPIRequestTypes } from './JanusCAPIRequestTypes';
-import { CapiIframeModel, resolveIframeTitle } from './schema';
+import { CapiIframeModel, resolveIframeDescription, resolveIframeTitle } from './schema';
 import { resolveAdaptiveIframeSource } from './sourceResolver';
 
 const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (props) => {
   const { model, configuremode, onConfigure, onCancelConfigure, onSaveConfigure } = props;
   const { z, width, height, src, configData } = model;
-  const iframeTitle = resolveIframeTitle(model.description);
   const id: string = props.id;
+  const iframeTitle = resolveIframeTitle(model.title);
+  const iframeDescription = resolveIframeDescription(model.description);
+  const descriptionId = `${id}-description`;
   const [simFrame, setSimFrame] = useState<HTMLIFrameElement>();
   const messageListener = useRef<any>(null);
   const [inConfigureMode, setInConfigureMode] = useState<boolean>(parseBoolean(configuremode));
@@ -392,6 +394,7 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
           <iframe
             ref={frameRef}
             title={iframeTitle}
+            aria-describedby={iframeDescription ? descriptionId : undefined}
             style={{ height: '100%', width: '100%' }}
             data-janus-type={tagName}
             src={resolvedSrc}
@@ -420,6 +423,7 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
                     <iframe
                       ref={frameRef}
                       title={iframeTitle}
+                      aria-describedby={iframeDescription ? descriptionId : undefined}
                       style={{ display: 'none', height: '100%', width: '100%' }}
                       data-janus-type={tagName}
                       scrolling={props.type?.toLowerCase() === 'janus-capi-iframe' ? 'no' : ''}
@@ -429,6 +433,11 @@ const CapiIframeAuthor: React.FC<AuthorPartComponentProps<CapiIframeModel>> = (p
               </div>
             </div>
           </div>
+        )}
+        {iframeDescription && (
+          <span id={descriptionId} className="sr-only">
+            {iframeDescription}
+          </span>
         )}
       </div>
     </React.Fragment>

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -17,7 +17,7 @@ import {
   getExternalIframeStyles,
   shouldAllowIframeScrolling,
 } from './iframeBehavior';
-import { CapiIframeModel, resolveIframeTitle } from './schema';
+import { CapiIframeModel, resolveIframeDescription, resolveIframeTitle } from './schema';
 import { resolveAdaptiveIframeSource, sanitizeAdaptiveIframeFallbackHref } from './sourceResolver';
 
 const externalActivityMap: Map<string, any> = new Map();
@@ -31,6 +31,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [initStateBindToFacts, setInitStateBindToFacts] = useState<any>({});
   const [screenContext, setScreenContext] = useState('');
   const id: string = props.id;
+  const descriptionId = `${id}-description`;
   const contextRef = useRef('VIEWER');
 
   const [scriptEnv, setScriptEnv] = useState<any>();
@@ -52,7 +53,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
   const [lessonId, setLessonId] = useState('');
 
   // these rely on being set every render and the "model" useState value being set
-  const { configData, description } = model;
+  const { configData, description, title } = model;
   const iframeFallback = model?.dynamicLinkFallback;
   const showIframeFallback = iframeFallback?.type === 'unresolved_internal_source';
   const fallbackMessage =
@@ -1225,7 +1226,8 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       ? templatizeText(description, simLife?.snapshot, scriptEnv)
       : description;
   }, [description, simLife.snapshot, scriptEnv]);
-  const iframeTitle = resolveIframeTitle(formattedDescription);
+  const iframeTitle = resolveIframeTitle(title);
+  const iframeDescription = resolveIframeDescription(formattedDescription);
 
   const resolvedFrameSrc = resolveAdaptiveIframeSource(frameSrc);
 
@@ -1238,9 +1240,14 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         title={iframeTitle}
         src={resolvedFrameSrc}
         scrolling={scrolling}
-        aria-describedby={id}
+        aria-describedby={iframeDescription ? descriptionId : undefined}
         allow="accelerometer *; magnetometer; gyroscope; fullscreen; autoplay; clipboard-write; encrypted-media; xr-spatial-tracking; gamepad *;"
       />
+      {iframeDescription && (
+        <span id={descriptionId} className="sr-only">
+          {iframeDescription}
+        </span>
+      )}
       {showIframeFallback && (
         <div role="status" aria-live="polite" style={fallbackOverlayStyles}>
           <div>{fallbackMessage}</div>

--- a/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
+++ b/assets/src/components/parts/janus-capi-iframe/ExternalActivity.tsx
@@ -17,7 +17,7 @@ import {
   getExternalIframeStyles,
   shouldAllowIframeScrolling,
 } from './iframeBehavior';
-import { CapiIframeModel } from './schema';
+import { CapiIframeModel, resolveIframeTitle } from './schema';
 import { resolveAdaptiveIframeSource, sanitizeAdaptiveIframeFallbackHref } from './sourceResolver';
 
 const externalActivityMap: Map<string, any> = new Map();
@@ -1225,6 +1225,7 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
       ? templatizeText(description, simLife?.snapshot, scriptEnv)
       : description;
   }, [description, simLife.snapshot, scriptEnv]);
+  const iframeTitle = resolveIframeTitle(formattedDescription);
 
   const resolvedFrameSrc = resolveAdaptiveIframeSource(frameSrc);
 
@@ -1234,10 +1235,9 @@ const ExternalActivity: React.FC<PartComponentProps<CapiIframeModel>> = (props) 
         data-janus-type={tagName}
         ref={frameRef}
         style={getExternalIframeStyles(externalActivityStyles, iframeScrollingEnabled)}
-        title={formattedDescription || description}
+        title={iframeTitle}
         src={resolvedFrameSrc}
         scrolling={scrolling}
-        aria-label={formattedDescription || description}
         aria-describedby={id}
         allow="accelerometer *; magnetometer; gyroscope; fullscreen; autoplay; clipboard-write; encrypted-media; xr-spatial-tracking; gamepad *;"
       />

--- a/assets/src/components/parts/janus-capi-iframe/schema.ts
+++ b/assets/src/components/parts/janus-capi-iframe/schema.ts
@@ -20,6 +20,7 @@ export interface IframeDynamicLinkFallback {
 
 export interface CapiIframeModel extends JanusAbsolutePositioned, JanusCustomCss {
   src: string;
+  description?: string;
   source?: string;
   sourceType?: IframeSourceMode;
   sourcePageSlug?: string;
@@ -30,6 +31,11 @@ export interface CapiIframeModel extends JanusAbsolutePositioned, JanusCustomCss
   configData: any;
   allowScrolling: boolean;
 }
+
+export const DEFAULT_IFRAME_TITLE = 'Embedded content';
+
+export const resolveIframeTitle = (title?: string): string =>
+  title?.trim() ? title : DEFAULT_IFRAME_TITLE;
 
 const SOURCE_PREFIX = '/course/link/';
 const defaultSourceConfig = (): IframeSourceEditorConfig => ({
@@ -108,8 +114,8 @@ export const simpleSchema: JSONSchema7Object = {
     type: 'boolean',
   },
   description: {
-    title: 'description',
-    description: 'provides title and aria-label content',
+    title: 'Title',
+    description: 'Provides an accessible title for the embedded content',
     type: 'string',
   },
 };
@@ -124,8 +130,8 @@ export const schema: JSONSchema7Object = {
     type: 'string',
   },
   description: {
-    title: 'description',
-    description: 'provides title and aria-label content',
+    title: 'Title',
+    description: 'Provides an accessible title for the embedded content',
     type: 'string',
   },
   allowScrolling: {
@@ -228,6 +234,7 @@ export const transformModelToSchema = (model: Partial<CapiIframeModel>) => {
 
   return {
     ...model,
+    description: resolveIframeTitle(model.description),
     source: encodeSourceConfig(sourceConfig),
   };
 };
@@ -282,6 +289,7 @@ export const simpleUISchema = {
 
 export const createSchema = (): Partial<CapiIframeModel> => ({
   customCssClass: '',
+  description: DEFAULT_IFRAME_TITLE,
   src: '',
   source: encodeSourceConfig(defaultSourceConfig()),
   sourceType: 'url',

--- a/assets/src/components/parts/janus-capi-iframe/schema.ts
+++ b/assets/src/components/parts/janus-capi-iframe/schema.ts
@@ -20,6 +20,7 @@ export interface IframeDynamicLinkFallback {
 
 export interface CapiIframeModel extends JanusAbsolutePositioned, JanusCustomCss {
   src: string;
+  title?: string;
   description?: string;
   source?: string;
   sourceType?: IframeSourceMode;
@@ -36,6 +37,9 @@ export const DEFAULT_IFRAME_TITLE = 'Embedded content';
 
 export const resolveIframeTitle = (title?: string): string =>
   title?.trim() ? title : DEFAULT_IFRAME_TITLE;
+
+export const resolveIframeDescription = (description?: string): string | undefined =>
+  description?.trim() ? description : undefined;
 
 const SOURCE_PREFIX = '/course/link/';
 const defaultSourceConfig = (): IframeSourceEditorConfig => ({
@@ -113,9 +117,14 @@ export const simpleSchema: JSONSchema7Object = {
     title: 'Allow Scrolling',
     type: 'boolean',
   },
-  description: {
+  title: {
     title: 'Title',
     description: 'Provides an accessible title for the embedded content',
+    type: 'string',
+  },
+  description: {
+    title: 'Description',
+    description: 'Provides additional accessible context for the embedded content',
     type: 'string',
   },
 };
@@ -129,9 +138,14 @@ export const schema: JSONSchema7Object = {
     title: 'Source',
     type: 'string',
   },
-  description: {
+  title: {
     title: 'Title',
     description: 'Provides an accessible title for the embedded content',
+    type: 'string',
+  },
+  description: {
+    title: 'Description',
+    description: 'Provides additional accessible context for the embedded content',
     type: 'string',
   },
   allowScrolling: {
@@ -234,7 +248,7 @@ export const transformModelToSchema = (model: Partial<CapiIframeModel>) => {
 
   return {
     ...model,
-    description: resolveIframeTitle(model.description),
+    title: resolveIframeTitle(model.title),
     source: encodeSourceConfig(sourceConfig),
   };
 };
@@ -289,7 +303,8 @@ export const simpleUISchema = {
 
 export const createSchema = (): Partial<CapiIframeModel> => ({
   customCssClass: '',
-  description: DEFAULT_IFRAME_TITLE,
+  title: DEFAULT_IFRAME_TITLE,
+  description: '',
   src: '',
   source: encodeSourceConfig(defaultSourceConfig()),
   sourceType: 'url',

--- a/assets/test/advanced_authoring/right_menu/component/iframe_source_schema_test.ts
+++ b/assets/test/advanced_authoring/right_menu/component/iframe_source_schema_test.ts
@@ -1,10 +1,60 @@
 import {
+  DEFAULT_IFRAME_TITLE,
+  createSchema,
   decodeSourceConfig,
+  resolveIframeTitle,
+  schema,
+  simpleSchema,
   transformModelToSchema,
   transformSchemaToModel,
 } from 'components/parts/janus-capi-iframe/schema';
 
 describe('janus-capi-iframe source schema transforms', () => {
+  it('exposes the accessible title in simple and advanced authoring', () => {
+    expect(simpleSchema.description).toMatchObject({
+      title: 'Title',
+      type: 'string',
+    });
+    expect(schema.description).toMatchObject({
+      title: 'Title',
+      type: 'string',
+    });
+  });
+
+  it('creates new iframes with the default accessible title', () => {
+    expect(createSchema().description).toBe(DEFAULT_IFRAME_TITLE);
+  });
+
+  it.each([undefined, '', '   '])(
+    'uses the default accessible title when the stored title is %p',
+    (description) => {
+      expect(resolveIframeTitle(description)).toBe(DEFAULT_IFRAME_TITLE);
+      expect(
+        transformModelToSchema({ src: 'https://example.com/widget', description }).description,
+      ).toBe(DEFAULT_IFRAME_TITLE);
+    },
+  );
+
+  it('preserves an author-provided accessible title', () => {
+    const description = 'Interactive population model';
+
+    expect(resolveIframeTitle(description)).toBe(description);
+    expect(
+      transformModelToSchema({ src: 'https://example.com/widget', description }).description,
+    ).toBe(description);
+    expect(
+      transformSchemaToModel({
+        source: JSON.stringify({
+          mode: 'url',
+          pageId: null,
+          pageSlug: '',
+          url: 'https://example.com/widget',
+        }),
+        description,
+      }).description,
+    ).toBe(description);
+  });
+
   it('encodes legacy external src into source config for editor', () => {
     const transformed = transformModelToSchema({
       src: 'https://example.com/widget',

--- a/assets/test/advanced_authoring/right_menu/component/iframe_source_schema_test.ts
+++ b/assets/test/advanced_authoring/right_menu/component/iframe_source_schema_test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_IFRAME_TITLE,
   createSchema,
   decodeSourceConfig,
+  resolveIframeDescription,
   resolveIframeTitle,
   schema,
   simpleSchema,
@@ -10,38 +11,58 @@ import {
 } from 'components/parts/janus-capi-iframe/schema';
 
 describe('janus-capi-iframe source schema transforms', () => {
-  it('exposes the accessible title in simple and advanced authoring', () => {
+  it('exposes separate accessible title and description fields in both authoring modes', () => {
+    expect(simpleSchema.title).toMatchObject({
+      title: 'Title',
+      type: 'string',
+    });
     expect(simpleSchema.description).toMatchObject({
+      title: 'Description',
+      type: 'string',
+    });
+    expect(schema.title).toMatchObject({
       title: 'Title',
       type: 'string',
     });
     expect(schema.description).toMatchObject({
-      title: 'Title',
+      title: 'Description',
       type: 'string',
     });
   });
 
   it('creates new iframes with the default accessible title', () => {
-    expect(createSchema().description).toBe(DEFAULT_IFRAME_TITLE);
+    expect(createSchema()).toMatchObject({
+      title: DEFAULT_IFRAME_TITLE,
+      description: '',
+    });
   });
 
   it.each([undefined, '', '   '])(
     'uses the default accessible title when the stored title is %p',
-    (description) => {
-      expect(resolveIframeTitle(description)).toBe(DEFAULT_IFRAME_TITLE);
-      expect(
-        transformModelToSchema({ src: 'https://example.com/widget', description }).description,
-      ).toBe(DEFAULT_IFRAME_TITLE);
+    (title) => {
+      expect(resolveIframeTitle(title)).toBe(DEFAULT_IFRAME_TITLE);
+      expect(transformModelToSchema({ src: 'https://example.com/widget', title }).title).toBe(
+        DEFAULT_IFRAME_TITLE,
+      );
     },
   );
 
-  it('preserves an author-provided accessible title', () => {
-    const description = 'Interactive population model';
+  it.each([undefined, '', '   '])(
+    'omits the accessible description when the stored description is %p',
+    (description) => {
+      expect(resolveIframeDescription(description)).toBeUndefined();
+    },
+  );
 
-    expect(resolveIframeTitle(description)).toBe(description);
+  it('preserves separate author-provided title and description values', () => {
+    const title = 'Population model';
+    const description = 'An interactive model of population growth';
+
+    expect(resolveIframeTitle(title)).toBe(title);
+    expect(resolveIframeDescription(description)).toBe(description);
     expect(
-      transformModelToSchema({ src: 'https://example.com/widget', description }).description,
-    ).toBe(description);
+      transformModelToSchema({ src: 'https://example.com/widget', title, description }),
+    ).toMatchObject({ title, description });
     expect(
       transformSchemaToModel({
         source: JSON.stringify({
@@ -50,9 +71,21 @@ describe('janus-capi-iframe source schema transforms', () => {
           pageSlug: '',
           url: 'https://example.com/widget',
         }),
+        title,
         description,
-      }).description,
-    ).toBe(description);
+      }),
+    ).toMatchObject({ title, description });
+  });
+
+  it('maps an existing description to the accessible description and defaults its title', () => {
+    const description = 'Legacy iframe description';
+
+    expect(
+      transformModelToSchema({ src: 'https://example.com/widget', description }),
+    ).toMatchObject({
+      title: DEFAULT_IFRAME_TITLE,
+      description,
+    });
   });
 
   it('encodes legacy external src into source config for editor', () => {


### PR DESCRIPTION
This is a fix for [MER-5780](https://eliterate.atlassian.net/browse/MER-5780). I am adding an aria label to the iframe component in Advanced Author and Simple Author. The previously set description should also still be available and continue being announced. 

- Adds a separate, editable Title field to the iframe component in Simple Author and Advanced Author.
- Defaults missing or blank iframe titles to `Embedded content`, including existing content.
- Preserves the existing Description field and uses it as the iframe’s accessible description.
- Associates descriptions through a dedicated `aria-describedby` target.
- Removes the redundant `aria-label` and the previous container-level description association that caused repeated and unrelated screen-reader announcements.
- Requires no content or database migration.

## Testing

### Automated

- 43 related Jest tests pass.
- TypeScript check passes.
- ESLint passes.
- Prettier passes.
- Git diff check passes.

### Manual

Verified in authoring and delivery that:

- Title and Description are separate editable fields.
- Custom values persist after saving and refreshing.
- Existing iframe descriptions remain available.
- Missing titles use `Embedded content`.
- Empty descriptions do not add `aria-describedby`.
- VoiceOver announces the title once, followed by the description.
- Surrounding screen titles are no longer included in the iframe announcement.
- External iframe content continues to load and scroll normally.

[MER-5780]: https://eliterate.atlassian.net/browse/MER-5780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ