### PR TITLE
[ENHANCEMENT] [MER-5673] Add Dazzling d-Orbitals adaptive lesson Playwright coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ update this file accordingly.
 - `PLAYWRIGHT_ASSETS_BUCKET` and `PLAYWRIGHT_AUTOMATION_API_KEY` are local/test-runner
   configuration only and are not required for the Torus application runtime. Neither has a
   default value — never reuse a value that appears in this repo for either. Without
-  `PLAYWRIGHT_AUTOMATION_API_KEY` the MER-5672 Playwright test is skipped; without
+  `PLAYWRIGHT_AUTOMATION_API_KEY` the MER-5672 and MER-5673 Playwright tests are skipped; without
   `PLAYWRIGHT_ASSETS_BUCKET` it fails, since the private test assets endpoint has no bucket
   to read from.
 

--- a/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
+++ b/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
@@ -24,6 +24,7 @@ export type ScreenScan = {
   firstSelectOptions: string[];
   fibs: number;
   radios: number;
+  radioGroups: Array<{ group: string; labels: string }>;
   checkboxes: number;
   mcqLabels: string;
   textInputs: number;
@@ -195,12 +196,26 @@ export class AdaptiveDeckPO {
             .filter((el) => vis(el) && !inFeedback(el));
         const firstSelect = q('select.dropdown')[0] as HTMLSelectElement | undefined;
 
+        const radioInputs = q('.mcq-item input[type="radio"]');
+        const byGroup = new Map<string, string[]>();
+        radioInputs.forEach((input, i) => {
+          const item = input.closest('.mcq-item');
+          if (!item) return;
+          const name = (input as HTMLInputElement).name || `anon:${i}`;
+          const label = ((item as HTMLElement).innerText || '').trim();
+          byGroup.set(name, [...(byGroup.get(name) ?? []), label]);
+        });
+
         return {
           iframes: q('iframe').map((f) => (f as HTMLIFrameElement).src),
           selects: q('select.dropdown').length,
           firstSelectOptions: firstSelect ? Array.from(firstSelect.options).map((o) => o.text) : [],
           fibs: q('.fib-select-display').length,
-          radios: q('.mcq-item input[type="radio"]').length,
+          radios: radioInputs.length,
+          radioGroups: Array.from(byGroup, ([group, labels]) => ({
+            group,
+            labels: labels.join(' | '),
+          })),
           checkboxes: q('.mcq-item input[type="checkbox"]').length,
           mcqLabels: q('.mcq-item label')
             .map((l) => (l as HTMLElement).innerText)
@@ -214,6 +229,7 @@ export class AdaptiveDeckPO {
         firstSelectOptions: [],
         fibs: 0,
         radios: 0,
+        radioGroups: [],
         checkboxes: 0,
         mcqLabels: '',
         textInputs: 0,
@@ -223,21 +239,33 @@ export class AdaptiveDeckPO {
   // ------------------------------------------------------------ janus parts
 
   /** Select the MCQ item (radio or checkbox) whose text matches. */
-  async selectMcqByText(text: RegExp) {
+  async selectMcqByText(text: RegExp): Promise<boolean> {
     const item = this.page.locator('.mcq-item').filter({ hasText: text }).first();
-    if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return;
-    await this.selectMcqItem(item);
+    if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return false;
+    return this.selectMcqItem(item);
   }
 
-  async selectFirstMcqItem() {
-    await this.selectMcqItem(this.page.locator('.mcq-item').first());
+  /** Select the radio option matching pick within one group (input name). */
+  async selectMcqInGroup(group: string, pick: RegExp): Promise<boolean> {
+    const scope = group.startsWith('anon:')
+      ? this.page.locator('.mcq-item')
+      : this.page
+          .locator('.mcq-item')
+          .filter({ has: this.page.locator(`input[name=${JSON.stringify(group)}]`) });
+    const item = scope.filter({ hasText: pick }).first();
+    if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return false;
+    return this.selectMcqItem(item);
+  }
+
+  async selectFirstMcqItem(): Promise<boolean> {
+    return this.selectMcqItem(this.page.locator('.mcq-item').first());
   }
 
   /**
    * Click the label (like a real user); verify the input registered and retry
    * through input.check — React-controlled inputs can lag right after mount.
    */
-  private async selectMcqItem(item: Locator) {
+  private async selectMcqItem(item: Locator): Promise<boolean> {
     await item
       .locator('label')
       .first()
@@ -246,9 +274,9 @@ export class AdaptiveDeckPO {
     await this.page.waitForTimeout(300);
 
     const input = item.locator('input').first();
-    if (!(await input.isChecked({ timeout: 2_000 }).catch(() => false))) {
-      await input.check({ force: true, ...ACTION_TIMEOUT }).catch(() => undefined);
-    }
+    if (await input.isChecked({ timeout: 2_000 }).catch(() => false)) return true;
+    await input.check({ force: true, ...ACTION_TIMEOUT }).catch(() => undefined);
+    return input.isChecked({ timeout: 1_000 }).catch(() => false);
   }
 
   /**
@@ -404,26 +432,32 @@ export class AdaptiveDeckPO {
     return true;
   }
 
-  /** Swiper image carousel: click next arrow until all slides viewed. */
+  /** Swiper image carousels: click each carousel's next arrow until all its slides viewed. */
   async clickThroughCarousels(): Promise<number> {
-    const bullets = this.page.locator('.janus-image-carousel .swiper-pagination-bullet');
-    const count = await bullets.count();
-    if (count <= 1) return 0;
+    const carousels = this.page.locator('.janus-image-carousel');
+    const carouselCount = await carousels.count();
 
     let clicked = 0;
-    const nextBtn = this.page.locator('.janus-image-carousel .swiper-button-next').first();
-    for (let i = 1; i < count; i++) {
-      const ok = await nextBtn.click({ timeout: 3_000 }).then(
-        () => true,
-        () => false,
-      );
-      if (ok) clicked++;
-      await this.page.waitForTimeout(500);
+    for (let c = 0; c < carouselCount; c++) {
+      const carousel = carousels.nth(c);
+      const bullets = await carousel.locator('.swiper-pagination-bullet').count();
+      if (bullets <= 1) continue;
+
+      const nextBtn = carousel.locator('.swiper-button-next').first();
+      for (let i = 1; i < bullets; i++) {
+        const ok = await nextBtn.click({ timeout: 3_000 }).then(
+          () => true,
+          () => false,
+        );
+        if (!ok) break;
+        clicked++;
+        await this.page.waitForTimeout(500);
+      }
     }
     return clicked;
   }
 
-  /** Play any video at 16x speed so CAPI registers a full watch quickly. */
+  /** Play any video at 16x speed to its ended event, so CAPI registers a full watch. */
   async playVideos(): Promise<number> {
     const videos = this.page.locator('video');
     const count = await videos.count();
@@ -431,8 +465,8 @@ export class AdaptiveDeckPO {
 
     let played = 0;
     for (let i = 0; i < count; i++) {
-      const duration = await videos
-        .nth(i)
+      const video = videos.nth(i);
+      const duration = await video
         .evaluate(async (v: HTMLVideoElement) => {
           v.muted = true;
           v.playbackRate = 16;
@@ -440,9 +474,28 @@ export class AdaptiveDeckPO {
           return v.duration || 0;
         })
         .catch(() => 0);
-      if (duration > 0) played++;
-      const waitMs = Math.min(Math.ceil((duration / 16) * 1000) + 1500, 15_000);
-      await this.page.waitForTimeout(waitMs);
+      if (!Number.isFinite(duration) || duration <= 0) continue;
+
+      const timeoutMs = Math.min(Math.ceil((duration / 16) * 1000) + 5_000, 120_000);
+      const ended = await video
+        .evaluate(
+          (v: HTMLVideoElement, timeout: number) =>
+            new Promise<boolean>((resolve) => {
+              if (v.ended) return resolve(true);
+              const onEnded = () => {
+                clearTimeout(timer);
+                resolve(true);
+              };
+              const timer = setTimeout(() => {
+                v.removeEventListener('ended', onEnded);
+                resolve(false);
+              }, timeout);
+              v.addEventListener('ended', onEnded, { once: true });
+            }),
+          timeoutMs,
+        )
+        .catch(() => false);
+      if (ended) played++;
     }
     return played;
   }

--- a/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
+++ b/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
@@ -224,7 +224,9 @@ export class AdaptiveDeckPO {
 
   /** Select the MCQ item (radio or checkbox) whose text matches. */
   async selectMcqByText(text: RegExp) {
-    await this.selectMcqItem(this.page.locator('.mcq-item').filter({ hasText: text }).first());
+    const item = this.page.locator('.mcq-item').filter({ hasText: text }).first();
+    if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return;
+    await this.selectMcqItem(item);
   }
 
   async selectFirstMcqItem() {
@@ -244,7 +246,7 @@ export class AdaptiveDeckPO {
     await this.page.waitForTimeout(300);
 
     const input = item.locator('input').first();
-    if (!(await input.isChecked().catch(() => false))) {
+    if (!(await input.isChecked({ timeout: 2_000 }).catch(() => false))) {
       await input.check({ force: true, ...ACTION_TIMEOUT }).catch(() => undefined);
     }
   }
@@ -381,11 +383,11 @@ export class AdaptiveDeckPO {
    * does not trigger it). boundingBox() on frame elements is page-relative,
    * so page.mouse coordinates line up.
    */
-  async mouseDragInFrame(item: Locator, zone: Locator) {
-    await item.scrollIntoViewIfNeeded().catch(() => undefined);
-    const itemBox = await item.boundingBox();
-    const zoneBox = await zone.boundingBox();
-    if (!itemBox || !zoneBox) return;
+  async mouseDragInFrame(item: Locator, zone: Locator): Promise<boolean> {
+    await item.scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
+    const itemBox = await item.boundingBox({ timeout: 5_000 }).catch(() => null);
+    const zoneBox = await zone.boundingBox({ timeout: 5_000 }).catch(() => null);
+    if (!itemBox || !zoneBox) return false;
 
     const fromX = itemBox.x + itemBox.width / 2;
     const fromY = itemBox.y + itemBox.height / 2;
@@ -399,6 +401,50 @@ export class AdaptiveDeckPO {
     await this.page.mouse.move(toX, toY, { steps: 4 });
     await this.page.mouse.up();
     await this.page.waitForTimeout(500);
+    return true;
+  }
+
+  /** Swiper image carousel: click next arrow until all slides viewed. */
+  async clickThroughCarousels(): Promise<number> {
+    const bullets = this.page.locator('.janus-image-carousel .swiper-pagination-bullet');
+    const count = await bullets.count();
+    if (count <= 1) return 0;
+
+    let clicked = 0;
+    const nextBtn = this.page.locator('.janus-image-carousel .swiper-button-next').first();
+    for (let i = 1; i < count; i++) {
+      const ok = await nextBtn.click({ timeout: 3_000 }).then(
+        () => true,
+        () => false,
+      );
+      if (ok) clicked++;
+      await this.page.waitForTimeout(500);
+    }
+    return clicked;
+  }
+
+  /** Play any video at 16x speed so CAPI registers a full watch quickly. */
+  async playVideos(): Promise<number> {
+    const videos = this.page.locator('video');
+    const count = await videos.count();
+    if (count === 0) return 0;
+
+    let played = 0;
+    for (let i = 0; i < count; i++) {
+      const duration = await videos
+        .nth(i)
+        .evaluate(async (v: HTMLVideoElement) => {
+          v.muted = true;
+          v.playbackRate = 16;
+          await v.play();
+          return v.duration || 0;
+        })
+        .catch(() => 0);
+      if (duration > 0) played++;
+      const waitMs = Math.min(Math.ceil((duration / 16) * 1000) + 1500, 15_000);
+      await this.page.waitForTimeout(waitMs);
+    }
+    return played;
   }
 
   /** spr-widget-grouping: drag each item (by aria-label) into its group. */
@@ -412,6 +458,33 @@ export class AdaptiveDeckPO {
         frame.locator(`.group-area[aria-label="${group}"]`).first(),
       );
     }
+  }
+
+  /** Custom drag-and-drop CAPI widget: detect disambiguates same-src variants. */
+  async dragCustomDnD(
+    srcFragment: string,
+    detect: string,
+    placements: Array<[string, string]>,
+  ): Promise<boolean> {
+    const frame = await this.widgetFrame(srcFragment, 'button[aria-roledescription="draggable"]');
+    if (!frame) return false;
+
+    const confirmed = await frame
+      .locator(detect)
+      .first()
+      .isVisible({ timeout: 2_000 })
+      .catch(() => false);
+    if (!confirmed) return false;
+
+    let dragged = 0;
+    for (const [itemSel, zoneSel] of placements) {
+      const ok = await this.mouseDragInFrame(
+        frame.locator(itemSel).first(),
+        frame.locator(zoneSel).first(),
+      );
+      if (ok) dragged++;
+    }
+    return dragged === placements.length;
   }
 
   /**

--- a/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
@@ -1,0 +1,185 @@
+import { Page } from '@playwright/test';
+import { AdaptiveDeckPO } from '@pom/delivery/AdaptiveDeckPO';
+
+type GroupingWidget = { src_fragment: string; placements: Array<{ item: string; group: string }> };
+type CustomDnDWidget = {
+  src_fragment: string;
+  detect: string;
+  placements: Array<{ item: string; zone: string }>;
+};
+
+export type LessonAnswers = {
+  lesson: { title: string; search_term: string; completion_text: string };
+  widgets: {
+    grouping: GroupingWidget | GroupingWidget[];
+    ordering: { src_fragment: string; order: string[] };
+    matching: { src_fragment: string; links: Array<{ left: string; right: string }> };
+    frame_selects: Array<{
+      src_fragment: string;
+      ready_selector: string;
+      values: Record<string, string>;
+    }>;
+    custom_dnd?: CustomDnDWidget[];
+  };
+  native_dropdowns: Array<{ when_option_includes: string; picks: string[] }>;
+  fib: {
+    by_label_when_count: { count: number; labels: string[] };
+    option_sets: Array<{ match: string; pick: string }>;
+  };
+  mcq: {
+    radios: Array<{ when_labels_match: string; when_iframe?: string; pick: string }>;
+    checkboxes: string[];
+  };
+  text_input_value: string;
+};
+
+export async function completeAdaptiveHappyPath(
+  page: Page,
+  deck: AdaptiveDeckPO,
+  key: LessonAnswers,
+) {
+  let stuckCount = 0;
+
+  for (let step = 0; step < 60; step += 1) {
+    if (await deck.lessonEnded()) {
+      console.log(`Lesson end reached at step ${step}`);
+      return;
+    }
+
+    let label: string;
+    try {
+      label = await answerCurrentScreen(deck, key);
+      for (let poll = 0; poll < 3 && label.startsWith('content screen'); poll += 1) {
+        await page.waitForTimeout(1_200);
+        label = await answerCurrentScreen(deck, key);
+      }
+    } catch (e) {
+      label = `answer error: ${(e as Error).message.split('\n')[0].slice(0, 100)}`;
+    }
+
+    const moved = await deck.advance();
+    console.log(`[screen ${step}] ${label} -> advanced=${moved}`);
+
+    if (moved) {
+      stuckCount = 0;
+      if (!(await deck.lessonEnded())) await deck.waitForDeckReady();
+      continue;
+    }
+
+    stuckCount += 1;
+    if (stuckCount >= 3) {
+      const feedback = await deck.feedbackText();
+      throw new Error(
+        `Stuck at screen ${step} (${label}). Feedback: ${feedback.replace(/\s+/g, ' ').slice(0, 200)}`,
+      );
+    }
+  }
+
+  throw new Error('Exceeded max steps without reaching the lesson end');
+}
+
+async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Promise<string> {
+  const scan = await deck.scanScreen();
+  const hasIframe = (fragment: string) => scan.iframes.some((src) => src.includes(fragment));
+  const re = (source: string) => new RegExp(source, 'i');
+
+  const { grouping, ordering, matching, frame_selects } = key.widgets;
+  const customDnd = key.widgets.custom_dnd ?? [];
+  const groupings = Array.isArray(grouping) ? grouping : [grouping];
+
+  for (const dnd of customDnd) {
+    if (hasIframe(dnd.src_fragment)) {
+      const done = await deck.dragCustomDnD(
+        dnd.src_fragment,
+        dnd.detect,
+        dnd.placements.map((p) => [p.item, p.zone]),
+      );
+      if (done) return 'custom drag-and-drop';
+    }
+  }
+  for (const g of groupings) {
+    if (hasIframe(g.src_fragment)) {
+      await deck.dragItemsToGroups(
+        g.src_fragment,
+        g.placements.map((p) => [p.item, p.group]),
+      );
+      return 'grouping widget';
+    }
+  }
+  if (hasIframe(ordering.src_fragment)) {
+    await deck.reorderList(ordering.src_fragment, ordering.order);
+    return 'ordering widget';
+  }
+  if (hasIframe(matching.src_fragment)) {
+    await deck.linkMatchingPairs(
+      matching.src_fragment,
+      matching.links.map((l) => [re(l.left), re(l.right)]),
+    );
+    return 'matching widget';
+  }
+  for (const table of frame_selects) {
+    if (hasIframe(table.src_fragment)) {
+      await deck.fillFrameSelects(table.src_fragment, table.ready_selector, table.values);
+      return `frame selects (${table.src_fragment})`;
+    }
+  }
+
+  if (scan.selects > 0) {
+    for (const rule of key.native_dropdowns) {
+      if (scan.firstSelectOptions.some((o) => o.includes(rule.when_option_includes))) {
+        await deck.setNativeDropdowns(rule.picks);
+        return `dropdowns (${rule.when_option_includes})`;
+      }
+    }
+  }
+
+  const parts: string[] = [];
+
+  if (scan.fibs > 0 && scan.fibs === key.fib.by_label_when_count.count) {
+    await deck.setFibDropdownsByLabel(key.fib.by_label_when_count.labels);
+    parts.push(`FITB by label (${scan.fibs})`);
+  } else if (scan.fibs > 0) {
+    await deck.setFibDropdownsByOptionSet(key.fib.option_sets.map((o) => [re(o.match), o.pick]));
+    parts.push(`FITB (${scan.fibs})`);
+  }
+
+  if (scan.radios > 0) {
+    const matched: string[] = [];
+    for (const rule of key.mcq.radios) {
+      if (!re(rule.when_labels_match).test(scan.mcqLabels)) continue;
+      if (rule.when_iframe && !hasIframe(rule.when_iframe)) continue;
+
+      await deck.selectMcqByText(re(rule.pick));
+      matched.push(rule.pick.slice(0, 30));
+      break;
+    }
+    if (matched.length > 0) {
+      parts.push(`MCQ (${matched.join(' + ')})`);
+    } else {
+      await deck.selectFirstMcqItem();
+      parts.push('MCQ (any)');
+    }
+  }
+
+  if (scan.checkboxes > 0) {
+    for (const source of key.mcq.checkboxes) {
+      await deck.selectMcqByText(re(source));
+    }
+    parts.push('checkboxes');
+  }
+
+  if (scan.textInputs > 0) {
+    await deck.fillTextInputs(key.text_input_value);
+    parts.push('text input');
+  }
+
+  if (parts.length > 0) return parts.join(' + ');
+
+  const carouselClicks = await deck.clickThroughCarousels();
+  if (carouselClicks > 0) return `carousel (${carouselClicks} clicks)`;
+
+  const videosPlayed = await deck.playVideos();
+  if (videosPlayed > 0) return `video (${videosPlayed})`;
+
+  return 'content screen (no interaction)';
+}

--- a/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
@@ -67,7 +67,7 @@ export async function completeAdaptiveHappyPath(
     }
 
     stuckCount += 1;
-    if (stuckCount >= 3) {
+    if (stuckCount >= 5) {
       const feedback = await deck.feedbackText();
       throw new Error(
         `Stuck at screen ${step} (${label}). Feedback: ${feedback.replace(/\s+/g, ' ').slice(0, 200)}`,
@@ -144,28 +144,34 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
   }
 
   if (scan.radios > 0) {
-    const matched: string[] = [];
-    for (const rule of key.mcq.radios) {
-      if (!re(rule.when_labels_match).test(scan.mcqLabels)) continue;
-      if (rule.when_iframe && !hasIframe(rule.when_iframe)) continue;
+    const labels: string[] = [];
+    for (const group of scan.radioGroups) {
+      const rule = key.mcq.radios.find(
+        (r) =>
+          re(r.when_labels_match).test(group.labels) &&
+          (!r.when_iframe || hasIframe(r.when_iframe)),
+      );
+      if (!rule) continue;
 
-      await deck.selectMcqByText(re(rule.pick));
-      matched.push(rule.pick.slice(0, 30));
-      break;
+      const pick = rule.pick.slice(0, 30);
+      labels.push(
+        (await deck.selectMcqInGroup(group.group, re(rule.pick)))
+          ? `MCQ (${pick})`
+          : `MCQ pick NOT selected (${pick})`,
+      );
     }
-    if (matched.length > 0) {
-      parts.push(`MCQ (${matched.join(' + ')})`);
-    } else {
-      await deck.selectFirstMcqItem();
-      parts.push('MCQ (any)');
+    if (labels.length === 0) {
+      labels.push((await deck.selectFirstMcqItem()) ? 'MCQ (any)' : 'MCQ (none selected)');
     }
+    parts.push(...labels);
   }
 
   if (scan.checkboxes > 0) {
+    let selected = 0;
     for (const source of key.mcq.checkboxes) {
-      await deck.selectMcqByText(re(source));
+      if (await deck.selectMcqByText(re(source))) selected++;
     }
-    parts.push('checkboxes');
+    parts.push(`checkboxes (${selected} selected)`);
   }
 
   if (scan.textInputs > 0) {

--- a/assets/automation/src/systems/torus/tasks/AutomationAssetsTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AutomationAssetsTask.ts
@@ -1,0 +1,47 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { APIRequestContext } from '@playwright/test';
+import { getScenarioToken } from '@core/runtimeConfig';
+
+export async function fetchTestAsset(
+  request: APIRequestContext,
+  key: string,
+  baseUrl: string,
+): Promise<Buffer> {
+  const url = new URL(`/test/assets/${key}`, baseUrl).toString();
+  const response = await request.get(url, {
+    headers: { 'x-playwright-scenario-token': getScenarioToken() },
+  });
+
+  if (!response.ok()) {
+    throw new Error(`Failed to download test asset (${response.status()}): ${url}`);
+  }
+
+  return response.body();
+}
+
+export async function fetchTestArchiveToTempFile(
+  key: string,
+  baseUrl: string,
+): Promise<{ filePath: string; tempDir: string }> {
+  const url = new URL(`/test/assets/${key}`, baseUrl).toString();
+  const response = await fetch(url, {
+    headers: { 'x-playwright-scenario-token': getScenarioToken() },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to download test asset (${response.status}): ${url}`);
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'torus-qa-asset-'));
+  try {
+    const filePath = path.join(tempDir, path.basename(key));
+    await fs.writeFile(filePath, buffer);
+    return { filePath, tempDir };
+  } catch (e) {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    throw e;
+  }
+}

--- a/assets/automation/src/systems/torus/tasks/AutomationSetupTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AutomationSetupTask.ts
@@ -91,6 +91,42 @@ export async function teardownAutomationCourse(
     console.warn(
       `automation_teardown failed (${response.status()}): ${await truncatedBody(response)}`,
     );
+    return;
+  }
+
+  const context = `project=${seeded.project.slug} section=${seeded.section.slug}`;
+  let payload: unknown;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+  if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
+    console.warn(
+      `automation_teardown returned unreadable payload (${context}): ${await truncatedBody(response)}`,
+    );
+    return;
+  }
+
+  const entityResults = [
+    'author_deleted',
+    'educator_deleted',
+    'learner_deleted',
+    'section_deleted',
+    'project_deleted',
+  ];
+  const failures = entityResults.flatMap((entity) => {
+    const result = (payload as Record<string, unknown>)[entity];
+    if (typeof result !== 'object' || result === null) {
+      return [`${entity}: missing or malformed result`];
+    }
+    const { success, message } = result as { success?: unknown; message?: unknown };
+    if (success === true) return [];
+    return [`${entity}: ${typeof message === 'string' ? message : 'no message'}`];
+  });
+
+  if (failures.length > 0) {
+    console.warn(`automation_teardown left records behind (${context}): ${failures.join('; ')}`);
   }
 }
 

--- a/assets/automation/src/systems/torus/tasks/AutomationSetupTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AutomationSetupTask.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { APIRequestContext } from '@playwright/test';
+import { TYPE_USER } from '@pom/types/type-user';
 
 /**
  * Thin client for the /api/v1/automation_setup|teardown endpoints, which
@@ -101,4 +102,43 @@ async function truncatedBody(response: { text(): Promise<string> }): Promise<str
 
 function buildAutomationAuthHeader(rawKey: string) {
   return `Bearer ${Buffer.from(rawKey).toString('base64')}`;
+}
+
+export function buildAutomationLoginData(learnerEmail: string, learnerPassword: string) {
+  const authorLike = (type: (typeof TYPE_USER)[keyof typeof TYPE_USER]) => ({
+    type,
+    pageTitle: 'OLI Torus',
+    role: 'Course Author',
+    welcomeText: 'Welcome to OLI Torus',
+    welcomeTitle: 'Course Author',
+    email: 'unused@example.com',
+    pass: 'unused',
+    header: 'Course Author',
+  });
+
+  return {
+    student: {
+      type: TYPE_USER.student,
+      pageTitle: 'OLI Torus',
+      role: 'Student',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Hi, Test',
+      email: learnerEmail,
+      name: 'Test',
+      last_name: 'Learner',
+      pass: learnerPassword,
+    },
+    instructor: {
+      type: TYPE_USER.instructor,
+      pageTitle: 'OLI Torus',
+      role: 'Instructor',
+      welcomeText: 'Welcome to OLI Torus',
+      welcomeTitle: 'Instructor Dashboard',
+      email: 'unused@example.com',
+      pass: 'unused',
+      header: 'Instructor Dashboard',
+    },
+    author: authorLike(TYPE_USER.author),
+    administrator: authorLike(TYPE_USER.administrator),
+  };
 }

--- a/assets/automation/tests/torus/automation-teardown-warnings.spec.ts
+++ b/assets/automation/tests/torus/automation-teardown-warnings.spec.ts
@@ -1,0 +1,127 @@
+import { APIRequestContext, expect, test } from '@playwright/test';
+import { AutomationSetupResponse, teardownAutomationCourse } from '@tasks/AutomationSetupTask';
+
+const seeded: AutomationSetupResponse = {
+  success: true,
+  author: { email: 'author@example.com', password: 'pw' },
+  educator: { email: 'educator@example.com', password: 'pw' },
+  learner: { email: 'learner@example.com', password: 'pw' },
+  project: { slug: 'proj-slug', title: 'Project' },
+  section: { slug: 'sect-slug' },
+};
+
+const options = { baseUrl: 'http://localhost', apiKey: 'key' };
+
+function stubRequest(response: {
+  ok: boolean;
+  status?: number;
+  json?: unknown;
+  text?: string;
+}): APIRequestContext {
+  return {
+    post: async () => ({
+      ok: () => response.ok,
+      status: () => response.status ?? (response.ok ? 200 : 500),
+      json: async () => {
+        if (response.json === undefined) throw new Error('invalid JSON');
+        return response.json;
+      },
+      text: async () => response.text ?? '',
+    }),
+  } as unknown as APIRequestContext;
+}
+
+const allSuccess = {
+  author_deleted: { success: true },
+  educator_deleted: { success: true },
+  learner_deleted: { success: true },
+  section_deleted: { success: true },
+  project_deleted: { success: true },
+};
+
+let warnings: string[];
+const originalWarn = console.warn;
+
+test.beforeEach(() => {
+  warnings = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(' '));
+  };
+});
+
+test.afterEach(() => {
+  console.warn = originalWarn;
+});
+
+test('all-success payload emits no warnings', async () => {
+  await teardownAutomationCourse(stubRequest({ ok: true, json: allSuccess }), seeded, options);
+  expect(warnings).toEqual([]);
+});
+
+test('partial failure warns once naming failed entities, messages, and slugs', async () => {
+  await teardownAutomationCourse(
+    stubRequest({
+      ok: true,
+      json: {
+        ...allSuccess,
+        section_deleted: { success: false, message: 'Could not delete section' },
+        project_deleted: { success: false },
+      },
+    }),
+    seeded,
+    options,
+  );
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('project=proj-slug section=sect-slug');
+  expect(warnings[0]).toContain('section_deleted: Could not delete section');
+  expect(warnings[0]).toContain('project_deleted: no message');
+  expect(warnings[0]).not.toContain('author_deleted');
+});
+
+test('invalid JSON body warns as unreadable without rejecting', async () => {
+  await teardownAutomationCourse(
+    stubRequest({ ok: true, text: 'not json at all' }),
+    seeded,
+    options,
+  );
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('unreadable payload');
+  expect(warnings[0]).toContain('not json at all');
+});
+
+test('non-object JSON payloads warn as unreadable', async () => {
+  for (const json of [null, 'string', 42, [1, 2]]) {
+    warnings = [];
+    await teardownAutomationCourse(stubRequest({ ok: true, json }), seeded, options);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('unreadable payload');
+  }
+});
+
+test('missing or malformed entity results warn per entity', async () => {
+  await teardownAutomationCourse(
+    stubRequest({
+      ok: true,
+      json: { author_deleted: { success: true }, project_deleted: null },
+    }),
+    seeded,
+    options,
+  );
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('educator_deleted: missing or malformed result');
+  expect(warnings[0]).toContain('learner_deleted: missing or malformed result');
+  expect(warnings[0]).toContain('section_deleted: missing or malformed result');
+  expect(warnings[0]).toContain('project_deleted: missing or malformed result');
+  expect(warnings[0]).not.toContain('author_deleted');
+});
+
+test('non-2xx response keeps existing warning path and skips payload parsing', async () => {
+  await teardownAutomationCourse(
+    stubRequest({ ok: false, status: 500, text: 'boom' }),
+    seeded,
+    options,
+  );
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0]).toContain('automation_teardown failed (500)');
+  expect(warnings[0]).toContain('boom');
+});

--- a/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
@@ -14,11 +14,10 @@ import { fetchTestAsset, fetchTestArchiveToTempFile } from '@tasks/AutomationAss
 import { completeAdaptiveHappyPath, LessonAnswers } from '@tasks/AdaptiveHappyPathTask';
 
 /**
- * MER-5672: Adaptive Lesson — RC I Exploration: Decoding the Mystery of
- * Greenhouse Molecules.
+ * MER-5673: Adaptive Lesson — RC II Exploration: Dazzling d-Orbitals.
  *
- * Imports the full REAL CHEM I course archive, creates an open-and-free
- * section with a learner, and drives the 33-screen adaptive lesson through
+ * Imports the full REAL CHEM II course archive, creates an open-and-free
+ * section with a learner, and drives the 30-screen adaptive lesson through
  * its happy path (correct answers only).
  *
  * All course content — the lesson title and every correct answer — lives in a
@@ -41,17 +40,18 @@ import { completeAdaptiveHappyPath, LessonAnswers } from '@tasks/AdaptiveHappyPa
  *   - the private assets seeded ONCE in your own playwright assets bucket
  *     (MinIO in dev, console at :9001; name it whatever you like, e.g.
  *     torus-playwright-assets-dev — there's no default, export that name as
- *     PLAYWRIGHT_ASSETS_BUCKET server-side): mer-5672/real-chem-course.zip
- *     and mer-5672/answers.json. The test fetches them through
+ *     PLAYWRIGHT_ASSETS_BUCKET server-side): mer-5673/real-chem-ii-course.zip
+ *     and mer-5673/answers.json. The test fetches them through
  *     GET /test/assets/* on the server. The server must also be started with
  *     PLAYWRIGHT_SCENARIO_TOKEN.
  *
- * Then: npx playwright test real-chem-greenhouse-molecules
+ * Then: npx playwright test real-chem-dazzling-d-orbitals
  */
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const archiveKey = 'mer-5672/real-chem-course.zip';
-const answersKey = 'mer-5672/answers.json';
+const archiveKey = 'mer-5673/real-chem-ii-course.zip';
+const answersKey = 'mer-5673/answers.json';
 const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
+const EXPECTED_LESSON = /Dazzling d-Orbitals/i;
 
 let seededCourse: AutomationSetupResponse | null = null;
 let answers: LessonAnswers | null = null;
@@ -68,7 +68,7 @@ test.skip(
   'Set PLAYWRIGHT_AUTOMATION_API_KEY to run this test (see setup instructions above)',
 );
 
-test.describe.serial('Real Chem I greenhouse molecules adaptive lesson', () => {
+test.describe.serial('Real Chem II dazzling d-orbitals adaptive lesson', () => {
   test.beforeAll(async ({ request }) => {
     test.setTimeout(240_000);
 
@@ -82,6 +82,12 @@ test.describe.serial('Real Chem I greenhouse molecules adaptive lesson', () => {
 
     const answersBuffer = await answersPromise;
     answers = JSON.parse(answersBuffer.toString('utf8')) as LessonAnswers;
+
+    if (!EXPECTED_LESSON.test(answers.lesson.title)) {
+      throw new Error(
+        `Answer key targets "${answers.lesson.title}", expected ${EXPECTED_LESSON} (MER-5673)`,
+      );
+    }
 
     seededCourse = await importArchiveAndCreateSection(request, archive.filePath, {
       baseUrl,
@@ -98,11 +104,21 @@ test.describe.serial('Real Chem I greenhouse molecules adaptive lesson', () => {
   test.afterAll(async ({ request }) => {
     try {
       if (seededCourse) {
-        await teardownAutomationCourse(request, seededCourse, {
-          baseUrl,
-          apiKey: automationApiKey!,
-        });
+        await Promise.race([
+          teardownAutomationCourse(request, seededCourse, {
+            baseUrl,
+            apiKey: automationApiKey!,
+          }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('teardown timeout')), 15_000),
+          ),
+        ]);
       }
+    } catch (e) {
+      const ids = seededCourse
+        ? `project=${seededCourse.project.slug}, section=${seededCourse.section.slug}`
+        : 'unknown';
+      console.warn(`[MER-5673] teardown failed (${ids}): ${(e as Error).message}`);
     } finally {
       if (archiveTempDir) {
         await fs.rm(archiveTempDir, { recursive: true, force: true });
@@ -111,8 +127,8 @@ test.describe.serial('Real Chem I greenhouse molecules adaptive lesson', () => {
     }
   });
 
-  test('student completes the greenhouse molecules happy path', async ({ page }) => {
-    test.setTimeout(900_000); // 33 screens with server-side rule evaluation per check
+  test('student completes the dazzling d-orbitals happy path', async ({ page }) => {
+    test.setTimeout(900_000); // 30 screens with server-side rule evaluation per check
 
     if (!seededCourse || !answers) {
       throw new Error('Automation setup did not produce seeded course data and answers');

--- a/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
@@ -102,6 +102,10 @@ test.describe.serial('Real Chem II dazzling d-orbitals adaptive lesson', () => {
   });
 
   test.afterAll(async ({ request }) => {
+    // Full-course project deletion was observed to exceed both cowboy's 60s
+    // idle_timeout and the 600s dev Repo timeout (see TRIAGE-2419: unindexed
+    // FKs referencing revisions), so cleanup is bounded and best-effort;
+    // leaked slugs are named in the warning below.
     try {
       if (seededCourse) {
         await Promise.race([


### PR DESCRIPTION
[MER-5673](https://eliterate.atlassian.net/browse/MER-5673)

## Summary

- Adds Playwright E2E test for the adaptive lesson **"Exploration: Dazzling d-Orbitals"** (REAL CHEM II), driving all 29 screens through the happy path (correct answers only)
- Extracts shared adaptive-lesson infrastructure from MER-5672's greenhouse-molecules test into reusable modules, reducing that spec from ~360 to ~95 lines
- Adds new PO methods for carousels (Swiper.js), HTML5 video playback, and @dnd-kit drag-and-drop

## What changed

**New files:**
- `real-chem-dazzling-d-orbitals.spec.ts` — the d-orbitals E2E test (152 lines)
- `AdaptiveHappyPathTask.ts` — generic adaptive lesson driver with stuckCount retry, extracted from greenhouse spec
- `AutomationAssetsTask.ts` — shared `fetchTestAsset` / `fetchTestArchiveToTempFile` helpers with temp-dir cleanup on failure
- `automation-teardown-warnings.spec.ts` — regression coverage for the teardown warning behavior (stubbed request, no server needed)

**Modified files:**
- `AdaptiveDeckPO.ts` — new methods: `clickThroughCarousels` (per-carousel iteration), `playVideos` (waits for the `ended` event with a duration-derived bounded timeout, so CAPI registers the full watch), `dragCustomDnD`, `selectMcqInGroup`; `scanScreen` now also returns visible radio groups keyed by input name; MCQ selection verifies the input actually registered and reports the result
- `AdaptiveHappyPathTask.ts` — MCQ answering is group-scoped: each visible radio group is resolved to its own answer rule and answered within that group (screens can carry several required MCQ groups — matching option text globally selected the wrong group when option text overlaps, and first-match-only left second groups unanswered). Stuck threshold raised to 5 to absorb screens that reveal parts progressively (video → FITB → MCQ → MCQ), each reveal consuming one advance attempt
- `AutomationSetupTask.ts` — extracted `buildAutomationLoginData` for reuse across specs; `teardownAutomationCourse` now parses the HTTP-200 teardown payload and emits one aggregated warning naming each entity that failed to delete (with project/section slugs), since the endpoint reports per-entity failures inside a successful response. Warnings only — the non-fatal contract is unchanged
- `real-chem-greenhouse-molecules.spec.ts` — refactored to use shared modules (-266 lines)
- `CHANGELOG.md` — updated skip notice to include MER-5673

## CI/test environment setup

Same env vars as MER-5672 (`PLAYWRIGHT_SCENARIO_TOKEN`, `PLAYWRIGHT_ASSETS_BUCKET`, `PLAYWRIGHT_AUTOMATION_API_KEY`).

**Seed the bucket** with the MER-5673 private assets (ask the team for both files — course IP, not in the repo):

```
<your-bucket>/
├── mer-5672/          # (already seeded from MER-5672)
│   ├── real-chem-course.zip
│   └── answers.json
└── mer-5673/          # NEW — seed these
    ├── real-chem-ii-course.zip
    └── answers.json
```

The `mer-5673/` folder and filenames are hardcoded in the spec — must match exactly.

## Running locally

```bash
cd assets/automation
npx playwright test real-chem-dazzling-d-orbitals
```

Takes ~5 minutes (29 screens with server-side rule evaluation per check). Without `PLAYWRIGHT_AUTOMATION_API_KEY` the test is skipped with an explicit message.

## Verification

- Test ran end-to-end multiple times against a real local server (MinIO + Postgres), completing the full lesson including a two-MCQ-group screen and a progressive-reveal screen (video → FITB → two MCQ groups)
- Greenhouse-molecules test verified passing after the refactor (earlier session; not re-run after the group-scoping change — its bucket assets aren't seeded locally)
- Cross-model code review: 7 rounds on the original change set, 3 on the teardown warning, 3 on the CI AI-review fixes + group-scoped MCQ answering — all approved
- Teardown warning coverage: 6/6 stubbed cases pass (`npx playwright test automation-teardown-warnings`)
- `tsc`, `eslint`, and `prettier` clean on all touched files

## Known limitation: teardown leaks (server-side bug, ticketed)

`automation_teardown` cannot fully delete the imported project — each run leaves the project in the dev DB and the spec logs a warning naming the leaked slugs. This is a server-side bug (measured root cause: unindexed FKs make the bulk revision delete exceed all timeouts; plus a product/blueprint FK constraint for archives containing products), fully diagnosed in [TRIAGE-2419](https://eliterate.atlassian.net/browse/TRIAGE-2419). The specs treat cleanup as bounded best-effort by design until that ticket lands.

## Follow-up

- [TRIAGE-2419](https://eliterate.atlassian.net/browse/TRIAGE-2419) — automation teardown cannot delete imported projects (revision-delete timeout + product FK constraint); measured root cause, repro, and fix directions in the ticket
- [TRIAGE-2416](https://eliterate.atlassian.net/browse/TRIAGE-2416) — compile-gated adapter to replace the per-env automation API key with the scenario token; deferred until archive-backed suites multiply

[MER-5673]: https://eliterate.atlassian.net/browse/MER-5673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[TRIAGE-2419]: https://eliterate.atlassian.net/browse/TRIAGE-2419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ