### PR TITLE
[FEATURE] [MER-5783] Add flashcards to Simple Author

### DIFF
--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlashcardIcon.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlashcardIcon.tsx
@@ -1,16 +1,26 @@
 import * as React from 'react';
 
 export const FlashcardIcon: React.FC<{ stroke?: string; fill?: string }> = ({
-  stroke: _stroke,
-  fill: _fill,
+  stroke = '#222439',
+  fill = '#F3F5F8',
   ...props
 }) => (
-  <img
-    src="/images/icons/icon-part-flashcards.svg"
+  <svg
     width={24}
     height={24}
-    alt=""
-    draggable={false}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
     {...props}
-  />
+  >
+    <rect width={24} height={24} rx={3} fill={fill} />
+    <g fill={stroke} fillRule="evenodd">
+      <rect x={8} y={2} width={12} height={16} rx={1.5} opacity={0.35} />
+      <rect x={6} y={4} width={12} height={16} rx={1.5} opacity={0.6} />
+      <rect x={4} y={6} width={12} height={16} rx={1.5} />
+      <rect x={7} y={10} width={6} height={1.25} rx={0.625} />
+      <rect x={7} y={13} width={4.5} height={1.25} rx={0.625} />
+      <rect x={7} y={16} width={5.5} height={1.25} rx={0.625} />
+    </g>
+  </svg>
 );

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlashcardIcon.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlashcardIcon.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+
+export const FlashcardIcon: React.FC<{ stroke?: string; fill?: string }> = ({
+  stroke: _stroke,
+  fill: _fill,
+  ...props
+}) => (
+  <img
+    src="/images/icons/icon-part-flashcards.svg"
+    width={24}
+    height={24}
+    alt=""
+    draggable={false}
+    {...props}
+  />
+);

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
+import type { PartComponentDefinition } from 'components/activities/types';
 import {
   selectCurrentPartPropertyFocus,
   setCurrentSelection,
@@ -37,7 +38,7 @@ import { TextInputIcon } from './TextInputIcon';
 import { UndoIcon } from './UndoIcon';
 import { toolbarIcons, toolbarTooltips } from './toolbar-icons';
 
-export const staticComponents: string[] = [
+export const staticComponents = [
   'janus_text_flow',
   'janus_image',
   'janus_video',
@@ -47,7 +48,7 @@ export const staticComponents: string[] = [
   'janus_audio',
   'janus_capi_iframe',
   'janus_ai_trigger',
-];
+] as const;
 
 export const questionComponents: string[] = [
   'janus_mcq',
@@ -62,7 +63,9 @@ export const questionComponents: string[] = [
 
 const normalizeAdaptivePartSlug = (slug: string) => slug.replace(/_/g, '-');
 
-export const applySimpleAuthorPartDefaults = (part: any) =>
+export const applySimpleAuthorPartDefaults = (
+  part: PartComponentDefinition,
+): PartComponentDefinition =>
   part.type === 'janus-flashcards'
     ? { ...part, custom: { ...part.custom, capiEnabled: false } }
     : part;
@@ -163,7 +166,7 @@ export const FlowchartHeaderNav: React.FC = () => {
     dispatch(redo(null));
   };
 
-  const addPartToCurrentScreen = (newPartData: any) => {
+  const addPartToCurrentScreen = (newPartData: PartComponentDefinition) => {
     if (!currentActivityTree?.length) {
       return;
     }

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav.tsx
@@ -37,10 +37,11 @@ import { TextInputIcon } from './TextInputIcon';
 import { UndoIcon } from './UndoIcon';
 import { toolbarIcons, toolbarTooltips } from './toolbar-icons';
 
-const staticComponents: string[] = [
+export const staticComponents: string[] = [
   'janus_text_flow',
   'janus_image',
   'janus_video',
+  'janus_flashcards',
   'janus_formula',
   'janus_popup',
   'janus_audio',
@@ -60,6 +61,11 @@ export const questionComponents: string[] = [
 ];
 
 const normalizeAdaptivePartSlug = (slug: string) => slug.replace(/_/g, '-');
+
+export const applySimpleAuthorPartDefaults = (part: any) =>
+  part.type === 'janus-flashcards'
+    ? { ...part, custom: { ...part.custom, capiEnabled: false } }
+    : part;
 
 export const simpleAuthorQuestionPartTypes = new Set(
   questionComponents.map(normalizeAdaptivePartSlug),
@@ -163,7 +169,12 @@ export const FlowchartHeaderNav: React.FC = () => {
     }
 
     const [currentActivity] = currentActivityTree.slice(-1);
-    dispatch(addPart({ activityId: currentActivity.id, newPartData }));
+    dispatch(
+      addPart({
+        activityId: currentActivity.id,
+        newPartData: applySimpleAuthorPartDefaults(newPartData),
+      }),
+    );
   };
 
   const handlePartPasteClick = () => {

--- a/assets/src/apps/authoring/components/Flowchart/toolbar/toolbar-icons.tsx
+++ b/assets/src/apps/authoring/components/Flowchart/toolbar/toolbar-icons.tsx
@@ -4,6 +4,7 @@ import { AudioIcon } from './AudioIcon';
 import { CarouselIcon } from './CarouselIcon';
 import { CheckboxIcon } from './CheckboxIcon';
 import { DropdownIcon } from './DropdownIcon';
+import { FlashcardIcon } from './FlashcardIcon';
 import { FormulaIcon } from './FormulaIcon';
 import { HubSpokeIcon } from './HubSpokeIcon';
 import { IframeIcon } from './IframeIcon';
@@ -20,6 +21,7 @@ export const toolbarIcons: Record<string, React.FC<{ fill?: string; stroke?: str
   janus_text_flow: ParagraphIcon,
   janus_image: ImageIcon,
   janus_video: VideoIcon,
+  janus_flashcards: FlashcardIcon,
   janus_image_carousel: CarouselIcon,
   janus_popup: PopupIcon,
   janus_audio: AudioIcon,
@@ -40,6 +42,7 @@ export const toolbarTooltips: Record<string, string> = {
   janus_text_flow: 'Text block',
   janus_image: 'Image',
   janus_video: 'Video',
+  janus_flashcards: 'Flashcards',
   janus_image_carousel: 'Image carousel',
   janus_popup: 'Popup',
   janus_audio: 'Audio',

--- a/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
+++ b/assets/src/apps/authoring/components/RightMenu/PartPropertyEditor.tsx
@@ -182,6 +182,7 @@ const simplifiedLabels: Record<string, string> = {
   'janus-image': 'Image',
   'janus-ai-trigger': 'AI Activation Point',
   'janus-video': 'Video',
+  'janus-flashcards': 'Flashcards',
   'janus-popup': 'Popup Icon',
   'janus-audio': 'Audio',
   'janus-capi-iframe': 'iFrame',

--- a/assets/src/components/parts/janus-flashcards/Flashcard.tsx
+++ b/assets/src/components/parts/janus-flashcards/Flashcard.tsx
@@ -35,12 +35,13 @@ const buildFlipResponses = (
 
 const Flashcard: React.FC<PartComponentProps<FlashcardsModel>> = (props) => {
   const { id, model, onInit, onReady, onSave, onResize } = props;
+  const capiEnabled = model.capiEnabled !== false;
   const [ready, setReady] = useState(false);
   const [flipAllSignal, setFlipAllSignal] = useState(0);
   const lastAutoLayoutKeyRef = useRef('');
 
   useEffect(() => {
-    if (!props.notify) return;
+    if (!capiEnabled || !props.notify) return;
 
     const handleChanges = (changes: PrimitiveChanges) => {
       const flipAll = changes[`stage.${id}.flipAllCards`];
@@ -66,7 +67,7 @@ const Flashcard: React.FC<PartComponentProps<FlashcardsModel>> = (props) => {
       stateUnsub();
       contextUnsub();
     };
-  }, [props.notify, id]);
+  }, [capiEnabled, props.notify, id]);
 
   useEffect(() => {
     let mounted = true;
@@ -75,11 +76,13 @@ const Flashcard: React.FC<PartComponentProps<FlashcardsModel>> = (props) => {
       try {
         await onInit({
           id,
-          responses: buildFlipResponses({
-            flippedCards: [],
-            hasCardBeenFlipped: false,
-            allCardsFlipped: false,
-          }),
+          responses: capiEnabled
+            ? buildFlipResponses({
+                flippedCards: [],
+                hasCardBeenFlipped: false,
+                allCardsFlipped: false,
+              })
+            : [],
         });
         if (!mounted) {
           return;
@@ -98,7 +101,7 @@ const Flashcard: React.FC<PartComponentProps<FlashcardsModel>> = (props) => {
     return () => {
       mounted = false;
     };
-  }, [id, onInit, onReady]);
+  }, [capiEnabled, id, onInit, onReady]);
 
   useEffect(() => {
     if (!ready || typeof onResize !== 'function') {
@@ -158,7 +161,7 @@ const Flashcard: React.FC<PartComponentProps<FlashcardsModel>> = (props) => {
       model={model}
       cssBundle="delivery"
       flipAllSignal={flipAllSignal}
-      onFlipStateChange={handleFlipStateChange}
+      onFlipStateChange={capiEnabled ? handleFlipStateChange : undefined}
     />
   ) : null;
 };

--- a/assets/src/components/parts/janus-flashcards/schema.ts
+++ b/assets/src/components/parts/janus-flashcards/schema.ts
@@ -8,6 +8,7 @@ import { MarkupTree } from '../janus-text-flow/TextFlow';
 import { JanusAbsolutePositioned, JanusCustomCss } from '../types/parts';
 
 export interface FlashcardsModel extends JanusAbsolutePositioned, JanusCustomCss {
+  capiEnabled?: boolean;
   customCssClass: string;
   enabled: boolean;
   randomize: boolean;
@@ -249,6 +250,10 @@ export const getCapabilities = () => ({
 });
 
 export const adaptivitySchema = ({ currentModel }: { currentModel: any }) => {
+  if (currentModel?.capiEnabled === false) {
+    return {};
+  }
+
   const adaptivitySchema: Record<string, unknown> = {};
   adaptivitySchema.flippedCards = CapiVariableTypes.ARRAY;
   adaptivitySchema.hasCardBeenFlipped = CapiVariableTypes.BOOLEAN;

--- a/assets/test/advanced_authoring/adaptive_scorable_part_types_test.ts
+++ b/assets/test/advanced_authoring/adaptive_scorable_part_types_test.ts
@@ -1,7 +1,9 @@
 import { availableQuestionTypes } from '../../src/apps/authoring/components/Flowchart/paths/path-options';
 import {
+  applySimpleAuthorPartDefaults,
   hasSimpleAuthorQuestionPart,
   questionComponents,
+  staticComponents,
 } from '../../src/apps/authoring/components/Flowchart/toolbar/FlowchartHeaderNav';
 import {
   adaptiveScorablePartTypes,
@@ -57,10 +59,27 @@ describe('adaptive scorable part types', () => {
     expect(
       hasSimpleAuthorQuestionPart({
         content: {
-          partsLayout: [{ type: 'janus-input-text' }],
+          partsLayout: [{ type: 'janus-flashcards' }, { type: 'janus-input-text' }],
         },
       }),
     ).toBe(true);
+  });
+
+  it('adds flashcards as static Simple Author components with CAPI disabled', () => {
+    expect(staticComponents).toContain('janus_flashcards');
+    expect(questionComponents).not.toContain('janus_flashcards');
+
+    const flashcard = {
+      id: 'janus-flashcards-1',
+      type: 'janus-flashcards',
+      custom: { capiEnabled: true, cards: [] },
+    };
+
+    expect(applySimpleAuthorPartDefaults(flashcard)).toEqual({
+      ...flashcard,
+      custom: { ...flashcard.custom, capiEnabled: false },
+    });
+    expect(flashcard.custom.capiEnabled).toBe(true);
   });
 
   describe('manual-only part scoring transforms (capi iframe)', () => {

--- a/assets/test/parts/flashcards_test.tsx
+++ b/assets/test/parts/flashcards_test.tsx
@@ -1,7 +1,12 @@
-import { act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { EventEmitter } from 'events';
+import { NotificationType } from '../../src/apps/delivery/components/NotificationContext';
+import Flashcard from '../../src/components/parts/janus-flashcards/Flashcard';
 import '../../src/components/parts/janus-flashcards/authoring-entry';
 import { stripFlashcardImageDimensions } from '../../src/components/parts/janus-flashcards/flashcardContent';
 import {
+  adaptivitySchema,
   computeCardsPerRow,
   computeFlashcardsLayoutHeight,
   resolveCardHeightForLayout,
@@ -32,6 +37,18 @@ const fiveCardResponsiveModel = {
   cards: Array.from({ length: 5 }, (_, index) => ({ id: `responsive-card-${index + 1}` })),
 };
 
+const buildDeliveryProps = (model: typeof fourCardModel & { capiEnabled?: boolean }) => ({
+  id: 'flashcards-delivery',
+  type: 'janus-flashcards',
+  model,
+  state: {},
+  onInit: jest.fn().mockResolvedValue({ snapshot: {} }),
+  onReady: jest.fn().mockResolvedValue(true),
+  onSave: jest.fn().mockResolvedValue(true),
+  onSubmit: jest.fn().mockResolvedValue(true),
+  onResize: jest.fn().mockResolvedValue(true),
+});
+
 describe('flashcard layout helpers', () => {
   test('normalizes row bounds and computes the four-card layout', () => {
     const bounds = resolveCardsPerRowBounds({ minCardsPerRow: 4, maxCardsPerRow: 2 });
@@ -53,6 +70,76 @@ describe('flashcard layout helpers', () => {
 
     expect(containerWidth).toBe(470);
     expect(computeFlashcardsLayoutHeight(5, containerWidth, fiveCardResponsiveModel)).toBe(572);
+  });
+});
+
+describe('flashcard CAPI behavior', () => {
+  test('returns no adaptivity variables when CAPI is disabled', () => {
+    expect(adaptivitySchema({ currentModel: { capiEnabled: false } })).toEqual({});
+    expect(adaptivitySchema({ currentModel: {} })).toEqual({
+      flippedCards: expect.any(Number),
+      hasCardBeenFlipped: expect.any(Number),
+      allCardsFlipped: expect.any(Number),
+      flipAllCards: expect.any(Number),
+    });
+  });
+
+  test('keeps disabled-CAPI flips local and ignores flip-all notifications', async () => {
+    const notify = new EventEmitter();
+    const props = buildDeliveryProps({ ...fourCardModel, capiEnabled: false });
+
+    render(<Flashcard {...props} notify={notify} />);
+
+    const [firstCard, secondCard] = await screen.findAllByRole('button');
+    expect(props.onInit).toHaveBeenCalledWith({ id: props.id, responses: [] });
+
+    act(() => {
+      notify.emit(NotificationType.STATE_CHANGED, {
+        mutateChanges: { [`stage.${props.id}.flipAllCards`]: true },
+      });
+    });
+    expect(firstCard).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(firstCard);
+    expect(firstCard).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.keyDown(secondCard, { key: 'Enter' });
+    expect(secondCard).toHaveAttribute('aria-pressed', 'true');
+    expect(props.onSave).not.toHaveBeenCalled();
+  });
+
+  test('preserves existing Advanced Author CAPI behavior by default', async () => {
+    const notify = new EventEmitter();
+    const props = buildDeliveryProps(fourCardModel);
+
+    render(<Flashcard {...props} notify={notify} />);
+
+    const cards = await screen.findAllByRole('button');
+    expect(props.onInit).toHaveBeenCalledWith({
+      id: props.id,
+      responses: expect.arrayContaining([
+        expect.objectContaining({ key: 'flippedCards', value: [] }),
+        expect.objectContaining({ key: 'hasCardBeenFlipped', value: false }),
+        expect.objectContaining({ key: 'allCardsFlipped', value: false }),
+        expect.objectContaining({ key: 'flipAllCards', value: false }),
+      ]),
+    });
+
+    act(() => {
+      notify.emit(NotificationType.STATE_CHANGED, {
+        mutateChanges: { [`stage.${props.id}.flipAllCards`]: true },
+      });
+    });
+
+    await waitFor(() =>
+      cards.forEach((card) => expect(card).toHaveAttribute('aria-pressed', 'true')),
+    );
+    expect(props.onSave).toHaveBeenCalledWith({
+      id: props.id,
+      responses: expect.arrayContaining([
+        expect.objectContaining({ key: 'allCardsFlipped', value: true }),
+      ]),
+    });
   });
 });
 


### PR DESCRIPTION
Adds the existing flashcard component to Simple Author as a static, viewable component.

Simple Author flashcards:
Retain the existing authoring, layout, and visual flip behavior, do not expose flashcard variables to the rules engine, and do not persist learner flip state

Advanced Author flashcards retain their existing CAPI behavior. Existing flashcards remain backward compatible because CAPI is enabled unless `capiEnabled` is explicitly set to `false`.

## Testing

- Added coverage for Simple Author static-component classification and `capiEnabled: false`
- Added coverage confirming disabled-CAPI flashcards:
  - initialize with no responses
  - ignore `flipAllCards`
  - do not save flip responses
  - continue flipping with the mouse and keyboard
- Added regression coverage confirming existing Advanced Author CAPI behavior remains enabled
- Ran the existing flashcard layout and Advanced Author canvas-persistence tests

### Verification

- 3 test suites passed
- 21 tests passed
- ESLint passed
- Prettier passed
- TypeScript type checking passed
- Production webpack build passed with existing bundle-size warnings

## Manual Testing

Confirmed that previously saved flashcards persist. Also, the new flashcards in both Advanced and Simple Author work as intended. For more testing after merging, we need to test for old flashcard components persisting and new components working as intended. 