### PR TITLE
[BUG FIX] [MER-5438] Fix CATA delivery spec choice selectors

### DIFF
--- a/assets/automation/tests/torus/student_delivery/cata-delivery.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/cata-delivery.spec.ts
@@ -64,8 +64,8 @@ test.describe('CATA delivery', () => {
   }) => {
     await openStudentDeliveryPractice(homeTask, page, sections.positive, activityTitle);
     const activity = page.locator('.activity.cata-activity');
-    const choiceOne = page.getByRole('checkbox', { name: 'choice 1', exact: true });
-    const choiceTwo = page.getByRole('checkbox', { name: 'choice 2', exact: true });
+    const choiceOne = page.getByRole('checkbox', { name: 'Correct 1', exact: true });
+    const choiceTwo = page.getByRole('checkbox', { name: 'Correct 2', exact: true });
     const submitButton = page.getByRole('button', { name: 'submit', exact: true });
 
     await expect(activity).toBeVisible();


### PR DESCRIPTION
[MER-5438](https://eliterate.atlassian.net/browse/MER-5438)

## Problem

The CATA delivery spec times out on its first test before submitting. The feature works fine — the test is querying selectors that no longer exist.

## Root cause

A recent accessibility change to `ChoicesDelivery.tsx`, the component shared by MCQ and CATA, replaced the synthetic positional label on each choice:

```diff
-  aria-label={`choice ${index + 1}`}
+  aria-labelledby={choiceContentId}
```

Screen readers now announce the real answer text, which is the right behavior. As a side effect, each choice's accessible name changed from `choice 1` / `choice 2` to the rendered content (`Correct 1` / `Correct 2`), and the spec was still querying the old labels.

## Fix

Target the rendered choice text, which now matches the scenario YAML:

```ts
const choiceOne = page.getByRole('checkbox', { name: 'Correct 1', exact: true });
const choiceTwo = page.getByRole('checkbox', { name: 'Correct 2', exact: true });
```

Only the first test was affected — the negative test filters by `hasText: 'Incorrect'`. `ordering-delivery.spec.ts` uses similar labels but is **not** affected: it renders through `ResponseChoices.tsx`, which still sets `itemAriaLabel`.

[MER-5438]: https://eliterate.atlassian.net/browse/MER-5438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ