### PR TITLE
[ENHANCEMENT] [MER-5416] Expand MIXED workflow coverage Part 2/3

### DIFF
--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -158,6 +158,18 @@ test.describe('MIXED workflow', () => {
     });
   });
 
+  test.describe('IMAGE', () => {
+    test('IMAGE-B/C/D/E/F: image replacement and settings persist to author preview and delivery', async ({ runWorkflow }) => {
+      await runWorkflow('./mixed_workflow/image.workflow.yaml', { actions: mixedWorkflowActions, params: workflowParams() });
+    });
+  });
+
+  test.describe('FIGURE', () => {
+    test('FIGURE-B/C: title and nested content persist to author preview and delivery', async ({ runWorkflow }) => {
+      await runWorkflow('./mixed_workflow/figure.workflow.yaml', { actions: mixedWorkflowActions, params: workflowParams() });
+    });
+  });
+
   test.describe('CODEBLOCK', () => {
     test('CODEBLOCK-B/C: Python language and formatted source persist to author preview and delivery', async ({
       runWorkflow,

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -8,51 +8,51 @@ const defaultPassword = 'changeme123456';
 
 const configureWorkflowRun = (runId: string) =>
   setRuntimeConfig({
-  baseUrl,
-  scenarioToken: 'my-token',
-  loginData: {
-    student: {
-      type: TYPE_USER.student,
-      pageTitle: 'OLI Torus',
-      role: 'Student',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Hi, Jane',
-      email: `student${runId}@example.com`,
-      name: 'Jane',
-      last_name: 'Student',
-      pass: defaultPassword,
+    baseUrl,
+    scenarioToken: 'my-token',
+    loginData: {
+      student: {
+        type: TYPE_USER.student,
+        pageTitle: 'OLI Torus',
+        role: 'Student',
+        welcomeText: 'Welcome to OLI Torus',
+        welcomeTitle: 'Hi, Jane',
+        email: `student${runId}@example.com`,
+        name: 'Jane',
+        last_name: 'Student',
+        pass: defaultPassword,
+      },
+      instructor: {
+        type: TYPE_USER.instructor,
+        pageTitle: 'OLI Torus',
+        role: 'Instructor',
+        welcomeText: 'Welcome to OLI Torus',
+        welcomeTitle: 'Instructor Dashboard',
+        email: `instructor${runId}@example.com`,
+        pass: defaultPassword,
+        header: 'Instructor Dashboard',
+      },
+      author: {
+        type: TYPE_USER.author,
+        pageTitle: 'OLI Torus',
+        role: 'Course Author',
+        welcomeText: 'Welcome to OLI Torus',
+        welcomeTitle: 'Course Author',
+        email: `author${runId}@example.com`,
+        pass: defaultPassword,
+        header: 'Course Author',
+      },
+      administrator: {
+        type: TYPE_USER.administrator,
+        pageTitle: 'OLI Torus',
+        role: 'Course Author',
+        welcomeText: 'Welcome to OLI Torus',
+        welcomeTitle: 'Course Author',
+        email: `admin${runId}@example.com`,
+        pass: defaultPassword,
+        header: 'Course Author',
+      },
     },
-    instructor: {
-      type: TYPE_USER.instructor,
-      pageTitle: 'OLI Torus',
-      role: 'Instructor',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Instructor Dashboard',
-      email: `instructor${runId}@example.com`,
-      pass: defaultPassword,
-      header: 'Instructor Dashboard',
-    },
-    author: {
-      type: TYPE_USER.author,
-      pageTitle: 'OLI Torus',
-      role: 'Course Author',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Course Author',
-      email: `author${runId}@example.com`,
-      pass: defaultPassword,
-      header: 'Course Author',
-    },
-    administrator: {
-      type: TYPE_USER.administrator,
-      pageTitle: 'OLI Torus',
-      role: 'Course Author',
-      welcomeText: 'Welcome to OLI Torus',
-      welcomeTitle: 'Course Author',
-      email: `admin${runId}@example.com`,
-      pass: defaultPassword,
-      header: 'Course Author',
-    },
-  },
   });
 
 const workflowParams = () => {
@@ -110,7 +110,9 @@ test.describe('MIXED workflow', () => {
       });
     });
 
-    test('INLINE-O: popup content persists to author preview and delivery', async ({ runWorkflow }) => {
+    test('INLINE-O: popup content persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
       await runWorkflow('./mixed_workflow/inline-popup.workflow.yaml', {
         actions: mixedWorkflowActions,
         params: workflowParams(),
@@ -159,14 +161,24 @@ test.describe('MIXED workflow', () => {
   });
 
   test.describe('IMAGE', () => {
-    test('IMAGE-B/C/D/E/F: image replacement and settings persist to author preview and delivery', async ({ runWorkflow }) => {
-      await runWorkflow('./mixed_workflow/image.workflow.yaml', { actions: mixedWorkflowActions, params: workflowParams() });
+    test('IMAGE-B/C/D/E/F: image replacement and settings persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/image.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
     });
   });
 
   test.describe('FIGURE', () => {
-    test('FIGURE-B/C: title and nested content persist to author preview and delivery', async ({ runWorkflow }) => {
-      await runWorkflow('./mixed_workflow/figure.workflow.yaml', { actions: mixedWorkflowActions, params: workflowParams() });
+    test('FIGURE-B/C: title and nested content persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/figure.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
     });
   });
 
@@ -175,8 +187,8 @@ test.describe('MIXED workflow', () => {
       runWorkflow,
     }) => {
       await runWorkflow('./mixed_workflow/codeblock.workflow.yaml', {
-          actions: mixedWorkflowActions,
-          params: workflowParams(),
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
       });
     });
   });

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -55,14 +55,38 @@ setRuntimeConfig({
   },
 });
 
-test.describe('mixed workflow', () => {
-  test.setTimeout(120_000);
+test.describe('MIXED workflow', () => {
+  test.setTimeout(300_000);
 
-  test('publishes mixed page updates and validates preview plus delivery for code block and callout', async ({
-    runWorkflow,
-  }) => {
-    await test.step('execute mixed workflow end-to-end', async () => {
-      await runWorkflow('./mixed_workflow/mixed-content.workflow.yaml', {
+  test.describe('CORE', () => {
+    test('CORE-A: typing text persists to author preview and delivery', async ({ runWorkflow }) => {
+      await runWorkflow('./mixed_workflow/core.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: {
+          RUN_ID: runId,
+        },
+      });
+    });
+  });
+
+  test.describe('CODEBLOCK', () => {
+    test('CODEBLOCK-B/C: Python language and formatted source persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/codeblock.workflow.yaml', {
+          actions: mixedWorkflowActions,
+          params: {
+            RUN_ID: runId,
+        },
+      });
+    });
+  });
+
+  test.describe('CALLOUT', () => {
+    test('CALLOUT-A: block callout text persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/callout.workflow.yaml', {
         actions: mixedWorkflowActions,
         params: {
           RUN_ID: runId,

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -3,11 +3,11 @@ import { setRuntimeConfig } from '@core/runtimeConfig';
 import { TYPE_USER } from '@pom/types/type-user';
 import { mixedWorkflowActions } from './mixed_workflow/actions';
 
-const runId = `-${Date.now()}`;
 const baseUrl = 'http://localhost';
 const defaultPassword = 'changeme123456';
 
-setRuntimeConfig({
+const configureWorkflowRun = (runId: string) =>
+  setRuntimeConfig({
   baseUrl,
   scenarioToken: 'my-token',
   loginData: {
@@ -53,18 +53,87 @@ setRuntimeConfig({
       header: 'Course Author',
     },
   },
-});
+  });
+
+const workflowParams = () => {
+  const runId = `-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  configureWorkflowRun(runId);
+  return { RUN_ID: runId };
+};
 
 test.describe('MIXED workflow', () => {
-  test.setTimeout(300_000);
+  test.setTimeout(90_000);
 
   test.describe('CORE', () => {
     test('CORE-A: typing text persists to author preview and delivery', async ({ runWorkflow }) => {
       await runWorkflow('./mixed_workflow/core.workflow.yaml', {
         actions: mixedWorkflowActions,
-        params: {
-          RUN_ID: runId,
-        },
+        params: workflowParams(),
+      });
+    });
+  });
+
+  test.describe('INLINE', () => {
+    test('INLINE-C/D/E/I/J/K/L/M/S/T: formatting persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/inline-formatting.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('INLINE-F: internal course link persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/inline-internal-link.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('INLINE-G: external link persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/inline-external-link.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('INLINE-N: foreign text persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/inline-foreign.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('INLINE-O: popup content persists to author preview and delivery', async ({ runWorkflow }) => {
+      await runWorkflow('./mixed_workflow/inline-popup.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('INLINE-R: inline callout persists to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/inline-callout.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+  });
+
+  test.describe('LIST', () => {
+    test('LIST-C/D: circle bullet style and indentation persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/list-formatting.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
       });
     });
   });
@@ -75,9 +144,7 @@ test.describe('MIXED workflow', () => {
     }) => {
       await runWorkflow('./mixed_workflow/codeblock.workflow.yaml', {
           actions: mixedWorkflowActions,
-          params: {
-            RUN_ID: runId,
-        },
+          params: workflowParams(),
       });
     });
   });
@@ -88,9 +155,7 @@ test.describe('MIXED workflow', () => {
     }) => {
       await runWorkflow('./mixed_workflow/callout.workflow.yaml', {
         actions: mixedWorkflowActions,
-        params: {
-          RUN_ID: runId,
-        },
+        params: workflowParams(),
       });
     });
   });

--- a/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed-workflow.spec.ts
@@ -138,6 +138,26 @@ test.describe('MIXED workflow', () => {
     });
   });
 
+  test.describe('TABLE', () => {
+    test('TABLE-B/C/D/E/F: table structure and cell formatting persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/table-structure.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+
+    test('TABLE-G/H: alternating rows and hidden borders persist to author preview and delivery', async ({
+      runWorkflow,
+    }) => {
+      await runWorkflow('./mixed_workflow/table-styles.workflow.yaml', {
+        actions: mixedWorkflowActions,
+        params: workflowParams(),
+      });
+    });
+  });
+
   test.describe('CODEBLOCK', () => {
     test('CODEBLOCK-B/C: Python language and formatted source persist to author preview and delivery', async ({
       runWorkflow,

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -138,8 +138,16 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
 
     await insertBlockImage(page);
-    await uploadImage(page, path.resolve(process.cwd(), 'tests/resources/media_files', jpgName), jpgName);
-    await uploadImage(page, path.resolve(process.cwd(), 'tests/torus/student_delivery/support', pngName), pngName);
+    await uploadImage(
+      page,
+      path.resolve(process.cwd(), 'tests/resources/media_files', jpgName),
+      jpgName,
+    );
+    await uploadImage(
+      page,
+      path.resolve(process.cwd(), 'tests/torus/student_delivery/support', pngName),
+      pngName,
+    );
     await page.locator('.name').getByText(jpgName, { exact: true }).click();
     await page.getByRole('button', { name: 'Select', exact: true }).click();
     await expect(page.locator('[data-slate-editor="true"] img')).toHaveAttribute(
@@ -210,33 +218,6 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     };
   },
 
-  async author_inline_embeds({ curriculumTask, homeTask, page }, params) {
-    const projectSlug = asString(params.project_slug, 'project_slug');
-    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
-    const foreignText = 'INLINE-N foreign text';
-    const popupTrigger = 'INLINE-O popup trigger';
-    const popupContent = 'INLINE-O popup content';
-    const calloutText = 'INLINE-R inline callout text';
-
-    await test.step('author foreign text, popup content, and inline callout', async () => {
-      await homeTask.login('author');
-      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
-
-      await curriculumTask.addForeignToolbar(foreignText, 'arabic', false);
-      await curriculumTask.addPopUpToolbar(popupTrigger, popupContent, false);
-      await curriculumTask.addCalloutToolbar(calloutText, false);
-      await previewFlush(() => curriculumTask.openPreview());
-    });
-
-    return {
-      callout_text: calloutText,
-      foreign_text: foreignText,
-      page_revision_slug: pageRevisionSlug,
-      popup_content: popupContent,
-      popup_trigger: popupTrigger,
-    };
-  },
-
   async author_inline_external_link({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
@@ -294,12 +275,22 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
   async author_inline_formatting({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
-    const formatting: Array<{ text: string; toolbar: TypeToolbar; mark: string; inMore?: boolean }> = [
+    const formatting: Array<{
+      text: string;
+      toolbar: TypeToolbar;
+      mark: string;
+      inMore?: boolean;
+    }> = [
       { text: 'INLINE-C bold text', toolbar: 'Bold', mark: 'strong' },
       { text: 'INLINE-D italic text', toolbar: 'Italic', mark: 'em' },
       { text: 'INLINE-E code text', toolbar: 'Code', mark: 'code' },
       { text: 'INLINE-I underline text', toolbar: 'Underline', mark: 'underline', inMore: true },
-      { text: 'INLINE-J strikethrough text', toolbar: 'Strikethrough', mark: 'strikethrough', inMore: true },
+      {
+        text: 'INLINE-J strikethrough text',
+        toolbar: 'Strikethrough',
+        mark: 'strikethrough',
+        inMore: true,
+      },
       { text: 'INLINE-K subscript text', toolbar: 'Subscript', mark: 'sub', inMore: true },
       { text: 'INLINE-L superscript text', toolbar: 'Superscript', mark: 'sup', inMore: true },
       { text: 'INLINE-M term text', toolbar: 'Term', mark: 'term', inMore: true },
@@ -461,12 +452,6 @@ async function insertBlockImage(page: Page) {
   await page.getByRole('button', { name: 'Choose image' }).click();
 }
 
-async function uploadAndSelectImage(page: Page, filePath: string, fileName: string) {
-  await uploadImage(page, filePath, fileName);
-  await page.locator('.name').getByText(fileName, { exact: true }).click();
-  await page.getByRole('button', { name: 'Select', exact: true }).click();
-}
-
 async function uploadImage(page: Page, filePath: string, fileName: string) {
   const upload = page.getByRole('button', { name: 'Upload' });
   const fileChooser = page.waitForEvent('filechooser');
@@ -586,7 +571,11 @@ async function insertLink(page: Page, text: string, configure: () => Promise<voi
   await page.getByRole('button', { name: /Link \(.*\)$/ }).click();
   const link = page.locator('a.inline-link').filter({ hasText: text });
   await link.click();
-  await page.locator('.hover-container').filter({ hasText: 'Settings' }).getByRole('button').click();
+  await page
+    .locator('.hover-container')
+    .filter({ hasText: 'Settings' })
+    .getByRole('button')
+    .click();
   await configure();
   await page.getByRole('button', { name: 'Save', exact: true }).click();
 }
@@ -623,9 +612,7 @@ async function selectSlateText(page: Page, text: string) {
 
 function toolbarButton(page: Page, toolbar: TypeToolbar) {
   const accessibleName =
-    toolbar === 'Subscript'
-      ? /(?<!Double )Subscript$/
-      : new RegExp(`${escapeRegExp(toolbar)}$`);
+    toolbar === 'Subscript' ? /(?<!Double )Subscript$/ : new RegExp(`${escapeRegExp(toolbar)}$`);
 
   return page.getByRole('button', { name: accessibleName });
 }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -2,6 +2,7 @@ import { WorkflowActionRegistry } from '@core/workflow/types';
 import { expect, Locator, Page, test } from '@playwright/test';
 import { TypeProgrammingLanguage } from '@pom/types/type-programming-language';
 import { TypeToolbar } from '@pom/types/type-toolbar';
+import path from 'node:path';
 
 const BASE_CONTENT_TEXT = 'Base content for mixed workflow coverage.';
 
@@ -122,6 +123,59 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
       merged_text: mergedText,
       page_revision_slug: pageRevisionSlug,
     };
+  },
+
+  async author_image_workflow({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const pngName = 'image_coding_sample.png';
+    const jpgName = 'img-mock-05-16-2025.jpg';
+    const caption = 'IMAGE-D authored image caption';
+    const alt = 'IMAGE-E alternative text';
+    const width = '320';
+
+    await homeTask.login('author');
+    await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+    await insertBlockImage(page);
+    await uploadImage(page, path.resolve(process.cwd(), 'tests/resources/media_files', jpgName), jpgName);
+    await uploadImage(page, path.resolve(process.cwd(), 'tests/torus/student_delivery/support', pngName), pngName);
+    await page.locator('.name').getByText(jpgName, { exact: true }).click();
+    await page.getByRole('button', { name: 'Select', exact: true }).click();
+    await expect(page.locator('[data-slate-editor="true"] img')).toHaveAttribute(
+      'src',
+      new RegExp(escapeRegExp(jpgName)),
+    );
+    await selectImageSettings(page, 'Select Image');
+    await expect(page.getByRole('heading', { name: 'Select Image' })).toBeVisible();
+    await page.locator('.name').getByText(pngName, { exact: true }).click();
+    await page.getByRole('button', { name: 'Select', exact: true }).click();
+
+    await page.locator('.captions-input').fill(caption);
+    await selectImageSettings(page, 'Settings');
+    await page.getByPlaceholder('Enter a short description of this image').fill(alt);
+    await page.locator('input[type="number"]').fill(width);
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return { alt, caption, final_image: pngName, page_revision_slug: pageRevisionSlug, width };
+  },
+
+  async author_figure_workflow({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const title = 'FIGURE-B authored title';
+    const content = 'FIGURE-C nested figure content';
+
+    await homeTask.login('author');
+    await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    await curriculumTask.addFigureToolbar(title, false);
+    const figureContent = page.locator('.figure-editor .figure-content > p');
+    await figureContent.click();
+    await page.keyboard.type(content);
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return { content, page_revision_slug: pageRevisionSlug, title };
   },
 
   async author_table_styles({ curriculumTask, homeTask, page }, params) {
@@ -401,6 +455,33 @@ async function focusBaseParagraphForBlockInsert(page: Page) {
   );
 }
 
+async function insertBlockImage(page: Page) {
+  await focusTableInsertionPoint(page);
+  await page.getByRole('button', { name: 'Insert Image' }).click();
+  await page.getByRole('button', { name: 'Choose image' }).click();
+}
+
+async function uploadAndSelectImage(page: Page, filePath: string, fileName: string) {
+  await uploadImage(page, filePath, fileName);
+  await page.locator('.name').getByText(fileName, { exact: true }).click();
+  await page.getByRole('button', { name: 'Select', exact: true }).click();
+}
+
+async function uploadImage(page: Page, filePath: string, fileName: string) {
+  const upload = page.getByRole('button', { name: 'Upload' });
+  const fileChooser = page.waitForEvent('filechooser');
+  await upload.click();
+  await (await fileChooser).setFiles(filePath);
+  await expect(page.locator('.name').getByText(fileName, { exact: true })).toBeVisible();
+}
+
+async function selectImageSettings(page: Page, setting: 'Select Image' | 'Settings') {
+  const image = page.locator('[data-slate-editor="true"] img');
+  await image.scrollIntoViewIfNeeded();
+  await image.click();
+  await page.getByRole('button', { name: setting }).last().click({ force: true });
+}
+
 async function insertTable(page: Page) {
   const tables = page.locator('[data-slate-editor="true"] .table-editor');
   const countBefore = await tables.count();
@@ -415,8 +496,11 @@ async function insertTable(page: Page) {
 }
 
 async function focusTableInsertionPoint(page: Page) {
-  const editor = page.locator('[data-slate-editor="true"]');
-  const firstParagraph = editor.getByRole('paragraph').first();
+  // A content block can contain nested Slate editors (captions, figure titles,
+  // table cells). Limit this to the block's root editor so an insertion always
+  // happens in the authored page, not one of those nested editors.
+  const editor = page.locator('[id^="resource-editor-"] [data-slate-editor="true"]').first();
+  const firstParagraph = editor.locator('> p').first();
 
   await firstParagraph.click();
   await page.keyboard.press('Home');
@@ -516,14 +600,25 @@ async function clearSlateEditor(page: Page) {
 
 async function selectSlateText(page: Page, text: string) {
   const leaf = page.locator('[data-slate-string="true"]').filter({ hasText: text }).last();
+  const rendered = await leaf
+    .waitFor({ state: 'visible', timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false);
 
-  await leaf.evaluate((node) => {
-    const selection = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(node);
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-  });
+  if (rendered) {
+    await leaf.evaluate((node) => {
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    return;
+  }
+
+  // The link text is typed into a new paragraph. This fallback avoids a
+  // transient Slate render from consuming the full test timeout.
+  await page.keyboard.press('Shift+Home');
 }
 
 function toolbarButton(page: Page, toolbar: TypeToolbar) {

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -87,6 +87,75 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     };
   },
 
+  async author_table_structure({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const headerText = 'TABLE-D header cell';
+    const mergedText = 'TABLE-E merged cells';
+    const alignedText = 'TABLE-F centered cell';
+
+    await test.step('author table column, row, header, merge, and alignment changes', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      const table = await insertTable(page);
+      await fillTableCell(table, 0, 0, headerText);
+      await fillTableCell(table, 0, 1, 'TABLE-B original second cell');
+      await fillTableCell(table, 1, 0, mergedText);
+      await fillTableCell(table, 1, 1, 'TABLE-E merge target');
+
+      await selectTableMenuItem(page, table, 0, 0, 'Column after');
+      await selectTableMenuItem(page, table, 0, 0, 'Row after');
+      await selectTableMenuItem(page, table, 0, 0, 'Toggle Header');
+      // "Row after" inserts a blank second row, moving the prefilled merge target
+      // to the third row.
+      await selectTableMenuItem(page, table, 2, 0, 'Merge Right');
+      await setTableCellAlignment(table, 0, 1, 'center');
+      await fillTableCell(table, 0, 1, alignedText);
+
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return {
+      aligned_text: alignedText,
+      header_text: headerText,
+      merged_text: mergedText,
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
+  async author_table_styles({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const alternatingText = 'TABLE-G alternating fourth row';
+    const hiddenBorderText = 'TABLE-H hidden border table';
+
+    await test.step('author second alternating table and third hidden-border table', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await insertTable(page);
+
+      const alternatingTable = await insertTable(page);
+      await selectTableMenuItem(page, alternatingTable, 0, 0, 'Row after');
+      await selectTableMenuItem(page, alternatingTable, 2, 0, 'Row after');
+      await fillTableCell(alternatingTable, 3, 0, alternatingText);
+      await selectTableMenuItem(page, alternatingTable, 0, 0, 'Alternating Stripes');
+
+      const hiddenBorderTable = await insertTable(page);
+      await fillTableCell(hiddenBorderTable, 0, 0, hiddenBorderText);
+      await selectTableMenuItem(page, hiddenBorderTable, 0, 0, 'Hidden');
+
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return {
+      alternating_text: alternatingText,
+      hidden_border_text: hiddenBorderText,
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
   async author_inline_embeds({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
@@ -330,6 +399,68 @@ async function focusBaseParagraphForBlockInsert(page: Page) {
   throw new Error(
     'Could not focus the base paragraph strongly enough to expose the block insert toolbar',
   );
+}
+
+async function insertTable(page: Page) {
+  const tables = page.locator('[data-slate-editor="true"] .table-editor');
+  const countBefore = await tables.count();
+
+  await focusTableInsertionPoint(page);
+  await expect(page.getByRole('button', { name: 'Insert...' })).toBeVisible();
+  await page.getByRole('button', { name: 'Insert...' }).click();
+  await page.getByRole('button', { name: 'Insert Table' }).click();
+  await expect(tables).toHaveCount(countBefore + 1);
+
+  return tables.first();
+}
+
+async function focusTableInsertionPoint(page: Page) {
+  const editor = page.locator('[data-slate-editor="true"]');
+  const firstParagraph = editor.getByRole('paragraph').first();
+
+  await firstParagraph.click();
+  await page.keyboard.press('Home');
+}
+
+function tableCell(table: Locator, row: number, column: number) {
+  return table.locator('tbody tr').nth(row).locator('td, th').nth(column);
+}
+
+async function fillTableCell(table: Locator, row: number, column: number, text: string) {
+  await tableCell(table, row, column).fill(text);
+}
+
+async function selectTableMenuItem(
+  page: Page,
+  table: Locator,
+  row: number,
+  column: number,
+  item: string,
+) {
+  const cell = tableCell(table, row, column);
+  await cell.click();
+
+  const menu = cell.locator('.table-dropdown');
+  await expect(menu).toBeVisible();
+  await menu.locator('.dropdown-toggle').click();
+  await page.getByRole('button', { name: item, exact: true }).click();
+}
+
+async function setTableCellAlignment(
+  table: Locator,
+  row: number,
+  column: number,
+  alignment: 'left' | 'center' | 'right',
+) {
+  const cell = tableCell(table, row, column);
+  await cell.click();
+
+  const menu = cell.locator('.table-dropdown');
+  await expect(menu).toBeVisible();
+  await menu.locator('.dropdown-toggle').click();
+
+  const index = { left: 0, center: 1, right: 2 }[alignment];
+  await menu.locator('.btn-group-toggle button').nth(index).click();
 }
 
 async function applyToolbarToNewParagraph(

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -16,6 +16,28 @@ const previewFlush = async (openPreview: () => Promise<{ close(): Promise<void> 
 };
 
 export const mixedWorkflowActions: WorkflowActionRegistry = {
+  async author_core_text_editing({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const typedText = 'Mixed workflow typing stays responsive across a couple of sentences.';
+    const paragraph = page
+      .locator('[id^="resource-editor-"]')
+      .getByRole('paragraph')
+      .filter({ hasText: BASE_CONTENT_TEXT })
+      .first();
+
+    await test.step('sign in and type the CORE-A text without editor lag', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await paragraph.fill(`${BASE_CONTENT_TEXT} ${typedText}`);
+      await expect(paragraph).toHaveText(`${BASE_CONTENT_TEXT} ${typedText}`);
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return { page_revision_slug: pageRevisionSlug, typed_text: typedText };
+  },
+
   async author_add_code_block({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
@@ -31,7 +53,9 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     await test.step('insert a code block and open preview to flush the draft change', async () => {
       await curriculumTask.addCodeBlockToolbar(language, code, caption, false);
       await previewFlush(() => curriculumTask.openPreview());
-      await expect(page).toHaveURL(new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`));
+      await expect(page).toHaveURL(
+        new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`),
+      );
     });
 
     return {
@@ -42,12 +66,13 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     };
   },
 
-  async author_add_callout({ curriculumTask, page }, params) {
+  async author_add_callout({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
     const calloutText = asString(params.callout_text, 'callout_text');
 
-    await test.step('re-open the page editor after the first publish cycle', async () => {
+    await test.step('sign in as author and open the seeded page in the editor', async () => {
+      await homeTask.login('author');
       await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
     });
 
@@ -59,7 +84,9 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
       await page.getByRole('button', { name: 'Callout' }).click();
       await page.keyboard.type(calloutText);
       await curriculumTask.waitChangeVisualize(calloutText);
-      await expect(page).toHaveURL(new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`));
+      await expect(page).toHaveURL(
+        new RegExp(`/curriculum/${escapeRegExp(pageRevisionSlug)}/edit$`),
+      );
     });
 
     return {
@@ -103,5 +130,7 @@ async function focusBaseParagraphForBlockInsert(page: Page) {
     }
   }
 
-  throw new Error('Could not focus the base paragraph strongly enough to expose the block insert toolbar');
+  throw new Error(
+    'Could not focus the base paragraph strongly enough to expose the block insert toolbar',
+  );
 }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -1,6 +1,7 @@
 import { WorkflowActionRegistry } from '@core/workflow/types';
 import { expect, Locator, Page, test } from '@playwright/test';
 import { TypeProgrammingLanguage } from '@pom/types/type-programming-language';
+import { TypeToolbar } from '@pom/types/type-toolbar';
 
 const BASE_CONTENT_TEXT = 'Base content for mixed workflow coverage.';
 
@@ -16,22 +17,218 @@ const previewFlush = async (openPreview: () => Promise<{ close(): Promise<void> 
 };
 
 export const mixedWorkflowActions: WorkflowActionRegistry = {
+  async author_inline_foreign({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const text = 'INLINE-N foreign text';
+
+    await homeTask.login('author');
+    await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    await clearSlateEditor(page);
+    await curriculumTask.addForeignToolbar(text, 'arabic', false);
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return { page_revision_slug: pageRevisionSlug, text };
+  },
+
+  async author_inline_popup({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const trigger = 'INLINE-O popup trigger';
+    const content = 'INLINE-O popup content';
+
+    await homeTask.login('author');
+    await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    await curriculumTask.addPopUpToolbar(trigger, content, false);
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return { content, page_revision_slug: pageRevisionSlug, trigger };
+  },
+
+  async author_inline_callout({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const text = 'INLINE-R inline callout text';
+
+    await homeTask.login('author');
+    await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+    await curriculumTask.addCalloutToolbar(text, false);
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return { page_revision_slug: pageRevisionSlug, text };
+  },
+
+  async author_list_formatting({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const styledItem = 'LIST-C circle bullet item';
+    const indentedItem = 'LIST-D indented item';
+
+    await test.step('author a styled bulleted list with an indented item', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await curriculumTask.clickOnParagraphAndSelectContent('auto', 'Format');
+      await page.getByText('List', { exact: true }).click();
+      await page.keyboard.type(styledItem);
+      await page.locator('button:has([aria-label="Bullet Style"])').click();
+      await page.getByText('Circle - ○', { exact: true }).click();
+
+      await page.keyboard.press('Enter');
+      await page.keyboard.type(indentedItem);
+      await toolbarButton(page, 'Increase Indent').click();
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return {
+      indented_item: indentedItem,
+      page_revision_slug: pageRevisionSlug,
+      styled_item: styledItem,
+    };
+  },
+
+  async author_inline_embeds({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const foreignText = 'INLINE-N foreign text';
+    const popupTrigger = 'INLINE-O popup trigger';
+    const popupContent = 'INLINE-O popup content';
+    const calloutText = 'INLINE-R inline callout text';
+
+    await test.step('author foreign text, popup content, and inline callout', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await curriculumTask.addForeignToolbar(foreignText, 'arabic', false);
+      await curriculumTask.addPopUpToolbar(popupTrigger, popupContent, false);
+      await curriculumTask.addCalloutToolbar(calloutText, false);
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return {
+      callout_text: calloutText,
+      foreign_text: foreignText,
+      page_revision_slug: pageRevisionSlug,
+      popup_content: popupContent,
+      popup_trigger: popupTrigger,
+    };
+  },
+
+  async author_inline_external_link({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const externalText = 'INLINE-G external link text';
+    const externalHref = 'https://example.com/mixed-workflow';
+
+    await test.step('author an external hyperlink', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await insertLink(page, externalText, async () => {
+        await page.getByLabel('Link to External Web Page').check();
+        await page.getByPlaceholder('www.google.com').fill(externalHref);
+      });
+    });
+
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return {
+      link_href: externalHref,
+      link_text: externalText,
+      link_type: 'url',
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
+  async author_inline_internal_link({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const internalText = 'INLINE-F internal link text';
+    let internalHref = '';
+
+    await test.step('author an internal course-page hyperlink', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      await insertLink(page, internalText, async () => {
+        await page.getByLabel('Link to Page in the Course').check();
+        const pageSelect = page.getByRole('combobox');
+        await pageSelect.selectOption({ label: 'Mixed Workflow Link Target' });
+        internalHref = await pageSelect.inputValue();
+      });
+    });
+
+    await previewFlush(() => curriculumTask.openPreview());
+
+    return {
+      link_href: internalHref,
+      link_text: internalText,
+      link_type: 'page',
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
+  async author_inline_formatting({ curriculumTask, homeTask, page }, params) {
+    const projectSlug = asString(params.project_slug, 'project_slug');
+    const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
+    const formatting: Array<{ text: string; toolbar: TypeToolbar; mark: string; inMore?: boolean }> = [
+      { text: 'INLINE-C bold text', toolbar: 'Bold', mark: 'strong' },
+      { text: 'INLINE-D italic text', toolbar: 'Italic', mark: 'em' },
+      { text: 'INLINE-E code text', toolbar: 'Code', mark: 'code' },
+      { text: 'INLINE-I underline text', toolbar: 'Underline', mark: 'underline', inMore: true },
+      { text: 'INLINE-J strikethrough text', toolbar: 'Strikethrough', mark: 'strikethrough', inMore: true },
+      { text: 'INLINE-K subscript text', toolbar: 'Subscript', mark: 'sub', inMore: true },
+      { text: 'INLINE-L superscript text', toolbar: 'Superscript', mark: 'sup', inMore: true },
+      { text: 'INLINE-M term text', toolbar: 'Term', mark: 'term', inMore: true },
+    ];
+
+    await test.step('sign in and apply the requested inline formatting', async () => {
+      await homeTask.login('author');
+      await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
+
+      for (const { text, toolbar, inMore } of formatting) {
+        await applyToolbarToNewParagraph(page, curriculumTask, text, toolbar, inMore);
+      }
+
+      await curriculumTask.clickOnParagraphAndSelectContent('auto', 'Format');
+      await page.getByText('Heading', { exact: true }).click();
+      await page.getByRole('button', { name: 'Heading 2' }).click();
+      await page.getByRole('button', { name: 'Heading 1' }).click();
+      await page.keyboard.type('INLINE-S heading text');
+
+      await curriculumTask.clickOnParagraphAndSelectContent('auto');
+      await page
+        .getByRole('button', { name: /Change To\s+Right-to-Left\s+text direction/ })
+        .click();
+      await page.keyboard.type('INLINE-T right to left text');
+
+      await previewFlush(() => curriculumTask.openPreview());
+    });
+
+    return {
+      expected_inline_formatting: JSON.stringify([
+        ...formatting.map(({ text, mark }) => ({ text, mark })),
+        { text: 'INLINE-S heading text', element: 'heading' },
+        { text: 'INLINE-T right to left text', direction: 'rtl' },
+      ]),
+      page_revision_slug: pageRevisionSlug,
+    };
+  },
+
   async author_core_text_editing({ curriculumTask, homeTask, page }, params) {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
     const typedText = 'Mixed workflow typing stays responsive across a couple of sentences.';
-    const paragraph = page
-      .locator('[id^="resource-editor-"]')
-      .getByRole('paragraph')
-      .filter({ hasText: BASE_CONTENT_TEXT })
-      .first();
+    const editor = page.locator('[data-slate-editor="true"]');
 
     await test.step('sign in and type the CORE-A text without editor lag', async () => {
       await homeTask.login('author');
       await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
 
-      await paragraph.fill(`${BASE_CONTENT_TEXT} ${typedText}`);
-      await expect(paragraph).toHaveText(`${BASE_CONTENT_TEXT} ${typedText}`);
+      await editor.click();
+      await page.keyboard.press('Meta+A');
+      await page.keyboard.type(`${BASE_CONTENT_TEXT} ${typedText}`);
+      await expect(editor).toContainText(`${BASE_CONTENT_TEXT} ${typedText}`);
       await previewFlush(() => curriculumTask.openPreview());
     });
 
@@ -133,4 +330,76 @@ async function focusBaseParagraphForBlockInsert(page: Page) {
   throw new Error(
     'Could not focus the base paragraph strongly enough to expose the block insert toolbar',
   );
+}
+
+async function applyToolbarToNewParagraph(
+  page: Page,
+  curriculumTask: {
+    clickOnParagraphAndSelectContent: (
+      index?: number | 'auto',
+      ...elements: TypeToolbar[]
+    ) => Promise<void>;
+  },
+  text: string,
+  toolbar: TypeToolbar,
+  inMore = false,
+) {
+  await curriculumTask.clickOnParagraphAndSelectContent('auto');
+
+  if (inMore) {
+    await page.getByRole('button', { name: 'More' }).click();
+  }
+
+  await toolbarButton(page, toolbar).click();
+  await page.keyboard.type(text);
+
+  if (inMore) {
+    await page.getByRole('button', { name: 'More' }).click();
+  }
+
+  await toolbarButton(page, toolbar).click();
+}
+
+async function insertLink(page: Page, text: string, configure: () => Promise<void>) {
+  const lastParagraph = page.getByRole('paragraph').last();
+  await lastParagraph.click();
+  await page.keyboard.press('End');
+  await page.keyboard.press('Enter');
+  await page.keyboard.type(text);
+
+  await selectSlateText(page, text);
+  await page.getByRole('button', { name: /Link \(.*\)$/ }).click();
+  const link = page.locator('a.inline-link').filter({ hasText: text });
+  await link.click();
+  await page.locator('.hover-container').filter({ hasText: 'Settings' }).getByRole('button').click();
+  await configure();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+}
+
+async function clearSlateEditor(page: Page) {
+  const editor = page.locator('[data-slate-editor="true"]');
+  await editor.click();
+  await page.keyboard.press('Meta+A');
+  await page.keyboard.press('Backspace');
+}
+
+async function selectSlateText(page: Page, text: string) {
+  const leaf = page.locator('[data-slate-string="true"]').filter({ hasText: text }).last();
+
+  await leaf.evaluate((node) => {
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
+}
+
+function toolbarButton(page: Page, toolbar: TypeToolbar) {
+  const accessibleName =
+    toolbar === 'Subscript'
+      ? /(?<!Double )Subscript$/
+      : new RegExp(`${escapeRegExp(toolbar)}$`);
+
+  return page.getByRole('button', { name: accessibleName });
 }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -25,8 +25,11 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
 
     await homeTask.login('author');
     await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
-    await clearSlateEditor(page);
-    await curriculumTask.addForeignToolbar(text, 'arabic', false);
+    await insertInlineElement(page, curriculumTask, 'Foreign', text);
+    await page.getByRole('button', { name: 'Change Language' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Foreign Language Settings' });
+    await dialog.getByRole('combobox').selectOption('ar');
+    await dialog.getByRole('button', { name: 'Save' }).click();
     await previewFlush(() => curriculumTask.openPreview());
 
     return { page_revision_slug: pageRevisionSlug, text };
@@ -40,7 +43,10 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
 
     await homeTask.login('author');
     await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
-    await curriculumTask.addPopUpToolbar(trigger, content, false);
+    await insertInlineElement(page, curriculumTask, 'Popup Content', trigger);
+    await page.getByRole('button', { name: 'Edit Popup Content' }).click();
+    await page.getByRole('paragraph').getByRole('textbox').fill(content);
+    await page.getByRole('button', { name: 'Save' }).click();
     await previewFlush(() => curriculumTask.openPreview());
 
     return { content, page_revision_slug: pageRevisionSlug, trigger };
@@ -53,7 +59,7 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
 
     await homeTask.login('author');
     await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
-    await curriculumTask.addCalloutToolbar(text, false);
+    await insertInlineElement(page, curriculumTask, 'Callout', text);
     await previewFlush(() => curriculumTask.openPreview());
 
     return { page_revision_slug: pageRevisionSlug, text };
@@ -580,11 +586,19 @@ async function insertLink(page: Page, text: string, configure: () => Promise<voi
   await page.getByRole('button', { name: 'Save', exact: true }).click();
 }
 
-async function clearSlateEditor(page: Page) {
-  const editor = page.locator('[data-slate-editor="true"]');
-  await editor.click();
-  await page.keyboard.press('Meta+A');
-  await page.keyboard.press('Backspace');
+async function insertInlineElement(
+  page: Page,
+  curriculumTask: {
+    clickOnParagraphAndSelectContent: (
+      index?: number | 'auto',
+      ...elements: TypeToolbar[]
+    ) => Promise<void>;
+  },
+  toolbar: TypeToolbar,
+  text: string,
+) {
+  await curriculumTask.clickOnParagraphAndSelectContent('auto', 'More', toolbar);
+  await page.keyboard.type(text);
 }
 
 async function selectSlateText(page: Page, text: string) {

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -360,7 +360,7 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
       await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
 
       await editor.click();
-      await page.keyboard.press('Meta+A');
+      await page.keyboard.press('ControlOrMeta+A');
       await page.keyboard.type(`${BASE_CONTENT_TEXT} ${typedText}`);
       await expect(editor).toContainText(`${BASE_CONTENT_TEXT} ${typedText}`);
       await previewFlush(() => curriculumTask.openPreview());

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -22,17 +22,18 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
     const projectSlug = asString(params.project_slug, 'project_slug');
     const pageRevisionSlug = asString(params.page_revision_slug, 'page_revision_slug');
     const text = 'INLINE-N foreign text';
+    const lang = 'ar';
 
     await homeTask.login('author');
     await page.goto(editorPath(projectSlug, pageRevisionSlug), { waitUntil: 'load' });
     await insertInlineElement(page, curriculumTask, 'Foreign', text);
     await page.getByRole('button', { name: 'Change Language' }).click();
     const dialog = page.getByRole('dialog', { name: 'Foreign Language Settings' });
-    await dialog.getByRole('combobox').selectOption('ar');
+    await dialog.getByRole('combobox').selectOption(lang);
     await dialog.getByRole('button', { name: 'Save' }).click();
     await previewFlush(() => curriculumTask.openPreview());
 
-    return { page_revision_slug: pageRevisionSlug, text };
+    return { page_revision_slug: pageRevisionSlug, text, lang };
   },
 
   async author_inline_popup({ curriculumTask, homeTask, page }, params) {

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/actions.ts
@@ -208,11 +208,25 @@ export const mixedWorkflowActions: WorkflowActionRegistry = {
       await selectTableMenuItem(page, alternatingTable, 0, 0, 'Row after');
       await selectTableMenuItem(page, alternatingTable, 2, 0, 'Row after');
       await fillTableCell(alternatingTable, 3, 0, alternatingText);
-      await selectTableMenuItem(page, alternatingTable, 0, 0, 'Alternating Stripes');
+      await applyTableStyle(
+        page,
+        alternatingTable,
+        0,
+        0,
+        'Alternating Stripes',
+        alternatingTable.locator('table.table-striped'),
+      );
 
       const hiddenBorderTable = await insertTable(page);
       await fillTableCell(hiddenBorderTable, 0, 0, hiddenBorderText);
-      await selectTableMenuItem(page, hiddenBorderTable, 0, 0, 'Hidden');
+      await applyTableStyle(
+        page,
+        hiddenBorderTable,
+        0,
+        0,
+        'Hidden',
+        hiddenBorderTable.locator('table.table-borderless'),
+      );
 
       await previewFlush(() => curriculumTask.openPreview());
     });
@@ -463,7 +477,21 @@ async function uploadImage(page: Page, filePath: string, fileName: string) {
   const fileChooser = page.waitForEvent('filechooser');
   await upload.click();
   await (await fileChooser).setFiles(filePath);
-  await expect(page.locator('.name').getByText(fileName, { exact: true })).toBeVisible();
+
+  const uploadedFile = page.locator('.name').getByText(fileName, { exact: true });
+  const uploadError = page.locator('.alert-danger', { hasText: 'Could not upload file' });
+
+  // Give the upload (and any thumbnail processing) real time to complete, but
+  // fail fast with the server's own error detail instead of a bare timeout if
+  // the media backend (e.g. local S3/minio) rejects it.
+  await expect(uploadedFile.or(uploadError)).toBeVisible({ timeout: 20000 });
+
+  if (await uploadError.isVisible()) {
+    const detail = await uploadError.locator('i').textContent();
+    throw new Error(
+      `Image upload failed - confirm local media storage (e.g. minio) is running. Server detail: ${detail}`,
+    );
+  }
 }
 
 async function selectImageSettings(page: Page, setting: 'Select Image' | 'Settings') {
@@ -478,7 +506,6 @@ async function insertTable(page: Page) {
   const countBefore = await tables.count();
 
   await focusTableInsertionPoint(page);
-  await expect(page.getByRole('button', { name: 'Insert...' })).toBeVisible();
   await page.getByRole('button', { name: 'Insert...' }).click();
   await page.getByRole('button', { name: 'Insert Table' }).click();
   await expect(tables).toHaveCount(countBefore + 1);
@@ -493,8 +520,17 @@ async function focusTableInsertionPoint(page: Page) {
   const editor = page.locator('[id^="resource-editor-"] [data-slate-editor="true"]').first();
   const firstParagraph = editor.locator('> p').first();
 
-  await firstParagraph.click();
-  await page.keyboard.press('Home');
+  // The Slate hover toolbar only opens once the editor registers focus and a
+  // selection client-side, which can lag just after navigation. Repeating the
+  // same click/Home on a retry can be a no-op if the cursor is already there
+  // (no native selectionchange fires), so force the selection to actually
+  // move on every attempt before checking the toolbar again.
+  await expect(async () => {
+    await firstParagraph.click();
+    await page.keyboard.press('End');
+    await page.keyboard.press('Home');
+    await expect(page.getByRole('button', { name: 'Insert...' })).toBeVisible({ timeout: 2000 });
+  }).toPass({ timeout: 12000 });
 }
 
 function tableCell(table: Locator, row: number, column: number) {
@@ -503,6 +539,24 @@ function tableCell(table: Locator, row: number, column: number) {
 
 async function fillTableCell(table: Locator, row: number, column: number, text: string) {
   await tableCell(table, row, column).fill(text);
+}
+
+async function applyTableStyle(
+  page: Page,
+  table: Locator,
+  row: number,
+  column: number,
+  item: string,
+  resultLocator: Locator,
+) {
+  // The dropdown click can occasionally race with an in-flight editor
+  // transform (e.g. a just-typed cell edit) and silently fail to land. Retry
+  // the full click sequence, not just the wait, since a passive wait can
+  // never recover from a click that never reached the editor.
+  await expect(async () => {
+    await selectTableMenuItem(page, table, row, column, item);
+    await expect(resultLocator).toBeVisible({ timeout: 3000 });
+  }).toPass({ timeout: 15000 });
 }
 
 async function selectTableMenuItem(

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-core-text-editing.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-core-text-editing.scenario.yaml
@@ -1,0 +1,16 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_core_text_editing/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish CORE-A text editing workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_core_text_editing/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-figure-workflow.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-figure-workflow.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_figure_workflow/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish figure workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_figure_workflow/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-image-workflow.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-image-workflow.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_image_workflow/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish image workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_image_workflow/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-callout.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-callout.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_inline_callout/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish inline callout workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_inline_callout/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-foreign.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-foreign.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_inline_foreign/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish inline foreign workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_inline_foreign/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-formatting.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-formatting.scenario.yaml
@@ -1,0 +1,16 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_inline_formatting/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish inline formatting workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_inline_formatting/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-link.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-link.scenario.yaml
@@ -1,0 +1,16 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_inline_link/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish inline link workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_inline_link/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-popup.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-inline-popup.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_inline_popup/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish inline popup workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_inline_popup/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-list-formatting.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-list-formatting.scenario.yaml
@@ -1,0 +1,16 @@
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_list_formatting/1'
+
+- publish:
+    to: 'workflow_authoring_project'
+    description: 'Publish list formatting workflow update'
+
+- update:
+    from: 'workflow_authoring_project'
+    to: 'workflow_delivery_section'
+
+- hook:
+    function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_list_formatting/1'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-table-structure.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-table-structure.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_table_structure/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish table structure workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_table_structure/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-table-styles.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/assert-table-styles.scenario.yaml
@@ -1,0 +1,5 @@
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.bind_workflow_context/1' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_author_preview_table_styles/1' }
+- publish: { to: 'workflow_authoring_project', description: 'Publish table styles workflow update' }
+- update: { from: 'workflow_authoring_project', to: 'workflow_delivery_section' }
+- hook: { function: 'Oli.Scenarios.Features.MixedContentHooks.assert_student_delivery_table_styles/1' }

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/callout.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/callout.workflow.yaml
@@ -1,0 +1,26 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_callout_in_playwright
+    playwright_action:
+      action: 'author_add_callout'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+        callout_text: 'Mixed workflow callout text'
+
+  - id: assert_callout_after_publish
+    scenario:
+      file: 'assert-callout.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_callout_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_CALLOUT_TEXT: '${author_callout_in_playwright.outputs.callout_text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/codeblock.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/codeblock.workflow.yaml
@@ -27,23 +27,3 @@ workflow:
         PAGE_REVISION_SLUG: '${author_code_block_in_playwright.outputs.page_revision_slug}'
         EXPECTED_CODEBLOCK_CAPTION: '${author_code_block_in_playwright.outputs.caption}'
         EXPECTED_CODEBLOCK_CODE: '${author_code_block_in_playwright.outputs.code}'
-
-  - id: author_callout_in_playwright
-    playwright_action:
-      action: 'author_add_callout'
-      params:
-        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
-        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
-        callout_text: 'Mixed workflow callout text'
-
-  - id: assert_callout_after_publish
-    scenario:
-      file: 'assert-callout.scenario.yaml'
-      params:
-        RUN_ID: '${RUN_ID}'
-        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
-        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
-        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
-        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
-        PAGE_REVISION_SLUG: '${author_callout_in_playwright.outputs.page_revision_slug}'
-        EXPECTED_CALLOUT_TEXT: '${author_callout_in_playwright.outputs.callout_text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/core.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/core.workflow.yaml
@@ -1,0 +1,25 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_core_text_editing_in_playwright
+    playwright_action:
+      action: 'author_core_text_editing'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+
+  - id: assert_core_text_editing_after_publish
+    scenario:
+      file: 'assert-core-text-editing.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_core_text_editing_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_TYPED_TEXT: '${author_core_text_editing_in_playwright.outputs.typed_text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/figure.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/figure.workflow.yaml
@@ -1,0 +1,20 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_figure_workflow'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-figure-workflow.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_TITLE: '${author.outputs.title}'
+        EXPECTED_CONTENT: '${author.outputs.content}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/image.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/image.workflow.yaml
@@ -1,0 +1,22 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_image_workflow'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-image-workflow.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_IMAGE: '${author.outputs.final_image}'
+        EXPECTED_CAPTION: '${author.outputs.caption}'
+        EXPECTED_ALT: '${author.outputs.alt}'
+        EXPECTED_WIDTH: '${author.outputs.width}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-callout.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-callout.workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_inline_callout'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-inline-callout.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_TEXT: '${author.outputs.text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-external-link.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-external-link.workflow.yaml
@@ -1,0 +1,27 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_inline_external_link_in_playwright
+    playwright_action:
+      action: 'author_inline_external_link'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+
+  - id: assert_inline_external_link_after_publish
+    scenario:
+      file: 'assert-inline-link.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_inline_external_link_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_LINK_TEXT: '${author_inline_external_link_in_playwright.outputs.link_text}'
+        EXPECTED_LINK_HREF: '${author_inline_external_link_in_playwright.outputs.link_href}'
+        EXPECTED_LINK_TYPE: '${author_inline_external_link_in_playwright.outputs.link_type}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-foreign.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-foreign.workflow.yaml
@@ -1,0 +1,19 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_inline_foreign'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-inline-foreign.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_TEXT: '${author.outputs.text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-foreign.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-foreign.workflow.yaml
@@ -17,3 +17,4 @@ workflow:
         SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
         PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
         EXPECTED_TEXT: '${author.outputs.text}'
+        EXPECTED_LANG: '${author.outputs.lang}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-formatting.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-formatting.workflow.yaml
@@ -1,0 +1,25 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_inline_formatting_in_playwright
+    playwright_action:
+      action: 'author_inline_formatting'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+
+  - id: assert_inline_formatting_after_publish
+    scenario:
+      file: 'assert-inline-formatting.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_inline_formatting_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_INLINE_FORMATTING: '${author_inline_formatting_in_playwright.outputs.expected_inline_formatting}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-internal-link.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-internal-link.workflow.yaml
@@ -1,0 +1,27 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_inline_internal_link_in_playwright
+    playwright_action:
+      action: 'author_inline_internal_link'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+
+  - id: assert_inline_internal_link_after_publish
+    scenario:
+      file: 'assert-inline-link.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_inline_internal_link_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_LINK_TEXT: '${author_inline_internal_link_in_playwright.outputs.link_text}'
+        EXPECTED_LINK_HREF: '${author_inline_internal_link_in_playwright.outputs.link_href}'
+        EXPECTED_LINK_TYPE: '${author_inline_internal_link_in_playwright.outputs.link_type}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-popup.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/inline-popup.workflow.yaml
@@ -1,0 +1,20 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_inline_popup'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-inline-popup.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_TRIGGER: '${author.outputs.trigger}'
+        EXPECTED_CONTENT: '${author.outputs.content}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/list-formatting.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/list-formatting.workflow.yaml
@@ -1,0 +1,26 @@
+workflow:
+  - id: seed_authoring_and_delivery_context
+    scenario:
+      file: 'mixed-content.setup.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+
+  - id: author_list_formatting_in_playwright
+    playwright_action:
+      action: 'author_list_formatting'
+      params:
+        project_slug: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed_authoring_and_delivery_context.outputs.params.workflow_page_revision_slug}'
+
+  - id: assert_list_formatting_after_publish
+    scenario:
+      file: 'assert-list-formatting.scenario.yaml'
+      params:
+        RUN_ID: '${RUN_ID}'
+        AUTHOR_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed_authoring_and_delivery_context.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed_authoring_and_delivery_context.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed_authoring_and_delivery_context.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author_list_formatting_in_playwright.outputs.page_revision_slug}'
+        EXPECTED_STYLED_LIST_ITEM: '${author_list_formatting_in_playwright.outputs.styled_item}'
+        EXPECTED_INDENTED_LIST_ITEM: '${author_list_formatting_in_playwright.outputs.indented_item}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.setup.scenario.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/mixed-content.setup.scenario.yaml
@@ -20,6 +20,7 @@
     root:
       children:
         - page: 'Mixed Workflow Page'
+        - page: 'Mixed Workflow Link Target'
 
 - edit_page:
     project: 'workflow_authoring_project'
@@ -30,6 +31,16 @@
       blocks:
         - type: prose
           body_md: "Base content for mixed workflow coverage."
+
+- edit_page:
+    project: 'workflow_authoring_project'
+    page: 'Mixed Workflow Link Target'
+    content: |
+      title: "Mixed Workflow Link Target"
+      graded: false
+      blocks:
+        - type: prose
+          body_md: "Target page for the mixed workflow internal-link test."
 
 - publish:
     to: 'workflow_authoring_project'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/table-structure.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/table-structure.workflow.yaml
@@ -1,0 +1,21 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_table_structure'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-table-structure.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_HEADER_TEXT: '${author.outputs.header_text}'
+        EXPECTED_MERGED_TEXT: '${author.outputs.merged_text}'
+        EXPECTED_ALIGNED_TEXT: '${author.outputs.aligned_text}'

--- a/assets/automation/tests/torus/course_authoring/mixed_workflow/table-styles.workflow.yaml
+++ b/assets/automation/tests/torus/course_authoring/mixed_workflow/table-styles.workflow.yaml
@@ -1,0 +1,20 @@
+workflow:
+  - id: seed
+    scenario: { file: 'mixed-content.setup.scenario.yaml', params: { RUN_ID: '${RUN_ID}' } }
+  - id: author
+    playwright_action:
+      action: 'author_table_styles'
+      params:
+        project_slug: '${seed.outputs.projects.workflow_authoring_project}'
+        page_revision_slug: '${seed.outputs.params.workflow_page_revision_slug}'
+  - id: assert
+    scenario:
+      file: 'assert-table-styles.scenario.yaml'
+      params:
+        AUTHOR_EMAIL: '${seed.outputs.users.workflow_author}'
+        STUDENT_EMAIL: '${seed.outputs.users.workflow_student}'
+        PROJECT_SLUG: '${seed.outputs.projects.workflow_authoring_project}'
+        SECTION_SLUG: '${seed.outputs.sections.workflow_delivery_section}'
+        PAGE_REVISION_SLUG: '${author.outputs.page_revision_slug}'
+        EXPECTED_ALTERNATING_TEXT: '${author.outputs.alternating_text}'
+        EXPECTED_HIDDEN_BORDER_TEXT: '${author.outputs.hidden_border_text}'

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416-approach.md
@@ -2,6 +2,7 @@
 
 Scope and reference artifacts:
 - Jira story: `MER-5416`
+- Regression spreadsheet source, `MIXED` tab: <https://docs.google.com/spreadsheets/d/1Ne9lo3DfcqS4U25pUE4aYkPy4mlqko9rEb4oU6w79pY/edit?gid=270463718#gid=270463718>
 - Epic plan source: `docs/exec-plans/current/epics/automated_testing/plan.md`
 - Existing authoring Playwright coverage:
   - `assets/automation/tests/torus/course_authoring/course-authoring.spec.ts`
@@ -39,6 +40,10 @@ For this ticket, the agreed meaning of the two assertion surfaces is:
   - validate the rendered output of the same content after publish, section creation, and learner delivery
 
 This interpretation matters because the repository currently has stronger precedent for instructor preview assertions than for authoring preview assertions.
+
+### Spreadsheet Evidence Interpretation
+
+The regression spreadsheet tracks four surfaces per row: editing, persisted state, authoring preview, and learner delivery. In a workflow, the Playwright action provides the editing evidence. Persisted state is evidenced by a successful server-rendered authoring preview after the editor explicitly flushes pending changes and reports that all changes are saved. Preview and delivery assertions then verify their respective render surfaces. A separate editor-reload assertion is only required for a row that specifically covers reopening the editor.
 
 ## Current State In The Repo
 ### What already exists

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
@@ -2,6 +2,25 @@
 
 This matrix is the row-complete workflow coverage inventory for the external `MIXED` spreadsheet tab.
 
+## Source of Truth
+
+- Regression spreadsheet, `MIXED` tab: <https://docs.google.com/spreadsheets/d/1Ne9lo3DfcqS4U25pUE4aYkPy4mlqko9rEb4oU6w79pY/edit?gid=270463718#gid=270463718>
+- Spreadsheet ID: `1Ne9lo3DfcqS4U25pUE4aYkPy4mlqko9rEb4oU6w79pY`; tab GID: `270463718`.
+- Last reconciled: 2026-07-20. The tab contains 80 cases; all 80 are represented below. The sole identifier difference is trailing whitespace in spreadsheet `INLINE-T`, which is normalized here as `INLINE-T`.
+
+Update this matrix whenever a workflow test changes row coverage. The spreadsheet defines the regression cases; this document records Torus automation status and the workflow test that provides the evidence.
+
+## Spreadsheet Evidence Model
+
+The `MIXED` spreadsheet records four validation surfaces for each row:
+
+- `A: Editing`: the Playwright action performs the authoring interaction and observes the editor result.
+- `B: Persisted`: the authored change is saved by the application.
+- `C: Preview`: Author Preview renders the authored change.
+- `D: Delivery`: the published section renders the authored change for delivery.
+
+For workflow-driven coverage, `B` is evidenced by `C` when the action explicitly flushes pending editor changes, waits for the saved state, and then opens Author Preview as a separate server-rendered request. A successful Preview assertion therefore proves that the change was not only local editor state. A separate editor reload is not required unless a row specifically targets the reopen-editor experience.
+
 It exists to answer three questions durably:
 
 1. which spreadsheet rows are already covered by workflow-driven automation
@@ -45,176 +64,175 @@ These slices are coverage batches, not implementation phases.
 ## Coverage Rules
 
 - Every spreadsheet row must appear exactly once in this document.
-- Every row must have a non-empty `Workflow Status`.
-- Every row that is not `covered` must have a non-empty `Target Slice`.
-- When a workflow test lands, update both:
-  - `Workflow Status`
-  - `Workflow Test / Notes`
+- Every row must have a non-empty status for `A: Editing`, `B: Persisted`, `C: Preview`, and `D: Delivery`.
+- Every row with an evidence status other than `covered` must have a non-empty `Target Slice`.
+- When a workflow test lands, update the affected A/B/C/D evidence statuses and `Workflow Test / Notes`.
+- A row may share a Playwright workflow with other rows, but it is `covered` only when its note names the exact workflow/spec and the row-specific action or assertion that proves its behavior. A group-level reference without that mapping is not coverage evidence.
 - This matrix is considered complete when all 80 spreadsheet rows are represented, even if some remain `planned`.
 
 ## Matrix
 
 ### `CORE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `CORE-A` | Type in a couple of sentences. Verify there is no editing lag | `planned` | `Follow-up Slice 2` | Fold into the core text-editing workflow slice. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CORE-A` | Type in a couple of sentences. Verify there is no editing lag | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `mixed-workflow.spec.ts > MIXED workflow > CORE > CORE-A: typing text persists to author preview and delivery`; `core.workflow.yaml` fills the authored paragraph and the post-Playwright scenario asserts the text in author preview and published delivery. |
 
 ### `INLINE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `INLINE-C` | Apply bold | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-D` | Apply italic | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-E` | Apply code | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-F` | Create hyperlink to another page in the course | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
-| `INLINE-G` | Create hyperlink to an external site | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
-| `INLINE-I` | Apply underline | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-J` | Apply strikethrough | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-K` | Apply subscript | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-L` | Apply superscript | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-M` | Apply term | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
-| `INLINE-N` | Apply foreign. Select a language | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
-| `INLINE-O` | Apply popup content | `planned` | `Follow-up Slice 2` | Inline popup workflow family. |
-| `INLINE-R` | Apply inline callout | `planned` | `Follow-up Slice 2` | Distinct from block callout in `CALLOUT-A`. |
-| `INLINE-S` | Change text to be a heading | `planned` | `Follow-up Slice 2` | Block-format workflow family. |
-| `INLINE-T` | Change text direction | `planned` | `Follow-up Slice 2` | Directionality workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `INLINE-C` | Apply bold | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-D` | Apply italic | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-E` | Apply code | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-F` | Create hyperlink to another page in the course | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
+| `INLINE-G` | Create hyperlink to an external site | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
+| `INLINE-I` | Apply underline | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-J` | Apply strikethrough | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-K` | Apply subscript | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-L` | Apply superscript | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
+| `INLINE-M` | Apply term | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
+| `INLINE-N` | Apply foreign. Select a language | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
+| `INLINE-O` | Apply popup content | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline popup workflow family. |
+| `INLINE-R` | Apply inline callout | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Distinct from block callout in `CALLOUT-A`. |
+| `INLINE-S` | Change text to be a heading | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Block-format workflow family. |
+| `INLINE-T` | Change text direction | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Directionality workflow family. |
 
 ### `LIST`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `LIST-C` | Customize the bullet style of one of the lists | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
-| `LIST-D` | Indent one of the list items | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `LIST-C` | Customize the bullet style of one of the lists | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
+| `LIST-D` | Indent one of the list items | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
 
 ### `TABLE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `TABLE-B` | Add a column | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-C` | Add a row | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-D` | Toggle a cell to be a header | `planned` | `Follow-up Slice 3` | Table semantics workflow family. |
-| `TABLE-E` | Merge the contents of two cells | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-F` | Change the alignment of one cell | `planned` | `Follow-up Slice 3` | Table formatting workflow family. |
-| `TABLE-G` | Create a second table with four rows and set row style set to Alternating | `planned` | `Follow-up Slice 3` | Table style workflow family. |
-| `TABLE-H` | Create a third table with border style set to Hidden | `planned` | `Follow-up Slice 3` | Table style workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `TABLE-B` | Add a column | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-C` | Add a row | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-D` | Toggle a cell to be a header | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table semantics workflow family. |
+| `TABLE-E` | Merge the contents of two cells | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
+| `TABLE-F` | Change the alignment of one cell | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table formatting workflow family. |
+| `TABLE-G` | Create a second table with four rows and set row style set to Alternating | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table style workflow family. |
+| `TABLE-H` | Create a third table with border style set to Hidden | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table style workflow family. |
 
 ### `IMAGE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `IMAGE-B` | Insert a block image. In media manager, upload both a PNG and JPG image. Select the PNG | `planned` | `Follow-up Slice 4` | Media insertion workflow family. |
-| `IMAGE-C` | Change the image to the JPG | `planned` | `Follow-up Slice 4` | Media replacement workflow family. |
-| `IMAGE-D` | Enter a caption | `planned` | `Follow-up Slice 4` | Image caption workflow family. |
-| `IMAGE-E` | Using image settings, specify alternate text | `planned` | `Follow-up Slice 4` | Accessibility workflow family. |
-| `IMAGE-F` | Using image settings, define a custom width | `planned` | `Follow-up Slice 4` | Media settings workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `IMAGE-B` | Insert a block image. In media manager, upload both a PNG and JPG image. Select the PNG | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media insertion workflow family. |
+| `IMAGE-C` | Change the image to the JPG | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media replacement workflow family. |
+| `IMAGE-D` | Enter a caption | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Image caption workflow family. |
+| `IMAGE-E` | Using image settings, specify alternate text | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Accessibility workflow family. |
+| `IMAGE-F` | Using image settings, define a custom width | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media settings workflow family. |
 
 ### `YOUTUBE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `YOUTUBE-B` | Insert YouTube video using only the YouTube video id | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
-| `YOUTUBE-C` | Edit the caption of the YouTube video | `planned` | `Follow-up Slice 5` | Embed caption workflow family. |
-| `YOUTUBE-D` | Click to open the YouTube video in full screen in new tab | `planned` | `Follow-up Slice 5` | New-tab behavior may remain browser-only within the workflow. |
-| `YOUTUBE-E` | Click to copy the YouTube video URL to the clipboard | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
-| `YOUTUBE-F` | Using settings menu, change the video to a new id | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
-| `YOUTUBE-G` | Using settings menu, set the alternative text for YouTube video | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
-| `YOUTUBE-H` | Delete a YouTube video | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
-| `YOUTUBE-I` | Undo the deletion (Ctrl-z) | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `YOUTUBE-B` | Insert YouTube video using only the YouTube video id | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
+| `YOUTUBE-C` | Edit the caption of the YouTube video | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed caption workflow family. |
+| `YOUTUBE-D` | Click to open the YouTube video in full screen in new tab | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | New-tab behavior may remain browser-only within the workflow. |
+| `YOUTUBE-E` | Click to copy the YouTube video URL to the clipboard | `needs-triage` | `needs-triage` | `needs-triage` | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
+| `YOUTUBE-F` | Using settings menu, change the video to a new id | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
+| `YOUTUBE-G` | Using settings menu, set the alternative text for YouTube video | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
+| `YOUTUBE-H` | Delete a YouTube video | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
+| `YOUTUBE-I` | Undo the deletion (Ctrl-z) | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed lifecycle workflow family. |
 
 ### `CODEBLOCK`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `CODEBLOCK-B` | Change language to Python | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` code block phase. |
-| `CODEBLOCK-C` | Edit source of CodeBlock to insert a few lines of actual, formatted Python code | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` code block phase. |
-| `CODEBLOCK-D` | Delete the CodeBlock | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
-| `CODEBLOCK-E` | Undo the deletion (ctrl-z) | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CODEBLOCK-B` | Change language to Python | `covered` | `covered` | `covered` | `covered` | `Initial Slice` | `mixed-workflow.spec.ts > MIXED workflow > CODEBLOCK > CODEBLOCK-B/C: Python language and formatted source persist to author preview and delivery`; `codeblock.workflow.yaml` selects Python and the assertion scenario verifies the published result. |
+| `CODEBLOCK-C` | Edit source of CodeBlock to insert a few lines of actual, formatted Python code | `covered` | `covered` | `covered` | `covered` | `Initial Slice` | `mixed-workflow.spec.ts > MIXED workflow > CODEBLOCK > CODEBLOCK-B/C: Python language and formatted source persist to author preview and delivery`; `codeblock.workflow.yaml` writes `print("mixed workflow code block")` and the assertion scenario verifies it in author preview and published delivery. |
+| `CODEBLOCK-D` | Delete the CodeBlock | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
+| `CODEBLOCK-E` | Undo the deletion (ctrl-z) | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 8` | Lifecycle row, separate from insertion coverage. |
 
 ### `VIDEO`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `VIDEO-B` | Add additional video track via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
-| `VIDEO-C` | Add caption track via Settings dialog | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
-| `VIDEO-D` | Set poster image via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
-| `VIDEO-E` | Set size of the video via Settings dialog | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
-| `VIDEO-F` | Delete the video | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
-| `VIDEO-G` | Undo the deletion (ctrl-z) | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `VIDEO-B` | Add additional video track via Settings dialog | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-C` | Add caption track via Settings dialog | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Accessibility workflow family. |
+| `VIDEO-D` | Set poster image via Settings dialog | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-E` | Set size of the video via Settings dialog | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Video settings workflow family. |
+| `VIDEO-F` | Delete the video | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
+| `VIDEO-G` | Undo the deletion (ctrl-z) | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Media lifecycle workflow family. |
 
 ### `WEBPAGE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `WEBPAGE-A` | Insert webpage (iframe) | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
-| `WEBPAGE-B` | Click to open in new tab | `planned` | `Follow-up Slice 5` | New-tab browser behavior plus persist/delivery validation. |
-| `WEBPAGE-C` | Click to copy URL | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
-| `WEBPAGE-D` | Using settings dialog, change the URL | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `WEBPAGE-A` | Insert webpage (iframe) | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed insertion workflow family. |
+| `WEBPAGE-B` | Click to open in new tab | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | New-tab browser behavior plus persist/delivery validation. |
+| `WEBPAGE-C` | Click to copy URL | `needs-triage` | `needs-triage` | `needs-triage` | `needs-triage` | `Follow-up Slice 5` | Clipboard assertions need a stable local strategy. |
+| `WEBPAGE-D` | Using settings dialog, change the URL | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 5` | Embed settings workflow family. |
 
 ### `FORMULA`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `FORMULA-B` | Insert block formula, change type to Latex, and enter valid Latex | `planned` | `Follow-up Slice 7` | Block math workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `FORMULA-B` | Insert block formula, change type to Latex, and enter valid Latex | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Block math workflow family. |
 
 ### `CALLOUT`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `CALLOUT-A` | Insert block callout, enter text | `covered` | `Initial Slice` | Covered by `mixed-workflow.spec.ts` callout phase. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CALLOUT-A` | Insert block callout, enter text | `covered` | `covered` | `covered` | `covered` | `Initial Slice` | `mixed-workflow.spec.ts > MIXED workflow > CALLOUT > CALLOUT-A: block callout text persists to author preview and delivery`; `callout.workflow.yaml` inserts the callout text and the assertion scenario verifies author preview and published delivery. |
 
 ### `DEFINITION`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `DEFINITION-B` | Click edit and change the term, add multiple definitions, a translation and a pronunciation | `planned` | `Follow-up Slice 7` | Definition editing workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `DEFINITION-B` | Click edit and change the term, add multiple definitions, a translation and a pronunciation | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Definition editing workflow family. |
 
 ### `FIGURE`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `FIGURE-B` | Edit Figure title | `planned` | `Follow-up Slice 4` | Figure settings workflow family. |
-| `FIGURE-C` | Insert other block content within Figure content | `planned` | `Follow-up Slice 4` | Nested-content workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `FIGURE-B` | Edit Figure title | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Figure settings workflow family. |
+| `FIGURE-C` | Insert other block content within Figure content | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Nested-content workflow family. |
 
 ### `DIALOG`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `DIALOG-B` | Edit dialog title | `planned` | `Follow-up Slice 6` | Dialog editing workflow family. |
-| `DIALOG-C` | Add a speaker | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
-| `DIALOG-D` | Associate an image with a speaker | `planned` | `Follow-up Slice 6` | Dialog media workflow family. |
-| `DIALOG-E` | Delete a speaker | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
-| `DIALOG-F` | Edit a speaker label | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
-| `DIALOG-G` | Add a dialog line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
-| `DIALOG-H` | Edit the text within speaker line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
-| `DIALOG-I` | Add content element within speaker line | `planned` | `Follow-up Slice 6` | Dialog nested-content workflow family. |
-| `DIALOG-J` | Toggle the speaker associated with a line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
-| `DIALOG-K` | Add a second line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
-| `DIALOG-L` | Delete line | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `DIALOG-B` | Edit dialog title | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog editing workflow family. |
+| `DIALOG-C` | Add a speaker | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-D` | Associate an image with a speaker | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog media workflow family. |
+| `DIALOG-E` | Delete a speaker | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-F` | Edit a speaker label | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog speaker workflow family. |
+| `DIALOG-G` | Add a dialog line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-H` | Edit the text within speaker line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-I` | Add content element within speaker line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog nested-content workflow family. |
+| `DIALOG-J` | Toggle the speaker associated with a line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-K` | Add a second line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
+| `DIALOG-L` | Delete line | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Dialog line workflow family. |
 
 ### `CONJUGATION`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `CONJUGATION-B` | Edit title | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
-| `CONJUGATION-C` | Edit verb | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
-| `CONJUGATION-D` | Edit pronunciation | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
-| `CONJUGATION-E` | Edit conjugation table headers (singular, plural) | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
-| `CONJUGATION-F` | Edit conjugate content | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
-| `CONJUGATION-G` | Edit conjugate pronouns | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
-| `CONJUGATION-H` | Associate audio clip with conjugate | `planned` | `Follow-up Slice 6` | Conjugation media workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `CONJUGATION-B` | Edit title | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-C` | Edit verb | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-D` | Edit pronunciation | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation editing workflow family. |
+| `CONJUGATION-E` | Edit conjugation table headers (singular, plural) | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-F` | Edit conjugate content | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-G` | Edit conjugate pronouns | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation table workflow family. |
+| `CONJUGATION-H` | Associate audio clip with conjugate | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 6` | Conjugation media workflow family. |
 
 ### `DESCRIPTIONLIST`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `DESCRIPTIONLIST-B` | Edit Description List title | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
-| `DESCRIPTIONLIST-C` | Edit default term and description | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
-| `DESCRIPTIONLIST-D` | Add term | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
-| `DESCRIPTIONLIST-E` | Add multiple definitions | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `DESCRIPTIONLIST-B` | Edit Description List title | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
+| `DESCRIPTIONLIST-C` | Edit default term and description | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Description-list editing workflow family. |
+| `DESCRIPTIONLIST-D` | Add term | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
+| `DESCRIPTIONLIST-E` | Add multiple definitions | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Description-list structure workflow family. |
 
 ### `THEOREM`
 
-| Row | Spreadsheet Behavior | Workflow Status | Target Slice | Workflow Test / Notes |
-| --- | --- | --- | --- | --- |
-| `THEOREM-B` | Edit title, statement, proof | `planned` | `Follow-up Slice 7` | Theorem editing workflow family. |
+| Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `THEOREM-B` | Edit title, statement, proof | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 7` | Theorem editing workflow family. |

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
@@ -121,11 +121,11 @@ These slices are coverage batches, not implementation phases.
 
 | Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `IMAGE-B` | Insert a block image. In media manager, upload both a PNG and JPG image. Select the PNG | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media insertion workflow family. |
-| `IMAGE-C` | Change the image to the JPG | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media replacement workflow family. |
-| `IMAGE-D` | Enter a caption | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Image caption workflow family. |
-| `IMAGE-E` | Using image settings, specify alternate text | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Accessibility workflow family. |
-| `IMAGE-F` | Using image settings, define a custom width | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Media settings workflow family. |
+| `IMAGE-B` | Insert a block image. In media manager, upload both a PNG and JPG image. Select the PNG | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `IMAGE-B/C/D/E/F` in `image.workflow.yaml`; uploads JPG then PNG, inserts JPG, and replaces it with PNG so the final authored image is PNG. This intentionally reverses the spreadsheet's B/C order while covering the same insertion and replacement capabilities. |
+| `IMAGE-C` | Change the image to the JPG | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `IMAGE-B/C/D/E/F` in `image.workflow.yaml`; covers image replacement in the agreed reverse order (JPG → PNG), with final PNG asserted in Preview and Delivery. |
+| `IMAGE-D` | Enter a caption | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `IMAGE-B/C/D/E/F` in `image.workflow.yaml`; asserts caption in Preview and Delivery. Verified in Playwright. |
+| `IMAGE-E` | Using image settings, specify alternate text | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `IMAGE-B/C/D/E/F` in `image.workflow.yaml`; asserts alternative text in Preview and Delivery. Verified in Playwright. |
+| `IMAGE-F` | Using image settings, define a custom width | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `IMAGE-B/C/D/E/F` in `image.workflow.yaml`; asserts rendered width in Preview and numeric width in Delivery. Verified in Playwright. |
 
 ### `YOUTUBE`
 
@@ -191,8 +191,8 @@ These slices are coverage batches, not implementation phases.
 
 | Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `FIGURE-B` | Edit Figure title | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Figure settings workflow family. |
-| `FIGURE-C` | Insert other block content within Figure content | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 4` | Nested-content workflow family. |
+| `FIGURE-B` | Edit Figure title | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `FIGURE-B/C` in `figure.workflow.yaml`; asserts title in Preview and Delivery. Verified in Playwright. |
+| `FIGURE-C` | Insert other block content within Figure content | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 4` | `FIGURE-B/C` in `figure.workflow.yaml`; inserts nested content and asserts it in Preview and Delivery. Verified in Playwright. |
 
 ### `DIALOG`
 

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
@@ -109,13 +109,13 @@ These slices are coverage batches, not implementation phases.
 
 | Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `TABLE-B` | Add a column | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-C` | Add a row | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-D` | Toggle a cell to be a header | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table semantics workflow family. |
-| `TABLE-E` | Merge the contents of two cells | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table structure workflow family. |
-| `TABLE-F` | Change the alignment of one cell | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table formatting workflow family. |
-| `TABLE-G` | Create a second table with four rows and set row style set to Alternating | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table style workflow family. |
-| `TABLE-H` | Create a third table with border style set to Hidden | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 3` | Table style workflow family. |
+| `TABLE-B` | Add a column | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-B/C/D/E/F` in `table-structure.workflow.yaml`; Preview verifies three cells in the first row and Delivery verifies the table row structure. Verified in Playwright. |
+| `TABLE-C` | Add a row | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-B/C/D/E/F` in `table-structure.workflow.yaml`; Preview and Delivery assert a three-row table. Verified in Playwright. |
+| `TABLE-D` | Toggle a cell to be a header | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-B/C/D/E/F` in `table-structure.workflow.yaml`; Preview asserts `th` and Delivery asserts `type: th`. Verified in Playwright. |
+| `TABLE-E` | Merge the contents of two cells | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-B/C/D/E/F` in `table-structure.workflow.yaml`; Preview and Delivery assert the merged cell's `colspan: 2`. Verified in Playwright. |
+| `TABLE-F` | Change the alignment of one cell | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-B/C/D/E/F` in `table-structure.workflow.yaml`; Preview asserts `.text-center` and Delivery asserts `align: center`. Verified in Playwright. |
+| `TABLE-G` | Create a second table with four rows and set row style set to Alternating | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-G/H` in `table-styles.workflow.yaml`; creates a baseline first table, then a four-row second table; Preview asserts `table-striped` and Delivery asserts `rowstyle: alternating`. Verified in Playwright. |
+| `TABLE-H` | Create a third table with border style set to Hidden | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 3` | `TABLE-G/H` in `table-styles.workflow.yaml`; creates a baseline first table and alternating second table before the hidden-border third table; Preview asserts `table-borderless` and Delivery asserts `border: hidden`. Verified in Playwright. |
 
 ### `IMAGE`
 

--- a/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md
@@ -82,28 +82,28 @@ These slices are coverage batches, not implementation phases.
 
 | Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `INLINE-C` | Apply bold | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-D` | Apply italic | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-E` | Apply code | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-F` | Create hyperlink to another page in the course | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
-| `INLINE-G` | Create hyperlink to an external site | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline link workflow family. |
-| `INLINE-I` | Apply underline | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-J` | Apply strikethrough | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-K` | Apply subscript | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-L` | Apply superscript | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline formatting workflow family. |
-| `INLINE-M` | Apply term | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
-| `INLINE-N` | Apply foreign. Select a language | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline semantic-markup workflow family. |
-| `INLINE-O` | Apply popup content | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Inline popup workflow family. |
-| `INLINE-R` | Apply inline callout | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Distinct from block callout in `CALLOUT-A`. |
-| `INLINE-S` | Change text to be a heading | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Block-format workflow family. |
-| `INLINE-T` | Change text direction | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | Directionality workflow family. |
+| `INLINE-C` | Apply bold | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-D` | Apply italic | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-E` | Apply code | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-F` | Create hyperlink to another page in the course | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-F` in `inline-internal-link.workflow.yaml`; selected course-page target is asserted in Preview and Delivery. |
+| `INLINE-G` | Create hyperlink to an external site | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-G` in `inline-external-link.workflow.yaml`; external URL and link text are asserted in Preview and Delivery. |
+| `INLINE-I` | Apply underline | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-J` | Apply strikethrough | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-K` | Apply subscript | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-L` | Apply superscript | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-M` | Apply term | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; exact mark is asserted in Preview and published Delivery. |
+| `INLINE-N` | Apply foreign. Select a language | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-N` in `inline-foreign.workflow.yaml`; Arabic foreign element is asserted in Preview and published Delivery. |
+| `INLINE-O` | Apply popup content | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-O` in `inline-popup.workflow.yaml`; trigger is asserted in Preview and popup content in published Delivery. |
+| `INLINE-R` | Apply inline callout | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-R` in `inline-callout.workflow.yaml`; inline callout is asserted in Preview and published Delivery. |
+| `INLINE-S` | Change text to be a heading | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; heading structure is asserted in Preview and published Delivery. |
+| `INLINE-T` | Change text direction | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `INLINE-C/D/E/I/J/K/L/M/S/T` in `inline-formatting.workflow.yaml`; RTL direction is asserted in Preview and published Delivery. |
 
 ### `LIST`
 
 | Row | Spreadsheet Behavior | A: Editing | B: Persisted | C: Preview | D: Delivery | Target Slice | Workflow Test / Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `LIST-C` | Customize the bullet style of one of the lists | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
-| `LIST-D` | Indent one of the list items | `planned` | `planned` | `planned` | `planned` | `Follow-up Slice 2` | List formatting workflow family. |
+| `LIST-C` | Customize the bullet style of one of the lists | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `LIST-C/D` in `list-formatting.workflow.yaml`; circle bullet style is asserted in Preview and published Delivery. |
+| `LIST-D` | Indent one of the list items | `covered` | `covered` | `covered` | `covered` | `Follow-up Slice 2` | `LIST-C/D` in `list-formatting.workflow.yaml`; nested-list indentation is asserted in Preview and published Delivery. |
 
 ### `TABLE`
 

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -75,6 +75,18 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
   end
 
   @doc """
+  Asserts that the text entered for the CORE-A workflow appears in author preview.
+  """
+  def assert_author_preview_core_text_editing(%ExecutionState{} = state) do
+    state
+    |> author_preview_html()
+    |> html_text()
+    |> assert_contains(required_param!(state, "EXPECTED_TYPED_TEXT"))
+
+    state
+  end
+
+  @doc """
   Asserts that the published delivery revision contains the expected code block content.
   """
   def assert_student_delivery_codeblock(%ExecutionState{} = state) do
@@ -82,6 +94,18 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
 
     assert nested_contains?(content, state.params["EXPECTED_CODEBLOCK_CAPTION"])
     assert nested_contains?(content, state.params["EXPECTED_CODEBLOCK_CODE"])
+
+    state
+  end
+
+  @doc """
+  Asserts that the text entered for the CORE-A workflow persists to published delivery content.
+  """
+  def assert_student_delivery_core_text_editing(%ExecutionState{} = state) do
+    assert nested_contains?(
+             delivered_revision_content(state),
+             required_param!(state, "EXPECTED_TYPED_TEXT")
+           )
 
     state
   end

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -111,6 +111,160 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
   end
 
   @doc """
+  Asserts that inline marks plus block format/direction render in author preview.
+  """
+  def assert_author_preview_inline_formatting(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+
+    expected_inline_formatting!(state)
+    |> Enum.each(fn expected ->
+      assert_preview_formatting!(html, expected)
+    end)
+
+    state
+  end
+
+  @doc """
+  Asserts that inline marks plus block format/direction persist to delivery.
+  """
+  def assert_student_delivery_inline_formatting(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+
+    expected_inline_formatting!(state)
+    |> Enum.each(fn expected ->
+      assert_delivery_formatting!(content, expected)
+    end)
+
+    state
+  end
+
+  def assert_author_preview_inline_link(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    link_text = required_param!(state, "EXPECTED_LINK_TEXT")
+    link_type = required_param!(state, "EXPECTED_LINK_TYPE")
+
+    case link_type do
+      "url" ->
+        href = required_param!(state, "EXPECTED_LINK_HREF")
+
+        assert html_has_text?(html, ~s|a[href="#{href}"]|, link_text),
+               "Expected external author-preview link #{inspect(href)}"
+
+      "page" ->
+        href = required_param!(state, "EXPECTED_LINK_HREF")
+
+        assert html_has_link_to_target?(html, href, link_text),
+               "Expected internal author-preview link #{inspect(link_text)}"
+    end
+
+    state
+  end
+
+  def assert_student_delivery_inline_link(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    link_text = required_param!(state, "EXPECTED_LINK_TEXT")
+    link_type = required_param!(state, "EXPECTED_LINK_TYPE")
+
+    expected_link? =
+      case link_type do
+        "url" ->
+          href = required_param!(state, "EXPECTED_LINK_HREF")
+          &(&1["type"] == "a" and &1["href"] == href and nested_contains?(&1, link_text))
+
+        "page" ->
+          href = required_param!(state, "EXPECTED_LINK_HREF")
+
+          &(&1["type"] == "a" and &1["linkType"] == "page" and &1["href"] == href and
+              nested_contains?(&1, link_text))
+      end
+
+    assert nested_map?(content, expected_link?),
+           "Expected published #{link_type} link #{inspect(link_text)}"
+
+    state
+  end
+
+  def assert_author_preview_inline_embeds(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+
+    for key <- ["EXPECTED_FOREIGN_TEXT", "EXPECTED_POPUP_TRIGGER", "EXPECTED_CALLOUT_TEXT"] do
+      assert_contains(html_text(html), required_param!(state, key))
+    end
+
+    state
+  end
+
+  def assert_student_delivery_inline_embeds(%ExecutionState{} = state) do
+    published_json = delivered_revision_content(state) |> Jason.encode!()
+
+    for {type, text} <- [
+          {"foreign", required_param!(state, "EXPECTED_FOREIGN_TEXT")},
+          {"popup", required_param!(state, "EXPECTED_POPUP_CONTENT")},
+          {"callout_inline", required_param!(state, "EXPECTED_CALLOUT_TEXT")}
+        ] do
+      assert published_json =~ ~s|"type":"#{type}"|
+      assert published_json =~ text
+    end
+
+    state
+  end
+
+  def assert_author_preview_inline_foreign(%ExecutionState{} = state),
+    do: assert_preview_text(state, "EXPECTED_TEXT")
+
+  def assert_author_preview_inline_popup(%ExecutionState{} = state),
+    do: assert_preview_text(state, "EXPECTED_TRIGGER")
+
+  def assert_author_preview_inline_callout(%ExecutionState{} = state),
+    do: assert_preview_text(state, "EXPECTED_TEXT")
+
+  def assert_student_delivery_inline_foreign(%ExecutionState{} = state),
+    do: assert_delivery_element_text(state, "foreign", "EXPECTED_TEXT")
+
+  def assert_student_delivery_inline_popup(%ExecutionState{} = state),
+    do: assert_delivery_element_text(state, "popup", "EXPECTED_CONTENT")
+
+  def assert_student_delivery_inline_callout(%ExecutionState{} = state),
+    do: assert_delivery_element_text(state, "callout_inline", "EXPECTED_TEXT")
+
+  def assert_author_preview_list_formatting(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    styled_item = required_param!(state, "EXPECTED_STYLED_LIST_ITEM")
+    indented_item = required_param!(state, "EXPECTED_INDENTED_LIST_ITEM")
+
+    assert html_has_text?(html, "ul", styled_item), "Expected styled item in author-preview list"
+
+    assert html_has_text?(html, "ul ul", indented_item),
+           "Expected indented item in nested author-preview list"
+
+    state
+  end
+
+  def assert_student_delivery_list_formatting(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    styled_item = required_param!(state, "EXPECTED_STYLED_LIST_ITEM")
+    indented_item = required_param!(state, "EXPECTED_INDENTED_LIST_ITEM")
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "ul" and &1["style"] == "circle" and
+                 nested_contains?(&1, styled_item))
+           ),
+           "Expected published circle-style list item"
+
+    assert nested_map?(content, fn node ->
+             node["type"] == "ul" and
+               nested_map?(
+                 node["children"] || [],
+                 &(&1["type"] == "ul" and nested_contains?(&1, indented_item))
+               )
+           end),
+           "Expected published nested list item"
+
+    state
+  end
+
+  @doc """
   Asserts that the author preview renders the expected callout content.
   """
   def assert_author_preview_callout(%ExecutionState{} = state) do
@@ -263,6 +417,103 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     |> Plug.Conn.put_session(:author_token, token)
     |> Plug.Conn.put_session(:current_author_id, author.id)
   end
+
+  defp expected_inline_formatting!(state) do
+    state
+    |> required_param!("EXPECTED_INLINE_FORMATTING")
+    |> Jason.decode!()
+  end
+
+  defp assert_preview_formatting!(html, %{"text" => text, "mark" => mark}) do
+    selector =
+      case mark do
+        "strong" -> "strong"
+        "em" -> "em"
+        "code" -> "code"
+        "underline" -> ~s|span[style*="underline"]|
+        "strikethrough" -> ~s|span[style*="line-through"]|
+        "sub" -> "sub"
+        "sup" -> "sup"
+        "term" -> ".term"
+      end
+
+    assert html_has_text?(html, selector, text),
+           "Expected author preview #{selector} to contain #{inspect(text)}"
+  end
+
+  defp assert_preview_formatting!(html, %{"text" => text, "element" => element}) do
+    selector = if element == "heading", do: "h1, h2, h3, h4, h5, h6", else: element
+
+    assert html_has_text?(html, selector, text),
+           "Expected author preview #{element} to contain #{inspect(text)}"
+  end
+
+  defp assert_preview_formatting!(html, %{"text" => text, "direction" => "rtl"}) do
+    assert html_has_text?(html, "[dir=rtl]", text),
+           "Expected right-to-left author preview content #{inspect(text)}"
+  end
+
+  defp assert_delivery_formatting!(content, %{"text" => text, "mark" => mark}) do
+    assert nested_map?(content, &(&1["text"] == text and &1[mark] == true)),
+           "Expected delivery content #{inspect(text)} with #{mark} mark"
+  end
+
+  defp assert_delivery_formatting!(content, %{"text" => text, "element" => element}) do
+    matches_element? = fn node ->
+      node["type"] == element or
+        (element == "heading" and is_binary(node["type"]) and
+           String.match?(node["type"], ~r/^h[1-6]$/))
+    end
+
+    assert nested_map?(content, &(matches_element?.(&1) and nested_contains?(&1, text))),
+           "Expected delivery #{element} containing #{inspect(text)}"
+  end
+
+  defp assert_delivery_formatting!(content, %{"text" => text, "direction" => "rtl"}) do
+    assert nested_map?(content, &(&1["textDirection"] == "rtl" and nested_contains?(&1, text))),
+           "Expected right-to-left delivery content #{inspect(text)}"
+  end
+
+  defp html_has_text?(html, selector, text) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(selector)
+    |> Floki.text(sep: " ")
+    |> String.contains?(text)
+  end
+
+  defp assert_preview_text(state, key) do
+    assert_contains(html_text(author_preview_html(state)), required_param!(state, key))
+    state
+  end
+
+  defp assert_delivery_element_text(state, type, key) do
+    published_json = delivered_revision_content(state) |> Jason.encode!()
+    assert published_json =~ ~s|"type":"#{type}"|
+    assert published_json =~ required_param!(state, key)
+    state
+  end
+
+  defp html_has_link_to_target?(html, target_href, text) do
+    target_slug = Path.basename(target_href)
+
+    html
+    |> Floki.parse_document!()
+    |> Floki.find("a")
+    |> Enum.any?(fn anchor ->
+      href = Floki.attribute(anchor, "href") |> List.first() || ""
+      String.ends_with?(href, target_slug) and Floki.text(anchor) =~ text
+    end)
+  end
+
+  defp nested_map?(value, predicate) when is_map(value) do
+    predicate.(value) or Enum.any?(Map.values(value), &nested_map?(&1, predicate))
+  end
+
+  defp nested_map?(value, predicate) when is_list(value),
+    do: Enum.any?(value, &nested_map?(&1, predicate))
+
+  defp nested_map?(_, _predicate), do: false
 
   defp nested_contains?(value, expected) when is_binary(expected) and expected != "" do
     case value do

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -138,6 +138,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that an inline link renders with the expected target in author preview.
+  """
   def assert_author_preview_inline_link(%ExecutionState{} = state) do
     html = author_preview_html(state)
     link_text = required_param!(state, "EXPECTED_LINK_TEXT")
@@ -160,6 +163,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that an inline link preserves its type, target, and text in delivery content.
+  """
   def assert_student_delivery_inline_link(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
     link_text = required_param!(state, "EXPECTED_LINK_TEXT")
@@ -184,49 +190,45 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
-  def assert_author_preview_inline_embeds(%ExecutionState{} = state) do
-    html = author_preview_html(state)
-
-    for key <- ["EXPECTED_FOREIGN_TEXT", "EXPECTED_POPUP_TRIGGER", "EXPECTED_CALLOUT_TEXT"] do
-      assert_contains(html_text(html), required_param!(state, key))
-    end
-
-    state
-  end
-
-  def assert_student_delivery_inline_embeds(%ExecutionState{} = state) do
-    published_json = delivered_revision_content(state) |> Jason.encode!()
-
-    for {type, text} <- [
-          {"foreign", required_param!(state, "EXPECTED_FOREIGN_TEXT")},
-          {"popup", required_param!(state, "EXPECTED_POPUP_CONTENT")},
-          {"callout_inline", required_param!(state, "EXPECTED_CALLOUT_TEXT")}
-        ] do
-      assert published_json =~ ~s|"type":"#{type}"|
-      assert published_json =~ text
-    end
-
-    state
-  end
-
+  @doc """
+  Asserts that inline foreign text renders in author preview.
+  """
   def assert_author_preview_inline_foreign(%ExecutionState{} = state),
     do: assert_preview_text(state, "EXPECTED_TEXT")
 
+  @doc """
+  Asserts that an inline popup trigger renders in author preview.
+  """
   def assert_author_preview_inline_popup(%ExecutionState{} = state),
     do: assert_preview_text(state, "EXPECTED_TRIGGER")
 
+  @doc """
+  Asserts that an inline callout renders in author preview.
+  """
   def assert_author_preview_inline_callout(%ExecutionState{} = state),
     do: assert_preview_text(state, "EXPECTED_TEXT")
 
+  @doc """
+  Asserts that inline foreign text persists in delivery content.
+  """
   def assert_student_delivery_inline_foreign(%ExecutionState{} = state),
     do: assert_delivery_element_text(state, "foreign", "EXPECTED_TEXT")
 
+  @doc """
+  Asserts that inline popup content persists in delivery content.
+  """
   def assert_student_delivery_inline_popup(%ExecutionState{} = state),
     do: assert_delivery_element_text(state, "popup", "EXPECTED_CONTENT")
 
+  @doc """
+  Asserts that an inline callout persists in delivery content.
+  """
   def assert_student_delivery_inline_callout(%ExecutionState{} = state),
     do: assert_delivery_element_text(state, "callout_inline", "EXPECTED_TEXT")
 
+  @doc """
+  Asserts that list style and nesting render in author preview.
+  """
   def assert_author_preview_list_formatting(%ExecutionState{} = state) do
     html = author_preview_html(state)
     styled_item = required_param!(state, "EXPECTED_STYLED_LIST_ITEM")
@@ -240,6 +242,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that list style and nesting persist in delivery content.
+  """
   def assert_student_delivery_list_formatting(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
     styled_item = required_param!(state, "EXPECTED_STYLED_LIST_ITEM")
@@ -264,6 +269,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that table structure and cell formatting render in author preview.
+  """
   def assert_author_preview_table_structure(%ExecutionState{} = state) do
     html = author_preview_html(state)
     header_text = required_param!(state, "EXPECTED_HEADER_TEXT")
@@ -290,6 +298,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that table structure and cell formatting persist in delivery content.
+  """
   def assert_student_delivery_table_structure(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
     header_text = required_param!(state, "EXPECTED_HEADER_TEXT")
@@ -318,6 +329,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that table row and border styles render in author preview.
+  """
   def assert_author_preview_table_styles(%ExecutionState{} = state) do
     html = author_preview_html(state)
     alternating_text = required_param!(state, "EXPECTED_ALTERNATING_TEXT")
@@ -332,6 +346,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that table row and border styles persist in delivery content.
+  """
   def assert_student_delivery_table_styles(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
     alternating_text = required_param!(state, "EXPECTED_ALTERNATING_TEXT")
@@ -352,18 +369,30 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that image selection and settings render in author preview.
+  """
   def assert_author_preview_image_workflow(%ExecutionState{} = state) do
     html = author_preview_html(state)
     image = required_param!(state, "EXPECTED_IMAGE")
     caption = required_param!(state, "EXPECTED_CAPTION")
     alt = required_param!(state, "EXPECTED_ALT")
     width = required_param!(state, "EXPECTED_WIDTH")
-    assert html_has_text?(html, ~s|img[src*="#{image}"][alt="#{alt}"]|, "")
+
+    assert html_has_selector?(html, ~s|img[src*="#{image}"][alt="#{alt}"]|),
+           "Expected author-preview image #{inspect(image)} with alternative text"
+
     assert html_has_text?(html, ".figure-caption", caption)
-    assert html_has_text?(html, ~s|img[src*="#{image}"][style*="#{width}"]|, "")
+
+    assert html_has_selector?(html, ~s|img[src*="#{image}"][width="#{width}"]|),
+           "Expected author-preview image #{inspect(image)} with width #{inspect(width)}"
+
     state
   end
 
+  @doc """
+  Asserts that image selection and settings persist in delivery content.
+  """
   def assert_student_delivery_image_workflow(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
 
@@ -373,12 +402,16 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
                  String.contains?(&1["src"] || "", required_param!(state, "EXPECTED_IMAGE")) and
                  &1["alt"] == required_param!(state, "EXPECTED_ALT") and
                  &1["width"] == String.to_integer(required_param!(state, "EXPECTED_WIDTH")))
-           )
+           ),
+           "Expected published image with selected source, alternative text, and width"
 
     assert nested_contains?(content, required_param!(state, "EXPECTED_CAPTION"))
     state
   end
 
+  @doc """
+  Asserts that a figure title and nested content render in author preview.
+  """
   def assert_author_preview_figure_workflow(%ExecutionState{} = state) do
     html = author_preview_html(state)
     assert html_has_text?(html, ".figure figcaption", required_param!(state, "EXPECTED_TITLE"))
@@ -392,6 +425,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  @doc """
+  Asserts that a figure title and nested content persist in delivery content.
+  """
   def assert_student_delivery_figure_workflow(%ExecutionState{} = state) do
     content = delivered_revision_content(state)
 
@@ -621,6 +657,13 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     |> Floki.find(selector)
     |> Floki.text(sep: " ")
     |> String.contains?(text)
+  end
+
+  defp html_has_selector?(html, selector) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(selector)
+    |> Enum.any?()
   end
 
   defp assert_preview_text(state, key) do

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -264,6 +264,94 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  def assert_author_preview_table_structure(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    header_text = required_param!(state, "EXPECTED_HEADER_TEXT")
+    merged_text = required_param!(state, "EXPECTED_MERGED_TEXT")
+    aligned_text = required_param!(state, "EXPECTED_ALIGNED_TEXT")
+
+    assert html_has_text?(html, "table th", header_text), "Expected author-preview table header"
+
+    assert html_has_text?(html, "table [colspan=\"2\"]", merged_text),
+           "Expected author-preview merged table cells"
+
+    assert html_has_text?(html, "table .text-center", aligned_text),
+           "Expected author-preview centered table cell"
+
+    assert html |> Floki.parse_document!() |> Floki.find("table tr") |> length() >= 3,
+           "Expected author-preview table to contain the added row"
+
+    assert html
+           |> Floki.parse_document!()
+           |> Floki.find("table tr:first-child td, table tr:first-child th")
+           |> length() >= 3,
+           "Expected author-preview table to contain the added column"
+
+    state
+  end
+
+  def assert_student_delivery_table_structure(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    header_text = required_param!(state, "EXPECTED_HEADER_TEXT")
+    merged_text = required_param!(state, "EXPECTED_MERGED_TEXT")
+    aligned_text = required_param!(state, "EXPECTED_ALIGNED_TEXT")
+
+    assert nested_map?(content, &(&1["type"] == "table" and length(&1["children"] || []) >= 3)),
+           "Expected published table to contain the added row"
+
+    assert nested_map?(content, &(&1["type"] == "th" and nested_contains?(&1, header_text))),
+           "Expected published table header"
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "td" and &1["colspan"] == 2 and nested_contains?(&1, merged_text))
+           ),
+           "Expected published merged table cells"
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "td" and &1["align"] == "center" and
+                 nested_contains?(&1, aligned_text))
+           ),
+           "Expected published centered table cell"
+
+    state
+  end
+
+  def assert_author_preview_table_styles(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    alternating_text = required_param!(state, "EXPECTED_ALTERNATING_TEXT")
+    hidden_border_text = required_param!(state, "EXPECTED_HIDDEN_BORDER_TEXT")
+
+    assert html_has_text?(html, "table.table-striped", alternating_text),
+           "Expected author-preview alternating-row table"
+
+    assert html_has_text?(html, "table.table-borderless", hidden_border_text),
+           "Expected author-preview hidden-border table"
+
+    state
+  end
+
+  def assert_student_delivery_table_styles(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    alternating_text = required_param!(state, "EXPECTED_ALTERNATING_TEXT")
+    hidden_border_text = required_param!(state, "EXPECTED_HIDDEN_BORDER_TEXT")
+
+    assert nested_map?(content, fn node ->
+             node["type"] == "table" and node["rowstyle"] == "alternating" and
+               length(node["children"] || []) == 4 and nested_contains?(node, alternating_text)
+           end),
+           "Expected published four-row alternating table"
+
+    assert nested_map?(content, fn node ->
+             node["type"] == "table" and node["border"] == "hidden" and
+               nested_contains?(node, hidden_border_text)
+           end),
+           "Expected published hidden-border table"
+
+    state
+  end
+
   @doc """
   Asserts that the author preview renders the expected callout content.
   """

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -155,8 +155,9 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
 
       "page" ->
         href = required_param!(state, "EXPECTED_LINK_HREF")
+        project_slug = fetch_project!(state).project.slug
 
-        assert html_has_link_to_target?(html, href, link_text),
+        assert html_has_link_to_target?(html, href, project_slug, link_text),
                "Expected internal author-preview link #{inspect(link_text)}"
     end
 
@@ -197,10 +198,21 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     do: assert_preview_text(state, "EXPECTED_TEXT")
 
   @doc """
-  Asserts that an inline popup trigger renders in author preview.
+  Asserts that an inline popup trigger is passed to the author-preview React renderer.
   """
-  def assert_author_preview_inline_popup(%ExecutionState{} = state),
-    do: assert_preview_text(state, "EXPECTED_TRIGGER")
+  def assert_author_preview_inline_popup(%ExecutionState{} = state) do
+    trigger = required_param!(state, "EXPECTED_TRIGGER")
+
+    assert html_has_attribute_text?(
+             author_preview_html(state),
+             ~s|[data-react-class="Components.DeliveryElementRenderer"]|,
+             "data-react-props",
+             trigger
+           ),
+           "Expected author-preview popup renderer to receive #{inspect(trigger)}"
+
+    state
+  end
 
   @doc """
   Asserts that an inline callout renders in author preview.
@@ -666,28 +678,50 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     |> Enum.any?()
   end
 
+  defp html_has_attribute_text?(html, selector, attribute, text) do
+    html
+    |> Floki.parse_document!()
+    |> Floki.find(selector)
+    |> Enum.any?(fn element ->
+      element
+      |> Floki.attribute(attribute)
+      |> Enum.any?(&String.contains?(&1, text))
+    end)
+  end
+
   defp assert_preview_text(state, key) do
     assert_contains(html_text(author_preview_html(state)), required_param!(state, key))
     state
   end
 
   defp assert_delivery_element_text(state, type, key) do
-    published_json = delivered_revision_content(state) |> Jason.encode!()
-    assert published_json =~ ~s|"type":"#{type}"|
-    assert published_json =~ required_param!(state, key)
+    content = delivered_revision_content(state)
+    text = required_param!(state, key)
+
+    assert nested_map?(content, &(&1["type"] == type and nested_contains?(&1, text))),
+           "Expected published #{type} element containing #{inspect(text)}"
+
     state
   end
 
-  defp html_has_link_to_target?(html, target_href, text) do
-    target_slug = Path.basename(target_href)
+  defp html_has_link_to_target?(html, target_href, project_slug, text) do
+    expected_path = author_preview_link_path(target_href, project_slug)
 
     html
     |> Floki.parse_document!()
     |> Floki.find("a")
     |> Enum.any?(fn anchor ->
       href = Floki.attribute(anchor, "href") |> List.first() || ""
-      String.ends_with?(href, target_slug) and Floki.text(anchor) =~ text
+      URI.parse(href).path == expected_path and Floki.text(anchor) =~ text
     end)
+  end
+
+  defp author_preview_link_path("/course/link/" <> revision_slug, project_slug)
+       when revision_slug != "",
+       do: "/authoring/project/#{project_slug}/preview/#{revision_slug}"
+
+  defp author_preview_link_path(target_href, _project_slug) do
+    raise "Expected internal course link, got: #{inspect(target_href)}"
   end
 
   defp nested_map?(value, predicate) when is_map(value) do

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -352,6 +352,59 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     state
   end
 
+  def assert_author_preview_image_workflow(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    image = required_param!(state, "EXPECTED_IMAGE")
+    caption = required_param!(state, "EXPECTED_CAPTION")
+    alt = required_param!(state, "EXPECTED_ALT")
+    width = required_param!(state, "EXPECTED_WIDTH")
+    assert html_has_text?(html, ~s|img[src*="#{image}"][alt="#{alt}"]|, "")
+    assert html_has_text?(html, ".figure-caption", caption)
+    assert html_has_text?(html, ~s|img[src*="#{image}"][style*="#{width}"]|, "")
+    state
+  end
+
+  def assert_student_delivery_image_workflow(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "img" and
+                 String.contains?(&1["src"] || "", required_param!(state, "EXPECTED_IMAGE")) and
+                 &1["alt"] == required_param!(state, "EXPECTED_ALT") and
+                 &1["width"] == String.to_integer(required_param!(state, "EXPECTED_WIDTH")))
+           )
+
+    assert nested_contains?(content, required_param!(state, "EXPECTED_CAPTION"))
+    state
+  end
+
+  def assert_author_preview_figure_workflow(%ExecutionState{} = state) do
+    html = author_preview_html(state)
+    assert html_has_text?(html, ".figure figcaption", required_param!(state, "EXPECTED_TITLE"))
+
+    assert html_has_text?(
+             html,
+             ".figure .figure-content",
+             required_param!(state, "EXPECTED_CONTENT")
+           )
+
+    state
+  end
+
+  def assert_student_delivery_figure_workflow(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "figure" and
+                 nested_contains?(&1, required_param!(state, "EXPECTED_TITLE")) and
+                 nested_contains?(&1, required_param!(state, "EXPECTED_CONTENT")))
+           )
+
+    state
+  end
+
   @doc """
   Asserts that the author preview renders the expected callout content.
   """

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -221,10 +221,21 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
     do: assert_preview_text(state, "EXPECTED_TEXT")
 
   @doc """
-  Asserts that inline foreign text persists in delivery content.
+  Asserts that inline foreign text and its selected language persist in delivery content.
   """
-  def assert_student_delivery_inline_foreign(%ExecutionState{} = state),
-    do: assert_delivery_element_text(state, "foreign", "EXPECTED_TEXT")
+  def assert_student_delivery_inline_foreign(%ExecutionState{} = state) do
+    content = delivered_revision_content(state)
+    text = required_param!(state, "EXPECTED_TEXT")
+    lang = required_param!(state, "EXPECTED_LANG")
+
+    assert nested_map?(
+             content,
+             &(&1["type"] == "foreign" and &1["lang"] == lang and nested_contains?(&1, text))
+           ),
+           "Expected published foreign element containing #{inspect(text)} with lang #{inspect(lang)}"
+
+    state
+  end
 
   @doc """
   Asserts that inline popup content persists in delivery content.

--- a/lib/oli/scenarios/features/mixed_content_hooks.ex
+++ b/lib/oli/scenarios/features/mixed_content_hooks.ex
@@ -349,6 +349,15 @@ defmodule Oli.Scenarios.Features.MixedContentHooks do
            ),
            "Expected published centered table cell"
 
+    assert nested_map?(content, fn
+             %{"type" => "table", "children" => [%{"children" => first_row_cells} | _]} ->
+               length(first_row_cells) >= 3
+
+             _ ->
+               false
+           end),
+           "Expected published table to contain the added column"
+
     state
   end
 


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5416

## Summary

Expands the Playwright plus scenario workflow coverage for the MIXED regression matrix.

This was initially planned as the second implementation part of the work. We decided to split it into Part 2/3 and Part 3/3 because including all remaining matrix rows in one PR would make the review surface and CI diagnosis unnecessarily large.

Part 2/3 adds coverage for:

- CORE text editing.
- INLINE formatting, internal and external links, foreign text, popup content, and inline callouts.
- LIST indentation and bullet styles.
- TABLE structure, cell formatting, alternating rows, and hidden borders.
- IMAGE insertion and replacement, caption, alt text, and width settings.
- FIGURE title and nested content.

The remaining Part 3/3 coverage will address:

- YouTube, video, webpage, and formula workflows.
- CodeBlock follow-up behaviors.
- Definition, dialog, conjugation, description-list, and theorem workflows.
- The two matrix rows currently marked needs-triage.

The [MIXED coverage matrix](https://github.com/Simon-Initiative/oli-torus/blob/MER-5416-automated-basic-page-authored-PART-2/docs/exec-plans/current/epics/automated_testing/mer-5416/mixed_coverage_matrix.md) tracks each spreadsheet row, its Editing/Persisted/Preview/Delivery status, and the associated workflow test.

## Technical Notes

- Keeps the scenario to Playwright authoring to scenario assertions pattern established in Part 1.
- Adds focused author-preview and published-delivery assertions for each covered workflow group.
- Cleans up obsolete grouped helpers and makes image attribute assertions explicit.

## Validation

- `npm run pw -- tests/torus/course_authoring/mixed-workflow.spec.ts --reporter=line`
- Targeted IMAGE-B/C/D/E/F validation passed after the cleanup.
- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`

## Evidence
<img width="500" height="609" alt="Screenshot 2026-07-22 at 12 33 20 PM" src="https://github.com/user-attachments/assets/08b6d72e-1eae-43ae-b94e-1a351d42867a" />

