### PR TITLE
[FEATURE] [MER-5789] Shared activities repair tool

### DIFF
--- a/docs/exec-plans/current/features/online-project-fix/fdd.md
+++ b/docs/exec-plans/current/features/online-project-fix/fdd.md
@@ -1,0 +1,364 @@
+# Online Project Repair Tool - Functional Design Document
+
+## 1. Executive Summary
+Implement the feature as a small authoring-domain context, `Oli.Authoring.ProjectRepair`, plus a project-scoped LiveView. The context owns system-admin authorization, project resolution, streamed analysis of current unpublished page revisions, issue classification, lock-aware repair planning, activity cloning, page revision updates, structured results, and operational telemetry. The LiveView owns only route orchestration and presentation.
+
+Analysis streams current page revisions from the project's working publication, discards each full content payload after extracting a compact `MapSet` of nested activity resource ids, and builds both page-to-activity and activity-to-page maps. Pages with top-level `%{"advancedDelivery" => true}` are counted as skipped and excluded from every issue map. Referenced activity ids are resolved in bounded batches through `Oli.Publishing.AuthoringResolver`; unresolved ids are reported as missing and are never mutated.
+
+Repair always performs a fresh analysis, builds a deterministic plan in which the lowest page resource id keeps each original activity, acquires existing authoring locks for all affected page and source-activity resources, and revalidates the plan before writing. Each page to be changed is repaired in its own database transaction by cloning each applicable source activity through `Oli.Authoring.Editing.ContainerEditor.deep_copy_activity/3`, rewiring all matching references in that page, and recording one new unpublished page revision through `Oli.Publishing.ChangeTracker.track_revision/3`. Processing stops on the first page failure, preserves already committed pages, returns a structured partial result, and reruns analysis so the administrator sees the actual resulting state.
+
+## 2. Requirements & Assumptions
+- Functional requirements:
+  - Enforce system-admin-only access at both the web route and context API boundaries (`FR-001`).
+  - Provide non-mutating analysis of current unpublished Basic-page revisions (`FR-002`, `FR-003`).
+  - Traverse all nested `activity-reference` elements while bounding retained content memory (`FR-004`).
+  - Report unresolved activity ids without removing or modifying their references (`FR-005`, `FR-010`).
+  - Group cross-page shared resources, distinguish resolvable from missing resources, and expose deterministic page metadata for preview (`FR-006`, `FR-007`).
+  - Ignore browser-held preview data during repair, analyze fresh state, and require an explicit repair invocation (`FR-008`).
+  - Reuse established activity-copy and authoring-revision mechanisms (`FR-009`).
+  - Return typed reports and repair outcomes that can be rendered, tested, logged, and safely retried (`FR-011`).
+- Non-functional requirements:
+  - Keep full page JSON bounded to the Ecto stream/batch and the single page currently being repaired.
+  - Avoid N+1 activity resolution by resolving unique ids in bounded batches.
+  - Use existing durable authoring locks and deterministic ordering to avoid overwriting active edits and to prevent lock-order deadlocks.
+  - Do not add schema migrations, background jobs, caches, feature flags, or delivery/publication mutations.
+  - Keep the LiveView server-rendered, accessible, and intentionally thin; no React application is needed.
+- Assumptions:
+  - The current Adaptive-page discriminator is the top-level boolean key `advancedDelivery`; only the literal boolean `true` is excluded. Missing and boolean `false` are Basic.
+  - Current authoring state is the unpublished `PublishedResource` mapping returned by the project's working publication and `AuthoringResolver`.
+  - Existing `ContainerEditor.deep_copy_activity/3` defines the required complete copy semantics for duplicated Basic-page activities and must be reused rather than reimplemented.
+  - Repeated references to one activity within a single page are one page/activity relationship. If that activity is cloned for the page, every matching reference in that page is rewired to the same new activity resource.
+  - A system administrator's `%Author{}` is authorized by existing authoring APIs for every project, as implemented by `Oli.Accounts.can_access?/2`.
+  - The tool is manually invoked and low-concurrency, but it must still respect active authoring locks and detect state changes between analysis and mutation.
+
+## 3. Repository Context Summary
+- What we know:
+  - `Oli.Publishing.AuthoringResolver` resolves revisions from the unpublished working publication. Its `existing_activity_resource_ids/2` projection returns only ids backed by current project activity revisions, allowing analysis to validate existence/type without loading complete activity content.
+  - `AuthoringResolver.all_pages/1` materializes all page revisions, so the repair context needs a focused Ecto stream query over `PublishedResource` and `Revision` to meet the content-memory requirement.
+  - `Oli.Authoring.Editing.Utils.activity_references/1` returns a `MapSet` of nested activity ids using `Oli.Resources.PageContent.flat_filter/2`, the same traversal family used by Basic-page duplication.
+  - `Oli.Resources.PageContent.map/2` and `map_reduce/4` traverse nested `model`, `children`, `caption`, `pronunciation`, `translations`, `content`, and `meanings` properties and can rewire references without rebuilding the page schema.
+  - `Oli.Authoring.Editing.ContainerEditor.deep_copy_activity/3` resolves the source through `AuthoringResolver` and invokes `ActivityEditor.create/9`, which creates the activity resource, revision, project-resource association, and working-publication mapping transactionally.
+  - `Oli.Publishing.ChangeTracker.track_revision/3` creates a revision from the current page revision and updates the working-publication mapping. It is the appropriate authoring mechanism for a server-owned content rewrite; `ContainerEditor.edit_page/3` intentionally strips content, and `PageEditor.edit/4` expects client-side `activitySlug` payloads and applies ordinary editor deletion semantics.
+  - `Oli.Authoring.Locks` provides durable publication/resource locks and broadcasts lock acquisition/release. It can lock both affected pages and source activities by resource id.
+  - The existing page editor path is `/workspaces/course_author/:project_slug/curriculum/:revision_slug/edit`.
+  - Existing project LiveViews run under the `:protected_authoring_workspaces` session. The repair route additionally needs the `:require_authenticated_system_admin` pipeline because normal project authorization permits authors and lower admin roles.
+  - The resource/revision and publication model isolates unpublished authoring changes from immutable published publications and delivery sections.
+- Unknowns to confirm:
+  - The Jira issue that will serve as the implementation system of record has not been supplied.
+  - The final module/file name for the LiveView can follow local naming conventions discovered during implementation; this design uses `OliWeb.Workspaces.CourseAuthor.ProjectRepairLive`.
+  - The exact telemetry event prefix should be reconciled with nearby authoring instrumentation during implementation; this design proposes `[:oli, :authoring, :project_repair]`.
+
+## 4. Proposed Design
+### 4.1 Component Roles & Interactions
+- `Oli.Authoring.ProjectRepair`:
+  - Public boundary for `analyze_project/3` and `repair_project/3`.
+  - Validates `Oli.Accounts.is_system_admin?/1`, resolves the project and working publication, and normalizes errors.
+  - Owns the stream query, compact relationship maps, activity resolution, report construction, deterministic repair plan, lock lifecycle, page-level transactions, and telemetry.
+- `Oli.Authoring.ProjectRepair.Report` and related structs:
+  - Define stable context-to-LiveView data contracts without web paths or rendered markup.
+  - Carry page resource id, current revision id/slug, title, activity resource id, repairability, counts, and failures.
+- `OliWeb.Workspaces.CourseAuthor.ProjectRepairLive`:
+  - Receives `project_id` (the existing router parameter name, containing the project slug) and `current_author` from the authoring workspace setup.
+  - Calls the context on mount and on `"make_changes"`.
+  - Builds editor hyperlinks from report page revision slugs.
+  - Renders loading, empty, issue, success, partial-failure, and fatal-error states.
+- Existing dependencies:
+  - `AuthoringResolver` for activity existence/current revision resolution.
+  - `Utils.activity_references/1` for nested extraction.
+  - `PageContent.map/2` for targeted rewiring.
+  - `ContainerEditor.deep_copy_activity/3` for activity copying.
+  - `ChangeTracker.track_revision/3` for page revision creation and working-publication mapping updates.
+  - `Locks.acquire/4`, `Locks.update/4`, and `Locks.release/4` for concurrency control.
+  - `Broadcaster.broadcast_revision/2` after successful page commits so authoring listeners observe changed revisions.
+
+```mermaid
+flowchart TD
+  LV[ProjectRepairLive] -->|analyze_project| Context[ProjectRepair context]
+  Context -->|stream current page revisions| WorkingPub[(Working publication)]
+  Context -->|nested id extraction| Maps[Compact relationship maps]
+  Maps -->|batched resolution| Resolver[AuthoringResolver]
+  Resolver --> Report[Structured preview report]
+  Report --> LV
+  LV -->|explicit make_changes| Context
+  Context --> Fresh[Fresh analysis and deterministic plan]
+  Fresh --> Locks[Acquire page and activity locks]
+  Locks --> Revalidate[Revalidate repair fingerprint]
+  Revalidate --> Copy[Existing activity copy API]
+  Copy --> PageRevision[Per-page ChangeTracker revision]
+  PageRevision --> After[Fresh after-analysis]
+  After --> LV
+```
+
+### 4.2 State & Data Flow
+1. `analyze_project/3` authorizes the actor, resolves the project and unpublished working publication, and opens a read-only `Repo.transaction` for `Repo.stream/2`.
+2. The stream query joins the working publication's `PublishedResource` rows to non-deleted project page `Revision` rows, orders by page `resource_id`, and selects only `revision_id`, `resource_id`, `slug`, `title`, and `content`.
+3. For each streamed row:
+   - If `content["advancedDelivery"] == true`, increment `skipped_adaptive_pages_count` and retain no page/content relationship data.
+   - Otherwise, extract `MapSet<activity_resource_id>` through `Utils.activity_references/1`.
+   - Store a compact page record with revision id, resource id, slug, title, and the activity-id set.
+   - Update `activity_resource_id -> MapSet<page_resource_id>` as part of the same reduce.
+   - Allow the row's full content map to become unreachable before reading the next row.
+4. After the page cursor is exhausted, resolve the unique activity ids through `AuthoringResolver.existing_activity_resource_ids/2` in configurable bounded chunks (default 500). This resolver projection selects only ids for current project activity revisions, avoiding full activity JSON and preventing wrong-type resources from becoming repairable. Build a set from the returned ids.
+5. Build missing-reference records for every Basic page/id pair not in the resolved-id set. Build shared groups for inverted-map entries with page-set cardinality greater than one and mark each group `repairable?: true` only when its activity id resolved.
+6. Sort pages, missing records, and groups by numeric resource id before returning the report. Stable ordering controls display, keeper selection, lock acquisition, and tests.
+7. The LiveView renders the report. It computes links with `~p"/workspaces/course_author/#{project.slug}/curriculum/#{page.revision_slug}/edit"`; URLs stay out of the domain context.
+8. `repair_project/3` does not accept or trust the LiveView's prior report. It runs analysis again and creates a repair fingerprint from sorted `{activity_resource_id, [{page_resource_id, revision_id}]}` tuples for repairable groups.
+9. For each repairable group, the lowest page resource id is the keeper. Invert the remaining group members into `page_resource_id -> MapSet<source_activity_resource_id>` so each changed page is written exactly once even when it participates in several groups.
+10. Acquire durable locks in ascending `{resource_kind, resource_id}` order for all repairable source activities and all pages in their groups, including keeper pages. If any lock cannot be acquired, release every lock acquired by this invocation and return an unchanged failed result.
+11. With locks held, run analysis again and compare the repair fingerprint with the pre-lock fingerprint. A mismatch returns `:stale_project_state`, releases locks, and performs no mutations.
+12. Repair non-keeper pages in ascending page resource-id order. For each page, one `Repo.transaction`:
+    - Resolve the locked current page revision and confirm it is the revision represented in the validated plan and is still Basic.
+    - For every source activity assigned to the page, call `ContainerEditor.deep_copy_activity/3` once and retain the returned new activity id.
+    - Use `PageContent.map/2` to replace the `activity_id` of every matching `activity-reference` while preserving all other reference fields.
+    - Recompute the page's `activity_refs` array through `Utils.activity_references/1`.
+    - Call `ChangeTracker.track_revision/3` with `content`, `activity_refs`, and `author_id`.
+    - Commit all activity clones and the page revision together, then broadcast the new page revision.
+13. Stop on the first page transaction failure. Previously committed pages remain valid and isolated; the failed page creates no clones because its transaction rolls back.
+14. Release all held locks in an `after`-style cleanup path. Run a final analysis and return it in `RepairResult` for completed, partial, and failed mutation outcomes.
+
+### 4.3 Lifecycle & Ownership
+- Reports and repair plans are request/LiveView-process state only; they are not persisted.
+- PostgreSQL remains the only source of truth. The working publication owns current authoring revision mappings, and each repair creates normal resource/revision history.
+- The context owns lock acquisition and guarantees best-effort release for every resource it acquired. Lock-release failures are included as warnings and remain recoverable through the existing ten-minute lock expiration.
+- The LiveView may assign the latest `Report` and `RepairResult`, but it never stores page content or derives repair operations.
+- The LiveView disables the action while repair is executing to prevent duplicate events from the same socket. Context idempotency and locking remain the authoritative protection across sockets/nodes.
+- No Oban job is introduced. The operation is synchronous so the administrator sees the result of the explicit action; the streaming design limits memory, while telemetry exposes duration for future reevaluation.
+
+### 4.4 Alternatives Considered
+- Use `AuthoringResolver.all_pages/1`: rejected because it loads every full page revision/content payload into memory and conflicts with the explicit streaming requirement.
+- Detect sharing entirely with PostgreSQL JSON-path queries: rejected because it would duplicate Torus's established nested page traversal semantics, make Basic/Adaptive behavior harder to keep aligned, and add raw-SQL transformation risk.
+- Use `PageEditor.edit/4` for repaired page content: rejected because that API is designed for client payloads containing `activitySlug`, manages normal editor reference deletion/resurrection, and would incorrectly mark the original shared activity deleted while a keeper page still uses it.
+- Create a new activity-copy implementation: rejected because `ContainerEditor.deep_copy_activity/3` is the tested Basic-page duplication path explicitly required by the informal specification.
+- One full-project transaction: rejected because it would keep a large transaction open across all cloning and page writes and make a single failure roll back potentially extensive work. Per-page transactions bound rollback scope and support safe retry.
+- Continue after arbitrary page failures: rejected for the first iteration. Fail-fast page processing is simpler to reason about; the structured after-report clearly identifies remaining shared groups, and rerunning is safe.
+- Trust the report rendered in the browser: rejected because authoring content may change between preview and repair. Repair derives all mutations from a fresh, lock-revalidated server-side plan.
+
+## 5. Interfaces
+- Public context API:
+
+```elixir
+@spec analyze_project(Project.t() | String.t(), Author.t(), keyword()) ::
+        {:ok, Report.t()} | {:error, :not_authorized | :not_found | term()}
+def analyze_project(project_or_slug, actor, opts \\ [])
+
+@spec repair_project(Project.t() | String.t(), Author.t(), keyword()) ::
+        {:ok, RepairResult.t()}
+        | {:error, RepairResult.t() | :not_authorized | :not_found | term()}
+def repair_project(project_or_slug, actor, opts \\ [])
+```
+
+  Supported options are internal/test-oriented, initially `:resolution_batch_size` and `:stream_max_rows`; defaults remain owned by the context and are not exposed in the UI.
+- Report contracts:
+
+```elixir
+%Report{
+  project_id: integer(),
+  project_slug: String.t(),
+  scanned_pages_count: non_neg_integer(),
+  skipped_adaptive_pages_count: non_neg_integer(),
+  missing_activity_references: [%MissingActivityReference{}],
+  shared_activity_references: [%SharedActivityReference{}],
+  summary: %Summary{}
+}
+
+%PageSummary{
+  resource_id: integer(),
+  revision_id: integer(),
+  revision_slug: String.t(),
+  title: String.t()
+}
+
+%MissingActivityReference{
+  activity_resource_id: integer(),
+  page: %PageSummary{}
+}
+
+%SharedActivityReference{
+  activity_resource_id: integer(),
+  pages: [%PageSummary{}],
+  repairable?: boolean()
+}
+
+%Summary{
+  scanned_pages_count: non_neg_integer(),
+  skipped_adaptive_pages_count: non_neg_integer(),
+  missing_activity_reference_count: non_neg_integer(),
+  missing_activity_affected_page_count: non_neg_integer(),
+  repairable_shared_activity_resource_count: non_neg_integer(),
+  repairable_shared_activity_affected_page_count: non_neg_integer(),
+  non_repairable_shared_missing_activity_resource_count: non_neg_integer()
+}
+```
+
+- Repair result contract:
+
+```elixir
+%RepairResult{
+  status: :completed | :partial | :failed,
+  report_before_repair: %Report{},
+  report_after_repair: %Report{},
+  cloned_activity_count: non_neg_integer(),
+  updated_page_count: non_neg_integer(),
+  failures: [%RepairFailure{}],
+  warnings: [:lock_release_failed | :lock_refresh_failed]
+}
+```
+
+- Expected top-level errors include `:not_authorized`, `:project_not_found`, and `:working_publication_not_found`. Structured repair failures use a closed, content-free reason code (`:lock_not_acquired`, `:stale_project_state`, `:activity_copy_failed`, `:page_update_failed`, `:invalid_page_content`, `:lock_release_failed`, or `:unexpected_error`) plus optional page/activity resource ids. Raw exceptions, changesets, page content, and lock-holder account details must not cross the context boundary.
+- LiveView route: add `live("/:project_id/repair_tool", ProjectRepairLive)` under a dedicated workspace scope/live session using `:browser`, `:authoring_protected`, and `:require_authenticated_system_admin`, while retaining the standard project assignment and `AuthorizeProject` on-mount hooks.
+- LiveView events:
+  - Mount: call `analyze_project/3` and assign the report or fatal error.
+  - `"make_changes"`: call `repair_project/3`; replace the displayed report with `report_after_repair` for both success and structured partial/failure results.
+  - No event accepts activity ids, page ids, or a serialized repair plan from the browser.
+
+## 6. Data Model & Storage
+- No database schema or migration changes.
+- Reads are limited to `projects`, the unpublished `publications` row, `published_resources`, and current page/activity `revisions`.
+- Successful repair writes use existing models:
+  - one new activity `resources` row and initial activity `revisions` row per cloned page/activity relationship;
+  - one `projects_resources` association and one working-publication `published_resources` mapping per cloned activity;
+  - one new page `revisions` row per changed page;
+  - an update to that page's existing working-publication mapping to point to the new revision;
+  - transient lock fields on affected `published_resources` rows.
+- Existing published publications, their `published_resources`, delivery sections, attempts, and learner data are never selected for mutation.
+- Page revisions persist both rewritten `content` and recomputed `activity_refs` so denormalized reference metadata stays aligned with JSON content.
+- Missing activity ids remain present only in the page JSON and the generated report; this feature creates no durable issue table.
+
+## 7. Consistency & Transactions
+- Analysis uses an Ecto stream inside a read-only transaction only long enough to enumerate current page mappings and extract compact relationships. Activity resolution occurs after the cursor is closed.
+- Repair has three consistency gates:
+  1. fresh server-side analysis rather than browser report reuse;
+  2. deterministic acquisition of locks for every participant page and source activity;
+  3. post-lock repair-fingerprint equality before the first write.
+- Locks are acquired in deterministic order and released in reverse order. Failure to acquire the complete set causes zero mutations.
+- The repair fingerprint contains source activity ids plus every participant page resource id and revision id. Any changed membership or page revision invalidates the plan.
+- Each changed page is one transaction containing all of that page's activity clones and its new page revision. This guarantees no orphan clone from a failed page repair.
+- Page transactions are processed sequentially. The first failure stops further writes and returns `:partial` if earlier pages committed or `:failed` if none committed.
+- A retry is safe: fresh analysis omits relationships already isolated by earlier transactions and plans only those still shared. Missing references remain visible but non-repairable.
+- Because all participant resources remain locked for the mutation loop, normal authoring editors cannot interleave source activity or page changes. Operations approaching the existing ten-minute lock TTL should refresh held locks with `Locks.update/4` between page transactions.
+
+## 8. Caching Strategy
+N/A. Reports reflect mutable authoring state and must be recomputed. Adding Cachex or LiveView-level reuse across repair invocations would undermine stale-state safety. The LiveView may retain its displayed report only as presentation state; `repair_project/3` never trusts it.
+
+## 9. Performance & Scalability Posture
+- Memory complexity is `O(P + A + E)`, where `P` is Basic pages, `A` is unique referenced activity ids, and `E` is unique page/activity relationships. Full JSON memory is bounded by the Ecto stream buffer plus one actively repaired page.
+- `Repo.stream/2` uses a bounded `max_rows` (proposed default 100). The context does not call `AuthoringResolver.all_pages/1`.
+- Activity resolution uses `AuthoringResolver.existing_activity_resource_ids/2` over unique ids in chunks (proposed default 500), preventing one query per reference, avoiding an unbounded `IN` parameter list, and selecting no activity JSON.
+- Both maps use `MapSet` to deduplicate repeated references within a page and to make cardinality checks direct.
+- Deterministic sorting is performed only on compact ids/report records, not page content.
+- Repair performs two analysis passes before mutation and one after. This is an intentional safety cost for a manually invoked admin operation. Telemetry will expose project size and duration before any need for asynchronous execution is considered.
+- Database review should confirm the working-publication/page stream query uses existing `published_resources.publication_id`, revision primary-key, and resource-type indexes and does not introduce N+1 page or activity queries.
+- No all-project scan is supported; every query is scoped to one resolved project and its unpublished publication.
+
+## 10. Failure Modes & Resilience
+- Unauthorized actor: return `{:error, :not_authorized}` before project content access; route pipeline also redirects non-system-admin authors.
+- Unknown/inactive project or absent working publication: return a fatal, non-mutating error rendered by the LiveView.
+- Malformed page content that prevents established traversal: fail analysis with the page resource id; do not silently omit the page or expose a repair button for an incomplete report.
+- Missing activity revision: include it in missing records, mark a multi-page group non-repairable, and never pass it to the copy API.
+- Active author lock: abort before mutation, release locks acquired by this invocation, and display the conflicting resource/holder information already returned by `Locks`.
+- Project changes while locks are being gathered: repair-fingerprint mismatch aborts with no mutations and a refreshed report.
+- Activity-copy or page-revision error: roll back that page transaction, stop processing, release locks, rerun analysis, and return a structured partial/failed result.
+- Process crash during repair: the active page transaction rolls back; earlier page transactions remain valid. Durable locks expire under the existing lock TTL, and a later rerun repairs only remaining relationships.
+- Lock release error: record a warning, continue releasing other locks, and rely on lock expiration as a backstop. Do not report the content repair itself as rolled back when it committed.
+- Telemetry/logging error: must never change repair behavior; instrumentation receives only bounded metadata and no page JSON.
+- Duplicate button event or concurrent administrator invocation: LiveView disables its button locally, while resource locks ensure only one invocation can mutate a repair group.
+
+## 11. Observability
+- Wrap analysis and repair in telemetry spans using the proposed prefix `[:oli, :authoring, :project_repair]` with `:start`, `:stop`, and `:exception` events.
+- Metadata is bounded and includes operation, project id/slug, actor id, scanned/skipped page counts, missing count, repairable/non-repairable shared counts, planned/updated page counts, clone count, status, failure category, and duration. Do not include page content, activity content, titles, author email, or full reports.
+- Emit one structured `Logger.info` completion entry for successful analysis/repair and `Logger.warning` or `Logger.error` for lock conflicts, stale plans, partial failures, and fatal failures, using the same bounded metadata.
+- Existing AppSignal integration receives exceptions and telemetry timing. No new dashboard, alert, or product analytics event is required for this manually invoked tool.
+- `RepairResult` remains the operator-facing audit for the current LiveView session; this design does not add a persistent repair-history table.
+
+## 12. Security & Privacy
+- Place the route behind `:require_authenticated_system_admin`, not the broader `:require_authenticated_admin` or ordinary project-author pipeline.
+- Require the actor in both public context functions and call `Accounts.is_system_admin?/1` before project resolution or page enumeration. This prevents accidental future use from a less-restricted web surface or console wrapper.
+- Continue using standard `AuthorizeProject` on-mount behavior and scope all resolver/query/write operations to the resolved project's unpublished publication.
+- Accept only the route project slug and the authenticated author from server assigns. The mutation event carries no resource identifiers or report payload, preventing client tampering with repair scope.
+- Use parameterized Ecto queries. Do not construct raw SQL from project slugs or resource ids.
+- Render titles through HEEx escaping and generate editor links with verified routes.
+- Logs and telemetry exclude page/activity JSON and titles, which may contain authored or sensitive course material.
+- CSRF, secure headers, authenticated author session, and LiveView event integrity are inherited from the existing browser/authoring pipelines.
+- Run required security and performance reviews, plus Elixir, UI, and requirements reviews for the implementation change set.
+
+## 13. Testing Strategy
+- Context tests in `test/oli/authoring/project_repair_test.exs` are the primary automated suite. Use factories and real Repo/authoring APIs; no scenario DSL or browser automation is needed because this is one authoring context boundary.
+- Authorization and route coverage:
+  - System-admin context access and project-scoped analysis (`AC-001`).
+  - Non-system-admin context denial plus one route/pipeline smoke test proving denial before LiveView use (`AC-002`). Detailed LiveView rendering/event tests remain outside the initial requirement.
+- Read-only scope and classification:
+  - Snapshot resource/revision/mapping counts before and after analysis (`AC-003`).
+  - Adaptive true is counted/skipped and never reported or changed (`AC-004`); missing/false flags are Basic (`AC-005`).
+  - Nested reference fixtures exercise the same traversal properties as page duplication (`AC-006`).
+  - Instrumented small stream/batch settings and compact report assertions provide automated coverage, with a review/manual memory check for large fixtures (`AC-007`).
+  - Pages without references and repeated same-page references behave correctly (`AC-008`, `AC-009`).
+- Missing/shared report behavior:
+  - Unresolved ids include page metadata and remain unchanged after analysis and repair (`AC-010`, `AC-011`).
+  - Existing shared ids create repairable grouped reports; shared missing ids create non-repairable groups (`AC-012`, `AC-013`).
+  - Summary counts cover scanned/skipped pages, missing references/pages, repairable groups/pages, and non-repairable missing groups (`AC-014`).
+  - LiveView/manual checks verify `Make Changes` visibility and editor links/status presentation (`AC-015`, `AC-024`).
+- Repair behavior:
+  - Mutate project state between preview and repair and assert the context uses a fresh/revalidated plan (`AC-016`).
+  - Assert deterministic lowest-id keeper selection (`AC-017`).
+  - Assert each non-keeper page receives one distinct copy per source activity through existing duplication semantics (`AC-018`).
+  - Assert all matching nested references and the persisted `activity_refs` array are updated in one new page revision (`AC-019`).
+  - Assert a missing shared activity creates no resource/revision/mapping writes (`AC-020`).
+  - Assert multiple independent groups, including several groups affecting one page, remain distinct (`AC-021`).
+  - Assert post-repair analysis removes successful shared relationships while retaining missing reports (`AC-022`).
+  - Force lock, copy, and page-update failures to verify structured result counts/failures, rollback of the active page, stop-on-first-failure, and safe rerun (`AC-023`).
+- Observability:
+  - Attach a telemetry test handler or capture logs to verify bounded operation/count/outcome metadata and absence of full content (`AC-025`). Intentional logs must use `capture_log` or `@tag capture_log: true` per repository rules.
+- Verification gates:
+  - `mix test test/oli/authoring/project_repair_test.exs`
+  - the targeted route authorization test, if placed separately
+  - `mix format` on changed Elixir/HEEx/test files
+  - broader authoring editing/resolver tests if shared helper signatures are changed
+  - manual prepared-project exercise covering links, empty state, missing-only state, successful repair, partial failure, and unchanged published delivery state
+
+## 14. Backwards Compatibility
+- No migration, existing route change, or existing UI navigation change.
+- The new route is additive and direct-navigation-only.
+- Existing page/activity resources and revision history remain valid; repairs add normal authoring revisions and resources to the unpublished working publication.
+- Published publications and sections continue resolving their existing immutable revisions, so learner-facing content does not change until a later normal project publication.
+- Existing Basic-page duplication behavior remains the source of copy semantics. If a small helper must be extracted to expose the created activity revision/id more directly, preserve `ContainerEditor.deep_copy_activity/3` behavior and tests.
+- Missing references remain byte-for-byte unchanged by repair except when the same page also receives an unrelated shared-activity rewrite; in that case the missing reference node is preserved unchanged in the new page content.
+- No feature flag is introduced. Access control and manual invocation provide rollout containment.
+
+## 15. Risks & Mitigations
+- Long-running synchronous scan or repair: stream content, batch resolver calls, expose duration telemetry, refresh locks between page transactions, and keep the scope to one project.
+- Activity copy semantics drift: call `ContainerEditor.deep_copy_activity/3` directly or extract its body without behavioral change and retain its existing tests.
+- Ordinary page-edit semantics delete the keeper's source activity: bypass `PageEditor.edit/4` for this system rewrite and use `ChangeTracker.track_revision/3` with an explicitly recomputed `activity_refs` array.
+- Concurrent edits create stale or lost updates: lock participant pages and activities, compare revision-bearing repair fingerprints after locks, and abort before writing on mismatch.
+- Partial completion confuses the administrator: stop at the first failed page, return committed counts plus a concrete failure, and render the fresh after-report as the next actionable state.
+- Lock leakage: release in guaranteed cleanup, collect release warnings, refresh during long runs, and rely on existing TTL expiration after process failure.
+- Adaptive content is accidentally transformed: centralize `content["advancedDelivery"] == true` exclusion in one predicate used by analysis and per-page repair validation.
+- Full content leaks into logs: centralize telemetry metadata construction and test that content/title fields are absent.
+- Context becomes a general repair framework: keep only the two defined detectors and the single shared-activity repair path; do not introduce pluggable repair rules.
+
+## 16. Open Questions & Follow-ups
+- Assign and link the Jira issue before implementation planning so execution and review remain traceable in the repository's system of record.
+- Confirm the final telemetry prefix against nearby authoring events during implementation; changing the proposed prefix does not affect functional behavior.
+- During implementation, verify whether `ContainerEditor.deep_copy_activity/3` should remain the direct dependency or be behavior-preservingly extracted to a narrower shared copy helper. The tool must not introduce alternate copy semantics.
+- Product follow-up, outside this work item: determine whether missing activity references need a separate guided repair workflow after administrators gain visibility into their prevalence.
+
+## 17. References
+- `docs/exec-plans/current/features/online-project-fix/informal.md`
+- `docs/exec-plans/current/features/online-project-fix/prd.md`
+- `docs/exec-plans/current/features/online-project-fix/requirements.yml`
+- `ARCHITECTURE.md`
+- `docs/BACKEND.md`
+- `docs/FRONTEND.md`
+- `docs/TESTING.md`
+- `docs/OPERATIONS.md`
+- `docs/design-docs/high-level.md`
+- `docs/design-docs/page-model.md`
+- `docs/design-docs/publication-model.md`
+- `docs/design-docs/locking.md`
+- `lib/oli/publishing/authoring_resolver.ex`
+- `lib/oli/publishing/tracker.ex`
+- `lib/oli/authoring/locks.ex`
+- `lib/oli/authoring/editing/util.ex`
+- `lib/oli/authoring/editing/container_editor.ex`
+- `lib/oli/authoring/editing/page_editor.ex`
+- `lib/oli/resources/page_content.ex`
+- `lib/oli_web/router.ex`

--- a/docs/exec-plans/current/features/online-project-fix/informal.md
+++ b/docs/exec-plans/current/features/online-project-fix/informal.md
@@ -1,0 +1,338 @@
+# Online Project Repair Tool Informal Requirements
+
+## Intent
+
+Build a manually invoked admin/developer repair tool for course projects. The tool should inspect a single authoring project, report structural problems in page activity references, and optionally apply safe repairs after an explicit admin confirmation.
+
+The initial repair scope is intentionally narrow:
+
+- pages that share the same embedded activity resource
+- pages that reference missing activity resources, for reporting only
+
+The tool must only consider Basic pages. Adaptive pages are out of scope for both analysis and repair.
+
+The tool should be accessible from a project-scoped route so an admin can navigate directly to a URL such as `/workspaces/course_author/<project_slug>/repair_tool`. It should not include a project picker.
+
+## Problem Background
+
+Some older projects were affected by a now-fixed duplication bug. When a page was duplicated, not every referenced activity was duplicated with it. As a result, multiple pages can point at the same activity resource. That is structurally wrong for these projects because editing or repairing one page's activity can unintentionally affect another page that shares the same activity resource.  Torus has a hard schema requirement that pages cannot share the same activity references.
+
+Separately, some Basic pages contain `activity-reference` entries for activities that no longer exist in the project. Those references should be reported to the admin, but this tool must not remove them.
+
+## Goals
+
+- Provide a robust project repair tool that can be run manually by a system admin.
+- Run in two phases:
+  - read-only analysis and preview
+  - explicit opt-in repair
+- Analyze and repair Basic pages only.
+- Detect Basic pages that share activity resources.
+- Detect Basic pages that reference missing activity resources.
+- Report missing activity references without removing them.
+- Avoid cloning shared activity references when the shared activity resource is missing.
+- Keep memory usage bounded by streaming page/revision content and retaining only the minimal IDs and issue summaries needed for detection and reporting.
+- Keep the core implementation outside `OliWeb` in a dedicated non-web context.
+- Keep the LiveView thin: it should invoke the context, display the analysis results, link to affected page editors, and trigger the repair phase.
+- Include unit tests for the repair context.
+- Restrict access to system admins.
+- Keep the implementation of this tool as simple as possible, to make it trivial to code review and to reduce the risk of using this tool.
+
+## Non-Goals
+
+- No automatic scheduled/background repair.
+- No project picker UI.
+- No LiveView test requirement for the initial implementation.
+- No attempt to repair arbitrary page schema problems beyond the two issue types listed here.
+- No removal of missing activity references.
+- No analysis or repair of Adaptive pages.
+- No repair of published delivery section state. This tool targets authoring project structure and operates directly on the unpublished revisions of these resources (that is, those resources resolved via AuthoringResolver)
+- No requirement to optimize for all-project/global scans; invocation is scoped to one project.
+
+## Basic Page Scope
+
+The tool must only inspect and repair Basic pages.
+
+Adaptive pages are identified by page content with a top-level flag:
+
+```elixir
+%{"advancedDelivery" => true}
+```
+
+If the top-level `advancedDelivery` flag is missing or set to `false`, the page is a Basic page and is in scope.
+
+If the top-level `advancedDelivery` flag is set to `true`, the page is Adaptive and must be skipped entirely:
+
+- do not include it in page/activity maps
+- do not report its missing activity references
+- do not report its shared activity references
+- do not clone activity resources for it
+- do not update its page revision
+
+Implementation note: confirm the exact content key spelling against existing page content code. This requirement uses `advancedDelivery` because that is the concrete content pattern for Adaptive pages.
+
+## Access And Route
+
+Add a project-scoped LiveView route:
+
+```text
+/workspaces/course_author/<project_slug>/repair_tool
+```
+
+Only system admins may access this route. Non-admin users must be denied using the existing project/admin authorization conventions.
+
+The LiveView should resolve the project from the route slug and pass the project to the repair context.
+
+## Two-Phase Workflow
+
+### Phase 1: Analyze / Preview
+
+The initial phase must be read-only. It scans the project, detects issues, and returns a report that the LiveView can render.
+
+The preview should include:
+
+- missing activity references
+  - page resource id
+  - page title
+  - missing activity resource id
+  - link to the affected page editor
+- shared activity references
+  - shared activity resource id
+  - count of pages referencing it
+  - affected page resource ids
+  - affected page titles
+  - links to each affected page editor
+  - whether the shared activity exists and is repairable
+- summary counts
+  - scanned page count
+  - skipped Adaptive page count
+  - missing activity reference count
+  - affected page count for missing activities
+  - repairable shared activity resource count
+  - non-repairable shared missing activity resource count, if any
+  - affected page count for shared activities
+
+The preview must not mutate page revisions, activity revisions, resources, or project state.
+
+### Phase 2: Make Changes
+
+After reviewing the analysis report, the admin can click a "Make Changes" button. This action applies repairs to the same project.
+
+The repair phase should either rerun analysis immediately before applying changes or otherwise protect against stale preview state. The implementation should not blindly apply an old report if project content may have changed between preview and repair.
+
+The repair phase must only repair shared references to existing activity resources. It must not remove missing activity references.
+
+If two or more Basic pages share the same missing activity resource id, the tool should report those missing references but must not attempt to clone that activity. A missing activity cannot be used as the source for a repair.
+
+## Issue 1: Pages Sharing Activities
+
+### Detection
+
+For each page in the project:
+
+1. stream or otherwise incrementally read the page's current revision content
+2. skip the page if its content is Adaptive, identified by top-level `%{"advancedDelivery" => true}`
+3. extract all embedded `activity-reference` activity resource ids.  There are existing functions to use to correctly find ALL nested activity-reference instances.  Use the same approach that the current "page duplication" logic uses.
+4. build a minimal in-memory map of:
+
+```text
+page_resource_id -> Set(activity_resource_id)
+```
+
+Then build an inverted map:
+
+```text
+activity_resource_id -> Set(page_resource_id)
+```
+
+Any `activity_resource_id` whose page set has cardinality greater than one is a shared activity issue candidate.
+
+Before repair, the tool must resolve the activity resource through the authoring resolver for the project:
+
+- if the activity resolves, it is a repairable shared activity issue
+- if the activity does not resolve, it is a missing activity reference and must not be cloned
+
+The report should group shared activity issues by activity resource id and clearly distinguish repairable shared activities from shared missing activity ids.
+
+### Repair
+
+For each shared existing activity resource, preserve one Basic page's reference to the original activity resource and repair the other Basic page references.
+
+For each additional page that references the shared activity:
+
+1. create a new activity resource
+2. create a complete copy of the original activity revision/content for that new resource
+3. update that page's content so its `activity-reference` points to the new activity resource id
+4. create/update the page revision with the repaired page content
+
+The resulting state should be that no two pages in the project share the same embedded activity resource as a result of these duplicated-page artifacts.
+
+The implementation should be deterministic about which page keeps the original activity resource, for example the first page in ascending resource id order.
+
+If the shared activity resource is missing, do not attempt repair for that group.
+
+There is existing, well tested code for "Duplicating" or "Copying" an activity.  This Repair must use that existing impl, and
+not create some impl anew.
+
+## Issue 2: Missing Activities
+
+### Detection
+
+Use the Basic-page-only page-to-activity map from the analysis pass:
+
+```text
+page_resource_id -> Set(activity_resource_id)
+```
+
+For each activity resource id referenced by each page, attempt to resolve its current revision using the authoring resolver for the project.
+
+If the resolver returns `nil`, the activity is missing from the project and the Basic page has a missing activity reference.
+
+### Reporting Only
+
+Missing activity references are report-only in this tool.
+
+The tool must not remove missing `activity-reference` entries from page content. It should report enough detail for an admin or later tool to understand which Basic pages contain missing activity references.
+
+If the same missing activity resource id appears on multiple Basic pages, the tool should report it as missing and ensure the shared-activity repair phase skips it.
+
+## Streaming And Memory Requirements
+
+This tool may be run on large course projects, so the implementation must avoid loading full project content into memory at once.
+
+Expected approach:
+
+- stream or batch page/revision reads
+- skip Adaptive pages after reading only the page content needed to identify `advancedDelivery`
+- parse one page content payload at a time
+- retain only compact maps and summaries:
+  - page resource id to activity resource id set
+  - activity resource id to page resource id set
+  - page metadata required for display, such as title and editor link target
+  - issue summaries
+- avoid retaining full page JSON/content after each page has been processed, except when actively repairing that specific page
+
+The implementation can keep ID sets in memory because the detection algorithm needs global relationships across pages and activity references. It should not keep every full page revision body in memory.
+
+## Safety Requirements
+
+This tool must be safe to run manually in production-like environments.
+
+- The default action is analysis only.
+- No changes occur until the admin clicks "Make Changes".
+- The repair phase should rerun or validate analysis before mutating content.
+- Missing activity references must be reported only, not removed.
+- Shared activity repair must only clone activity resources that resolve through the authoring resolver.
+- Adaptive pages must be skipped and never updated.
+- Updates should be scoped to the selected project only.
+- Activity resolution must use the authoring resolver for the selected project.
+- Page revision updates must use established authoring/project revision mechanisms rather than ad hoc database writes.
+- Shared activity cloning must perform a complete activity copy, including the activity revision content needed for the new resource to behave like the original.
+- Repair operations should be idempotent where practical. Running the tool again after a successful repair should report no instances of the same repairable shared-activity issues. Missing activity references may still be reported because they are intentionally not repaired by this tool.
+- Failures should be surfaced clearly in the LiveView rather than silently ignored.
+- The context should return structured results that are easy to log, test, and render.
+
+## Context Design
+
+Create a new non-`OliWeb` context for the repair implementation. A working namespace could be:
+
+```elixir
+Oli.Authoring.ProjectRepair
+```
+
+The exact name can change during implementation, but the responsibilities should stay outside the LiveView.
+
+Suggested public API shape:
+
+```elixir
+analyze_project(project_or_slug, opts \\ [])
+repair_project(project_or_slug, opts \\ [])
+```
+
+The analysis function should return a structured read model, for example:
+
+```elixir
+{:ok,
+ %ProjectRepair.Report{
+   project_id: project.id,
+   project_slug: project.slug,
+   scanned_pages_count: integer,
+   missing_activity_references: [%MissingActivityReference{}],
+   shared_activity_references: [%SharedActivityReference{}],
+   summary: %ProjectRepair.Summary{}
+ }}
+```
+
+The repair function should return a structured repair result, for example:
+
+```elixir
+{:ok,
+ %ProjectRepair.RepairResult{
+   report_before_repair: %ProjectRepair.Report{},
+   cloned_activity_count: integer,
+   updated_page_count: integer,
+   report_after_repair: %ProjectRepair.Report{}
+ }}
+```
+
+The context should own:
+
+- project resolution
+- page/revision enumeration
+- page content streaming/batching
+- Basic page filtering using the top-level `advancedDelivery` flag
+- activity-reference extraction
+- missing activity detection
+- shared activity detection
+- skipping missing activity ids during shared-activity repair
+- page content transformations
+- activity cloning
+- page revision updates
+- structured reporting for the LiveView and tests
+
+## LiveView Requirements
+
+The LiveView should be simple and project-scoped.
+
+It should:
+
+- require system-admin access
+- resolve the project from `project_slug`
+- call the context to analyze the project
+- render summary counts
+- render missing activity references
+- render shared activity groups
+- render affected page titles as clickable hyperlinks to the page editor
+- provide a "Make Changes" button when repairable shared-activity issues exist
+- disable or hide "Make Changes" when no repairable shared-activity issues exist
+- show repair success/failure results after the repair action
+
+The LiveView should not duplicate detection or repair logic.
+
+## Testing Requirements
+
+Add unit tests for the non-web repair context.
+
+Required coverage:
+
+- detects no issues in a valid project
+- skips Adaptive pages identified by `%{"advancedDelivery" => true}`
+- treats missing or false `advancedDelivery` as Basic page content
+- detects missing activity references in Basic page content
+- reports missing activity references without removing them
+- detects one shared activity referenced by multiple pages
+- clones shared activities and updates all but one page to point at new activity resources
+- does not clone a shared activity id that is missing
+- rerunning analysis after repair reports the repaired shared-activity issues as gone
+- handles pages with no activity references
+- handles multiple references in one page
+- handles multiple independent shared activity groups
+
+LiveView tests are not required for the initial implementation.
+
+## Open Implementation Details
+
+- Confirm the exact existing route helper/path for linking from the repair LiveView to a page editor.
+- Confirm the best existing authoring API for creating a complete activity resource/revision copy.
+- Confirm the correct project revision update API to use when writing repaired page content.
+- Confirm the exact persisted content key for Adaptive pages if existing code differs from `advancedDelivery`.
+- Decide whether repair should be one transaction per page/activity group or a larger transaction. The design should favor safe partial failure reporting if a full-project transaction is not practical.

--- a/docs/exec-plans/current/features/online-project-fix/phase_1_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_1_execution_record.md
@@ -1,0 +1,73 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `1 - Domain Contracts, Authorization, and Test Foundation`
+
+## Scope from plan.md
+- Establish the smallest compilable `Oli.Authoring.ProjectRepair` domain boundary.
+- Add typed, content-free report and repair-result contracts.
+- Implement system-admin authorization, project normalization, working-publication resolution, and safe option defaults.
+- Establish real authoring fixtures for later Basic, Adaptive, nested, shared, and missing-reference tests.
+- Do not implement streamed analysis, repair mutation, telemetry, routing, or LiveView behavior.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added the fail-closed `Oli.Authoring.ProjectRepair` Phase 1 boundary.
+  - Added current-project normalization for both `%Project{}` and slug inputs.
+  - Added unpublished working-publication resolution and explicitly bounded internal batch options.
+  - Valid project calls stop at explicit `:analysis_not_implemented` and `:repair_not_implemented` phase boundaries; no analysis or mutation behavior was introduced early.
+- [x] Data or interface changes
+  - Added documented/typespecified `Report`, `Summary`, `PageSummary`, `MissingActivityReference`, and `SharedActivityReference` contracts, with one top-level module per source file.
+  - Added documented/typespecified `RepairResult` and `RepairFailure` contracts, with closed content-free failure and warning codes.
+  - Added an explicit `repairable_shared_activity_affected_page_count` summary field so later phases cannot conflate repairable pages with shared missing references.
+  - Domain contracts retain revision metadata needed by later stale checks but deliberately contain no page JSON or web URLs.
+- [x] Access-control or safety checks
+  - Both public entry points require a system-admin `%Author{}` and authorize before options, project, or publication lookup.
+  - Authorization reloads the author by id and checks the current persisted role, preventing stale or hand-built caller structs from granting access.
+  - Persisted projects are re-resolved and stale/hand-built structs must match both id and slug.
+  - Inactive/unknown projects, missing working publications, malformed actors, unknown options, and out-of-range batch sizes return deterministic errors.
+- [x] Observability or operational updates when needed
+  - No telemetry or logging added; operational instrumentation belongs to Phase 4.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added eleven focused context tests covering compact contracts, system-admin access through project/slug inputs, shared preparation for repair, unknown/stale projects, missing working publications, authorization precedence, current persisted role enforcement, nonexistent actors, option bounds, and real authoring fixtures.
+  - Fixture foundation now creates and verifies current unpublished Basic, Adaptive, nested, shared, and intentionally missing activity-reference states for later phases.
+- [x] Required verification commands run
+  - `mix format lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair/*.ex test/oli/authoring/project_repair_test.exs`
+  - `mix test test/oli/authoring/project_repair_test.exs`
+  - `mix format --check-formatted lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair/*.ex test/oli/authoring/project_repair_test.exs`
+  - `mix compile --warnings-as-errors`
+- [x] Results captured
+  - Targeted tests passed: 11 tests, 0 failures.
+  - Targeted formatting check passed.
+  - Full warnings-as-errors compilation passed after compiling 1,750 Elixir files.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - Updated the FDD contract to name the repairable-shared affected-page count explicitly and constrain repair failures/warnings to content-free reason codes.
+  - No product or plan divergence found. Explicit not-implemented results are temporary fail-closed Phase 1 boundaries and will be replaced by the already-planned Phase 2 and Phase 3 engines.
+- [x] Open questions added to docs when needed
+  - No new open question introduced in Phase 1.
+
+## Review Loop
+- Round 1 findings:
+  - Security/performance: processing options had lower bounds but no upper bounds.
+  - Security: repair failures and warnings accepted arbitrary terms that could expose authored content or internal details.
+  - Elixir/security: authorization trusted role data on the caller's `%Author{}` instead of current persisted state.
+  - Elixir: multiple top-level contract modules shared source files.
+  - Requirements: the repairable-shared affected-page count was ambiguously named, and repair lacked a direct valid non-admin test.
+- Round 1 fixes:
+  - Added explicit maximum cursor and resolver batch sizes with maximum and maximum-plus-one tests.
+  - Replaced arbitrary failure/warning terms with closed content-free atom types and synchronized the FDD.
+  - Reloaded actors by id before checking their system role; added demotion and nonexistent-account regression tests.
+  - Split every contract into one top-level module per source file.
+  - Added the explicit `repairable_shared_activity_affected_page_count` field and exercised repair with a persisted non-admin actor.
+- Round 2 findings (optional): No additional findings during post-fix targeted verification.
+- Round 2 fixes (optional): None required.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/phase_2_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_2_execution_record.md
@@ -1,0 +1,78 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `2 - Streamed Read-Only Analysis and Reporting`
+
+## Scope from plan.md
+- Implement the non-mutating, publication-scoped analysis path.
+- Stream current page content and retain only compact relationship maps and report metadata.
+- Exclude Adaptive pages, report missing activities, and classify cross-page sharing deterministically.
+- Add complete context coverage for the Phase 2 analysis portions of `AC-003` through `AC-014`; defer `AC-011`'s post-repair assertion to Phase 3.
+- Do not implement repair writes, locks, telemetry, routing, or LiveView behavior.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added a parameterized working-publication page query over current, non-deleted, project-scoped revisions.
+  - Enumerated page content with `Repo.stream/2` inside its required transaction and bounded each cursor fetch with `:stream_max_rows`.
+  - Classified only exact top-level boolean `advancedDelivery: true` as Adaptive; missing and false flags remain Basic.
+  - Extracted nested references through `Oli.Authoring.Editing.Utils.activity_references/1`, retained both compact `MapSet` relationship directions, and discarded each page body after reduction.
+  - Resolved sorted unique activity ids through `AuthoringResolver.existing_activity_resource_ids/2` in bounded chunks, selecting only validated ids and no activity JSON.
+  - Returned deterministically ordered missing records and shared groups, including non-repairable shared missing ids and all required summary cardinalities.
+- [x] Data or interface changes
+  - Replaced the Phase 1 `:analysis_not_implemented` boundary with `{:ok, %Report{}}` for valid analysis calls.
+  - Added the content-free `{:invalid_page_content, page_resource_id}` analysis error.
+  - Kept the Phase 3 repair boundary explicitly fail-closed as `:repair_not_implemented`.
+- [x] Access-control or safety checks
+  - Preserved persisted system-admin authorization before every option, project, publication, or page query.
+  - Excluded Adaptive page metadata and references from both relationship maps, not merely from final rendering.
+  - Rejected malformed page trees and non-positive/non-integer activity ids before resolver queries rather than returning a partial report or leaking lower-level exceptions.
+  - Analysis performs no writes and missing references remain report-only.
+- [x] Observability or operational updates when needed
+  - No project-repair telemetry or logging added; bounded operational instrumentation remains Phase 4 scope.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Updated Phase 1 boundary tests for real read-only reports while retaining authorization, normalization, and option-bound coverage.
+  - Added coverage for empty/no-reference projects, missing/false/true Adaptive flags, nested and repeated references, two independent repairable groups, one shared missing group, compact deterministic output, deleted/non-project rows, malformed traversable content, wrong-type references, and corrupt mapping/revision mismatches.
+  - Added before/after counts plus full relevant authoring, mapping, publication, delivery-section, and learner-access row snapshots proving analysis neither inserts nor updates state.
+  - Counted resolver telemetry events with a one-id batch size to prove unique ids are chunked and repeated page relationships do not create an N+1.
+- [x] Required verification commands run
+  - `mix test test/oli/authoring/project_repair_test.exs`
+  - `mix test test/oli/authoring/project_repair_test.exs test/oli/publishing/authoring_resolver_test.exs --exclude flaky`
+  - `mix format --check-formatted lib/oli/publishing/authoring_resolver.ex lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair/*.ex test/oli/authoring/project_repair_test.exs`
+  - `mix compile --warnings-as-errors`
+- [x] Results captured
+  - Targeted context suite passed: 17 tests, 0 failures.
+  - Combined project-repair and existing authoring-resolver suites passed: 38 tests, 0 failures, with one pre-existing `@tag :flaky` ordering test excluded.
+  - Formatting check passed.
+  - Warnings-as-errors compilation passed.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - Updated the FDD and plan to record the activity-only resolver projection introduced during review. The projection preserves the approved project scoping and batching while selecting no full activity JSON and rejecting wrong-type resources.
+- [x] Open questions added to docs when needed
+  - No new open question introduced in Phase 2.
+
+## Review Loop
+- Round 1 findings:
+  - Security/Elixir: generic non-`nil` revisions could classify page/container ids as repairable activity sources.
+  - Performance: generic resolver batches loaded complete activity revisions even though analysis needed only existence/type ids.
+  - Requirements: non-mutation snapshots used counts where full row comparisons were needed, and report tests did not assert title/editor-target metadata.
+  - Requirements/Elixir: Phase 2 records and Gate B overstated the post-repair portion of `AC-011`, which belongs to Phase 3.
+- Round 1 fixes:
+  - Added `AuthoringResolver.existing_activity_resource_ids/2`, which selects only current project activity ids and no activity JSON.
+  - Added wrong-resource-type coverage and title/revision-slug assertions for missing and shared page summaries.
+  - Strengthened persistence snapshots to compare current project revisions/content, mappings, project/publication state, and relevant delivery/learner rows in addition to global insert-detection counts.
+  - Clarified the Phase 2 execution record and Gate B wording to defer `AC-011` post-repair verification to Gate C.
+- Round 2 findings (optional):
+  - Security: the new resolver projection needed to prove mapping and revision resource ids match before certifying an activity.
+  - Performance: test snapshots retained unrelated/global rows and historical project revisions unnecessarily.
+- Round 2 fixes (optional):
+  - Added the mapping/revision resource-id equality predicate and a deliberately corrupt mapping regression test.
+  - Scoped snapshots to current working-publication revisions and the selected project's delivery/learner rows while retaining global counts for insert detection.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/phase_3_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_3_execution_record.md
@@ -1,0 +1,79 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `3 - Lock-Aware Deterministic Repair`
+
+## Scope from plan.md
+- Derive repair work only from fresh server-side analysis and revision-bearing fingerprints.
+- Lock every source activity and participant page in deterministic order and guarantee best-effort cleanup.
+- Preserve one lowest-id keeper page per shared activity and repair every non-keeper page transactionally.
+- Reuse established activity-copy and authoring revision APIs; preserve missing references and Adaptive pages.
+- Return structured completed, partial, and failed results with a fresh after-report.
+- Do not implement routing, LiveView behavior, or operational telemetry.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added `Oli.Authoring.ProjectRepair.Repair` to build deterministic repair fingerprints from fresh analysis, select the lowest page resource id as keeper, invert non-keeper work per page, clone shared source activities through `ContainerEditor.deep_copy_activity/3`, rewire nested Basic-page references with `PageContent.map/2`, recompute `activity_refs`, and write page revisions through `ChangeTracker.track_revision/3`.
+  - Missing activity references remain report-only and are never passed to clone or removal logic.
+  - Adaptive pages remain excluded by the existing Basic-page predicate before planning or mutation.
+- [x] Data or interface changes
+  - `ProjectRepair.repair_project/3` now returns real `RepairResult` values for completed, failed, and partial repairs instead of the prior phase-boundary placeholder.
+  - Added `AuthoringResolver.existing_activity_resource_ids/2` in the earlier analysis path and kept its activity-only projection compatible with Phase 3 repairability checks.
+  - Hardened the page analysis stream join so a working-publication mapping is trusted only when the selected revision belongs to the same resource id.
+- [x] Access-control or safety checks
+  - Repair still reuses the Phase 1 system-admin authorization and persisted-actor reload before resolving project content.
+  - Repair acquires all participant source-activity and page locks in deterministic order before mutation.
+  - Repair uses repair-owned conditional lock acquisition with a `lock_updated_at` ownership stamp, so an existing same-admin lock is a conflict and release/refresh only affect locks this invocation still owns.
+  - Repair reruns analysis after locks and aborts with `:stale_project_state` when the repair fingerprint changed.
+  - Each changed page is one transaction, so page-local clone and page-revision failures roll back together while earlier committed pages remain retryable.
+- [x] Observability or operational updates when needed
+  - No Phase 3 telemetry/logging was added; operational instrumentation remains intentionally deferred to Phase 4.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added/updated context tests for missing-only report-only repair, deterministic keeper behavior, clone fidelity, nested rewiring, missing-reference preservation, Adaptive-page exclusion, idempotent rerun, multiple groups affecting one page, fresh analysis instead of browser preview, post-lock stale fingerprint rejection, lock conflict cleanup, same-admin lock non-adoption, copy failure rollback/partial retry, page-update failure rollback/retry, and corrupt mapping/revision mismatch hardening.
+- [x] Required verification commands run
+  - `mix test test/oli/authoring/project_repair_test.exs`
+  - `mix test test/oli/editing/container_editor_test.exs`
+  - `mix test test/oli/publishing/authoring_resolver_test.exs`
+  - `mix format --check-formatted lib/oli/publishing/authoring_resolver.ex lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair/analysis.ex lib/oli/authoring/project_repair/repair.ex lib/oli/authoring/project_repair/report.ex lib/oli/authoring/project_repair/repair_result.ex test/oli/authoring/project_repair_test.exs`
+  - `mix compile --warnings-as-errors`
+  - `python3 <skills_root>/validate/scripts/validate_work_item.py docs/exec-plans/current/features/online-project-fix --check all`
+- [x] Results captured
+  - `project_repair_test.exs`: 27 tests, 0 failures.
+  - `container_editor_test.exs`: 12 tests, 0 failures.
+  - `authoring_resolver_test.exs`: 22 tests, 0 failures.
+  - Format check passed.
+  - Compile with warnings as errors passed.
+  - Work-item validation passed.
+  - A plan-listed command using `test/oli/authoring/editing/container_editor_test.exs` was attempted and failed because that path does not exist in this checkout; the equivalent existing suite is `test/oli/editing/container_editor_test.exs` and passed.
+  - An attempted parallel run of the two dependent suites produced startup/order noise, so the same suites were rerun sequentially and passed.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - No PRD/FDD/plan contract change was required for Phase 3. Implementation stayed within Gate C scope.
+- [x] Open questions added to docs when needed
+  - No new open questions were introduced for Phase 3.
+
+## Review Loop
+- Round 1 findings:
+  - Security: pre-read plus `Locks.acquire/4` could adopt and later release another same-admin session's lock in a race.
+  - Performance: lock acquisition performed duplicate reads per target; refresh attempted every lock before every page transaction.
+  - Elixir/Ecto correctness: the page stream joined mapping to revision by revision id only, not resource id.
+  - Requirements: AC-016 stale fingerprint rejection and AC-023 page-update failure lacked direct tests; this execution record still had no Gate C evidence.
+- Round 1 fixes:
+  - Replaced normal repair acquisition with conditional update-based, repair-owned locks and stamp-matched refresh/release.
+  - Reduced refresh scope to the current page and that page's source activity locks.
+  - Added the mapping/revision resource-id join predicate and regression coverage.
+  - Added stale-fingerprint and page-update failure tests.
+  - Completed this execution record.
+- Round 2 findings (optional):
+  - Not run; Round 1 findings were concrete and addressed, and verification passed after fixes.
+- Round 2 fixes (optional):
+  - N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/phase_4_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_4_execution_record.md
@@ -1,0 +1,72 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `4 - Operational Instrumentation and Performance Hardening`
+
+## Scope from plan.md
+- Add bounded analysis and repair telemetry/logging without authored content.
+- Ensure observability failures cannot change context return values.
+- Verify resolver batching/query posture for streamed analysis.
+- Keep Phase 4 scoped to backend context instrumentation; do not add route or LiveView behavior.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added `Oli.Authoring.ProjectRepair.Instrumentation` for bounded public analysis/repair stop telemetry and one completion log per public invocation.
+  - Kept instrumentation outside the domain mutation path so analysis and repair return values are computed before best-effort operational recording.
+  - Optimized Phase 3 repair cleanup by skipping final full-project analysis when no page update committed; the before-report is reused as the after-report for zero-write lock/stale/fatal failures.
+  - Converted acquired locks to a target-keyed map for constant-time refresh lookup and replaced per-target lock acquisition with one conditional batch update using a shared invocation stamp.
+- [x] Data or interface changes
+  - Added stop telemetry events under `[:oli, :authoring, :project_repair, :analysis, :stop]` and `[:oli, :authoring, :project_repair, :repair, :stop]`.
+  - Telemetry measurements include `count` and `duration_ms`; metadata includes bounded project/actor identity after successful preparation, option batch sizes, status, failure category, repair counts, warning/failure counts, and summary counts.
+  - Added `:lock_update_failed` as a distinct repair failure reason so database/update errors are not conflated with ordinary lock contention.
+- [x] Access-control or safety checks
+  - Instrumentation records persisted `prepared.project` and `prepared.actor` only after authorization/project preparation succeeds.
+  - Prepare-time failures emit nil project/actor identity so untrusted slugs or hand-built author ids cannot be written to logs or telemetry.
+  - The Phase 3 stale-plan hook is now allowed only in `Mix.env() == :test`; it is not documented as a public production option.
+- [x] Observability or operational updates when needed
+  - Completion logs use the same bounded metadata as telemetry and exclude page content, page titles, activity content, author emails, lock-holder details, and full reports.
+  - Telemetry and logging are wrapped in best-effort rescue/catch paths so handler/logger failures cannot alter context results.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added operational instrumentation tests for analysis metadata privacy, repair success/stale/lock-conflict/partial/fatal outcomes, and telemetry-handler failure resilience.
+  - Existing resolver telemetry test exercises four one-id resolver batches for four unique Basic-page activity ids, proving batching rather than relationship N+1 behavior under `resolution_batch_size: 1`.
+  - Existing stream tests run with `stream_max_rows: 1`, exercising multiple cursor fetches without retaining page content in reports.
+- [x] Required verification commands run
+  - `mix test test/oli/authoring/project_repair_test.exs`
+  - `mix format --check-formatted lib/oli/publishing/authoring_resolver.ex lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair/analysis.ex lib/oli/authoring/project_repair/repair.ex lib/oli/authoring/project_repair/instrumentation.ex lib/oli/authoring/project_repair/repair_failure.ex lib/oli/authoring/project_repair/report.ex lib/oli/authoring/project_repair/repair_result.ex test/oli/authoring/project_repair_test.exs`
+  - `mix compile --warnings-as-errors`
+- [x] Results captured
+  - `project_repair_test.exs`: 30 tests, 0 failures.
+  - Format check passed.
+  - Compile with warnings as errors passed.
+  - AC-007 evidence: the read-only analysis test uses `stream_max_rows: 1` and `resolution_batch_size: 1`; resolver telemetry observes exactly four resolver calls for four unique Basic-page ids, while repeated same-page references and Adaptive-only ids do not create extra resolver calls.
+  - AC-025 evidence: telemetry assertions cover required identity, counts, duration, status, failure stage/reason, and privacy exclusions; repair telemetry covers completed, stale, lock conflict, partial, and fatal outcomes; a raising telemetry handler does not change the analysis result.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - No PRD/FDD/plan contract change was required for Phase 4. Implementation stayed within Gate D scope.
+- [x] Open questions added to docs when needed
+  - No new open questions were introduced for Phase 4.
+
+## Review Loop
+- Round 1 findings:
+  - Requirements: Phase 4 execution record lacked AC-007/AC-025 evidence and Gate D completion details.
+  - Security: instrumentation originally used caller-supplied slug/actor values on prepare-time failures.
+  - Performance: zero-write failures reran full final analysis; acquired-lock refresh lookup was list-based; lock acquisition was still one update per target.
+  - Elixir: a start event was emitted after completion; the stale-plan hook was exposed as a public option; lock update exceptions were normalized as ordinary lock conflicts.
+- Round 1 fixes:
+  - Completed this Phase 4 execution record with AC-007/AC-025 evidence.
+  - Changed instrumentation to use prepared persisted identity only, and nil identity on prepare failures.
+  - Skipped final analysis for zero-write outcomes, converted acquired locks to a map, and batched initial lock acquisition with one conditional update.
+  - Removed the misleading start event, made the stale-plan hook test-only, and added `:lock_update_failed`.
+- Round 2 findings (optional):
+  - Not run; Round 1 findings were addressed and verification passed after fixes.
+- Round 2 fixes (optional):
+  - N/A.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/phase_5_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_5_execution_record.md
@@ -1,0 +1,86 @@
+# Phase 5 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `5 - System-Admin Route and Thin LiveView`
+
+## Scope from plan.md
+- Expose the validated project repair context through `/workspaces/course_author/:project_id/repair_tool`.
+- Gate the route to system administrators while retaining standard authoring workspace project assignment and authorization hooks.
+- Render context report/result structs in an accessible, thin LiveView without duplicating detection or mutation rules in `OliWeb`.
+- Add one focused route/pipeline smoke test for system-admin access and non-system-admin denial.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Added `OliWeb.Workspaces.CourseAuthor.ProjectRepairLive`.
+  - LiveView mount starts async `Oli.Authoring.ProjectRepair.analyze_project/3` from server-side project/author assigns.
+  - `"make_changes"` event sends no page/activity ids or repair plan, requires server-side confirmation state, and starts async `repair_project/3` from current server-side state.
+  - The displayed report is replaced with `report_after_repair` for completed, partial, and structured failed repair results.
+  - Display analysis uses bounded preview limits while preserving full summary counts; repair analysis remains uncapped.
+- [x] Data or interface changes
+  - No schema changes.
+  - Added internal preview-limit options to the context analysis path.
+  - Added `page_count` to `SharedActivityReference` so bounded UI page lists still show full group cardinality.
+  - Added only a Phoenix LiveView route and server-rendered presentation.
+- [x] Access-control or safety checks
+  - Added a dedicated `:system_admin_authoring_workspaces` LiveSession under `:browser`, `:authoring_protected`, and `:require_authenticated_system_admin`.
+  - Retained `SetProjectOrSection` and `AuthorizeProject` on-mount hooks.
+  - LiveView relies on the context's existing system-admin reauthorization for defense in depth.
+- [x] Observability or operational updates when needed
+  - No new operational instrumentation in Phase 5; Phase 4 context instrumentation remains the source of operational events.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added `test/oli_web/project_repair_route_test.exs`.
+  - Covered successful mount for a system administrator.
+  - Covered non-system-admin redirect before LiveView mount.
+  - Covered server-enforced repair confirmation and successful async repair result.
+  - Covered bounded shared-group display retaining the full page count.
+- [x] Required verification commands run
+  - `mix test test/oli_web/project_repair_route_test.exs test/oli/authoring/project_repair_test.exs`
+  - `mix format --check-formatted lib/oli_web/router.ex lib/oli_web/live/workspaces/course_author/project_repair_live.ex test/oli_web/project_repair_route_test.exs`
+  - `mix compile --warnings-as-errors`
+  - `python3 /Users/darren/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/features/online-project-fix --check all`
+- [x] Results captured
+  - Targeted route/context tests: passed, `34 tests, 0 failures`.
+  - Format check: passed.
+  - Compile with warnings as errors: passed.
+  - Preflight validation: passed.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - No implementation divergence from Phase 5 plan.
+- [x] Open questions added to docs when needed
+  - No new open questions from Phase 5.
+
+## Review Loop
+- Round 1 findings:
+  - Performance: synchronous mount/repair work and unbounded LiveView diff.
+  - UI: destructive repair lacked confirmation; summary metric semantics were fragile.
+  - Requirements: missing repairable affected-page summary card.
+  - Security/Elixir: confirmation needed server-side enforcement.
+- Round 1 fixes:
+  - Moved analysis and repair to `start_async`/`handle_async`.
+  - Added inline confirmation with server-side `confirming_repair?` guard.
+  - Replaced summary `<dl>` with list/card semantics.
+  - Added repairable affected-page summary card.
+  - Added route tests for confirmation, direct-event bypass, and repair result.
+- Round 2 findings (optional):
+  - UI/requirements: bounded shared-group display showed truncated page count.
+  - Elixir: lock acquisition could infer ownership ambiguously for same-admin concurrent repairs.
+  - Performance: UI analysis still built complete issue lists; repair clone loop resolved source revisions per clone.
+- Round 2 fixes (optional):
+  - Added `SharedActivityReference.page_count` and rendered full page count with truncation notice.
+  - Reworked repair lock acquisition to a row-locking all-or-none transaction.
+  - Added preview limits to analysis and used them from the LiveView only.
+  - Added pre-resolved `ContainerEditor.deep_copy_activity_revision/4` and batched source revision lookup per repaired page.
+
+## Manual Verification Notes
+- Automated route/pipeline coverage verifies system-admin access and non-system-admin denial.
+- Automated LiveView route coverage verifies confirmation, success status, and bounded display count.
+- Full browser/manual checks for prepared projects remain part of Phase 6 integrated verification.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/phase_6_execution_record.md
+++ b/docs/exec-plans/current/features/online-project-fix/phase_6_execution_record.md
@@ -1,0 +1,98 @@
+# Phase 6 Execution Record
+
+Work item: `docs/exec-plans/current/features/online-project-fix`
+Phase: `6 - Integrated Verification, Review, and Delivery Readiness`
+
+## Scope from plan.md
+- Run targeted and broader authoring tests affected by resolver, duplication, locks, publication mapping, and routing changes.
+- Run format, compile, review, requirements traceability, and work-item validation gates.
+- Resolve concrete security, performance, Elixir, UI, and requirements review findings.
+- Confirm all implementation evidence is captured for handoff.
+
+## Implementation Blocks
+- [x] Core behavior changes
+  - Hardened Phase 5 LiveView based on review:
+    - async initial analysis and async repair execution;
+    - server-enforced confirmation before repair;
+    - bounded UI preview analysis;
+    - full shared-group page count retained when display pages are truncated.
+  - Hardened repair locking:
+    - replaced ambiguous timestamp-based partial acquisition inference with an all-or-none row-locking transaction.
+  - Hardened repair copy performance:
+    - added `ContainerEditor.deep_copy_activity_revision/4` so repair can batch-resolve source activity revisions per page while preserving existing duplication semantics.
+- [x] Data or interface changes
+  - No database schema or migration changes.
+  - Added context analysis preview-limit options for UI analysis only.
+  - Added `SharedActivityReference.page_count` to preserve full group cardinality across bounded display lists.
+- [x] Access-control or safety checks
+  - Direct `make_changes` LiveView events are ignored unless the socket has entered confirmation state.
+  - Context-level system-admin reauthorization remains authoritative.
+  - Lock acquisition is transactional and does not adopt locks from another invocation.
+- [x] Observability or operational updates when needed
+  - No new telemetry fields in Phase 6; Phase 4 bounded telemetry/logging remains in place.
+
+## Test Blocks
+- [x] Tests added or updated
+  - Added/updated route tests for:
+    - system-admin mount;
+    - non-system-admin denial;
+    - server-enforced repair confirmation/direct-event bypass;
+    - successful async repair result;
+    - bounded shared-group display retaining full page count.
+  - Added implementation proof reference for `AC-022`.
+- [x] Required verification commands run
+  - `mix test test/oli_web/project_repair_route_test.exs test/oli/authoring/project_repair_test.exs`
+  - `mix test test/oli/authoring/editing/container_editor_test.exs test/oli/publishing/authoring_resolver_test.exs`
+  - `mix format --check-formatted`
+  - `mix compile --warnings-as-errors`
+  - `python3 /Users/darren/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/features/online-project-fix --action master_validate --stage implementation_complete`
+  - `python3 /Users/darren/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/features/online-project-fix --check all`
+- [x] Results captured
+  - Context + route tests: passed, `34 tests, 0 failures`.
+  - ContainerEditor + AuthoringResolver tests: passed, `22 tests, 0 failures`.
+  - Full format check: passed.
+  - Compile with warnings as errors: passed.
+  - Requirements traceability: passed.
+  - Work-item validation: passed.
+
+## Work-Item Sync
+- [x] PRD, FDD, and plan updated when implementation diverged
+  - No PRD/FDD/plan contract changes were needed.
+  - Execution records capture review-driven implementation hardening.
+- [x] Open questions added to docs when needed
+  - No new open questions.
+
+## Review Loop
+- Round 1 findings:
+  - Security: no blocking route/context authorization findings; residual direct-event confirmation gap later surfaced in second pass.
+  - Performance: synchronous LiveView analysis/repair and unbounded LiveView diff.
+  - Elixir: synchronous LiveView work and insufficient event coverage.
+  - UI: destructive action lacked confirmation; summary `<dl>` semantics were fragile.
+  - Requirements: missing summary display for repairable shared affected pages.
+- Round 1 fixes:
+  - Moved analysis and repair to async LiveView tasks.
+  - Added confirmation UI and clearer repair CTA.
+  - Replaced summary semantics with list/card structure.
+  - Added repairable affected-page summary card.
+  - Added route tests for confirmation and repair result.
+- Round 2 findings:
+  - Security/Elixir: confirmation needed server-side enforcement.
+  - UI/requirements: bounded display needed full shared-group page count and unambiguous editor-link labels.
+  - Elixir: same-admin concurrent repair lock ownership could be ambiguous.
+  - Performance: UI analysis needed context-level preview limits; repair clone loop should avoid resolver query per clone.
+- Round 2 fixes:
+  - Enforced confirmation in `handle_event/3` and added direct-event bypass test.
+  - Added `SharedActivityReference.page_count`, full-count rendering, truncation copy, and duplicate-safe aria labels.
+  - Reworked lock acquisition to all-or-none row-locked transaction.
+  - Added analysis preview limits and used them from LiveView analysis only.
+  - Added `ContainerEditor.deep_copy_activity_revision/4` and batch source-revision resolution per repaired page.
+
+## Manual Verification Notes
+- Automated coverage verifies the core route, confirmation, repair result, editor-link path construction, and bounded display behavior.
+- Browser-only focus restoration/axe checks were not run in this terminal session. The confirmation is rendered as an inline `role="region"` rather than a modal dialog to avoid unsupported dialog semantics.
+
+## Done Definition
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/online-project-fix/plan.md
+++ b/docs/exec-plans/current/features/online-project-fix/plan.md
@@ -1,0 +1,197 @@
+# Online Project Repair Tool - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/features/online-project-fix/prd.md`
+- FDD: `docs/exec-plans/current/features/online-project-fix/fdd.md`
+- Canonical requirements: `docs/exec-plans/current/features/online-project-fix/requirements.yml`
+- Supplemental technical detail: `docs/exec-plans/current/features/online-project-fix/informal.md`
+
+## Scope
+Deliver a synchronous, project-scoped system-administrator tool that streams current unpublished Basic-page revisions, reports missing and cross-page shared activity references, and repairs only shared activities that resolve through the project's authoring resolver. Repair must clone through existing activity-duplication behavior, preserve one deterministic keeper page, update normal authoring revisions, respect durable authoring locks, report partial failures, and leave Adaptive pages, missing references, published content, delivery state, and learner data unchanged.
+
+The implementation is limited to a focused `Oli.Authoring.ProjectRepair` context, its typed report/result contracts, a thin Phoenix LiveView and route, targeted ExUnit coverage, bounded telemetry/logging, and documentation/comments needed to make the safety-critical behavior easy to review.
+
+Mandatory source-commenting standard: all new or modified source code must be commented liberally. Every module must have useful module documentation; public functions and structured contracts must have documentation and typespecs; and streaming assumptions, Basic/Adaptive classification, map inversion, deterministic keeper selection, stale-plan fingerprints, lock ordering/cleanup, per-page transaction boundaries, activity-copy reuse, missing-reference preservation, and failure normalization must have clear inline comments explaining intent and safety invariants. Tests and LiveView code must also comment non-obvious fixture construction, authorization setup, and why assertions protect production safety. Comments should explain behavior and reasoning rather than restating syntax.
+
+## Clarifications & Default Assumptions
+- `advancedDelivery == true` is the sole Adaptive-page exclusion. Missing and boolean `false` are Basic.
+- Missing activities are report-only in every phase; no code path removes their references.
+- `Oli.Authoring.Editing.Utils.activity_references/1` and `Oli.Resources.PageContent` remain the nested traversal primitives.
+- Use `Oli.Authoring.Editing.ContainerEditor.deep_copy_activity/3` directly unless implementation proves that a behavior-preserving helper extraction is necessary. Do not create alternate copy semantics.
+- Use `Oli.Publishing.ChangeTracker.track_revision/3`, not `PageEditor.edit/4`, for server-owned page rewrites, and explicitly recompute `activity_refs`.
+- Repair is fail-fast across pages and transactional within one page. Earlier committed pages remain valid; the failed page rolls back its clones and page revision; the after-report identifies remaining work.
+- The browser preview is never accepted as a mutation plan. Repair performs fresh analysis, locks all participant pages/source activities, and validates a revision-bearing fingerprint before writing.
+- The proposed telemetry prefix is `[:oli, :authoring, :project_repair]`; reconcile it with nearby authoring telemetry during implementation without changing event payload constraints.
+- No feature flag, migration, background job, cache, project picker, or detailed LiveView interaction test suite is planned. Add one focused route authorization test because access control is an automated requirement.
+- Jira is the execution system of record. The missing issue key does not block local implementation planning, but it must be linked before final delivery.
+- Liberal source comments are a release requirement. Each phase gate includes a comment/documentation review, and uncommented safety-critical logic fails the gate.
+
+## Phase 1: Domain Contracts, Authorization, and Test Foundation
+- Goal: Establish the smallest compilable domain boundary, stable result contracts, test fixtures, and defense-in-depth authorization before implementing analysis or mutation.
+- Tasks:
+  - [ ] Create `Oli.Authoring.ProjectRepair` with documented public `analyze_project/3` and `repair_project/3` contracts that require the authenticated `%Author{}` actor.
+  - [ ] Add documented/typespecified structs for `Report`, `Summary`, `PageSummary`, `MissingActivityReference`, `SharedActivityReference`, `RepairResult`, and `RepairFailure`; keep web URLs and HEEx concerns out of these structs.
+  - [ ] Implement common actor authorization, project/project-slug normalization, working-publication resolution, deterministic error normalization, and safe option defaults for stream and resolution batch sizes.
+  - [ ] Reject non-system-admin actors before project content is queried (`FR-001`, `AC-001`, `AC-002`).
+  - [ ] Establish `test/oli/authoring/project_repair_test.exs` with reusable fixtures/helpers for Basic pages, Adaptive pages, nested references, shared activities, and intentionally missing ids.
+  - [ ] Add liberal `@moduledoc`, `@doc`, `@spec`, struct field documentation, and inline comments explaining why authorization exists in both the context and eventual route and why report structs contain revision ids but no page content.
+- Testing Tasks:
+  - [ ] Test system-admin access with both `%Project{}` and project slug inputs and deterministic not-found/working-publication failures (`AC-001`).
+  - [ ] Test non-system-admin denial occurs before page analysis or mutation entry points (`AC-002`).
+  - [ ] Compile the new modules with warnings treated as actionable and verify fixture helpers produce current unpublished project revisions.
+  - Command(s): `mix test test/oli/authoring/project_repair_test.exs`; `mix format --check-formatted lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair test/oli/authoring/project_repair_test.exs`
+- Definition of Done:
+  - Public contracts compile, authorization/project normalization tests pass, typed results are sufficient for later context and LiveView phases, and no analysis or repair behavior is prematurely implemented in the web layer.
+  - Every created source/test module and non-obvious contract is liberally documented and commented according to the mandatory standard.
+- Gate:
+  - Gate A: domain contracts are approved, system-admin denial is proven, targeted tests pass, formatting passes, and comment review finds no undocumented public API or safety assumption.
+- Dependencies:
+  - Validated PRD, FDD, and `requirements.yml`; no code dependency on later phases.
+- Parallelizable Work:
+  - Struct/type documentation and test fixture helpers may be developed in parallel after public field names are agreed. Changes to the main context file should remain serialized.
+
+## Phase 2: Streamed Read-Only Analysis and Reporting
+- Goal: Implement and fully test the non-mutating analysis path before any repair writes are introduced.
+- Tasks:
+  - [ ] Add a parameterized Ecto query over the selected project's unpublished `PublishedResource` page mappings and current non-deleted project `Revision` rows; select only revision id, resource id, slug, title, and content.
+  - [ ] Enumerate the query with `Repo.stream/2` inside the required transaction and a bounded `max_rows`; do not call `AuthoringResolver.all_pages/1` or retain all page content (`FR-002`, `FR-004`, `AC-003`, `AC-007`).
+  - [ ] Centralize the Basic-page predicate so top-level boolean `advancedDelivery: true` increments the skipped count and is excluded from both relationship maps, while missing/false is included (`FR-003`, `AC-004`, `AC-005`).
+  - [ ] Extract all nested activity ids through `Utils.activity_references/1`, store one `MapSet` per Basic page, and build the inverted activity-to-page `MapSet` during the same reduce (`AC-006`, `AC-008`, `AC-009`).
+  - [ ] Resolve unique activity ids through the project-scoped `AuthoringResolver.existing_activity_resource_ids/2` projection in bounded chunks, retaining only validated activity ids, selecting no activity JSON, and avoiding N+1 queries.
+  - [ ] Produce deterministic missing-reference records and shared groups, mark shared missing ids non-repairable, and compute every preview summary count (`FR-005`, `FR-006`, `FR-007`, `FR-010`, `AC-010`, `AC-012`, `AC-013`, `AC-014`).
+  - [ ] Treat malformed traversable page content as an explicit page-scoped analysis failure rather than returning an incomplete report.
+  - [ ] Add liberal comments around stream lifetime, why content is discarded, relationship-map memory complexity, nested traversal reuse, MapSet deduplication, resolver batching, and the absolute exclusion of Adaptive pages.
+- Testing Tasks:
+  - [ ] Prove analysis creates no resources, revisions, mappings, publication changes, delivery changes, or learner changes (`AC-003`).
+  - [ ] Cover no-issue projects, no-reference pages, nested references, repeated same-page references, missing/false/true `advancedDelivery`, missing activity ids, one shared group, shared missing ids, and multiple independent groups (`AC-004` through `AC-014`).
+  - [ ] Run analysis with small configured stream/resolver batch sizes to exercise multiple batches and assert deterministic output ordering (`AC-007`).
+  - [ ] Assert report structs contain compact metadata and ids but never full page content.
+  - Command(s): `mix test test/oli/authoring/project_repair_test.exs`; `mix format --check-formatted lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair test/oli/authoring/project_repair_test.exs`
+- Definition of Done:
+  - Analysis returns a complete, deterministic report for all required Basic-page cases, reports but never changes missing references, excludes Adaptive pages entirely, performs bounded activity resolution, and has no mutation side effects.
+  - Streaming and classification implementation is liberally commented enough for a reviewer to verify why full JSON cannot accumulate and why Adaptive content cannot enter repair maps.
+- Gate:
+  - Gate B: all Phase 2 analysis portions of `AC-003`–`AC-014` pass; `AC-011`'s post-repair assertion remains for Gate C. A query/performance inspection finds no page/activity N+1 path, formatting passes, and source-comment review approves all memory and classification invariants.
+- Dependencies:
+  - Gate A.
+- Parallelizable Work:
+  - Report summary tests and malformed-content tests may proceed alongside the stream reducer once the report contract is fixed. Query and reducer changes should remain coordinated because they share memory assumptions.
+
+## Phase 3: Lock-Aware Deterministic Repair
+- Goal: Add the only mutation path, deriving it exclusively from fresh analysis and preserving safe, retryable authoring history.
+- Tasks:
+  - [ ] Build a deterministic repair fingerprint from repairable shared activity ids and sorted participant page resource/revision ids; select the lowest page resource id as keeper (`FR-008`, `AC-016`, `AC-017`).
+  - [ ] Invert non-keeper work into `page_resource_id -> MapSet<source_activity_resource_id>` so a page involved in multiple groups receives one page revision.
+  - [ ] Acquire `Oli.Authoring.Locks` for every participant page, keeper page, and source activity in deterministic order; release all acquired locks on acquisition failure and refresh locks between long-running page transactions.
+  - [ ] Rerun analysis after complete lock acquisition and abort with `:stale_project_state` and zero writes when the repair fingerprint differs (`AC-016`).
+  - [ ] For each non-keeper page in ascending id order, open one transaction, re-resolve and validate the current Basic page revision, clone each assigned source once through `ContainerEditor.deep_copy_activity/3`, and reuse the returned new id for every matching reference on that page (`FR-009`, `AC-018`).
+  - [ ] Rewire nested references with `PageContent.map/2` while preserving all unrelated node fields and every missing activity reference; recompute `activity_refs`; create the new page revision through `ChangeTracker.track_revision/3`; broadcast only after commit (`AC-011`, `AC-019`, `AC-020`).
+  - [ ] Stop on the first page failure, roll back that page's clones/revision, preserve earlier committed pages, release all locks, rerun analysis, and return `:completed`, `:partial`, or `:failed` structured results with counts/failures/warnings (`FR-011`, `AC-021`, `AC-022`, `AC-023`).
+  - [ ] Ensure no repair plan is generated for shared ids whose authoring resolution is `nil` and no code attempts to copy them (`FR-010`, `AC-020`).
+  - [ ] Add liberal comments explaining keeper determinism, lock membership/order/refresh/reverse release, fingerprint contents, why the browser report is ignored, why `PageEditor.edit/4` is not used, page transaction scope, same-page clone reuse, missing-reference preservation, and safe retry after partial completion.
+- Testing Tasks:
+  - [ ] Verify lowest-id keeper behavior, distinct clones for every non-keeper page, full existing duplication semantics, nested rewiring, and aligned persisted `activity_refs` (`AC-017`–`AC-019`).
+  - [ ] Verify a missing shared id creates no new resource, revision, project-resource row, or mapping and remains present in page JSON (`AC-011`, `AC-020`).
+  - [ ] Verify multiple groups and several groups affecting one page are not conflated and produce one page revision per changed page (`AC-021`).
+  - [ ] Change project state between preview and repair and during pre-lock planning to prove fresh analysis/fingerprint rejection (`AC-016`).
+  - [ ] Hold a participant lock with another author and prove zero repair writes; force copy/page-update failures and prove active-page rollback, fail-fast behavior, structured partial results, lock cleanup, and safe rerun (`AC-023`).
+  - [ ] Rerun analysis after successful and partial repair to prove repaired relationships disappear while missing references remain (`AC-022`).
+  - Command(s): `mix test test/oli/authoring/project_repair_test.exs`; `mix test test/oli/authoring/editing/container_editor_test.exs`; `mix format --check-formatted lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair test/oli/authoring/project_repair_test.exs`
+- Definition of Done:
+  - Repair is deterministic, lock-aware, stale-safe, page-transactional, fail-fast, idempotent on rerun, and incapable of mutating missing references or Adaptive pages.
+  - All mutation and cleanup paths have liberal intent/safety comments, including rollback and partial-failure semantics.
+- Gate:
+  - Gate C: repair acceptance criteria (`AC-011`, `AC-016`–`AC-023`) pass, existing duplication tests remain green, lock cleanup is proven for every failure path, formatting passes, and comment review can trace every write to a documented invariant.
+- Dependencies:
+  - Gate B; activity-copy behavior and report contracts must be stable.
+- Parallelizable Work:
+  - Failure-injection test cases may be prepared while the happy-path transaction is implemented. Lock orchestration, fingerprinting, and transaction code should be integrated serially to avoid competing safety assumptions.
+
+## Phase 4: Operational Instrumentation and Performance Hardening
+- Goal: Make analysis and repair observable without leaking content, and verify the streaming/query posture under representative project sizes.
+- Tasks:
+  - [ ] Add analysis/repair telemetry spans using the reconciled authoring prefix and bounded metadata for operation, project/actor ids, counts, status, failure category, and duration (`AC-025`).
+  - [ ] Add one bounded structured completion log and warning/error logs for lock conflicts, stale state, partial repair, and fatal failures; exclude page/activity content, titles, author emails, and full reports.
+  - [ ] Ensure telemetry/logging failures cannot alter analysis or repair results.
+  - [ ] Review query plans/index use for the working-publication page stream and confirm activity resolution is chunked rather than N+1.
+  - [ ] Exercise a larger generated project and record qualitative memory/query behavior for the implementation handoff; do not introduce an arbitrary latency SLA or an all-project benchmark.
+  - [ ] Add liberal comments documenting telemetry privacy boundaries, why metadata is bounded, configured stream/resolver batch defaults, and why multiple analysis passes are an intentional safety tradeoff.
+- Testing Tasks:
+  - [ ] Attach a telemetry handler and use `capture_log`/`@tag capture_log: true` to assert required operation/count/outcome fields and absence of authored content (`AC-025`).
+  - [ ] Exercise multiple stream/resolver batches and inspect query counts to guard against page/activity N+1 regressions (`AC-007`).
+  - [ ] Verify instrumentation on successful, stale, lock-conflict, partial, and fatal outcomes without changing returned values.
+  - Command(s): `mix test test/oli/authoring/project_repair_test.exs`; `mix format --check-formatted lib/oli/authoring/project_repair.ex lib/oli/authoring/project_repair test/oli/authoring/project_repair_test.exs`
+- Definition of Done:
+  - AppSignal-compatible telemetry/logging captures bounded operational outcomes, content is not logged, representative batching is verified, and instrumentation does not affect correctness.
+  - Performance and privacy decisions are liberally documented in source next to the relevant code.
+- Gate:
+  - Gate D: `AC-007` and `AC-025` verification passes, no sensitive/full-content fields appear in instrumentation, query review finds no unbounded/N+1 path, formatting passes, and comments explain every tuning and privacy decision.
+- Dependencies:
+  - Gates B and C so final result shapes and failure categories are stable.
+- Parallelizable Work:
+  - Telemetry test-handler work and representative-project fixture generation can proceed in parallel. Instrumentation wrappers should land after context return shapes stabilize.
+
+## Phase 5: System-Admin Route and Thin LiveView
+- Goal: Expose the validated context through an accessible, project-scoped LiveView without moving domain logic into `OliWeb`.
+- Tasks:
+  - [ ] Add a dedicated workspace route/live session for `/workspaces/course_author/:project_id/repair_tool` behind `:browser`, `:authoring_protected`, and `:require_authenticated_system_admin`, retaining standard project assignment and authorization hooks (`FR-001`, `AC-001`, `AC-002`).
+  - [ ] Implement `OliWeb.Workspaces.CourseAuthor.ProjectRepairLive` mount to call `analyze_project/3` with server assigns and render fatal errors without exposing a repair action.
+  - [ ] Render summary counts, missing references, repairable shared groups, and non-repairable shared missing groups from context structs only; build page editor links with the verified route `/workspaces/course_author/:project_slug/curriculum/:revision_slug/edit` (`FR-007`, `AC-010`, `AC-012`–`AC-015`, `AC-024`).
+  - [ ] Render `Make Changes` only when repairable groups exist, disable it while running, send no page/activity ids or serialized plan from the browser, call `repair_project/3`, and replace the preview with the returned after-report and explicit success/partial/failure status (`AC-015`, `AC-023`, `AC-024`).
+  - [ ] Use semantic headings/lists/tables as appropriate, descriptive page links, visible focus, text status labels, and live-region behavior for operation results; reuse existing Torus components and avoid a React application.
+  - [ ] Add liberal comments documenting the defense-in-depth route choice, why the event carries no repair plan, why links are built in the web layer, and why the LiveView contains no detection/transformation logic.
+- Testing Tasks:
+  - [ ] Add `test/oli_web/project_repair_route_test.exs` as a focused route/pipeline smoke test for system-admin access and non-system-admin redirect/denial (`AC-001`, `AC-002`); do not expand into a detailed LiveView behavior suite.
+  - [ ] Manually verify missing-only, no-issue, repairable, successful, partial, and fatal states; verify page-title links, button visibility, keyboard navigation, focus, and text status (`AC-015`, `AC-024`).
+  - [ ] Confirm the LiveView never retains page content and sends no client-controlled resource ids to the repair context.
+  - Command(s): `mix test test/oli_web/project_repair_route_test.exs test/oli/authoring/project_repair_test.exs`; `mix format --check-formatted lib/oli_web/router.ex lib/oli_web/live/workspaces/course_author/project_repair_live.ex test/oli_web/project_repair_route_test.exs`
+- Definition of Done:
+  - The direct route is usable only by system admins, preview and result states accurately render context data, editor links work, the repair action is appropriately gated, and the LiveView remains accessible and domain-logic-free.
+  - Route and LiveView source is liberally commented at every security or orchestration boundary.
+- Gate:
+  - Gate E: route authorization automation passes, manual `AC-015`/`AC-024` checks pass, context tests remain green, formatting passes, and review confirms both thin-LiveView separation and liberal comments.
+- Dependencies:
+  - Gates A–D; the LiveView depends on stable `Report` and `RepairResult` contracts.
+- Parallelizable Work:
+  - Static HEEx rendering and route-guard test setup may begin after report/result structs stabilize, in parallel with late Phase 4 instrumentation. Event wiring waits for Gate C.
+
+## Phase 6: Integrated Verification, Review, and Delivery Readiness
+- Goal: Prove the complete feature meets safety, performance, security, traceability, documentation, and operational expectations before handoff.
+- Tasks:
+  - [ ] Run targeted and broader authoring tests affected by resolver, duplication, locks, publication mapping, and routing changes.
+  - [ ] Run `mix format` and compile with warnings reviewed; remove dead options, stale assigns, duplicated helpers, and speculative abstractions.
+  - [ ] Audit every new/modified source and test file against the mandatory liberal-commenting standard. Add missing module/function/typespec documentation and inline rationale for every safety-critical branch; remove comments that merely paraphrase syntax or have become inaccurate.
+  - [ ] Perform repository-required reviews: security and performance always, plus Elixir, UI, and requirements reviews for the affected files. Address concrete findings before completion.
+  - [ ] Manually exercise a prepared project containing valid Basic pages, Adaptive pages, nested references, missing-only references, repairable shared groups, shared missing ids, and multiple independent groups.
+  - [ ] Confirm initial analysis performs no writes, Adaptive and published/delivery state remain unchanged, repair counts match persisted changes, post-repair analysis removes repaired groups, and missing references remain (`AC-003`, `AC-004`, `AC-011`, `AC-020`, `AC-022`).
+  - [ ] Confirm operational events are visible through local telemetry/logging conventions without authored content (`AC-025`).
+  - [ ] Link the Jira implementation issue and ensure PRD/FDD/plan references remain repository-relative.
+  - [ ] Rerun Harness requirement and work-item validation if implementation causes any documented contract change.
+- Testing Tasks:
+  - [ ] Run the full targeted context and route suites and any existing tests touched by helper extraction.
+  - [ ] Run broader `mix test` according to risk/time available; any unexplained failure blocks delivery.
+  - [ ] Complete the manual production-like safety checklist and retain concise evidence in the implementation handoff/PR.
+  - Command(s): `mix test test/oli/authoring/project_repair_test.exs test/oli_web/project_repair_route_test.exs`; `mix test test/oli/authoring/editing/container_editor_test.exs test/oli/publishing/authoring_resolver_test.exs`; `mix format --check-formatted`; `mix compile --warnings-as-errors`
+- Definition of Done:
+  - Every functional requirement (`FR-001`–`FR-011`) and acceptance criterion (`AC-001`–`AC-025`) has automated or recorded manual evidence; targeted tests, formatting, compilation, and required reviews pass; no feature flag/migration is introduced; Jira is linked; and the source is liberally, accurately commented throughout.
+- Gate:
+  - Gate F: all implementation evidence is green, no unresolved high/medium review finding remains, manual safety verification is complete, all locks/content/privacy invariants are confirmed, and the final comment/documentation audit passes.
+- Dependencies:
+  - Gates A–E.
+- Parallelizable Work:
+  - Security, performance, Elixir, UI, and requirements reviews can run in parallel after the implementation diff stabilizes. Manual validation can run alongside review but must be repeated for any behavior-changing fix.
+
+## Parallelization Notes
+- The core context is intentionally small and safety-sensitive; avoid concurrent edits to the same orchestration module. Parallelize fixtures, typed structs, focused tests, telemetry handlers, and static LiveView markup only after their contracts are fixed.
+- Phase 2 analysis must gate Phase 3 repair because mutation correctness depends on complete Basic-page filtering, missing classification, and deterministic relationship maps.
+- After Gate C, Phase 4 instrumentation and the non-event portions of Phase 5 can proceed concurrently. LiveView mutation wiring depends on stable repair results.
+- Required review lenses can run concurrently in Phase 6, then findings should be merged and resolved before final verification.
+- Liberal commenting is continuous work, not a final documentation pass. Every parallel workstream owns comments and docs for the code it changes; phase owners enforce consistency at each gate.
+
+## Phase Gate Summary
+- Gate A: context contracts, system-admin authorization, fixtures, formatting, and liberal API/safety documentation are approved.
+- Gate B: streamed read-only analysis satisfies the Phase 2 analysis portions of `AC-003`–`AC-014`, with `AC-011` post-repair verification deferred to Gate C; analysis has bounded query/memory behavior and clearly comments all classification and streaming invariants.
+- Gate C: deterministic lock-aware repair satisfies `AC-011` and `AC-016`–`AC-023`, safely rolls back/stops/retries, and comments every mutation and cleanup invariant.
+- Gate D: telemetry, privacy, and performance verification satisfy `AC-007`/`AC-025`, with bounded metadata and documented tuning decisions.
+- Gate E: system-admin route and accessible thin LiveView satisfy `AC-001`, `AC-002`, `AC-015`, and `AC-024`, with commented security/orchestration boundaries.
+- Gate F: all `FR-001`–`FR-011` and `AC-001`–`AC-025` evidence, required reviews, manual safety checks, Jira linkage, formatting, compilation, and final liberal-comment audit pass.

--- a/docs/exec-plans/current/features/online-project-fix/prd.md
+++ b/docs/exec-plans/current/features/online-project-fix/prd.md
@@ -1,0 +1,135 @@
+# Online Project Repair Tool - Product Requirements Document
+
+## 1. Overview
+The Online Project Repair Tool gives system administrators a safe, project-scoped way to inspect authoring content for two legacy structural problems: Basic pages that share an activity resource and Basic pages that reference an activity resource missing from the project. The tool first presents a read-only preview. After review, an administrator may explicitly repair resolvable shared activities by cloning the shared activity for all but one affected page. Missing activity references are reported only and Adaptive pages are excluded from both analysis and repair.
+
+## 2. Background & Problem Statement
+An old, now-fixed page-duplication bug did not always duplicate every activity referenced by the copied page. Some older course projects therefore contain multiple pages that point to the same activity resource, violating Torus's structural requirement that pages not share activity references and creating a risk that work on one page affects another.
+
+Some pages also reference activity resources that no longer resolve in the authoring project. Administrators need visibility into these missing references, but removal is intentionally outside this tool's scope because an absent activity cannot be safely reconstructed and automatically changing the page would be destructive.
+
+The repair surface must be safe to invoke against production-like authoring projects, must not affect published delivery state, and must remain practical for large projects by processing page revision content incrementally rather than retaining all page bodies in memory.
+
+## 3. Goals & Non-Goals
+### Goals
+- Give system administrators a direct, project-scoped diagnostic and repair surface.
+- Separate read-only analysis from an explicit repair action.
+- Analyze only Basic pages and completely exclude Adaptive pages identified by top-level `advancedDelivery: true` content.
+- Report missing activity references without modifying them.
+- Repair shared, resolvable activities using existing authoring duplication and revision APIs.
+- Prevent repair attempts when a shared activity resource is missing.
+- Keep memory use bounded by streaming or batching revisions and retaining compact identifiers, metadata, and issue summaries.
+- Keep domain behavior in a non-web context with a thin LiveView and focused context unit tests.
+
+### Non-Goals
+- Removing or otherwise repairing missing activity references.
+- Analyzing or repairing Adaptive pages.
+- Repairing arbitrary page schema defects beyond the two defined issue types.
+- Modifying published publications, delivery sections, or learner state.
+- Automatically scheduling repairs or scanning multiple projects.
+- Providing a project picker.
+- Requiring LiveView tests in the initial implementation.
+
+## 4. Users & Use Cases
+- System administrator: navigates directly to a known project's repair route, reviews detected issues, follows page-title links to inspect affected content, and chooses whether to apply shared-activity repairs.
+- Developer or support engineer with system-admin access: diagnoses legacy project structure without changing content during analysis and uses structured results to understand any failed repair.
+- Course author: indirectly benefits from restored page/activity isolation but is not permitted to access or invoke this administrative tool solely by being a project author.
+
+## 5. UX / UI Requirements
+- Expose the LiveView at `/workspaces/course_author/:project_slug/repair_tool`; the route resolves the project from the slug and does not include a project picker.
+- On initial load, show a read-only analysis with summary counts, missing activity references, repairable shared activities, and shared missing activity identifiers.
+- Render each affected page title as a hyperlink to that page's existing authoring editor route.
+- For missing references, show the page identity and missing activity resource id.
+- For shared references, group affected pages by activity resource id and show page count, page identities, and whether the activity is repairable.
+- Show a clearly labeled `Make Changes` action only when at least one repairable shared activity exists; hide or disable it otherwise.
+- After repair, show success counts and the refreshed analysis, or a clear failure result that identifies work that was not completed.
+- Ensure links, buttons, status messages, and grouped issue information are keyboard accessible and conveyed with text rather than color alone.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+- Security: only system administrators may access the route or invoke analysis and repair; all reads and writes remain scoped to the route's selected project.
+- Safety: analysis is non-mutating, repair requires an explicit action, missing references are never removed, Adaptive pages are never changed, and activity/page updates use established authoring APIs rather than ad hoc database writes.
+- Reliability: repair must use fresh project state, report failures explicitly, and produce a state where rerunning analysis no longer finds the successfully repaired shared relationships.
+- Performance: enumerate page revisions through a stream or bounded batches, process one page content payload at a time, and retain only compact relationship maps, page-display metadata, and issue summaries after each page is processed.
+- Maintainability: the implementation should be intentionally small and reviewable, reuse existing nested activity-reference extraction and activity-copy behavior, and keep all detection and mutation rules outside `OliWeb`.
+- Accessibility: the administrative LiveView must support keyboard operation, visible focus, descriptive links and actions, and semantic presentation of issue groups and statuses.
+
+## 9. Data, Interfaces & Dependencies
+- The context should expose project analysis and repair operations, with a working API shape of `analyze_project(project_or_slug, opts \\ [])` and `repair_project(project_or_slug, opts \\ [])`.
+- Analysis returns a structured report containing project identity, scan/skip counts, missing-reference records, grouped shared-reference records, repairability, and summary counts.
+- Repair returns structured before/after reports plus cloned-activity and updated-page counts, or a structured error suitable for logging and LiveView display.
+- Page classification uses the top-level page content key `advancedDelivery`: only boolean `true` is Adaptive; missing or boolean `false` is Basic.
+- Missing and repairability checks resolve unpublished project revisions through the project's `AuthoringResolver`.
+- Nested `activity-reference` extraction depends on the same established content traversal used by page duplication.
+- Shared-activity repair depends on the existing, tested activity duplication/copy implementation and established project revision update mechanisms.
+- Page-editor links depend on the existing authoring page-editor route helper.
+- Jira is the repository's issue-tracking system of record; no Jira issue key was supplied with this work item.
+
+## 10. Repository & Platform Considerations
+- Put analysis and repair behavior in a focused context under `lib/oli/`, with `Oli.Authoring.ProjectRepair` as the working namespace; keep the LiveView under `lib/oli_web/` limited to authorization, orchestration, and rendering.
+- Respect the resource/revision and publication model: inspect and update unpublished authoring revisions resolved for the selected project, without changing immutable publication or delivery state.
+- Use existing project authorization conventions in the router/live session and enforce system-admin access server-side.
+- Use Ecto streaming or bounded pagination in a form compatible with repository transaction and connection constraints; do not preload all revision content.
+- Add focused ExUnit context tests using repository test factories and run targeted `mix test` and `mix format` gates.
+- Code review must include security and performance reviews plus Elixir, UI, and requirements reviews because this work changes backend domain behavior, authorization, a LiveView surface, and PRD traceability.
+
+## 11. Feature Flagging, Rollout & Migration
+No feature flags present in this work item
+
+The route is intentionally undiscoverable except by direct project-scoped navigation and is restricted to system administrators. No data migration or automatic invocation occurs at deployment; administrators opt into analysis and each repair manually.
+
+## 12. Telemetry & Success Metrics
+- Emit or log a bounded, structured operational result for each analysis and repair invocation, including project identity, pages scanned/skipped, issue counts, clone/update counts, duration, and success or failure, without logging full page content.
+- Use existing Phoenix telemetry/logging and AppSignal conventions rather than introducing a product analytics pipeline.
+- Success means analysis performs no mutations, Adaptive pages remain untouched, missing references remain report-only, and a post-repair analysis reports zero instances of each successfully repaired shared-activity relationship.
+- Context tests covering all required classifications and repair outcomes pass, and manual verification confirms that only system administrators can use the project-scoped workflow.
+
+## 13. Risks & Mitigations
+- Risk: an Adaptive page is accidentally included and mutated. Mitigation: centralize the exact top-level `%{"advancedDelivery" => true}` exclusion and cover true, false, and missing-key cases in context tests.
+- Risk: stale preview data causes repair of content that changed after analysis. Mitigation: rerun analysis from current authoring revisions immediately before mutation and derive repair work from that fresh result.
+- Risk: a missing shared activity is treated as a clone source. Mitigation: require successful `AuthoringResolver` resolution before classifying a shared group as repairable and skip unresolved groups.
+- Risk: cloning creates an incomplete activity. Mitigation: call the existing tested activity duplication/copy implementation rather than reproducing copy semantics.
+- Risk: a large project exhausts application memory or monopolizes a database connection. Mitigation: stream or batch revision reads, discard full content after extraction, retain only compact maps, and include performance review of query and transaction shape.
+- Risk: partial repair leaves an unclear project state. Mitigation: define transaction boundaries explicitly in design, return per-operation failures, and always present a fresh after-analysis when repair completes or partially fails.
+- Risk: unauthorized users discover or invoke the route. Mitigation: enforce system-admin authorization in server-side route/session setup and context-facing entry points, not only through hidden navigation.
+
+## 14. Open Questions & Assumptions
+### Open Questions
+- Should one failed shared-activity group stop the entire repair action, or should independent groups continue with a detailed partial-failure result?
+- Which existing helper is canonical for building page-editor links from page resource ids in this authoring route scope?
+- Which existing activity-copy and page-revision update APIs should the FDD designate as the supported integration points?
+- Which Jira issue should be linked as the execution record for this work item?
+
+### Assumptions
+- The persisted Adaptive-page discriminator is the confirmed top-level boolean key `advancedDelivery`; values missing or equal to boolean `false` identify Basic pages.
+- The tool operates only on current unpublished authoring revisions returned by `AuthoringResolver` for the selected project.
+- Exactly one deterministically selected Basic page, such as the lowest page resource id, may retain the original resolvable shared activity; every other affected Basic page receives a distinct copy.
+- Duplicate references to the same activity within one page are represented once in the page-to-activity set and do not by themselves constitute cross-page sharing.
+- No new product analytics events or feature flags are needed for this manually invoked, system-admin-only repair surface.
+
+## 15. QA Plan
+- Automated validation:
+  - Add context tests for a valid project, pages with no references, nested references, duplicate references within one page, missing activities, one and multiple shared groups, and fresh analysis after repair.
+  - Test that `advancedDelivery: true` pages are absent from all issue reports and never updated, while missing or false values are treated as Basic.
+  - Test that analysis performs no writes and repair leaves missing references unchanged.
+  - Test that resolvable shared activities are copied through existing duplication behavior, all but one affected page receive new activity ids, and page revisions contain the updated references.
+  - Test that unresolved shared activity ids are reported as missing and are never cloned.
+  - Test structured success/error results and project scoping at the context boundary.
+  - Run the targeted ExUnit test file and `mix format`; expand to broader authoring tests if integration changes warrant it.
+- Manual validation:
+  - Verify direct system-admin access and denial for a non-system-admin user.
+  - Verify preview counts, grouping, repairability labels, and page-editor links against a prepared project containing each issue type.
+  - Confirm initial analysis makes no revision changes and `Make Changes` is unavailable when no repairable shared activity exists.
+  - Invoke repair, confirm displayed clone/update counts, and rerun analysis to verify repaired shared issues are gone while missing references remain.
+  - Inspect a skipped Adaptive page and published delivery state to confirm neither changed.
+  - Inspect operational output in local logs/AppSignal-compatible instrumentation and confirm no full page content is recorded.
+
+## 16. Definition of Done
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/features/online-project-fix/requirements.yml
+++ b/docs/exec-plans/current/features/online-project-fix/requirements.yml
@@ -1,0 +1,133 @@
+work_item: online-project-fix
+requirements:
+- title: Restrict the project-scoped repair tool to system administrators
+  id: FR-001
+- title: Analyze current unpublished revisions for Basic pages without mutating project
+    state
+  id: FR-002
+- title: Exclude Adaptive pages from all analysis, reporting, and repair behavior
+  id: FR-003
+- title: Detect nested activity references with bounded page-content memory usage
+  id: FR-004
+- title: Resolve and report missing activity references without changing page content
+  id: FR-005
+- title: Detect and classify activity resources referenced by more than one Basic
+    page
+  id: FR-006
+- title: Present a project-scoped preview with actionable issue details and page-editor
+    links
+  id: FR-007
+- title: Require an explicit repair action based on fresh authoring state
+  id: FR-008
+- title: Repair resolvable shared activities through established activity-copy and
+    page-revision APIs
+  id: FR-009
+- title: Skip repair for every shared activity resource that does not resolve
+  id: FR-010
+- title: Return structured analysis, repair, and failure results suitable for tests,
+    rendering, and operational reporting
+  id: FR-011
+acceptance_criteria:
+- title: A system administrator can open `/workspaces/course_author/:project_slug/repair_tool`
+    for an existing project without selecting it from a project picker
+  verification_method: hybrid
+  id: AC-001
+- title: A user who is not a system administrator is denied access to the repair route
+    and cannot invoke its repair action
+  verification_method: automated
+  id: AC-002
+- title: Initial project analysis creates no resources or revisions and makes no changes
+    to project, publication, delivery, or learner state
+  verification_method: automated
+  id: AC-003
+- title: 'A page whose top-level content contains boolean `advancedDelivery: true`
+    is not scanned for issues, reported, cloned for, or updated'
+  verification_method: automated
+  id: AC-004
+- title: 'Pages with a missing `advancedDelivery` key or boolean `advancedDelivery:
+    false` are analyzed as Basic pages'
+  verification_method: automated
+  id: AC-005
+- title: Activity references nested at every content depth supported by existing page
+    duplication traversal are included in analysis
+  verification_method: automated
+  id: AC-006
+- title: Analysis processes revision content incrementally and does not retain all
+    full page content payloads after relationship extraction
+  verification_method: hybrid
+  id: AC-007
+- title: A page with no activity references is analyzed without error and produces
+    no activity issue
+  verification_method: automated
+  id: AC-008
+- title: Multiple references to the same activity within one page are deduplicated
+    for cross-page sharing detection
+  verification_method: automated
+  id: AC-009
+- title: An activity id that returns `nil` from the selected project's `AuthoringResolver`
+    is reported with its Basic page id, page title, missing resource id, and editor-link
+    target
+  verification_method: automated
+  id: AC-010
+- title: Missing activity references remain unchanged after both analysis and repair
+    actions
+  verification_method: automated
+  id: AC-011
+- title: A resolvable activity referenced by two or more Basic pages is reported as
+    one repairable shared group with its resource id, page count, affected page identities,
+    and editor-link targets
+  verification_method: automated
+  id: AC-012
+- title: A missing activity id referenced by two or more Basic pages is reported as
+    missing and as a non-repairable shared group
+  verification_method: automated
+  id: AC-013
+- title: Preview summary counts distinguish scanned Basic pages, skipped Adaptive
+    pages, missing references and affected pages, repairable shared resources and
+    affected pages, and non-repairable shared missing resources
+  verification_method: automated
+  id: AC-014
+- title: '`Make Changes` is available only when the fresh report contains at least
+    one repairable shared activity'
+  verification_method: manual
+  id: AC-015
+- title: Invoking `Make Changes` reruns analysis or equivalently validates current
+    authoring revisions before deriving mutations
+  verification_method: automated
+  id: AC-016
+- title: For each resolvable shared group, the Basic page selected by deterministic
+    page-resource ordering retains the original activity resource
+  verification_method: automated
+  id: AC-017
+- title: Every other Basic page in a resolvable shared group receives a distinct complete
+    activity copy created through the existing tested duplication implementation
+  verification_method: automated
+  id: AC-018
+- title: Each repaired Basic page receives an authoring revision whose nested activity
+    reference points to its new activity resource
+  verification_method: automated
+  id: AC-019
+- title: No activity resource is created and no page is updated for a shared group
+    whose activity does not resolve
+  verification_method: automated
+  id: AC-020
+- title: Multiple independent resolvable shared groups can be repaired without conflating
+    their page or activity mappings
+  verification_method: automated
+  id: AC-021
+- title: Analysis after a successful repair no longer reports the repaired cross-page
+    shared relationships while still reporting unresolved missing references
+  verification_method: automated
+  id: AC-022
+- title: Analysis and repair return structured counts, grouped issue data, and explicit
+    error information that the LiveView can render without implementing domain logic
+  verification_method: automated
+  id: AC-023
+- title: The LiveView displays page titles as working links to the existing editor
+    route and clearly displays refreshed success or failure status after repair
+  verification_method: manual
+  id: AC-024
+- title: Operational output records bounded project identity, counts, duration, and
+    outcome without recording full page content
+  verification_method: hybrid
+  id: AC-025

--- a/lib/oli/authoring/editing/container_editor.ex
+++ b/lib/oli/authoring/editing/container_editor.ex
@@ -542,6 +542,24 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
   def deep_copy_activity(%{"type" => "activity-reference"} = item, project_slug, author) do
     activity_revision = AuthoringResolver.from_resource_id(project_slug, item["activity_id"])
 
+    deep_copy_activity_revision(item, project_slug, author, activity_revision)
+  end
+
+  def deep_copy_activity(item, _project_slug, _author), do: {:ok, item}
+
+  @doc """
+  Copies an activity-reference node from a revision that has already been resolved.
+
+  This keeps `deep_copy_activity/3` behavior available for ordinary callers while
+  allowing repair tools to batch-resolve activity revisions before cloning many
+  sources. The create path below remains the same tested duplication mechanism.
+  """
+  def deep_copy_activity_revision(
+        %{"type" => "activity-reference"} = item,
+        project_slug,
+        author,
+        %Revision{} = activity_revision
+      ) do
     activity_type = Activities.get_registration(activity_revision.activity_type_id)
 
     case ActivityEditor.create(
@@ -568,7 +586,8 @@ defmodule Oli.Authoring.Editing.ContainerEditor do
     end
   end
 
-  def deep_copy_activity(item, _project_slug, _author), do: {:ok, item}
+  def deep_copy_activity_revision(item, _project_slug, _author, _activity_revision),
+    do: {:ok, item}
 
   # if no container is specified then this is a no-op
   defp remove_from_container(nil, _project_slug, _revision, _author), do: {:ok, nil}

--- a/lib/oli/authoring/project_repair.ex
+++ b/lib/oli/authoring/project_repair.ex
@@ -1,0 +1,334 @@
+defmodule Oli.Authoring.ProjectRepair do
+  @moduledoc """
+  Provides the non-web boundary for analyzing and repairing authoring projects.
+
+  Analysis streams current Basic-page revisions from one project's unpublished
+  working publication and returns compact, deterministic issue records. Both public
+  functions authorize the actor before resolving any project content, normalize a
+  project struct or slug back to current database state, require an unpublished
+  working publication, and validate bounded processing options.
+
+  Repair derives work from fresh analysis, protects participant resources with
+  durable authoring locks, and commits each changed page independently so failures
+  remain bounded and retryable.
+  """
+
+  alias Oli.Accounts
+  alias Oli.Accounts.Author
+  alias Oli.Authoring.Course
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.ProjectRepair.{Analysis, Instrumentation, Repair}
+  alias Oli.Publishing
+
+  @default_stream_max_rows 100
+  @max_stream_rows 500
+  @default_resolution_batch_size 500
+  @max_resolution_batch_size 1_000
+  @max_preview_issue_rows 5_000
+  @max_preview_group_pages 500
+  @test_only_option_keys if Mix.env() == :test, do: [:after_lock_acquisition], else: []
+  @option_keys [
+                 :stream_max_rows,
+                 :resolution_batch_size,
+                 :preview_issue_limit,
+                 :preview_group_page_limit
+               ] ++
+                 @test_only_option_keys
+
+  @typedoc "A persisted project or its slug."
+  @type project_ref :: Project.t() | String.t()
+
+  @typedoc "Bounded processing options shared by analysis and repair preparation."
+  @type option ::
+          {:stream_max_rows, pos_integer()}
+          | {:resolution_batch_size, pos_integer()}
+          | {:preview_issue_limit, pos_integer()}
+          | {:preview_group_page_limit, pos_integer()}
+
+  @typedoc "Errors normalized at the project repair context boundary."
+  @type error ::
+          :not_authorized
+          | :project_not_found
+          | :working_publication_not_found
+          | {:invalid_page_content, pos_integer()}
+          | {:invalid_options, term()}
+
+  @doc """
+  Analyzes the current unpublished Basic pages in an authoring project.
+
+  The operation is strictly read-only. It streams page content long enough to
+  classify the page and extract nested activity ids, then retains only compact
+  relationship maps and display metadata. Missing activities are reported but are
+  never removed, and top-level Adaptive pages are excluded from all issue maps.
+  """
+  @spec analyze_project(project_ref(), Author.t(), [option()]) ::
+          {:ok, Oli.Authoring.ProjectRepair.Report.t()} | {:error, error()}
+  def analyze_project(project_or_slug, actor, opts \\ []) do
+    started_at = Instrumentation.start_time()
+
+    case prepare(project_or_slug, actor, opts) do
+      {:ok, prepared} ->
+        result = Analysis.analyze(prepared.project, prepared.publication, prepared.options)
+
+        # Successful preparation gives instrumentation trusted persisted identity
+        # values. Raw caller slugs or hand-built actors are never logged.
+        Instrumentation.record(
+          :analysis,
+          started_at,
+          result,
+          prepared.project,
+          prepared.actor,
+          instrumentation_options(prepared.options)
+        )
+
+      {:error, _reason} = error ->
+        # Prepare failures intentionally emit no project or actor identity. This
+        # preserves the authorization-first privacy boundary and keeps arbitrary
+        # caller-supplied slugs out of logs and telemetry.
+        Instrumentation.record(
+          :analysis,
+          started_at,
+          error,
+          nil,
+          nil,
+          instrumentation_options(opts)
+        )
+    end
+  end
+
+  @doc """
+  Repairs every currently resolvable cross-page shared activity in a project.
+
+  Repair derives its plan from fresh server-side analysis, locks every source
+  activity and participant page, and revalidates the revision-bearing plan before
+  writing. Missing references are report-only and Adaptive pages cannot enter the
+  repair plan. Operation-level failures are returned in a structured
+  `%Oli.Authoring.ProjectRepair.RepairResult{}` rather than raised to the caller.
+  """
+  @spec repair_project(project_ref(), Author.t(), [option()]) ::
+          {:ok, Oli.Authoring.ProjectRepair.RepairResult.t()} | {:error, error()}
+  def repair_project(project_or_slug, actor, opts \\ []) do
+    started_at = Instrumentation.start_time()
+
+    case prepare(project_or_slug, actor, opts) do
+      {:ok, prepared} ->
+        result =
+          with {:ok, report} <-
+                 Analysis.analyze(prepared.project, prepared.publication, prepared.options) do
+            Repair.repair(
+              prepared.project,
+              prepared.publication,
+              prepared.actor,
+              prepared.options,
+              report
+            )
+          end
+
+        # The repair path may internally analyze several times for safety. The
+        # public invocation emits one completion event/log based on the final result
+        # so operators see one record per admin action rather than per internal pass.
+        Instrumentation.record(
+          :repair,
+          started_at,
+          result,
+          prepared.project,
+          prepared.actor,
+          instrumentation_options(prepared.options)
+        )
+
+      {:error, _reason} = error ->
+        Instrumentation.record(
+          :repair,
+          started_at,
+          error,
+          nil,
+          nil,
+          instrumentation_options(opts)
+        )
+    end
+  end
+
+  # Authorization intentionally runs first. Besides providing defense in depth for
+  # future console or service callers, this ordering prevents an unauthorized actor
+  # from using error differences to probe whether a project or publication exists.
+  defp prepare(project_or_slug, actor, opts) do
+    with {:ok, persisted_actor} <- authorize(actor),
+         {:ok, normalized_opts} <- normalize_options(opts),
+         {:ok, project} <- resolve_project(project_or_slug),
+         {:ok, publication} <- resolve_working_publication(project) do
+      {:ok,
+       %{
+         project: project,
+         publication: publication,
+         actor: persisted_actor,
+         options: normalized_opts
+       }}
+    end
+  end
+
+  defp authorize(%Author{id: actor_id}) when is_integer(actor_id) do
+    # Never trust role data carried by the caller's struct. An author may have
+    # been demoted since the LiveView session was established, and non-web callers
+    # can construct structs by hand. Reloading here makes the database's current
+    # role assignment the authorization source of truth for every invocation.
+    case Accounts.get_author(actor_id) do
+      %Author{} = persisted_actor ->
+        case Accounts.is_system_admin?(persisted_actor) do
+          true -> {:ok, persisted_actor}
+          false -> {:error, :not_authorized}
+        end
+
+      nil ->
+        # A nonexistent account is indistinguishable from any other unauthorized
+        # actor so this boundary does not disclose account lifecycle information.
+        {:error, :not_authorized}
+    end
+  end
+
+  defp authorize(_actor), do: {:error, :not_authorized}
+
+  # A caller may hold an old or hand-built Project struct. Re-resolving by slug and
+  # matching the id ensures all later work uses current persisted project state.
+  defp resolve_project(%Project{id: id, slug: slug}) when is_integer(id) and is_binary(slug) do
+    case Course.get_project_by_slug(slug) do
+      %Project{id: ^id, status: :active} = project -> {:ok, project}
+      _other -> {:error, :project_not_found}
+    end
+  end
+
+  defp resolve_project(slug) when is_binary(slug) do
+    case Course.get_project_by_slug(slug) do
+      %Project{status: :active} = project -> {:ok, project}
+      _other -> {:error, :project_not_found}
+    end
+  end
+
+  defp resolve_project(_project_or_slug), do: {:error, :project_not_found}
+
+  # AuthoringResolver and every later write must be scoped to this unpublished
+  # publication. Failing here prevents accidental fallback to a published snapshot.
+  defp resolve_working_publication(%Project{slug: project_slug}) do
+    case Publishing.project_working_publication(project_slug) do
+      nil -> {:error, :working_publication_not_found}
+      publication -> {:ok, publication}
+    end
+  end
+
+  # Batch sizes are internal tuning controls rather than user input. Strictly
+  # validating a small allowlist keeps tests configurable without creating an
+  # unbounded or surprising execution mode for future callers.
+  defp normalize_options(opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         :ok <- reject_unknown_options(opts),
+         {:ok, stream_max_rows} <-
+           bounded_positive_option(
+             opts,
+             :stream_max_rows,
+             @default_stream_max_rows,
+             @max_stream_rows
+           ),
+         {:ok, resolution_batch_size} <-
+           bounded_positive_option(
+             opts,
+             :resolution_batch_size,
+             @default_resolution_batch_size,
+             @max_resolution_batch_size
+           ),
+         {:ok, preview_issue_limit} <-
+           optional_bounded_positive_option(opts, :preview_issue_limit, @max_preview_issue_rows),
+         {:ok, preview_group_page_limit} <-
+           optional_bounded_positive_option(
+             opts,
+             :preview_group_page_limit,
+             @max_preview_group_pages
+           ),
+         {:ok, after_lock_acquisition} <- test_only_lock_hook_option(opts) do
+      {:ok,
+       %{
+         stream_max_rows: stream_max_rows,
+         resolution_batch_size: resolution_batch_size,
+         preview_issue_limit: preview_issue_limit,
+         preview_group_page_limit: preview_group_page_limit,
+         after_lock_acquisition: after_lock_acquisition
+       }}
+    else
+      false -> {:error, {:invalid_options, :expected_keyword_list}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp normalize_options(_opts), do: {:error, {:invalid_options, :expected_keyword_list}}
+
+  defp reject_unknown_options(opts) do
+    case Keyword.keys(opts) -- @option_keys do
+      [] -> :ok
+      unknown -> {:error, {:invalid_options, {:unknown_options, Enum.uniq(unknown)}}}
+    end
+  end
+
+  # Explicit ceilings are as important as positive lower bounds. These options
+  # will directly control database cursor and resolver query sizes in Phase 2, so
+  # accepting an arbitrary integer would defeat the bounded-memory guarantee.
+  defp bounded_positive_option(opts, key, default, maximum) do
+    case Keyword.get(opts, key, default) do
+      value when is_integer(value) and value > 0 and value <= maximum ->
+        {:ok, value}
+
+      _value ->
+        {:error, {:invalid_options, {:expected_integer_between, key, 1, maximum}}}
+    end
+  end
+
+  defp optional_bounded_positive_option(opts, key, maximum) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} when is_integer(value) and value > 0 and value <= maximum ->
+        {:ok, value}
+
+      {:ok, _value} ->
+        {:error, {:invalid_options, {:expected_integer_between, key, 1, maximum}}}
+
+      :error ->
+        {:ok, nil}
+    end
+  end
+
+  if Mix.env() == :test do
+    # This hook exists only to prove the Phase 3 stale-fingerprint gate. It is not
+    # part of the production option allowlist because arbitrary callbacks do not
+    # belong in a safety-critical repair API.
+    defp test_only_lock_hook_option(opts) do
+      case Keyword.get(opts, :after_lock_acquisition) do
+        nil -> {:ok, nil}
+        hook when is_function(hook, 0) -> {:ok, hook}
+        _other -> {:error, {:invalid_options, {:expected_function, :after_lock_acquisition, 0}}}
+      end
+    end
+  else
+    defp test_only_lock_hook_option(_opts), do: {:ok, nil}
+  end
+
+  defp instrumentation_options(%{
+         stream_max_rows: stream_max_rows,
+         resolution_batch_size: resolution_batch_size
+       }) do
+    %{
+      stream_max_rows: stream_max_rows,
+      resolution_batch_size: resolution_batch_size
+    }
+  end
+
+  defp instrumentation_options(opts) when is_list(opts) do
+    %{
+      stream_max_rows: Keyword.get(opts, :stream_max_rows, @default_stream_max_rows),
+      resolution_batch_size:
+        Keyword.get(opts, :resolution_batch_size, @default_resolution_batch_size)
+    }
+  end
+
+  defp instrumentation_options(_opts) do
+    %{
+      stream_max_rows: @default_stream_max_rows,
+      resolution_batch_size: @default_resolution_batch_size
+    }
+  end
+end

--- a/lib/oli/authoring/project_repair/analysis.ex
+++ b/lib/oli/authoring/project_repair/analysis.ex
@@ -1,0 +1,359 @@
+defmodule Oli.Authoring.ProjectRepair.Analysis do
+  @moduledoc """
+  Implements bounded, read-only analysis for the project repair tool.
+
+  The database cursor yields one current page revision at a time. Full page JSON is
+  used only to classify that row and extract nested activity references; it is never
+  placed in the accumulator or returned report. The retained state is therefore
+  limited to compact page metadata and the two relationship maps required to detect
+  missing and cross-page shared activity resources.
+
+  This module is an internal domain service. Callers should use
+  `Oli.Authoring.ProjectRepair.analyze_project/3`, which applies authorization and
+  project/publication normalization before entering this analysis path.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.Editing.Utils
+
+  alias Oli.Authoring.ProjectRepair.{
+    MissingActivityReference,
+    PageSummary,
+    Report,
+    SharedActivityReference,
+    Summary
+  }
+
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Repo
+  alias Oli.Resources.{ResourceType, Revision}
+
+  @typedoc "Validated controls for database cursor and resolver batch sizes."
+  @type options :: %{
+          stream_max_rows: pos_integer(),
+          resolution_batch_size: pos_integer(),
+          preview_issue_limit: pos_integer() | nil,
+          preview_group_page_limit: pos_integer() | nil
+        }
+
+  @type error :: {:invalid_page_content, pos_integer()}
+
+  @doc """
+  Streams and classifies the current unpublished pages for one normalized project.
+
+  The returned report is sorted by numeric resource identifiers and contains no
+  authored content. A malformed page fails the complete analysis with its resource
+  id; returning a partial report would make a subsequent repair preview unsafe.
+  """
+  @spec analyze(Project.t(), Publication.t(), options()) ::
+          {:ok, Report.t()} | {:error, error()}
+  def analyze(
+        %Project{} = project,
+        %Publication{} = publication,
+        %{
+          stream_max_rows: stream_max_rows,
+          resolution_batch_size: resolution_batch_size
+        } = options
+      ) do
+    with {:ok, relationships} <- stream_relationships(publication.id, stream_max_rows) do
+      resolved_activity_ids =
+        resolve_activity_ids(
+          project.slug,
+          Map.keys(relationships.activity_to_pages),
+          resolution_batch_size
+        )
+
+      {:ok, build_report(project, relationships, resolved_activity_ids, options)}
+    end
+  end
+
+  # The query is tied directly to the already-normalized working publication id.
+  # Joining its mappings to their selected revisions avoids historical revisions,
+  # while the type, deleted, and project-scope predicates exclude non-current or
+  # non-project page rows before any JSON reaches the application process.
+  defp page_stream_query(publication_id) do
+    page_type_id = ResourceType.id_for_page()
+
+    from(mapping in PublishedResource,
+      join: revision in Revision,
+      on:
+        revision.id == mapping.revision_id and
+          revision.resource_id == mapping.resource_id,
+      where:
+        mapping.publication_id == ^publication_id and
+          revision.resource_type_id == ^page_type_id and
+          revision.deleted == false and
+          revision.resource_scope == :project,
+      order_by: [asc: revision.resource_id],
+      select: %{
+        revision_id: revision.id,
+        resource_id: revision.resource_id,
+        revision_slug: revision.slug,
+        title: revision.title,
+        content: revision.content
+      }
+    )
+  end
+
+  defp stream_relationships(publication_id, stream_max_rows) do
+    initial = %{
+      pages: %{},
+      page_to_activities: %{},
+      activity_to_pages: %{},
+      scanned_pages_count: 0,
+      skipped_adaptive_pages_count: 0
+    }
+
+    # PostgreSQL cursors are valid only inside a transaction. `max_rows` bounds
+    # each fetch, and `Enum.reduce_while/3` ensures malformed content stops the
+    # cursor immediately instead of producing a deceptively incomplete report.
+    transaction_result =
+      Repo.transaction(fn ->
+        publication_id
+        |> page_stream_query()
+        |> Repo.stream(max_rows: stream_max_rows)
+        |> Enum.reduce_while({:ok, initial}, fn page, {:ok, acc} ->
+          reduce_page(page, acc)
+        end)
+      end)
+
+    case transaction_result do
+      {:ok, result} -> result
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  # Adaptive exclusion is absolute: once the top-level boolean is true, this row
+  # contributes only to the skipped count. Its page id, metadata, and nested
+  # activity ids never enter either relationship map and cannot become repair work.
+  defp reduce_page(%{content: content} = page, acc) do
+    case basic_page?(content) do
+      false ->
+        {:cont, {:ok, Map.update!(acc, :skipped_adaptive_pages_count, fn count -> count + 1 end)}}
+
+      true ->
+        case activity_references(content, page.resource_id) do
+          {:ok, activity_ids} ->
+            summary = page_summary(page)
+
+            # `Utils.activity_references/1` returns a MapSet, so duplicate nodes
+            # within one page become one relationship. Keeping both map directions
+            # makes missing reporting and shared-cardinality checks straightforward
+            # without retaining the page's full content payload.
+            activity_to_pages =
+              Enum.reduce(activity_ids, acc.activity_to_pages, fn activity_id, inverted ->
+                Map.update(
+                  inverted,
+                  activity_id,
+                  MapSet.new([page.resource_id]),
+                  &MapSet.put(&1, page.resource_id)
+                )
+              end)
+
+            {:cont,
+             {:ok,
+              %{
+                acc
+                | pages: Map.put(acc.pages, page.resource_id, summary),
+                  page_to_activities:
+                    Map.put(acc.page_to_activities, page.resource_id, activity_ids),
+                  activity_to_pages: activity_to_pages,
+                  scanned_pages_count: acc.scanned_pages_count + 1
+              }}}
+
+          {:error, _reason} = error ->
+            {:halt, error}
+        end
+    end
+  end
+
+  @doc """
+  Returns whether page content belongs to the Basic authoring format.
+
+  This predicate is shared by analysis and repair-time validation. Missing and
+  boolean false values are Basic; only the exact top-level boolean true is Adaptive.
+  Nested flags and truthy strings intentionally do not exclude a page.
+  """
+  @spec basic_page?(map()) :: boolean()
+  def basic_page?(%{"advancedDelivery" => true}), do: false
+  def basic_page?(_content), do: true
+
+  defp activity_references(%{"model" => model} = content, page_resource_id)
+       when is_list(model) do
+    try do
+      activity_ids = Utils.activity_references(content)
+
+      # Resolver queries require persisted resource ids. Treat a missing, string,
+      # zero, or otherwise malformed `activity_id` as page-content corruption here
+      # so it cannot escape later as an Ecto cast exception during batched lookup.
+      case Enum.all?(activity_ids, &(is_integer(&1) and &1 > 0)) do
+        true -> {:ok, activity_ids}
+        false -> {:error, {:invalid_page_content, page_resource_id}}
+      end
+    rescue
+      # Existing traversal deliberately expects valid page nodes. Normalize any
+      # traversal shape failure to a content-free page-scoped error rather than
+      # exposing an exception or silently treating the page as reference-free.
+      _exception -> {:error, {:invalid_page_content, page_resource_id}}
+    end
+  end
+
+  defp activity_references(_content, page_resource_id),
+    do: {:error, {:invalid_page_content, page_resource_id}}
+
+  defp page_summary(page) do
+    %PageSummary{
+      resource_id: page.resource_id,
+      revision_id: page.revision_id,
+      revision_slug: page.revision_slug,
+      title: page.title
+    }
+  end
+
+  defp resolve_activity_ids(_project_slug, [], _batch_size), do: MapSet.new()
+
+  defp resolve_activity_ids(project_slug, activity_ids, batch_size) do
+    activity_ids
+    |> Enum.sort()
+    |> Enum.chunk_every(batch_size)
+    |> Enum.reduce(MapSet.new(), fn activity_id_batch, resolved_ids ->
+      # The resolver's activity-id projection executes one parameterized query for
+      # the chunk and selects no revision JSON. Besides avoiding a relationship N+1,
+      # this type-checks clone candidates and prevents large activity bodies from
+      # replacing the page stream's bounded-memory win.
+      project_slug
+      |> AuthoringResolver.existing_activity_resource_ids(activity_id_batch)
+      |> Enum.reduce(resolved_ids, &MapSet.put(&2, &1))
+    end)
+  end
+
+  defp build_report(project, relationships, resolved_activity_ids, options) do
+    issue_limit = Map.get(options, :preview_issue_limit)
+    group_page_limit = Map.get(options, :preview_group_page_limit)
+
+    missing_activity_references =
+      build_missing_activity_references(relationships, resolved_activity_ids, issue_limit)
+
+    shared_activity_references =
+      build_shared_activity_references(
+        relationships,
+        resolved_activity_ids,
+        issue_limit,
+        group_page_limit
+      )
+
+    summary = build_summary(relationships, resolved_activity_ids)
+
+    %Report{
+      project_id: project.id,
+      project_slug: project.slug,
+      scanned_pages_count: relationships.scanned_pages_count,
+      skipped_adaptive_pages_count: relationships.skipped_adaptive_pages_count,
+      missing_activity_references: missing_activity_references,
+      shared_activity_references: shared_activity_references,
+      summary: summary
+    }
+  end
+
+  defp build_missing_activity_references(relationships, resolved_activity_ids, limit) do
+    relationships.page_to_activities
+    |> Enum.flat_map(fn {page_resource_id, activity_ids} ->
+      page = Map.fetch!(relationships.pages, page_resource_id)
+
+      activity_ids
+      |> MapSet.difference(resolved_activity_ids)
+      |> Enum.map(fn activity_resource_id ->
+        %MissingActivityReference{
+          activity_resource_id: activity_resource_id,
+          page: page
+        }
+      end)
+    end)
+    |> Enum.sort_by(fn missing -> {missing.page.resource_id, missing.activity_resource_id} end)
+    |> maybe_take(limit)
+  end
+
+  defp build_shared_activity_references(
+         relationships,
+         resolved_activity_ids,
+         issue_limit,
+         group_page_limit
+       ) do
+    relationships.activity_to_pages
+    |> Enum.filter(fn {_activity_resource_id, page_ids} -> MapSet.size(page_ids) > 1 end)
+    |> Enum.map(fn {activity_resource_id, page_ids} ->
+      pages =
+        page_ids
+        |> Enum.map(&Map.fetch!(relationships.pages, &1))
+        |> Enum.sort_by(& &1.resource_id)
+
+      %SharedActivityReference{
+        activity_resource_id: activity_resource_id,
+        pages: maybe_take(pages, group_page_limit),
+        page_count: length(pages),
+        repairable?: MapSet.member?(resolved_activity_ids, activity_resource_id)
+      }
+    end)
+    |> Enum.sort_by(& &1.activity_resource_id)
+    |> maybe_take(issue_limit)
+  end
+
+  defp build_summary(relationships, resolved_activity_ids) do
+    {missing_count, missing_page_ids} =
+      Enum.reduce(relationships.page_to_activities, {0, MapSet.new()}, fn {page_resource_id,
+                                                                           activity_ids},
+                                                                          {count, page_ids} ->
+        missing_activity_ids = MapSet.difference(activity_ids, resolved_activity_ids)
+        missing_activity_count = MapSet.size(missing_activity_ids)
+
+        page_ids =
+          case missing_activity_count > 0 do
+            true -> MapSet.put(page_ids, page_resource_id)
+            false -> page_ids
+          end
+
+        {count + missing_activity_count, page_ids}
+      end)
+
+    shared_groups =
+      relationships.activity_to_pages
+      |> Enum.filter(fn {_activity_resource_id, page_ids} -> MapSet.size(page_ids) > 1 end)
+
+    # A page involved in several shared groups is one affected page. Counting a
+    # union here keeps the UI's page cardinality distinct from its resource-group
+    # cardinality and prevents inflated preview totals.
+    {repairable_shared_count, repairable_shared_page_ids, non_repairable_shared_count} =
+      Enum.reduce(shared_groups, {0, MapSet.new(), 0}, fn {activity_resource_id, page_ids},
+                                                          {repairable_count, affected_pages,
+                                                           non_repairable_count} ->
+        case MapSet.member?(resolved_activity_ids, activity_resource_id) do
+          true ->
+            {
+              repairable_count + 1,
+              MapSet.union(affected_pages, page_ids),
+              non_repairable_count
+            }
+
+          false ->
+            {repairable_count, affected_pages, non_repairable_count + 1}
+        end
+      end)
+
+    %Summary{
+      scanned_pages_count: relationships.scanned_pages_count,
+      skipped_adaptive_pages_count: relationships.skipped_adaptive_pages_count,
+      missing_activity_reference_count: missing_count,
+      missing_activity_affected_page_count: MapSet.size(missing_page_ids),
+      repairable_shared_activity_resource_count: repairable_shared_count,
+      repairable_shared_activity_affected_page_count: MapSet.size(repairable_shared_page_ids),
+      non_repairable_shared_missing_activity_resource_count: non_repairable_shared_count
+    }
+  end
+
+  defp maybe_take(items, nil), do: items
+  defp maybe_take(items, limit), do: Enum.take(items, limit)
+end

--- a/lib/oli/authoring/project_repair/instrumentation.ex
+++ b/lib/oli/authoring/project_repair/instrumentation.ex
@@ -1,0 +1,227 @@
+defmodule Oli.Authoring.ProjectRepair.Instrumentation do
+  @moduledoc """
+  Emits bounded operational telemetry and logs for project repair operations.
+
+  This module deliberately receives only public return values and compact options.
+  It never receives page content, page titles, activity bodies, raw exceptions, or
+  full reports, so observability cannot accidentally expose authored course data.
+  All emitters are best-effort: telemetry handlers or logger failures must not
+  change the result returned by the repair context.
+  """
+
+  require Logger
+
+  alias Oli.Accounts.Author
+  alias Oli.Authoring.Course.Project
+
+  alias Oli.Authoring.ProjectRepair.{
+    RepairFailure,
+    RepairResult,
+    Report,
+    Summary
+  }
+
+  @telemetry_prefix [:oli, :authoring, :project_repair]
+
+  @typedoc "Public operation names emitted as part of the telemetry event path."
+  @type operation :: :analysis | :repair
+
+  @doc """
+  Captures the monotonic start time used by `record/5`.
+
+  Keeping the start time outside the operation avoids a wrapper that could alter
+  control flow. The public context computes the result normally, then calls
+  `record/5` with this value.
+  """
+  @spec start_time() :: integer()
+  def start_time, do: System.monotonic_time()
+
+  @doc """
+  Emits a stop event and one bounded completion log.
+
+  Metadata is intentionally scalar and count-oriented so AppSignal and log
+  consumers can group outcomes without seeing authored content. The returned value
+  is always the original `result`, even if an attached telemetry handler raises.
+  """
+  @spec record(
+          operation(),
+          integer(),
+          term(),
+          Project.t() | String.t(),
+          Author.t() | term(),
+          map()
+        ) ::
+          term()
+  def record(operation, started_at, result, project_ref, actor, options)
+      when operation in [:analysis, :repair] do
+    base_metadata = base_metadata(operation, project_ref, actor, options)
+
+    final_metadata =
+      result
+      |> result_metadata()
+      |> Map.merge(base_metadata)
+
+    duration_ms =
+      System.monotonic_time()
+      |> Kernel.-(started_at)
+      |> System.convert_time_unit(:native, :millisecond)
+
+    safe_telemetry_execute(
+      operation,
+      :stop,
+      %{count: 1, duration_ms: duration_ms},
+      final_metadata
+    )
+
+    safe_log(operation, final_metadata, duration_ms)
+
+    result
+  end
+
+  defp base_metadata(operation, project_ref, actor, options) do
+    %{
+      operation: operation,
+      project_id: project_id(project_ref),
+      project_slug: project_slug(project_ref),
+      actor_id: actor_id(actor),
+      stream_max_rows: Map.get(options, :stream_max_rows),
+      resolution_batch_size: Map.get(options, :resolution_batch_size)
+    }
+  end
+
+  defp result_metadata({:ok, %Report{} = report}) do
+    report
+    |> summary_metadata()
+    |> Map.merge(%{
+      status: :completed,
+      failure_stage: nil,
+      failure_reason: nil,
+      cloned_activity_count: 0,
+      updated_page_count: 0,
+      failure_count: 0,
+      warning_count: 0
+    })
+  end
+
+  defp result_metadata({:ok, %RepairResult{} = result}) do
+    failure = List.first(result.failures)
+
+    result.report_after_repair
+    |> summary_metadata()
+    |> Map.merge(%{
+      status: result.status,
+      failure_stage: failure_stage(failure),
+      failure_reason: failure_reason(failure),
+      cloned_activity_count: result.cloned_activity_count,
+      updated_page_count: result.updated_page_count,
+      failure_count: length(result.failures),
+      warning_count: length(result.warnings)
+    })
+  end
+
+  defp result_metadata({:error, reason}) do
+    empty_summary_metadata()
+    |> Map.merge(%{
+      status: :failed,
+      failure_stage: :context,
+      failure_reason: normalize_reason(reason),
+      cloned_activity_count: 0,
+      updated_page_count: 0,
+      failure_count: 1,
+      warning_count: 0
+    })
+  end
+
+  defp result_metadata(_other) do
+    empty_summary_metadata()
+    |> Map.merge(%{
+      status: :failed,
+      failure_stage: :context,
+      failure_reason: :unexpected_result,
+      cloned_activity_count: 0,
+      updated_page_count: 0,
+      failure_count: 1,
+      warning_count: 0
+    })
+  end
+
+  defp summary_metadata(%Report{summary: %Summary{} = summary}) do
+    %{
+      scanned_pages_count: summary.scanned_pages_count,
+      skipped_adaptive_pages_count: summary.skipped_adaptive_pages_count,
+      missing_activity_reference_count: summary.missing_activity_reference_count,
+      missing_activity_affected_page_count: summary.missing_activity_affected_page_count,
+      repairable_shared_activity_resource_count:
+        summary.repairable_shared_activity_resource_count,
+      repairable_shared_activity_affected_page_count:
+        summary.repairable_shared_activity_affected_page_count,
+      non_repairable_shared_missing_activity_resource_count:
+        summary.non_repairable_shared_missing_activity_resource_count
+    }
+  end
+
+  defp summary_metadata(_report), do: empty_summary_metadata()
+
+  defp empty_summary_metadata do
+    %{
+      scanned_pages_count: 0,
+      skipped_adaptive_pages_count: 0,
+      missing_activity_reference_count: 0,
+      missing_activity_affected_page_count: 0,
+      repairable_shared_activity_resource_count: 0,
+      repairable_shared_activity_affected_page_count: 0,
+      non_repairable_shared_missing_activity_resource_count: 0
+    }
+  end
+
+  defp safe_telemetry_execute(operation, phase, measurements, metadata) do
+    try do
+      :telemetry.execute(@telemetry_prefix ++ [operation, phase], measurements, metadata)
+    rescue
+      _exception -> :ok
+    catch
+      _kind, _reason -> :ok
+    end
+  end
+
+  defp safe_log(operation, metadata, duration_ms) do
+    log_metadata = Map.put(metadata, :duration_ms, duration_ms)
+
+    try do
+      Logger.log(
+        log_level(metadata),
+        "project_repair #{operation} completed #{inspect(log_metadata)}"
+      )
+    rescue
+      _exception -> :ok
+    catch
+      _kind, _reason -> :ok
+    end
+  end
+
+  defp log_level(%{status: :completed, warning_count: 0}), do: :info
+  defp log_level(%{failure_stage: :lock}), do: :warning
+  defp log_level(%{failure_stage: :stale_plan}), do: :warning
+  defp log_level(%{status: :partial}), do: :warning
+  defp log_level(%{failure_count: count}) when count > 0, do: :error
+  defp log_level(_metadata), do: :info
+
+  defp project_id(%Project{id: id}), do: id
+  defp project_id(_project_ref), do: nil
+
+  defp project_slug(%Project{slug: slug}), do: slug
+  defp project_slug(_project_ref), do: nil
+
+  defp actor_id(%Author{id: id}), do: id
+  defp actor_id(_actor), do: nil
+
+  defp failure_stage(%RepairFailure{stage: stage}), do: stage
+  defp failure_stage(_failure), do: nil
+
+  defp failure_reason(%RepairFailure{reason: reason}), do: reason
+  defp failure_reason(_failure), do: nil
+
+  defp normalize_reason(reason) when is_atom(reason), do: reason
+  defp normalize_reason({reason, _detail}) when is_atom(reason), do: reason
+  defp normalize_reason(_reason), do: :unknown
+end

--- a/lib/oli/authoring/project_repair/missing_activity_reference.ex
+++ b/lib/oli/authoring/project_repair/missing_activity_reference.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Authoring.ProjectRepair.MissingActivityReference do
+  @moduledoc """
+  Describes a Basic page reference whose activity does not resolve in the project.
+
+  Missing references are intentionally report-only. This struct carries enough
+  information for an administrator to locate the page while containing no field
+  that could be mistaken for a repair instruction.
+  """
+
+  alias Oli.Authoring.ProjectRepair.PageSummary
+
+  @typedoc "A missing activity resource id paired with the affected Basic page."
+  @type t :: %__MODULE__{
+          activity_resource_id: pos_integer(),
+          page: PageSummary.t()
+        }
+
+  @enforce_keys [:activity_resource_id, :page]
+  defstruct [:activity_resource_id, :page]
+end

--- a/lib/oli/authoring/project_repair/page_summary.ex
+++ b/lib/oli/authoring/project_repair/page_summary.ex
@@ -1,0 +1,20 @@
+defmodule Oli.Authoring.ProjectRepair.PageSummary do
+  @moduledoc """
+  Identifies one current authoring page without retaining its full content.
+
+  Repair reports cross the domain-to-web boundary and can remain assigned in a
+  LiveView process. Keeping only stable identifiers and display metadata here is
+  therefore an important part of the repair tool's bounded-memory contract.
+  """
+
+  @typedoc "A compact reference to the current unpublished revision of a page."
+  @type t :: %__MODULE__{
+          resource_id: pos_integer(),
+          revision_id: pos_integer(),
+          revision_slug: String.t(),
+          title: String.t()
+        }
+
+  @enforce_keys [:resource_id, :revision_id, :revision_slug, :title]
+  defstruct [:resource_id, :revision_id, :revision_slug, :title]
+end

--- a/lib/oli/authoring/project_repair/repair.ex
+++ b/lib/oli/authoring/project_repair/repair.ex
@@ -1,0 +1,712 @@
+defmodule Oli.Authoring.ProjectRepair.Repair do
+  @moduledoc """
+  Applies lock-aware, deterministic shared-activity repairs.
+
+  Repair never accepts a browser-provided plan. It receives a fresh analysis report
+  from the context, locks every source activity and every participant page, reruns
+  analysis under those locks, and compares a revision-bearing fingerprint before
+  the first write. Each changed page is then one transaction containing all of its
+  activity clones and exactly one new page revision.
+
+  Page transactions are intentionally sequential and fail-fast. Earlier commits
+  remain valid after a later failure, while the failed page rolls back all clones
+  and its page revision. A final analysis report makes partial completion safely
+  retryable because already-isolated relationships no longer appear as shared.
+  """
+
+  alias Oli.Accounts.Author
+  alias Oli.Authoring.Broadcaster
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.Editing.{ContainerEditor, Utils}
+
+  alias Oli.Authoring.ProjectRepair.{
+    Analysis,
+    PageSummary,
+    RepairFailure,
+    RepairResult,
+    Report
+  }
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Publishing.ChangeTracker
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Repo
+  alias Oli.Resources.{PageContent, ResourceType, Revision}
+
+  @lock_ttl_seconds 10 * 60
+
+  @typedoc "A lock target kind and resource id in deterministic acquisition order."
+  @type lock_target :: {:activity | :page, pos_integer()}
+
+  @typedoc "A lock acquired by this repair invocation, including its ownership stamp."
+  @type acquired_lock :: %{target: lock_target(), stamp: NaiveDateTime.t()}
+
+  @typedoc "Invocation-owned locks keyed by target for constant-time refresh lookup."
+  @type acquired_locks :: %{lock_target() => acquired_lock()}
+
+  @typedoc "Compact repair work for one non-keeper page."
+  @type page_work :: %{
+          page: PageSummary.t(),
+          source_activity_ids: MapSet.t(pos_integer())
+        }
+
+  @typedoc "A content-free plan derived from one fresh report."
+  @type plan :: %{
+          fingerprint: list(),
+          lock_targets: [lock_target()],
+          page_work: %{pos_integer() => page_work()}
+        }
+
+  @typedoc "Validated analysis controls passed through to post-lock/final analysis."
+  @type options :: Analysis.options()
+
+  @doc """
+  Executes a repair from a fresh report produced for the normalized project.
+
+  Expected operational failures return `{:ok, %RepairResult{status: :failed}}` or
+  `:partial`; only context preparation and the initial analysis use top-level error
+  tuples. This keeps lock conflicts, stale plans, and page failures renderable by a
+  thin LiveView without exposing raw exceptions or authored content.
+  """
+  @spec repair(Project.t(), Publication.t(), Author.t(), options(), Report.t()) ::
+          {:ok, RepairResult.t()}
+  def repair(
+        %Project{} = project,
+        %Publication{} = publication,
+        %Author{} = actor,
+        options,
+        %Report{} = report_before_repair
+      ) do
+    plan = build_plan(report_before_repair)
+
+    case plan.lock_targets do
+      [] ->
+        # A missing-only or issue-free project is already complete. In particular,
+        # no missing id is ever converted into page work or passed to copy logic.
+        {:ok,
+         %RepairResult{
+           status: :completed,
+           report_before_repair: report_before_repair,
+           report_after_repair: report_before_repair
+         }}
+
+      _targets ->
+        execute_with_locks(
+          project,
+          publication,
+          actor,
+          options,
+          report_before_repair,
+          plan
+        )
+    end
+  end
+
+  defp build_plan(%Report{} = report) do
+    repairable_groups =
+      report.shared_activity_references
+      |> Enum.filter(& &1.repairable?)
+      |> Enum.sort_by(& &1.activity_resource_id)
+
+    fingerprint = repair_fingerprint(repairable_groups)
+
+    {page_work, lock_targets} =
+      Enum.reduce(repairable_groups, {%{}, MapSet.new()}, fn group, {work, locks} ->
+        pages = Enum.sort_by(group.pages, & &1.resource_id)
+        [_keeper | non_keeper_pages] = pages
+
+        locks =
+          locks
+          |> MapSet.put({:activity, group.activity_resource_id})
+          |> then(fn targets ->
+            Enum.reduce(pages, targets, fn page, acc ->
+              MapSet.put(acc, {:page, page.resource_id})
+            end)
+          end)
+
+        work =
+          Enum.reduce(non_keeper_pages, work, fn page, acc ->
+            Map.update(
+              acc,
+              page.resource_id,
+              %{page: page, source_activity_ids: MapSet.new([group.activity_resource_id])},
+              fn existing ->
+                %{
+                  existing
+                  | source_activity_ids:
+                      MapSet.put(existing.source_activity_ids, group.activity_resource_id)
+                }
+              end
+            )
+          end)
+
+        {work, locks}
+      end)
+
+    %{
+      fingerprint: fingerprint,
+      page_work: page_work,
+      lock_targets: Enum.sort_by(lock_targets, &lock_sort_key/1)
+    }
+  end
+
+  # Fingerprints include every source id and participant page revision. Membership
+  # changes, page edits, newly Adaptive pages, or newly missing source activities
+  # therefore invalidate the plan before any mutation begins.
+  defp repair_fingerprint(repairable_groups) do
+    Enum.map(repairable_groups, fn group ->
+      pages =
+        group.pages
+        |> Enum.sort_by(& &1.resource_id)
+        |> Enum.map(&{&1.resource_id, &1.revision_id})
+
+      {group.activity_resource_id, pages}
+    end)
+  end
+
+  defp lock_sort_key({:activity, resource_id}), do: {0, resource_id}
+  defp lock_sort_key({:page, resource_id}), do: {1, resource_id}
+
+  defp execute_with_locks(project, publication, actor, options, before_report, plan) do
+    case acquire_locks(project, publication, actor, plan.lock_targets) do
+      {:ok, acquired_locks} ->
+        outcome =
+          try do
+            run_after_lock_acquisition_hook(options)
+            execute_locked(project, publication, actor, options, plan, acquired_locks)
+          rescue
+            # Repair must never leak exceptions, changesets, activity/page content,
+            # or lock-holder details through its public result contract.
+            _exception -> failed_outcome(unexpected_failure(), acquired_locks)
+          catch
+            _kind, _reason -> failed_outcome(unexpected_failure(), acquired_locks)
+          end
+
+        warnings = release_locks(project, publication, actor, outcome.acquired_locks)
+
+        finalize_result(
+          project,
+          publication,
+          options,
+          before_report,
+          outcome,
+          warnings
+        )
+
+      {:error, failure, acquired_locks} ->
+        warnings = release_locks(project, publication, actor, acquired_locks)
+
+        finalize_result(
+          project,
+          publication,
+          options,
+          before_report,
+          failed_outcome(failure, acquired_locks),
+          warnings
+        )
+    end
+  end
+
+  defp acquire_locks(project, publication, actor, lock_targets) do
+    stamp = lock_stamp()
+    stale_cutoff = NaiveDateTime.add(stamp, -@lock_ttl_seconds, :second)
+    stale_cutoff_datetime = DateTime.from_naive!(stale_cutoff, "Etc/UTC")
+    resource_ids = Enum.map(lock_targets, fn {_kind, resource_id} -> resource_id end)
+
+    # Acquisition is all-or-none. We first lock the mapping rows with `FOR UPDATE`
+    # and validate every target before writing any lock fields. That avoids the
+    # partial-update trap where one target is stamped and a later conflict causes
+    # the invocation to fail while still owning a leaked lock.
+    result =
+      try do
+        Repo.transaction(fn ->
+          mappings =
+            lockable_mappings_query(publication.id, resource_ids)
+            |> lock("FOR UPDATE")
+            |> Repo.all()
+
+          mapping_by_resource_id = Map.new(mappings, &{&1.resource_id, &1})
+
+          case unavailable_lock_target(
+                 lock_targets,
+                 mapping_by_resource_id,
+                 stale_cutoff,
+                 stale_cutoff_datetime
+               ) do
+            nil ->
+              case stamp_lock_targets(publication.id, resource_ids, actor.id, stamp) do
+                {updated_count, _updated} when updated_count == length(lock_targets) ->
+                  :ok
+
+                _other ->
+                  Repo.rollback({:error, lock_update_failure(List.first(lock_targets))})
+              end
+
+            failed_target ->
+              Repo.rollback({:error, lock_failure(failed_target)})
+          end
+        end)
+      rescue
+        _exception -> :lock_update_failed
+      end
+
+    case result do
+      {:ok, :ok} ->
+        acquired_locks =
+          acquired_locks_from_targets(project, publication, actor, lock_targets, stamp)
+
+        {:ok, acquired_locks}
+
+      :lock_update_failed ->
+        {:error, lock_update_failure(List.first(lock_targets)), %{}}
+
+      {:error, {:error, %RepairFailure{} = failure}} ->
+        {:error, failure, %{}}
+    end
+  end
+
+  defp acquired_locks_from_targets(project, publication, actor, lock_targets, stamp) do
+    Enum.reduce(lock_targets, %{}, fn target, acquired ->
+      {_kind, resource_id} = target
+      Broadcaster.broadcast_lock_acquired(project.slug, publication.id, resource_id, actor.id)
+      Map.put(acquired, target, %{target: target, stamp: stamp})
+    end)
+  end
+
+  defp lockable_mappings_query(publication_id, resource_ids) do
+    from(mapping in PublishedResource,
+      where:
+        mapping.publication_id == ^publication_id and
+          mapping.resource_id in ^resource_ids,
+      select: mapping
+    )
+  end
+
+  defp unavailable_lock_target(
+         lock_targets,
+         mapping_by_resource_id,
+         stale_cutoff,
+         stale_cutoff_datetime
+       ) do
+    Enum.find(lock_targets, fn {_kind, resource_id} ->
+      case Map.fetch(mapping_by_resource_id, resource_id) do
+        {:ok, mapping} -> not lock_available?(mapping, stale_cutoff, stale_cutoff_datetime)
+        :error -> true
+      end
+    end)
+  end
+
+  defp lock_available?(%{locked_by_id: nil}, _stale_cutoff, _stale_cutoff_datetime), do: true
+
+  defp lock_available?(
+         %{lock_updated_at: lock_updated_at},
+         stale_cutoff,
+         _stale_cutoff_datetime
+       )
+       when not is_nil(lock_updated_at) do
+    NaiveDateTime.compare(lock_updated_at, stale_cutoff) == :lt
+  end
+
+  defp lock_available?(%{updated_at: updated_at}, _stale_cutoff, stale_cutoff_datetime) do
+    DateTime.compare(updated_at, stale_cutoff_datetime) == :lt
+  end
+
+  defp stamp_lock_targets(publication_id, resource_ids, actor_id, stamp) do
+    from(mapping in PublishedResource,
+      where:
+        mapping.publication_id == ^publication_id and
+          mapping.resource_id in ^resource_ids
+    )
+    |> Repo.update_all(set: [locked_by_id: actor_id, lock_updated_at: stamp])
+  end
+
+  defp execute_locked(project, publication, actor, options, plan, acquired_locks) do
+    case Analysis.analyze(project, publication, options) do
+      {:ok, locked_report} ->
+        locked_plan = build_plan(locked_report)
+
+        case locked_plan.fingerprint == plan.fingerprint do
+          true -> repair_pages(project, publication, actor, plan, acquired_locks)
+          false -> failed_outcome(stale_failure(), acquired_locks)
+        end
+
+      {:error, {:invalid_page_content, page_resource_id}} ->
+        failed_outcome(invalid_page_failure(page_resource_id), acquired_locks)
+    end
+  end
+
+  defp repair_pages(project, publication, actor, plan, acquired_locks) do
+    plan.page_work
+    |> Enum.sort_by(fn {page_resource_id, _work} -> page_resource_id end)
+    |> Enum.reduce_while(empty_outcome(acquired_locks), fn {_page_resource_id, work}, outcome ->
+      # Refresh only the locks needed for the next page transaction. The complete
+      # participant set stays locked, but refreshing every lock before every page
+      # would scale as changed_pages * total_locks for large repair batches.
+      refresh_targets = refresh_targets_for_page(work)
+
+      case refresh_locks(project, publication, actor, refresh_targets, outcome.acquired_locks) do
+        {:ok, refreshed_locks} ->
+          outcome = %{outcome | acquired_locks: refreshed_locks}
+
+          case repair_page(project, actor, work) do
+            {:ok, %{revision: revision, cloned_activity_count: clone_count}} ->
+              # PubSub must observe only committed page revisions. Activity copying
+              # remains inside the transaction and the page broadcast happens here.
+              Broadcaster.broadcast_revision(revision, project.slug)
+
+              {:cont,
+               %{
+                 outcome
+                 | updated_page_count: outcome.updated_page_count + 1,
+                   cloned_activity_count: outcome.cloned_activity_count + clone_count
+               }}
+
+            {:error, %RepairFailure{} = failure} ->
+              {:halt, add_failure(outcome, failure)}
+          end
+
+        {:error, failure, refreshed_locks} ->
+          {:halt, add_failure(%{outcome | acquired_locks: refreshed_locks}, failure)}
+      end
+    end)
+  end
+
+  defp refresh_targets_for_page(%{page: page, source_activity_ids: source_activity_ids}) do
+    source_activity_ids
+    |> Enum.map(&{:activity, &1})
+    |> Kernel.++([{:page, page.resource_id}])
+    |> Enum.sort_by(&lock_sort_key/1)
+  end
+
+  defp refresh_locks(project, publication, actor, lock_targets, acquired_locks) do
+    Enum.reduce_while(lock_targets, {:ok, acquired_locks}, fn target, {:ok, locks} ->
+      case Map.fetch(locks, target) do
+        :error ->
+          {:halt, {:error, lock_failure(target), locks}}
+
+        {:ok, acquired_lock} ->
+          case refresh_repair_lock(project, publication, actor, acquired_lock) do
+            {:ok, refreshed_lock} ->
+              {:cont, {:ok, Map.put(locks, target, refreshed_lock)}}
+
+            {:error, %RepairFailure{} = failure} ->
+              {:halt, {:error, failure, locks}}
+          end
+      end
+    end)
+  end
+
+  defp refresh_repair_lock(project, publication, actor, %{target: target, stamp: old_stamp}) do
+    {_kind, resource_id} = target
+    new_stamp = lock_stamp()
+
+    result =
+      try do
+        from(mapping in PublishedResource,
+          where:
+            mapping.publication_id == ^publication.id and
+              mapping.resource_id == ^resource_id and
+              mapping.locked_by_id == ^actor.id and
+              mapping.lock_updated_at == ^old_stamp
+        )
+        |> Repo.update_all(set: [lock_updated_at: new_stamp])
+      rescue
+        _exception -> :lock_update_failed
+      end
+
+    case result do
+      {1, _updated} ->
+        Broadcaster.broadcast_lock_acquired(project.slug, publication.id, resource_id, actor.id)
+        {:ok, %{target: target, stamp: new_stamp}}
+
+      :lock_update_failed ->
+        {:error, lock_update_failure(target)}
+
+      _other ->
+        {:error, lock_failure(target)}
+    end
+  end
+
+  defp repair_page(project, actor, %{page: planned_page} = work) do
+    transaction_result =
+      Repo.transaction(fn ->
+        with {:ok, current_page} <- validate_current_page(project.slug, planned_page),
+             {:ok, copies} <-
+               clone_sources(project.slug, actor, work.source_activity_ids, planned_page),
+             {:ok, rewritten_content} <- rewrite_page(current_page.content, copies, planned_page),
+             activity_refs <-
+               rewritten_content
+               |> Utils.activity_references()
+               |> Enum.sort(),
+             {:ok, updated_page} <-
+               ChangeTracker.track_revision(project.slug, current_page, %{
+                 content: rewritten_content,
+                 activity_refs: activity_refs,
+                 author_id: actor.id
+               }) do
+          %{revision: updated_page, cloned_activity_count: map_size(copies)}
+        else
+          {:error, %RepairFailure{} = failure} -> Repo.rollback(failure)
+          _other -> Repo.rollback(page_update_failure(planned_page.resource_id))
+        end
+      end)
+
+    case transaction_result do
+      {:ok, result} -> {:ok, result}
+      {:error, %RepairFailure{} = failure} -> {:error, failure}
+      {:error, _reason} -> {:error, page_update_failure(planned_page.resource_id)}
+    end
+  rescue
+    _exception -> {:error, page_update_failure(planned_page.resource_id)}
+  catch
+    _kind, _reason -> {:error, page_update_failure(planned_page.resource_id)}
+  end
+
+  defp validate_current_page(project_slug, %PageSummary{} = planned_page) do
+    case AuthoringResolver.from_resource_id(project_slug, planned_page.resource_id) do
+      %Revision{
+        id: revision_id,
+        resource_type_id: resource_type_id,
+        deleted: false,
+        resource_scope: :project,
+        content: content
+      } = revision
+      when revision_id == planned_page.revision_id ->
+        case resource_type_id == ResourceType.id_for_page() and Analysis.basic_page?(content) do
+          true -> {:ok, revision}
+          false -> {:error, invalid_page_failure(planned_page.resource_id)}
+        end
+
+      _other ->
+        {:error, stale_failure(planned_page.resource_id)}
+    end
+  end
+
+  defp clone_sources(project_slug, actor, source_activity_ids, planned_page) do
+    sorted_source_activity_ids = Enum.sort(source_activity_ids)
+
+    source_revisions =
+      project_slug
+      |> AuthoringResolver.from_resource_id(sorted_source_activity_ids)
+      |> List.wrap()
+      |> Map.new(&{&1.resource_id, &1})
+
+    sorted_source_activity_ids
+    |> Enum.reduce_while({:ok, %{}}, fn source_activity_id, {:ok, copies} ->
+      # `deep_copy_activity_revision/4` is the pre-resolved form of the existing
+      # tested duplication implementation. Resolving the source revisions once per
+      # page avoids resolver queries per clone while preserving `ContainerEditor`
+      # activity-create semantics.
+      source_reference = %{
+        "id" => "project-repair-source-#{source_activity_id}",
+        "type" => "activity-reference",
+        "activity_id" => source_activity_id,
+        "children" => []
+      }
+
+      result =
+        try do
+          case Map.fetch(source_revisions, source_activity_id) do
+            {:ok, source_revision} ->
+              ContainerEditor.deep_copy_activity_revision(
+                source_reference,
+                project_slug,
+                actor,
+                source_revision
+              )
+
+            :error ->
+              {:error, :copy_failed}
+          end
+        rescue
+          _exception -> {:error, :copy_failed}
+        end
+
+      case result do
+        {:ok, %{"activity_id" => new_activity_id}} when is_integer(new_activity_id) ->
+          {:cont, {:ok, Map.put(copies, source_activity_id, new_activity_id)}}
+
+        _other ->
+          {:halt, {:error, activity_copy_failure(planned_page.resource_id, source_activity_id)}}
+      end
+    end)
+  end
+
+  defp rewrite_page(content, copies, planned_page) do
+    try do
+      rewritten =
+        PageContent.map(content, fn
+          %{"type" => "activity-reference", "activity_id" => source_id} = node ->
+            case Map.fetch(copies, source_id) do
+              {:ok, new_activity_id} -> Map.put(node, "activity_id", new_activity_id)
+              :error -> node
+            end
+
+          node ->
+            node
+        end)
+
+      {:ok, rewritten}
+    rescue
+      _exception -> {:error, invalid_page_failure(planned_page.resource_id)}
+    end
+  end
+
+  defp release_locks(project, publication, actor, acquired_locks) do
+    # Release runs in reverse deterministic lock order. Every release is attempted
+    # even if an earlier release fails, and each update still matches the repair
+    # ownership stamp so another same-admin session cannot be released.
+    acquired_locks =
+      acquired_locks
+      |> Map.values()
+      |> Enum.sort_by(fn %{target: target} -> lock_sort_key(target) end, :desc)
+
+    case Enum.reduce(acquired_locks, false, fn %{target: {_kind, resource_id}, stamp: stamp},
+                                               failed? ->
+           result =
+             try do
+               from(mapping in PublishedResource,
+                 where:
+                   mapping.publication_id == ^publication.id and
+                     mapping.resource_id == ^resource_id and
+                     mapping.locked_by_id == ^actor.id and
+                     mapping.lock_updated_at == ^stamp
+               )
+               |> Repo.update_all(set: [locked_by_id: nil, lock_updated_at: nil])
+             rescue
+               _exception -> {0, nil}
+             end
+
+           case result do
+             {1, _updated} ->
+               Broadcaster.broadcast_lock_released(project.slug, publication.id, resource_id)
+               failed?
+
+             _other ->
+               true
+           end
+         end) do
+      true -> [:lock_release_failed]
+      false -> []
+    end
+  end
+
+  defp finalize_result(project, publication, options, before_report, outcome, warnings) do
+    {after_report, outcome} =
+      case outcome.updated_page_count do
+        0 ->
+          # If no page committed, the caller's before-report is still the best
+          # after-report and avoids a second full project scan on ordinary lock or
+          # stale-plan failures.
+          {before_report, outcome}
+
+        _updated_pages ->
+          case Analysis.analyze(project, publication, options) do
+            {:ok, report} ->
+              {report, outcome}
+
+            {:error, {:invalid_page_content, page_resource_id}} ->
+              # A concurrent malformed unrelated page can prevent final reporting
+              # even though participant-page locks protected committed repairs.
+              # Preserve a content-free failure and the last complete report as a
+              # safe fallback.
+              {before_report, add_failure(outcome, invalid_page_failure(page_resource_id))}
+          end
+      end
+
+    {:ok,
+     %RepairResult{
+       status: outcome_status(outcome),
+       report_before_repair: before_report,
+       report_after_repair: after_report,
+       cloned_activity_count: outcome.cloned_activity_count,
+       updated_page_count: outcome.updated_page_count,
+       failures: Enum.reverse(outcome.failures),
+       warnings: warnings
+     }}
+  end
+
+  defp empty_outcome(acquired_locks) do
+    %{
+      cloned_activity_count: 0,
+      updated_page_count: 0,
+      failures: [],
+      acquired_locks: acquired_locks
+    }
+  end
+
+  defp failed_outcome(failure, acquired_locks),
+    do: add_failure(empty_outcome(acquired_locks), failure)
+
+  defp add_failure(outcome, failure),
+    do: %{outcome | failures: [failure | outcome.failures]}
+
+  defp outcome_status(%{failures: []}), do: :completed
+  defp outcome_status(%{updated_page_count: count}) when count > 0, do: :partial
+  defp outcome_status(_outcome), do: :failed
+
+  defp lock_failure({kind, resource_id}) do
+    identifiers = failure_identifiers(kind, resource_id)
+    struct!(RepairFailure, [stage: :lock, reason: :lock_not_acquired] ++ identifiers)
+  end
+
+  defp lock_update_failure({kind, resource_id}) do
+    identifiers = failure_identifiers(kind, resource_id)
+    struct!(RepairFailure, [stage: :lock, reason: :lock_update_failed] ++ identifiers)
+  end
+
+  defp stale_failure(page_resource_id \\ nil) do
+    %RepairFailure{
+      stage: :stale_plan,
+      reason: :stale_project_state,
+      page_resource_id: page_resource_id
+    }
+  end
+
+  defp invalid_page_failure(page_resource_id) do
+    %RepairFailure{
+      stage: :page_update,
+      reason: :invalid_page_content,
+      page_resource_id: page_resource_id
+    }
+  end
+
+  defp activity_copy_failure(page_resource_id, activity_resource_id) do
+    %RepairFailure{
+      stage: :activity_copy,
+      reason: :activity_copy_failed,
+      page_resource_id: page_resource_id,
+      activity_resource_id: activity_resource_id
+    }
+  end
+
+  defp page_update_failure(page_resource_id) do
+    %RepairFailure{
+      stage: :page_update,
+      reason: :page_update_failed,
+      page_resource_id: page_resource_id
+    }
+  end
+
+  defp unexpected_failure do
+    %RepairFailure{stage: :cleanup, reason: :unexpected_error}
+  end
+
+  defp failure_identifiers(:activity, resource_id),
+    do: [activity_resource_id: resource_id]
+
+  defp failure_identifiers(:page, resource_id), do: [page_resource_id: resource_id]
+
+  defp lock_stamp do
+    NaiveDateTime.utc_now()
+    |> NaiveDateTime.truncate(:microsecond)
+  end
+
+  defp run_after_lock_acquisition_hook(%{after_lock_acquisition: hook}) when is_function(hook, 0),
+    do: hook.()
+
+  defp run_after_lock_acquisition_hook(_options), do: :ok
+end

--- a/lib/oli/authoring/project_repair/repair_failure.ex
+++ b/lib/oli/authoring/project_repair/repair_failure.ex
@@ -1,0 +1,39 @@
+defmodule Oli.Authoring.ProjectRepair.RepairFailure do
+  @moduledoc """
+  Normalizes one failure encountered while preparing or applying a repair.
+
+  Optional page and activity ids keep failures actionable without retaining page
+  or activity content. `stage` identifies the failed safety boundary so the web
+  layer can display a useful result without decoding arbitrary exceptions.
+  """
+
+  @typedoc "The normalized stage at which a repair failed."
+  @type stage :: :lock | :stale_plan | :activity_copy | :page_update | :cleanup
+
+  @typedoc """
+  A content-free failure code approved to cross the context boundary.
+
+  Internal exceptions and changesets must be normalized to one of these atoms;
+  raw terms can contain authored content, SQL details, or account information.
+  """
+  @type reason ::
+          :lock_not_acquired
+          | :stale_project_state
+          | :activity_copy_failed
+          | :page_update_failed
+          | :lock_update_failed
+          | :invalid_page_content
+          | :lock_release_failed
+          | :unexpected_error
+
+  @typedoc "A bounded, content-free repair failure."
+  @type t :: %__MODULE__{
+          stage: stage(),
+          reason: reason(),
+          page_resource_id: pos_integer() | nil,
+          activity_resource_id: pos_integer() | nil
+        }
+
+  @enforce_keys [:stage, :reason]
+  defstruct [:stage, :reason, :page_resource_id, :activity_resource_id]
+end

--- a/lib/oli/authoring/project_repair/repair_result.ex
+++ b/lib/oli/authoring/project_repair/repair_result.ex
@@ -1,0 +1,37 @@
+defmodule Oli.Authoring.ProjectRepair.RepairResult do
+  @moduledoc """
+  Captures the actual state before and after an explicit repair invocation.
+
+  Partial completion is a supported, retryable outcome. Carrying both reports and
+  committed counts makes that state explicit and prevents callers from inferring
+  success from a flash message or an exception alone.
+  """
+
+  alias Oli.Authoring.ProjectRepair.{RepairFailure, Report}
+
+  @typedoc "The completion state of a repair invocation."
+  @type status :: :completed | :partial | :failed
+
+  @typedoc "A non-fatal, content-free condition surfaced after repair cleanup."
+  @type warning :: :lock_release_failed | :lock_refresh_failed
+
+  @typedoc "A structured repair outcome suitable for rendering and verification."
+  @type t :: %__MODULE__{
+          status: status(),
+          report_before_repair: Report.t(),
+          report_after_repair: Report.t(),
+          cloned_activity_count: non_neg_integer(),
+          updated_page_count: non_neg_integer(),
+          failures: [RepairFailure.t()],
+          warnings: [warning()]
+        }
+
+  @enforce_keys [:status, :report_before_repair, :report_after_repair]
+  defstruct status: nil,
+            report_before_repair: nil,
+            report_after_repair: nil,
+            cloned_activity_count: 0,
+            updated_page_count: 0,
+            failures: [],
+            warnings: []
+end

--- a/lib/oli/authoring/project_repair/report.ex
+++ b/lib/oli/authoring/project_repair/report.ex
@@ -1,0 +1,35 @@
+defmodule Oli.Authoring.ProjectRepair.Report do
+  @moduledoc """
+  Defines the complete read model returned by project repair analysis.
+
+  A report deliberately contains revision ids and slugs but never page JSON. The
+  revision id later participates in stale-plan detection, while the slug lets the
+  web layer build an editor URL without introducing an `OliWeb` dependency here.
+  """
+
+  alias Oli.Authoring.ProjectRepair.{
+    MissingActivityReference,
+    SharedActivityReference,
+    Summary
+  }
+
+  @typedoc "A deterministic, content-free analysis report for one authoring project."
+  @type t :: %__MODULE__{
+          project_id: pos_integer(),
+          project_slug: String.t(),
+          scanned_pages_count: non_neg_integer(),
+          skipped_adaptive_pages_count: non_neg_integer(),
+          missing_activity_references: [MissingActivityReference.t()],
+          shared_activity_references: [SharedActivityReference.t()],
+          summary: Summary.t()
+        }
+
+  @enforce_keys [:project_id, :project_slug]
+  defstruct project_id: nil,
+            project_slug: nil,
+            scanned_pages_count: 0,
+            skipped_adaptive_pages_count: 0,
+            missing_activity_references: [],
+            shared_activity_references: [],
+            summary: %Summary{}
+end

--- a/lib/oli/authoring/project_repair/shared_activity_reference.ex
+++ b/lib/oli/authoring/project_repair/shared_activity_reference.ex
@@ -1,0 +1,22 @@
+defmodule Oli.Authoring.ProjectRepair.SharedActivityReference do
+  @moduledoc """
+  Groups Basic pages that reference the same activity resource.
+
+  `repairable?` is false when the resource cannot be resolved from the selected
+  project's authoring publication. Keeping that distinction in the domain result
+  prevents the LiveView from having to repeat safety-sensitive resolver logic.
+  """
+
+  alias Oli.Authoring.ProjectRepair.PageSummary
+
+  @typedoc "A shared activity id and the Basic pages that reference it."
+  @type t :: %__MODULE__{
+          activity_resource_id: pos_integer(),
+          pages: [PageSummary.t()],
+          page_count: non_neg_integer(),
+          repairable?: boolean()
+        }
+
+  @enforce_keys [:activity_resource_id, :pages, :repairable?]
+  defstruct [:activity_resource_id, :pages, :repairable?, page_count: 0]
+end

--- a/lib/oli/authoring/project_repair/summary.ex
+++ b/lib/oli/authoring/project_repair/summary.ex
@@ -1,0 +1,29 @@
+defmodule Oli.Authoring.ProjectRepair.Summary do
+  @moduledoc """
+  Stores the bounded aggregate counts rendered by the project repair preview.
+
+  Counts live in a dedicated struct so callers do not need to recalculate subtly
+  different page and resource cardinalities from issue lists. In particular,
+  repairable shared pages are counted separately from groups whose shared activity
+  is missing and therefore must remain report-only.
+  """
+
+  @typedoc "Aggregate counts for one project repair analysis."
+  @type t :: %__MODULE__{
+          scanned_pages_count: non_neg_integer(),
+          skipped_adaptive_pages_count: non_neg_integer(),
+          missing_activity_reference_count: non_neg_integer(),
+          missing_activity_affected_page_count: non_neg_integer(),
+          repairable_shared_activity_resource_count: non_neg_integer(),
+          repairable_shared_activity_affected_page_count: non_neg_integer(),
+          non_repairable_shared_missing_activity_resource_count: non_neg_integer()
+        }
+
+  defstruct scanned_pages_count: 0,
+            skipped_adaptive_pages_count: 0,
+            missing_activity_reference_count: 0,
+            missing_activity_affected_page_count: 0,
+            repairable_shared_activity_resource_count: 0,
+            repairable_shared_activity_affected_page_count: 0,
+            non_repairable_shared_missing_activity_resource_count: 0
+end

--- a/lib/oli/publishing/authoring_resolver.ex
+++ b/lib/oli/publishing/authoring_resolver.ex
@@ -61,6 +61,39 @@ defmodule Oli.Publishing.AuthoringResolver do
     |> emit([:oli, :resolvers, :authoring], :duration)
   end
 
+  @doc """
+  Returns the subset of resource ids that resolve to current project activities.
+
+  This projection is intended for callers that need existence and type validation
+  without loading complete activity revision content. The query remains scoped to
+  the project's unpublished publication and preserves no caller ordering; callers
+  that require deterministic presentation should sort their own compact ids.
+  """
+  @spec existing_activity_resource_ids(String.t(), [pos_integer()]) :: [pos_integer()]
+  def existing_activity_resource_ids(_project_slug, []), do: []
+
+  def existing_activity_resource_ids(project_slug, resource_ids) when is_list(resource_ids) do
+    fn ->
+      from(mapping in PublishedResource,
+        join: revision in Revision,
+        on:
+          revision.id == mapping.revision_id and
+            revision.resource_id == mapping.resource_id,
+        where:
+          mapping.publication_id in subquery(project_working_publication(project_slug)) and
+            mapping.resource_id in ^resource_ids and
+            revision.resource_type_id == @activity_id and
+            revision.deleted == false and
+            revision.resource_scope == :project,
+        select: mapping.resource_id,
+        distinct: true
+      )
+      |> Repo.all()
+    end
+    |> run()
+    |> emit([:oli, :resolvers, :authoring], :duration)
+  end
+
   @impl Resolver
   def from_revision_slug(project_slug, revision_slug) do
     fn ->

--- a/lib/oli_web/live/workspaces/course_author/project_repair_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/project_repair_live.ex
@@ -1,0 +1,628 @@
+defmodule OliWeb.Workspaces.CourseAuthor.ProjectRepairLive do
+  @moduledoc """
+  Thin LiveView wrapper for the authoring project repair context.
+
+  The domain context owns every safety-sensitive rule: Basic-page filtering,
+  missing-reference classification, shared-activity repair planning, locking, and
+  mutation. This module only coordinates the authenticated project route, renders
+  the content-free report structs, and starts an explicit server-side repair.
+  """
+
+  use OliWeb, :live_view
+
+  alias Oli.Authoring.ProjectRepair
+
+  alias Oli.Authoring.ProjectRepair.{
+    MissingActivityReference,
+    RepairFailure,
+    RepairResult,
+    Report,
+    SharedActivityReference,
+    Summary
+  }
+
+  @issue_preview_limit 500
+  @group_page_preview_limit 100
+
+  @impl Phoenix.LiveView
+  def mount(_params, _session, socket) do
+    # The router places this LiveView behind both the normal project workspace
+    # hooks and a system-admin pipeline. Calling the context with the server-side
+    # project/author assigns keeps the same defense-in-depth authorization that
+    # protects console or future non-web callers.
+    %{current_author: author, project: project} = socket.assigns
+
+    socket =
+      socket
+      |> assign(
+        author: author,
+        confirming_repair?: false,
+        fatal_error: nil,
+        page_title: "Project Repair Tool | #{project.title}",
+        project: project,
+        repairing?: false,
+        report_loading?: true,
+        repair_result: nil,
+        repair_status_message: nil,
+        report: nil,
+        resource_slug: project.slug,
+        resource_title: project.title
+      )
+      |> start_report_analysis()
+
+    {:ok, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_event("show_repair_confirmation", _params, socket) do
+    # This first click is intentionally non-mutating. The tool changes authoring
+    # state only after the administrator reviews the inline confirmation and
+    # submits the separate parameter-free `make_changes` event below.
+    {:noreply, assign(socket, confirming_repair?: true)}
+  end
+
+  def handle_event("cancel_repair_confirmation", _params, socket) do
+    {:noreply, assign(socket, confirming_repair?: false)}
+  end
+
+  def handle_event("make_changes", _params, %{assigns: %{repairing?: true}} = socket) do
+    # Duplicate clicks from the same socket should not queue multiple repair
+    # attempts. Cross-socket and cross-node safety remains enforced by the context
+    # resource locks; this guard is only local UI hygiene.
+    {:noreply, socket}
+  end
+
+  def handle_event("make_changes", _params, %{assigns: %{confirming_repair?: true}} = socket) do
+    # The browser sends no resource ids, activity ids, or serialized preview plan.
+    # The repair process below recomputes fresh project state on the server before
+    # acquiring locks and writing, so tampered or stale browser state is irrelevant.
+    socket =
+      socket
+      |> assign(
+        confirming_repair?: false,
+        repairing?: true,
+        repair_result: nil,
+        repair_status_message: "Repair is running. This may take a moment."
+      )
+      |> start_repair()
+
+    {:noreply, socket}
+  end
+
+  def handle_event("make_changes", _params, socket) do
+    # Confirmation is enforced server-side, not only by hiding/showing buttons in
+    # the DOM. A forged or stale LiveView event cannot start mutation unless this
+    # socket has first entered the explicit confirmation state.
+    {:noreply, socket}
+  end
+
+  @impl Phoenix.LiveView
+  def handle_async(:load_report, {:ok, {:ok, %Report{} = report}}, socket) do
+    {:noreply,
+     assign(socket,
+       fatal_error: nil,
+       report: to_display_report(report),
+       report_loading?: false
+     )}
+  end
+
+  def handle_async(:load_report, {:ok, {:error, reason}}, socket) do
+    {:noreply,
+     assign(socket,
+       fatal_error: humanize_error(reason),
+       report_loading?: false
+     )}
+  end
+
+  def handle_async(:load_report, {:exit, _reason}, socket) do
+    {:noreply,
+     assign(socket,
+       fatal_error: "The project analysis task did not complete.",
+       report_loading?: false
+     )}
+  end
+
+  def handle_async(:repair_project, {:ok, {:ok, %RepairResult{} = result}}, socket) do
+    {:noreply, assign_repair_result(socket, result)}
+  end
+
+  def handle_async(:repair_project, {:ok, {:error, %RepairResult{} = result}}, socket) do
+    {:noreply, assign_repair_result(socket, result)}
+  end
+
+  def handle_async(:repair_project, {:ok, {:error, reason}}, socket) do
+    {:noreply,
+     assign(socket,
+       fatal_error: humanize_error(reason),
+       repairing?: false,
+       repair_status_message: nil
+     )}
+  end
+
+  def handle_async(:repair_project, {:exit, _reason}, socket) do
+    {:noreply,
+     assign(socket,
+       fatal_error: "The repair task did not complete.",
+       repairing?: false,
+       repair_status_message: nil
+     )}
+  end
+
+  @impl Phoenix.LiveView
+  def render(assigns) do
+    ~H"""
+    <div class="container mx-auto p-8 project-repair-tool">
+      <header class="mb-4">
+        <p class="text-muted mb-1">System administration</p>
+        <h1 class="display-6">Project Repair Tool</h1>
+        <p class="lead">
+          Preview Basic-page structural issues, then optionally repair only resolvable shared
+          activity references. Missing activities are reported here but are not changed.
+        </p>
+      </header>
+
+      <div :if={@fatal_error} class="alert alert-danger" role="alert">
+        {@fatal_error}
+      </div>
+
+      <div
+        :if={@repair_status_message}
+        class="alert alert-info"
+        role="status"
+        aria-live="polite"
+      >
+        {@repair_status_message}
+      </div>
+
+      <.repair_result result={@repair_result} />
+
+      <div :if={@report_loading?} class="alert alert-info" role="status" aria-live="polite">
+        Analyzing current Basic pages…
+      </div>
+
+      <.report_preview
+        :if={@report}
+        report={@report}
+        project_slug={@project.slug}
+        confirming_repair?={@confirming_repair?}
+        repairing?={@repairing?}
+      />
+    </div>
+    """
+  end
+
+  attr :report, Report, required: true
+  attr :project_slug, :string, required: true
+  attr :confirming_repair?, :boolean, required: true
+  attr :repairing?, :boolean, required: true
+
+  defp report_preview(assigns) do
+    ~H"""
+    <section aria-labelledby="repair-summary-heading">
+      <div class="d-flex align-items-start justify-content-between gap-3 flex-wrap mb-3">
+        <div>
+          <h2 id="repair-summary-heading" class="h4 mb-2">Current analysis</h2>
+          <p class="text-muted mb-0">
+            This analysis is read-only and reflects current unpublished authoring revisions.
+          </p>
+        </div>
+
+        <button
+          :if={repairable_shared_groups?(@report) and !@confirming_repair?}
+          id="project-repair-show-confirmation"
+          type="button"
+          class="btn btn-danger"
+          phx-click="show_repair_confirmation"
+          disabled={@repairing?}
+        >
+          Repair shared activity references
+        </button>
+      </div>
+
+      <.repair_confirmation
+        :if={@confirming_repair?}
+        report={@report}
+        repairing?={@repairing?}
+      />
+
+      <.summary_cards summary={@report.summary} />
+
+      <.missing_references
+        references={@report.missing_activity_references}
+        summary={@report.summary}
+        project_slug={@project_slug}
+      />
+
+      <.shared_references
+        groups={@report.shared_activity_references}
+        summary={@report.summary}
+        project_slug={@project_slug}
+      />
+    </section>
+    """
+  end
+
+  attr :summary, Summary, required: true
+
+  defp summary_cards(assigns) do
+    ~H"""
+    <ul class="row g-3 mb-4 list-unstyled">
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-scanned">
+          <div class="card-body">
+            <h3 id="repair-summary-scanned" class="h6 text-muted">Basic pages scanned</h3>
+            <p class="h3 mb-0">{@summary.scanned_pages_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-adaptive">
+          <div class="card-body">
+            <h3 id="repair-summary-adaptive" class="h6 text-muted">Adaptive pages skipped</h3>
+            <p class="h3 mb-0">{@summary.skipped_adaptive_pages_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-missing">
+          <div class="card-body">
+            <h3 id="repair-summary-missing" class="h6 text-muted">Missing references</h3>
+            <p class="h3 mb-0">{@summary.missing_activity_reference_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-missing-pages">
+          <div class="card-body">
+            <h3 id="repair-summary-missing-pages" class="h6 text-muted">
+              Pages with missing references
+            </h3>
+            <p class="h3 mb-0">{@summary.missing_activity_affected_page_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-shared">
+          <div class="card-body">
+            <h3 id="repair-summary-shared" class="h6 text-muted">
+              Repairable shared activities
+            </h3>
+            <p class="h3 mb-0">{@summary.repairable_shared_activity_resource_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-shared-pages">
+          <div class="card-body">
+            <h3 id="repair-summary-shared-pages" class="h6 text-muted">
+              Pages with repairable shared activities
+            </h3>
+            <p class="h3 mb-0">{@summary.repairable_shared_activity_affected_page_count}</p>
+          </div>
+        </article>
+      </li>
+      <li class="col-md-4">
+        <article class="card h-100" aria-labelledby="repair-summary-shared-missing">
+          <div class="card-body">
+            <h3 id="repair-summary-shared-missing" class="h6 text-muted">
+              Shared missing activities
+            </h3>
+            <p class="h3 mb-0">
+              {@summary.non_repairable_shared_missing_activity_resource_count}
+            </p>
+          </div>
+        </article>
+      </li>
+    </ul>
+    """
+  end
+
+  attr :report, Report, required: true
+  attr :repairing?, :boolean, required: true
+
+  defp repair_confirmation(assigns) do
+    ~H"""
+    <section
+      id="project-repair-confirmation"
+      class="alert alert-warning"
+      role="region"
+      aria-labelledby="project-repair-confirmation-heading"
+      aria-describedby="project-repair-confirmation-description"
+    >
+      <h2 id="project-repair-confirmation-heading" class="h4">
+        Confirm shared activity repair
+      </h2>
+      <p id="project-repair-confirmation-description">
+        This will repair {@report.summary.repairable_shared_activity_resource_count} shared activity groups affecting {@report.summary.repairable_shared_activity_affected_page_count} Basic pages. Missing activity references will remain unchanged.
+      </p>
+      <div class="d-flex gap-2 flex-wrap">
+        <button
+          id="project-repair-confirm-make-changes"
+          type="button"
+          class="btn btn-danger"
+          phx-click="make_changes"
+          phx-disable-with="Repairing..."
+          disabled={@repairing?}
+        >
+          Confirm repair shared activity references
+        </button>
+        <button
+          type="button"
+          class="btn btn-outline-secondary"
+          phx-click="cancel_repair_confirmation"
+          disabled={@repairing?}
+        >
+          Cancel
+        </button>
+      </div>
+    </section>
+    """
+  end
+
+  attr :references, :list, required: true
+  attr :summary, Summary, required: true
+  attr :project_slug, :string, required: true
+
+  defp missing_references(assigns) do
+    assigns = assign(assigns, :issue_preview_limit, @issue_preview_limit)
+
+    ~H"""
+    <section class="mb-5" aria-labelledby="missing-activity-heading">
+      <h2 id="missing-activity-heading" class="h4">Missing activity references</h2>
+      <p class="text-muted">
+        These references are report-only. This tool does not remove missing activity nodes.
+      </p>
+      <p
+        :if={@summary.missing_activity_reference_count > length(@references)}
+        class="text-muted"
+      >
+        Showing the first {@issue_preview_limit} missing references. Summary counts above reflect
+        the full analysis.
+      </p>
+
+      <p :if={Enum.empty?(@references)} class="alert alert-success">
+        No missing activity references were found in Basic pages.
+      </p>
+
+      <div :if={!Enum.empty?(@references)} class="table-responsive">
+        <table class="table table-striped align-middle">
+          <caption class="visually-hidden">
+            Basic pages containing activity references that do not resolve in this project.
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Missing activity resource id</th>
+              <th scope="col">Page</th>
+              <th scope="col">Page resource id</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr :for={%MissingActivityReference{} = reference <- @references}>
+              <td>{reference.activity_resource_id}</td>
+              <td>
+                <.page_editor_link page={reference.page} project_slug={@project_slug} />
+              </td>
+              <td>{reference.page.resource_id}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+    """
+  end
+
+  attr :groups, :list, required: true
+  attr :summary, Summary, required: true
+  attr :project_slug, :string, required: true
+
+  defp shared_references(assigns) do
+    assigns = assign(assigns, :issue_preview_limit, @issue_preview_limit)
+
+    ~H"""
+    <section aria-labelledby="shared-activity-heading">
+      <h2 id="shared-activity-heading" class="h4">Shared activity references</h2>
+      <p class="text-muted">
+        Repairable groups will keep the lowest page resource id on the original activity and
+        clone that activity for each other page. Groups whose activity is missing are not repaired.
+      </p>
+      <p
+        :if={
+          @summary.repairable_shared_activity_resource_count +
+            @summary.non_repairable_shared_missing_activity_resource_count > length(@groups)
+        }
+        class="text-muted"
+      >
+        Showing the first {@issue_preview_limit} shared activity groups. Summary counts above
+        reflect the full analysis.
+      </p>
+
+      <p :if={Enum.empty?(@groups)} class="alert alert-success">
+        No cross-page shared activity references were found in Basic pages.
+      </p>
+
+      <div :for={%SharedActivityReference{} = group <- @groups} class="card mb-3">
+        <div class="card-header d-flex align-items-center justify-content-between gap-3 flex-wrap">
+          <h3 class="h5 mb-0">Activity resource {group.activity_resource_id}</h3>
+          <span class={"badge #{repairability_badge_class(group)}"}>
+            {repairability_label(group)}
+          </span>
+        </div>
+
+        <div class="card-body">
+          <p>
+            Referenced by {group.page_count} Basic pages.
+            <span :if={group.page_count > length(group.pages)}>
+              Showing the first {length(group.pages)}.
+            </span>
+          </p>
+
+          <ul class="mb-0">
+            <li :for={page <- group.pages}>
+              <.page_editor_link page={page} project_slug={@project_slug} />
+              <span class="text-muted">(page resource {page.resource_id})</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  attr :page, :map, required: true
+  attr :project_slug, :string, required: true
+
+  defp page_editor_link(assigns) do
+    ~H"""
+    <.link
+      href={~p"/workspaces/course_author/#{@project_slug}/curriculum/#{@page.revision_slug}/edit"}
+      aria-label={"Open page editor for #{@page.title}, page resource #{@page.resource_id}"}
+    >
+      {@page.title}
+    </.link>
+    """
+  end
+
+  attr :result, RepairResult, default: nil
+
+  defp repair_result(%{result: nil} = assigns), do: ~H""
+
+  defp repair_result(assigns) do
+    ~H"""
+    <section class={repair_result_alert_class(@result)} role="status" aria-live="polite">
+      <h2 class="h4">{repair_result_heading(@result)}</h2>
+      <p>
+        Updated {@result.updated_page_count} pages and cloned {@result.cloned_activity_count} activities. The analysis below has been refreshed from current project state.
+      </p>
+
+      <ul :if={!Enum.empty?(@result.failures)}>
+        <li :for={%RepairFailure{} = failure <- @result.failures}>
+          {failure_message(failure)}
+        </li>
+      </ul>
+
+      <p :if={!Enum.empty?(@result.warnings)} class="mb-0">
+        Warnings: {Enum.map_join(@result.warnings, ", ", &humanize_atom/1)}
+      </p>
+    </section>
+    """
+  end
+
+  defp start_report_analysis(socket) do
+    %{author: author, project: project} = socket.assigns
+
+    # Analysis can scan every Basic page in a project. Running it as a LiveView
+    # async task renders the admin shell immediately and keeps the socket process
+    # responsive while the context performs its bounded database stream. Preview
+    # limits are passed only to this read-only display analysis; repair planning
+    # always reanalyzes without display caps so no mutation work is hidden.
+    start_async(socket, :load_report, fn ->
+      ProjectRepair.analyze_project(project, author,
+        preview_issue_limit: @issue_preview_limit,
+        preview_group_page_limit: @group_page_preview_limit
+      )
+    end)
+  end
+
+  defp start_repair(socket) do
+    %{author: author, project: project} = socket.assigns
+
+    # Repair may re-analyze, lock resources, clone activities, and write revisions.
+    # `start_async/3` avoids monopolizing the LiveView process while preserving
+    # the context's authoritative locking and fresh-plan validation.
+    start_async(socket, :repair_project, fn ->
+      ProjectRepair.repair_project(project, author)
+    end)
+  end
+
+  defp assign_repair_result(socket, %RepairResult{} = result) do
+    assign(socket,
+      fatal_error: nil,
+      repairing?: false,
+      repair_result: display_repair_result(result),
+      repair_status_message: nil,
+      report: to_display_report(result.report_after_repair)
+    )
+  end
+
+  defp to_display_report(%Report{} = report) do
+    # The domain report remains complete for context tests and repair safety, but
+    # the LiveView keeps only a bounded preview in socket assigns. Summary counts
+    # still reflect the full analysis, so administrators can see scale without a
+    # very large issue list becoming one very large LiveView diff.
+    %Report{
+      report
+      | missing_activity_references:
+          Enum.take(report.missing_activity_references, @issue_preview_limit),
+        shared_activity_references:
+          report.shared_activity_references
+          |> Enum.take(@issue_preview_limit)
+          |> Enum.map(&limit_group_pages/1)
+    }
+  end
+
+  defp limit_group_pages(%SharedActivityReference{} = group) do
+    %SharedActivityReference{group | pages: Enum.take(group.pages, @group_page_preview_limit)}
+  end
+
+  defp display_repair_result(%RepairResult{} = result) do
+    # The rendered result uses counts, failures, and warnings only. Dropping the
+    # full before/after reports from this assign avoids retaining duplicate issue
+    # lists; the bounded after-report is assigned separately as `:report`.
+    %RepairResult{result | report_before_repair: nil, report_after_repair: nil}
+  end
+
+  defp repairable_shared_groups?(%Report{summary: %Summary{} = summary}) do
+    summary.repairable_shared_activity_resource_count > 0
+  end
+
+  defp repairability_label(%SharedActivityReference{repairable?: true}), do: "Repairable"
+  defp repairability_label(%SharedActivityReference{repairable?: false}), do: "Missing activity"
+
+  defp repairability_badge_class(%SharedActivityReference{repairable?: true}),
+    do: "text-bg-success"
+
+  defp repairability_badge_class(%SharedActivityReference{repairable?: false}),
+    do: "text-bg-warning"
+
+  defp repair_result_heading(%RepairResult{status: :completed}), do: "Repair completed"
+  defp repair_result_heading(%RepairResult{status: :partial}), do: "Repair partially completed"
+  defp repair_result_heading(%RepairResult{status: :failed}), do: "Repair failed"
+
+  defp repair_result_alert_class(%RepairResult{status: :completed}), do: "alert alert-success"
+  defp repair_result_alert_class(%RepairResult{status: :partial}), do: "alert alert-warning"
+  defp repair_result_alert_class(%RepairResult{status: :failed}), do: "alert alert-danger"
+
+  defp failure_message(%RepairFailure{} = failure) do
+    [
+      "Stage: #{humanize_atom(failure.stage)}",
+      "Reason: #{humanize_atom(failure.reason)}",
+      scoped_id("page", failure.page_resource_id),
+      scoped_id("activity", failure.activity_resource_id)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("; ")
+  end
+
+  defp scoped_id(_label, nil), do: nil
+  defp scoped_id(label, id), do: "#{label} resource id: #{id}"
+
+  defp humanize_error(:not_authorized), do: "You are not authorized to use this repair tool."
+  defp humanize_error(:project_not_found), do: "The selected project could not be found."
+
+  defp humanize_error(:working_publication_not_found),
+    do: "The selected project does not have a working authoring publication."
+
+  defp humanize_error({:invalid_page_content, page_resource_id}),
+    do: "Analysis stopped because page resource #{page_resource_id} has invalid content."
+
+  defp humanize_error({:invalid_options, _reason}),
+    do: "The repair tool was invoked with invalid processing options."
+
+  defp humanize_error(_reason), do: "The project repair tool could not complete the request."
+
+  defp humanize_atom(atom) when is_atom(atom) do
+    atom
+    |> Atom.to_string()
+    |> String.replace("_", " ")
+  end
+end

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1042,6 +1042,31 @@ defmodule OliWeb.Router do
 
   ### Workspaces
   scope "/workspaces", OliWeb.Workspaces do
+    pipe_through([:browser, :authoring_protected, :require_authenticated_system_admin])
+
+    # The repair tool is intentionally split from the ordinary project-author
+    # LiveSession. Standard project assignment/authorization hooks still run, but
+    # the plug pipeline rejects non-system-admin authors before the LiveView can
+    # mount or invoke the domain repair context.
+    live_session :system_admin_authoring_workspaces,
+      root_layout: {OliWeb.LayoutView, :delivery},
+      layout: {OliWeb.Layouts, :workspace},
+      on_mount: [
+        {OliWeb.AuthorAuth, :ensure_authenticated},
+        OliWeb.LiveSessionPlugs.SetCtx,
+        OliWeb.LiveSessionPlugs.AssignActiveMenu,
+        OliWeb.LiveSessionPlugs.SetSidebar,
+        OliWeb.LiveSessionPlugs.SetPreviewMode,
+        OliWeb.LiveSessionPlugs.SetProjectOrSection,
+        OliWeb.LiveSessionPlugs.AuthorizeProject
+      ] do
+      scope "/course_author", CourseAuthor do
+        live("/:project_id/repair_tool", ProjectRepairLive)
+      end
+    end
+  end
+
+  scope "/workspaces", OliWeb.Workspaces do
     pipe_through([:browser, :authoring_protected])
 
     live_session :authoring_workspaces,

--- a/test/oli/authoring/project_repair_test.exs
+++ b/test/oli/authoring/project_repair_test.exs
@@ -1,0 +1,1576 @@
+defmodule Oli.Authoring.ProjectRepairTest do
+  use Oli.DataCase
+
+  import Ecto.Query, warn: false
+  import ExUnit.CaptureLog
+
+  @moduletag capture_log: true
+
+  alias Oli.Accounts
+  alias Oli.Accounts.{Author, SystemRole}
+  alias Oli.Authoring.Course.ProjectResource
+  alias Oli.Authoring.Editing.Utils
+  alias Oli.Authoring.Locks
+  alias Oli.Authoring.ProjectRepair
+
+  alias Oli.Authoring.ProjectRepair.{
+    MissingActivityReference,
+    PageSummary,
+    RepairFailure,
+    RepairResult,
+    Report,
+    SharedActivityReference,
+    Summary
+  }
+
+  alias Oli.Delivery.Attempts.Core.ResourceAccess
+  alias Oli.Delivery.Sections.Section
+  alias Oli.Publishing
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Resources
+  alias Oli.Resources.{Resource, Revision}
+
+  setup do
+    # The standard seed creates a real unpublished project publication and two
+    # current Basic pages. Using real authoring mappings here ensures Phase 1
+    # project normalization is tested against the same state later phases scan.
+    seed = Seeder.base_project_with_resource2()
+
+    system_admin =
+      author_fixture(%{system_role_id: SystemRole.role_id().system_admin})
+
+    {:ok, Map.put(seed, :system_admin, system_admin)}
+  end
+
+  describe "domain contracts" do
+    test "report contracts retain compact page metadata but no page content", %{project: project} do
+      page = %PageSummary{
+        resource_id: 101,
+        revision_id: 201,
+        revision_slug: "example-page",
+        title: "Example page"
+      }
+
+      missing = %MissingActivityReference{activity_resource_id: 301, page: page}
+
+      shared = %SharedActivityReference{
+        activity_resource_id: 302,
+        pages: [page],
+        repairable?: true
+      }
+
+      summary = %Summary{missing_activity_reference_count: 1}
+
+      assert summary.repairable_shared_activity_affected_page_count == 0
+
+      report = %Report{
+        project_id: project.id,
+        project_slug: project.slug,
+        missing_activity_references: [missing],
+        shared_activity_references: [shared],
+        summary: summary
+      }
+
+      failure = %RepairFailure{stage: :lock, reason: :lock_not_acquired}
+
+      result = %RepairResult{
+        status: :failed,
+        report_before_repair: report,
+        report_after_repair: report,
+        failures: [failure]
+      }
+
+      # Reports can remain in LiveView state, so full JSON must never become part
+      # of their public shape. The revision id is retained for later stale checks.
+      refute Map.has_key?(Map.from_struct(page), :content)
+      refute Map.has_key?(Map.from_struct(report), :content)
+      assert result.report_before_repair.project_id == project.id
+      assert result.failures == [failure]
+    end
+  end
+
+  describe "authorization and project preparation" do
+    test "a system admin analyzes a persisted project", %{
+      project: project,
+      system_admin: system_admin
+    } do
+      assert {:ok, %Report{} = report} = ProjectRepair.analyze_project(project, system_admin)
+      assert report.project_id == project.id
+      assert report.project_slug == project.slug
+    end
+
+    test "a system admin receives the same deterministic report from a project slug", %{
+      project: project,
+      system_admin: system_admin
+    } do
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(project.slug, system_admin,
+                 stream_max_rows: 1,
+                 resolution_batch_size: 1
+               )
+
+      assert report.project_id == project.id
+      assert report.scanned_pages_count == 2
+      assert report.skipped_adaptive_pages_count == 0
+      assert report.missing_activity_references == []
+      assert report.shared_activity_references == []
+    end
+
+    test "repair uses the same preparation boundary as analysis", %{
+      project: project,
+      system_admin: system_admin
+    } do
+      assert {:ok, %RepairResult{status: :completed} = result} =
+               ProjectRepair.repair_project(project.slug, system_admin)
+
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert result.failures == []
+    end
+
+    test "unknown and stale project references fail deterministically", %{
+      project: project,
+      system_admin: system_admin
+    } do
+      assert {:error, :project_not_found} =
+               ProjectRepair.analyze_project("project-that-does-not-exist", system_admin)
+
+      # Matching both id and slug prevents a hand-built or stale struct from being
+      # trusted merely because it contains the slug of a real project.
+      stale_project = %{project | id: project.id + 1}
+
+      assert {:error, :project_not_found} =
+               ProjectRepair.analyze_project(stale_project, system_admin)
+    end
+
+    test "a project without an unpublished publication fails deterministically", %{
+      project: project,
+      publication: publication,
+      system_admin: system_admin
+    } do
+      {:ok, _published} =
+        Publishing.update_publication(publication, %{published: DateTime.utc_now()})
+
+      assert {:error, :working_publication_not_found} =
+               ProjectRepair.analyze_project(project, system_admin)
+
+      assert {:error, :working_publication_not_found} =
+               ProjectRepair.repair_project(project.slug, system_admin)
+    end
+
+    test "non-system-admin and malformed actors are rejected before project probing", %{
+      author: author
+    } do
+      # The intentionally unknown project and malformed options prove authorization
+      # is evaluated first: neither lower-priority error may leak to this caller.
+      assert {:error, :not_authorized} =
+               ProjectRepair.analyze_project("private-project", author,
+                 stream_max_rows: 0,
+                 unknown: :option
+               )
+
+      assert {:error, :not_authorized} =
+               ProjectRepair.repair_project("private-project", author,
+                 stream_max_rows: 0,
+                 unknown: :option
+               )
+
+      assert {:error, :not_authorized} =
+               ProjectRepair.repair_project("private-project", nil)
+    end
+
+    test "authorization uses current persisted role state rather than the caller struct", %{
+      project: project,
+      system_admin: stale_system_admin
+    } do
+      {:ok, persisted_author} =
+        Accounts.update_author(stale_system_admin, %{
+          system_role_id: SystemRole.role_id().author
+        })
+
+      refute Accounts.is_system_admin?(persisted_author)
+      assert Accounts.is_system_admin?(stale_system_admin)
+
+      # The original struct still carries the system-admin role. Rejection proves
+      # the context reloaded the actor before making its authorization decision.
+      assert {:error, :not_authorized} =
+               ProjectRepair.analyze_project(project, stale_system_admin)
+
+      assert {:error, :not_authorized} =
+               ProjectRepair.repair_project(project, stale_system_admin)
+    end
+
+    test "a hand-built author with no persisted account is rejected", %{project: project} do
+      nonexistent_actor = %Author{
+        id: 2_000_000_000,
+        system_role_id: SystemRole.role_id().system_admin
+      }
+
+      assert {:error, :not_authorized} =
+               ProjectRepair.analyze_project(project, nonexistent_actor)
+
+      assert {:error, :not_authorized} =
+               ProjectRepair.repair_project(project, nonexistent_actor)
+    end
+
+    test "processing options are restricted to positive bounded batch sizes", %{
+      project: project,
+      system_admin: system_admin
+    } do
+      assert {:error, {:invalid_options, {:expected_integer_between, :stream_max_rows, 1, 500}}} =
+               ProjectRepair.analyze_project(project, system_admin, stream_max_rows: 0)
+
+      assert {:error,
+              {:invalid_options, {:expected_integer_between, :resolution_batch_size, 1, 1_000}}} =
+               ProjectRepair.analyze_project(project, system_admin, resolution_batch_size: 1_001)
+
+      # The upper bounds themselves remain valid and produce the same read-only
+      # report as default options.
+      assert {:ok, %Report{scanned_pages_count: 2}} =
+               ProjectRepair.analyze_project(project, system_admin,
+                 stream_max_rows: 500,
+                 resolution_batch_size: 1_000
+               )
+
+      assert {:error, {:invalid_options, {:unknown_options, [:unsafe_option]}}} =
+               ProjectRepair.analyze_project(project, system_admin, unsafe_option: :infinity)
+
+      assert {:error, {:invalid_options, :expected_keyword_list}} =
+               ProjectRepair.analyze_project(project, system_admin, [:not_a_keyword])
+    end
+  end
+
+  describe "lock-aware deterministic repair" do
+    test "missing-only shared references are report-only and create no writes", seed do
+      missing_activity_id = missing_activity_resource_id()
+
+      first_page =
+        page_fixture(
+          seed,
+          "First missing-only page",
+          activity_reference_content([missing_activity_id])
+        )
+
+      second_page =
+        page_fixture(
+          seed,
+          "Second missing-only page",
+          activity_reference_content([missing_activity_id])
+        )
+
+      before_repair = storage_snapshot(seed)
+
+      assert {:ok, %RepairResult{status: :completed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert result.failures == []
+      assert result.warnings == []
+      assert result.report_after_repair.summary.missing_activity_reference_count == 2
+
+      assert AuthoringResolver.from_resource_id(seed.project.slug, first_page.resource.id).content ==
+               first_page.revision.content
+
+      assert AuthoringResolver.from_resource_id(seed.project.slug, second_page.resource.id).content ==
+               second_page.revision.content
+
+      assert storage_snapshot(seed) == before_repair
+    end
+
+    test "repairs a shared activity deterministically and preserves missing references", seed do
+      source_activity = activity_fixture(seed, "Complete source activity")
+
+      {:ok, source_revision} =
+        Resources.update_revision(source_activity.revision, %{
+          content: %{"stem" => "source activity content", "custom" => %{"value" => 7}},
+          objectives: %{"part-1" => [101, 202]}
+        })
+
+      missing_activity_id = missing_activity_resource_id()
+
+      keeper_page =
+        page_fixture(
+          seed,
+          "Lowest-id keeper page",
+          activity_reference_content([source_activity.resource.id, missing_activity_id])
+        )
+
+      second_page =
+        page_fixture(
+          seed,
+          "Second repaired page",
+          activity_reference_content([source_activity.resource.id, missing_activity_id])
+        )
+
+      third_page =
+        page_fixture(
+          seed,
+          "Third repaired page",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      adaptive_page =
+        page_fixture(
+          seed,
+          "Unchanged Adaptive page",
+          activity_reference_content([source_activity.resource.id], true)
+        )
+
+      assert {:ok, %RepairResult{status: :completed} = result} =
+               ProjectRepair.repair_project(seed.project.slug, seed.system_admin,
+                 stream_max_rows: 1,
+                 resolution_batch_size: 1
+               )
+
+      assert result.cloned_activity_count == 2
+      assert result.updated_page_count == 2
+      assert result.failures == []
+      assert result.warnings == []
+
+      current_keeper = current_revision(seed, keeper_page)
+      current_second = current_revision(seed, second_page)
+      current_third = current_revision(seed, third_page)
+      current_adaptive = current_revision(seed, adaptive_page)
+
+      # Lowest page resource id is the deterministic keeper. Adaptive content is
+      # absent from the plan and therefore retains both its revision and source id.
+      assert current_keeper.id == keeper_page.revision.id
+
+      assert referenced_activity_ids(current_keeper) ==
+               MapSet.new([source_activity.resource.id, missing_activity_id])
+
+      assert current_adaptive.id == adaptive_page.revision.id
+
+      assert referenced_activity_ids(current_adaptive) ==
+               MapSet.new([source_activity.resource.id])
+
+      second_ids = referenced_activity_ids(current_second)
+      third_ids = referenced_activity_ids(current_third)
+      second_clone_id = Enum.find(second_ids, &(&1 != missing_activity_id))
+      [third_clone_id] = MapSet.to_list(third_ids)
+
+      refute second_clone_id == source_activity.resource.id
+      refute third_clone_id == source_activity.resource.id
+      refute second_clone_id == third_clone_id
+
+      for clone_id <- [second_clone_id, third_clone_id] do
+        clone = AuthoringResolver.from_resource_id(seed.project.slug, clone_id)
+        assert clone.title == source_revision.title
+        assert clone.content == source_revision.content
+        assert clone.objectives == source_revision.objectives
+      end
+
+      # The repair rewrites only `activity_id`; unrelated node fields and missing
+      # references survive byte-for-byte in the new page content.
+      assert activity_reference_node(current_second, missing_activity_id) ==
+               activity_reference_node(second_page.revision, missing_activity_id)
+
+      assert activity_reference_node(current_second, second_clone_id)["customData"] == %{
+               "preserve" => 0
+             }
+
+      assert current_second.activity_refs == Enum.sort(MapSet.to_list(second_ids))
+      assert current_third.activity_refs == Enum.sort(MapSet.to_list(third_ids))
+
+      assert result.report_after_repair.summary.repairable_shared_activity_resource_count == 0
+      assert result.report_after_repair.summary.missing_activity_reference_count == 2
+
+      assert_locks_released(seed, [
+        source_activity.resource.id,
+        keeper_page.resource.id,
+        second_page.resource.id,
+        third_page.resource.id
+      ])
+
+      # AC-022: rerunning is idempotent because repaired relationships no longer
+      # produce work, while unresolved references remain report-only.
+      assert {:ok, rerun} = ProjectRepair.repair_project(seed.project, seed.system_admin)
+      assert rerun.status == :completed
+      assert rerun.cloned_activity_count == 0
+      assert rerun.updated_page_count == 0
+      assert rerun.report_after_repair.summary.missing_activity_reference_count == 2
+    end
+
+    test "several shared groups affecting one page create one page revision", seed do
+      first_activity = activity_fixture(seed, "First independent source")
+      second_activity = activity_fixture(seed, "Second independent source")
+
+      first_keeper =
+        page_fixture(
+          seed,
+          "First group keeper",
+          activity_reference_content([first_activity.resource.id])
+        )
+
+      second_keeper =
+        page_fixture(
+          seed,
+          "Second group keeper",
+          activity_reference_content([second_activity.resource.id])
+        )
+
+      shared_non_keeper =
+        page_fixture(
+          seed,
+          "Two-group non-keeper",
+          activity_reference_content([
+            first_activity.resource.id,
+            second_activity.resource.id
+          ])
+        )
+
+      revision_count_before = Repo.aggregate(Revision, :count, :id)
+
+      assert {:ok, %RepairResult{status: :completed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 2
+      assert result.updated_page_count == 1
+
+      current_non_keeper = current_revision(seed, shared_non_keeper)
+      assert current_non_keeper.previous_revision_id == shared_non_keeper.revision.id
+      assert MapSet.size(referenced_activity_ids(current_non_keeper)) == 2
+
+      # Two activity revisions plus exactly one page revision were added. Keeper
+      # pages remain on their original revisions and retain the original sources.
+      assert Repo.aggregate(Revision, :count, :id) == revision_count_before + 3
+      assert current_revision(seed, first_keeper).id == first_keeper.revision.id
+      assert current_revision(seed, second_keeper).id == second_keeper.revision.id
+    end
+
+    test "repair derives work from fresh state instead of an earlier preview", seed do
+      source_activity = activity_fixture(seed, "Fresh-plan source")
+
+      keeper =
+        page_fixture(
+          seed,
+          "Preview keeper",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      second_page =
+        page_fixture(
+          seed,
+          "Preview second page",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      assert {:ok, preview} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      assert [preview_group] = preview.shared_activity_references
+      assert length(preview_group.pages) == 2
+
+      third_page =
+        page_fixture(
+          seed,
+          "Added after preview",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      assert {:ok, %RepairResult{status: :completed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 2
+      assert result.updated_page_count == 2
+      assert [fresh_group] = result.report_before_repair.shared_activity_references
+
+      assert Enum.map(fresh_group.pages, & &1.resource_id) ==
+               [keeper.resource.id, second_page.resource.id, third_page.resource.id]
+    end
+
+    test "post-lock project changes abort as stale without repair writes", seed do
+      source_activity = activity_fixture(seed, "Stale-plan source")
+
+      keeper_page =
+        page_fixture(
+          seed,
+          "Stale-plan keeper",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      changed_page =
+        page_fixture(
+          seed,
+          "Stale-plan changed page",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      resource_count_before = Repo.aggregate(Resource, :count, :id)
+      revision_count_before = Repo.aggregate(Revision, :count, :id)
+
+      # The hook runs after every participant lock is owned by this repair but
+      # before the mandatory post-lock analysis. Updating the page body in place
+      # creates the interleaving AC-016 cares about without adding extra revisions
+      # that would obscure whether repair itself wrote anything.
+      hook = fn ->
+        {:ok, _changed_revision} =
+          Resources.update_revision(changed_page.revision, %{
+            content: %{"model" => []},
+            activity_refs: []
+          })
+
+        send(self(), :stale_hook_ran)
+      end
+
+      assert {:ok, %RepairResult{status: :failed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin,
+                 after_lock_acquisition: hook
+               )
+
+      assert_received :stale_hook_ran
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert [%RepairFailure{stage: :stale_plan, reason: :stale_project_state}] = result.failures
+      assert Repo.aggregate(Resource, :count, :id) == resource_count_before
+      assert Repo.aggregate(Revision, :count, :id) == revision_count_before
+
+      assert_locks_released(seed, [
+        source_activity.resource.id,
+        keeper_page.resource.id,
+        changed_page.resource.id
+      ])
+    end
+
+    test "a participant lock conflict causes zero repair writes and preserves the holder", seed do
+      source_activity = activity_fixture(seed, "Locked source")
+
+      first_page =
+        page_fixture(
+          seed,
+          "Locked group first",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      second_page =
+        page_fixture(
+          seed,
+          "Locked group second",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      {:acquired} =
+        Locks.acquire(
+          seed.project.slug,
+          seed.publication.id,
+          second_page.resource.id,
+          seed.author2.id
+        )
+
+      resource_count_before = Repo.aggregate(Resource, :count, :id)
+      revision_count_before = Repo.aggregate(Revision, :count, :id)
+
+      assert {:ok, %RepairResult{status: :failed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert [%RepairFailure{stage: :lock, reason: :lock_not_acquired}] = result.failures
+      assert Repo.aggregate(Resource, :count, :id) == resource_count_before
+      assert Repo.aggregate(Revision, :count, :id) == revision_count_before
+      assert current_revision(seed, first_page).id == first_page.revision.id
+      assert current_revision(seed, second_page).id == second_page.revision.id
+
+      assert_locks_released(seed, [source_activity.resource.id, first_page.resource.id])
+
+      locked_page_mapping =
+        Publishing.get_published_resource!(seed.publication.id, second_page.resource.id)
+
+      assert locked_page_mapping.locked_by_id == seed.author2.id
+
+      assert {:ok} =
+               Locks.release(
+                 seed.project.slug,
+                 seed.publication.id,
+                 second_page.resource.id,
+                 seed.author2.id
+               )
+    end
+
+    test "a lock already held by the invoking admin is not adopted or released", seed do
+      source_activity = activity_fixture(seed, "Same-admin locked source")
+
+      page_fixture(
+        seed,
+        "Same-admin first page",
+        activity_reference_content([source_activity.resource.id])
+      )
+
+      page_fixture(
+        seed,
+        "Same-admin second page",
+        activity_reference_content([source_activity.resource.id])
+      )
+
+      {:acquired} =
+        Locks.acquire(
+          seed.project.slug,
+          seed.publication.id,
+          source_activity.resource.id,
+          seed.system_admin.id
+        )
+
+      assert {:ok, %RepairResult{status: :failed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert [%RepairFailure{stage: :lock, reason: :lock_not_acquired}] = result.failures
+
+      mapping =
+        Publishing.get_published_resource!(seed.publication.id, source_activity.resource.id)
+
+      assert mapping.locked_by_id == seed.system_admin.id
+
+      assert {:ok} =
+               Locks.release(
+                 seed.project.slug,
+                 seed.publication.id,
+                 source_activity.resource.id,
+                 seed.system_admin.id
+               )
+    end
+
+    test "a failed page rolls back its clones after earlier pages commit and is retryable",
+         seed do
+      valid_activity = activity_fixture(seed, "Valid partial source")
+      invalid_activity = activity_fixture(seed, "Invalid partial source")
+      original_activity_type_id = invalid_activity.revision.activity_type_id
+
+      {:ok, _invalid_revision} =
+        Resources.update_revision(invalid_activity.revision, %{activity_type_id: nil})
+
+      keeper =
+        page_fixture(
+          seed,
+          "Partial keeper",
+          activity_reference_content([valid_activity.resource.id, invalid_activity.resource.id])
+        )
+
+      successful_page =
+        page_fixture(
+          seed,
+          "Partial successful page",
+          activity_reference_content([valid_activity.resource.id])
+        )
+
+      failed_page =
+        page_fixture(
+          seed,
+          "Partial failed page",
+          activity_reference_content([valid_activity.resource.id, invalid_activity.resource.id])
+        )
+
+      resource_count_before = Repo.aggregate(Resource, :count, :id)
+      revision_count_before = Repo.aggregate(Revision, :count, :id)
+
+      assert {:ok, %RepairResult{status: :partial} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 1
+      assert result.updated_page_count == 1
+
+      assert [failure] = result.failures
+      assert failure.stage == :activity_copy
+      assert failure.reason == :activity_copy_failed
+      assert failure.page_resource_id == failed_page.resource.id
+      assert failure.activity_resource_id == invalid_activity.resource.id
+
+      assert current_revision(seed, keeper).id == keeper.revision.id
+      refute current_revision(seed, successful_page).id == successful_page.revision.id
+      assert current_revision(seed, failed_page).id == failed_page.revision.id
+
+      # The failed page cloned the lower-id valid source before the invalid source
+      # failed. Its outer page transaction rolls that clone back, so only the one
+      # clone and page revision from the earlier committed page remain.
+      assert Repo.aggregate(Resource, :count, :id) == resource_count_before + 1
+      assert Repo.aggregate(Revision, :count, :id) == revision_count_before + 2
+
+      assert result.report_after_repair.summary.repairable_shared_activity_resource_count == 2
+
+      assert_locks_released(seed, [
+        valid_activity.resource.id,
+        invalid_activity.resource.id,
+        keeper.resource.id,
+        successful_page.resource.id,
+        failed_page.resource.id
+      ])
+
+      current_invalid =
+        AuthoringResolver.from_resource_id(seed.project.slug, invalid_activity.resource.id)
+
+      {:ok, _fixed_revision} =
+        Resources.update_revision(current_invalid, %{activity_type_id: original_activity_type_id})
+
+      assert {:ok, %RepairResult{status: :completed} = retry_result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert retry_result.cloned_activity_count == 2
+      assert retry_result.updated_page_count == 1
+
+      assert retry_result.report_after_repair.summary.repairable_shared_activity_resource_count ==
+               0
+    end
+
+    test "a page revision failure rolls back cloned activities and is retryable", seed do
+      source_activity = activity_fixture(seed, "Page-update failure source")
+
+      keeper_page =
+        page_fixture(
+          seed,
+          "Page-update keeper",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      failed_page =
+        page_fixture(
+          seed,
+          "Page-update failed page",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      # `ChangeTracker.track_revision/3` creates a new revision from the current
+      # page revision. A nil title makes that new revision invalid after the clone
+      # has been created inside the transaction, proving the clone rolls back with
+      # the page update failure.
+      from(revision in Revision,
+        where: revision.id == ^failed_page.revision.id
+      )
+      |> Repo.update_all(set: [title: nil])
+
+      resource_count_before = Repo.aggregate(Resource, :count, :id)
+      revision_count_before = Repo.aggregate(Revision, :count, :id)
+
+      assert {:ok, %RepairResult{status: :failed} = result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert result.cloned_activity_count == 0
+      assert result.updated_page_count == 0
+      assert [%RepairFailure{stage: :page_update, reason: :page_update_failed}] = result.failures
+      assert Repo.aggregate(Resource, :count, :id) == resource_count_before
+      assert Repo.aggregate(Revision, :count, :id) == revision_count_before
+      assert current_revision(seed, failed_page).id == failed_page.revision.id
+
+      assert_locks_released(seed, [
+        source_activity.resource.id,
+        keeper_page.resource.id,
+        failed_page.resource.id
+      ])
+
+      from(revision in Revision,
+        where: revision.id == ^failed_page.revision.id
+      )
+      |> Repo.update_all(set: [title: failed_page.revision.title])
+
+      assert {:ok, %RepairResult{status: :completed} = retry_result} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert retry_result.cloned_activity_count == 1
+      assert retry_result.updated_page_count == 1
+
+      assert retry_result.report_after_repair.summary.repairable_shared_activity_resource_count ==
+               0
+    end
+  end
+
+  describe "operational instrumentation" do
+    test "analysis emits bounded telemetry and completion logs without authored content", seed do
+      handler =
+        attach_project_repair_telemetry([[:oli, :authoring, :project_repair, :analysis, :stop]])
+
+      page_fixture(
+        seed,
+        "Sensitive Page Title",
+        %{"model" => []}
+      )
+
+      assert {:ok, %Report{} = report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin,
+                 stream_max_rows: 1,
+                 resolution_batch_size: 1
+               )
+
+      assert report.scanned_pages_count == 3
+
+      assert_receive {:telemetry_event, [:oli, :authoring, :project_repair, :analysis, :stop],
+                      %{count: 1, duration_ms: duration_ms}, metadata}
+
+      assert is_integer(duration_ms)
+      assert metadata.operation == :analysis
+      assert metadata.status == :completed
+      assert metadata.project_id == seed.project.id
+      assert metadata.project_slug == seed.project.slug
+      assert metadata.actor_id == seed.system_admin.id
+      assert metadata.scanned_pages_count == 3
+      assert metadata.stream_max_rows == 1
+      assert metadata.resolution_batch_size == 1
+
+      # The operational contract is count-oriented. Page titles and JSON content
+      # are intentionally absent from both telemetry metadata and completion logs.
+      refute inspect(metadata) =~ "Sensitive Page Title"
+
+      :telemetry.detach(handler)
+    end
+
+    test "repair telemetry covers success, stale, lock, partial, and fatal outcomes", seed do
+      handler =
+        attach_project_repair_telemetry([[:oli, :authoring, :project_repair, :repair, :stop]])
+
+      assert {:ok, %RepairResult{status: :completed}} =
+               ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+      assert_repair_telemetry(:completed, nil, nil)
+
+      source_activity = activity_fixture(seed, "Telemetry stale source")
+
+      keeper_page =
+        page_fixture(
+          seed,
+          "Telemetry stale keeper",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      stale_page =
+        page_fixture(
+          seed,
+          "Telemetry stale changed",
+          activity_reference_content([source_activity.resource.id])
+        )
+
+      stale_hook = fn ->
+        {:ok, _changed_revision} =
+          Resources.update_revision(stale_page.revision, %{
+            content: %{"model" => []},
+            activity_refs: []
+          })
+      end
+
+      capture_log(fn ->
+        assert {:ok, %RepairResult{status: :failed}} =
+                 ProjectRepair.repair_project(seed.project, seed.system_admin,
+                   after_lock_acquisition: stale_hook
+                 )
+      end)
+
+      assert_repair_telemetry(:failed, :stale_plan, :stale_project_state)
+
+      assert_locks_released(seed, [
+        source_activity.resource.id,
+        keeper_page.resource.id,
+        stale_page.resource.id
+      ])
+
+      locked_activity = activity_fixture(seed, "Telemetry locked source")
+
+      page_fixture(
+        seed,
+        "Telemetry lock first",
+        activity_reference_content([locked_activity.resource.id])
+      )
+
+      locked_page =
+        page_fixture(
+          seed,
+          "Telemetry lock second",
+          activity_reference_content([locked_activity.resource.id])
+        )
+
+      {:acquired} =
+        Locks.acquire(
+          seed.project.slug,
+          seed.publication.id,
+          locked_page.resource.id,
+          seed.author2.id
+        )
+
+      capture_log(fn ->
+        assert {:ok, %RepairResult{status: :failed}} =
+                 ProjectRepair.repair_project(seed.project, seed.system_admin)
+      end)
+
+      assert_repair_telemetry(:failed, :lock, :lock_not_acquired)
+
+      assert {:ok} =
+               Locks.release(
+                 seed.project.slug,
+                 seed.publication.id,
+                 locked_page.resource.id,
+                 seed.author2.id
+               )
+
+      valid_activity = activity_fixture(seed, "Telemetry partial valid")
+      invalid_activity = activity_fixture(seed, "Telemetry partial invalid")
+
+      {:ok, _invalid_revision} =
+        Resources.update_revision(invalid_activity.revision, %{activity_type_id: nil})
+
+      page_fixture(
+        seed,
+        "Telemetry partial keeper",
+        activity_reference_content([valid_activity.resource.id, invalid_activity.resource.id])
+      )
+
+      page_fixture(
+        seed,
+        "Telemetry partial success",
+        activity_reference_content([valid_activity.resource.id])
+      )
+
+      page_fixture(
+        seed,
+        "Telemetry partial failure",
+        activity_reference_content([valid_activity.resource.id, invalid_activity.resource.id])
+      )
+
+      capture_log(fn ->
+        assert {:ok, %RepairResult{status: :partial}} =
+                 ProjectRepair.repair_project(seed.project, seed.system_admin)
+      end)
+
+      assert_repair_telemetry(:partial, :activity_copy, :activity_copy_failed)
+
+      malformed_page =
+        page_fixture(seed, "Telemetry malformed page", %{
+          "model" => [%{"id" => "node-without-required-type"}]
+        })
+
+      capture_log(fn ->
+        assert {:error, {:invalid_page_content, resource_id}} =
+                 ProjectRepair.repair_project(seed.project, seed.system_admin)
+
+        assert resource_id == malformed_page.resource.id
+      end)
+
+      assert_repair_telemetry(:failed, :context, :invalid_page_content)
+
+      :telemetry.detach(handler)
+    end
+
+    test "telemetry handler failures do not change analysis results", seed do
+      handler_id = "project-repair-raising-handler-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:oli, :authoring, :project_repair, :analysis, :stop],
+        fn _event, _measurements, _metadata, _config -> raise "handler failed" end,
+        nil
+      )
+
+      assert {:ok, %Report{scanned_pages_count: 2}} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      :telemetry.detach(handler_id)
+    end
+  end
+
+  describe "streamed read-only analysis" do
+    test "a project with reference-free pages returns an empty report without writes", seed do
+      before_analysis = storage_snapshot(seed)
+
+      assert {:ok, %Report{} = report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin,
+                 stream_max_rows: 1,
+                 resolution_batch_size: 1
+               )
+
+      # The base project contains two current Basic pages with empty models. A
+      # stream fetch size of one exercises multiple cursor fetches without changing
+      # the compact result or creating any authoring, delivery, or learner rows.
+      assert report.scanned_pages_count == 2
+      assert report.skipped_adaptive_pages_count == 0
+      assert report.missing_activity_references == []
+      assert report.shared_activity_references == []
+
+      assert report.summary == %Summary{
+               scanned_pages_count: 2,
+               skipped_adaptive_pages_count: 0,
+               missing_activity_reference_count: 0,
+               missing_activity_affected_page_count: 0,
+               repairable_shared_activity_resource_count: 0,
+               repairable_shared_activity_affected_page_count: 0,
+               non_repairable_shared_missing_activity_resource_count: 0
+             }
+
+      assert storage_snapshot(seed) == before_analysis
+    end
+
+    test "reports nested missing and shared references for Basic pages only", seed do
+      first_activity = activity_fixture(seed, "First shared activity")
+      second_activity = activity_fixture(seed, "Second shared activity")
+      missing_single_id = missing_activity_resource_id()
+      missing_shared_id = missing_activity_resource_id()
+      adaptive_only_missing_id = missing_activity_resource_id()
+
+      first_page =
+        page_fixture(
+          seed,
+          "First issue page",
+          activity_reference_content([
+            first_activity.resource.id,
+            first_activity.resource.id,
+            second_activity.resource.id,
+            missing_single_id
+          ])
+        )
+
+      second_page =
+        page_fixture(
+          seed,
+          "Second issue page",
+          activity_reference_content(
+            [first_activity.resource.id, missing_shared_id],
+            false
+          )
+        )
+
+      third_page =
+        page_fixture(
+          seed,
+          "Third issue page",
+          activity_reference_content([second_activity.resource.id, missing_shared_id])
+        )
+
+      no_reference_page = page_fixture(seed, "No-reference page", %{"model" => []})
+
+      adaptive_page =
+        page_fixture(
+          seed,
+          "Excluded Adaptive page",
+          activity_reference_content(
+            [first_activity.resource.id, adaptive_only_missing_id],
+            true
+          )
+        )
+
+      before_analysis = storage_snapshot(seed)
+      handler_id = "project-repair-resolver-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:oli, :resolvers, :authoring],
+        fn _event, _measurements, _metadata, test_pid -> send(test_pid, :resolver_batch) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(seed.project.slug, seed.system_admin,
+                 stream_max_rows: 1,
+                 resolution_batch_size: 1
+               )
+
+      # Four unique Basic-page activity ids require exactly four one-id resolver
+      # batches. The repeated first-page reference and Adaptive-only missing id do
+      # not create extra resolver queries, guarding against relationship N+1s.
+      for _index <- 1..4, do: assert_receive(:resolver_batch)
+      refute_receive :resolver_batch
+
+      assert report.scanned_pages_count == 6
+      assert report.skipped_adaptive_pages_count == 1
+
+      assert Enum.map(report.missing_activity_references, fn missing ->
+               {missing.page.resource_id, missing.activity_resource_id}
+             end) ==
+               [
+                 {first_page.resource.id, missing_single_id},
+                 {second_page.resource.id, missing_shared_id},
+                 {third_page.resource.id, missing_shared_id}
+               ]
+
+      assert Enum.map(report.missing_activity_references, fn missing ->
+               {missing.page.title, missing.page.revision_slug}
+             end) ==
+               [
+                 {first_page.revision.title, first_page.revision.slug},
+                 {second_page.revision.title, second_page.revision.slug},
+                 {third_page.revision.title, third_page.revision.slug}
+               ]
+
+      assert Enum.map(report.shared_activity_references, fn shared ->
+               {
+                 shared.activity_resource_id,
+                 Enum.map(shared.pages, & &1.resource_id),
+                 shared.repairable?
+               }
+             end) ==
+               [
+                 {first_activity.resource.id, [first_page.resource.id, second_page.resource.id],
+                  true},
+                 {second_activity.resource.id, [first_page.resource.id, third_page.resource.id],
+                  true},
+                 {missing_shared_id, [second_page.resource.id, third_page.resource.id], false}
+               ]
+
+      assert Enum.map(report.shared_activity_references, fn shared ->
+               Enum.map(shared.pages, &{&1.title, &1.revision_slug})
+             end) ==
+               [
+                 [
+                   {first_page.revision.title, first_page.revision.slug},
+                   {second_page.revision.title, second_page.revision.slug}
+                 ],
+                 [
+                   {first_page.revision.title, first_page.revision.slug},
+                   {third_page.revision.title, third_page.revision.slug}
+                 ],
+                 [
+                   {second_page.revision.title, second_page.revision.slug},
+                   {third_page.revision.title, third_page.revision.slug}
+                 ]
+               ]
+
+      assert report.summary == %Summary{
+               scanned_pages_count: 6,
+               skipped_adaptive_pages_count: 1,
+               missing_activity_reference_count: 3,
+               missing_activity_affected_page_count: 3,
+               repairable_shared_activity_resource_count: 2,
+               repairable_shared_activity_affected_page_count: 3,
+               non_repairable_shared_missing_activity_resource_count: 1
+             }
+
+      # Compact metadata is sufficient for future editor links and stale checks.
+      # Full JSON from all five new pages must have become unreachable after each
+      # cursor row and must never cross the context boundary.
+      expected_reported_page_ids =
+        [first_page, second_page, third_page]
+        |> Enum.map(& &1.resource.id)
+        |> Enum.sort()
+
+      actual_reported_page_ids =
+        report.shared_activity_references
+        |> Enum.flat_map(& &1.pages)
+        |> Enum.map(& &1.resource_id)
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      assert actual_reported_page_ids == expected_reported_page_ids
+      refute adaptive_page.resource.id in actual_reported_page_ids
+      refute no_reference_page.resource.id in actual_reported_page_ids
+
+      for shared <- report.shared_activity_references,
+          page <- shared.pages do
+        refute Map.has_key?(Map.from_struct(page), :content)
+      end
+
+      assert storage_snapshot(seed) == before_analysis
+    end
+
+    test "excludes deleted and non-project page revisions from the cursor", seed do
+      deleted_page = page_fixture(seed, "Deleted page", %{"model" => []})
+      blueprint_page = page_fixture(seed, "Blueprint-scoped page", %{"model" => []})
+
+      {:ok, _deleted_revision} =
+        Resources.update_revision(deleted_page.revision, %{deleted: true})
+
+      {:ok, _blueprint_revision} =
+        Resources.update_revision(blueprint_page.revision, %{resource_scope: :blueprint})
+
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      assert report.scanned_pages_count == 2
+      assert report.skipped_adaptive_pages_count == 0
+    end
+
+    test "a reference to a resolvable non-activity resource is never repairable", seed do
+      target_page = page_fixture(seed, "Wrong-type target page", %{"model" => []})
+
+      first_referring_page =
+        page_fixture(
+          seed,
+          "First wrong-type reference",
+          activity_reference_content([target_page.resource.id])
+        )
+
+      second_referring_page =
+        page_fixture(
+          seed,
+          "Second wrong-type reference",
+          activity_reference_content([target_page.resource.id])
+        )
+
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      # The generic authoring resolver can resolve the target page, but the repair
+      # analyzer's activity-only projection must classify it as missing. This keeps
+      # Phase 3 from ever passing a page/container revision to activity-copy code.
+      assert Enum.map(report.missing_activity_references, fn missing ->
+               {missing.page.resource_id, missing.activity_resource_id}
+             end) ==
+               [
+                 {first_referring_page.resource.id, target_page.resource.id},
+                 {second_referring_page.resource.id, target_page.resource.id}
+               ]
+
+      assert [shared] = report.shared_activity_references
+      assert shared.activity_resource_id == target_page.resource.id
+      refute shared.repairable?
+    end
+
+    test "a corrupt mapping cannot certify the wrong resource id as an activity", seed do
+      target_page = page_fixture(seed, "Corrupt-mapping target page", %{"model" => []})
+      unrelated_activity = activity_fixture(seed, "Unrelated mapped activity")
+
+      {:ok, unmapped_activity_revision} =
+        Resources.create_revision_from_previous(unrelated_activity.revision, %{})
+
+      target_mapping =
+        Repo.get_by!(PublishedResource,
+          publication_id: seed.publication.id,
+          resource_id: target_page.resource.id
+        )
+
+      # Deliberately create a mapping/revision resource mismatch that normal APIs
+      # never produce. The activity-only resolver must validate both ids, or this
+      # page resource id would be falsely certified by the activity revision type.
+      target_mapping
+      |> Ecto.Changeset.change(revision_id: unmapped_activity_revision.id)
+      |> Repo.update!()
+
+      referring_page =
+        page_fixture(
+          seed,
+          "Corrupt-mapping referring page",
+          activity_reference_content([target_page.resource.id])
+        )
+
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      assert [missing] = report.missing_activity_references
+      assert missing.page.resource_id == referring_page.resource.id
+      assert missing.activity_resource_id == target_page.resource.id
+      assert report.shared_activity_references == []
+    end
+
+    test "a corrupt page mapping cannot scan a mismatched revision", seed do
+      target_page = page_fixture(seed, "Corrupt page mapping target", %{"model" => []})
+      unrelated_page = page_fixture(seed, "Corrupt page mapping unrelated", %{"model" => []})
+
+      {:ok, unmapped_unrelated_revision} =
+        Resources.create_revision_from_previous(unrelated_page.revision, %{})
+
+      target_mapping =
+        Repo.get_by!(PublishedResource,
+          publication_id: seed.publication.id,
+          resource_id: target_page.resource.id
+        )
+
+      # A working-publication mapping must not be trusted unless its selected
+      # revision belongs to the same resource id. Without that join predicate this
+      # would scan a revision that is not actually current for the mapped resource.
+      target_mapping
+      |> Ecto.Changeset.change(revision_id: unmapped_unrelated_revision.id)
+      |> Repo.update!()
+
+      assert {:ok, report} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      assert report.scanned_pages_count == 3
+      assert report.shared_activity_references == []
+      assert report.missing_activity_references == []
+    end
+
+    test "fails with the page resource id when established traversal cannot read content", seed do
+      malformed_page =
+        page_fixture(seed, "Malformed page", %{
+          "model" => [%{"id" => "node-without-required-type"}]
+        })
+
+      before_analysis = storage_snapshot(seed)
+
+      assert {:error, {:invalid_page_content, resource_id}} =
+               ProjectRepair.analyze_project(seed.project, seed.system_admin)
+
+      assert resource_id == malformed_page.resource.id
+      assert storage_snapshot(seed) == before_analysis
+    end
+  end
+
+  describe "fixture foundation for later phases" do
+    test "helpers create current Basic, Adaptive, shared, nested, and missing references", seed do
+      activity = activity_fixture(seed, "Shared activity")
+
+      basic_page =
+        page_fixture(seed, "Nested Basic page", nested_reference_content(activity.resource.id))
+
+      adaptive_page =
+        page_fixture(
+          seed,
+          "Adaptive page",
+          nested_reference_content(activity.resource.id)
+          |> Map.put("advancedDelivery", true)
+        )
+
+      {shared_page_one, shared_page_two} = shared_page_fixtures(seed, activity.resource.id)
+      missing_activity_id = missing_activity_resource_id()
+
+      missing_page =
+        page_fixture(seed, "Missing activity page", nested_reference_content(missing_activity_id))
+
+      # Each fixture must be the revision currently resolved from the working
+      # publication; otherwise later tests could accidentally exercise stale rows.
+      for page <- [basic_page, adaptive_page, shared_page_one, shared_page_two, missing_page] do
+        resolved = AuthoringResolver.from_resource_id(seed.project.slug, page.resource.id)
+        assert resolved.id == page.revision.id
+      end
+
+      assert adaptive_page.revision.content["advancedDelivery"] == true
+      assert basic_page.revision.content["advancedDelivery"] == nil
+
+      assert AuthoringResolver.from_resource_id(seed.project.slug, activity.resource.id).id ==
+               activity.revision.id
+
+      assert AuthoringResolver.from_resource_id(seed.project.slug, missing_activity_id) == nil
+    end
+  end
+
+  # These helpers intentionally build real resources and working-publication
+  # mappings. Later phases can extend their content without replacing the reliable
+  # authoring setup established and verified in Phase 1.
+  defp activity_fixture(seed, title) do
+    Seeder.create_activity(%{title: title}, seed.publication, seed.project, seed.author)
+  end
+
+  defp page_fixture(seed, title, content) do
+    Seeder.create_page(title, seed.publication, seed.project, seed.author, content)
+  end
+
+  defp shared_page_fixtures(seed, activity_resource_id) do
+    content = nested_reference_content(activity_resource_id)
+
+    {
+      page_fixture(seed, "Shared page one", content),
+      page_fixture(seed, "Shared page two", content)
+    }
+  end
+
+  defp nested_reference_content(activity_resource_id) do
+    %{
+      "model" => [
+        %{
+          "id" => "outer-group",
+          "type" => "group",
+          "children" => [
+            %{
+              "id" => "nested-activity-reference",
+              "type" => "activity-reference",
+              "activity_id" => activity_resource_id,
+              "children" => []
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+  defp activity_reference_content(activity_resource_ids, advanced_delivery \\ :missing) do
+    # Nest references below two group levels to exercise the same recursive page
+    # traversal used by duplication. Tests pass repeated ids deliberately so the
+    # analysis MapSet contract is verified rather than assumed.
+    content = %{
+      "model" => [
+        %{
+          "id" => "outer-group",
+          "type" => "group",
+          "children" => [
+            %{
+              "id" => "inner-group",
+              "type" => "group",
+              "children" =>
+                activity_resource_ids
+                |> Enum.with_index()
+                |> Enum.map(fn {activity_resource_id, index} ->
+                  %{
+                    "id" => "activity-reference-#{index}",
+                    "type" => "activity-reference",
+                    "activity_id" => activity_resource_id,
+                    "customData" => %{"preserve" => index},
+                    "children" => []
+                  }
+                end)
+            }
+          ]
+        }
+      ]
+    }
+
+    case advanced_delivery do
+      :missing -> content
+      value -> Map.put(content, "advancedDelivery", value)
+    end
+  end
+
+  defp storage_snapshot(seed) do
+    project_resource_ids =
+      from(project_resource in ProjectResource,
+        where: project_resource.project_id == ^seed.project.id,
+        order_by: project_resource.resource_id,
+        select: project_resource.resource_id
+      )
+      |> Repo.all()
+
+    working_publication_mappings =
+      Repo.all(
+        from(mapping in PublishedResource,
+          where: mapping.publication_id == ^seed.publication.id,
+          order_by: [mapping.resource_id, mapping.id],
+          select: %{
+            id: mapping.id,
+            resource_id: mapping.resource_id,
+            revision_id: mapping.revision_id,
+            locked_by_id: mapping.locked_by_id,
+            lock_updated_at: mapping.lock_updated_at,
+            updated_at: mapping.updated_at
+          }
+        )
+      )
+
+    current_revision_ids = Enum.map(working_publication_mappings, & &1.revision_id)
+
+    relevant_sections =
+      Repo.all(
+        from(section in Section,
+          where: section.base_project_id == ^seed.project.id,
+          order_by: section.id
+        )
+      )
+
+    relevant_section_ids = Enum.map(relevant_sections, & &1.id)
+
+    # Global counts detect accidental inserts. Full scoped authoring rows and full
+    # relevant delivery/learner rows additionally detect in-place changes. Current
+    # revision projections include content because AC-003 specifically requires
+    # proving analysis leaves page bodies and denormalized references untouched.
+    %{
+      resource_count: Repo.aggregate(Resource, :count, :id),
+      revision_count: Repo.aggregate(Revision, :count, :id),
+      project_resource_count: Repo.aggregate(ProjectResource, :count, :resource_id),
+      published_resource_count: Repo.aggregate(PublishedResource, :count, :id),
+      publication_count: Repo.aggregate(Publication, :count, :id),
+      section_count: Repo.aggregate(Section, :count, :id),
+      resource_access_count: Repo.aggregate(ResourceAccess, :count, :id),
+      project: Repo.reload!(seed.project),
+      publication: Repo.reload!(seed.publication),
+      project_resources:
+        Repo.all(
+          from(project_resource in ProjectResource,
+            where: project_resource.project_id == ^seed.project.id,
+            order_by: project_resource.resource_id,
+            select: %{
+              project_id: project_resource.project_id,
+              resource_id: project_resource.resource_id
+            }
+          )
+        ),
+      resources:
+        Repo.all(
+          from(resource in Resource,
+            where: resource.id in ^project_resource_ids,
+            order_by: resource.id,
+            select: %{
+              id: resource.id,
+              inserted_at: resource.inserted_at,
+              updated_at: resource.updated_at
+            }
+          )
+        ),
+      current_revisions:
+        Repo.all(
+          from(revision in Revision,
+            where: revision.id in ^current_revision_ids,
+            order_by: revision.id,
+            select: %{
+              id: revision.id,
+              resource_id: revision.resource_id,
+              title: revision.title,
+              slug: revision.slug,
+              deleted: revision.deleted,
+              resource_scope: revision.resource_scope,
+              content: revision.content,
+              activity_refs: revision.activity_refs,
+              updated_at: revision.updated_at
+            }
+          )
+        ),
+      working_publication_mappings: working_publication_mappings,
+      sections: relevant_sections,
+      resource_accesses:
+        Repo.all(
+          from(resource_access in ResourceAccess,
+            where: resource_access.section_id in ^relevant_section_ids,
+            order_by: resource_access.id
+          )
+        )
+    }
+  end
+
+  defp current_revision(seed, page) do
+    AuthoringResolver.from_resource_id(seed.project.slug, page.resource.id)
+  end
+
+  defp referenced_activity_ids(revision) do
+    Utils.activity_references(revision.content)
+  end
+
+  defp activity_reference_node(revision, activity_resource_id) do
+    revision.content
+    |> Oli.Resources.PageContent.flat_filter(fn
+      %{"type" => "activity-reference", "activity_id" => ^activity_resource_id} -> true
+      _node -> false
+    end)
+    |> List.first()
+  end
+
+  defp assert_locks_released(seed, resource_ids) do
+    for resource_id <- resource_ids do
+      mapping = Publishing.get_published_resource!(seed.publication.id, resource_id)
+      assert mapping.locked_by_id == nil
+      assert mapping.lock_updated_at == nil
+    end
+  end
+
+  defp attach_project_repair_telemetry(events) do
+    handler_id = "project-repair-telemetry-test-#{System.unique_integer([:positive])}"
+    parent = self()
+
+    :telemetry.attach_many(
+      handler_id,
+      events,
+      fn event_name, measurements, metadata, _config ->
+        send(parent, {:telemetry_event, event_name, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    handler_id
+  end
+
+  defp assert_repair_telemetry(status, stage, reason) do
+    assert_receive {:telemetry_event, [:oli, :authoring, :project_repair, :repair, :stop],
+                    %{count: 1, duration_ms: duration_ms}, metadata}
+
+    assert is_integer(duration_ms)
+    assert metadata.operation == :repair
+    assert metadata.status == status
+    assert metadata.failure_stage == stage
+    assert metadata.failure_reason == reason
+    refute Map.has_key?(metadata, :content)
+    refute Map.has_key?(metadata, :title)
+  end
+
+  defp missing_activity_resource_id do
+    # Start well above normal test ids, then prove absence so the fixture cannot
+    # silently become valid as the shared SQL sandbox accumulates rows.
+    candidate = 1_000_000_000 + System.unique_integer([:positive])
+    assert Repo.get(Resource, candidate) == nil
+    candidate
+  end
+end

--- a/test/oli_web/project_repair_route_test.exs
+++ b/test/oli_web/project_repair_route_test.exs
@@ -1,0 +1,180 @@
+defmodule OliWeb.ProjectRepairRouteTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.Accounts.SystemRole
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Seeder
+
+  @moduletag capture_log: true
+
+  setup do
+    # Use a real seeded authoring project so the LiveView mount exercises the
+    # normal workspace project assignment hooks and the read-only analysis path.
+    seed = Seeder.base_project_with_resource2()
+
+    system_admin =
+      author_fixture(%{system_role_id: SystemRole.role_id().system_admin})
+
+    {:ok, Map.put(seed, :system_admin, system_admin)}
+  end
+
+  describe "system-admin project repair route" do
+    test "allows a system admin to mount the project-scoped tool", %{
+      conn: conn,
+      project: project,
+      system_admin: system_admin
+    } do
+      conn = log_in_author(conn, system_admin)
+
+      {:ok, view, html} = live(conn, repair_tool_path(project.slug))
+      html = html <> render_async(view, 5_000)
+
+      assert html =~ "Project Repair Tool"
+      assert has_element?(view, "h2", "Current analysis")
+      assert has_element?(view, "h3", "Basic pages scanned")
+      assert has_element?(view, "h3", "Pages with repairable shared activities")
+    end
+
+    test "requires confirmation before invoking repair and renders the async result", %{
+      author: author,
+      conn: conn,
+      project: project,
+      publication: publication,
+      system_admin: system_admin
+    } do
+      # Build the smallest repairable project shape through real authoring seed
+      # helpers: two Basic pages reference one resolvable activity. The route test
+      # then proves the Phase 5 LiveView wiring reaches the already-covered context
+      # repair path without trusting client-supplied ids.
+      activity =
+        Seeder.create_activity(%{title: "Shared activity"}, publication, project, author)
+
+      Seeder.create_page(
+        "Shared page one",
+        publication,
+        project,
+        author,
+        activity_reference_content(activity.resource.id)
+      )
+
+      Seeder.create_page(
+        "Shared page two",
+        publication,
+        project,
+        author,
+        activity_reference_content(activity.resource.id)
+      )
+
+      conn = log_in_author(conn, system_admin)
+
+      {:ok, view, _html} = live(conn, repair_tool_path(project.slug))
+      html = render_async(view, 5_000)
+
+      assert html =~ "Repair shared activity references"
+      refute html =~ "Confirm shared activity repair"
+
+      # AC-002/AC-015: confirmation is enforced by the server handler, not only by
+      # the button visibility. A forged direct event before confirmation is ignored.
+      html = render_click(view, "make_changes", %{})
+      refute html =~ "Repair completed"
+
+      assert {:ok, unrepaired_report} =
+               Oli.Authoring.ProjectRepair.analyze_project(project, system_admin)
+
+      assert unrepaired_report.summary.repairable_shared_activity_resource_count == 1
+
+      view
+      |> element("#project-repair-show-confirmation")
+      |> render_click()
+
+      assert has_element?(view, "#project-repair-confirmation")
+
+      view
+      |> element("#project-repair-confirm-make-changes")
+      |> render_click()
+
+      html = render_async(view, 10_000)
+
+      assert html =~ "Repair completed"
+      assert html =~ "Updated 1 pages and cloned 1 activities"
+
+      assert {:ok, report} =
+               Oli.Authoring.ProjectRepair.analyze_project(project, system_admin)
+
+      assert report.summary.repairable_shared_activity_resource_count == 0
+      assert AuthoringResolver.from_resource_id(project.slug, activity.resource.id)
+    end
+
+    test "keeps full shared page count visible when the display list is truncated", %{
+      author: author,
+      conn: conn,
+      project: project,
+      publication: publication,
+      system_admin: system_admin
+    } do
+      activity =
+        Seeder.create_activity(%{title: "Large shared activity"}, publication, project, author)
+
+      # The LiveView caps per-group page links at 100 to bound diffs, but AC-012
+      # still requires the actual page count to remain visible for the group.
+      for index <- 1..101 do
+        Seeder.create_page(
+          "Large shared page #{index}",
+          publication,
+          project,
+          author,
+          activity_reference_content(activity.resource.id)
+        )
+      end
+
+      conn = log_in_author(conn, system_admin)
+
+      {:ok, view, _html} = live(conn, repair_tool_path(project.slug))
+      html = render_async(view, 5_000)
+
+      assert html =~ "Referenced by 101 Basic pages"
+      assert html =~ "Showing the first 100"
+    end
+
+    test "redirects a non-system-admin author before the LiveView mounts", %{
+      conn: conn,
+      project: project
+    } do
+      # A normal author may be able to access ordinary project authoring routes,
+      # but this repair tool is intentionally gated by the stricter system-admin
+      # pipeline before project analysis can run.
+      conn = log_in_author(conn, author_fixture())
+
+      assert {:error,
+              {:redirect,
+               %{
+                 flash: %{"error" => "You must be a system admin to access this page."},
+                 to: "/workspaces/course_author"
+               }}} = live(conn, repair_tool_path(project.slug))
+    end
+  end
+
+  defp repair_tool_path(project_slug),
+    do: ~p"/workspaces/course_author/#{project_slug}/repair_tool"
+
+  defp activity_reference_content(activity_resource_id) do
+    %{
+      "model" => [
+        %{
+          "id" => "route-test-group",
+          "type" => "group",
+          "children" => [
+            %{
+              "id" => "route-test-activity-reference",
+              "type" => "activity-reference",
+              "activity_id" => activity_resource_id,
+              "children" => []
+            }
+          ]
+        }
+      ]
+    }
+  end
+end


### PR DESCRIPTION
This PR implements an admin facing tool that will find and fix the problems of "shared activities" in a course project's basic pages.  A previous bug allowed duplicated basic pages to erroneously "share" activities.  This tool will inventory all of these pages and activities and allow a second step to automatically fix these issues by cloning the activities in one of the pages. 

The tool also finds all pages that have "missing activities" - and lists those page titles and URLs.  This will allow a human to go into the page editor and manually fix missing activities (presumably by either rebuilding them, or deleting them).

<img width="1544" height="1203" alt="Screenshot 2026-07-17 at 2 12 59 PM" src="https://github.com/user-attachments/assets/ba789143-8350-4603-bb68-8f89b10b2d31" />

<img width="1544" height="1244" alt="Screenshot 2026-07-17 at 2 15 47 PM" src="https://github.com/user-attachments/assets/3c1c91a4-da98-4eda-9f92-f27d632e8848" />
