### PR TITLE
[BUG FIX] [MER-5798] Fix Migrated Adaptive Page Evaluation Refs

### DIFF
--- a/lib/oli/delivery/attempts/activity_lifecycle/adaptive_rule_requirements.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/adaptive_rule_requirements.ex
@@ -1,0 +1,119 @@
+defmodule Oli.Delivery.Attempts.ActivityLifecycle.AdaptiveRuleRequirements do
+  @moduledoc """
+  Infers adaptive screen dependencies needed to evaluate rule facts.
+
+  Migrated adaptive content can contain stale resource ids in
+  `activitiesRequiredForEvaluation`, while its rules still reference prior screens by
+  stable deck sequence ids. This module combines both sources so delivery can load
+  the prior activity attempts needed by the rules engine.
+  """
+
+  @doc """
+  Returns the activity resource ids required to evaluate the given adaptive rules.
+  """
+  @spec infer(map(), list() | nil, list() | nil) :: [integer()]
+  def infer(resource_attempt, activities_required_for_evaluation, rules) do
+    sequence_activity_map =
+      resource_attempt
+      |> page_content()
+      |> activity_sequence_map()
+
+    inferred_activity_ids =
+      rules
+      |> referenced_sequence_ids()
+      |> Enum.reduce([], fn sequence_id, activity_ids ->
+        case Map.get(sequence_activity_map, sequence_id) do
+          nil -> activity_ids
+          activity_id -> [activity_id | activity_ids]
+        end
+      end)
+
+    (normalize_required_activity_ids(activities_required_for_evaluation) ++ inferred_activity_ids)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_required_activity_ids(ids) when is_list(ids) do
+    Enum.map(ids, fn
+      id when is_integer(id) ->
+        id
+
+      id when is_binary(id) ->
+        case Integer.parse(id) do
+          {integer, ""} -> integer
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp normalize_required_activity_ids(_), do: []
+
+  defp page_content(%{content: content}) when is_map(content) and content != %{}, do: content
+  defp page_content(%{revision: %{content: content}}) when is_map(content), do: content
+  defp page_content(_), do: %{}
+
+  defp activity_sequence_map(content) do
+    content
+    |> collect_activity_sequence_refs([])
+    |> Map.new()
+  end
+
+  defp collect_activity_sequence_refs(%{} = map, refs) do
+    refs =
+      case map do
+        %{
+          "type" => "activity-reference",
+          "activity_id" => activity_id,
+          "custom" => %{"sequenceId" => sequence_id}
+        }
+        when is_binary(sequence_id) ->
+          [{sequence_id, activity_id} | refs]
+
+        _ ->
+          refs
+      end
+
+    map
+    |> Map.values()
+    |> Enum.reduce(refs, &collect_activity_sequence_refs/2)
+  end
+
+  defp collect_activity_sequence_refs(values, refs) when is_list(values) do
+    Enum.reduce(values, refs, &collect_activity_sequence_refs/2)
+  end
+
+  defp collect_activity_sequence_refs(_value, refs), do: refs
+
+  defp referenced_sequence_ids(rules) do
+    rules
+    |> collect_rule_facts([])
+    |> Enum.flat_map(fn fact ->
+      case String.split(fact, "|", parts: 2) do
+        [sequence_id, _local_fact] -> [sequence_id]
+        _ -> []
+      end
+    end)
+    |> Enum.uniq()
+  end
+
+  defp collect_rule_facts(%{"fact" => fact} = map, facts) when is_binary(fact) do
+    map
+    |> Map.delete("fact")
+    |> collect_rule_facts([fact | facts])
+  end
+
+  defp collect_rule_facts(%{} = map, facts) do
+    map
+    |> Map.values()
+    |> Enum.reduce(facts, &collect_rule_facts/2)
+  end
+
+  defp collect_rule_facts(values, facts) when is_list(values) do
+    Enum.reduce(values, facts, &collect_rule_facts/2)
+  end
+
+  defp collect_rule_facts(_value, facts), do: facts
+end

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -85,6 +85,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
   alias Oli.Activities.Model
   alias Oli.Delivery.Experiments.LogWorker
   alias Oli.Delivery.Attempts.ActivityLifecycle.ApplyClientEvaluation
+  alias Oli.Delivery.Attempts.ActivityLifecycle.AdaptiveRuleRequirements
   alias Oli.Delivery.Attempts.ActivityLifecycle.AdaptivePartEvaluation
   alias Oli.Delivery.Attempts.ActivityLifecycle.RollUp
   alias Oli.Activities.AdaptiveParts
@@ -445,7 +446,7 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
          part_attempts
        ) do
     activitiesRequiredForEvaluation =
-      infer_activities_required_for_evaluation(
+      AdaptiveRuleRequirements.infer(
         resource_attempt,
         activitiesRequiredForEvaluation,
         rules
@@ -567,115 +568,6 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         {:error, err}
     end
   end
-
-  defp infer_activities_required_for_evaluation(
-         resource_attempt,
-         activities_required_for_evaluation,
-         rules
-       ) do
-    sequence_activity_map =
-      resource_attempt
-      |> page_content()
-      |> activity_sequence_map()
-
-    inferred_activity_ids =
-      rules
-      |> referenced_sequence_ids()
-      |> Enum.reduce([], fn sequence_id, activity_ids ->
-        case Map.get(sequence_activity_map, sequence_id) do
-          nil -> activity_ids
-          activity_id -> [activity_id | activity_ids]
-        end
-      end)
-
-    (normalize_required_activity_ids(activities_required_for_evaluation) ++ inferred_activity_ids)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-  end
-
-  defp normalize_required_activity_ids(ids) when is_list(ids) do
-    Enum.map(ids, fn
-      id when is_integer(id) ->
-        id
-
-      id when is_binary(id) ->
-        case Integer.parse(id) do
-          {integer, ""} -> integer
-          _ -> nil
-        end
-
-      _ ->
-        nil
-    end)
-  end
-
-  defp normalize_required_activity_ids(_), do: []
-
-  defp page_content(%{content: content}) when is_map(content) and content != %{}, do: content
-  defp page_content(%{revision: %{content: content}}) when is_map(content), do: content
-  defp page_content(_), do: %{}
-
-  defp activity_sequence_map(content) do
-    content
-    |> collect_activity_sequence_refs([])
-    |> Map.new()
-  end
-
-  defp collect_activity_sequence_refs(%{} = map, refs) do
-    refs =
-      case map do
-        %{
-          "type" => "activity-reference",
-          "activity_id" => activity_id,
-          "custom" => %{"sequenceId" => sequence_id}
-        }
-        when is_binary(sequence_id) ->
-          [{sequence_id, activity_id} | refs]
-
-        _ ->
-          refs
-      end
-
-    map
-    |> Map.values()
-    |> Enum.reduce(refs, &collect_activity_sequence_refs/2)
-  end
-
-  defp collect_activity_sequence_refs(values, refs) when is_list(values) do
-    Enum.reduce(values, refs, &collect_activity_sequence_refs/2)
-  end
-
-  defp collect_activity_sequence_refs(_value, refs), do: refs
-
-  defp referenced_sequence_ids(rules) do
-    rules
-    |> collect_rule_facts([])
-    |> Enum.flat_map(fn fact ->
-      case String.split(fact, "|", parts: 2) do
-        [sequence_id, _local_fact] -> [sequence_id]
-        _ -> []
-      end
-    end)
-    |> Enum.uniq()
-  end
-
-  defp collect_rule_facts(%{"fact" => fact} = map, facts) when is_binary(fact) do
-    map
-    |> Map.delete("fact")
-    |> collect_rule_facts([fact | facts])
-  end
-
-  defp collect_rule_facts(%{} = map, facts) do
-    map
-    |> Map.values()
-    |> Enum.reduce(facts, &collect_rule_facts/2)
-  end
-
-  defp collect_rule_facts(values, facts) when is_list(values) do
-    Enum.reduce(values, facts, &collect_rule_facts/2)
-  end
-
-  defp collect_rule_facts(_value, facts), do: facts
 
   defp to_rule_client_results(score, out_of, feedback, part_inputs) do
     feedback =

--- a/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
+++ b/lib/oli/delivery/attempts/activity_lifecycle/evaluate.ex
@@ -444,6 +444,13 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
          datashop_session_id,
          part_attempts
        ) do
+    activitiesRequiredForEvaluation =
+      infer_activities_required_for_evaluation(
+        resource_attempt,
+        activitiesRequiredForEvaluation,
+        rules
+      )
+
     state =
       case variablesRequiredForEvaluation do
         nil ->
@@ -560,6 +567,115 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.Evaluate do
         {:error, err}
     end
   end
+
+  defp infer_activities_required_for_evaluation(
+         resource_attempt,
+         activities_required_for_evaluation,
+         rules
+       ) do
+    sequence_activity_map =
+      resource_attempt
+      |> page_content()
+      |> activity_sequence_map()
+
+    inferred_activity_ids =
+      rules
+      |> referenced_sequence_ids()
+      |> Enum.reduce([], fn sequence_id, activity_ids ->
+        case Map.get(sequence_activity_map, sequence_id) do
+          nil -> activity_ids
+          activity_id -> [activity_id | activity_ids]
+        end
+      end)
+
+    (normalize_required_activity_ids(activities_required_for_evaluation) ++ inferred_activity_ids)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_required_activity_ids(ids) when is_list(ids) do
+    Enum.map(ids, fn
+      id when is_integer(id) ->
+        id
+
+      id when is_binary(id) ->
+        case Integer.parse(id) do
+          {integer, ""} -> integer
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp normalize_required_activity_ids(_), do: []
+
+  defp page_content(%{content: content}) when is_map(content) and content != %{}, do: content
+  defp page_content(%{revision: %{content: content}}) when is_map(content), do: content
+  defp page_content(_), do: %{}
+
+  defp activity_sequence_map(content) do
+    content
+    |> collect_activity_sequence_refs([])
+    |> Map.new()
+  end
+
+  defp collect_activity_sequence_refs(%{} = map, refs) do
+    refs =
+      case map do
+        %{
+          "type" => "activity-reference",
+          "activity_id" => activity_id,
+          "custom" => %{"sequenceId" => sequence_id}
+        }
+        when is_binary(sequence_id) ->
+          [{sequence_id, activity_id} | refs]
+
+        _ ->
+          refs
+      end
+
+    map
+    |> Map.values()
+    |> Enum.reduce(refs, &collect_activity_sequence_refs/2)
+  end
+
+  defp collect_activity_sequence_refs(values, refs) when is_list(values) do
+    Enum.reduce(values, refs, &collect_activity_sequence_refs/2)
+  end
+
+  defp collect_activity_sequence_refs(_value, refs), do: refs
+
+  defp referenced_sequence_ids(rules) do
+    rules
+    |> collect_rule_facts([])
+    |> Enum.flat_map(fn fact ->
+      case String.split(fact, "|", parts: 2) do
+        [sequence_id, _local_fact] -> [sequence_id]
+        _ -> []
+      end
+    end)
+    |> Enum.uniq()
+  end
+
+  defp collect_rule_facts(%{"fact" => fact} = map, facts) when is_binary(fact) do
+    map
+    |> Map.delete("fact")
+    |> collect_rule_facts([fact | facts])
+  end
+
+  defp collect_rule_facts(%{} = map, facts) do
+    map
+    |> Map.values()
+    |> Enum.reduce(facts, &collect_rule_facts/2)
+  end
+
+  defp collect_rule_facts(values, facts) when is_list(values) do
+    Enum.reduce(values, facts, &collect_rule_facts/2)
+  end
+
+  defp collect_rule_facts(_value, facts), do: facts
 
   defp to_rule_client_results(score, out_of, feedback, part_inputs) do
     feedback =

--- a/lib/oli/interop/ingest/processor/internal_activity_refs.ex
+++ b/lib/oli/interop/ingest/processor/internal_activity_refs.ex
@@ -2,6 +2,7 @@ defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
   import Ecto.Query, warn: false
   alias Oli.Repo
   alias Oli.Interop.Ingest.State
+  alias Oli.Interop.Ingest.Processing.Rewiring
 
   @doc """
   Makes a pass across all activities to rewire internal activity references.
@@ -104,33 +105,9 @@ defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
   end
 
   defp mapped_resource_id(activity_map, id) do
-    activity_map
-    |> get_mapped_activity(id)
-    |> case do
+    case Rewiring.retrieve(activity_map, id) do
       nil -> nil
       revision -> revision.resource_id
-    end
-  end
-
-  defp get_mapped_activity(activity_map, id) do
-    case Map.get(activity_map, id) do
-      nil ->
-        case id do
-          integer when is_integer(integer) ->
-            Map.get(activity_map, Integer.to_string(integer))
-
-          binary when is_binary(binary) ->
-            case Integer.parse(binary) do
-              {integer, ""} -> Map.get(activity_map, integer)
-              _ -> nil
-            end
-
-          _ ->
-            nil
-        end
-
-      activity ->
-        activity
     end
   end
 end

--- a/lib/oli/interop/ingest/processor/internal_activity_refs.ex
+++ b/lib/oli/interop/ingest/processor/internal_activity_refs.ex
@@ -4,9 +4,7 @@ defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
   alias Oli.Interop.Ingest.State
 
   @doc """
-  Makes a pass across all activities to rewire internal activity references. Currently
-  the only place this is used is in the flowchart paths, where the destinationScreenId
-  is a reference to a resource id of another activity.
+  Makes a pass across all activities to rewire internal activity references.
   """
   def process(
         %State{project: project, legacy_to_resource_id_map: legacy_to_resource_id_map} = state
@@ -40,32 +38,18 @@ defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
   defp rewire_internal_refs(revision, activity_map) do
     try do
       case revision.content do
-        %{"authoring" => %{"flowchart" => %{"paths" => paths} = flowchart} = authoring} ->
-          if Enum.any?(paths, fn p -> Map.has_key?(p, "destinationScreenId") end) do
-            paths =
-              Enum.map(paths, fn path ->
-                case path do
-                  %{"destinationScreenId" => id} ->
-                    id_as_str = Integer.to_string(id)
+        %{"authoring" => authoring} ->
+          authoring =
+            authoring
+            |> rewire_flowchart(activity_map)
+            |> rewire_activities_required_for_evaluation(activity_map)
 
-                    Map.put(
-                      path,
-                      "destinationScreenId",
-                      Map.get(activity_map, id_as_str).resource_id
-                    )
+          content = Map.put(revision.content, "authoring", authoring)
 
-                  other ->
-                    other
-                end
-              end)
-
-            flowchart = Map.put(flowchart, "paths", paths)
-            authoring = Map.put(authoring, "flowchart", flowchart)
-            content = Map.put(revision.content, "authoring", authoring)
-
-            Oli.Resources.update_revision(revision, %{content: content})
-          else
+          if content == revision.content do
             {:ok, revision}
+          else
+            Oli.Resources.update_revision(revision, %{content: content})
           end
 
         _ ->
@@ -73,6 +57,80 @@ defmodule Oli.Interop.Ingest.Processor.InternalActivityRefs do
       end
     rescue
       _ in KeyError -> {:ok, revision}
+    end
+  end
+
+  defp rewire_flowchart(authoring, activity_map) do
+    case Map.fetch(authoring, "flowchart") do
+      {:ok, flowchart} when is_map(flowchart) ->
+        Map.put(authoring, "flowchart", rewire_flowchart_paths(flowchart, activity_map))
+
+      _ ->
+        authoring
+    end
+  end
+
+  defp rewire_flowchart_paths(flowchart, activity_map) do
+    case Map.fetch(flowchart, "paths") do
+      {:ok, paths} when is_list(paths) ->
+        paths =
+          Enum.map(paths, fn
+            %{"destinationScreenId" => id} = path ->
+              case mapped_resource_id(activity_map, id) do
+                nil -> path
+                resource_id -> Map.put(path, "destinationScreenId", resource_id)
+              end
+
+            other ->
+              other
+          end)
+
+        Map.put(flowchart, "paths", paths)
+
+      _ ->
+        flowchart
+    end
+  end
+
+  defp rewire_activities_required_for_evaluation(authoring, activity_map) do
+    case Map.fetch(authoring, "activitiesRequiredForEvaluation") do
+      {:ok, ids} when is_list(ids) ->
+        ids = Enum.map(ids, fn id -> mapped_resource_id(activity_map, id) || id end)
+        Map.put(authoring, "activitiesRequiredForEvaluation", ids)
+
+      _ ->
+        authoring
+    end
+  end
+
+  defp mapped_resource_id(activity_map, id) do
+    activity_map
+    |> get_mapped_activity(id)
+    |> case do
+      nil -> nil
+      revision -> revision.resource_id
+    end
+  end
+
+  defp get_mapped_activity(activity_map, id) do
+    case Map.get(activity_map, id) do
+      nil ->
+        case id do
+          integer when is_integer(integer) ->
+            Map.get(activity_map, Integer.to_string(integer))
+
+          binary when is_binary(binary) ->
+            case Integer.parse(binary) do
+              {integer, ""} -> Map.get(activity_map, integer)
+              _ -> nil
+            end
+
+          _ ->
+            nil
+        end
+
+      activity ->
+        activity
     end
   end
 end

--- a/lib/oli/interop/ingest/processor/rewiring.ex
+++ b/lib/oli/interop/ingest/processor/rewiring.ex
@@ -8,7 +8,11 @@ defmodule Oli.Interop.Ingest.Processing.Rewiring do
   alias Oli.Resources.PageContent
   require Logger
 
-  defp retrieve(map, key) do
+  @doc """
+  Looks up a key in a map while accepting integer and numeric-string id forms.
+  """
+  @spec retrieve(map(), term()) :: term() | nil
+  def retrieve(map, key) do
     case Map.get(map, key) do
       nil ->
         case key do

--- a/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
+++ b/test/oli/delivery/attempts/activity_lifecycle/evaluate_test.exs
@@ -824,6 +824,160 @@ defmodule Oli.Delivery.Attempts.ActivityLifecycle.EvaluateTest do
       assert updated_dropdown_2.lifecycle_state == :evaluated
     end
 
+    test "infers required adaptive activity attempts from deck sequence ids when stored resource ids are stale" do
+      user = insert(:user)
+      section = insert(:section)
+
+      required_activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "authoring" => %{"rules" => [], "parts" => []},
+          "partsLayout" => []
+        })
+
+      current_activity_revision =
+        create_activity_with_type("oli_adaptive", %{
+          "custom" => %{"maxScore" => 1, "maxAttempt" => 1},
+          "partsLayout" => [
+            %{
+              "id" => "targetFeasible",
+              "type" => "janus-mcq",
+              "custom" => %{}
+            }
+          ],
+          "authoring" => %{
+            "activitiesRequiredForEvaluation" => [715_804],
+            "parts" => [
+              %{
+                "id" => "targetFeasible",
+                "type" => "janus-mcq",
+                "gradingApproach" => "automatic"
+              }
+            ],
+            "rules" => [
+              %{
+                "id" => "correct",
+                "name" => "correct",
+                "disabled" => false,
+                "default" => false,
+                "correct" => true,
+                "conditions" => %{
+                  "all" => [
+                    %{
+                      "fact" => "stage.targetFeasible.selectedChoice",
+                      "operator" => "equal",
+                      "value" => 1
+                    },
+                    %{
+                      "fact" => "q:1461939992574:666|stage.maxWarmingTarget.selectedChoice",
+                      "operator" => "equal",
+                      "value" => 3
+                    }
+                  ]
+                },
+                "event" => %{"params" => %{"actions" => []}}
+              },
+              %{
+                "id" => "defaultWrong",
+                "name" => "defaultWrong",
+                "disabled" => false,
+                "default" => true,
+                "correct" => false,
+                "conditions" => %{"all" => []},
+                "event" => %{"params" => %{"actions" => []}}
+              }
+            ]
+          }
+        })
+
+      setup =
+        setup_adaptive_activity_attempt(user, section, current_activity_revision, [
+          "targetFeasible"
+        ])
+
+      page_content = %{
+        "model" => [
+          %{
+            "type" => "group",
+            "layout" => "deck",
+            "children" => [
+              %{
+                "type" => "activity-reference",
+                "activity_id" => required_activity_revision.resource_id,
+                "custom" => %{"sequenceId" => "q:1461939992574:666"}
+              },
+              %{
+                "type" => "activity-reference",
+                "activity_id" => current_activity_revision.resource_id,
+                "custom" => %{"sequenceId" => "q:1461940707229:780"}
+              }
+            ]
+          }
+        ]
+      }
+
+      setup.page_revision
+      |> Ecto.Changeset.change(content: page_content)
+      |> Oli.Repo.update!()
+
+      setup.resource_attempt
+      |> Ecto.Changeset.change(content: page_content)
+      |> Oli.Repo.update!()
+
+      required_activity_attempt =
+        %Core.ActivityAttempt{
+          attempt_guid: Ecto.UUID.generate(),
+          attempt_number: 1,
+          resource_id: required_activity_revision.resource_id,
+          revision_id: required_activity_revision.id,
+          resource_attempt_id: setup.resource_attempt.id,
+          lifecycle_state: :evaluated,
+          score: 1.0,
+          out_of: 1.0,
+          scoreable: true
+        }
+        |> Oli.Repo.insert!()
+
+      insert(:part_attempt,
+        activity_attempt: required_activity_attempt,
+        part_id: "maxWarmingTarget",
+        lifecycle_state: :evaluated,
+        response: %{
+          "selectedChoice" => %{
+            "path" => "q:1461939992574:666|stage.maxWarmingTarget.selectedChoice",
+            "value" => 3
+          }
+        }
+      )
+
+      [target_feasible_attempt] = setup.part_attempts
+
+      part_inputs = [
+        %{
+          attempt_guid: target_feasible_attempt.attempt_guid,
+          input: %StudentInput{
+            input: %{
+              "selectedChoice" => %{
+                "path" => "q:1461940707229:780|stage.targetFeasible.selectedChoice",
+                "value" => 1
+              }
+            }
+          },
+          timestamp: DateTime.utc_now()
+        }
+      ]
+
+      assert {:ok, result} =
+               Evaluate.evaluate_activity(
+                 section.slug,
+                 setup.activity_attempt.attempt_guid,
+                 part_inputs,
+                 nil
+               )
+
+      assert result["score"] == 1.0
+      assert result["out_of"] == 1.0
+    end
+
     test "finalizes automatic adaptive inputs even when the screen also contains manual inputs" do
       user = insert(:user)
       section = insert(:section)

--- a/test/oli/interop/ingest/processor/internal_activity_refs_test.exs
+++ b/test/oli/interop/ingest/processor/internal_activity_refs_test.exs
@@ -1,0 +1,89 @@
+defmodule Oli.Interop.Ingest.Processor.InternalActivityRefsTest do
+  use Oli.DataCase
+
+  alias Oli.Activities
+  alias Oli.Interop.Ingest.Processor.InternalActivityRefs
+  alias Oli.Interop.Ingest.State
+  alias Oli.Publishing.AuthoringResolver
+  alias Oli.Seeder
+
+  describe "process/1" do
+    setup do
+      Seeder.base_project_with_resource2()
+    end
+
+    test "rewires activities required for evaluation through the legacy resource map", %{
+      author: author,
+      project: project,
+      publication: publication
+    } do
+      required_activity =
+        Seeder.create_activity(
+          %{
+            title: "Select a Warming Limit",
+            activity_type_id: Activities.get_registration_by_slug("oli_adaptive").id
+          },
+          publication,
+          project,
+          author
+        ).revision
+
+      string_required_activity =
+        Seeder.create_activity(
+          %{
+            title: "Select Planet Type",
+            activity_type_id: Activities.get_registration_by_slug("oli_adaptive").id
+          },
+          publication,
+          project,
+          author
+        ).revision
+
+      dependent_activity =
+        Seeder.create_activity(
+          %{
+            title: "Is Your Target Possible?",
+            activity_type_id: Activities.get_registration_by_slug("oli_adaptive").id,
+            content: %{
+              "authoring" => %{
+                "activitiesRequiredForEvaluation" => [715_804, "715806"],
+                "flowchart" => %{
+                  "paths" => [%{"id" => "next", "destinationScreenId" => "715806"}]
+                }
+              }
+            }
+          },
+          publication,
+          project,
+          author
+        ).revision
+
+      state = %State{
+        project: project,
+        legacy_to_resource_id_map: %{
+          "715804" => required_activity.resource_id,
+          "715805" => dependent_activity.resource_id,
+          "715806" => string_required_activity.resource_id
+        }
+      }
+
+      InternalActivityRefs.process(state)
+
+      updated_dependent_activity =
+        AuthoringResolver.from_resource_id(project.slug, dependent_activity.resource_id)
+
+      assert get_in(updated_dependent_activity.content, [
+               "authoring",
+               "activitiesRequiredForEvaluation"
+             ]) == [required_activity.resource_id, string_required_activity.resource_id]
+
+      assert get_in(updated_dependent_activity.content, [
+               "authoring",
+               "flowchart",
+               "paths",
+               Access.at(0),
+               "destinationScreenId"
+             ]) == string_required_activity.resource_id
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fix adaptive rule evaluation when migrated pages contain stale `activitiesRequiredForEvaluation` resource ids.

Migrated Smart Sparrow adaptive screens can reference prior screens by old legacy resource ids. When those ids are not remapped, delivery fails to load the prior activity attempt state required by adaptive rules. In `Designer Planet`, this caused the “On Second Thought...” screen to always fall through to the default incorrect feedback because rules depending on the earlier warming target value could not match.

This change fixes the issue in two places:

- During ingest, remap `authoring.activitiesRequiredForEvaluation` entries through the legacy-to-resource-id map.
- During delivery evaluation, infer additional required activity ids from stable sequence ids referenced in adaptive rule facts and the current page deck structure. This allows already-published migrated content with stale ids to evaluate correctly without manual authoring edits.
