### PR TITLE
[ENHANCEMENT] [MER-5835] Relax payment code constraints

### DIFF
--- a/lib/oli/delivery/paywall.ex
+++ b/lib/oli/delivery/paywall.ex
@@ -322,8 +322,8 @@ defmodule Oli.Delivery.Paywall do
   {:error, {:not_enrolled}} if the student is not enrolled in the section
   {:error, {:unknown_section}} when the section slug does not pertain to a valid section
   {:error, {:unknown_code}} when no deferred payment record is found for `code`
-  {:error, {:invalid_code}} when the code is invalid, whether it has already been redeemed or
-    if it doesn't pertain to this section or blueprint product
+  {:error, {:invalid_code}} when the code is invalid or has already been redeemed
+  {:error, {:insufficient_value}} when the code amount does not cover the section cost
 
   """
   def redeem_code(human_readable_code, %User{} = user, section_slug) do
@@ -333,35 +333,58 @@ defmodule Oli.Delivery.Paywall do
           nil ->
             {:error, {:unknown_section}}
 
-          %Section{blueprint_id: blueprint_id, id: id} = section ->
+          %Section{} = section ->
             case get_payment_by(code: code) do
               nil ->
                 {:error, {:unknown_code}}
 
-              %Payment{
-                type: :deferred,
-                application_date: nil,
-                section_id: ^id,
-                enrollment_id: nil
-              } = payment ->
-                apply_payment(payment, user, section)
+              %Payment{} = payment ->
+                cond do
+                  not unused_deferred_code?(payment) ->
+                    {:error, {:invalid_code}}
 
-              %Payment{
-                type: :deferred,
-                application_date: nil,
-                section_id: ^blueprint_id,
-                enrollment_id: nil
-              } = payment ->
-                apply_payment(payment, user, section)
+                  not payment_covers_section_cost?(payment, section) ->
+                    {:error, {:insufficient_value}}
 
-              _ ->
-                {:error, {:invalid_code}}
+                  true ->
+                    apply_payment(payment, user, section)
+                end
             end
         end
 
       _ ->
         {:error, {:invalid_code}}
     end
+  end
+
+  defp unused_deferred_code?(%Payment{
+         type: :deferred,
+         application_date: nil,
+         enrollment_id: nil
+       }),
+       do: true
+
+  defp unused_deferred_code?(_), do: false
+
+  defp payment_covers_section_cost?(
+         %Payment{amount: %Money{currency: currency} = payment_amount},
+         %Section{
+           requires_payment: true,
+           amount: %Money{currency: currency} = section_amount
+         }
+       ) do
+    try do
+      section_has_positive_cost?(section_amount) and
+        Money.compare(payment_amount, section_amount) in [:eq, :gt]
+    rescue
+      _ -> false
+    end
+  end
+
+  defp payment_covers_section_cost?(_, _), do: false
+
+  defp section_has_positive_cost?(%Money{currency: currency} = amount) do
+    Money.compare(amount, Money.new(0, currency)) == :gt
   end
 
   defp apply_payment(payment, user, section) do
@@ -718,7 +741,7 @@ defmodule Oli.Delivery.Paywall do
   end
 
   @doc """
-  Gets the active payment for a given enrollment and section (or its associated blueprint).
+  Gets the active payment for a given enrollment.
   By active we mean a payment that has not been invalidated by an admin.
 
   Example:
@@ -727,26 +750,12 @@ defmodule Oli.Delivery.Paywall do
   iex> get_active_payment_for(1, %Section{id: 3})
   {:error, :no_active_payment_found}
   """
-  def get_active_payment_for(enrollment_id, section) do
-    # Build the complete where condition dynamically to handle nil blueprint_id
-    where_condition =
-      if is_nil(section.blueprint_id) do
-        dynamic(
-          [p],
-          p.enrollment_id == ^enrollment_id and
-            p.section_id == ^section.id and
-            p.type != :invalidated
-        )
-      else
-        dynamic(
-          [p],
-          p.enrollment_id == ^enrollment_id and
-            (p.section_id == ^section.id or p.section_id == ^section.blueprint_id) and
-            p.type != :invalidated
-        )
-      end
-
-    from(p in Payment, where: ^where_condition)
+  def get_active_payment_for(enrollment_id, _section) do
+    from(p in Payment,
+      where: p.enrollment_id == ^enrollment_id and p.type != :invalidated,
+      order_by: [desc: p.id],
+      limit: 1
+    )
     |> Repo.one()
     |> case do
       nil -> {:error, :no_active_payment_found}

--- a/test/oli/delivery/paywall_test.exs
+++ b/test/oli/delivery/paywall_test.exs
@@ -259,6 +259,7 @@ defmodule Oli.Delivery.PaywallTest do
 
       %{
         product: product,
+        product2: product2,
         section: section,
         map: map,
         user1: user1,
@@ -279,13 +280,15 @@ defmodule Oli.Delivery.PaywallTest do
                Paywall.redeem_code(hd(codes1) |> to_human(), user2, section.slug)
     end
 
-    test "redeem_code/3 fails when code applies to another product", %{
+    test "redeem_code/3 succeeds when code applies to another product with the same amount", %{
+      product2: product2,
       section: section,
       codes2: codes,
       user1: user
     } do
-      assert {:error, {:invalid_code}} ==
-               Paywall.redeem_code(hd(codes) |> to_human(), user, section.slug)
+      assert {:ok, payment} = Paywall.redeem_code(hd(codes) |> to_human(), user, section.slug)
+      assert payment.section_id == product2.id
+      assert payment.pending_section_id == section.id
     end
 
     test "redeem_code/3 fails when section does not exist", %{
@@ -310,6 +313,41 @@ defmodule Oli.Delivery.PaywallTest do
       codes1: codes
     } do
       assert {:ok, _} = Paywall.redeem_code(hd(codes) |> to_human(), user, section.slug)
+    end
+
+    test "redeem_code/3 succeeds when code amount is greater than section amount", %{
+      section: section,
+      user1: user,
+      codes2: codes
+    } do
+      code = hd(codes)
+      {:ok, code} = Paywall.update_payment(code, %{amount: Money.new(150, "USD")})
+
+      assert {:ok, _} = Paywall.redeem_code(to_human(code), user, section.slug)
+    end
+
+    test "redeem_code/3 fails when code amount is less than section amount", %{
+      section: section,
+      user1: user,
+      codes2: codes
+    } do
+      code = hd(codes)
+      {:ok, code} = Paywall.update_payment(code, %{amount: Money.new(50, "USD")})
+
+      assert {:error, {:insufficient_value}} =
+               Paywall.redeem_code(to_human(code), user, section.slug)
+    end
+
+    test "redeem_code/3 fails when code currency does not match section currency", %{
+      section: section,
+      user1: user,
+      codes2: codes
+    } do
+      code = hd(codes)
+      {:ok, code} = Paywall.update_payment(code, %{amount: Money.new(150, "EUR")})
+
+      assert {:error, {:insufficient_value}} =
+               Paywall.redeem_code(to_human(code), user, section.slug)
     end
 
     test "redeem_code/3 fails after it has been redeemed once", %{
@@ -946,6 +984,20 @@ defmodule Oli.Delivery.PaywallTest do
       assert found_payment.section_id == section.id
     end
 
+    test "returns payment associated with an unrelated section for the enrollment" do
+      section = insert(:section, %{type: :enrollable})
+      unrelated_product = insert(:section, %{type: :blueprint})
+      user = insert(:user)
+      enrollment = insert(:enrollment, user: user, section: section)
+
+      payment = insert(:payment, section: unrelated_product, enrollment: enrollment)
+
+      {:ok, found_payment} = Paywall.get_active_payment_for(enrollment.id, section)
+
+      assert found_payment.id == payment.id
+      assert found_payment.section_id == unrelated_product.id
+    end
+
     test "does not return invalidated payment even if it matches section or blueprint" do
       # Create a blueprint
       blueprint = insert(:section, %{type: :blueprint})
@@ -1025,6 +1077,29 @@ defmodule Oli.Delivery.PaywallTest do
       # No payment created
       assert Paywall.get_active_payment_for(enrollment.id, section) ==
                {:error, :no_active_payment_found}
+    end
+
+    test "returns the newest active payment when multiple active payments exist" do
+      section = insert(:section, %{type: :enrollable})
+      user = insert(:user)
+      enrollment = insert(:enrollment, user: user, section: section)
+
+      insert(:payment,
+        section: section,
+        enrollment: enrollment,
+        type: :direct
+      )
+
+      newest_payment =
+        insert(:payment,
+          section: section,
+          enrollment: enrollment,
+          type: :bypass
+        )
+
+      {:ok, found_payment} = Paywall.get_active_payment_for(enrollment.id, section)
+
+      assert found_payment.id == newest_payment.id
     end
   end
 


### PR DESCRIPTION
This PR relaxes the payment code redemption constraints - removing the constraint that a payment code for a section must have been generated by a template that created that section. 

The only constraints remaining are:
1. Payment code has to be unredeemed
2. Payment code must be of a value equal to or greater than the cost of the section