### PR TITLE
[ENHANCEMENT] [MER-5686] Improve Grouping screen reader and keyboard drag behavior

### DIFF
--- a/assets/src/components/parts/janus-item-bank/Grouping.scss
+++ b/assets/src/components/parts/janus-item-bank/Grouping.scss
@@ -157,7 +157,17 @@
     flex-wrap: wrap;
     gap: 12px;
     align-items: stretch;
-    overflow-x: hidden;
+    overflow-x: auto;
+  }
+
+  .grouping-board-introduction {
+    border-radius: 5px;
+
+    &:focus-visible {
+      outline: 3px solid #005ea8;
+      outline-offset: 2px;
+      box-shadow: 0 0 0 5px #fff;
+    }
   }
 
   .grouping-column {
@@ -224,6 +234,11 @@
 
     &:active {
       cursor: grabbing;
+    }
+
+    &.is-disabled {
+      cursor: default;
+      touch-action: auto;
     }
 
     &.is-dragging {

--- a/assets/src/components/parts/janus-item-bank/Grouping.tsx
+++ b/assets/src/components/parts/janus-item-bank/Grouping.tsx
@@ -291,6 +291,7 @@ const Grouping: React.FC<PartComponentProps<GroupingModel>> = (props) => {
     >
       {customCss ? <style>{customCss}</style> : null}
       <GroupingBoard
+        id={id}
         model={model as GroupingModel}
         placements={placements}
         onMove={handleMove}

--- a/assets/src/components/parts/janus-item-bank/GroupingBoard.tsx
+++ b/assets/src/components/parts/janus-item-bank/GroupingBoard.tsx
@@ -172,12 +172,7 @@ const DropZone: React.FC<DropZoneProps> = ({
       aria-label={`${title}, ${itemCount} item${itemCount === 1 ? '' : 's'}`}
     >
       <header className="grouping-column-header">{title}</header>
-      <div
-        id={domId}
-        ref={setNodeRef}
-        className={dropzoneClasses.join(' ')}
-        aria-dropeffect={enabled ? 'move' : undefined}
-      >
+      <div id={domId} ref={setNodeRef} className={dropzoneClasses.join(' ')}>
         {children}
         {itemCount === 0 && (
           <div className="grouping-empty-hint" aria-hidden="true">

--- a/assets/src/components/parts/janus-item-bank/GroupingBoard.tsx
+++ b/assets/src/components/parts/janus-item-bank/GroupingBoard.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import {
   Announcements,
   DndContext,
+  DragCancelEvent,
   DragEndEvent,
+  DragOverEvent,
   DragOverlay,
   DragStartEvent,
   KeyboardSensor,
@@ -15,7 +17,14 @@ import {
 } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import GroupingItemContent from './GroupingItemContent';
-import { groupingPointerCollision, snapCenterToCursor } from './grouping-dnd';
+import {
+  GROUPING_KEYBOARD_CODES,
+  GroupingKeyboardTarget,
+  confirmGroupingKeyboardTarget,
+  createGroupingKeyboardCoordinates,
+  groupingPointerCollision,
+  snapCenterToCursor,
+} from './grouping-dnd';
 import {
   BANK_ID,
   BANK_LABEL,
@@ -23,9 +32,13 @@ import {
   categoryTitle,
   groupingThemeStyles,
   isItemCorrect,
+  itemAccessibleText,
   itemsInZone,
 } from './grouping-util';
 import { GroupingItem, GroupingModel } from './schema';
+
+const GROUPING_KEYBOARD_INSTRUCTIONS =
+  'Move items from the Item Bank into categories. Tab to an item, then press Space or Enter to pick it up. While moving, use Tab, Right Arrow, or Down Arrow for the next location, and Shift plus Tab, Left Arrow, or Up Arrow for the previous location. Press Space or Enter to drop the item, or Escape to cancel.';
 
 const HintBadge: React.FC<{ type: 'correct' | 'incorrect' }> = ({ type }) => (
   <span className={`grouping-hint-badge is-${type}`} aria-hidden="true">
@@ -90,6 +103,9 @@ const DraggableItem: React.FC<DraggableItemProps> = ({
   if (isDragging) {
     classes.push('is-dragging');
   }
+  if (!enabled) {
+    classes.push('is-disabled');
+  }
   if (hint === 'correct') {
     classes.push('is-correct');
   }
@@ -97,9 +113,7 @@ const DraggableItem: React.FC<DraggableItemProps> = ({
     classes.push('is-incorrect');
   }
 
-  const describedText = `${item.label}, currently in ${zoneLabel}.${
-    enabled ? ' Press space or enter to pick up.' : ''
-  }`;
+  const describedText = `${itemAccessibleText(item)}, currently in ${zoneLabel}.`;
 
   return (
     <div
@@ -110,26 +124,37 @@ const DraggableItem: React.FC<DraggableItemProps> = ({
       {...attributes}
       tabIndex={enabled ? 0 : -1}
       aria-label={describedText}
+      aria-describedby={undefined}
+      aria-roledescription={enabled ? attributes['aria-roledescription'] : undefined}
       aria-disabled={!enabled}
-      aria-hidden={isDragging}
     >
       {hint === 'correct' && <HintBadge type="correct" />}
       {hint === 'incorrect' && <HintBadge type="incorrect" />}
-      <GroupingItemContent item={item} />
+      <GroupingItemContent item={item} imageDecorative />
     </div>
   );
 };
 
 interface DropZoneProps {
+  domId: string;
   zoneId: string;
   title: string;
   isBank: boolean;
+  enabled: boolean;
   children: React.ReactNode;
   itemCount: number;
 }
 
-const DropZone: React.FC<DropZoneProps> = ({ zoneId, title, isBank, children, itemCount }) => {
-  const { setNodeRef, isOver } = useDroppable({ id: zoneId });
+const DropZone: React.FC<DropZoneProps> = ({
+  domId,
+  zoneId,
+  title,
+  isBank,
+  enabled,
+  children,
+  itemCount,
+}) => {
+  const { setNodeRef, isOver } = useDroppable({ id: zoneId, disabled: !enabled });
   const columnClasses = ['grouping-column'];
   if (isBank) {
     columnClasses.push('grouping-column-bank');
@@ -147,11 +172,16 @@ const DropZone: React.FC<DropZoneProps> = ({ zoneId, title, isBank, children, it
       aria-label={`${title}, ${itemCount} item${itemCount === 1 ? '' : 's'}`}
     >
       <header className="grouping-column-header">{title}</header>
-      <div ref={setNodeRef} className={dropzoneClasses.join(' ')} aria-dropeffect="move">
+      <div
+        id={domId}
+        ref={setNodeRef}
+        className={dropzoneClasses.join(' ')}
+        aria-dropeffect={enabled ? 'move' : undefined}
+      >
         {children}
         {itemCount === 0 && (
           <div className="grouping-empty-hint" aria-hidden="true">
-            <span>{isBank ? 'No items' : 'Drop items here'}</span>
+            <span>{isBank || !enabled ? 'No items' : 'Drop items here'}</span>
           </div>
         )}
       </div>
@@ -160,6 +190,7 @@ const DropZone: React.FC<DropZoneProps> = ({ zoneId, title, isBank, children, it
 };
 
 export interface GroupingBoardProps {
+  id: string;
   model: GroupingModel;
   placements: Placements;
   onMove: (itemId: string, zoneId: string) => void;
@@ -169,11 +200,11 @@ export interface GroupingBoardProps {
 }
 
 /**
- * Shared accessible drag-and-drop board used by both the delivery component and
- * the authoring "Set Answer" view. Supports mouse, touch and keyboard via
- * dnd-kit sensors and announces moves to screen readers.
+ * Learner-facing drag-and-drop board used by delivery and live preview. Supports
+ * mouse, touch and keyboard via dnd-kit sensors and announces moves to screen readers.
  */
 const GroupingBoard: React.FC<GroupingBoardProps> = ({
+  id,
   model,
   placements,
   onMove,
@@ -182,11 +213,26 @@ const GroupingBoard: React.FC<GroupingBoardProps> = ({
 }) => {
   const [activeItem, setActiveItem] = useState<GroupingItem | null>(null);
   const [activeOverlayWidth, setActiveOverlayWidth] = useState<number | undefined>(undefined);
+  const keyboardTarget = useRef<GroupingKeyboardTarget>({ current: null, pending: null });
+  const instructionsId = `${id}-grouping-instructions`;
+  const zoneDomId = (zoneId: string) => `${id}-grouping-zone-${zoneId}`;
+  const keyboardCoordinates = useMemo(
+    () =>
+      createGroupingKeyboardCoordinates(
+        [BANK_ID, ...(model.categories || []).map((category) => category.id)],
+        keyboardTarget.current,
+      ),
+    [model.categories],
+  );
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 6 } }),
-    useSensor(KeyboardSensor),
+    useSensor(KeyboardSensor, {
+      keyboardCodes: GROUPING_KEYBOARD_CODES,
+      coordinateGetter: keyboardCoordinates,
+      scrollBehavior: 'auto',
+    }),
   );
 
   const zoneLabel = (zoneId: string): string => {
@@ -203,51 +249,83 @@ const GroupingBoard: React.FC<GroupingBoardProps> = ({
   const clearDragState = () => {
     setActiveItem(null);
     setActiveOverlayWidth(undefined);
+    keyboardTarget.current.current = null;
+    keyboardTarget.current.pending = null;
+  };
+
+  const scrollZoneIntoView = (zoneId: string) => {
+    document
+      .getElementById(zoneDomId(zoneId))
+      ?.scrollIntoView?.({ behavior: 'auto', block: 'nearest', inline: 'nearest' });
   };
 
   const handleDragStart = (event: DragStartEvent) => {
     const item = findItem(`${event.active.id}`);
+    keyboardTarget.current.current = `${event.active.data.current?.zoneId || BANK_ID}`;
+    keyboardTarget.current.pending = null;
     setActiveItem(item || null);
     const rect = event.active.rect.current.initial;
     setActiveOverlayWidth(rect ? Math.round(rect.width) : undefined);
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
-    clearDragState();
     const { active, over } = event;
+    const itemId = `${active.id}`;
+    const currentZone = placements[itemId] || BANK_ID;
+    clearDragState();
     if (!over) {
+      scrollZoneIntoView(currentZone);
       return;
     }
-    const itemId = `${active.id}`;
     const targetZone = `${over.id}`;
-    const currentZone = placements[itemId] || BANK_ID;
     if (targetZone !== currentZone) {
       onMove(itemId, targetZone);
+    } else {
+      scrollZoneIntoView(currentZone);
+    }
+  };
+
+  const handleDragCancel = (event: DragCancelEvent) => {
+    const sourceZone = `${event.active.data.current?.zoneId || BANK_ID}`;
+    clearDragState();
+    scrollZoneIntoView(sourceZone);
+  };
+
+  const handleDragOver = (event: DragOverEvent) => {
+    const overId = event.over ? `${event.over.id}` : null;
+    if (overId && confirmGroupingKeyboardTarget(keyboardTarget.current, overId)) {
+      scrollZoneIntoView(overId);
     }
   };
 
   const announcements: Announcements = {
     onDragStart({ active }) {
       const item = findItem(`${active.id}`);
-      return `Picked up item ${item?.label ?? active.id}.`;
+      const itemText = item ? itemAccessibleText(item) : `${active.id}`;
+      const currentZone = `${active.data.current?.zoneId || BANK_ID}`;
+      return `Picked up ${itemText}. Current location: ${zoneLabel(currentZone)}.`;
     },
     onDragOver({ active, over }) {
       const item = findItem(`${active.id}`);
+      const itemText = item ? itemAccessibleText(item) : `${active.id}`;
       if (over) {
-        return `Item ${item?.label ?? active.id} is over ${zoneLabel(`${over.id}`)}.`;
+        return `${itemText}. Current location: ${zoneLabel(`${over.id}`)}.`;
       }
-      return `Item ${item?.label ?? active.id} is no longer over a drop area.`;
+      return `${itemText}. Not over a valid location.`;
     },
     onDragEnd({ active, over }) {
       const item = findItem(`${active.id}`);
+      const itemText = item ? itemAccessibleText(item) : `${active.id}`;
       if (over) {
-        return `Item ${item?.label ?? active.id} was dropped into ${zoneLabel(`${over.id}`)}.`;
+        return `${itemText} dropped in ${zoneLabel(`${over.id}`)}.`;
       }
-      return `Item ${item?.label ?? active.id} was dropped.`;
+      return `${itemText} was not moved.`;
     },
     onDragCancel({ active }) {
       const item = findItem(`${active.id}`);
-      return `Dragging item ${item?.label ?? active.id} was cancelled.`;
+      const itemText = item ? itemAccessibleText(item) : `${active.id}`;
+      const currentZone = `${active.data.current?.zoneId || BANK_ID}`;
+      return `Move cancelled. ${itemText} remains in ${zoneLabel(currentZone)}.`;
     },
   };
 
@@ -263,9 +341,11 @@ const GroupingBoard: React.FC<GroupingBoardProps> = ({
     return (
       <DropZone
         key={zoneId}
+        domId={zoneDomId(zoneId)}
         zoneId={zoneId}
         title={title}
         isBank={isBank}
+        enabled={enabled}
         itemCount={zoneItems.length}
       >
         {zoneItems.map((item) => (
@@ -286,12 +366,27 @@ const GroupingBoard: React.FC<GroupingBoardProps> = ({
     <DndContext
       sensors={sensors}
       collisionDetection={groupingPointerCollision}
-      accessibility={{ announcements }}
+      accessibility={{
+        announcements,
+        screenReaderInstructions: { draggable: '' },
+      }}
       onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
-      onDragCancel={clearDragState}
+      onDragCancel={handleDragCancel}
     >
-      <div className="grouping-columns">
+      {enabled ? (
+        <span id={instructionsId} className="grouping-visually-hidden">
+          {GROUPING_KEYBOARD_INSTRUCTIONS}
+        </span>
+      ) : null}
+      <div
+        className="grouping-columns grouping-board-introduction"
+        role="group"
+        aria-label="Grouping activity"
+        aria-describedby={enabled ? instructionsId : undefined}
+        tabIndex={enabled ? 0 : -1}
+      >
         {renderZone(BANK_ID, BANK_LABEL, true)}
         {(model.categories || []).map((category, index) =>
           renderZone(category.id, categoryTitle(category, index), false),
@@ -307,8 +402,9 @@ const GroupingBoard: React.FC<GroupingBoardProps> = ({
           <div
             className={`grouping-item grouping-item-${activeItem.type} is-overlay`}
             style={activeOverlayWidth ? { width: activeOverlayWidth } : undefined}
+            aria-hidden="true"
           >
-            <GroupingItemContent item={activeItem} />
+            <GroupingItemContent item={activeItem} imageDecorative />
           </div>
         ) : null}
       </DragOverlay>

--- a/assets/src/components/parts/janus-item-bank/GroupingItemContent.tsx
+++ b/assets/src/components/parts/janus-item-bank/GroupingItemContent.tsx
@@ -1,18 +1,25 @@
 import React from 'react';
-import { itemDisplayText, itemImageCaption } from './grouping-util';
+import { itemAccessibleText, itemDisplayText, itemImageCaption } from './grouping-util';
 import { GroupingItem } from './schema';
 
 interface GroupingItemContentProps {
   item: GroupingItem;
+  imageDecorative?: boolean;
 }
 
-const GroupingItemContent: React.FC<GroupingItemContentProps> = ({ item }) => {
+const GroupingItemContent: React.FC<GroupingItemContentProps> = ({
+  item,
+  imageDecorative = false,
+}) => {
   if (item.type === 'image' && item.imageSrc) {
     const caption = itemImageCaption(item);
+    const hasAuthoredAlt = !!item.alt?.trim();
+    const imageAlt =
+      imageDecorative || (!hasAuthoredAlt && caption) ? '' : itemAccessibleText(item);
     return (
       <div className="grouping-item-content grouping-item-content--image">
         {caption ? <span className="grouping-item-caption">{caption}</span> : null}
-        <img className="grouping-item-image" src={item.imageSrc} alt={item.alt || item.label} />
+        <img className="grouping-item-image" src={item.imageSrc} alt={imageAlt} />
       </div>
     );
   }

--- a/assets/src/components/parts/janus-item-bank/ItemEditorModal.tsx
+++ b/assets/src/components/parts/janus-item-bank/ItemEditorModal.tsx
@@ -101,13 +101,10 @@ const ItemEditorModal: React.FC<ItemEditorModalProps> = ({
       if (!label.trim()) {
         setLabel(basenameFromUrl(url));
       }
-      if (!alt.trim()) {
-        setAlt(basenameFromUrl(url));
-      }
     }
     setImagePickerOpen(false);
     setPendingImageUrl('');
-  }, [alt, label, pendingImageUrl]);
+  }, [label, pendingImageUrl]);
 
   return (
     <>
@@ -185,7 +182,11 @@ const ItemEditorModal: React.FC<ItemEditorModalProps> = ({
                   <label className="iem-label">Image</label>
                   <div className="iem-image-row">
                     {imageSrc ? (
-                      <img className="iem-image-preview" src={imageSrc} alt={alt || label} />
+                      <img
+                        className="iem-image-preview"
+                        src={imageSrc}
+                        alt={alt.trim() || text.trim() || label.trim()}
+                      />
                     ) : (
                       <div className="iem-image-placeholder">No image selected</div>
                     )}

--- a/assets/src/components/parts/janus-item-bank/grouping-dnd.ts
+++ b/assets/src/components/parts/janus-item-bank/grouping-dnd.ts
@@ -1,4 +1,98 @@
-import { CollisionDetection, Modifier, rectIntersection } from '@dnd-kit/core';
+import {
+  CollisionDetection,
+  KeyboardCode,
+  KeyboardCodes,
+  KeyboardCoordinateGetter,
+  Modifier,
+  rectIntersection,
+} from '@dnd-kit/core';
+
+export const GROUPING_KEYBOARD_CODES: KeyboardCodes = {
+  start: [KeyboardCode.Space, KeyboardCode.Enter],
+  cancel: [KeyboardCode.Esc],
+  end: [KeyboardCode.Space, KeyboardCode.Enter],
+};
+
+export interface GroupingKeyboardTarget {
+  current: string | null;
+  pending: string | null;
+}
+
+export const confirmGroupingKeyboardTarget = (
+  keyboardTarget: GroupingKeyboardTarget,
+  overId: string | null,
+): boolean => {
+  if (!overId || overId !== keyboardTarget.pending) {
+    return false;
+  }
+
+  keyboardTarget.current = overId;
+  keyboardTarget.pending = null;
+  return true;
+};
+
+const keyboardNavigationDirection = (event: KeyboardEvent): number => {
+  if (
+    event.code === KeyboardCode.Left ||
+    event.code === KeyboardCode.Up ||
+    (event.code === KeyboardCode.Tab && event.shiftKey)
+  ) {
+    return -1;
+  }
+  if (
+    event.code === KeyboardCode.Right ||
+    event.code === KeyboardCode.Down ||
+    event.code === KeyboardCode.Tab
+  ) {
+    return 1;
+  }
+  return 0;
+};
+
+/**
+ * Moves the keyboard collision rectangle between Grouping destinations in model order.
+ * Centering the rectangle in the target avoids layout-dependent arrow increments.
+ */
+export const createGroupingKeyboardCoordinates =
+  (zoneIds: string[], keyboardTarget: GroupingKeyboardTarget): KeyboardCoordinateGetter =>
+  (event, { context }) => {
+    const direction = keyboardNavigationDirection(event);
+    if (direction === 0) {
+      return undefined;
+    }
+
+    const availableZoneIds = zoneIds.filter((zoneId) => {
+      const container = context.droppableContainers.get(zoneId);
+      return container && !container.disabled && context.droppableRects.has(zoneId);
+    });
+    if (availableZoneIds.length === 0) {
+      return undefined;
+    }
+
+    const overZoneId = context.over ? `${context.over.id}` : null;
+    if (overZoneId && availableZoneIds.includes(overZoneId)) {
+      confirmGroupingKeyboardTarget(keyboardTarget, overZoneId);
+    }
+
+    const sourceZoneId = `${context.active?.data.current?.zoneId || availableZoneIds[0]}`;
+    const currentZoneId = keyboardTarget.current || sourceZoneId;
+    const currentIndex = Math.max(availableZoneIds.indexOf(currentZoneId), 0);
+    const targetIndex =
+      (currentIndex + direction + availableZoneIds.length) % availableZoneIds.length;
+    const targetZoneId = availableZoneIds[targetIndex];
+    const targetRect = context.droppableRects.get(targetZoneId);
+    if (!targetRect) {
+      return undefined;
+    }
+
+    keyboardTarget.pending = targetZoneId;
+    const collisionWidth = context.collisionRect?.width || 0;
+    const collisionHeight = context.collisionRect?.height || 0;
+    return {
+      x: targetRect.left + targetRect.width / 2 - collisionWidth / 2,
+      y: targetRect.top + targetRect.height / 2 - collisionHeight / 2,
+    };
+  };
 
 const getActivatorCoordinates = (event: Event): { x: number; y: number } | null => {
   if ('clientX' in event && typeof (event as MouseEvent).clientX === 'number') {

--- a/assets/src/components/parts/janus-item-bank/grouping-util.ts
+++ b/assets/src/components/parts/janus-item-bank/grouping-util.ts
@@ -82,6 +82,14 @@ export const itemImageCaption = (item: GroupingItem): string => {
   return item.text.trim();
 };
 
+/** Returns learner-facing screen-reader text without exposing the CAPI label unnecessarily. */
+export const itemAccessibleText = (item: GroupingItem): string => {
+  if (item.type === 'image') {
+    return item.alt?.trim() || itemImageCaption(item) || item.label?.trim() || '';
+  }
+  return itemDisplayText(item);
+};
+
 /** Ensure image items always carry an explicit `text` value for redux lodash merge saves. */
 export const normalizeGroupingItemForSave = (item: GroupingItem): GroupingItem => {
   if (item.type !== 'image') {

--- a/assets/test/parts/grouping_accessibility_test.tsx
+++ b/assets/test/parts/grouping_accessibility_test.tsx
@@ -148,7 +148,7 @@ describe('GroupingBoard accessibility', () => {
       expect(item).not.toHaveClass('is-disabled');
     });
     container.querySelectorAll('.grouping-dropzone').forEach((dropzone) => {
-      expect(dropzone).toHaveAttribute('aria-dropeffect', 'move');
+      expect(dropzone).not.toHaveAttribute('aria-dropeffect');
     });
     expect(screen.getAllByText('Drop items here')).toHaveLength(2);
   });

--- a/assets/test/parts/grouping_accessibility_test.tsx
+++ b/assets/test/parts/grouping_accessibility_test.tsx
@@ -1,0 +1,374 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import GroupingBoard from '../../src/components/parts/janus-item-bank/GroupingBoard';
+import GroupingItemContent from '../../src/components/parts/janus-item-bank/GroupingItemContent';
+import { GroupingModel } from '../../src/components/parts/janus-item-bank/schema';
+
+const waitForKeyboardSensor = () =>
+  act(async () => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  });
+
+const model: GroupingModel = {
+  x: 0,
+  y: 0,
+  z: 0,
+  width: '100%',
+  height: 425,
+  customCssClass: '',
+  enabled: true,
+  themeColor: '#0070F3',
+  customCss: '',
+  categories: [
+    { id: 'category-one', title: 'Category One' },
+    { id: 'category-two', title: 'Category Two' },
+  ],
+  items: [
+    {
+      id: 'text-item',
+      type: 'text',
+      label: 'text-item-label',
+      text: 'A full glass of milk',
+    },
+    {
+      id: 'image-item',
+      type: 'image',
+      label: 'image-item-label',
+      text: 'A visible water caption',
+      imageSrc: 'https://example.com/water.png',
+      alt: 'A glass of water',
+    },
+    {
+      id: 'caption-fallback',
+      type: 'image',
+      label: 'caption-fallback-label',
+      text: 'A visible soda caption',
+      imageSrc: 'https://example.com/soda.png',
+      alt: '',
+    },
+    {
+      id: 'label-fallback',
+      type: 'image',
+      label: 'label fallback',
+      text: '',
+      imageSrc: 'https://example.com/juice.png',
+      alt: '',
+    },
+  ],
+  layoutPlacements: {},
+  correctAnswer: {},
+  showHints: false,
+  showCorrect: false,
+};
+
+describe('GroupingBoard accessibility', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('announces learner-facing item content and current locations', () => {
+    render(
+      <GroupingBoard
+        id="grouping-one"
+        model={model}
+        placements={{ 'text-item': 'category-one' }}
+        onMove={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: 'A full glass of milk, currently in Category One.',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'A full glass of milk, currently in Category One.',
+      }),
+    ).toHaveTextContent('A full glass of milk');
+    expect(
+      screen.getByRole('button', {
+        name: 'A glass of water, currently in Item Bank.',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'A visible soda caption, currently in Item Bank.',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'label fallback, currently in Item Bank.',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /text-item-label/ })).not.toBeInTheDocument();
+  });
+
+  test('exposes image content once using alt, caption, then label fallbacks', () => {
+    const { container, rerender } = render(<GroupingItemContent item={model.items[1]} />);
+
+    expect(screen.getByRole('img', { name: 'A glass of water' })).toBeInTheDocument();
+
+    rerender(<GroupingItemContent item={model.items[2]} />);
+
+    expect(screen.getAllByText('A visible soda caption')).toHaveLength(1);
+    expect(container.querySelector('img')).toHaveAttribute('alt', '');
+
+    rerender(<GroupingItemContent item={model.items[3]} />);
+
+    expect(screen.getByRole('img', { name: 'label fallback' })).toBeInTheDocument();
+  });
+
+  test('provides keyboard instructions once at the board level', () => {
+    const { container } = render(
+      <GroupingBoard id="grouping-one" model={model} placements={{}} onMove={jest.fn()} />,
+    );
+
+    const introduction = screen.getByRole('group', { name: 'Grouping activity' });
+    const instructionsId = introduction.getAttribute('aria-describedby');
+    const instructions = instructionsId ? document.getElementById(instructionsId) : null;
+
+    expect(introduction).toHaveAttribute('tabindex', '0');
+    expect(instructionsId).toBe('grouping-one-grouping-instructions');
+    expect(instructions).toHaveTextContent(
+      'Tab to an item, then press Space or Enter to pick it up.',
+    );
+    expect(instructions).toHaveTextContent(
+      'use Tab, Right Arrow, or Down Arrow for the next location',
+    );
+    expect(instructions).toHaveTextContent(
+      'Shift plus Tab, Left Arrow, or Up Arrow for the previous location',
+    );
+
+    screen.getAllByRole('button').forEach((item) => {
+      expect(item).not.toHaveAttribute('aria-describedby');
+      expect(item).toHaveAttribute('aria-roledescription', 'draggable');
+      expect(item).not.toHaveClass('is-disabled');
+    });
+    container.querySelectorAll('.grouping-dropzone').forEach((dropzone) => {
+      expect(dropzone).toHaveAttribute('aria-dropeffect', 'move');
+    });
+    expect(screen.getAllByText('Drop items here')).toHaveLength(2);
+  });
+
+  test('removes actionable drag instructions when the board is disabled', () => {
+    const { container } = render(
+      <GroupingBoard
+        id="grouping-disabled"
+        model={model}
+        placements={{}}
+        onMove={jest.fn()}
+        enabled={false}
+      />,
+    );
+
+    const introduction = screen.getByRole('group', { name: 'Grouping activity' });
+
+    expect(introduction).toHaveAttribute('tabindex', '-1');
+    expect(introduction).not.toHaveAttribute('aria-describedby');
+    expect(document.getElementById('grouping-disabled-grouping-instructions')).toBeNull();
+    screen.getAllByRole('button').forEach((item) => {
+      expect(item).toHaveAttribute('tabindex', '-1');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).not.toHaveAttribute('aria-roledescription');
+      expect(item).toHaveClass('is-disabled');
+    });
+    container.querySelectorAll('.grouping-dropzone').forEach((dropzone) => {
+      expect(dropzone).not.toHaveAttribute('aria-dropeffect');
+    });
+    expect(screen.queryByText('Drop items here')).not.toBeInTheDocument();
+    expect(screen.getAllByText('No items')).toHaveLength(2);
+  });
+
+  test('keeps authored text and the focused item exposed while dragging', async () => {
+    const helloModel: GroupingModel = {
+      ...model,
+      items: model.items.map((item) =>
+        item.id === 'text-item' ? { ...item, text: 'Hello World' } : item,
+      ),
+    };
+    render(
+      <GroupingBoard
+        id="grouping-one"
+        model={helloModel}
+        placements={{ 'text-item': 'category-one' }}
+        onMove={jest.fn()}
+      />,
+    );
+
+    const item = screen.getByRole('button', {
+      name: 'Hello World, currently in Category One.',
+    });
+
+    fireEvent.keyDown(item, { key: ' ', code: 'Space' });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Picked up Hello World. Current location: Category One.'),
+      ).toBeInTheDocument(),
+    );
+    expect(item).not.toHaveAttribute('aria-hidden');
+    expect(item).toHaveAttribute('aria-pressed', 'true');
+    expect(document.querySelector('.grouping-item.is-overlay')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+    await waitForKeyboardSensor();
+
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    await waitFor(() => expect(item).not.toHaveAttribute('aria-pressed'));
+  });
+
+  test('navigates with Tab, drops explicitly, and cancels without moving', async () => {
+    const rect = (left: number, top: number, width: number, height: number): DOMRect => ({
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    });
+
+    jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function getGroupingRect() {
+        if (this.classList.contains('grouping-item')) {
+          return rect(10, 10, 80, 40);
+        }
+        const section = this.closest('section');
+        const sectionName = section?.getAttribute('aria-label') || '';
+        if (sectionName.startsWith('Category One')) {
+          return rect(200, 0, 160, 200);
+        }
+        if (sectionName.startsWith('Category Two')) {
+          return rect(400, 0, 160, 200);
+        }
+        return rect(0, 0, 160, 200);
+      });
+
+    const onMove = jest.fn();
+    render(<GroupingBoard id="grouping-one" model={model} placements={{}} onMove={onMove} />);
+
+    const itemBankScrollIntoView = jest.fn();
+    const categoryOneScrollIntoView = jest.fn();
+    const categoryTwoScrollIntoView = jest.fn();
+    const itemBankDropZone = document.getElementById('grouping-one-grouping-zone-bank');
+    const categoryOneDropZone = document.getElementById('grouping-one-grouping-zone-category-one');
+    const categoryTwoDropZone = document.getElementById('grouping-one-grouping-zone-category-two');
+    if (itemBankDropZone) {
+      itemBankDropZone.scrollIntoView = itemBankScrollIntoView;
+    }
+    if (categoryOneDropZone) {
+      categoryOneDropZone.scrollIntoView = categoryOneScrollIntoView;
+    }
+    if (categoryTwoDropZone) {
+      categoryTwoDropZone.scrollIntoView = categoryTwoScrollIntoView;
+    }
+
+    const item = screen.getByRole('button', {
+      name: 'A full glass of milk, currently in Item Bank.',
+    });
+    item.focus();
+
+    fireEvent.keyDown(item, { key: ' ', code: 'Space' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Item Bank.'),
+      ).toBeInTheDocument(),
+    );
+    await waitForKeyboardSensor();
+
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category One.'),
+      ).toBeInTheDocument(),
+    );
+    expect(categoryOneScrollIntoView).toHaveBeenCalledWith({
+      behavior: 'auto',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    expect(onMove).not.toHaveBeenCalled();
+    expect(item).toHaveFocus();
+
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category Two.'),
+      ).toBeInTheDocument(),
+    );
+    expect(categoryTwoScrollIntoView).toHaveBeenCalledWith({
+      behavior: 'auto',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab', shiftKey: true });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category One.'),
+      ).toBeInTheDocument(),
+    );
+    expect(categoryOneScrollIntoView).toHaveBeenCalledTimes(2);
+
+    fireEvent.keyDown(document, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => expect(onMove).toHaveBeenCalledWith('text-item', 'category-one'));
+    expect(onMove).toHaveBeenCalledTimes(1);
+    expect(item).toHaveFocus();
+
+    fireEvent.keyDown(item, { key: 'Enter', code: 'Enter' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Item Bank.'),
+      ).toBeInTheDocument(),
+    );
+    await waitForKeyboardSensor();
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab', shiftKey: true });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category Two.'),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Move cancelled. A full glass of milk remains in Item Bank.'),
+      ).toBeInTheDocument(),
+    );
+    expect(onMove).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(item).not.toHaveAttribute('aria-pressed'));
+    expect(item).toHaveFocus();
+    expect(itemBankScrollIntoView).toHaveBeenCalledWith({
+      behavior: 'auto',
+      block: 'nearest',
+      inline: 'nearest',
+    });
+
+    fireEvent.keyDown(item, { key: ' ', code: 'Space' });
+    await waitForKeyboardSensor();
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category One.'),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.keyDown(document, { key: 'Tab', code: 'Tab' });
+    await waitFor(() =>
+      expect(
+        screen.getByText('A full glass of milk. Current location: Category Two.'),
+      ).toBeInTheDocument(),
+    );
+    fireEvent.keyDown(document, { key: 'Escape', code: 'Escape' });
+    await waitFor(() => {
+      expect(item).not.toHaveAttribute('aria-pressed');
+      expect(itemBankScrollIntoView).toHaveBeenCalledTimes(2);
+    });
+    expect(onMove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/assets/test/parts/grouping_accessibility_test.tsx
+++ b/assets/test/parts/grouping_accessibility_test.tsx
@@ -236,7 +236,7 @@ describe('GroupingBoard accessibility', () => {
 
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
-      .mockImplementation(function getGroupingRect() {
+      .mockImplementation(function getGroupingRect(this: any) {
         if (this.classList.contains('grouping-item')) {
           return rect(10, 10, 80, 40);
         }

--- a/assets/test/parts/grouping_dnd_test.ts
+++ b/assets/test/parts/grouping_dnd_test.ts
@@ -1,0 +1,183 @@
+import {
+  DroppableContainer,
+  KeyboardCode,
+  KeyboardCoordinateGetter,
+  UniqueIdentifier,
+} from '@dnd-kit/core';
+import {
+  GROUPING_KEYBOARD_CODES,
+  createGroupingKeyboardCoordinates,
+} from '../../src/components/parts/janus-item-bank/grouping-dnd';
+
+const rect = (left: number, top: number, width = 100, height = 100): DOMRect => ({
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+  x: left,
+  y: top,
+  toJSON: () => ({}),
+});
+
+class TestDroppableContainers extends Map<UniqueIdentifier, DroppableContainer> {
+  get(id: UniqueIdentifier | null | undefined): DroppableContainer | undefined {
+    return id == null ? undefined : super.get(id);
+  }
+
+  toArray(): DroppableContainer[] {
+    return Array.from(this.values());
+  }
+
+  getEnabled(): DroppableContainer[] {
+    return this.toArray().filter(({ disabled }) => !disabled);
+  }
+
+  getNodeFor(id: UniqueIdentifier | null | undefined): HTMLElement | undefined {
+    return this.get(id)?.node.current || undefined;
+  }
+}
+
+const coordinateArgs = (
+  overId: string,
+  sourceZoneId = 'bank',
+): Parameters<KeyboardCoordinateGetter>[1] => {
+  const droppableRects = new Map<UniqueIdentifier, DOMRect>([
+    ['bank', rect(0, 0)],
+    ['category-one', rect(200, 0)],
+    ['category-two', rect(400, 0)],
+  ]);
+  const droppableContainers = new TestDroppableContainers(
+    Array.from(droppableRects.entries()).map(([id, droppableRect]) => [
+      id,
+      {
+        id,
+        key: id,
+        data: { current: undefined },
+        disabled: false,
+        node: { current: null },
+        rect: { current: droppableRect },
+      },
+    ]),
+  );
+
+  return {
+    active: 'item-one',
+    currentCoordinates: { x: 0, y: 0 },
+    context: {
+      activatorEvent: null,
+      active: {
+        id: 'item-one',
+        data: {
+          current: {
+            zoneId: sourceZoneId,
+          },
+        },
+        rect: {
+          current: {
+            initial: null,
+            translated: null,
+          },
+        },
+      },
+      activeNode: null,
+      collisionRect: rect(0, 0, 20, 20),
+      collisions: null,
+      draggableNodes: new Map(),
+      draggingNode: null,
+      draggingNodeRect: null,
+      droppableContainers,
+      droppableRects,
+      over: {
+        id: overId,
+        rect: droppableRects.get(overId) || rect(0, 0),
+        disabled: false,
+        data: { current: undefined },
+      },
+      scrollableAncestors: [],
+      scrollAdjustedTranslate: null,
+    },
+  };
+};
+
+describe('Grouping keyboard drag configuration', () => {
+  const createCoordinateGetter = (current: string | null) => {
+    const keyboardTarget = { current, pending: null };
+    return {
+      coordinateGetter: createGroupingKeyboardCoordinates(
+        ['bank', 'category-one', 'category-two'],
+        keyboardTarget,
+      ),
+      keyboardTarget,
+    };
+  };
+
+  test('uses Space and Enter to start and end without treating Tab as a drop key', () => {
+    expect(GROUPING_KEYBOARD_CODES).toEqual({
+      start: [KeyboardCode.Space, KeyboardCode.Enter],
+      cancel: [KeyboardCode.Esc],
+      end: [KeyboardCode.Space, KeyboardCode.Enter],
+    });
+    expect(GROUPING_KEYBOARD_CODES.end).not.toContain(KeyboardCode.Tab);
+  });
+
+  test.each([
+    ['Tab', false, 'bank', { x: 240, y: 40 }],
+    ['ArrowRight', false, 'bank', { x: 240, y: 40 }],
+    ['ArrowDown', false, 'bank', { x: 240, y: 40 }],
+    ['Tab', true, 'category-one', { x: 40, y: 40 }],
+    ['ArrowLeft', false, 'category-one', { x: 40, y: 40 }],
+    ['ArrowUp', false, 'category-one', { x: 40, y: 40 }],
+  ])(
+    '%s navigates to the expected adjacent destination',
+    (code, shiftKey, overId, expectedCoordinates) => {
+      const event = new KeyboardEvent('keydown', { code, shiftKey });
+      const { coordinateGetter } = createCoordinateGetter(overId);
+
+      expect(coordinateGetter(event, coordinateArgs(overId))).toEqual(expectedCoordinates);
+    },
+  );
+
+  test('wraps forward and backward at the destination boundaries', () => {
+    const forward = createCoordinateGetter('category-two').coordinateGetter;
+    const backward = createCoordinateGetter('bank').coordinateGetter;
+
+    expect(
+      forward(new KeyboardEvent('keydown', { code: 'Tab' }), coordinateArgs('category-two')),
+    ).toEqual({ x: 40, y: 40 });
+    expect(
+      backward(
+        new KeyboardEvent('keydown', { code: 'Tab', shiftKey: true }),
+        coordinateArgs('bank'),
+      ),
+    ).toEqual({ x: 440, y: 40 });
+  });
+
+  test('starts from the item placement instead of a transient collision target', () => {
+    const { coordinateGetter, keyboardTarget } = createCoordinateGetter('bank');
+
+    expect(
+      coordinateGetter(
+        new KeyboardEvent('keydown', { code: 'Tab' }),
+        coordinateArgs('category-one', 'bank'),
+      ),
+    ).toEqual({ x: 240, y: 40 });
+    expect(keyboardTarget).toEqual({ current: 'bank', pending: 'category-one' });
+  });
+
+  test('does not advance until the pending destination is confirmed', () => {
+    const { coordinateGetter, keyboardTarget } = createCoordinateGetter('bank');
+    const tabEvent = new KeyboardEvent('keydown', { code: 'Tab' });
+
+    expect(coordinateGetter(tabEvent, coordinateArgs('bank'))).toEqual({ x: 240, y: 40 });
+    expect(coordinateGetter(tabEvent, coordinateArgs('bank'))).toEqual({ x: 240, y: 40 });
+    expect(keyboardTarget).toEqual({ current: 'bank', pending: 'category-one' });
+
+    expect(coordinateGetter(tabEvent, coordinateArgs('category-one'))).toEqual({
+      x: 440,
+      y: 40,
+    });
+    expect(keyboardTarget).toEqual({ current: 'category-one', pending: 'category-two' });
+  });
+});

--- a/assets/test/parts/grouping_item_editor_test.tsx
+++ b/assets/test/parts/grouping_item_editor_test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ItemEditorModal from '../../src/components/parts/janus-item-bank/ItemEditorModal';
+import { GroupingItem } from '../../src/components/parts/janus-item-bank/schema';
+
+jest.mock('../../src/apps/authoring/components/AdvancedAuthoringModal', () => {
+  const mockReact = jest.requireActual('react');
+  return {
+    AdvancedAuthoringModal: ({ show, children }: { show: boolean; children: React.ReactNode }) =>
+      show ? mockReact.createElement('div', null, children) : null,
+  };
+});
+
+jest.mock('../../src/apps/authoring/components/Modal/MediaPickerModal', () => {
+  const mockReact = jest.requireActual('react');
+  return {
+    MediaPickerModal: ({
+      onUrlChanged,
+      onOK,
+    }: {
+      onUrlChanged: (url: string) => void;
+      onOK: () => void;
+    }) =>
+      mockReact.createElement(
+        'div',
+        null,
+        mockReact.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: () => onUrlChanged('https://example.com/project/media/images?token=temporary'),
+          },
+          'Select soda image',
+        ),
+        mockReact.createElement(
+          'button',
+          {
+            type: 'button',
+            onClick: onOK,
+          },
+          'Use selected image',
+        ),
+      ),
+  };
+});
+
+describe('Grouping item editor image accessibility', () => {
+  test('preserves blank alt text through image selection, save, and reopen', () => {
+    const onSave = jest.fn();
+    const props = {
+      show: true,
+      initialItem: null,
+      existingLabels: [],
+      projectSlug: 'project',
+      onSave,
+      onCancel: jest.fn(),
+    };
+    const { rerender } = render(<ItemEditorModal {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Image' }));
+    fireEvent.change(screen.getByLabelText('Short label'), { target: { value: 'soda-id' } });
+    fireEvent.change(screen.getByLabelText('Text'), { target: { value: 'A can of soda' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Choose image' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Select soda image' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Use selected image' }));
+
+    expect(screen.getByLabelText('Alt text')).toHaveValue('');
+    expect(screen.getByRole('img', { name: 'A can of soda' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const savedItem = onSave.mock.calls[0][0] as GroupingItem;
+    expect(savedItem).toMatchObject({
+      type: 'image',
+      label: 'soda-id',
+      text: 'A can of soda',
+      imageSrc: 'https://example.com/project/media/images?token=temporary',
+      alt: '',
+    });
+
+    rerender(<ItemEditorModal {...props} initialItem={savedItem} />);
+
+    expect(screen.getByLabelText('Alt text')).toHaveValue('');
+    expect(screen.getByRole('img', { name: 'A can of soda' })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This was primarily to fix the way accessibility feedback was announced in preview (and student view) mode, but I decided to fix up a bit of how the keyboard commands work with the component, as I was having unintended auto-drop occur while testing. 

Resolves the remaining accessibility feedback for the learner-facing Grouping component and live preview.

- Announces full text for text items and alt text for images.
- Falls back from blank image alt text to the caption, then short label.
- Preserves blank alt text when saving image items (stop from grabbing alt text from url)
- Presents keyboard instructions once at the board level.
- Supports Tab, Shift+Tab, and arrow-key destination navigation.
- Requires Space or Enter to explicitly drop an item.
- Restores the original placement and visible focus area when cancelling (you can cancel by hitting ESC) 
- Keeps keyboard destinations visible without delaying consecutive navigation.
- Removes unavailable drag affordances when the component is disabled.
- Preserves existing short-label CAPI identifiers.

## Testing

I worked with Codex to make some tests to ensure that the changes pass without needing much manual testing (although I always recommend manual testing). Hopefully this also helps with any regression testing. 

- Added Grouping screen-reader and keyboard interaction coverage.
- Added keyboard coordinate-handler coverage.
- Added image-editor blank-alt coverage.
- Confirmed 3 Jest suites and 17 tests pass.
- Confirmed frontend TypeScript, ESLint, Prettier, and `git diff --check` pass.

## Manual verification

- Verified blank image alt text falls back to the visible caption.
- Verified authored alt text overrides the caption.
- Verified consecutive Tab and Shift+Tab navigation.
- Verified arrow-key navigation, wrapping, explicit drop, and Escape cancellation.
- Verified cancellation returns the original item area to view.
- Verified normal keyboard navigation still works after cancellation.
- Regression-checked mouse/touch behavior, disabled state, and visual layout.