### PR TITLE
[BUG FIX] [MER-5836] Fix admin/external tools view timeout

### DIFF
--- a/lib/oli/lti/platform_external_tools.ex
+++ b/lib/oli/lti/platform_external_tools.ex
@@ -236,30 +236,7 @@ defmodule Oli.Lti.PlatformExternalTools do
           query
       end
 
-    platform_instances = Repo.all(query)
-
-    platform_instances_usage_count =
-      platform_instances
-      |> Enum.map(& &1.id)
-      |> get_sections_grouped_by_platform_instance_ids()
-      |> Enum.map(fn {id, sections} -> {id, length(sections)} end)
-      |> Enum.into(%{})
-
-    platform_instances =
-      platform_instances
-      |> Enum.map(fn p ->
-        Map.put(
-          p,
-          :usage_count,
-          Map.get(platform_instances_usage_count, p.id, 0)
-        )
-      end)
-
-    if field == :usage_count do
-      Enum.sort_by(platform_instances, & &1.usage_count, direction)
-    else
-      platform_instances
-    end
+    Repo.all(query)
   end
 
   @doc """
@@ -390,37 +367,24 @@ defmodule Oli.Lti.PlatformExternalTools do
   end
 
   @doc """
-  Fetches all sections that include LTI activities registered under the given list of
-  `platform_instance_ids`, and groups them by platform ID.
+  Counts the distinct sections that use each of the given LTI platform instances.
 
-  ## Example
-
-      iex> get_sections_grouped_by_platform_instance_ids([id1, id2])
-      %{
-        ^id1 => [%Section{...}, ...],
-        ^id2 => [%Section{...}]
-      }
-
-  Returns a map of `platform_instance_id => list_of_sections`.
+  The aggregation is performed by PostgreSQL and returns a map of
+  `platform_instance_id => section_count`. Platform instances without usage are
+  omitted from the map.
   """
-  @spec get_sections_grouped_by_platform_instance_ids([integer()]) ::
-          %{integer() => [Section.t()]}
-  def get_sections_grouped_by_platform_instance_ids(platform_instance_ids) do
-    from(ar in ActivityRegistration,
-      join: d in assoc(ar, :lti_external_tool_activity_deployment),
+  @spec count_sections_by_platform_instance_ids([integer()]) ::
+          %{integer() => non_neg_integer()}
+  def count_sections_by_platform_instance_ids(platform_instance_ids) do
+    from(d in LtiExternalToolActivityDeployment,
       join: sr in SectionResource,
-      on: sr.activity_type_id == ar.id,
-      join: s in Section,
-      on: sr.section_id == s.id,
+      on: sr.activity_type_id == d.activity_registration_id,
       where: d.platform_instance_id in ^platform_instance_ids,
-      select: {d.platform_instance_id, s},
-      distinct: true
+      group_by: d.platform_instance_id,
+      select: {d.platform_instance_id, count(sr.section_id, :distinct)}
     )
     |> Repo.all()
-    |> Enum.group_by(
-      fn {platform_instance_id, _section} -> platform_instance_id end,
-      fn {_platform_instance_id, section} -> section end
-    )
+    |> Map.new()
   end
 
   @doc """

--- a/lib/oli_web/live/admin/external_tools/external_tools_view.ex
+++ b/lib/oli_web/live/admin/external_tools/external_tools_view.ex
@@ -191,7 +191,12 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
 
       platform_instance_ids ->
         start_async(socket, :usage_counts, fn ->
-          PlatformExternalTools.count_sections_by_platform_instance_ids(platform_instance_ids)
+          Appsignal.instrument(
+            "OliWeb.Admin.ExternalTools.ExternalToolsView#load_usage_counts",
+            fn ->
+              PlatformExternalTools.count_sections_by_platform_instance_ids(platform_instance_ids)
+            end
+          )
         end)
     end
   end

--- a/lib/oli_web/live/admin/external_tools/external_tools_view.ex
+++ b/lib/oli_web/live/admin/external_tools/external_tools_view.ex
@@ -1,6 +1,8 @@
 defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
   use OliWeb, :live_view
 
+  require Logger
+
   import OliWeb.Common.Params
   import OliWeb.DelegatedEvents
 
@@ -12,8 +14,6 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
   alias OliWeb.Icons
 
   @limit 25
-  @sort_by :name
-  @sort_order :asc
   @default_options %PlatformExternalTools.BrowseOptions{
     text_search: "",
     include_disabled: true,
@@ -32,24 +32,16 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
   end
 
   def mount(_, _session, socket) do
-    tools =
-      PlatformExternalTools.browse_platform_external_tools(
-        %Paging{offset: 0, limit: @limit},
-        %Sorting{field: @sort_by, direction: @sort_order},
-        @default_options
-      )
-
-    total_count = SortableTableModel.determine_total(tools)
-
-    {:ok, table_model} = TableModel.new(tools, socket.assigns.ctx)
+    {:ok, table_model} = TableModel.new([], socket.assigns.ctx)
 
     {:ok,
      assign(socket,
        title: "Manage LTI 1.3 External Tools",
        breadcrumbs: set_breadcrumbs(),
-       total_count: total_count,
+       total_count: 0,
        table_model: table_model,
        limit: @limit,
+       offset: 0,
        options: @default_options
      )}
   end
@@ -75,17 +67,31 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
         %Sorting{direction: table_model.sort_order, field: table_model.sort_by_spec.name},
         options
       )
+      |> Enum.map(&Map.put(&1, :usage_count, :loading))
 
     table_model = Map.put(table_model, :rows, tools)
     total_count = SortableTableModel.determine_total(tools)
 
-    {:noreply,
-     assign(socket,
-       offset: offset,
-       options: options,
-       table_model: table_model,
-       total_count: total_count
-     )}
+    socket =
+      assign(socket,
+        offset: offset,
+        options: options,
+        table_model: table_model,
+        total_count: total_count
+      )
+      |> load_usage_counts_async(tools)
+
+    {:noreply, socket}
+  end
+
+  def handle_async(:usage_counts, {:ok, usage_counts}, socket) do
+    {:noreply, put_usage_counts(socket, usage_counts)}
+  end
+
+  def handle_async(:usage_counts, {:exit, reason}, socket) do
+    Logger.warning("Failed to load LTI external tool usage counts: #{inspect(reason)}")
+
+    {:noreply, put_usage_counts(socket, :unknown)}
   end
 
   def render(assigns) do
@@ -174,4 +180,48 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsView do
        replace: true
      )}
   end
+
+  defp load_usage_counts_async(socket, tools) do
+    platform_instance_ids = Enum.map(tools, & &1.id)
+    socket = cancel_async(socket, :usage_counts)
+
+    case platform_instance_ids do
+      [] ->
+        socket
+
+      platform_instance_ids ->
+        start_async(socket, :usage_counts, fn ->
+          PlatformExternalTools.count_sections_by_platform_instance_ids(platform_instance_ids)
+        end)
+    end
+  end
+
+  defp put_usage_counts(socket, usage_counts) do
+    table_model = socket.assigns.table_model
+
+    rows =
+      Enum.map(table_model.rows, fn tool ->
+        usage_count =
+          case usage_counts do
+            %{} -> Map.get(usage_counts, tool.id, 0)
+            :unknown -> :unknown
+          end
+
+        Map.put(tool, :usage_count, usage_count)
+      end)
+
+    table_model =
+      table_model
+      |> Map.put(:rows, rows)
+      |> maybe_sort_by_usage_count()
+
+    assign(socket, table_model: table_model)
+  end
+
+  defp maybe_sort_by_usage_count(
+         %SortableTableModel{sort_by_spec: %{name: :usage_count}} = table_model
+       ),
+       do: SortableTableModel.sort(table_model)
+
+  defp maybe_sort_by_usage_count(table_model), do: table_model
 end

--- a/lib/oli_web/live/admin/external_tools/table_model.ex
+++ b/lib/oli_web/live/admin/external_tools/table_model.ex
@@ -71,8 +71,10 @@ defmodule OliWeb.Admin.ExternalTools.TableModel do
     """
   end
 
-  def render_usage_count_column(assigns, row, _) do
-    assigns = Map.merge(assigns, %{usage_count: row.usage_count, platform_instance_id: row.id})
+  def render_usage_count_column(assigns, %{usage_count: usage_count, id: id}, _)
+      when is_integer(usage_count) do
+    assigns =
+      Map.merge(assigns, %{usage_count: usage_count, platform_instance_id: id})
 
     ~H"""
     <.link
@@ -81,6 +83,18 @@ defmodule OliWeb.Admin.ExternalTools.TableModel do
     >
       {@usage_count}
     </.link>
+    """
+  end
+
+  def render_usage_count_column(assigns, %{usage_count: :loading}, _) do
+    ~H"""
+    <span class="text-sm text-gray-500 dark:text-gray-400">Calculating...</span>
+    """
+  end
+
+  def render_usage_count_column(assigns, _row, _) do
+    ~H"""
+    <span class="text-sm text-gray-500 dark:text-gray-400">Unknown</span>
     """
   end
 

--- a/test/oli/lti/platform_external_tools_test.exs
+++ b/test/oli/lti/platform_external_tools_test.exs
@@ -534,60 +534,53 @@ defmodule Oli.Lti.PlatformExternalToolsTest do
     end
   end
 
-  describe "get_sections_grouped_by_platform_instance_ids/1" do
-    test "returns sections grouped by platform_instance_id" do
-      section = insert(:section)
-      platform = insert(:platform_instance)
-      lti_deployment = insert(:lti_external_tool_activity_deployment, platform_instance: platform)
+  describe "count_sections_by_platform_instance_ids/1" do
+    test "counts distinct sections for each platform instance in PostgreSQL" do
+      platform_1 = insert(:platform_instance)
+      platform_2 = insert(:platform_instance)
 
-      activity_registration =
-        insert(:activity_registration,
-          lti_external_tool_activity_deployment: lti_deployment
-        )
+      deployment_1 =
+        insert(:lti_external_tool_activity_deployment, platform_instance: platform_1)
 
-      revision =
-        insert(:revision,
-          activity_type_id: activity_registration.id
-        )
+      deployment_2 =
+        insert(:lti_external_tool_activity_deployment, platform_instance: platform_2)
+
+      section_1 = insert(:section)
+      section_2 = insert(:section)
 
       insert(:section_resource,
-        section: section,
-        resource_id: revision.resource_id,
-        revision_id: revision.id,
-        activity_type_id: activity_registration.id
+        section: section_1,
+        activity_type_id: deployment_1.activity_registration_id
       )
 
-      result =
-        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
+      insert(:section_resource,
+        section: section_1,
+        activity_type_id: deployment_1.activity_registration_id
+      )
 
-      assert Map.has_key?(result, platform.id)
-      assert Enum.any?(result[platform.id], fn s -> s.id == section.id end)
+      insert(:section_resource,
+        section: section_2,
+        activity_type_id: deployment_1.activity_registration_id
+      )
+
+      insert(:section_resource,
+        section: section_2,
+        activity_type_id: deployment_2.activity_registration_id
+      )
+
+      assert PlatformExternalTools.count_sections_by_platform_instance_ids([
+               platform_1.id,
+               platform_2.id
+             ]) == %{
+               platform_1.id => 2,
+               platform_2.id => 1
+             }
     end
 
-    test "returns empty map when no deployments match" do
+    test "omits platform instances without section usage" do
       platform = insert(:platform_instance)
 
-      result =
-        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
-
-      assert result == %{}
-    end
-
-    test "excludes platforms with no linked sections" do
-      platform = insert(:platform_instance)
-
-      activity_registration = insert(:activity_registration)
-
-      _deployment =
-        insert(:lti_external_tool_activity_deployment,
-          platform_instance: platform,
-          activity_registration: activity_registration
-        )
-
-      result =
-        PlatformExternalTools.get_sections_grouped_by_platform_instance_ids([platform.id])
-
-      assert result == %{}
+      assert PlatformExternalTools.count_sections_by_platform_instance_ids([platform.id]) == %{}
     end
   end
 

--- a/test/oli_web/live/admin/external_tools/external_tools_view_test.exs
+++ b/test/oli_web/live/admin/external_tools/external_tools_view_test.exs
@@ -1,8 +1,12 @@
 defmodule OliWeb.Admin.ExternalTools.ExternalToolsViewTest do
   use OliWeb.ConnCase, async: true
+
+  import ExUnit.CaptureLog
   import Phoenix.LiveViewTest
   import Oli.Factory
   import Oli.TestHelpers
+
+  alias OliWeb.Admin.ExternalTools.{ExternalToolsView, TableModel}
 
   describe "External Tools LiveView" do
     setup [:admin_conn]
@@ -108,6 +112,55 @@ defmodule OliWeb.Admin.ExternalTools.ExternalToolsViewTest do
       assert has_element?(view, "td", platform1.description)
 
       assert has_element?(view, "h1", "LTI 1.3 External Tools")
+    end
+
+    test "loads usage counts asynchronously", %{
+      conn: conn,
+      deployment1: deployment,
+      platform1: platform
+    } do
+      section = insert(:section)
+
+      insert(:section_resource,
+        section: section,
+        activity_type_id: deployment.activity_registration_id
+      )
+
+      insert(:section_resource,
+        section: section,
+        activity_type_id: deployment.activity_registration_id
+      )
+
+      {:ok, view, html} = live(conn, ~p"/admin/external_tools")
+
+      assert html =~ "Calculating..."
+
+      render_async(view, 2_000)
+
+      assert has_element?(
+               view,
+               "a[href='/admin/external_tools/#{platform.id}/usage']",
+               "1"
+             )
+    end
+
+    test "marks usage counts as unknown when asynchronous loading fails" do
+      {:ok, table_model} =
+        TableModel.new(
+          [%{id: 1, name: "Tool", usage_count: :loading}],
+          nil
+        )
+
+      socket = %Phoenix.LiveView.Socket{
+        assigns: %{__changed__: %{}, table_model: table_model}
+      }
+
+      capture_log(fn ->
+        assert {:noreply, socket} =
+                 ExternalToolsView.handle_async(:usage_counts, {:exit, :timeout}, socket)
+
+        assert [%{usage_count: :unknown}] = socket.assigns.table_model.rows
+      end)
     end
 
     test "the view matches the url params", %{conn: conn} do


### PR DESCRIPTION
## Summary

  Improves the performance and resilience of the admin LTI External Tools page, which could load very slowly or return a 504 Gateway Timeout.

  ## Root cause

  The page calculated section-usage counts by querying every matching Section record, selecting all section columns, transferring those records into Elixir, and then grouping and counting them in application code.

  The same expensive query was also executed twice during the initial static LiveView request: once from mount/3 and again from handle_params/3.

  A [production AppSignal sample](https://appsignal.com/open-learning-initiative/sites/618539ab2cf81d7e3cd051ca/performance/incidents/960/samples/618539ab2cf81d7e3cd051ca-149321194841248426331784752380) confirmed this behavior:

  - Total request time: 42.13 seconds
  - First execution: 28.15 seconds
  - Second execution: 13.94 seconds
  - Combined database time: 42.09 seconds

  Query performance varied substantially with database load, cached data, planner statistics, and the volume of delivery resources. In some cases, a single execution ran longer than the gateway allowed the HTTP request to remain open, resulting in a 504 response.

  ## Changes

  - Replaced loading complete Section records with a PostgreSQL COUNT(DISTINCT section_id) grouped by external tool.
  - Removed now-unnecessary joins to sections and activity_registrations, which were previously needed only to materialize complete activity-registration and section records.
  - Removed the duplicate query execution between mount/3 and handle_params/3.
  - Moved usage-count loading into an asynchronous LiveView task.
  - Rendered the page immediately with `Calculating...` while counts load.
  - Displayed `Unknown` if the optional count query fails, allowing the rest of the page to remain usable.
  - Cancelled stale count tasks when pagination, filtering, or sorting changes.
  - Instrumented the asynchronous operation as an AppSignal background action so its Ecto query timing remains observable. The AppSignal action is named:

  `OliWeb.Admin.ExternalTools.ExternalToolsView#load_usage_counts`

  ## Verification

  - Added context-level coverage for PostgreSQL usage-count aggregation.
  - Added LiveView coverage for asynchronous loading and failure handling.
  - Focused context and LiveView tests pass.
  - Confirmed formatting and git diff --check.