### PR TITLE
[ENHANCEMENT] [MER-5851] Add playwright manual scoring coverage

### DIFF
--- a/assets/automation/src/systems/torus/pom/dashboard/ManualScoringPO.ts
+++ b/assets/automation/src/systems/torus/pom/dashboard/ManualScoringPO.ts
@@ -1,0 +1,106 @@
+import { expect, Locator, Page } from '@playwright/test';
+import { Verifier } from '@core/verify/Verifier';
+
+/**
+ * Instructor "Manual Scoring" queue (`/sections/:slug/scoring`).
+ *
+ * The queue only lists activity attempts whose lifecycle state is `submitted`, so an
+ * attempt disappears from it once it has been scored.
+ */
+export class ManualScoringPO {
+  private readonly screenBreadcrumb: Locator;
+  private readonly selectedAttemptPanel: Locator;
+  private readonly scoreInput: Locator;
+  private readonly feedbackInput: Locator;
+  private readonly applyButton: Locator;
+  private readonly scoredFlash: Locator;
+  private readonly feedbackRequiredMessage: Locator;
+
+  constructor(private readonly page: Page) {
+    this.screenBreadcrumb = page
+      .getByRole('navigation', { name: /breadcrumb/i })
+      .getByText('Manual Scoring');
+    this.selectedAttemptPanel = page.getByText('Selected Attempt').first();
+    this.scoreInput = page.getByLabel('Score', { exact: true }).first();
+    this.feedbackInput = page.getByLabel('Feedback').first();
+    this.applyButton = page.getByRole('button', { name: 'Apply Score and Feedback' });
+    this.scoredFlash = page.getByText('Student attempt scored.');
+    this.feedbackRequiredMessage = page
+      .getByText('Add feedback for this input to enable Apply Score and Feedback.')
+      .first();
+  }
+
+  async open(sectionSlug: string) {
+    await this.page.goto(`/sections/${sectionSlug}/scoring`, { waitUntil: 'domcontentloaded' });
+
+    // Checked before the socket wait: an instructor who cannot reach this screen lands on a
+    // plain error page, and waiting for a LiveView that will never connect hides the reason.
+    await Verifier.expectIsVisible(this.screenBreadcrumb, 'Manual Scoring screen');
+
+    // Rows and scoring inputs are driven by LiveView events and hooks, so nothing is
+    // interactive until the socket is connected.
+    await this.page.waitForSelector('[data-phx-main].phx-connected', { state: 'attached' });
+  }
+
+  /** Selects the queued attempt for a student on a page. Students render as "family, given". */
+  async selectAttempt(options: { pageTitle: string; student: string }) {
+    const row = this.queueRow(options);
+
+    // The queue query is heavy, so on a loaded machine the table can take well over the
+    // default expect timeout to render. Verifier has no timeout override, hence raw expect.
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    await row.click();
+
+    await Verifier.expectIsVisible(this.selectedAttemptPanel, 'Selected attempt panel');
+    await Verifier.expectIsVisible(this.scoreInput, 'Score input');
+  }
+
+  async enterScore(score: string) {
+    await this.scoreInput.fill(score);
+  }
+
+  /** The score hook clamps the value to the available points on blur, not while typing. */
+  async blurScore() {
+    await this.scoreInput.blur();
+  }
+
+  async enterFeedback(feedback: string) {
+    await this.feedbackInput.fill(feedback);
+  }
+
+  /** The 0% / 50% / 100% buttons next to the score input. */
+  async clickScoreShortcut(label: '0%' | '50%' | '100%') {
+    await this.scoreShortcut(label).click();
+  }
+
+  async expectScore(score: string) {
+    // Scores round trip through the server as floats, so 1 is re-rendered as "1.0".
+    const literal = score.replace(/\./g, '\\.');
+
+    await Verifier.expectToHaveValue(this.scoreInput, new RegExp(`^${literal}(\\.0+)?$`), 'Score');
+  }
+
+  /** Feedback is mandatory: a score on its own must not enable the apply button. */
+  async expectFeedbackRequired() {
+    await Verifier.expectIsVisible(this.feedbackRequiredMessage, 'Feedback required message');
+    await Verifier.expectIsDisabled(this.applyButton, 'Apply Score and Feedback');
+  }
+
+  async apply() {
+    await Verifier.expectIsEnabled(this.applyButton, 'Apply Score and Feedback');
+    await this.applyButton.click();
+    await Verifier.expectIsVisible(this.scoredFlash, 'Attempt scored confirmation');
+  }
+
+  private scoreShortcut(label: string) {
+    return this.page.getByRole('button', { name: label, exact: true }).first();
+  }
+
+  private queueRow({ pageTitle, student }: { pageTitle: string; student: string }) {
+    return this.page
+      .locator('table tbody tr')
+      .filter({ hasText: pageTitle })
+      .filter({ hasText: student })
+      .first();
+  }
+}

--- a/assets/automation/tests/torus/manual_scoring/manual-scoring.scenario.yaml
+++ b/assets/automation/tests/torus/manual_scoring/manual-scoring.scenario.yaml
@@ -1,0 +1,229 @@
+# Scenario: Seed basic and adaptive manually scored delivery workflows for Playwright.
+
+- project:
+    name: 'manual_scoring_basic_project'
+    title: 'Manual Scoring Basic Course ${RUN_ID}'
+    root:
+      children:
+        - page: 'Manual Short Answer'
+
+- create_activity:
+    project: 'manual_scoring_basic_project'
+    title: 'Manual Short Answer Question'
+    virtual_id: 'manual_short_answer'
+    type: 'oli_short_answer'
+    content_format: 'json'
+    content:
+      activityType: 'oli_short_answer'
+      stem:
+        id: 'manual_short_answer_stem'
+        content:
+          - type: 'p'
+            id: 'manual_short_answer_stem_p'
+            children:
+              - text: 'Explain your reasoning in a sentence.'
+      inputType: 'textarea'
+      authoring:
+        targeted: []
+        transformations: []
+        previewText: ''
+        parts:
+          - id: '1'
+            scoringStrategy: 'best'
+            gradingApproach: 'manual'
+            outOf: 1
+            responses:
+              # Manual grading means the instructor sets the real score, so this catch-all
+              # response exists only so the activity has a valid one.
+              - id: 'manual_short_answer_response'
+                rule: 'input like {.*}'
+                score: 0
+                feedback:
+                  id: 'manual_short_answer_feedback'
+                  content: []
+            hints: []
+
+- edit_page:
+    project: 'manual_scoring_basic_project'
+    page: 'Manual Short Answer'
+    content: |
+      title: "Manual Short Answer"
+      graded: true
+      blocks:
+        - type: activity_reference
+          virtual_id: "manual_short_answer"
+
+- publish:
+    to: 'manual_scoring_basic_project'
+    description: 'Initial manual scoring basic publication'
+
+- section:
+    name: 'manual_scoring_basic_section'
+    title: 'Manual Scoring Basic Course ${RUN_ID}'
+    from: 'manual_scoring_basic_project'
+    type: 'enrollable'
+    registration_open: true
+
+- project:
+    name: 'manual_scoring_adaptive_project'
+    title: 'Manual Scoring Adaptive Course ${RUN_ID}'
+    root:
+      children:
+        - page: 'Manual Adaptive Page'
+
+- create_activity:
+    project: 'manual_scoring_adaptive_project'
+    title: 'Manual Adaptive Activity'
+    virtual_id: 'manual_adaptive_activity'
+    scope: 'embedded'
+    type: 'oli_adaptive'
+    content_format: 'json'
+    content:
+      authoring:
+        parts:
+          - id: 'capi_iframe_part'
+            type: 'janus-capi-iframe'
+            gradingApproach: 'manual'
+            outOf: 1
+            src: '${STUB_URL}'
+            sourceType: 'url'
+            configData:
+              - key: 'x'
+                type: 1
+                value: '0'
+        rules:
+          - id: 'r:manual_adaptive.complete.correct'
+            name: 'manual adaptive completed'
+            disabled: false
+            additionalScore: 0.0
+            forceProgress: false
+            default: false
+            correct: true
+            conditions:
+              all:
+                - id: 'c:manual_adaptive.x'
+                  fact: 'stage.capi_iframe_part.x'
+                  operator: 'equal'
+                  value: 5
+            event:
+              type: 'r:manual_adaptive.complete.correct'
+              params:
+                actions:
+                  - type: 'mutateState'
+                    params:
+                      target: 'stage.capi_iframe_part.acknowledged'
+                      operator: '='
+                      type: 1
+                      value: 1
+      custom:
+        x: 0
+        y: 0
+        z: 0
+        width: 800
+        height: 600
+        # Evaluation reads this maxScore and falls back to the parts' outOf above when it is
+        # missing, while the part's own maxScore below drives its render. Keep the three in sync.
+        maxScore: 1
+      partsLayout:
+        - id: 'capi_iframe_part'
+          type: 'janus-capi-iframe'
+          custom:
+            x: 0
+            y: 0
+            z: 0
+            width: 800
+            height: 600
+            maxScore: 1
+            src: '${STUB_URL}'
+            sourceType: 'url'
+            requiresManualGrading: true
+            configData:
+              - key: 'x'
+                type: 1
+                value: '0'
+
+- edit_adaptive_page:
+    project: 'manual_scoring_adaptive_project'
+    page: 'Manual Adaptive Page'
+    activity_virtual_id: 'manual_adaptive_activity'
+    graded: true
+
+- publish:
+    to: 'manual_scoring_adaptive_project'
+    description: 'Initial manual scoring adaptive publication'
+
+- section:
+    name: 'manual_scoring_adaptive_section'
+    title: 'Manual Scoring Adaptive Course ${RUN_ID}'
+    from: 'manual_scoring_adaptive_project'
+    type: 'enrollable'
+    registration_open: true
+
+- user:
+    name: 'manual_scoring_student'
+    type: 'student'
+    email: 'manual-scoring-student${RUN_ID}@example.com'
+    given_name: 'Manual'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
+    name: 'manual_scoring_student_two'
+    type: 'student'
+    email: 'manual-scoring-student-two${RUN_ID}@example.com'
+    given_name: 'Second'
+    family_name: 'Student'
+    password: 'changeme123456'
+
+- user:
+    name: 'manual_scoring_instructor'
+    type: 'instructor'
+    email: 'manual-scoring-instructor${RUN_ID}@example.com'
+    given_name: 'Manual'
+    family_name: 'Instructor'
+    password: 'changeme123456'
+
+- enroll:
+    user: 'manual_scoring_student'
+    section: 'manual_scoring_basic_section'
+    role: 'student'
+
+- enroll:
+    user: 'manual_scoring_student'
+    section: 'manual_scoring_adaptive_section'
+    role: 'student'
+
+- enroll:
+    user: 'manual_scoring_instructor'
+    section: 'manual_scoring_basic_section'
+    role: 'instructor'
+
+- enroll:
+    user: 'manual_scoring_instructor'
+    section: 'manual_scoring_adaptive_section'
+    role: 'instructor'
+
+- enroll:
+    user: 'manual_scoring_student_two'
+    section: 'manual_scoring_basic_section'
+    role: 'student'
+
+# A second attempt left waiting for manual grading, seeded through the real page
+# lifecycle. It gives the grading queue more than one row, so selecting a row actually
+# has to pick the right one, and it is the attempt the score input test scribbles on.
+- visit_page:
+    student: 'manual_scoring_student_two'
+    section: 'manual_scoring_basic_section'
+    page: 'Manual Short Answer'
+
+- answer_question:
+    student: 'manual_scoring_student_two'
+    section: 'manual_scoring_basic_section'
+    page: 'Manual Short Answer'
+    activity_virtual_id: 'manual_short_answer'
+    response: 'Second student response awaiting review.'
+
+- finalize_attempt:
+    student: 'manual_scoring_student_two'
+    section: 'manual_scoring_basic_section'
+    page: 'Manual Short Answer'

--- a/assets/automation/tests/torus/manual_scoring/manual-scoring.spec.ts
+++ b/assets/automation/tests/torus/manual_scoring/manual-scoring.spec.ts
@@ -1,0 +1,354 @@
+import { expect, type FrameLocator, type Page } from '@playwright/test';
+import { test } from '@fixture/my-fixture';
+import { getBaseUrl, getScenarioToken } from '@core/runtimeConfig';
+import { ManualScoringPO } from '@pom/dashboard/ManualScoringPO';
+import { StudentCoursePO } from '@pom/course/StudentCoursePO';
+import path from 'node:path';
+import { waitForMainLiveView } from '../student_delivery/support';
+import {
+  CapiType,
+  countOf,
+  sendFromStub,
+  sendValueChange,
+  serveStubSim,
+  startHandshake,
+  stubFrame,
+  STUB_SIM_URL,
+} from '../capi/support/capiStub';
+
+const runId = `-${Date.now()}`;
+// Emails mirror the users the scenario seeds.
+const emails = {
+  student: `manual-scoring-student${runId}@example.com`,
+  instructor: `manual-scoring-instructor${runId}@example.com`,
+};
+const scenarioPath = path.resolve(__dirname, './manual-scoring.scenario.yaml');
+const basicPageTitle = 'Manual Short Answer';
+const adaptivePageTitle = 'Manual Adaptive Page';
+const basicFeedback = 'Basic response shows clear reasoning.';
+const adaptiveFeedback = 'Adaptive response is complete.';
+const manualScore = '1';
+// Matches outOf on the seeded activity.
+const activityOutOf = '1';
+// Tables render students as "family, given".
+const studentRowLabel = 'Student, Manual';
+// Second student's attempt is seeded straight into the queue and never scored, so it is
+// what the score input test can scribble on without disturbing the other workflows.
+const secondStudentRowLabel = 'Student, Second';
+
+let sections: { adaptive: string; basic: string };
+const deliveryPaths = new Map<string, string>();
+
+test.beforeAll(async ({ seedScenario }) => {
+  const response = await seedScenario(scenarioPath, { RUN_ID: runId, STUB_URL: STUB_SIM_URL });
+  const outputs = response.outputs as { sections?: Record<string, string> } | undefined;
+
+  sections = {
+    adaptive: outputs?.sections?.manual_scoring_adaptive_section ?? '',
+    basic: outputs?.sections?.manual_scoring_basic_section ?? '',
+  };
+
+  expect(sections.adaptive, 'seeded adaptive section slug').toBeTruthy();
+  expect(sections.basic, 'seeded basic section slug').toBeTruthy();
+});
+
+test.describe('manual scoring delivery workflows', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test('instructor scores a manually graded basic page attempt and student sees the result', async ({
+    page,
+  }) => {
+    await test.step('student submits a manually graded short answer', async () => {
+      await loginAs(page, 'student');
+      await openLesson(page, sections.basic, basicPageTitle, { startAttempt: true });
+
+      const activity = page.locator('oli-short-answer-delivery').first();
+      await expect(activity).toBeVisible();
+      await activity.getByLabel('answer submission textbox').fill('The answer needs human review.');
+
+      const submitButton = page.locator('#submit_answers');
+      await expect(submitButton).toBeVisible();
+      await submitButton.click();
+
+      await expect(page.getByText('Your response has been received')).toBeVisible();
+    });
+
+    await test.step('attempt waits for the instructor instead of being auto scored', async () => {
+      await openLesson(page, sections.basic, basicPageTitle);
+
+      await expectAttemptAwaitingScore(page);
+    });
+
+    await test.step('instructor applies score and feedback', async () => {
+      await loginAs(page, 'instructor');
+      await scoreQueuedAttempt(page, {
+        sectionSlug: sections.basic,
+        pageTitle: basicPageTitle,
+        student: studentRowLabel,
+        score: manualScore,
+        feedback: basicFeedback,
+      });
+    });
+
+    await test.step('student sees score and instructor feedback on review', async () => {
+      await loginAs(page, 'student');
+      await openLesson(page, sections.basic, basicPageTitle);
+
+      await expectAttemptScored(page, manualScore, activityOutOf);
+      await page.getByRole('link', { name: /review/i }).click();
+      await expect(page.getByText(basicFeedback)).toBeVisible();
+    });
+
+    await test.step('manual score reaches the instructor gradebook', async () => {
+      await loginAs(page, 'instructor');
+      await openGradebook(page, sections.basic);
+
+      const scoredRow = gradebookRow(page, studentRowLabel);
+      const pendingRow = gradebookRow(page, secondStudentRowLabel);
+
+      const scoreCell = `${rendered(manualScore)}/${rendered(activityOutOf)}`;
+
+      await expect(scoredRow).toBeVisible();
+      await expect(scoredRow.getByRole('link', { name: scoreCell })).toBeVisible();
+
+      // The second student's attempt is still queued, so its row must exist without a score.
+      await expect(pendingRow).toBeVisible();
+      await expect(pendingRow.getByRole('link', { name: scoreCell })).toHaveCount(0);
+    });
+  });
+
+  test('score input clamps to the available points and the shortcut buttons set it', async ({
+    page,
+  }) => {
+    await loginAs(page, 'instructor');
+
+    const manualScoring = new ManualScoringPO(page);
+
+    await manualScoring.open(sections.basic);
+    await manualScoring.selectAttempt({
+      pageTitle: basicPageTitle,
+      student: secondStudentRowLabel,
+    });
+
+    await test.step('a score above the available points is clamped on blur', async () => {
+      await manualScoring.enterScore('5');
+      await manualScoring.blurScore();
+
+      await manualScoring.expectScore('1');
+    });
+
+    await test.step('the shortcut buttons set 0, half and full credit', async () => {
+      await manualScoring.clickScoreShortcut('0%');
+      await manualScoring.expectScore('0');
+
+      await manualScoring.clickScoreShortcut('50%');
+      await manualScoring.expectScore('0.5');
+
+      await manualScoring.clickScoreShortcut('100%');
+      await manualScoring.expectScore('1');
+    });
+  });
+
+  test('instructor scores a manually graded adaptive attempt and student sees the result', async ({
+    page,
+  }) => {
+    await serveStubSim(page);
+
+    await test.step('student completes the adaptive screen for manual grading', async () => {
+      await loginAs(page, 'student');
+      await openLesson(page, sections.adaptive, adaptivePageTitle, { startAttempt: true });
+
+      const frame = stubFrame(page);
+
+      // The adaptive deck has to mount before the stub iframe exists, which does not fit in
+      // the default expect timeout. capi.spec.ts waits 30s for this same iframe.
+      await expect(frame.locator('#status')).toContainText('stub-sim loaded', {
+        timeout: 30_000,
+      });
+      await handshakeAndReady(frame);
+      await sendValueChange(frame, { x: { type: 1, value: '5' } });
+      await sendFromStub(frame, CapiType.CHECK_REQUEST);
+      await waitForCount(frame, CapiType.CHECK_START_RESPONSE);
+      // Torus only sends the check complete response once the evaluation round trip
+      // finished, so this is what tells us the attempt reached the grading queue.
+      await waitForCount(frame, CapiType.CHECK_COMPLETE_RESPONSE);
+    });
+
+    await test.step('instructor applies score and feedback', async () => {
+      await loginAs(page, 'instructor');
+      await scoreQueuedAttempt(page, {
+        sectionSlug: sections.adaptive,
+        pageTitle: adaptivePageTitle,
+        student: studentRowLabel,
+        score: manualScore,
+        feedback: adaptiveFeedback,
+      });
+    });
+
+    await test.step('student sees score and instructor feedback on the adaptive prologue', async () => {
+      await loginAs(page, 'student');
+      await openLesson(page, sections.adaptive, adaptivePageTitle);
+
+      await expectAttemptScored(page, manualScore, activityOutOf);
+      await expect(page.getByText('Instructor Feedback:')).toBeVisible();
+      await expect(page.getByText(adaptiveFeedback)).toBeVisible();
+    });
+  });
+});
+
+/**
+ * Signs in as a role through the test-only session endpoint, which creates the session
+ * server side for that email. No login form, so switching users cannot land on the
+ * previous one, and no page is loaded: every caller navigates somewhere right after.
+ */
+async function loginAs(page: Page, role: 'student' | 'instructor') {
+  await test.step(`sign in as ${role}`, async () => {
+    const loginUrl = new URL('/test/log_in_user', getBaseUrl());
+
+    loginUrl.searchParams.set('email', emails[role]);
+
+    // page.request shares the context cookie jar, so the browser ends up logged in without
+    // rendering anything: every caller navigates somewhere specific right after this.
+    const response = await page.request.get(loginUrl.toString(), {
+      headers: { 'x-playwright-scenario-token': getScenarioToken() },
+      maxRedirects: 0,
+    });
+
+    expect(response.status(), `log_in_user for ${role}`).toBeLessThan(400);
+  });
+}
+
+async function openLesson(
+  page: Page,
+  sectionSlug: string,
+  title: string,
+  options: { startAttempt?: boolean } = {},
+) {
+  const path = await deliveryPath(page, sectionSlug, title);
+
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByRole('heading', { name: title, exact: true })).toBeVisible();
+
+  if (options.startAttempt) {
+    const beginAttempt = page.locator('#begin_attempt_button');
+
+    await expect(beginAttempt).toBeVisible();
+    await beginAttempt.click();
+  }
+}
+
+/**
+ * Resolves the delivery path of a page from the course links and caches it, so every
+ * later visit is a direct navigation instead of a hunt through home/outline variants.
+ * Graded pages redirect to their prologue when there is no attempt in progress.
+ */
+async function deliveryPath(page: Page, sectionSlug: string, title: string) {
+  const cacheKey = `${sectionSlug}/${title}`;
+  const cached = deliveryPaths.get(cacheKey);
+
+  if (cached) return cached;
+
+  await page.goto(`/sections/${sectionSlug}?sidebar_expanded=true`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await new StudentCoursePO(page).goToCourseIfPrompted();
+
+  const lessonLink = page
+    .locator('a[href*="/lesson/"], a[href*="/adaptive_lesson/"]')
+    .filter({ hasText: title })
+    .first();
+
+  await expect(lessonLink).toBeVisible();
+
+  const href = await lessonLink.getAttribute('href');
+
+  expect(href, `delivery link for "${title}"`).toBeTruthy();
+
+  const resolved = new URL(href as string, page.url()).pathname;
+
+  deliveryPaths.set(cacheKey, resolved);
+
+  return resolved;
+}
+
+/** The prologue summary for the student's first attempt at the current page. */
+function attemptSummary(page: Page) {
+  return page.locator('#attempt_1_summary');
+}
+
+async function openGradebook(page: Page, sectionSlug: string) {
+  await page.goto(`/sections/${sectionSlug}/grades/gradebook`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await waitForMainLiveView(page);
+}
+
+/** A gradebook row holds one student and a score cell per graded page ("score/out of"). */
+function gradebookRow(page: Page, student: string) {
+  return page.locator('tr').filter({ hasText: student }).first();
+}
+
+async function expectAttemptAwaitingScore(page: Page) {
+  const summary = attemptSummary(page);
+
+  await expect(summary).toBeVisible();
+  await expect(summary).toContainText(/Attempt status:\s*Submitted/);
+  await expect(summary).not.toContainText('Attempt score:');
+}
+
+/** Scores come back as Elixir floats, which always carry a decimal: 1 -> "1.0", 0.5 -> "0.5". */
+function rendered(score: string) {
+  const value = Math.round(Number(score) * 100) / 100;
+
+  return Number.isInteger(value) ? value.toFixed(1) : String(value);
+}
+
+async function expectAttemptScored(page: Page, score: string, outOf: string) {
+  const summary = attemptSummary(page);
+  const pattern = (value: string) => rendered(value).replace(/\./g, '\\.');
+
+  await expect(summary).toBeVisible();
+  await expect(summary).toContainText(new RegExp(`Attempt score:\\s*${pattern(score)}`));
+  await expect(summary).toContainText(new RegExp(`Attempt out of:\\s*${pattern(outOf)}`));
+}
+
+/**
+ * Scores the student's queued attempt for a page, checking on the way that feedback is
+ * mandatory before the score can be applied.
+ */
+async function scoreQueuedAttempt(
+  page: Page,
+  options: {
+    sectionSlug: string;
+    pageTitle: string;
+    student: string;
+    score: string;
+    feedback: string;
+  },
+) {
+  const manualScoring = new ManualScoringPO(page);
+
+  await manualScoring.open(options.sectionSlug);
+  await manualScoring.selectAttempt({ pageTitle: options.pageTitle, student: options.student });
+
+  await manualScoring.enterScore(options.score);
+  await manualScoring.expectFeedbackRequired();
+
+  // Entering the feedback also blurs the score input, which is when its hook clamps the value.
+  await manualScoring.enterFeedback(options.feedback);
+  await manualScoring.expectScore(options.score);
+
+  await manualScoring.apply();
+}
+
+function waitForCount(frame: FrameLocator, type: CapiType) {
+  return expect.poll(() => countOf(frame, type), { timeout: 15_000 }).toBeGreaterThanOrEqual(1);
+}
+
+async function handshakeAndReady(frame: FrameLocator) {
+  await startHandshake(frame);
+  await waitForCount(frame, CapiType.HANDSHAKE_RESPONSE);
+  await sendFromStub(frame, CapiType.ON_READY);
+  await waitForCount(frame, CapiType.INITIAL_SETUP_COMPLETE);
+}


### PR DESCRIPTION
[MER-5851](https://eliterate.atlassian.net/browse/MER-5851)

## Summary

This PR adds Playwright automation coverage for manual scoring, verifying that basic page and adaptive activities that require manual grading are scoreable by instructors, and that the student sees the resulting score and feedback.

### Changes

- Covers the basic page flow: the student submits a manually graded short answer, the instructor scores that attempt, and the student sees the score and the feedback on review.
- Covers the same flow on an adaptive page, driven end to end through its CAPI part.
- Adds assertions around the flow: the attempt is not auto scored while it waits for the instructor, feedback is mandatory before a score can be applied, and the applied score reaches the instructor gradebook.
- Covers the score input clamping to the available points and the 0% / 50% / 100% shortcut buttons.
- Adds a scenario that seeds projects, pages, sections, users and enrollments, plus a second student attempt left waiting in the grading queue.
- Adds a page object for the manual scoring queue.

### Tests

- npm run pw -- tests/torus/manual_scoring/manual-scoring.spec.ts

[MER-5851]: https://eliterate.atlassian.net/browse/MER-5851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ