### PR TITLE
[ENHANCEMENT] [MER-5674] Add LotE Plate Tectonics adaptive lesson strict Playwright coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ update this file accordingly.
 - `PLAYWRIGHT_ASSETS_BUCKET` and `PLAYWRIGHT_AUTOMATION_API_KEY` are local/test-runner
   configuration only and are not required for the Torus application runtime. Neither has a
   default value — never reuse a value that appears in this repo for either. Without
-  `PLAYWRIGHT_AUTOMATION_API_KEY` the MER-5672 and MER-5673 Playwright tests are skipped; without
+  `PLAYWRIGHT_AUTOMATION_API_KEY` the MER-5672, MER-5673 and MER-5674 Playwright tests are skipped; without
   `PLAYWRIGHT_ASSETS_BUCKET` it fails, since the private test assets endpoint has no bucket
   to read from.
 

--- a/assets/automation/playwright.config.ts
+++ b/assets/automation/playwright.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
   reporter: [['html', { open: 'always' }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
+    /* An unbounded locator action can silently eat the whole test timeout
+       (a flaky CAPI iframe held getAttribute for 732s, MER-5674); every
+       longer wait in the POs passes its own explicit timeout. */
+    actionTimeout: 15_000,
     ignoreHTTPSErrors: true,
     launchOptions: {
       args: ['--start-maximized', '--ignore-certificate-errors'],

--- a/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
+++ b/assets/automation/src/systems/torus/pom/delivery/AdaptiveDeckPO.ts
@@ -39,12 +39,22 @@ export class AdaptiveDeckPO {
 
   // ------------------------------------------------------------ lifecycle
 
+  /**
+   * The footer control stays disabled until the deck finishes initialising the
+   * screen's parts (isLoading || !initPhaseComplete), so an ENABLED control is
+   * the readiness signal — no fixed settle needed.
+   */
   async waitForDeckReady() {
     await this.page
       .locator('[data-janus-type], .checkBtn, .closeFeedbackBtn')
       .first()
       .waitFor({ state: 'attached', timeout: 30_000 });
-    await this.page.waitForTimeout(2_000);
+
+    await this.page
+      .locator(FOOTER_BUTTON)
+      .first()
+      .waitFor({ state: 'visible', timeout: 30_000 })
+      .catch(() => undefined); // screens driven only by in-canvas controls have no footer
   }
 
   /** finalizeLesson redirects out of the deck or retires the footer. */
@@ -59,6 +69,20 @@ export class AdaptiveDeckPO {
       .catch(() => false);
   }
 
+  /**
+   * Whether the feedback popup is open. The deck swaps the footer button's
+   * class to closeFeedbackBtn exactly while feedback shows, so the control's
+   * presence is the signal — matching on "feedback" in any class name instead
+   * catches persistent chrome that is always present.
+   */
+  async feedbackVisible(): Promise<boolean> {
+    return this.page
+      .locator('.closeFeedbackBtn')
+      .first()
+      .isVisible()
+      .catch(() => false);
+  }
+
   async feedbackText(): Promise<string> {
     return this.page
       .locator('.feedbackContainer, [class*="feedback"]')
@@ -70,11 +94,16 @@ export class AdaptiveDeckPO {
   // ------------------------------------------------------------ navigation
 
   /**
-   * Click the primary control (footer button, else canvas nav button) up to
-   * maxClicks times until the screen changes. Returns whether it advanced.
+   * COMPATIBILITY-path navigation, deliberately unchanged from the merged
+   * MER-5672/5673 behaviour those specs were validated against: click the
+   * primary control (footer button, else canvas nav button) up to maxClicks
+   * times until the screen changes, acknowledging feedback along the way.
+   * This can re-submit through the deck's own ack-recheck semantics; the
+   * strict walk never uses it — it has submitCheck()/acknowledgeFeedback(),
+   * exactly one click each, driven by the evaluation response.
    */
-  async advance(maxClicks = 3, timeout = 12_000): Promise<boolean> {
-    const previous = await this.screenSignature();
+  async advance(maxClicks = 6, timeout = 12_000): Promise<boolean> {
+    const previous = await this.screenId();
 
     for (let i = 0; i < maxClicks; i += 1) {
       const footer = this.page.locator(FOOTER_BUTTON).first();
@@ -87,7 +116,7 @@ export class AdaptiveDeckPO {
         // evaluation in progress: wait for an enabled control or a change
         const deadline = Date.now() + 30_000;
         while (Date.now() < deadline) {
-          if ((await this.screenSignature()) !== previous) return true;
+          if ((await this.screenId()) !== previous) return true;
           if (await footer.isVisible({ timeout: 300 }).catch(() => false)) break;
           if (await nav.isVisible({ timeout: 300 }).catch(() => false)) break;
           await this.page.waitForTimeout(500);
@@ -103,27 +132,96 @@ export class AdaptiveDeckPO {
       }
 
       const outcome = await this.waitForSignatureChange(previous, timeout);
-      if (outcome === 'changed') {
-        await this.page.waitForTimeout(400);
-        return true;
-      }
+      if (outcome === 'changed') return true; // callers wait for readiness themselves
       // 'settled' (feedback showing) falls through to the next click immediately
     }
 
     return false;
   }
 
+  /** Strict: click the Check control exactly once. Throws if it is not available. */
+  async submitCheck() {
+    const check = this.page.locator('.checkBtn:not([disabled])').first();
+    if (!(await check.isVisible({ timeout: 10_000 }).catch(() => false))) {
+      throw new Error('strict submit: no enabled .checkBtn on screen');
+    }
+    await check.click(ACTION_TIMEOUT);
+  }
+
+  /** Strict: dismiss the open feedback popup exactly once. Throws if it is not open. */
+  async acknowledgeFeedback() {
+    const close = this.page.locator('.closeFeedbackBtn:not([disabled])').first();
+    if (!(await close.isVisible({ timeout: 1_000 }).catch(() => false))) {
+      throw new Error('strict acknowledge: feedback popup is not open');
+    }
+    await close.click(ACTION_TIMEOUT);
+  }
+
+  async waitForFeedbackOpen(timeout = 15_000) {
+    await this.page
+      .locator('.closeFeedbackBtn')
+      .first()
+      .waitFor({ state: 'visible', timeout })
+      .catch(() => {
+        throw new Error('strict transition: expected feedback popup did not open');
+      });
+  }
+
+  /** Strict: wait for the deck to retire after a terminal transition. */
+  async waitForLessonEnd(timeout = 30_000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (await this.lessonEnded()) return;
+      await this.page.waitForTimeout(250);
+    }
+    throw new Error(`strict transition: lesson did not end within ${timeout}ms`);
+  }
+
+  /** Strict: wait until the deck leaves fromId or the lesson ends. */
+  async waitForScreenChange(fromId: string, timeout = 30_000) {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      if (await this.lessonEnded()) return;
+      const current = await this.readScreenIdentity().catch(() => null);
+      if (current && current.id !== fromId) return;
+      await this.page.waitForTimeout(250);
+    }
+    throw new Error(`strict transition: still on screen ${fromId} after ${timeout}ms`);
+  }
+
   /**
-   * Screen signature: headings (per-screen title) + janus text content.
-   * Headings disambiguate sibling screens whose body text starts identically.
+   * Screen identity, preferring the activity id the deck serialises onto the
+   * delivery element's `model` attribute — a real identity, unlike rendered
+   * text, which can collide between sibling screens and can change in place
+   * when feedback renders.
+   *
+   * Falls back to a text digest when no `model` attribute is exposed. Feedback
+   * text is excluded there: it renders on the SAME screen after a check.
    */
-  private async screenSignature(): Promise<string> {
+  async screenId(): Promise<string> {
     return this.page
       .evaluate(() => {
+        // [model][context]: janus PARTS also carry a model attribute, so match
+        // on context too — only the activity delivery element receives both,
+        // otherwise this reads back a part id instead of the screen's activity
+        const ids = Array.from(document.querySelectorAll('[model][context]'))
+          .map((el) => {
+            try {
+              return JSON.parse(el.getAttribute('model') || '{}').id ?? null;
+            } catch {
+              return null;
+            }
+          })
+          .filter((id) => id !== null);
+        if (ids.length > 0) return `activity:${ids[ids.length - 1]}`;
+
+        const outsideFeedback = (el: Element) => !el.closest('[class*="feedback"]');
         const heads = Array.from(document.querySelectorAll('h1'))
+          .filter(outsideFeedback)
           .map((e) => (e as HTMLElement).innerText || '')
           .join(' # ');
         const body = Array.from(document.querySelectorAll('[data-janus-type="janus-text-flow"]'))
+          .filter(outsideFeedback)
           .map((e) => (e as HTMLElement).innerText || '')
           .join(' | ');
         return `${heads} :: ${body}`.replace(/\s+/g, ' ').trim().slice(0, 300);
@@ -132,9 +230,80 @@ export class AdaptiveDeckPO {
   }
 
   /**
+   * Strict screen identity: model.id (the archive's custom.sequenceId),
+   * model.resourceId, and the live attemptGuid the deck serialises onto the
+   * delivery element. Throws instead of falling back to rendered text — a
+   * missing stable identity is a contract failure in strict mode.
+   */
+  async readScreenIdentity(): Promise<{ id: string; resourceId: number; attemptGuid: string }> {
+    const found = await this.page
+      .evaluate(() =>
+        Array.from(document.querySelectorAll('[model][context]'))
+          .map((el) => {
+            try {
+              const model = JSON.parse(el.getAttribute('model') || '{}');
+              return {
+                id: typeof model.id === 'string' && model.id ? model.id : null,
+                resourceId: typeof model.resourceId === 'number' ? model.resourceId : null,
+                attemptGuid:
+                  typeof model.attemptGuid === 'string' && model.attemptGuid
+                    ? model.attemptGuid
+                    : null,
+              };
+            } catch {
+              return null;
+            }
+          })
+          .filter((m) => m !== null),
+      )
+      .catch(() => []);
+
+    const last = found[found.length - 1];
+    if (!last || last.id === null || last.resourceId === null || last.attemptGuid === null) {
+      throw new Error(
+        `strict screen identity unavailable: ${found.length} [model][context] element(s), ` +
+          `last=${JSON.stringify(last ?? null)}`,
+      );
+    }
+    return { id: last.id, resourceId: last.resourceId, attemptGuid: last.attemptGuid };
+  }
+
+  /**
+   * The current screen's part inventory from the serialised model attribute:
+   * part id, janus type, and iframe src where present. Lets the strict driver
+   * derive which state paths an answer must reach without guessing.
+   */
+  async readPartInventory(): Promise<Array<{ id: string; type: string; src: string | null }>> {
+    return this.page
+      .evaluate(() => {
+        const els = Array.from(document.querySelectorAll('[model][context]'));
+        for (let i = els.length - 1; i >= 0; i -= 1) {
+          try {
+            const model = JSON.parse(els[i].getAttribute('model') || '{}');
+            const parts = model?.content?.partsLayout;
+            if (Array.isArray(parts)) {
+              return parts.map(
+                (p: { id?: unknown; type?: unknown; custom?: { src?: unknown } }) => ({
+                  id: String(p?.id ?? ''),
+                  type: String(p?.type ?? ''),
+                  src: typeof p?.custom?.src === 'string' ? p.custom.src : null,
+                }),
+              );
+            }
+          } catch {
+            // fall through to the next delivery element
+          }
+        }
+        return [];
+      })
+      .catch(() => []);
+  }
+
+  /**
    * 'changed' — navigated to another screen.
    * 'settled' — the evaluation finished (button went disabled->enabled) but
-   *             stayed on the same screen: feedback is showing, click again.
+   *             stayed on the same screen: feedback is showing; the caller
+   *             decides whether acknowledging it is legal.
    * 'timeout' — nothing observable happened.
    */
   private async waitForSignatureChange(
@@ -145,7 +314,11 @@ export class AdaptiveDeckPO {
     let sawEvaluating = false;
 
     while (Date.now() < deadline) {
-      if ((await this.screenSignature()) !== previous) return 'changed';
+      if ((await this.screenId()) !== previous) return 'changed';
+      if (await this.lessonEnded()) return 'changed';
+
+      // feedback open == the check finished and we are still on this screen
+      if (await this.feedbackVisible()) return 'settled';
 
       const buttonEnabled = await this.page
         .locator(FOOTER_BUTTON)
@@ -155,7 +328,7 @@ export class AdaptiveDeckPO {
       if (!buttonEnabled) {
         sawEvaluating = true; // spinner/disabled phase while the check evaluates
       } else if (sawEvaluating) {
-        await this.page.waitForTimeout(300); // let the feedback finish rendering
+        await this.page.waitForTimeout(300);
         return 'settled';
       }
 
@@ -220,7 +393,9 @@ export class AdaptiveDeckPO {
           mcqLabels: q('.mcq-item label')
             .map((l) => (l as HTMLElement).innerText)
             .join(' | '),
-          textInputs: q('.short-text-input input, .text-input-blot input').length,
+          textInputs: q(
+            '.short-text-input input, .text-input-blot input, .long-text-input textarea',
+          ).length,
         };
       })
       .catch(() => ({
@@ -238,9 +413,13 @@ export class AdaptiveDeckPO {
 
   // ------------------------------------------------------------ janus parts
 
-  /** Select the MCQ item (radio or checkbox) whose text matches. */
-  async selectMcqByText(text: RegExp): Promise<boolean> {
-    const item = this.page.locator('.mcq-item').filter({ hasText: text }).first();
+  /**
+   * Select the MCQ item (radio or checkbox) whose text matches. `partId`
+   * scopes the search to one janus-mcq part, for screens rendering several.
+   */
+  async selectMcqByText(text: RegExp, partId?: string): Promise<boolean> {
+    const scope = partId ? this.page.locator(`#${partId}, [id="${partId}"]`).first() : this.page;
+    const item = scope.locator('.mcq-item').filter({ hasText: text }).first();
     if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return false;
     return this.selectMcqItem(item);
   }
@@ -255,10 +434,6 @@ export class AdaptiveDeckPO {
     const item = scope.filter({ hasText: pick }).first();
     if (!(await item.isVisible({ timeout: 2_000 }).catch(() => false))) return false;
     return this.selectMcqItem(item);
-  }
-
-  async selectFirstMcqItem(): Promise<boolean> {
-    return this.selectMcqItem(this.page.locator('.mcq-item').first());
   }
 
   /**
@@ -282,70 +457,137 @@ export class AdaptiveDeckPO {
   /**
    * Select native <select.dropdown> options positionally by a case-insensitive
    * substring of the option text (robust to Δ glyphs and curly apostrophes).
-   * Only visible selects outside the feedback popup count, matching what
-   * scanScreen reports.
+   * The key's answer count is the expected control count; a shortfall, an
+   * unmatched option, or a selection that does not read back throws. Error
+   * messages carry positions and counts, never answer text (the key is private).
    */
   async setNativeDropdowns(substrings: string[]) {
-    const selects = await this.interactableParts('select.dropdown');
+    const selects = await this.stableParts('select.dropdown', substrings.length);
 
-    for (let i = 0; i < Math.min(selects.length, substrings.length); i += 1) {
+    for (let i = 0; i < selects.length; i += 1) {
       const value = await selects[i].evaluate((el, needle) => {
         const option = Array.from((el as HTMLSelectElement).options).find((o) =>
           o.text.toLowerCase().includes(String(needle).toLowerCase()),
         );
         return option ? option.value : null;
       }, substrings[i]);
+      if (value == null) {
+        throw new Error(`native dropdown ${i + 1}/${selects.length}: expected option not offered`);
+      }
+      await selects[i].selectOption(value);
 
-      if (value != null) await selects[i].selectOption(value).catch(() => undefined);
+      const registered = await selects[i].evaluate(
+        (el, needle) =>
+          ((el as HTMLSelectElement).selectedOptions[0]?.text || '')
+            .toLowerCase()
+            .includes(String(needle).toLowerCase()),
+        substrings[i],
+      );
+      if (!registered) {
+        throw new Error(`native dropdown ${i + 1}/${selects.length}: selection did not register`);
+      }
     }
   }
 
-  /** Fill in-the-blank dropdown blots positionally by option label. */
+  /** Fill in-the-blank dropdown blots positionally by option label; verify by readback. */
   async setFibDropdownsByLabel(labels: string[]) {
-    const combos = await this.interactableParts('.fib-select-display');
+    const combos = await this.stableParts('.fib-select-display', labels.length);
 
-    for (let i = 0; i < Math.min(combos.length, labels.length); i += 1) {
+    for (let i = 0; i < combos.length; i += 1) {
       await this.openFibCombo(combos[i]);
       await this.page
         .getByRole('option', { name: labels[i], exact: true })
         .first()
         .click(ACTION_TIMEOUT)
         .catch(async () => {
-          await this.exactFibOption(labels[i])
-            .click(ACTION_TIMEOUT)
-            .catch(() => undefined);
+          await this.exactFibOption(labels[i]).click(ACTION_TIMEOUT);
         });
-      await this.page.waitForTimeout(300);
+      await this.verifyFibSelection(combos[i], labels[i], i, combos.length);
     }
   }
 
   /**
    * Answer each FITB combo by matching its own option set against a bank of
    * known-correct answers: [matcher over the combo's options, label to pick].
+   * A combo no rule matches is a key gap and throws — guessing an option
+   * would silently invalidate the answer key as the specification.
    */
   async setFibDropdownsByOptionSet(answers: Array<[RegExp, string]>) {
-    for (const combo of await this.interactableParts('.fib-select-display')) {
-      await this.openFibCombo(combo);
+    const combos = await this.stableParts('.fib-select-display');
+
+    for (let i = 0; i < combos.length; i += 1) {
+      await this.openFibCombo(combos[i]);
 
       const options = await this.page
         .locator('.fib-dropdown-option')
         .allInnerTexts()
         .catch(() => [] as string[]);
       const pick = answers.find(([re]) => options.some((o) => re.test(o.trim())));
-      const target = pick
-        ? this.exactFibOption(pick[1])
-        : this.page.locator('.fib-dropdown-option').first();
-
-      await target.click(ACTION_TIMEOUT).catch(() => undefined);
-      await this.page.waitForTimeout(400);
+      if (!pick) {
+        throw new Error(
+          `FITB combo ${i + 1}/${combos.length}: no answer rule matches its ${options.length} options`,
+        );
+      }
+      await this.exactFibOption(pick[1]).click(ACTION_TIMEOUT);
+      await this.verifyFibSelection(combos[i], pick[1], i, combos.length);
     }
   }
 
-  async fillTextInputs(value: string) {
-    const inputs = await this.interactableParts('.short-text-input input, .text-input-blot input');
-    for (const input of inputs) {
-      await input.fill(value, ACTION_TIMEOUT).catch(() => undefined);
+  private async verifyFibSelection(combo: Locator, label: string, index: number, total: number) {
+    await this.page.waitForTimeout(300);
+    const shown = ((await combo.innerText().catch(() => '')) || '').trim().toLowerCase();
+    if (!shown.includes(label.trim().toLowerCase())) {
+      throw new Error(`FITB blank ${index + 1}/${total}: selection did not register`);
     }
+  }
+
+  /** Fill short-text and multi-line (textarea) janus inputs; verify by readback. */
+  async fillTextInputs(value: string) {
+    const inputs = await this.interactableParts(
+      '.short-text-input input, .text-input-blot input, .long-text-input textarea',
+    );
+    for (let i = 0; i < inputs.length; i += 1) {
+      await inputs[i].fill(value, ACTION_TIMEOUT);
+      const readback = await inputs[i].inputValue().catch(() => '');
+      if (readback !== value) {
+        throw new Error(`text input ${i + 1}/${inputs.length}: value did not register`);
+      }
+    }
+
+    // the text parts save through a 250ms debounce with no observable signal,
+    // so a submit fired immediately would evaluate the previous value
+    if (inputs.length > 0) await this.page.waitForTimeout(400);
+
+    return inputs.length;
+  }
+
+  /**
+   * Interactable parts once their count stops moving: some widgets add
+   * controls while the page is already interactive, so a one-shot count can
+   * read a growing list. Two reads separated by a quiescence interval must
+   * agree — and match the expected count when the caller knows it — before
+   * the parts are trusted; otherwise this throws observed-vs-expected.
+   */
+  private async stableParts(
+    selector: string,
+    expected?: number,
+    timeout = 20_000,
+  ): Promise<Locator[]> {
+    const deadline = Date.now() + timeout;
+    let lastCount = -1;
+
+    while (Date.now() < deadline) {
+      const parts = await this.interactableParts(selector);
+      const settled = parts.length === lastCount && parts.length > 0;
+      const matches = expected === undefined || parts.length === expected;
+      if (settled && matches) return parts;
+      lastCount = parts.length;
+      await this.page.waitForTimeout(500);
+    }
+
+    throw new Error(
+      `parts for ${selector} never stabilised: saw ${lastCount}, expected ${expected ?? 'a settled count'}`,
+    );
   }
 
   /**
@@ -411,16 +653,49 @@ export class AdaptiveDeckPO {
    * does not trigger it). boundingBox() on frame elements is page-relative,
    * so page.mouse coordinates line up.
    */
-  async mouseDragInFrame(item: Locator, zone: Locator): Promise<boolean> {
+  /** Whether a top-document point actually reaches the widget's iframe. */
+  private async pointReachesFrame(x: number, y: number): Promise<boolean> {
+    return this.page
+      .evaluate(([px, py]) => document.elementFromPoint(px, py)?.tagName === 'IFRAME', [
+        x,
+        y,
+      ] as const)
+      .catch(() => false);
+  }
+
+  async mouseDragInFrame(
+    item: Locator,
+    zone: Locator,
+    at: { fx: number; fy: number } = { fx: 0.5, fy: 0.5 },
+  ): Promise<boolean> {
+    await zone.scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
     await item.scrollIntoViewIfNeeded({ timeout: 5_000 }).catch(() => undefined);
+
     const itemBox = await item.boundingBox({ timeout: 5_000 }).catch(() => null);
     const zoneBox = await zone.boundingBox({ timeout: 5_000 }).catch(() => null);
     if (!itemBox || !zoneBox) return false;
 
     const fromX = itemBox.x + itemBox.width / 2;
     const fromY = itemBox.y + itemBox.height / 2;
-    const toX = zoneBox.x + zoneBox.width / 2;
-    const toY = zoneBox.y + zoneBox.height / 2;
+    const toX = zoneBox.x + zoneBox.width * at.fx;
+    let toY = zoneBox.y + zoneBox.height * at.fy;
+
+    // page.mouse events land on whatever is topmost: the deck's fixed
+    // chrome can cover the zone's lower edge, so probe with
+    // elementFromPoint and walk the drop point up inside the zone until it
+    // actually reaches the widget's iframe
+    if (!(await this.pointReachesFrame(toX, toY))) {
+      let reachable = false;
+      for (const fy of [0.35, 0.2]) {
+        toY = zoneBox.y + zoneBox.height * fy;
+        if (await this.pointReachesFrame(toX, toY)) {
+          reachable = true;
+          break;
+        }
+      }
+      if (!reachable) return false;
+    }
+    if (!(await this.pointReachesFrame(fromX, fromY))) return false;
 
     await this.page.mouse.move(fromX, fromY);
     await this.page.mouse.down();
@@ -500,54 +775,121 @@ export class AdaptiveDeckPO {
     return played;
   }
 
-  /** spr-widget-grouping: drag each item (by aria-label) into its group. */
+  /**
+   * The drop is only proven when the item reads back as a DOM descendant of
+   * the zone — the SPR drag widgets re-parent an accepted item into its drop
+   * area (setParentOnDrop), and a snapped-back item can still sit
+   * geometrically over a zone the bank overlaps. Retries target different
+   * points of the zone. Labels carry positions only, never the placement
+   * mapping (it is answer content).
+   */
+  private async verifiedDrag(
+    item: Locator,
+    zone: Locator,
+    label: string,
+    landed: () => Promise<boolean>,
+  ) {
+    const targets = [
+      { fx: 0.5, fy: 0.5 },
+      { fx: 0.5, fy: 0.3 },
+      { fx: 0.3, fy: 0.5 },
+    ];
+    const original = this.page.viewportSize();
+    let grown = false;
+    try {
+      for (const at of targets) {
+        let moved = await this.mouseDragInFrame(item, zone, at);
+        if (!moved && !grown && original) {
+          // the deck's fixed footer can cover a zone at the bottom of a
+          // non-scrollable page; a taller window is what a real user would
+          // reach for
+          grown = true;
+          await this.page.setViewportSize({
+            width: original.width,
+            height: original.height + 240,
+          });
+          await this.page.waitForTimeout(300);
+          moved = await this.mouseDragInFrame(item, zone, at);
+        }
+        if (await landed()) return;
+        await this.page.waitForTimeout(500);
+      }
+      throw new Error(`drag ${label}: item did not land in its zone`);
+    } finally {
+      if (grown && original) {
+        await this.page.setViewportSize(original).catch(() => undefined);
+      }
+    }
+  }
+
+  /** spr-widget-grouping: drag each item (by aria-label) into its group; verify each drop. */
   async dragItemsToGroups(srcFragment: string, placements: Array<[string, string]>) {
     const frame = await this.widgetFrame(srcFragment, '.item');
-    if (!frame) return;
+    if (!frame) throw new Error(`grouping widget (${srcFragment}) not present`);
 
-    for (const [item, group] of placements) {
-      await this.mouseDragInFrame(
+    for (let i = 0; i < placements.length; i += 1) {
+      const [item, group] = placements[i];
+      const inGroup = frame
+        .locator(`.group-area[aria-label="${group}"] .item[aria-label="${item}"]`)
+        .first();
+      await this.verifiedDrag(
         frame.locator(`.item[aria-label="${item}"]`).first(),
         frame.locator(`.group-area[aria-label="${group}"]`).first(),
+        `${i + 1}/${placements.length} (grouping)`,
+        () => inGroup.isVisible().catch(() => false),
       );
     }
   }
 
-  /** Custom drag-and-drop CAPI widget: detect disambiguates same-src variants. */
+  /**
+   * Custom drag-and-drop CAPI widget: detect disambiguates same-src variants
+   * and doubles as the readiness selector — it is by definition an element
+   * unique to this screen's instance of the widget. Returns false only when
+   * this is a different screen's instance; once committed, every placement
+   * must verify or this throws.
+   */
   async dragCustomDnD(
     srcFragment: string,
     detect: string,
     placements: Array<[string, string]>,
   ): Promise<boolean> {
-    const frame = await this.widgetFrame(srcFragment, 'button[aria-roledescription="draggable"]');
+    const frame = await this.widgetFrame(srcFragment, detect);
     if (!frame) return false;
 
     const confirmed = await frame
       .locator(detect)
       .first()
-      .isVisible({ timeout: 2_000 })
+      .isVisible()
       .catch(() => false);
     if (!confirmed) return false;
 
-    let dragged = 0;
-    for (const [itemSel, zoneSel] of placements) {
-      const ok = await this.mouseDragInFrame(
+    for (let i = 0; i < placements.length; i += 1) {
+      const [itemSel, zoneSel] = placements[i];
+      const inZone = frame.locator(zoneSel).first().locator(itemSel).first();
+      // the widget's acceptance region is the drop area's sortable .items
+      // container, not the whole box — aim there when it exists
+      const itemsStrip = frame.locator(`${zoneSel} .items`).first();
+      const target = (await itemsStrip.count().catch(() => 0))
+        ? itemsStrip
+        : frame.locator(zoneSel).first();
+      await this.verifiedDrag(
         frame.locator(itemSel).first(),
-        frame.locator(zoneSel).first(),
+        target,
+        `${i + 1}/${placements.length} (custom dnd)`,
+        () => inZone.isVisible().catch(() => false),
       );
-      if (ok) dragged++;
     }
-    return dragged === placements.length;
+    return true;
   }
 
   /**
    * spr-widget-order-list: selection-sort the sortable list — for each target
    * position drag the desired item onto the item occupying it (dragging
-   * upward inserts above).
+   * upward inserts above). The final arrangement is read back and must match.
    */
   async reorderList(srcFragment: string, desiredOrder: string[]) {
     const frame = await this.widgetFrame(srcFragment, '.order-list-item');
-    if (!frame) return;
+    if (!frame) throw new Error(`ordering widget (${srcFragment}) not present`);
 
     const currentOrder = () =>
       frame
@@ -569,6 +911,16 @@ export class AdaptiveDeckPO {
         frame.locator('.order-list-item').nth(position),
       );
     }
+
+    const finalOrder = await currentOrder();
+    const misplaced = desiredOrder
+      .map((wanted, i) => (finalOrder[i]?.startsWith(wanted.slice(0, 25)) ? null : i + 1))
+      .filter((p) => p !== null);
+    if (misplaced.length > 0) {
+      throw new Error(
+        `ordering widget: positions ${misplaced.join(', ')} of ${desiredOrder.length} did not match after sort`,
+      );
+    }
   }
 
   /**
@@ -579,16 +931,18 @@ export class AdaptiveDeckPO {
    */
   async linkMatchingPairs(srcFragment: string, links: Array<[RegExp, RegExp]>) {
     const frame = await this.widgetFrame(srcFragment, '.left-column .item');
-    if (!frame) return;
+    if (!frame) throw new Error(`matching widget (${srcFragment}) not present`);
 
-    for (const [leftText, rightText] of links) {
+    for (let pair = 0; pair < links.length; pair += 1) {
+      const [leftText, rightText] = links[pair];
       const left = frame.locator('.left-column .item').filter({ hasText: leftText }).first();
       const right = frame.locator('.right-column .item').filter({ hasText: rightText }).first();
 
       let linked = false;
 
       for (let retry = 0; retry < 4; retry += 1) {
-        const leftClass = (await left.getAttribute('class').catch(() => '')) || '';
+        const leftClass =
+          (await left.getAttribute('class', { timeout: 5_000 }).catch(() => '')) || '';
         if (!/isSelected/i.test(leftClass)) {
           await left.press(' ', ACTION_TIMEOUT).catch(() => undefined);
           await this.page.waitForTimeout(400);
@@ -600,7 +954,7 @@ export class AdaptiveDeckPO {
         const unlinkLabel =
           (await left
             .locator('.remove-links')
-            .getAttribute('aria-label')
+            .getAttribute('aria-label', { timeout: 5_000 })
             .catch(() => '')) || '';
         if (!/Unlink 0 /i.test(unlinkLabel)) {
           linked = true;
@@ -612,27 +966,161 @@ export class AdaptiveDeckPO {
 
       if (!linked) {
         throw new Error(
-          `Failed to link matching pair (left: ${leftText}, right: ${rightText}) after 4 retries`,
+          `matching widget: pair ${pair + 1}/${links.length} did not link after 4 retries`,
         );
       }
     }
   }
 
-  /** Fill a widget's native selects by element id (e.g. the S3 table apps). */
+  /**
+   * Fill a widget's native selects by element id (e.g. the S3 table apps, and
+   * the fill-in-the-blanks widget's `drop-N` combos).
+   *
+   * `requiredOption` disambiguates screens that embed the SAME widget src: the
+   * frame must offer an option containing it, otherwise this is a different
+   * screen's instance of the widget and nothing is filled.
+   *
+   * In `strict` mode the caller's manifest scopes the answer to this exact
+   * screen, so a count that settles below the expected number keeps being
+   * polled (the widget adds selects while interactive) and times out loudly;
+   * in probe mode two agreeing reads that differ from the key mean "another
+   * instance of this src" and skip immediately.
+   *
+   * Options are matched by visible label first — the widget's option `value`
+   * attributes are not guaranteed to equal their text.
+   */
   async fillFrameSelects(
     srcFragment: string,
     readySelector: string,
     values: Record<string, string>,
-  ) {
+    requiredOption?: string,
+    strict = false,
+  ): Promise<boolean> {
     const frame = await this.widgetFrame(srcFragment, readySelector);
-    if (!frame) return;
+    if (!frame) return false;
 
-    for (const [id, value] of Object.entries(values)) {
-      await frame
-        .locator(`#${id}`)
-        .selectOption(value, { timeout: 3_000 })
-        .catch(() => undefined);
+    const expected = Object.keys(values).length;
+    const deadline = Date.now() + 20_000;
+    let selectCount = -1;
+    for (;;) {
+      const seen = await frame
+        .locator('select')
+        .count()
+        .catch(() => 0);
+      if (seen === selectCount) {
+        if (seen === expected) break;
+        if (!strict) {
+          console.log(
+            `[deck] frame selects skipped (${requiredOption ?? srcFragment}): saw ${seen} controls, key has ${expected}`,
+          );
+          return false;
+        }
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `frame selects (${srcFragment}): control count never reached the expected ${expected} (last saw ${seen})`,
+        );
+      }
+      selectCount = seen;
+      await this.page.waitForTimeout(500);
     }
+
+    if (requiredOption) {
+      // textContent, not innerText: options of a collapsed <select> are not
+      // rendered, so innerText reads back empty
+      const offered = await frame
+        .locator('select option')
+        .allTextContents()
+        .catch(() => [] as string[]);
+      const needle = requiredOption.toLowerCase();
+      if (!offered.some((o) => o.trim().toLowerCase().includes(needle))) return false;
+    }
+
+    const entries = Object.entries(values);
+    for (let i = 0; i < entries.length; i += 1) {
+      const [id, value] = entries[i];
+      const select = frame.locator(`#${id}`);
+
+      // the SPR widgets wrap each select in a jQuery-UI selectmenu: the
+      // native element is only the backing store, and programmatic changes
+      // to it never reach the widget's model (or CAPI). Drive the widget's
+      // own button + menu when present; plain selects get selectOption.
+      const menuButton = frame.locator(`#${id}-button`).first();
+      let ok: boolean;
+      if (await menuButton.isVisible({ timeout: 500 }).catch(() => false)) {
+        await menuButton.click(ACTION_TIMEOUT);
+        ok = await frame
+          .locator(`#${id}-menu li`)
+          .filter({ hasText: new RegExp(`^\\s*${escapeRegExp(value)}\\s*$`, 'i') })
+          .first()
+          .click(ACTION_TIMEOUT)
+          .then(
+            () => true,
+            () => false,
+          );
+      } else {
+        // a short attempt first: selectOption is the honest user-like path,
+        // but custom-styled widgets keep the native <select> out of the
+        // layout where it can never succeed — set it directly and notify
+        ok = await select.selectOption({ label: value }, { timeout: 500 }).then(
+          () => true,
+          () => false,
+        );
+        if (!ok) {
+          ok = await select
+            .evaluate((el, wanted) => {
+              const select = el as HTMLSelectElement;
+              const index = Array.from(select.options).findIndex(
+                (o) => (o.textContent || '').trim().toLowerCase() === String(wanted).toLowerCase(),
+              );
+              if (index < 0) return false;
+              select.selectedIndex = index;
+              select.dispatchEvent(new Event('input', { bubbles: true }));
+              select.dispatchEvent(new Event('change', { bubbles: true }));
+              return true;
+            }, value)
+            .catch(() => false);
+        }
+      }
+
+      const registered =
+        ok &&
+        (await select
+          .evaluate(
+            (el, wanted) =>
+              ((el as HTMLSelectElement).selectedOptions[0]?.textContent || '')
+                .trim()
+                .toLowerCase() === String(wanted).toLowerCase(),
+            value,
+          )
+          .catch(() => false));
+      if (!registered) {
+        throw new Error(
+          `frame selects (${srcFragment}): blank ${i + 1}/${entries.length} did not register`,
+        );
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Click a button rendered INSIDE a CAPI widget iframe (e.g. the cover
+   * screen's START LESSON), which the deck's own footer/canvas controls do not
+   * cover. The widget renders its button as a styled div, not a <button>.
+   */
+  async clickWidgetButton(srcFragment: string): Promise<boolean> {
+    const frame = await this.widgetFrame(srcFragment, '.button-widget');
+    if (!frame) return false;
+
+    return frame
+      .locator('.button-widget .button')
+      .first()
+      .click(ACTION_TIMEOUT)
+      .then(
+        () => true,
+        () => false,
+      );
   }
 }
 

--- a/assets/automation/src/systems/torus/tasks/AdaptiveEvaluationObserver.ts
+++ b/assets/automation/src/systems/torus/tasks/AdaptiveEvaluationObserver.ts
@@ -1,0 +1,244 @@
+import { Page, Request, Response } from '@playwright/test';
+import { AttemptCreation, CheckActions, EvaluationRecord } from '@tasks/AdaptiveStrictContract';
+
+const EVAL_URL = /\/activity_attempt\/([^/?#]+)(?:[?#]|$)/;
+const SAVE_URL = /\/activity_attempt\/([^/?#]+)\/active(?:[?#]|$)/;
+
+/**
+ * Multi-event collector for adaptive evaluation traffic. Unlike
+ * page.waitForResponse — which resolves with a single matched response —
+ * this stays attached through the whole screen transition, so a duplicate
+ * submission arriving after the first response is recorded, not lost.
+ *
+ * Attribution is by SCREEN, not attempt guid: the deck rotates the attempt
+ * when a check is incorrect, does not navigate away, and attempts remain
+ * (triggerCheck.ts:424), so one screen's evaluations can legally span
+ * several guids. The submitted part paths carry the stable `<sequenceId>|stage...`
+ * prefix, which is the same identity the manifest declares. Requests whose
+ * paths name a different screen — e.g. a late submission from the previous
+ * screen — are kept separately and never attributed to this one.
+ *
+ * Finalize saves PUT the same URL shape as evaluations; they are told apart
+ * by the response body (evaluations carry `actions`, finalizes a bare
+ * `type: "success"`) and excluded from `evaluations()`.
+ */
+export class AdaptiveEvaluationObserver {
+  private readonly own: EvaluationRecord[] = [];
+  private readonly foreign: EvaluationRecord[] = [];
+  private readonly pending = new Map<Request, EvaluationRecord>();
+  private readonly creationRecords: AttemptCreation[] = [];
+  private readonly pendingCreations = new Map<Request, AttemptCreation>();
+  private seq = 0;
+  private armed = false;
+
+  constructor(
+    private readonly page: Page,
+    private readonly screenId: string,
+  ) {}
+
+  private readonly onRequest = (request: Request) => {
+    const creation = request.method() === 'POST' ? EVAL_URL.exec(request.url()) : null;
+    if (creation) {
+      const record: AttemptCreation = {
+        targetGuid: creation[1],
+        newGuid: null,
+        requestSeq: ++this.seq,
+        responseSeq: null,
+        status: null,
+        parsed: false,
+      };
+      this.creationRecords.push(record);
+      this.pendingCreations.set(request, record);
+      return;
+    }
+    const save = request.method() === 'PATCH' ? SAVE_URL.exec(request.url()) : null;
+    const evaluation = request.method() === 'PUT' ? EVAL_URL.exec(request.url()) : null;
+    const match = save ?? evaluation;
+    if (!match) return;
+
+    const record: EvaluationRecord = {
+      attemptGuid: match[1],
+      screenId: null,
+      otherScreenIds: [],
+      llmFeedback: null,
+      kind: save ? 'save' : 'unknown',
+      url: request.url(),
+      partInputs: null,
+      requestAt: Date.now(),
+      responseAt: null,
+      requestSeq: ++this.seq,
+      responseSeq: null,
+      status: null,
+      actions: null,
+      correct: null,
+      parseError: null,
+      parsed: false,
+    };
+    let ownable = false;
+    try {
+      const body = request.postDataJSON() as { partInputs?: unknown } | null;
+      record.partInputs = Array.isArray(body?.partInputs) ? body.partInputs : null;
+      if (record.partInputs === null)
+        record.parseError = 'request body carries no partInputs array';
+      const ids = submittedScreenIds(record.partInputs);
+      record.screenId = ids.find((id) => id === this.screenId) ?? ids[0] ?? null;
+      // a mixed submission is attributed here but its other prefixes are
+      // preserved: the walk fails the screen if any of them belongs to a
+      // DIFFERENT manifest screen (layer parents are not manifest screens)
+      record.otherScreenIds = ids.filter((id) => id !== this.screenId);
+      // a screen with no answerable parts submits empty partInputs — no
+      // paths to attribute by. Late submissions from answered screens always
+      // carry paths, so a pathless evaluation belongs to the current screen.
+      ownable = record.screenId === this.screenId || ids.length === 0;
+    } catch (e) {
+      record.parseError = `unreadable request body: ${(e as Error).message}`;
+    }
+    (ownable ? this.own : this.foreign).push(record);
+    this.pending.set(request, record);
+  };
+
+  private readonly onResponse = (response: Response) => {
+    const creation = this.pendingCreations.get(response.request());
+    if (creation) {
+      this.pendingCreations.delete(response.request());
+      creation.responseSeq = ++this.seq;
+      creation.status = response.status();
+      void response
+        .json()
+        .then((body: { attemptState?: { attemptGuid?: unknown } }) => {
+          const minted = body?.attemptState?.attemptGuid;
+          creation.newGuid = typeof minted === 'string' ? minted : null;
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          creation.parsed = true;
+        });
+      return;
+    }
+    const record = this.pending.get(response.request());
+    if (!record) return;
+    this.pending.delete(response.request());
+    record.responseAt = Date.now();
+    record.responseSeq = ++this.seq;
+    record.status = response.status();
+    if (record.kind === 'save') {
+      record.parsed = true;
+      return;
+    }
+    void response
+      .json()
+      .then((body: { actions?: CheckActions; type?: string; llm_feedback?: { text?: string } }) => {
+        const actions = body?.actions;
+        if (actions && typeof actions.correct === 'boolean') {
+          record.kind = 'evaluation';
+          record.actions = actions;
+          record.correct = actions.correct;
+          // the deck opens feedback for server-generated LLM text too, so the
+          // transition derivation needs it (DeckLayoutFooter:546-558)
+          record.llmFeedback = body.llm_feedback ?? null;
+        } else if (body?.type === 'success') {
+          record.kind = 'finalize';
+        } else {
+          record.parseError ??= 'evaluation response carries no boolean actions.correct';
+        }
+      })
+      .catch((e: Error) => {
+        record.parseError ??= `unreadable evaluation response: ${e.message}`;
+      })
+      .finally(() => {
+        record.parsed = true;
+      });
+  };
+
+  arm() {
+    if (this.armed) throw new Error('evaluation observer is already armed');
+    this.page.on('request', this.onRequest);
+    this.page.on('response', this.onResponse);
+    this.armed = true;
+  }
+
+  dispose() {
+    this.page.off('request', this.onRequest);
+    this.page.off('response', this.onResponse);
+    this.armed = false;
+  }
+
+  /**
+   * This screen's evaluations. Saves and finalizes are excluded; a record
+   * whose response has not been parsed yet is still `unknown` and counts,
+   * so callers that need a stable count must `settle()` first.
+   */
+  evaluations(): EvaluationRecord[] {
+    return this.own.filter((r) => r.kind !== 'finalize' && r.kind !== 'save');
+  }
+
+  /**
+   * Resolve once every observed request has a parsed response, so counts no
+   * longer move and an in-flight finalize can no longer masquerade as an
+   * evaluation. Returns false if traffic is still outstanding at the deadline.
+   */
+  async settle(timeoutMs = 10_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const outstanding =
+        this.pending.size +
+        this.pendingCreations.size +
+        [...this.own, ...this.foreign].filter((r) => !r.parsed).length +
+        this.creationRecords.filter((c) => !c.parsed).length;
+      if (outstanding === 0) return true;
+      if (Date.now() >= deadline) return false;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  /** This screen's deferred PATCH saves — the deck persisting propagated part state. */
+  saves(): EvaluationRecord[] {
+    return this.own.filter((r) => r.kind === 'save');
+  }
+
+  /** Observed attempt rotations — POST mints of fresh attempts, any screen. */
+  creations(): AttemptCreation[] {
+    return this.creationRecords;
+  }
+
+  /** Evaluations whose submitted paths name a different screen, or none at all. */
+  foreignEvaluations(): EvaluationRecord[] {
+    return this.foreign.filter((r) => r.kind !== 'save');
+  }
+
+  async waitForEvaluation(expectedCount: number, timeoutMs: number): Promise<EvaluationRecord> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const parsed = this.evaluations().filter((r) => r.parsed);
+      if (parsed.length >= expectedCount) return parsed[expectedCount - 1];
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `no evaluation ${expectedCount} for screen ${this.screenId} within ${timeoutMs}ms ` +
+            `(own: ${this.own.length}, foreign: ${this.foreign.length})`,
+        );
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+}
+
+function submittedScreenIds(partInputs: unknown[] | null): string[] {
+  if (!partInputs) return [];
+  const ids = new Set<string>();
+  for (const part of partInputs) {
+    const response = (part as { response?: Record<string, unknown> | null })?.response;
+    if (!response || typeof response !== 'object') continue;
+    // evaluation PUTs nest the part map under `input`; PATCH saves inline it
+    const input =
+      response.input && typeof response.input === 'object'
+        ? (response.input as Record<string, unknown>)
+        : response;
+    for (const item of Object.values(input)) {
+      const entry = item as { path?: unknown } | null;
+      if (entry && typeof entry.path === 'string' && entry.path.includes('|')) {
+        ids.add(entry.path.split('|')[0]);
+      }
+    }
+  }
+  return Array.from(ids);
+}

--- a/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
+++ b/assets/automation/src/systems/torus/tasks/AdaptiveHappyPathTask.ts
@@ -1,5 +1,23 @@
 import { Page } from '@playwright/test';
 import { AdaptiveDeckPO } from '@pom/delivery/AdaptiveDeckPO';
+import { AdaptiveEvaluationObserver } from '@tasks/AdaptiveEvaluationObserver';
+import {
+  AnswerDirective,
+  AnswerReceipt,
+  DerivedTransition,
+  EvaluationRecord,
+  ExpectedSubmission,
+  LedgerEntry,
+  ManifestScreen,
+  ROLE_EVALUATIONS,
+  assertLedger,
+  deriveTransition,
+  extractSubmittedPairs,
+  formatLedger,
+  missingExpectedPaths,
+  resolveManifestScreen,
+  validateManifest,
+} from '@tasks/AdaptiveStrictContract';
 
 type GroupingWidget = { src_fragment: string; placements: Array<{ item: string; group: string }> };
 type CustomDnDWidget = {
@@ -8,21 +26,29 @@ type CustomDnDWidget = {
   placements: Array<{ item: string; zone: string }>;
 };
 
+/**
+ * Every widget family is optional: a lesson declares only the kinds it
+ * actually contains, instead of carrying placeholder entries for the rest.
+ */
 export type LessonAnswers = {
   lesson: { title: string; search_term: string; completion_text: string };
   widgets: {
-    grouping: GroupingWidget | GroupingWidget[];
-    ordering: { src_fragment: string; order: string[] };
-    matching: { src_fragment: string; links: Array<{ left: string; right: string }> };
-    frame_selects: Array<{
+    grouping?: GroupingWidget | GroupingWidget[];
+    ordering?: { src_fragment: string; order: string[] };
+    matching?: { src_fragment: string; links: Array<{ left: string; right: string }> };
+    frame_selects?: Array<{
       src_fragment: string;
       ready_selector: string;
       values: Record<string, string>;
+      /** disambiguates screens reusing the same widget src */
+      required_option?: string;
     }>;
     custom_dnd?: CustomDnDWidget[];
+    /** src fragments of widgets whose own button advances the screen */
+    in_widget_buttons?: string[];
   };
-  native_dropdowns: Array<{ when_option_includes: string; picks: string[] }>;
-  fib: {
+  native_dropdowns?: Array<{ when_option_includes: string; picks: string[] }>;
+  fib?: {
     by_label_when_count: { count: number; labels: string[] };
     option_sets: Array<{ match: string; pick: string }>;
   };
@@ -33,6 +59,688 @@ export type LessonAnswers = {
   text_input_value: string;
 };
 
+export type StrictLessonAnswers = {
+  lesson: LessonAnswers['lesson'];
+  screens: ManifestScreen[];
+};
+
+type PartInventory = Array<{ id: string; type: string; src: string | null }>;
+
+/**
+ * Strict entry point (MER-5674): walks exactly the screens the manifest
+ * declares, answers each graded screen from its own directives, submits with
+ * exactly one click, correlates the submitted payload and the server verdict
+ * through the evaluation observer, follows the transition the response
+ * itself dictates, and asserts the full ledger at the end. Any deviation
+ * throws with the (redacted) ledger. There is no fallback to the heuristic
+ * compatibility walk below.
+ */
+export async function completeAdaptiveHappyPathStrict(
+  page: Page,
+  deck: AdaptiveDeckPO,
+  key: { lesson?: unknown; screens?: unknown },
+): Promise<LedgerEntry[]> {
+  const screens = validateManifest(key.screens);
+  const ledger: LedgerEntry[] = [];
+  const liveResourceIds = new Map<string, number>();
+  const bail = (msg: string): never => {
+    throw new Error(`strict walk: ${msg}\n${formatLedger(ledger)}`);
+  };
+
+  await deck.waitForDeckReady();
+
+  for (let i = 0; i < screens.length; i += 1) {
+    if (await deck.lessonEnded()) {
+      bail(`lesson ended after ${i} of ${screens.length} screens`);
+    }
+
+    const identity = await deck.readScreenIdentity();
+    const screen = resolveManifestScreen(screens, identity);
+    if (screen.id !== screens[i].id) {
+      bail(`position ${i} shows "${screen.id}", manifest declares "${screens[i].id}"`);
+    }
+    const knownResource = liveResourceIds.get(screen.id);
+    if (knownResource !== undefined && knownResource !== identity.resourceId) {
+      bail(
+        `screen "${screen.id}" changed live resourceId ${knownResource} -> ${identity.resourceId}`,
+      );
+    }
+    liveResourceIds.set(screen.id, identity.resourceId);
+
+    const observer = new AdaptiveEvaluationObserver(page, identity.id);
+    observer.arm();
+    try {
+      let receipt: AnswerReceipt | null = null;
+      let verdict: boolean | null = null;
+      let payloadMatch: boolean | null = null;
+      let transition: DerivedTransition | null = null;
+
+      let expectedEvaluations: number | undefined;
+
+      if (screen.role === 'navigation') {
+        const action = screen.action;
+        if (!action) bail(`navigation screen "${screen.id}" has no action`);
+        if (!(await deck.clickWidgetButton(action!.src_fragment))) {
+          bail(`navigation screen "${screen.id}": in-widget button not clickable`);
+        }
+        // one click, one long wait: absence of traffic within any finite
+        // window is never proof the click reached nothing (the deck does
+        // awaited work before its evaluation PUT), so there is no re-click —
+        // a stuck widget fails loudly here instead
+        await deck.waitForScreenChange(identity.id, 90_000);
+        // this screen's traffic is judged after settle(), where the count is
+        // stable — see assertNavigationEvaluations
+      } else {
+        // videos and carousels can gate a screen's completion state and are
+        // not answers; play them before answering on every non-nav screen
+        await deck.playVideos();
+        await deck.clickThroughCarousels();
+
+        if (screen.role === 'graded') {
+          const parts = await deck.readPartInventory();
+          const answerStartedAt = Date.now();
+          receipt = await answerScreenStrict(deck, screen, parts);
+          if (receipt.awaitSaved && receipt.awaitSaved.length > 0) {
+            await waitForPropagatedState(observer, screen.id, receipt.awaitSaved, answerStartedAt);
+          }
+        }
+
+        await deck.submitCheck();
+        expectedEvaluations = 1;
+        const first = await waitForUsableEvaluation(observer, screen.id, 1);
+        transition = deriveTransition(first.actions!, first.llmFeedback);
+        // every role: the first evaluation must belong to the attempt this
+        // screen rendered. Guid rotation only affects the licensed SECOND
+        // evaluation, so pathless traffic from a stale attempt cannot satisfy
+        // a content screen either.
+        if (first.attemptGuid !== identity.attemptGuid) {
+          bail(
+            `screen "${screen.id}" (${screen.role}): evaluation used attempt ${first.attemptGuid}, ` +
+              `the screen rendered attempt ${identity.attemptGuid}`,
+          );
+        }
+        if (screen.role === 'graded') {
+          verdict = first.correct;
+          payloadMatch = evaluationMatchesReceipt(first, receipt!);
+          if (verdict !== true) bail(`graded screen "${screen.id}" verdict=${String(verdict)}`);
+          if (!payloadMatch) {
+            const missing = missingExpectedPaths(
+              extractSubmittedPairs(first.partInputs),
+              receipt!.expected,
+            );
+            bail(`graded screen "${screen.id}" payload missing: ${missing.join(', ')}`);
+          }
+        }
+
+        transition = await followTransition(deck, observer, screen, identity.id, transition, {
+          onSecondEvaluation: (second) => {
+            if (screen.role !== 'graded') {
+              bail(
+                `${screen.role} screen "${screen.id}" re-checked after feedback — only graded ` +
+                  `screens may submit twice`,
+              );
+            }
+            expectedEvaluations = 2;
+            verdict = verdict === true && second.correct === true;
+            if (receipt) {
+              payloadMatch = payloadMatch === true && evaluationMatchesReceipt(second, receipt);
+            }
+          },
+        });
+      }
+
+      // AUDIT AFTER THE BOUNDARY: hold the observer through readiness of the
+      // NEXT screen so a delayed duplicate — or late foreign traffic — from
+      // the screen just completed is still visible, then let every in-flight
+      // response parse before counting (an unparsed finalize would otherwise
+      // inflate the count).
+      if (!(await deck.lessonEnded())) await deck.waitForDeckReady();
+      if (!(await observer.settle())) {
+        bail(`screen "${screen.id}": evaluation traffic never settled after its transition`);
+      }
+
+      if (observer.foreignEvaluations().length > 0) {
+        const foreign = observer
+          .foreignEvaluations()
+          .map(
+            (r) => `${r.screenId ?? 'unattributed'}/${r.attemptGuid} (status=${String(r.status)})`,
+          )
+          .join(', ');
+        bail(
+          `screen "${screen.id}": ${observer.foreignEvaluations().length} submission(s) for a ` +
+            `different screen observed during its transition: ${foreign}`,
+        );
+      }
+      // a submission attributed here may still carry another MANIFEST
+      // screen's paths mixed in (layer parents are not manifest screens and
+      // are tolerated) — that is cross-screen contamination
+      const manifestIds = new Set(screens.map((s) => s.id));
+      for (const record of observer.evaluations()) {
+        const contaminated = record.otherScreenIds.filter(
+          (id) => id !== screen.id && manifestIds.has(id),
+        );
+        if (contaminated.length > 0) {
+          bail(
+            `screen "${screen.id}": its submission also carried parts of manifest screen(s) ` +
+              contaminated.join(', '),
+          );
+        }
+      }
+
+      const settled = observer.evaluations().length;
+      if (screen.role === 'navigation') {
+        assertNavigationEvaluations(observer, screen.id, identity.attemptGuid, bail);
+      } else if (expectedEvaluations !== undefined && settled !== expectedEvaluations) {
+        bail(
+          `screen "${screen.id}": ${settled} evaluation(s) once its transition settled, ` +
+            `the walk licensed exactly ${expectedEvaluations}`,
+        );
+      }
+
+      ledger.push({
+        screenId: screen.id,
+        resourceId: identity.resourceId,
+        attemptGuid: identity.attemptGuid,
+        role: screen.role,
+        receipt,
+        evaluationCount: settled,
+        expectedEvaluations,
+        verdict,
+        payloadMatch,
+        transition,
+      });
+      console.log(
+        `[strict ${i + 1}/${screens.length}] ${screen.id} ${screen.role} -> ` +
+          `${transition?.kind ?? 'no-evaluation'} evals=${settled} ` +
+          `verdict=${String(verdict)} payloadMatch=${String(payloadMatch)}`,
+      );
+    } finally {
+      observer.dispose();
+    }
+  }
+
+  if (!(await deck.lessonEnded())) {
+    bail('walked every declared screen but the lesson did not end');
+  }
+  assertLedger(ledger, screens);
+  return ledger;
+}
+
+/**
+ * Follow the transition the evaluation response dictates, mirroring
+ * DeckLayoutFooter: auto-navigation just waits; terminal waits for the deck
+ * to retire; feedback is acknowledged with exactly one click, which either
+ * navigates (queued target) or legally re-checks — that second evaluation
+ * must itself be correct and carry a usable transition.
+ */
+async function followTransition(
+  deck: AdaptiveDeckPO,
+  observer: AdaptiveEvaluationObserver,
+  screen: ManifestScreen,
+  fromId: string,
+  transition: DerivedTransition,
+  hooks: { onSecondEvaluation: (second: EvaluationRecord) => void },
+): Promise<DerivedTransition> {
+  switch (transition.kind) {
+    case 'auto-navigate':
+      await deck.waitForScreenChange(fromId);
+      return transition;
+    case 'terminal':
+      await deck.waitForLessonEnd();
+      return transition;
+    case 'none':
+      throw new Error(`strict transition: screen "${screen.id}" evaluation queued no transition`);
+    case 'feedback': {
+      await deck.waitForFeedbackOpen();
+      await deck.acknowledgeFeedback();
+      if (transition.ack.kind === 'navigate') {
+        await deck.waitForScreenChange(fromId);
+        return transition;
+      }
+      // acknowledged good feedback with no queued navigation re-checks
+      // (DeckLayoutFooter:680) — a second, expected evaluation
+      const second = await waitForUsableEvaluation(observer, screen.id, 2);
+      hooks.onSecondEvaluation(second);
+      const followup = deriveTransition(second.actions!, second.llmFeedback);
+      if (followup.kind === 'auto-navigate') {
+        await deck.waitForScreenChange(fromId);
+      } else if (followup.kind === 'terminal') {
+        await deck.waitForLessonEnd();
+      } else {
+        throw new Error(
+          `strict transition: screen "${screen.id}" re-check produced ${followup.kind}, ` +
+            `expected navigation or terminal`,
+        );
+      }
+      return followup;
+    }
+  }
+}
+
+/**
+ * A navigation screen's CAPI widget checks on its own schedule, and the deck
+ * rotates the attempt exactly when a check is incorrect, does not navigate
+ * away, and attempts remain (triggerCheck.ts:424). So two evaluations are
+ * licensed ONLY as that measured rotation: an incorrect non-navigating check,
+ * a server-minted fresh attempt (an observed POST creation targeting the
+ * first check's attempt), then a correct navigating check under the minted
+ * guid. The minted guid is server-generated, so requiring it proves the
+ * second check started after the rotation — no clock comparison can. Every
+ * counted record must be a usable server evaluation — a failed or malformed
+ * request cannot occupy a licensed slot.
+ */
+function assertNavigationEvaluations(
+  observer: AdaptiveEvaluationObserver,
+  screenId: string,
+  renderedGuid: string,
+  bail: (msg: string) => never,
+): void {
+  const evals = [...observer.evaluations()].sort((a, b) => a.requestSeq - b.requestSeq);
+  const guids = Array.from(new Set(evals.map((r) => r.attemptGuid)));
+  console.log(
+    `[strict nav ${screenId}] rendered=${renderedGuid.slice(0, 8)} ` +
+      `submitted=[${guids.map((g) => g.slice(0, 8)).join(', ')}]`,
+  );
+
+  const { min, max } = ROLE_EVALUATIONS.navigation;
+  if (evals.length < min || evals.length > max) {
+    bail(
+      `navigation screen "${screenId}": ${evals.length} evaluation(s) once its transition ` +
+        `settled, the licence allows ${min}-${max}`,
+    );
+  }
+  for (const r of evals) {
+    if (
+      r.kind !== 'evaluation' ||
+      r.status === null ||
+      r.status < 200 ||
+      r.status >= 300 ||
+      r.parseError !== null ||
+      !r.actions
+    ) {
+      bail(
+        `navigation screen "${screenId}": unusable evaluation in its licensed range ` +
+          `(kind=${r.kind}, status=${String(r.status)}` +
+          `${r.parseError ? `, ${r.parseError}` : ''})`,
+      );
+    }
+  }
+  if (evals.length === 2) {
+    const [first, second] = evals;
+    const firstMove = deriveTransition(first.actions!, first.llmFeedback);
+    const secondMove = deriveTransition(second.actions!, second.llmFeedback);
+    const mint = observer
+      .creations()
+      .find((c) => c.targetGuid === first.attemptGuid && c.newGuid === second.attemptGuid);
+    const causalMint =
+      mint !== undefined &&
+      mint.status !== null &&
+      mint.status >= 200 &&
+      mint.status < 300 &&
+      first.responseSeq !== null &&
+      mint.requestSeq > first.responseSeq &&
+      mint.responseSeq !== null &&
+      second.requestSeq > mint.responseSeq;
+    const measuredRotation =
+      first.attemptGuid !== second.attemptGuid &&
+      first.correct === false &&
+      !transitionNavigates(firstMove) &&
+      second.correct === true &&
+      transitionNavigates(secondMove) &&
+      causalMint;
+    if (!measuredRotation) {
+      bail(
+        `navigation screen "${screenId}": two evaluations are licensed only as the measured ` +
+          `rotation (incorrect non-navigating check, a server-minted fresh attempt created ` +
+          `between the checks, then a correct navigating check under that attempt); ` +
+          `saw correct=[${String(first.correct)}, ${String(second.correct)}] ` +
+          `attempts=[${first.attemptGuid.slice(0, 8)}, ${second.attemptGuid.slice(0, 8)}] ` +
+          `transitions=[${firstMove.kind}, ${secondMove.kind}] ` +
+          `mint=${mint ? 'observed' : 'missing'}`,
+      );
+    }
+  }
+}
+
+function transitionNavigates(t: DerivedTransition): boolean {
+  return (
+    t.kind === 'auto-navigate' ||
+    t.kind === 'terminal' ||
+    (t.kind === 'feedback' && t.ack.kind === 'navigate')
+  );
+}
+
+async function waitForUsableEvaluation(
+  observer: AdaptiveEvaluationObserver,
+  screenId: string,
+  expectedCount: number,
+): Promise<EvaluationRecord> {
+  const record = await observer.waitForEvaluation(expectedCount, 45_000);
+  if (record.status === null || record.status < 200 || record.status >= 300) {
+    throw new Error(`screen "${screenId}": evaluation returned status ${String(record.status)}`);
+  }
+  if (record.parseError || !record.actions) {
+    throw new Error(`screen "${screenId}": evaluation unusable: ${record.parseError}`);
+  }
+  return record;
+}
+
+async function waitForPropagatedState(
+  observer: AdaptiveEvaluationObserver,
+  screenId: string,
+  awaitSaved: ExpectedSubmission,
+  sinceMs: number,
+): Promise<void> {
+  const deadline = Date.now() + 20_000;
+  let lastMissing: string[] = [];
+  for (;;) {
+    const candidates = observer.saves().filter((r) => r.requestAt >= sinceMs);
+    for (const save of candidates) {
+      lastMissing = missingExpectedPaths(extractSubmittedPairs(save.partInputs), awaitSaved);
+      if (lastMissing.length === 0) return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `screen "${screenId}": widget state never reached the deck — no deferred save ` +
+          `carried the answered parts within 20s (saves seen: ${candidates.length}; ` +
+          `still missing: ${lastMissing.join(', ') || 'all'})`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+}
+
+function evaluationMatchesReceipt(record: EvaluationRecord, receipt: AnswerReceipt): boolean {
+  const pairs = extractSubmittedPairs(record.partInputs);
+  return pairs.length > 0 && missingExpectedPaths(pairs, receipt.expected).length === 0;
+}
+
+async function answerScreenStrict(
+  deck: AdaptiveDeckPO,
+  screen: ManifestScreen,
+  parts: PartInventory,
+): Promise<AnswerReceipt> {
+  const expected: ExpectedSubmission = [];
+  const awaitSaved: ExpectedSubmission = [];
+  const performed: string[] = [];
+
+  for (const directive of screen.answers ?? []) {
+    await performDirective(deck, screen.id, directive);
+    const derived = expectedForDirective(screen.id, directive, parts);
+    if (derived.length === 0) {
+      throw new Error(
+        `screen "${screen.id}": ${directive.kind} produced no expected parts — ` +
+          `payload correlation would be vacuous (part inventory mismatch)`,
+      );
+    }
+    expected.push(...derived);
+    awaitSaved.push(...savedSignalForDirective(screen.id, directive, parts));
+    performed.push(directive.kind);
+  }
+
+  return {
+    screenId: screen.id,
+    directive: performed.join('+'),
+    readback: `verified: ${performed.join('+')}`,
+    expected,
+    awaitSaved,
+  };
+}
+
+const CAPI_DIRECTIVES: ReadonlyArray<AnswerDirective['kind']> = [
+  'frame_selects',
+  'custom_dnd',
+  'grouping',
+  'ordering',
+  'matching',
+];
+
+/**
+ * The deferred-save evidence that a directive's widget state actually
+ * reached the deck. Janus parts write to the script environment
+ * synchronously and need none; CAPI widgets must show up in a PATCH save
+ * first — for fill-in-the-blanks the per-blank Selected Index turning
+ * non-negative, for the other widget families any post-answer save of the
+ * iframe's state cluster.
+ */
+function savedSignalForDirective(
+  screenId: string,
+  d: AnswerDirective,
+  parts: PartInventory,
+): ExpectedSubmission {
+  if (!CAPI_DIRECTIVES.includes(d.kind)) return [];
+
+  const withSrc = d as { src_fragment: string };
+  const frame = parts.find(
+    (p) => p.type === 'janus-capi-iframe' && !!p.src && p.src.includes(withSrc.src_fragment),
+  );
+  if (!frame) {
+    throw new Error(
+      `screen "${screenId}": no capi iframe matching ${withSrc.src_fragment} in the live inventory`,
+    );
+  }
+
+  if (d.kind === 'frame_selects') {
+    return Object.keys(d.values).map((dropId) => ({
+      path: `stage.${frame.id}.Inputs.${dropId}.Selected Index`,
+      value_matches: '^(?:0|[1-9][0-9]*)$',
+    }));
+  }
+  return [{ path_prefix: `stage.${frame.id}.` }];
+}
+
+async function performDirective(deck: AdaptiveDeckPO, screenId: string, d: AnswerDirective) {
+  const re = (source: string) => new RegExp(source, 'i');
+
+  switch (d.kind) {
+    case 'frame_selects': {
+      const ok = await deck.fillFrameSelects(
+        d.src_fragment,
+        d.ready_selector,
+        d.values,
+        d.required_option,
+        true,
+      );
+      if (!ok)
+        throw new Error(`screen "${screenId}": frame-selects widget did not accept the fill`);
+      return;
+    }
+    case 'custom_dnd': {
+      const ok = await deck.dragCustomDnD(
+        d.src_fragment,
+        d.detect,
+        d.placements.map((p) => [p.item, p.zone]),
+      );
+      if (!ok) throw new Error(`screen "${screenId}": drag-and-drop widget not present`);
+      return;
+    }
+    case 'grouping':
+      return deck.dragItemsToGroups(
+        d.src_fragment,
+        d.placements.map((p) => [p.item, p.group]),
+      );
+    case 'ordering':
+      return deck.reorderList(d.src_fragment, d.order);
+    case 'matching':
+      return deck.linkMatchingPairs(
+        d.src_fragment,
+        d.links.map((l) => [re(l.left), re(l.right)]),
+      );
+    case 'native_dropdowns':
+      return deck.setNativeDropdowns(d.picks);
+    case 'fib_labels':
+      return deck.setFibDropdownsByLabel(d.labels);
+    case 'mcq_radio': {
+      if (!(await deck.selectMcqByText(re(d.pick), d.part_id))) {
+        throw new Error(`screen "${screenId}": MCQ option matching the key was not selectable`);
+      }
+      return;
+    }
+    case 'mcq_checkboxes': {
+      for (let i = 0; i < d.picks.length; i += 1) {
+        if (!(await deck.selectMcqByText(re(d.picks[i]), d.part_id))) {
+          throw new Error(
+            `screen "${screenId}": checkbox ${i + 1}/${d.picks.length} was not selectable`,
+          );
+        }
+      }
+      return;
+    }
+    case 'text_input': {
+      if ((await deck.fillTextInputs(d.value)) === 0) {
+        throw new Error(`screen "${screenId}": no text inputs found`);
+      }
+      return;
+    }
+  }
+}
+
+/** Answer text is a regex source by key convention; reuse it as a matcher safely. */
+const escapeForMatch = (source: string) => source;
+
+/**
+ * The single part of `type` a directive owns. Ambiguity is a manifest error:
+ * a screen rendering several parts of the same family must name one, or the
+ * directive could answer/correlate against the wrong owner.
+ */
+function needOwningPart(
+  screenId: string,
+  parts: PartInventory,
+  type: string,
+  partId?: string,
+): PartInventory[number] {
+  const candidates = parts.filter((p) => p.type === type);
+  if (partId) {
+    const named = candidates.find((p) => p.id === partId);
+    if (!named) throw new Error(`screen "${screenId}": no ${type} part with id "${partId}"`);
+    return named;
+  }
+  if (candidates.length === 0) {
+    throw new Error(`screen "${screenId}": no ${type} part in the live inventory`);
+  }
+  if (candidates.length > 1) {
+    throw new Error(
+      `screen "${screenId}": ${candidates.length} ${type} parts — the directive must declare part_id`,
+    );
+  }
+  return candidates[0];
+}
+
+/**
+ * The janus-mcq part a directive owns. A screen with several MCQ parts must
+ * name one in the manifest — picking the first would let a directive answer
+ * or correlate against the wrong owner.
+ */
+function needMcq(screenId: string, parts: PartInventory, partId?: string): PartInventory[number] {
+  const mcqs = parts.filter((p) => p.type === 'janus-mcq');
+  if (partId) {
+    const named = mcqs.find((p) => p.id === partId);
+    if (!named) {
+      throw new Error(`screen "${screenId}": no janus-mcq part with id "${partId}"`);
+    }
+    return named;
+  }
+  if (mcqs.length === 0) {
+    throw new Error(`screen "${screenId}": no janus-mcq part in the live inventory`);
+  }
+  if (mcqs.length > 1) {
+    throw new Error(
+      `screen "${screenId}": ${mcqs.length} janus-mcq parts — the directive must declare part_id`,
+    );
+  }
+  return mcqs[0];
+}
+
+/**
+ * The state paths a directive's answer must reach in the submitted
+ * partInputs. Janus parts expose typed keys; CAPI iframes submit an opaque
+ * variable cluster, so their receipts assert cluster presence only.
+ */
+function expectedForDirective(
+  screenId: string,
+  d: AnswerDirective,
+  parts: PartInventory,
+): ExpectedSubmission {
+  const need = (predicate: (p: PartInventory[number]) => boolean, what: string) => {
+    const part = parts.find(predicate);
+    if (!part) throw new Error(`screen "${screenId}": no ${what} part in the live inventory`);
+    return part;
+  };
+
+  switch (d.kind) {
+    case 'mcq_radio': {
+      const mcq = needMcq(screenId, parts, d.part_id);
+      return [{ path: `stage.${mcq.id}.selectedChoiceText`, value_matches: d.pick }];
+    }
+    case 'mcq_checkboxes': {
+      const mcq = needMcq(screenId, parts, d.part_id);
+      return d.picks.map((pick) => ({
+        path: `stage.${mcq.id}.selectedChoicesText`,
+        value_matches: pick,
+      }));
+    }
+    case 'text_input': {
+      const input = need(
+        (p) => p.type === 'janus-multi-line-text' || p.type === 'janus-input-text',
+        'text input',
+      );
+      return [{ path: `stage.${input.id}.text`, value: d.value }];
+    }
+    case 'native_dropdowns': {
+      // positional: the Nth visible dropdown part receives the Nth pick, the
+      // same order setNativeDropdowns fills them in
+      const dropdowns = d.part_id
+        ? [needOwningPart(screenId, parts, 'janus-dropdown', d.part_id)]
+        : parts.filter((p) => p.type === 'janus-dropdown');
+      if (dropdowns.length !== d.picks.length) {
+        throw new Error(
+          `screen "${screenId}": ${dropdowns.length} dropdown part(s) but the key has ${d.picks.length} pick(s)`,
+        );
+      }
+      return dropdowns.map((p, i) => ({
+        path: `stage.${p.id}.selectedItem`,
+        value_matches: escapeForMatch(d.picks[i]),
+      }));
+    }
+    case 'fib_labels': {
+      const blanks = needOwningPart(screenId, parts, 'janus-fill-blanks', d.part_id);
+      // every declared label must appear under the owning part, and a label
+      // repeated N times needs N distinct matching submitted values
+      const byLabel = new Map<string, number>();
+      for (const label of d.labels) byLabel.set(label, (byLabel.get(label) ?? 0) + 1);
+      return Array.from(byLabel, ([label, count]) => ({
+        path_prefix: `stage.${blanks.id}.`,
+        value_matches: escapeForMatch(label),
+        min_count: count,
+      }));
+    }
+    case 'frame_selects': {
+      const frame = need(
+        (p) => p.type === 'janus-capi-iframe' && !!p.src && p.src.includes(d.src_fragment),
+        `capi iframe matching ${d.src_fragment}`,
+      );
+      return Object.keys(d.values).map((dropId) => ({
+        path: `stage.${frame.id}.Inputs.${dropId}.Selected Index`,
+        value_matches: '^(?:0|[1-9][0-9]*)$',
+      }));
+    }
+    default: {
+      const frame = need(
+        (p) => p.type === 'janus-capi-iframe' && !!p.src && p.src.includes(d.src_fragment),
+        `capi iframe matching ${d.src_fragment}`,
+      );
+      return [{ path_prefix: `stage.${frame.id}.` }];
+    }
+  }
+}
+
+/**
+ * COMPATIBILITY walk, deliberately preserving the merged MER-5672/5673
+ * dynamics those specs were validated against (tolerant labels, re-answering
+ * each iteration, multi-click advance). Correctness fixes that flow through
+ * the shared helpers — verified fills, no first-option guessing — still
+ * apply; everything stricter lives in completeAdaptiveHappyPathStrict.
+ */
 export async function completeAdaptiveHappyPath(
   page: Page,
   deck: AdaptiveDeckPO,
@@ -46,6 +754,9 @@ export async function completeAdaptiveHappyPath(
       return;
     }
 
+    const stepStartedAt = Date.now();
+    const before = await deck.screenId();
+
     let label: string;
     try {
       label = await answerCurrentScreen(deck, key);
@@ -56,9 +767,22 @@ export async function completeAdaptiveHappyPath(
     } catch (e) {
       label = `answer error: ${(e as Error).message.split('\n')[0].slice(0, 100)}`;
     }
+    const answeredAt = Date.now();
+
+    // an in-widget button navigates by itself; driving the deck as well would
+    // click the screen we just landed on and skip it
+    if ((await deck.screenId()) !== before) {
+      console.log(`[screen ${step}] ${label} -> advanced by the interaction itself`);
+      stuckCount = 0;
+      if (!(await deck.lessonEnded())) await deck.waitForDeckReady();
+      continue;
+    }
 
     const moved = await deck.advance();
-    console.log(`[screen ${step}] ${label} -> advanced=${moved}`);
+    console.log(
+      `[screen ${step}] ${label} -> advanced=${moved} ` +
+        `(answer ${answeredAt - stepStartedAt}ms, advance ${Date.now() - answeredAt}ms)`,
+    );
 
     if (moved) {
       stuckCount = 0;
@@ -83,9 +807,10 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
   const hasIframe = (fragment: string) => scan.iframes.some((src) => src.includes(fragment));
   const re = (source: string) => new RegExp(source, 'i');
 
-  const { grouping, ordering, matching, frame_selects } = key.widgets;
+  const { grouping, ordering, matching } = key.widgets;
+  const frameSelects = key.widgets.frame_selects ?? [];
   const customDnd = key.widgets.custom_dnd ?? [];
-  const groupings = Array.isArray(grouping) ? grouping : [grouping];
+  const groupings = grouping ? (Array.isArray(grouping) ? grouping : [grouping]) : [];
 
   for (const dnd of customDnd) {
     if (hasIframe(dnd.src_fragment)) {
@@ -106,26 +831,31 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
       return 'grouping widget';
     }
   }
-  if (hasIframe(ordering.src_fragment)) {
+  if (ordering && hasIframe(ordering.src_fragment)) {
     await deck.reorderList(ordering.src_fragment, ordering.order);
     return 'ordering widget';
   }
-  if (hasIframe(matching.src_fragment)) {
+  if (matching && hasIframe(matching.src_fragment)) {
     await deck.linkMatchingPairs(
       matching.src_fragment,
       matching.links.map((l) => [re(l.left), re(l.right)]),
     );
     return 'matching widget';
   }
-  for (const table of frame_selects) {
-    if (hasIframe(table.src_fragment)) {
-      await deck.fillFrameSelects(table.src_fragment, table.ready_selector, table.values);
-      return `frame selects (${table.src_fragment})`;
-    }
+  for (const table of frameSelects) {
+    if (!hasIframe(table.src_fragment)) continue;
+
+    const done = await deck.fillFrameSelects(
+      table.src_fragment,
+      table.ready_selector,
+      table.values,
+      table.required_option,
+    );
+    if (done) return `frame selects (${table.required_option ?? table.src_fragment})`;
   }
 
   if (scan.selects > 0) {
-    for (const rule of key.native_dropdowns) {
+    for (const rule of key.native_dropdowns ?? []) {
       if (scan.firstSelectOptions.some((o) => o.includes(rule.when_option_includes))) {
         await deck.setNativeDropdowns(rule.picks);
         return `dropdowns (${rule.when_option_includes})`;
@@ -135,10 +865,10 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
 
   const parts: string[] = [];
 
-  if (scan.fibs > 0 && scan.fibs === key.fib.by_label_when_count.count) {
+  if (key.fib && scan.fibs > 0 && scan.fibs === key.fib.by_label_when_count.count) {
     await deck.setFibDropdownsByLabel(key.fib.by_label_when_count.labels);
     parts.push(`FITB by label (${scan.fibs})`);
-  } else if (scan.fibs > 0) {
+  } else if (key.fib && scan.fibs > 0) {
     await deck.setFibDropdownsByOptionSet(key.fib.option_sets.map((o) => [re(o.match), o.pick]));
     parts.push(`FITB (${scan.fibs})`);
   }
@@ -160,9 +890,6 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
           : `MCQ pick NOT selected (${pick})`,
       );
     }
-    if (labels.length === 0) {
-      labels.push((await deck.selectFirstMcqItem()) ? 'MCQ (any)' : 'MCQ (none selected)');
-    }
     parts.push(...labels);
   }
 
@@ -180,6 +907,12 @@ async function answerCurrentScreen(deck: AdaptiveDeckPO, key: LessonAnswers): Pr
   }
 
   if (parts.length > 0) return parts.join(' + ');
+
+  for (const fragment of key.widgets.in_widget_buttons ?? []) {
+    if (hasIframe(fragment) && (await deck.clickWidgetButton(fragment))) {
+      return `in-widget button (${fragment})`;
+    }
+  }
 
   const carouselClicks = await deck.clickThroughCarousels();
   if (carouselClicks > 0) return `carousel (${carouselClicks} clicks)`;

--- a/assets/automation/src/systems/torus/tasks/AdaptiveStrictContract.ts
+++ b/assets/automation/src/systems/torus/tasks/AdaptiveStrictContract.ts
@@ -1,0 +1,513 @@
+/**
+ * Strict adaptive-driver contract (MER-5674 §10 step 1).
+ *
+ * Identity: a screen is `model.id` (the archive's `custom.sequenceId`),
+ * correlated to evaluation traffic by the live `attemptGuid`. The manifest's
+ * resource_id is the ARCHIVE activity id — imports remap activity ids, so it
+ * is cross-checked offline against the archive, while the walk records the
+ * live `model.resourceId` and enforces its run-internal consistency. No
+ * rendered-text fallback.
+ *
+ * Receipt: every answered screen yields a receipt naming the directive that
+ * answered it plus the canonical submission expected in the evaluation
+ * request body — part path suffixes and values, dynamic prefixes excluded.
+ *
+ * Transition: derived from the evaluation response's own actions, mirroring
+ * DeckLayoutFooter's default single-event path — feedback present means an
+ * acknowledgement is legal and either navigates (queued target) or re-checks
+ * (a second, expected evaluation); navigation without feedback
+ * auto-navigates; target `endOfLesson` is terminal; neither is a
+ * mutation-only stay. In delivery mode every check PUTs an evaluation
+ * regardless of screen role, so evaluation counts are per-role expectations.
+ *
+ * Ledger invariants (asserted in §10 step 10): ordered full coverage of the
+ * manifest, exact cardinality, per-role evaluation counts with attempt-GUID
+ * and payload match, true verdict per graded screen, no undeclared screens,
+ * no unexpected evaluations, terminal transition only at the last screen.
+ */
+
+export type ScreenRole = 'graded' | 'content' | 'navigation';
+
+/**
+ * Text matchers in directives (`pick`, `picks`, `labels_match`, matching
+ * `links`) are case-insensitive REGEX SOURCES by key convention — the merged
+ * private keys escape their own metacharacters (e.g. `more dense\\.`), and
+ * the same convention carries into strict manifests deliberately.
+ */
+export type AnswerDirective =
+  | {
+      kind: 'frame_selects';
+      src_fragment: string;
+      ready_selector: string;
+      values: Record<string, string>;
+      required_option?: string;
+    }
+  | {
+      kind: 'custom_dnd';
+      src_fragment: string;
+      detect: string;
+      placements: Array<{ item: string; zone: string }>;
+    }
+  | { kind: 'grouping'; src_fragment: string; placements: Array<{ item: string; group: string }> }
+  | { kind: 'ordering'; src_fragment: string; order: string[] }
+  | { kind: 'matching'; src_fragment: string; links: Array<{ left: string; right: string }> }
+  | { kind: 'native_dropdowns'; picks: string[]; part_id?: string }
+  /** `part_id` scopes the receipt when a screen renders several fill-blanks parts */
+  | { kind: 'fib_labels'; labels: string[]; part_id?: string }
+  /** `part_id` scopes both the click and the receipt when a screen has several janus-mcq parts */
+  | { kind: 'mcq_radio'; labels_match: string; pick: string; part_id?: string }
+  | { kind: 'mcq_checkboxes'; picks: string[]; part_id?: string }
+  | { kind: 'text_input'; value: string };
+
+export type ScreenAction = { kind: 'in_widget_button'; src_fragment: string };
+
+export type ManifestScreen = {
+  id: string;
+  resource_id: number;
+  role: ScreenRole;
+  answers?: AnswerDirective[];
+  action?: ScreenAction;
+};
+
+export type ScreenIdentity = { id: string; resourceId: number; attemptGuid: string };
+
+/**
+ * Expected part paths are suffix-matched: live paths carry dynamic prefixes.
+ * `value` compares exactly (JSON equality); `value_matches` is a
+ * case-insensitive regex over the stringified value (option texts flatten
+ * markup and whitespace unpredictably); `path_prefix` asserts presence only —
+ * CAPI widget variables are not statically derivable, so those receipts prove
+ * the widget's state cluster was submitted at all.
+ */
+export type ExpectedPart =
+  | { path: string; value: unknown }
+  | { path: string; value_matches: string }
+  | { path_prefix: string }
+  /**
+   * at least `min_count` (default 1) distinct submitted parts under this
+   * prefix must carry a value matching the regex — cardinality matters when
+   * the same answer label legitimately fills several blanks
+   */
+  | { path_prefix: string; value_matches: string; min_count?: number };
+export type ExpectedSubmission = ExpectedPart[];
+
+export type AnswerReceipt = {
+  screenId: string;
+  /** the directive kind(s) that answered the screen, '+'-joined when several */
+  directive: string;
+  readback: string;
+  expected: ExpectedSubmission;
+  /**
+   * CAPI widget state reaches the deck asynchronously (iframe postMessage →
+   * applyState → redux) and the evaluation snapshots that state at check
+   * time; these parts must appear in a deferred PATCH save BEFORE the check
+   * is clicked, or the submission would carry the widget's initial state.
+   */
+  awaitSaved?: ExpectedSubmission;
+};
+
+export type CheckActions = {
+  correct: boolean;
+  score?: number;
+  out_of?: number;
+  results?: Array<{
+    params?: { actions?: Array<{ type: string; params?: Record<string, unknown> }> };
+  }>;
+};
+
+export type DerivedTransition =
+  | { kind: 'auto-navigate'; target: string }
+  | { kind: 'terminal' }
+  | { kind: 'feedback'; ack: { kind: 'navigate'; target: string } | { kind: 'recheck' } }
+  | { kind: 'none' };
+
+export type EvaluationRecord = {
+  attemptGuid: string;
+  /** sequenceId prefix of the submitted part paths — the screen this request belongs to */
+  screenId: string | null;
+  /** any other sequenceId prefixes in the same submission (mixed traffic) */
+  otherScreenIds: string[];
+  /** server-generated feedback text; the deck opens feedback for it too */
+  llmFeedback: { text?: string } | null;
+  /**
+   * finalize saves PUT the same URL as evaluations (response body tells them
+   * apart); deferred part-state saves PATCH the /active variant
+   */
+  kind: 'evaluation' | 'finalize' | 'save' | 'unknown';
+  url: string;
+  partInputs: unknown[] | null;
+  requestAt: number;
+  responseAt: number | null;
+  /**
+   * Monotonic per-observer event order — request and response stamps share
+   * one counter, so ordering between any two observed events is strict and
+   * never ambiguous the way millisecond clocks are.
+   */
+  requestSeq: number;
+  responseSeq: number | null;
+  status: number | null;
+  actions: CheckActions | null;
+  correct: boolean | null;
+  parseError: string | null;
+  parsed: boolean;
+};
+
+/**
+ * An observed attempt rotation: POST /activity_attempt/<targetGuid> minting a
+ * fresh attempt. The minted guid is server-generated, so a later evaluation
+ * submitted under it proves it started after this response — the causal
+ * anchor the navigation licence requires.
+ */
+export type AttemptCreation = {
+  targetGuid: string;
+  newGuid: string | null;
+  requestSeq: number;
+  responseSeq: number | null;
+  status: number | null;
+  parsed: boolean;
+};
+
+export type LedgerEntry = {
+  screenId: string;
+  resourceId: number;
+  attemptGuid: string;
+  role: ScreenRole;
+  receipt: AnswerReceipt | null;
+  evaluationCount: number;
+  /**
+   * The exact number of evaluations the walk itself licensed (1, or 2 when a
+   * legal feedback re-check occurred). When present the ledger requires
+   * equality — an accidental extra submission can never hide inside a range.
+   */
+  expectedEvaluations?: number;
+  verdict: boolean | null;
+  payloadMatch: boolean | null;
+  transition: DerivedTransition | null;
+};
+
+const ROLES: readonly ScreenRole[] = ['graded', 'content', 'navigation'];
+
+const isNonEmptyString = (v: unknown): v is string => typeof v === 'string' && v.length > 0;
+const isStringArray = (v: unknown): v is string[] =>
+  Array.isArray(v) && v.length > 0 && v.every((x) => isNonEmptyString(x));
+const isPairArray = (v: unknown, left: string, right: string): boolean =>
+  Array.isArray(v) &&
+  v.length > 0 &&
+  v.every(
+    (x) =>
+      !!x &&
+      typeof x === 'object' &&
+      isNonEmptyString((x as Record<string, unknown>)[left]) &&
+      isNonEmptyString((x as Record<string, unknown>)[right]),
+  );
+
+const DIRECTIVE_VALIDATORS: Record<string, (d: Record<string, unknown>) => boolean> = {
+  frame_selects: (d) =>
+    isNonEmptyString(d.src_fragment) &&
+    isNonEmptyString(d.ready_selector) &&
+    !!d.values &&
+    typeof d.values === 'object' &&
+    Object.values(d.values).length > 0 &&
+    Object.values(d.values).every((v) => typeof v === 'string'),
+  custom_dnd: (d) =>
+    isNonEmptyString(d.src_fragment) &&
+    isNonEmptyString(d.detect) &&
+    isPairArray(d.placements, 'item', 'zone'),
+  grouping: (d) => isNonEmptyString(d.src_fragment) && isPairArray(d.placements, 'item', 'group'),
+  ordering: (d) => isNonEmptyString(d.src_fragment) && isStringArray(d.order),
+  matching: (d) => isNonEmptyString(d.src_fragment) && isPairArray(d.links, 'left', 'right'),
+  native_dropdowns: (d) => isStringArray(d.picks),
+  fib_labels: (d) => isStringArray(d.labels),
+  mcq_radio: (d) => isNonEmptyString(d.labels_match) && isNonEmptyString(d.pick),
+  mcq_checkboxes: (d) => isStringArray(d.picks),
+  text_input: (d) => isNonEmptyString(d.value),
+};
+
+const fail = (msg: string): never => {
+  throw new Error(`invalid strict manifest: ${msg}`);
+};
+
+export function validateManifest(raw: unknown): ManifestScreen[] {
+  if (!Array.isArray(raw) || raw.length === 0) {
+    fail('screens must be a non-empty array (strict mode requires a per-screen manifest)');
+  }
+  const screens = raw as Array<Record<string, unknown>>;
+  const seen = new Set<string>();
+
+  screens.forEach((s, i) => {
+    const at = `screens[${i}]`;
+    if (!s || typeof s !== 'object' || Array.isArray(s)) fail(`${at} is not an object`);
+    if (!isNonEmptyString(s.id)) fail(`${at}.id must be a non-empty string`);
+    const id = s.id as string;
+    if (seen.has(id)) fail(`duplicate screen id "${id}"`);
+    seen.add(id);
+    if (typeof s.resource_id !== 'number') fail(`${at} ("${id}").resource_id must be a number`);
+    if (!ROLES.includes(s.role as ScreenRole)) {
+      fail(`${at} ("${id}").role must be one of ${ROLES.join('|')}`);
+    }
+
+    if (s.role === 'graded') {
+      if (!Array.isArray(s.answers) || s.answers.length === 0) {
+        fail(`${at} ("${id}") is graded and must declare a non-empty answers array`);
+      }
+      (s.answers as Array<Record<string, unknown>>).forEach((a, j) => {
+        const dat = `${at}.answers[${j}]`;
+        if (!a || typeof a !== 'object') fail(`${dat} is not an object`);
+        const validator = DIRECTIVE_VALIDATORS[a.kind as string];
+        if (!validator) fail(`${dat} has unknown kind "${String(a.kind)}"`);
+        if (!validator(a))
+          fail(`${dat} (${String(a.kind)}) is missing or mistypes required fields`);
+      });
+    } else if (s.answers !== undefined) {
+      fail(`${at} ("${id}") is ${String(s.role)} and must not declare answers`);
+    }
+
+    if (s.role === 'navigation') {
+      const action = s.action as Record<string, unknown> | undefined;
+      if (!action || action.kind !== 'in_widget_button' || !isNonEmptyString(action.src_fragment)) {
+        fail(`${at} ("${id}") is navigation and must declare an in_widget_button action`);
+      }
+    } else if (s.action !== undefined) {
+      fail(`${at} ("${id}") is ${String(s.role)} and must not declare an action`);
+    }
+  });
+
+  return raw as ManifestScreen[];
+}
+
+/**
+ * Live identity resolution matches by sequenceId only: the manifest's
+ * resource_id is the ARCHIVE activity id, valid for offline validation, but
+ * a course import remaps activity ids — the live resourceId differs by
+ * design. The walk enforces run-internal consistency (one live resourceId
+ * per sequenceId) instead.
+ */
+export function resolveManifestScreen(
+  screens: ManifestScreen[],
+  identity: ScreenIdentity,
+): ManifestScreen {
+  const screen = screens.find((s) => s.id === identity.id);
+  if (!screen) {
+    throw new Error(
+      `undeclared screen "${identity.id}" (live resource ${identity.resourceId}) is not in the strict manifest`,
+    );
+  }
+  return screen;
+}
+
+type SubmittedPair = { path: string; value: unknown };
+
+/**
+ * Evaluation PUTs nest the part map under `response.input`; deferred PATCH
+ * saves inline it directly under `response`. Both shapes carry
+ * `{path, value}` items.
+ */
+export function extractSubmittedPairs(partInputs: unknown[] | null): SubmittedPair[] {
+  if (!partInputs) return [];
+  const pairs: SubmittedPair[] = [];
+  for (const part of partInputs) {
+    const response = (part as { response?: Record<string, unknown> | null })?.response;
+    if (!response || typeof response !== 'object') continue;
+    const input =
+      response.input && typeof response.input === 'object'
+        ? (response.input as Record<string, unknown>)
+        : response;
+    for (const item of Object.values(input)) {
+      const entry = item as { path?: unknown; value?: unknown } | null;
+      if (entry && typeof entry.path === 'string') {
+        pairs.push({ path: entry.path, value: entry.value });
+      }
+    }
+  }
+  return pairs;
+}
+
+const sameValue = (a: unknown, b: unknown) => JSON.stringify(a) === JSON.stringify(b);
+
+const partSatisfied = (pairs: SubmittedPair[], e: ExpectedPart): boolean => {
+  if ('path_prefix' in e) {
+    const underPrefix = pairs.filter((p) => p.path.includes(e.path_prefix));
+    if (!('value_matches' in e)) return underPrefix.length > 0;
+    const re = new RegExp(e.value_matches, 'i');
+    const matched = underPrefix.filter((p) => re.test(String(p.value)));
+    return matched.length >= (e.min_count ?? 1);
+  }
+  const atPath = pairs.filter((p) => p.path === e.path || p.path.endsWith(e.path));
+  if ('value_matches' in e) {
+    const re = new RegExp(e.value_matches, 'i');
+    return atPath.some((p) => re.test(String(p.value)));
+  }
+  return atPath.some((p) => sameValue(p.value, e.value));
+};
+
+export function missingExpectedPaths(
+  pairs: SubmittedPair[],
+  expected: ExpectedSubmission,
+): string[] {
+  return expected
+    .filter((e) => !partSatisfied(pairs, e))
+    .map((e) => ('path_prefix' in e ? `${e.path_prefix}*` : e.path));
+}
+
+export function deriveTransition(
+  actions: CheckActions,
+  llmFeedback?: { text?: string } | null,
+): DerivedTransition {
+  const acts = actions.results?.[0]?.params?.actions ?? [];
+  const feedback = acts.filter((a) => a.type === 'feedback');
+  const nav = acts.filter((a) => a.type === 'navigation');
+  const target = nav.length > 0 ? String(nav[0].params?.target ?? '') : '';
+
+  if (feedback.length > 0 || llmFeedback?.text) {
+    return {
+      kind: 'feedback',
+      ack: nav.length > 0 ? { kind: 'navigate', target } : { kind: 'recheck' },
+    };
+  }
+  if (nav.length > 0) {
+    return target === 'endOfLesson' ? { kind: 'terminal' } : { kind: 'auto-navigate', target };
+  }
+  return { kind: 'none' };
+}
+
+/**
+ * The strict per-screen oracle: exactly one evaluation, answered by the
+ * server with 2xx, a boolean `actions.correct === true`, a non-empty
+ * submitted payload, and — when a receipt provides one — every expected
+ * part present with its expected value. Failure messages name part paths
+ * only, never answer values: traces run with the key, which is private.
+ */
+/**
+ * Per-role evaluation expectations. In delivery mode every footer check PUTs
+ * an evaluation regardless of role, so content screens evaluate too; graded
+ * screens may legally evaluate twice when correct feedback carries no queued
+ * navigation and the acknowledgement re-checks. A navigation screen's
+ * in-widget button can itself trigger checks, and the first can fire before
+ * the widget's state lands (observed on the LotE cover: wrong verdict, deck
+ * spawns a fresh attempt, immediate re-check is correct and navigates) — so
+ * up to two evaluations, verdict unasserted.
+ */
+export const ROLE_EVALUATIONS: Record<
+  ScreenRole,
+  { min: number; max: number; assertVerdict: boolean }
+> = {
+  graded: { min: 1, max: 2, assertVerdict: true },
+  content: { min: 1, max: 1, assertVerdict: false },
+  navigation: { min: 0, max: 2, assertVerdict: false },
+};
+
+/** Redacted ledger rendering: identities, counts and kinds — never values. */
+export function formatLedger(ledger: LedgerEntry[]): string {
+  const lines = ledger.map((e, i) => {
+    const t = e.transition ? e.transition.kind : 'none-observed';
+    return (
+      `${String(i).padStart(2)} ${e.screenId} role=${e.role} evals=${e.evaluationCount} ` +
+      `verdict=${String(e.verdict)} payloadMatch=${String(e.payloadMatch)} transition=${t}`
+    );
+  });
+  return lines.join('\n');
+}
+
+export function assertLedger(ledger: LedgerEntry[], screens: ManifestScreen[]): void {
+  const bail = (msg: string): never => {
+    throw new Error(`strict ledger violation: ${msg}\n${formatLedger(ledger)}`);
+  };
+
+  if (ledger.length !== screens.length) {
+    bail(`visited ${ledger.length} screens, manifest declares ${screens.length}`);
+  }
+  ledger.forEach((entry, i) => {
+    const declared = screens[i];
+    if (entry.screenId !== declared.id) {
+      bail(`position ${i} visited "${entry.screenId}", manifest declares "${declared.id}"`);
+    }
+    if (entry.role !== declared.role) {
+      bail(
+        `screen "${entry.screenId}" recorded role ${entry.role}, manifest says ${declared.role}`,
+      );
+    }
+
+    const expected = ROLE_EVALUATIONS[entry.role];
+    if (entry.role === 'navigation') {
+      // the widget's own check dance is not licensed click-by-click
+      if (entry.evaluationCount < expected.min || entry.evaluationCount > expected.max) {
+        bail(
+          `screen "${entry.screenId}" (navigation) saw ${entry.evaluationCount} evaluation(s), ` +
+            `expected ${expected.min}-${expected.max}`,
+        );
+      }
+    } else if (entry.expectedEvaluations === undefined) {
+      // fail closed: a submitting screen without an explicit licence cannot
+      // fall back to a permissive range
+      bail(
+        `screen "${entry.screenId}" (${entry.role}) recorded no licensed evaluation count ` +
+          `(saw ${entry.evaluationCount})`,
+      );
+    } else if (entry.evaluationCount !== entry.expectedEvaluations) {
+      bail(
+        `screen "${entry.screenId}" (${entry.role}) saw ${entry.evaluationCount} evaluation(s), ` +
+          `the walk licensed exactly ${entry.expectedEvaluations}`,
+      );
+    }
+    if (expected.assertVerdict) {
+      if (entry.receipt === null) bail(`graded screen "${entry.screenId}" has no answer receipt`);
+      if (entry.verdict !== true) {
+        bail(`graded screen "${entry.screenId}" verdict=${String(entry.verdict)}`);
+      }
+      if (entry.payloadMatch !== true) {
+        bail(`graded screen "${entry.screenId}" payloadMatch=${String(entry.payloadMatch)}`);
+      }
+    }
+
+    const isLast = i === ledger.length - 1;
+    const isTerminal = entry.transition?.kind === 'terminal';
+    if (isTerminal && !isLast) {
+      bail(`screen "${entry.screenId}" at position ${i} is terminal before the last screen`);
+    }
+    // a lesson may end via an explicit endOfLesson target OR by navigating
+    // "next" off its final screen, where the deck finalizes; the walk
+    // separately asserts the lesson actually ended
+    if (isLast && !isTerminal && entry.transition?.kind !== 'auto-navigate') {
+      bail(
+        `last screen "${entry.screenId}" ended on ${entry.transition?.kind ?? 'no transition'}, ` +
+          `expected terminal or auto-navigate`,
+      );
+    }
+  });
+}
+
+export function verifyScreenEvaluation(opts: {
+  screenId: string;
+  records: EvaluationRecord[];
+  expected?: ExpectedSubmission;
+  attemptGuid?: string;
+}): void {
+  const { screenId, records, expected, attemptGuid } = opts;
+  const bail = (msg: string): never => {
+    throw new Error(`[strict ${screenId}] ${msg}`);
+  };
+
+  if (records.length === 0) bail('no evaluation request observed');
+  if (records.length > 1) {
+    bail(`${records.length} evaluation requests observed, expected exactly one`);
+  }
+  const r = records[0];
+  if (attemptGuid && r.attemptGuid !== attemptGuid) {
+    bail(`evaluation belongs to attempt ${r.attemptGuid}, expected ${attemptGuid}`);
+  }
+  if (r.responseAt === null) bail('evaluation request received no response');
+  if (r.status === null || r.status < 200 || r.status >= 300) {
+    bail(`evaluation returned status ${String(r.status)}`);
+  }
+  if (r.parseError) bail(`evaluation unusable: ${r.parseError}`);
+  if (r.correct !== true) bail(`server verdict correct=${String(r.correct)}`);
+
+  const pairs = extractSubmittedPairs(r.partInputs);
+  if (pairs.length === 0) bail('submitted partInputs carry no part responses');
+  if (expected && expected.length > 0) {
+    const missing = missingExpectedPaths(pairs, expected);
+    if (missing.length > 0) {
+      bail(`submitted payload is missing expected parts: ${missing.join(', ')}`);
+    }
+  }
+}

--- a/assets/automation/tests/torus/student_delivery/adaptive-strict-driver.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/adaptive-strict-driver.spec.ts
@@ -1,0 +1,764 @@
+import { Page, Route, expect, test } from '@playwright/test';
+import { AdaptiveEvaluationObserver } from '@tasks/AdaptiveEvaluationObserver';
+import {
+  EvaluationRecord,
+  ExpectedSubmission,
+  LedgerEntry,
+  assertLedger,
+  deriveTransition,
+  extractSubmittedPairs,
+  missingExpectedPaths,
+  resolveManifestScreen,
+  validateManifest,
+  verifyScreenEvaluation,
+} from '@tasks/AdaptiveStrictContract';
+
+/**
+ * MER-5674: negative tests for the strict adaptive driver's contract and
+ * evaluation observer. Stubbed — no Torus server, no credentials: the page
+ * is a routed fake origin and every evaluation response is fabricated.
+ */
+
+const GUID = 'attempt-guid-current';
+const ORIGIN = 'https://adaptive-stub.local';
+
+const PART = {
+  attemptGuid: 'part-guid-1',
+  response: {
+    input: { selectedItem: { path: 'q:1|stage.dropdown.selectedItem', value: 'Basalt' } },
+  },
+};
+const EXPECTED: ExpectedSubmission = [{ path: 'stage.dropdown.selectedItem', value: 'Basalt' }];
+
+const CORRECT_BODY = {
+  actions: {
+    correct: true,
+    score: 1,
+    out_of: 1,
+    results: [{ params: { actions: [{ type: 'navigation', params: { target: 'next' } }] } }],
+  },
+};
+
+function gradedScreen(over: Record<string, unknown> = {}) {
+  return {
+    id: 'q:1',
+    resource_id: 101,
+    role: 'graded',
+    answers: [{ kind: 'text_input', value: 'basalt' }],
+    ...over,
+  };
+}
+
+function record(over: Partial<EvaluationRecord> = {}): EvaluationRecord {
+  return {
+    attemptGuid: GUID,
+    screenId: 'q:1',
+    otherScreenIds: [],
+    llmFeedback: null,
+    kind: 'evaluation',
+    url: `${ORIGIN}/state/course/s1/activity_attempt/${GUID}`,
+    partInputs: [PART],
+    requestAt: 1,
+    responseAt: 2,
+    requestSeq: 1,
+    responseSeq: 2,
+    status: 200,
+    actions: CORRECT_BODY.actions,
+    correct: true,
+    parseError: null,
+    parsed: true,
+    ...over,
+  };
+}
+
+async function bootStub(page: Page, onEvaluation: (route: Route) => Promise<void> | void) {
+  await page.route(`${ORIGIN}/**`, async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' });
+    }
+    return onEvaluation(route);
+  });
+  await page.goto(`${ORIGIN}/`);
+}
+
+function fireEvaluation(page: Page, guid: string, body: unknown = { partInputs: [PART] }) {
+  return page.evaluate(
+    async (args) => {
+      const res = await fetch(`/state/course/s1/activity_attempt/${args.guid}`, {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(args.body),
+      });
+      return res.status;
+    },
+    { guid, body },
+  );
+}
+
+test.describe('strict manifest validation', () => {
+  test('accepts a legal manifest and resolves screens by identity', () => {
+    const screens = validateManifest([
+      gradedScreen(),
+      { id: 'c:2', resource_id: 102, role: 'content' },
+      {
+        id: 'n:3',
+        resource_id: 103,
+        role: 'navigation',
+        action: { kind: 'in_widget_button', src_fragment: 'nav-widget.html' },
+      },
+    ]);
+    expect(screens).toHaveLength(3);
+
+    const hit = resolveManifestScreen(screens, { id: 'q:1', resourceId: 101, attemptGuid: 'g' });
+    expect(hit.role).toBe('graded');
+  });
+
+  test('rejects a missing or empty manifest', () => {
+    expect(() => validateManifest(undefined)).toThrow(/non-empty array/);
+    expect(() => validateManifest([])).toThrow(/non-empty array/);
+  });
+
+  test('rejects duplicate screen ids', () => {
+    expect(() => validateManifest([gradedScreen(), gradedScreen({ resource_id: 999 })])).toThrow(
+      /duplicate screen id "q:1"/,
+    );
+  });
+
+  test('rejects a graded screen without answers', () => {
+    expect(() => validateManifest([gradedScreen({ answers: undefined })])).toThrow(
+      /graded and must declare/,
+    );
+    expect(() => validateManifest([gradedScreen({ answers: [] })])).toThrow(
+      /graded and must declare/,
+    );
+  });
+
+  test('rejects answers on non-graded screens', () => {
+    expect(() => validateManifest([gradedScreen({ role: 'content' })])).toThrow(
+      /content and must not declare answers/,
+    );
+  });
+
+  test('rejects a navigation screen without an in-widget action', () => {
+    expect(() => validateManifest([{ id: 'n:1', resource_id: 1, role: 'navigation' }])).toThrow(
+      /must declare an in_widget_button action/,
+    );
+  });
+
+  test('rejects unknown roles and directive kinds, and mistyped directives', () => {
+    expect(() => validateManifest([gradedScreen({ role: 'bonus' })])).toThrow(/role must be one/);
+    expect(() => validateManifest([gradedScreen({ answers: [{ kind: 'telepathy' }] })])).toThrow(
+      /unknown kind "telepathy"/,
+    );
+    expect(() =>
+      validateManifest([gradedScreen({ answers: [{ kind: 'ordering', src_fragment: 'x' }] })]),
+    ).toThrow(/missing or mistypes/);
+  });
+
+  test('rejects an undeclared live screen; live resource ids do not need to match the archive', () => {
+    const screens = validateManifest([gradedScreen()]);
+    expect(() =>
+      resolveManifestScreen(screens, { id: 'ghost', resourceId: 7, attemptGuid: 'g' }),
+    ).toThrow(/undeclared screen "ghost"/);
+    // imports remap activity ids: a live resourceId differing from the
+    // archive's is normal and must resolve
+    expect(
+      resolveManifestScreen(screens, { id: 'q:1', resourceId: 999, attemptGuid: 'g' }).id,
+    ).toBe('q:1');
+  });
+});
+
+test.describe('submitted payload correlation', () => {
+  test('extracts part path/value pairs from partInputs', () => {
+    expect(extractSubmittedPairs([PART])).toEqual([
+      { path: 'q:1|stage.dropdown.selectedItem', value: 'Basalt' },
+    ]);
+    expect(extractSubmittedPairs(null)).toEqual([]);
+    expect(extractSubmittedPairs([{ attemptGuid: 'x', response: { input: null } }])).toEqual([]);
+  });
+
+  test('extracts pairs from the deferred-save shape, where response inlines the map', () => {
+    expect(
+      extractSubmittedPairs([
+        {
+          attemptGuid: 'x',
+          response: {
+            selectedIndex: {
+              key: 'selectedIndex',
+              path: 'q:1|stage.Recap.Selected Index',
+              value: 3,
+            },
+          },
+        },
+      ]),
+    ).toEqual([{ path: 'q:1|stage.Recap.Selected Index', value: 3 }]);
+  });
+
+  test('matches expected parts by path suffix, ignoring dynamic prefixes', () => {
+    const pairs = extractSubmittedPairs([PART]);
+    expect(missingExpectedPaths(pairs, EXPECTED)).toEqual([]);
+    expect(
+      missingExpectedPaths(pairs, [{ path: 'stage.dropdown.selectedItem', value: 'Granite' }]),
+    ).toEqual(['stage.dropdown.selectedItem']);
+    expect(missingExpectedPaths([], EXPECTED)).toEqual(['stage.dropdown.selectedItem']);
+  });
+});
+
+test.describe('per-screen evaluation verdicts', () => {
+  const verify = (records: EvaluationRecord[], expected?: ExpectedSubmission) => () =>
+    verifyScreenEvaluation({ screenId: 'q:1', records, expected, attemptGuid: GUID });
+
+  test('passes on exactly one correct, payload-matched evaluation', () => {
+    expect(verify([record()], EXPECTED)).not.toThrow();
+  });
+
+  test('fails without any evaluation', () => {
+    expect(verify([])).toThrow(/no evaluation request observed/);
+  });
+
+  test('fails on a duplicate evaluation', () => {
+    expect(verify([record(), record()])).toThrow(/2 evaluation requests observed/);
+  });
+
+  test('fails on a wrong attempt guid', () => {
+    expect(verify([record({ attemptGuid: 'attempt-guid-other' })])).toThrow(
+      /belongs to attempt attempt-guid-other/,
+    );
+  });
+
+  test('fails without a response or on a non-2xx response', () => {
+    expect(verify([record({ responseAt: null })])).toThrow(/received no response/);
+    expect(verify([record({ status: 403 })])).toThrow(/status 403/);
+  });
+
+  test('fails on a false, missing, or non-boolean server verdict', () => {
+    expect(verify([record({ correct: false })])).toThrow(/correct=false/);
+    expect(
+      verify([
+        record({
+          correct: null,
+          parseError: 'evaluation response carries no boolean actions.correct',
+        }),
+      ]),
+    ).toThrow(/no boolean actions.correct/);
+  });
+
+  test('fails on empty submitted inputs', () => {
+    expect(verify([record({ partInputs: [] })])).toThrow(/no part responses/);
+  });
+
+  test('fails on a mismatched payload without leaking the answer value', () => {
+    const mismatched = verify(
+      [record()],
+      [{ path: 'stage.dropdown.selectedItem', value: 'Granite' }],
+    );
+    let message = '';
+    try {
+      mismatched();
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain('missing expected parts: stage.dropdown.selectedItem');
+    expect(message).not.toContain('Granite');
+    expect(message).not.toContain('Basalt');
+  });
+});
+
+test.describe('transition derivation from response actions', () => {
+  test('mirrors the footer branching', () => {
+    const withActions = (actions: Array<{ type: string; params?: Record<string, unknown> }>) => ({
+      correct: true,
+      results: [{ params: { actions } }],
+    });
+
+    expect(
+      deriveTransition(withActions([{ type: 'navigation', params: { target: 'next' } }])),
+    ).toEqual({ kind: 'auto-navigate', target: 'next' });
+    expect(
+      deriveTransition(withActions([{ type: 'navigation', params: { target: 'endOfLesson' } }])),
+    ).toEqual({ kind: 'terminal' });
+    expect(
+      deriveTransition(
+        withActions([
+          { type: 'feedback', params: { feedback: {} } },
+          { type: 'navigation', params: { target: 'q:2' } },
+        ]),
+      ),
+    ).toEqual({ kind: 'feedback', ack: { kind: 'navigate', target: 'q:2' } });
+    expect(deriveTransition(withActions([{ type: 'feedback', params: { feedback: {} } }]))).toEqual(
+      {
+        kind: 'feedback',
+        ack: { kind: 'recheck' },
+      },
+    );
+    expect(deriveTransition(withActions([{ type: 'mutateState' }]))).toEqual({ kind: 'none' });
+    expect(deriveTransition({ correct: true }, { text: 'llm feedback' })).toEqual({
+      kind: 'feedback',
+      ack: { kind: 'recheck' },
+    });
+  });
+});
+
+test.describe('evaluation observer against a stubbed page', () => {
+  const SCREEN = 'q:1';
+
+  test('captures the submission, verdict, and payload of one evaluation', async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      const evaluation = await observer.waitForEvaluation(1, 5_000);
+
+      expect(evaluation.status).toBe(200);
+      expect(evaluation.correct).toBe(true);
+      expect(evaluation.kind).toBe('evaluation');
+      expect(evaluation.screenId).toBe(SCREEN);
+      expect(extractSubmittedPairs(evaluation.partInputs)).toEqual([
+        { path: 'q:1|stage.dropdown.selectedItem', value: 'Basalt' },
+      ]);
+      expect(() =>
+        verifyScreenEvaluation({
+          screenId: SCREEN,
+          records: observer.evaluations(),
+          expected: EXPECTED,
+          attemptGuid: GUID,
+        }),
+      ).not.toThrow();
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('records a duplicate submission arriving after the first response', async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      await observer.waitForEvaluation(1, 5_000);
+      await fireEvaluation(page, GUID);
+
+      await expect.poll(() => observer.evaluations().length, { timeout: 5_000 }).toBe(2);
+      expect(() =>
+        verifyScreenEvaluation({ screenId: SCREEN, records: observer.evaluations() }),
+      ).toThrow(/2 evaluation requests observed/);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('attributes evaluations across rotating attempt guids to this screen', async ({ page }) => {
+    // the deck rotates the attempt after an incorrect non-navigating check
+    // with attempts remaining (triggerCheck.ts:424), so one screen's
+    // evaluations can legally span several guids
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, 'attempt-guid-first');
+      await fireEvaluation(page, 'attempt-guid-second');
+
+      await expect.poll(() => observer.evaluations().length, { timeout: 5_000 }).toBe(2);
+      expect(observer.foreignEvaluations()).toHaveLength(0);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('settle() blocks on an unparsed mint and exposes the minted guid once it lands', async ({
+    page,
+  }) => {
+    let heldMint: Route | null = null;
+    await bootStub(page, (route) => {
+      if (route.request().method() === 'POST') {
+        heldMint = route;
+        return;
+      }
+      return route.fulfill({ status: 200, json: CORRECT_BODY });
+    });
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await page.evaluate(async (guid) => {
+        void fetch(`/state/course/s1/activity_attempt/${guid}`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ seedResponsesWithPrevious: true }),
+        });
+      }, GUID);
+      await expect.poll(() => observer.creations().length, { timeout: 5_000 }).toBe(1);
+      await expect.poll(() => heldMint !== null, { timeout: 5_000 }).toBe(true);
+
+      expect(await observer.settle(500)).toBe(false);
+      expect(observer.creations()[0].parsed).toBe(false);
+
+      await heldMint!.fulfill({
+        status: 200,
+        json: { attemptState: { attemptGuid: 'minted-guid' } },
+      });
+      expect(await observer.settle(5_000)).toBe(true);
+      expect(observer.creations()[0]).toMatchObject({
+        targetGuid: GUID,
+        newGuid: 'minted-guid',
+        status: 200,
+        parsed: true,
+      });
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('preserves the other prefixes of a mixed submission for contamination checks', async ({
+    page,
+  }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID, {
+        partInputs: [
+          PART,
+          {
+            attemptGuid: 'part-guid-8',
+            response: {
+              input: { stray: { path: 'q:9|stage.other.value', value: 'stale' } },
+            },
+          },
+        ],
+      });
+      const evaluation = await observer.waitForEvaluation(1, 5_000);
+
+      expect(evaluation.screenId).toBe(SCREEN);
+      expect(evaluation.otherScreenIds).toEqual(['q:9']);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test("never attributes another screen's submission to this one", async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID, {
+        partInputs: [
+          {
+            attemptGuid: 'part-guid-9',
+            response: {
+              input: { late: { path: 'q:0|stage.iframe.value', value: 'stale' } },
+            },
+          },
+        ],
+      });
+
+      await expect.poll(() => observer.foreignEvaluations().length, { timeout: 5_000 }).toBe(1);
+      expect(observer.evaluations()).toHaveLength(0);
+      expect(observer.foreignEvaluations()[0].screenId).toBe('q:0');
+      await expect(observer.waitForEvaluation(1, 400)).rejects.toThrow(
+        /no evaluation 1 for screen q:1.*foreign: 1/,
+      );
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('classifies a finalize save separately from evaluations', async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: { type: 'success' } }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      await expect(observer.waitForEvaluation(1, 1_000)).rejects.toThrow(/no evaluation 1/);
+      expect(observer.evaluations()).toHaveLength(0);
+      expect(observer.foreignEvaluations()).toHaveLength(0);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('marks a malformed response body unusable', async ({ page }) => {
+    await bootStub(page, (route) =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: 'not json at all' }),
+    );
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      const evaluation = await observer.waitForEvaluation(1, 5_000);
+
+      expect(evaluation.parseError).toMatch(/unreadable evaluation response/);
+      expect(() =>
+        verifyScreenEvaluation({ screenId: SCREEN, records: observer.evaluations() }),
+      ).toThrow(/evaluation unusable/);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('marks a non-boolean verdict unusable', async ({ page }) => {
+    await bootStub(page, (route) =>
+      route.fulfill({ status: 200, json: { actions: { correct: 'yes' } } }),
+    );
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      const evaluation = await observer.waitForEvaluation(1, 5_000);
+
+      expect(evaluation.correct).toBeNull();
+      expect(() =>
+        verifyScreenEvaluation({ screenId: SCREEN, records: observer.evaluations() }),
+      ).toThrow(/no boolean actions.correct/);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('records a failed evaluation as a failure, not as missing feedback', async ({ page }) => {
+    await bootStub(page, (route) =>
+      route.fulfill({ status: 403, json: { error: 'already_submitted' } }),
+    );
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await fireEvaluation(page, GUID);
+      const evaluation = await observer.waitForEvaluation(1, 5_000);
+
+      expect(evaluation.status).toBe(403);
+      expect(() =>
+        verifyScreenEvaluation({ screenId: SCREEN, records: observer.evaluations() }),
+      ).toThrow(/status 403/);
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('times out loudly when no evaluation request appears', async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    try {
+      await expect(observer.waitForEvaluation(1, 300)).rejects.toThrow(
+        /no evaluation 1 for screen q:1 within 300ms \(own: 0, foreign: 0\)/,
+      );
+    } finally {
+      observer.dispose();
+    }
+  });
+
+  test('detaches its listeners on dispose and refuses double arming', async ({ page }) => {
+    await bootStub(page, (route) => route.fulfill({ status: 200, json: CORRECT_BODY }));
+    const emitter = page as unknown as NodeJS.EventEmitter;
+    const before = emitter.listenerCount('request');
+
+    const observer = new AdaptiveEvaluationObserver(page, SCREEN);
+    observer.arm();
+    expect(emitter.listenerCount('request')).toBe(before + 1);
+    expect(() => observer.arm()).toThrow(/already armed/);
+
+    observer.dispose();
+    expect(emitter.listenerCount('request')).toBe(before);
+
+    await fireEvaluation(page, GUID);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(observer.evaluations()).toHaveLength(0);
+  });
+});
+
+test.describe('expected-part matching variants', () => {
+  const pairs = extractSubmittedPairs([
+    PART,
+    {
+      attemptGuid: 'part-guid-2',
+      response: {
+        input: {
+          selectedChoiceText: {
+            path: 'q:1|stage.mcq1.selectedChoiceText',
+            value: 'The soup is moving without any stirring',
+          },
+          simState: { path: 'q:1|stage.frame7.Blank1', value: 'upward' },
+        },
+      },
+    },
+  ]);
+
+  test('value_matches tests a regex over the stringified value', () => {
+    expect(
+      missingExpectedPaths(pairs, [
+        { path: 'stage.mcq1.selectedChoiceText', value_matches: 'moving without any stirring' },
+      ]),
+    ).toEqual([]);
+    expect(
+      missingExpectedPaths(pairs, [
+        { path: 'stage.mcq1.selectedChoiceText', value_matches: 'perfectly still' },
+      ]),
+    ).toEqual(['stage.mcq1.selectedChoiceText']);
+  });
+
+  test('path_prefix asserts presence of a widget state cluster', () => {
+    expect(missingExpectedPaths(pairs, [{ path_prefix: 'stage.frame7.' }])).toEqual([]);
+    expect(missingExpectedPaths(pairs, [{ path_prefix: 'stage.frame9.' }])).toEqual([
+      'stage.frame9.*',
+    ]);
+  });
+
+  test('a prefix expectation can also require a value under that cluster', () => {
+    expect(
+      missingExpectedPaths(pairs, [{ path_prefix: 'stage.frame7.', value_matches: 'upward' }]),
+    ).toEqual([]);
+    // present cluster, wrong value — must NOT satisfy
+    expect(
+      missingExpectedPaths(pairs, [{ path_prefix: 'stage.frame7.', value_matches: 'downward' }]),
+    ).toEqual(['stage.frame7.*']);
+  });
+});
+
+test.describe('ledger invariants', () => {
+  const MANIFEST = validateManifest([
+    {
+      id: 'n:0',
+      resource_id: 100,
+      role: 'navigation',
+      action: { kind: 'in_widget_button', src_fragment: 'button-widget' },
+    },
+    { id: 'c:1', resource_id: 101, role: 'content' },
+    gradedScreen({ id: 'q:2', resource_id: 102 }),
+    { id: 'c:3', resource_id: 103, role: 'content' },
+  ]);
+
+  const receipt = (screenId: string) => ({
+    screenId,
+    directive: 'text_input' as const,
+    readback: 'redacted',
+    expected: [],
+  });
+
+  const entry = (over: Partial<LedgerEntry> & { screenId: string }): LedgerEntry => {
+    const declared = MANIFEST.find((s) => s.id === over.screenId);
+    const role = over.role ?? declared?.role ?? 'content';
+    return {
+      resourceId: declared?.resource_id ?? 0,
+      attemptGuid: `guid-${over.screenId}`,
+      role,
+      receipt: role === 'graded' ? receipt(over.screenId) : null,
+      evaluationCount: role === 'navigation' ? 0 : 1,
+      expectedEvaluations: role === 'navigation' ? undefined : 1,
+      verdict: role === 'graded' ? true : null,
+      payloadMatch: role === 'graded' ? true : null,
+      transition: { kind: 'auto-navigate', target: 'next' },
+      ...over,
+    };
+  };
+
+  const fullWalk = (): LedgerEntry[] => [
+    entry({ screenId: 'n:0', transition: null }),
+    entry({ screenId: 'c:1' }),
+    entry({ screenId: 'q:2' }),
+    entry({ screenId: 'c:3', transition: { kind: 'terminal' } }),
+  ];
+
+  test('passes a complete, ordered, correct walk', () => {
+    expect(() => assertLedger(fullWalk(), MANIFEST)).not.toThrow();
+  });
+
+  test('fails on skipped, repeated, or out-of-order screens', () => {
+    const skipped = fullWalk().filter((e) => e.screenId !== 'q:2');
+    expect(() => assertLedger(skipped, MANIFEST)).toThrow(/visited 3 screens.*declares 4/);
+
+    const repeated = fullWalk();
+    repeated[1] = entry({ screenId: 'q:2' });
+    expect(() => assertLedger(repeated, MANIFEST)).toThrow(
+      /position 1 visited "q:2", manifest declares "c:1"/,
+    );
+  });
+
+  test('fails on a graded screen without evaluation, receipt, verdict, or payload match', () => {
+    const noEval = fullWalk();
+    noEval[2] = entry({ screenId: 'q:2', evaluationCount: 0 });
+    expect(() => assertLedger(noEval, MANIFEST)).toThrow(
+      /saw 0 evaluation\(s\), the walk licensed exactly 1/,
+    );
+
+    // an accidental extra submission cannot hide inside a role range: the
+    // walk licenses an exact count (2 only on a legal feedback re-check)
+    const strayDuplicate = fullWalk();
+    strayDuplicate[2] = entry({ screenId: 'q:2', evaluationCount: 2 });
+    expect(() => assertLedger(strayDuplicate, MANIFEST)).toThrow(
+      /saw 2 evaluation\(s\), the walk licensed exactly 1/,
+    );
+
+    const legalRecheck = fullWalk();
+    legalRecheck[2] = entry({ screenId: 'q:2', evaluationCount: 2, expectedEvaluations: 2 });
+    expect(() => assertLedger(legalRecheck, MANIFEST)).not.toThrow();
+
+    // fail closed: a submitting screen with no recorded licence never falls
+    // back to the permissive role range
+    const unlicensed = fullWalk();
+    unlicensed[2] = entry({ screenId: 'q:2', evaluationCount: 2, expectedEvaluations: undefined });
+    expect(() => assertLedger(unlicensed, MANIFEST)).toThrow(
+      /recorded no licensed evaluation count/,
+    );
+
+    const noReceipt = fullWalk();
+    noReceipt[2] = entry({ screenId: 'q:2', receipt: null });
+    expect(() => assertLedger(noReceipt, MANIFEST)).toThrow(/has no answer receipt/);
+
+    const wrongVerdict = fullWalk();
+    wrongVerdict[2] = entry({ screenId: 'q:2', verdict: false });
+    expect(() => assertLedger(wrongVerdict, MANIFEST)).toThrow(/verdict=false/);
+
+    const noMatch = fullWalk();
+    noMatch[2] = entry({ screenId: 'q:2', payloadMatch: false });
+    expect(() => assertLedger(noMatch, MANIFEST)).toThrow(/payloadMatch=false/);
+  });
+
+  test('tolerates up to two navigation-screen evaluations, fails beyond', () => {
+    // a navigation widget's own check can evaluate wrong-then-right across a
+    // fresh attempt (observed on the LotE cover) — two are legal, three are not
+    const twoEvals = fullWalk();
+    twoEvals[0] = entry({ screenId: 'n:0', evaluationCount: 2, transition: null });
+    expect(() => assertLedger(twoEvals, MANIFEST)).not.toThrow();
+
+    const threeEvals = fullWalk();
+    threeEvals[0] = entry({ screenId: 'n:0', evaluationCount: 3, transition: null });
+    expect(() => assertLedger(threeEvals, MANIFEST)).toThrow(
+      /\(navigation\) saw 3 evaluation\(s\), expected 0-2/,
+    );
+  });
+
+  test('fails on premature or missing terminal transition', () => {
+    const premature = fullWalk();
+    premature[1] = entry({ screenId: 'c:1', transition: { kind: 'terminal' } });
+    expect(() => assertLedger(premature, MANIFEST)).toThrow(
+      /position 1 is terminal before the last screen/,
+    );
+
+    // a lesson may also end by auto-navigating off its last screen
+    const autoNavEnd = fullWalk();
+    autoNavEnd[3] = entry({
+      screenId: 'c:3',
+      transition: { kind: 'auto-navigate', target: 'next' },
+    });
+    expect(() => assertLedger(autoNavEnd, MANIFEST)).not.toThrow();
+
+    const unfinished = fullWalk();
+    unfinished[3] = entry({ screenId: 'c:3', transition: { kind: 'none' } });
+    expect(() => assertLedger(unfinished, MANIFEST)).toThrow(
+      /ended on none, expected terminal or auto-navigate/,
+    );
+  });
+
+  test('ledger failure output is redacted to identities and counts', () => {
+    const wrongVerdict = fullWalk();
+    wrongVerdict[2] = entry({ screenId: 'q:2', verdict: false });
+    let message = '';
+    try {
+      assertLedger(wrongVerdict, MANIFEST);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toContain('q:2 role=graded evals=1 verdict=false');
+    expect(message).not.toContain('basalt');
+  });
+});

--- a/assets/automation/tests/torus/student_delivery/adaptive-strict-walk.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/adaptive-strict-walk.spec.ts
@@ -1,0 +1,762 @@
+import { Page, Route, expect, test } from '@playwright/test';
+import { AdaptiveDeckPO } from '@pom/delivery/AdaptiveDeckPO';
+import { completeAdaptiveHappyPathStrict } from '@tasks/AdaptiveHappyPathTask';
+
+/**
+ * MER-5674: orchestration tests for the strict walk itself. The observer and
+ * contract helpers are covered in adaptive-strict-driver.spec.ts; this file
+ * drives completeAdaptiveHappyPathStrict against a scripted fake deck so the
+ * escapes that only exist BETWEEN those pieces — attempt-guid correlation per
+ * role, licensing of a second submission, traffic arriving after the
+ * transition boundary — are exercised.
+ *
+ * The page is a routed fake origin; the fake deck issues real PUTs from it,
+ * so the walk's own observer sees genuine request/response traffic.
+ */
+
+const ORIGIN = 'https://adaptive-walk-stub.local';
+
+type ScriptedScreen = {
+  id: string;
+  role: 'graded' | 'content' | 'navigation';
+  attemptGuid: string;
+  /** guid the submission is made under, when it must differ from the rendered one */
+  submitGuid?: string;
+  answers?: Array<Record<string, unknown>>;
+  parts?: Array<{ id: string; type: string; src: string | null }>;
+  /** evaluation bodies this screen returns, in order */
+  responses: unknown[];
+  /** extra submissions fired after the screen's transition completed */
+  lateSubmissions?: Array<{
+    guid: string;
+    body: unknown;
+    screenId: string;
+    /** POST simulates the deck minting a fresh attempt (rotation) */
+    method?: 'PUT' | 'POST';
+    /** response status override — e.g. a failing mint */
+    responseStatus?: number;
+    /** request payload override — e.g. a malformed body with no partInputs */
+    payload?: unknown;
+    /** hold this request's RESPONSE until the named guid's request arrives */
+    holdUntil?: string;
+    /** batches fire in ascending order, each awaited before the next starts */
+    batch?: number;
+  }>;
+};
+
+const navAction = { kind: 'in_widget_button', src_fragment: 'button-widget' };
+
+type LateItem = {
+  guid: string;
+  response: unknown;
+  method: string;
+  status: number;
+  payload: unknown;
+  holdUntil: string | null;
+  batch: number;
+};
+
+const answeredBody = (target = 'next') => ({
+  actions: {
+    correct: true,
+    results: [{ params: { actions: [{ type: 'navigation', params: { target } }] } }],
+  },
+});
+
+const wrongNonNavigatingBody = () => ({
+  actions: { correct: false, results: [{ params: { actions: [] } }] },
+});
+
+const feedbackRecheckBody = () => ({
+  actions: {
+    correct: true,
+    results: [{ params: { actions: [{ type: 'feedback', params: { feedback: {} } }] } }],
+  },
+});
+
+const textPart = (id: string) => ({ id, type: 'janus-multi-line-text', src: null });
+
+const textInput = (value: string) => ({ kind: 'text_input', value });
+
+function submissionFor(screenId: string, partId: string, value: string) {
+  return {
+    partInputs: [
+      {
+        attemptGuid: `part-${screenId}`,
+        response: { input: { text: { path: `${screenId}|stage.${partId}.text`, value } } },
+      },
+    ],
+  };
+}
+
+/**
+ * A deck whose every method is scripted. It fires real PUTs so the walk's
+ * observer records genuine traffic, and it advances only when the walk drives
+ * it, so ordering bugs surface as failures rather than hangs.
+ */
+class FakeDeck {
+  index = 0;
+  private responseCursor = 0;
+  private feedbackOpen = false;
+
+  constructor(
+    private readonly page: Page,
+    private readonly script: ScriptedScreen[],
+  ) {}
+
+  private get current(): ScriptedScreen {
+    return this.script[Math.min(this.index, this.script.length - 1)];
+  }
+
+  private async submit(): Promise<void> {
+    const screen = this.current;
+    const body = screen.responses[this.responseCursor] ?? answeredBody();
+    const partId = screen.parts?.[0]?.id ?? 'input1';
+    await this.page.evaluate(
+      async (args) => {
+        (window as unknown as { __next?: unknown }).__next = args.response;
+        await fetch(`/state/course/s1/activity_attempt/${args.guid}`, {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(args.payload),
+        });
+      },
+      {
+        guid: screen.submitGuid ?? screen.attemptGuid,
+        response: body,
+        payload: submissionFor(screen.id, partId, 'an answer'),
+      },
+    );
+    this.responseCursor += 1;
+  }
+
+  private async fireLate(): Promise<void> {
+    const lates = this.current.lateSubmissions ?? [];
+    if (lates.length === 0) return;
+    const items = lates.map((late) => ({
+      guid: late.guid,
+      response: late.body,
+      method: late.method ?? 'PUT',
+      status: late.responseStatus ?? 200,
+      payload: late.payload ?? submissionFor(late.screenId, 'input1', 'late'),
+      holdUntil: late.holdUntil ?? null,
+      batch: late.batch ?? 0,
+    }));
+    const batches = new Map<number, LateItem[]>();
+    for (const item of items) {
+      batches.set(item.batch, [...(batches.get(item.batch) ?? []), item]);
+    }
+    for (const key of Array.from(batches.keys()).sort((a, b) => a - b)) {
+      await this.fireBatch(batches.get(key)!);
+    }
+  }
+
+  private async fireBatch(items: LateItem[]): Promise<void> {
+    const concurrent = items.some((it) => it.holdUntil);
+    // when any item in the batch holds, the batch fires in flight together: a
+    // held request's response is released only when the named guid's request
+    // arrives
+    await this.page.evaluate(
+      async (args) => {
+        const send = (it: {
+          guid: string;
+          response: unknown;
+          method: string;
+          status: number;
+          payload: unknown;
+          holdUntil: string | null;
+        }) =>
+          fetch(`/state/course/s1/activity_attempt/${it.guid}`, {
+            method: it.method,
+            headers: {
+              'content-type': 'application/json',
+              'x-stub-response': JSON.stringify(it.response),
+              'x-stub-status': String(it.status),
+              ...(it.holdUntil ? { 'x-stub-hold-until': it.holdUntil } : {}),
+            },
+            body: JSON.stringify(it.payload),
+          });
+        if (args.concurrent) {
+          await Promise.all(args.items.map((it) => send(it)));
+        } else {
+          for (const it of args.items) await send(it);
+        }
+      },
+      { items, concurrent },
+    );
+  }
+
+  async waitForDeckReady(): Promise<void> {}
+
+  async lessonEnded(): Promise<boolean> {
+    return this.index >= this.script.length;
+  }
+
+  async readScreenIdentity() {
+    const s = this.current;
+    return { id: s.id, resourceId: 100 + this.index, attemptGuid: s.attemptGuid };
+  }
+
+  async readPartInventory() {
+    return this.current.parts ?? [textPart('input1')];
+  }
+
+  async playVideos(): Promise<number> {
+    return 0;
+  }
+
+  async clickThroughCarousels(): Promise<number> {
+    return 0;
+  }
+
+  async fillTextInputs(): Promise<number> {
+    return 1;
+  }
+
+  async submitCheck(): Promise<void> {
+    await this.submit();
+    this.feedbackOpen = true;
+  }
+
+  async clickWidgetButton(): Promise<boolean> {
+    if (this.current.responses.length > 0) await this.submit();
+    return true;
+  }
+
+  async waitForFeedbackOpen(): Promise<void> {
+    if (!this.feedbackOpen) throw new Error('feedback popup did not open');
+  }
+
+  async acknowledgeFeedback(): Promise<void> {
+    this.feedbackOpen = false;
+    await this.submit();
+  }
+
+  async waitForScreenChange(): Promise<void> {
+    await this.fireLate();
+    this.index += 1;
+    this.responseCursor = 0;
+    this.feedbackOpen = false;
+  }
+
+  async waitForLessonEnd(): Promise<void> {
+    await this.fireLate();
+    this.index = this.script.length;
+  }
+}
+
+async function walk(page: Page, script: ScriptedScreen[]) {
+  const held = new Map<string, Array<{ route: Route; json: object; status: number }>>();
+  await page.route(`${ORIGIN}/**`, async (route) => {
+    const request = route.request();
+    if (request.method() === 'GET') {
+      return route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' });
+    }
+    const headerBody = request.headers()['x-stub-response'];
+    const json = headerBody
+      ? (JSON.parse(headerBody) as object)
+      : (((await page.evaluate(() => (window as unknown as { __next?: unknown }).__next)) ??
+          answeredBody()) as object);
+    const status = Number(request.headers()['x-stub-status'] ?? 200);
+    const guid = /activity_attempt\/([^/?#]+)/.exec(request.url())?.[1] ?? '';
+    const releasable = held.get(guid);
+    if (releasable) {
+      held.delete(guid);
+      // the released response must land strictly after this request
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      for (const h of releasable) await h.route.fulfill({ status: h.status, json: h.json });
+    }
+    const holdUntil = request.headers()['x-stub-hold-until'];
+    if (holdUntil) {
+      held.set(holdUntil, [...(held.get(holdUntil) ?? []), { route, json, status }]);
+      return;
+    }
+    return route.fulfill({ status, json });
+  });
+  await page.goto(`${ORIGIN}/`);
+
+  const deck = new FakeDeck(page, script);
+  const screens = script.map((s) => ({
+    id: s.id,
+    resource_id: 1,
+    role: s.role,
+    ...(s.role === 'graded' ? { answers: s.answers ?? [textInput('an answer')] } : {}),
+    ...(s.role === 'navigation' ? { action: navAction } : {}),
+  }));
+
+  return completeAdaptiveHappyPathStrict(page, deck as unknown as AdaptiveDeckPO, {
+    lesson: {},
+    screens,
+  });
+}
+
+test.describe('strict walk orchestration', () => {
+  test('passes a clean two-screen walk and records one licensed evaluation each', async ({
+    page,
+  }) => {
+    const ledger = await walk(page, [
+      { id: 'q:1', role: 'graded', attemptGuid: 'g1', responses: [answeredBody()] },
+      { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+    ]);
+
+    expect(ledger).toHaveLength(2);
+    expect(ledger[0]).toMatchObject({ evaluationCount: 1, expectedEvaluations: 1, verdict: true });
+    expect(ledger[1]).toMatchObject({ evaluationCount: 1, expectedEvaluations: 1 });
+  });
+
+  test('fails when a graded screen submits under a different attempt than it rendered', async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'q:1',
+          role: 'graded',
+          attemptGuid: 'rendered-guid',
+          submitGuid: 'stale-guid',
+          responses: [answeredBody('endOfLesson')],
+        },
+      ]),
+    ).rejects.toThrow(/evaluation used attempt stale-guid, the screen rendered attempt/);
+  });
+
+  test('fails when a CONTENT screen submits under a stale attempt', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'c:1',
+          role: 'content',
+          attemptGuid: 'rendered-guid',
+          submitGuid: 'stale-guid',
+          responses: [answeredBody('endOfLesson')],
+        },
+      ]),
+    ).rejects.toThrow(/\(content\): evaluation used attempt stale-guid/);
+  });
+
+  test('tolerates a navigation screen submitting under a rotated attempt', async ({ page }) => {
+    // the Cover widget can check during init, rotating the attempt before the
+    // walk clicks — measured on LotE, so the rendered guid is not the anchor
+    const ledger = await walk(page, [
+      {
+        id: 'n:1',
+        role: 'navigation',
+        attemptGuid: 'rendered-guid',
+        submitGuid: 'rotated-guid',
+        responses: [answeredBody()],
+      },
+      { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+    ]);
+    expect(ledger[0]).toMatchObject({ role: 'navigation', evaluationCount: 1 });
+  });
+
+  test('licenses the measured navigation rotation: wrong non-navigating, then right on a fresh attempt', async ({
+    page,
+  }) => {
+    // an incorrect check with no navigation rotates the attempt
+    // (triggerCheck.ts:424): the deck POSTs to mint a fresh attempt and the
+    // second check submits under the minted guid — the Cover was measured
+    // doing exactly this
+    const ledger = await walk(page, [
+      {
+        id: 'n:1',
+        role: 'navigation',
+        attemptGuid: 'g1',
+        responses: [wrongNonNavigatingBody()],
+        lateSubmissions: [
+          {
+            guid: 'g1',
+            method: 'POST',
+            body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+            screenId: 'n:1',
+          },
+          { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+        ],
+      },
+      { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+    ]);
+    expect(ledger[0]).toMatchObject({ role: 'navigation', evaluationCount: 2 });
+  });
+
+  test('fails wrong-then-right across attempts when no fresh attempt was minted between them', async ({
+    page,
+  }) => {
+    // the round-7 window: second check starts after the first response but
+    // the rotation artifact never happened — without an observed mint whose
+    // guid the second check uses, the pair is not the measured rotation
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [{ guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=missing/);
+  });
+
+  test('fails when the mint produced a different guid than the second check used', async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [
+            {
+              guid: 'g1',
+              method: 'POST',
+              body: { attemptState: { attemptGuid: 'some-other-mint' } },
+              screenId: 'n:1',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=missing/);
+  });
+
+  test("fails when the mint targeted a different attempt than the first check's", async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [
+            {
+              guid: 'unrelated-attempt',
+              method: 'POST',
+              body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+              screenId: 'n:1',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=missing/);
+  });
+
+  test('fails when the mint returned a non-2xx status', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [
+            {
+              guid: 'g1',
+              method: 'POST',
+              body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+              responseStatus: 500,
+              screenId: 'n:1',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=observed/);
+  });
+
+  test('fails when the second check starts before the mint response lands', async ({ page }) => {
+    // the mint's response is held until the second check's request arrives,
+    // so the second check cannot have learned its guid from this mint
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [
+            {
+              guid: 'g1',
+              method: 'POST',
+              body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+              screenId: 'n:1',
+              holdUntil: 'rotated-attempt',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=observed/);
+  });
+
+  test('fails when the mint was requested before the first response landed', async ({ page }) => {
+    // batch 0: the first check's response is held until the mint's request
+    // arrives, so the mint cannot be a reaction to it; batch 1 stages the
+    // second check strictly after the mint response, so the mint-after-first
+    // guard is the only one violated
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [],
+          lateSubmissions: [
+            {
+              guid: 'g1',
+              body: wrongNonNavigatingBody(),
+              screenId: 'n:1',
+              holdUntil: 'g1',
+            },
+            {
+              guid: 'g1',
+              method: 'POST',
+              body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+              screenId: 'n:1',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1', batch: 1 },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=observed/);
+  });
+
+  test('licenses the dance among several mints when exactly one chain qualifies', async ({
+    page,
+  }) => {
+    const ledger = await walk(page, [
+      {
+        id: 'n:1',
+        role: 'navigation',
+        attemptGuid: 'g1',
+        responses: [wrongNonNavigatingBody()],
+        lateSubmissions: [
+          {
+            guid: 'unrelated-attempt',
+            method: 'POST',
+            body: { attemptState: { attemptGuid: 'noise-mint' } },
+            screenId: 'n:1',
+          },
+          {
+            guid: 'g1',
+            method: 'POST',
+            body: { attemptState: { attemptGuid: 'rotated-attempt' } },
+            screenId: 'n:1',
+          },
+          { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+        ],
+      },
+      { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+    ]);
+    expect(ledger[0]).toMatchObject({ role: 'navigation', evaluationCount: 2 });
+  });
+
+  test('fails a navigation duplicate: two correct evaluations across attempts', async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [answeredBody()],
+          lateSubmissions: [{ guid: 'other-attempt', body: answeredBody(), screenId: 'n:1' }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/two evaluations are licensed only as the measured rotation/);
+  });
+
+  test('fails the rotation shape when both evaluations share one attempt', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [{ guid: 'g1', body: answeredBody(), screenId: 'n:1' }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/two evaluations are licensed only as the measured rotation/);
+  });
+
+  test('fails when an unusable request occupies a navigation licence slot', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [{ guid: 'rotated-attempt', body: {}, screenId: 'n:1' }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/unusable evaluation in its licensed range/);
+  });
+
+  test('fails overlapping in-flight checks that mimic the rotation shape', async ({ page }) => {
+    // both requests are in flight together — the wrong one's response is held
+    // until the correct one's request arrives, so no rotation can have
+    // happened between them
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [],
+          lateSubmissions: [
+            {
+              guid: 'g1',
+              body: wrongNonNavigatingBody(),
+              screenId: 'n:1',
+              holdUntil: 'rotated-attempt',
+            },
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/licensed only as the measured rotation.*mint=missing/);
+  });
+
+  test('fails a malformed request whose response looks like a valid evaluation', async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [],
+          lateSubmissions: [{ guid: 'g1', body: answeredBody(), screenId: 'n:1', payload: {} }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/unusable evaluation in its licensed range/);
+  });
+
+  test('fails when a navigation screen exceeds its evaluation licence', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'n:1',
+          role: 'navigation',
+          attemptGuid: 'g1',
+          responses: [wrongNonNavigatingBody()],
+          lateSubmissions: [
+            { guid: 'rotated-attempt', body: answeredBody(), screenId: 'n:1' },
+            { guid: 'third-attempt', body: answeredBody(), screenId: 'n:1' },
+          ],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/3 evaluation\(s\) once its transition settled, the licence allows 0-2/);
+  });
+
+  test('licenses a second evaluation for a graded feedback re-check', async ({ page }) => {
+    const ledger = await walk(page, [
+      {
+        id: 'q:1',
+        role: 'graded',
+        attemptGuid: 'g1',
+        responses: [feedbackRecheckBody(), answeredBody('endOfLesson')],
+      },
+    ]);
+
+    expect(ledger[0]).toMatchObject({ evaluationCount: 2, expectedEvaluations: 2, verdict: true });
+  });
+
+  test('refuses a second evaluation for a CONTENT screen', async ({ page }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'c:1',
+          role: 'content',
+          attemptGuid: 'g1',
+          responses: [feedbackRecheckBody(), answeredBody('endOfLesson')],
+        },
+      ]),
+    ).rejects.toThrow(/content screen "c:1" re-checked after feedback/);
+  });
+
+  test('catches a duplicate submission that lands after the transition boundary', async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'q:1',
+          role: 'graded',
+          attemptGuid: 'g1',
+          responses: [answeredBody('endOfLesson')],
+          lateSubmissions: [{ guid: 'g1', body: answeredBody(), screenId: 'q:1' }],
+        },
+      ]),
+    ).rejects.toThrow(/2 evaluation\(s\) once its transition settled, the walk licensed exactly 1/);
+  });
+
+  test("catches another manifest screen's traffic arriving after the boundary", async ({
+    page,
+  }) => {
+    await expect(
+      walk(page, [
+        {
+          id: 'q:1',
+          role: 'graded',
+          attemptGuid: 'g1',
+          responses: [answeredBody()],
+          lateSubmissions: [{ guid: 'g9', body: answeredBody(), screenId: 'q:9' }],
+        },
+        { id: 'c:2', role: 'content', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+      ]),
+    ).rejects.toThrow(/submission\(s\) for a different screen observed during its transition/);
+  });
+
+  test('fails when the walk visits a screen the manifest does not declare next', async ({
+    page,
+  }) => {
+    const script: ScriptedScreen[] = [
+      { id: 'q:1', role: 'graded', attemptGuid: 'g1', responses: [answeredBody()] },
+      { id: 'q:2', role: 'graded', attemptGuid: 'g2', responses: [answeredBody('endOfLesson')] },
+    ];
+    // the deck renders them in the wrong order
+    const swapped = [script[1], script[0]];
+    await expect(
+      (async () => {
+        await page.route(`${ORIGIN}/**`, async (route) => {
+          if (route.request().method() === 'GET') {
+            return route.fulfill({ status: 200, contentType: 'text/html', body: '<html></html>' });
+          }
+          return route.fulfill({ status: 200, json: answeredBody() });
+        });
+        await page.goto(`${ORIGIN}/`);
+        const deck = new FakeDeck(page, swapped);
+        return completeAdaptiveHappyPathStrict(page, deck as unknown as AdaptiveDeckPO, {
+          lesson: {},
+          screens: script.map((s) => ({
+            id: s.id,
+            resource_id: 1,
+            role: s.role,
+            answers: [textInput('an answer')],
+          })),
+        });
+      })(),
+    ).rejects.toThrow(/position 0 shows "q:2", manifest declares "q:1"/);
+  });
+});

--- a/assets/automation/tests/torus/student_delivery/lote-plate-tectonics.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/lote-plate-tectonics.spec.ts
@@ -1,0 +1,173 @@
+import fs from 'node:fs/promises';
+import { test } from '@fixture/my-fixture';
+import { setRuntimeConfig } from '@core/runtimeConfig';
+import { expect } from '@playwright/test';
+import { HomeTask } from '@tasks/HomeTask';
+import { AdaptiveLessonTask } from '@tasks/AdaptiveLessonTask';
+import {
+  AutomationSetupResponse,
+  buildAutomationLoginData,
+  importArchiveAndCreateSection,
+  teardownAutomationCourse,
+} from '@tasks/AutomationSetupTask';
+import { fetchTestAsset, fetchTestArchiveToTempFile } from '@tasks/AutomationAssetsTask';
+import { completeAdaptiveHappyPathStrict, StrictLessonAnswers } from '@tasks/AdaptiveHappyPathTask';
+import { formatLedger, validateManifest } from '@tasks/AdaptiveStrictContract';
+
+/**
+ * MER-5674: Adaptive Lesson — Living on the Edge: Plate Tectonics.
+ *
+ * Imports the full Living on the Edge course archive, creates an
+ * open-and-free section with a learner, and drives the 22-screen adaptive
+ * lesson through the STRICT driver: a per-screen manifest declares every
+ * screen's identity, role and answers; each graded screen is answered from
+ * its own directives, submitted with exactly one click, and proven through
+ * the evaluation request/response — submitted payload correlated against
+ * the key, server verdict actions.correct === true, and an ordered
+ * full-coverage ledger asserted at the end. Reaching the lesson end proves
+ * nothing on its own; the ledger is the pass condition.
+ *
+ * All course content — the lesson title and every correct answer — lives in
+ * a PRIVATE answers JSON that must not be committed (course IP + answer
+ * keys). Both the course zip and the answers JSON live in the playwright
+ * assets bucket and are fetched through the server. The archive download
+ * uses plain fetch (not the Playwright request context) and lands on disk:
+ * with trace:'on', a multi-MB buffer flowing through Playwright's traced
+ * request context on BOTH the download and the multipart upload
+ * intermittently corrupts the trace archive.
+ *
+ * Requirements to run locally:
+ *   - Torus dev server running (mix phx.server) against your local DB,
+ *     started with PLAYWRIGHT_SCENARIO_TOKEN and PLAYWRIGHT_ASSETS_BUCKET
+ *     (a mistyped bucket name silently 404s every asset).
+ *   - An API key with automation_setup_enabled (created as admin at
+ *     /admin/api_keys), exported as PLAYWRIGHT_AUTOMATION_API_KEY — never
+ *     reuse a value that appears in this repo.
+ *   - The private assets seeded once in your playwright assets bucket:
+ *     mer-5674/living-on-the-edge-course.zip and mer-5674/answers.json
+ *     (strict per-screen manifest shape — see StrictLessonAnswers).
+ *   - PLAYWRIGHT_BASE_URL=http://127.0.0.1 — NOT localhost: the plain-fetch
+ *     archive download resolves localhost to ::1 and dies with ECONNREFUSED
+ *     (reproduced 2026-07-30).
+ *
+ * Then: npx playwright test lote-plate-tectonics
+ */
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
+const archiveKey = 'mer-5674/living-on-the-edge-course.zip';
+const answersKey = 'mer-5674/answers.json';
+const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
+const EXPECTED_LESSON = /Plate Tectonics/i;
+const EXPECTED_SCREENS = 22;
+
+let seededCourse: AutomationSetupResponse | null = null;
+let answers: StrictLessonAnswers | null = null;
+let archiveTempDir: string | null = null;
+
+setRuntimeConfig({
+  baseUrl,
+  scenarioToken: process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token',
+  loginData: buildAutomationLoginData('placeholder@example.com', 'placeholder'),
+});
+
+test.skip(
+  !automationApiKey,
+  'Set PLAYWRIGHT_AUTOMATION_API_KEY to run this test (see setup instructions above)',
+);
+
+test.describe.serial('Living on the Edge plate tectonics adaptive lesson', () => {
+  test.beforeAll(async ({ request }) => {
+    test.setTimeout(240_000);
+
+    const answersPromise = fetchTestAsset(request, answersKey, baseUrl);
+    const archivePromise = fetchTestArchiveToTempFile(archiveKey, baseUrl);
+    answersPromise.catch(() => {});
+    archivePromise.catch(() => {});
+
+    const archive = await archivePromise;
+    archiveTempDir = archive.tempDir;
+
+    const answersBuffer = await answersPromise;
+    const parsed = JSON.parse(answersBuffer.toString('utf8')) as StrictLessonAnswers;
+
+    const screens = validateManifest(parsed.screens);
+    if (screens.length !== EXPECTED_SCREENS) {
+      throw new Error(
+        `Manifest declares ${screens.length} screens, expected ${EXPECTED_SCREENS} (MER-5674)`,
+      );
+    }
+    if (!EXPECTED_LESSON.test(parsed.lesson.title)) {
+      throw new Error(
+        `Answer key targets "${parsed.lesson.title}", expected ${EXPECTED_LESSON} (MER-5674)`,
+      );
+    }
+    answers = parsed;
+
+    seededCourse = await importArchiveAndCreateSection(request, archive.filePath, {
+      baseUrl,
+      apiKey: automationApiKey!,
+    });
+    setRuntimeConfig({
+      loginData: buildAutomationLoginData(
+        seededCourse.learner.email,
+        seededCourse.learner.password,
+      ),
+    });
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Full-course project deletion was observed to exceed both cowboy's 60s
+    // idle_timeout and the 600s dev Repo timeout (see TRIAGE-2419: unindexed
+    // FKs referencing revisions), so cleanup is bounded and best-effort;
+    // leaked slugs are named in the warning below.
+    try {
+      if (seededCourse) {
+        await Promise.race([
+          teardownAutomationCourse(request, seededCourse, {
+            baseUrl,
+            apiKey: automationApiKey!,
+          }),
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('teardown timeout')), 15_000),
+          ),
+        ]);
+      }
+    } catch (e) {
+      const ids = seededCourse
+        ? `project=${seededCourse.project.slug}, section=${seededCourse.section.slug}`
+        : 'unknown';
+      console.warn(`[MER-5674] teardown failed (${ids}): ${(e as Error).message}`);
+    } finally {
+      if (archiveTempDir) {
+        await fs.rm(archiveTempDir, { recursive: true, force: true });
+        archiveTempDir = null;
+      }
+    }
+  });
+
+  test('student completes the plate tectonics happy path with a strict ledger', async ({
+    page,
+  }) => {
+    test.setTimeout(900_000); // 22 screens with server-side rule evaluation per check
+
+    if (!seededCourse || !answers) {
+      throw new Error('Automation setup did not produce seeded course data and answers');
+    }
+
+    const adaptiveLesson = new AdaptiveLessonTask(page);
+
+    await page.goto('/');
+    await new HomeTask(page).login('student');
+    await adaptiveLesson.openFromOutline(
+      seededCourse.section.slug,
+      answers.lesson.title,
+      answers.lesson.search_term,
+    );
+
+    const ledger = await completeAdaptiveHappyPathStrict(page, adaptiveLesson.deck, answers);
+    console.log(`[MER-5674] strict ledger:\n${formatLedger(ledger)}`);
+
+    await expect(page.getByText(new RegExp(answers.lesson.completion_text, 'i'))).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+});


### PR DESCRIPTION
[MER-5674](https://eliterate.atlassian.net/browse/MER-5674)

## Summary

- Adds Playwright E2E coverage for the adaptive lesson **"Plate Tectonics"** (Living on the Edge, Unit 1: Geologic Risk), driving all 22 screens through the happy path
- Introduces a **strict verification path** for adaptive lessons: instead of asserting the completion text, the walk verifies per screen that the answer actually registered (readback + deferred-save receipt), the submitted request body carried the intended answer, and the server's own evaluation returned `actions.correct: true`, with an ordered ledger asserted at the end
- Why: recon runs reached the lesson end with 4 of 22 screens never answered and the old assertion passed — 3 of 22 screens are authored to navigate away even on a wrong answer, so "reached the end" proves neither answered nor correct
- The two merged specs (MER-5672/5673) keep their existing compatibility walk unchanged; they benefit only from shared helper fixes (verified fills, no first-option guessing)

## What changed

**New files:**
- `lote-plate-tectonics.spec.ts` — the E2E test on the strict entry point (173 lines)
- `AdaptiveStrictContract.ts` — manifest validation, receipt/ledger types, payload matchers, `assertLedger`
- `AdaptiveEvaluationObserver.ts` — multi-event evaluation collector; attributes traffic by submitted part-path prefixes (attempt GUIDs rotate legally), separates saves/finalizes/evaluations by shape
- `adaptive-strict-driver.spec.ts`, `adaptive-strict-walk.spec.ts` — 64 stubbed tests (no server): observer negatives, ledger negatives, and a scripted fake deck driving the strict walk through duplicate/foreign/out-of-order traffic

**Modified files:**
- `AdaptiveHappyPathTask.ts` — new `completeAdaptiveHappyPathStrict` (per-screen manifest, one click per action, explicit transition state machine, navigation licensed via the server-minted attempt chain); the existing `completeAdaptiveHappyPath` compat walk preserved verbatim
- `AdaptiveDeckPO.ts` — screen identity from `[model][context]` (sequenceId/resourceId/attemptGuid), part inventory, verified widget drivers (fill-in-the-blanks via the widget's own selectmenu — programmatic DOM writes never reach the CAPI model and submit `Selected Index: -1`; drag-and-drop verified by DOM re-parenting, not geometry)
- `playwright.config.ts` — actionTimeout (a flaky iframe once held a getAttribute for 732 s)
- `CHANGELOG.md` — skip notice includes MER-5674

## Test environment setup

CI does not run these suites yet — [MER-5857](https://eliterate.atlassian.net/browse/MER-5857) tracks provisioning; this is for running locally.

Same env vars as MER-5672/5673 (`PLAYWRIGHT_SCENARIO_TOKEN`, `PLAYWRIGHT_ASSETS_BUCKET`, `PLAYWRIGHT_AUTOMATION_API_KEY`).

**Seed the bucket** with the MER-5674 private assets (course IP, not in the repo):

    <your-bucket>/
    └── mer-5674/
        ├── living-on-the-edge-course.zip
        └── answers.json   # strict per-screen manifest (22 screens)

`PLAYWRIGHT_BASE_URL` must be `http://127.0.0.1` — `localhost` resolves to `::1` and the archive fetch dies with ECONNREFUSED.

## Running locally

    cd assets/automation
    npx playwright test lote-plate-tectonics      # ~5 min live
    npx playwright test adaptive-strict           # 64 stubbed tests, ~17 s, no server

## Verification

- Live strict runs green ×4 (4.5–4.8 min), all 22 screens with `verdict=true payloadMatch=true`
- Canary: poisoning one answer fails the run at exactly that screen — the test can fail for the reason it exists
- Cross-model code review: 9 rounds, final verdict approved; every should-fix applied and re-verified
- Stubbed suites 64/64; `tsc`/`eslint`/`prettier` clean on touched files (2 pre-existing `liveSocket` tsc errors excluded, present on clean master)

## Known limitations

- Transition derivation reads `results[0]`; activities with `custom.combineFeedback` (4 of these 22 screens) can process several results — runs pass because the derivations agree here; recorded as a limit, addressed by the follow-up framework ticket
- Teardown leaks the imported project per run — server-side bug, diagnosed in [TRIAGE-2419](https://eliterate.atlassian.net/browse/TRIAGE-2419)

## Follow-up

- **Adaptive Lessons: Strict Verification Framework** (ticket TBD, linked to this one) — restructures this machinery into a shared journal/registry/oracle framework and migrates MER-5672/5673 to the strict path; spec already drafted and cross-reviewed (8 design passes)
- [MER-5857](https://eliterate.atlassian.net/browse/MER-5857) — CI provisioning for archive-backed suites


[MER-5674]: https://eliterate.atlassian.net/browse/MER-5674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-5857]: https://eliterate.atlassian.net/browse/MER-5857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ