### PR TITLE
[BUG FIX] [MER-5782] Announce answer text for basic MCQ/CATA choices

### DIFF
--- a/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
+++ b/assets/src/components/activities/common/choices/delivery/ChoicesDelivery.tsx
@@ -3,6 +3,7 @@ import { Choice, ChoiceId } from 'components/activities/types';
 import { WriterContext } from 'data/content/writers/context';
 import { HtmlContentModelRenderer } from 'data/content/writers/renderer';
 import { classNames } from 'utils/classNames';
+import guid from 'utils/guid';
 import styles from './ChoicesDelivery.modules.scss';
 
 const INTERACTIVE_SELECTOR = [
@@ -38,6 +39,7 @@ export const ChoicesDelivery: React.FC<Props> = ({
   disabled = false,
   multiSelect = false,
 }) => {
+  const [idPrefix] = useState(() => `choices-delivery-${guid()}`);
   const choiceRefs = useRef<(HTMLDivElement | null)[]>([]);
   const isSelected = (choiceId: ChoiceId) => !!selected.find((s) => s === choiceId);
   const renderIcon = (icon: React.ReactNode) =>
@@ -148,40 +150,47 @@ export const ChoicesDelivery: React.FC<Props> = ({
 
   return (
     <div className={styles.choicesContainer} role={containerRole} aria-label="answer choices">
-      {choices.map((choice, index) => (
-        <div
-          key={choice.id}
-          ref={(el) => (choiceRefs.current[index] = el)}
-          role={itemRole}
-          aria-checked={isSelected(choice.id)}
-          aria-disabled={disabled}
-          aria-label={`choice ${index + 1}`}
-          tabIndex={getTabIndex(index)}
-          onClick={disabled ? undefined : onClicked(choice.id, index)}
-          onKeyDown={disabled ? undefined : onKeyDown(choice.id, index)}
-          className={classNames(
-            'rounded outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary',
-            isSelected(choice.id) ? 'selected' : '',
-            disabled ? 'disabled' : '',
-          )}
-          style={{ cursor: disabled ? 'default' : 'pointer' }}
-        >
-          <div className={styles.choicesChoiceWrapper} dir={choice.textDirection}>
-            <div className={styles.choicesChoiceLabel}>
-              <div className="d-flex align-items-center col">
-                {renderIcon(isSelected(choice.id) ? selectedIcon : unselectedIcon)}
-                <div className={classNames('content', styles.choicesChoiceContent)}>
-                  <HtmlContentModelRenderer
-                    content={choice.content}
-                    context={context}
-                    direction={choice.textDirection}
-                  />
+      {choices.map((choice, index) => {
+        const choiceContentId = `${idPrefix}-choice-${choice.id}`;
+
+        return (
+          <div
+            key={choice.id}
+            ref={(el) => (choiceRefs.current[index] = el)}
+            role={itemRole}
+            aria-checked={isSelected(choice.id)}
+            aria-disabled={disabled}
+            aria-labelledby={choiceContentId}
+            tabIndex={getTabIndex(index)}
+            onClick={disabled ? undefined : onClicked(choice.id, index)}
+            onKeyDown={disabled ? undefined : onKeyDown(choice.id, index)}
+            className={classNames(
+              'rounded outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary',
+              isSelected(choice.id) ? 'selected' : '',
+              disabled ? 'disabled' : '',
+            )}
+            style={{ cursor: disabled ? 'default' : 'pointer' }}
+          >
+            <div className={styles.choicesChoiceWrapper} dir={choice.textDirection}>
+              <div className={styles.choicesChoiceLabel}>
+                <div className="d-flex align-items-center col">
+                  {renderIcon(isSelected(choice.id) ? selectedIcon : unselectedIcon)}
+                  <div
+                    id={choiceContentId}
+                    className={classNames('content', styles.choicesChoiceContent)}
+                  >
+                    <HtmlContentModelRenderer
+                      content={choice.content}
+                      context={context}
+                      direction={choice.textDirection}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/assets/test/activities/choices_delivery_test.tsx
+++ b/assets/test/activities/choices_delivery_test.tsx
@@ -1,12 +1,62 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ChoicesDelivery } from 'components/activities/common/choices/delivery/ChoicesDelivery';
 import { makeChoice } from 'components/activities/types';
+import { Checkbox } from 'components/misc/icons/checkbox/Checkbox';
 import { Radio } from 'components/misc/icons/radio/Radio';
 import { defaultWriterContext } from 'data/content/writers/context';
 
 describe('ChoicesDelivery', () => {
+  it.each([
+    ['radio', false],
+    ['checkbox', true],
+  ] as const)('uses the rendered answer text as the accessible %s name', (role, multiSelect) => {
+    render(
+      <ChoicesDelivery
+        choices={[makeChoice('Paris', 'choice-a')]}
+        selected={[]}
+        context={defaultWriterContext({ projectSlug: 'project' })}
+        onSelect={jest.fn()}
+        isEvaluated={false}
+        unselectedIcon={multiSelect ? <Checkbox.Unchecked /> : <Radio.Unchecked />}
+        selectedIcon={multiSelect ? <Checkbox.Checked /> : <Radio.Checked />}
+        multiSelect={multiSelect}
+      />,
+    );
+
+    expect(screen.getByRole(role, { name: 'Paris' })).toBeInTheDocument();
+    expect(screen.queryByRole(role, { name: 'choice 1' })).not.toBeInTheDocument();
+  });
+
+  it('generates unique label ids for repeated component instances', () => {
+    const props = {
+      choices: [makeChoice('Paris', 'choice-a')],
+      selected: [],
+      context: defaultWriterContext({ projectSlug: 'project' }),
+      onSelect: jest.fn(),
+      isEvaluated: false,
+      unselectedIcon: <Radio.Unchecked />,
+      selectedIcon: <Radio.Checked />,
+    };
+
+    const { container } = render(
+      <>
+        <ChoicesDelivery {...props} />
+        <ChoicesDelivery {...props} />
+      </>,
+    );
+
+    const choices = Array.from(container.querySelectorAll<HTMLElement>('[role="radio"]'));
+    const labelIds = choices.map((choice) => choice.getAttribute('aria-labelledby'));
+
+    expect(new Set(labelIds).size).toBe(2);
+    labelIds.forEach((labelId) => {
+      expect(labelId).not.toBeNull();
+      expect(container.querySelectorAll(`[id="${labelId}"]`)).toHaveLength(1);
+    });
+  });
+
   it('keeps disabled radio icons inert', () => {
     const onSelect = jest.fn();
 
@@ -24,7 +74,7 @@ describe('ChoicesDelivery', () => {
     );
 
     const radioIcon = container.querySelector('input[type="radio"]') as HTMLInputElement;
-    const choice = container.querySelector('[aria-label="choice 1"]') as HTMLElement;
+    const choice = container.querySelector('[role="radio"]') as HTMLElement;
 
     expect(radioIcon).toBeDisabled();
 

--- a/assets/test/check_all_that_apply/cata_delivery_test.tsx
+++ b/assets/test/check_all_that_apply/cata_delivery_test.tsx
@@ -54,7 +54,7 @@ describe('check all that apply delivery', () => {
     );
 
     // expect 2 choices
-    const choices = screen.queryAllByLabelText(/choice [0-9]/);
+    const choices = screen.getAllByRole('checkbox', { name: /Choice [12]/ });
     expect(choices).toHaveLength(2);
 
     // expect submit button

--- a/assets/test/multiple_choice/mc_delivery_test.tsx
+++ b/assets/test/multiple_choice/mc_delivery_test.tsx
@@ -70,7 +70,7 @@ describe('multiple choice delivery', () => {
     expect(await screen.findAllByLabelText(/hint [0-9]/)).toHaveLength(1);
 
     // expect 2 choices
-    const choices = screen.queryAllByLabelText(/choice [0-9]/);
+    const choices = screen.getAllByRole('radio', { name: /Choice [AB]/ });
     expect(choices).toHaveLength(2);
 
     // expect clicking a choice to save but not submit the activity


### PR DESCRIPTION
## Summary

Fixes [MER-5782](https://eliterate.atlassian.net/browse/MER-5782), where screen readers announced basic-activity answer options as “Choice 1,” “Choice 2,” etc. instead of reading the rendered answer text.

This affects both Multiple Choice and Check All That Apply activities because they share `ChoicesDelivery`.

## Root cause

The regression originated in [PR #6113](https://github.com/Simon-Initiative/oli-torus/pull/6113), which added standard keyboard navigation, focus highlighting, and ARIA radio/checkbox semantics to choice rows.

Before that PR, each choice wrapper already had an ordinal label:

```tsx
aria-label={`choice ${index + 1}`}
```

At the time, the wrapper was not the focusable radio or checkbox control. PR #6113 moved focus and interaction semantics onto that wrapper by adding `role="radio"` or `role="checkbox"`, `aria-checked`, and `tabIndex`.

As a result, the pre-existing ordinal `aria-label` became the control’s accessible name and overrode its rendered answer content.

## Changes

- Remove the ordinal `aria-label` from choice controls.
- Give each rendered answer-content container a unique ID.
- Associate the radio or checkbox with that content using `aria-labelledby`.
- Generate a stable prefix per mounted `ChoicesDelivery` instance to prevent duplicate IDs when the same choices appear in multiple views.
- Update MCQ and CATA delivery tests to locate choices by their accessible answer text.
- Add regression coverage for:
  - Radio accessible names.
  - Checkbox accessible names.
  - Removal of the ordinal names.
  - Unique label IDs across repeated component instances.

The keyboard behavior introduced by PR #6113 remains unchanged:

- Radio groups use roving `tabIndex`.
- Arrow keys move focus without automatically selecting an answer.
- Space or Enter selects the focused answer.
- Checkboxes remain individually tabbable.
- Existing focus highlighting and checked-state announcements are preserved.

## Verification

- Targeted Jest tests: 3 suites, 7 tests passed.
- TypeScript type check passed.
- ESLint passed.
- Prettier check passed.
- Playwright verification confirmed:
  - MCQ and CATA choices expose their rendered answer text.
  - Arrow navigation moves radio focus without selecting.
  - Space selects the focused answer.
  - Tab exits one radio group and enters the next without additional stops.
- Manual VoiceOver smoke testing confirmed meaningful answer announcements without detectable duplicate unnamed controls.


[MER-5782]: https://eliterate.atlassian.net/browse/MER-5782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ