### PR TITLE
[ENHANCEMENT] [MER-5850] Add parameterized OAuth login Playwright tests

### DIFF
--- a/assets/automation/README.md
+++ b/assets/automation/README.md
@@ -9,6 +9,7 @@ This platform contains the automated e2e tests.
 - Scenario seeding is authenticated with a default token of `my-token`; change this in the spec runtime config and in your Phoenix `PLAYWRIGHT_SCENARIO_TOKEN` if needed.
 - Browser auto-close behavior is controlled by runtime config in specs (defaults to keep the browser open between tests).
 - The nightly LTI spec reads `CANVAS_UI_EMAIL` and `CANVAS_UI_PASSWORD` from the environment instead of hardcoding credentials.
+- The live OAuth login spec reads its target, dedicated accounts, provider UI selectors, and expected Torus destinations from the remote YAML selected by `PLAYWRIGHT_PARAMETER_CONFIG_URL`.
 - GitHub Actions wiring for the nightly run lives in `.github/workflows/nightly-playwright.yml` and expects those values as environment secrets on the `nightly-ui` environment.
 
 ## 🧪 Configuration Tests & Report
@@ -35,6 +36,62 @@ Open the latest Playwright HTML report
 
 ```bash
 npm run show-report
+```
+
+### Live OAuth login smoke tests
+
+The OAuth suite exercises the complete provider redirect for one learner and one author account. It runs headed Chrome because Google rejects the automated headless sign-in browser. It does not save authenticated storage state, and tracing is disabled because OAuth traces can expose credentials, session cookies, or authorization response data.
+
+Host the following YAML in a secret-protected location and point `PLAYWRIGHT_PARAMETER_CONFIG_URL` at it. Do not commit real account credentials or this runtime configuration to the repository.
+
+```yaml
+target:
+  base_url: https://torus.example.test
+tests:
+  oauth_logins:
+    timeout_ms: 120000
+    provider:
+      name: Google
+      authorization_hostname: accounts.google.com
+      selectors:
+        email_input: 'input[name="identifier"], input#identifierId, input[aria-label="Email or phone"]'
+        email_submit: '#identifierNext'
+        password_input: 'input[type="password"]:not([aria-hidden="true"]):not([name="hiddenPassword"])'
+        password_submit: '#passwordNext'
+        consent_submit: 'button:has-text("Continue")'
+        error_message: 'text=/couldn.t find this account|wrong password|browser or app may not be secure|couldn.t sign you in/i'
+    accounts:
+      learner:
+        email: dedicated-learner@example.test
+        password: replace-at-runtime
+        torus_account_name: OAuth Learner
+        login_path: /users/log_in
+        authorization_path: /users/auth/google/new
+        callback_path: /users/auth/google/callback
+        landing_path: /workspaces/student
+        workspace_heading: Courses available
+        account_settings_link_name: Account Settings
+        account_settings_path: /users/settings
+        logout_path: /
+      author:
+        email: dedicated-author@example.test
+        password: replace-at-runtime
+        torus_account_name: OAuth Author
+        login_path: /authors/log_in
+        authorization_path: /authors/auth/google/new
+        callback_path: /authors/auth/google/callback
+        landing_path: /workspaces/course_author
+        workspace_heading: Course Author
+        account_settings_link_name: Edit Account
+        account_settings_path: /authors/settings
+        account_label: Author
+        logout_path: /authors/log_in
+```
+
+The dedicated provider accounts must already be linked to the corresponding Torus account class and configured without MFA, CAPTCHA, recovery, or other interactive challenges. Keep them least-privileged and isolated from production data. Omit `consent_submit` only when consent has already been granted and the provider never renders that step.
+
+```bash
+PLAYWRIGHT_PARAMETER_CONFIG_URL=https://config.example.test/oauth.yaml npm run test-oauth-logins
 ```
 
 ## 🤖 Automated Configurations

--- a/assets/automation/README.md
+++ b/assets/automation/README.md
@@ -9,7 +9,7 @@ This platform contains the automated e2e tests.
 - Scenario seeding is authenticated with a default token of `my-token`; change this in the spec runtime config and in your Phoenix `PLAYWRIGHT_SCENARIO_TOKEN` if needed.
 - Browser auto-close behavior is controlled by runtime config in specs (defaults to keep the browser open between tests).
 - The nightly LTI spec reads `CANVAS_UI_EMAIL` and `CANVAS_UI_PASSWORD` from the environment instead of hardcoding credentials.
-- The live OAuth login spec reads its target, dedicated accounts, provider UI selectors, and expected Torus destinations from the remote YAML selected by `PLAYWRIGHT_PARAMETER_CONFIG_URL`.
+- The live OAuth login spec reads its target, operation timeout, and dedicated accounts from the remote YAML selected by `PLAYWRIGHT_PARAMETER_CONFIG_URL`.
 - GitHub Actions wiring for the nightly run lives in `.github/workflows/nightly-playwright.yml` and expects those values as environment secrets on the `nightly-ui` environment.
 
 ## 🧪 Configuration Tests & Report
@@ -42,7 +42,9 @@ npm run show-report
 
 The OAuth suite exercises the complete provider redirect for one learner and one author account. It runs headed Chrome because Google rejects the automated headless sign-in browser. It does not save authenticated storage state, and tracing is disabled because OAuth traces can expose credentials, session cookies, or authorization response data.
 
-Host the following YAML in a secret-protected location and point `PLAYWRIGHT_PARAMETER_CONFIG_URL` at it. Do not commit real account credentials or this runtime configuration to the repository.
+The Google selectors and expected Torus routes and copy are stable test constants. The runtime YAML contains only values that vary by environment or account. `timeout_ms` is the timeout for each external operation; the complete test receives three times that budget.
+
+Host the YAML in a secret-protected location and point `PLAYWRIGHT_PARAMETER_CONFIG_URL` at it. Do not commit real account credentials or this runtime configuration to the repository.
 
 ```yaml
 target:
@@ -50,49 +52,82 @@ target:
 tests:
   oauth_logins:
     timeout_ms: 120000
-    provider:
-      name: Google
-      authorization_hostname: accounts.google.com
-      selectors:
-        email_input: 'input[name="identifier"], input#identifierId, input[aria-label="Email or phone"]'
-        email_submit: '#identifierNext'
-        password_input: 'input[type="password"]:not([aria-hidden="true"]):not([name="hiddenPassword"])'
-        password_submit: '#passwordNext'
-        consent_submit: 'button:has-text("Continue")'
-        error_message: 'text=/couldn.t find this account|wrong password|browser or app may not be secure|couldn.t sign you in/i'
     accounts:
       learner:
-        email: dedicated-learner@example.test
-        password: replace-at-runtime
-        torus_account_name: OAuth Learner
-        login_path: /users/log_in
-        authorization_path: /users/auth/google/new
-        callback_path: /users/auth/google/callback
-        landing_path: /workspaces/student
-        workspace_heading: Courses available
-        account_settings_link_name: Account Settings
-        account_settings_path: /users/settings
-        logout_path: /
+        email: REPLACE_WITH_LEARNER_GOOGLE_EMAIL
+        password: REPLACE_WITH_LEARNER_GOOGLE_PASSWORD
       author:
-        email: dedicated-author@example.test
-        password: replace-at-runtime
-        torus_account_name: OAuth Author
-        login_path: /authors/log_in
-        authorization_path: /authors/auth/google/new
-        callback_path: /authors/auth/google/callback
-        landing_path: /workspaces/course_author
-        workspace_heading: Course Author
-        account_settings_link_name: Edit Account
-        account_settings_path: /authors/settings
+        email: REPLACE_WITH_AUTHOR_GOOGLE_EMAIL
+        password: REPLACE_WITH_AUTHOR_GOOGLE_PASSWORD
         account_label: Author
-        logout_path: /authors/log_in
 ```
 
-The dedicated provider accounts must already be linked to the corresponding Torus account class and configured without MFA, CAPTCHA, recovery, or other interactive challenges. Keep them least-privileged and isolated from production data. Omit `consent_submit` only when consent has already been granted and the provider never renders that step.
+The dedicated provider accounts must be linked to the corresponding Torus account class and configured without MFA, CAPTCHA, recovery, or other interactive challenges. Keep them least-privileged and isolated from production data.
+
+#### One-time automation setup
+
+From the repository root:
 
 ```bash
-PLAYWRIGHT_PARAMETER_CONFIG_URL=https://config.example.test/oauth.yaml npm run test-oauth-logins
+cd assets/automation
+npm install
+npx playwright install --with-deps chrome
 ```
+
+#### Running locally
+
+1. Configure a Google OAuth web client with these authorized redirect URIs:
+
+   ```text
+   http://localhost/users/auth/google/callback
+   http://localhost/authors/auth/google/callback
+   ```
+
+2. Start or restart Torus from the repository root with `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` set.
+3. Log in once manually with each dedicated account through `http://localhost/users/log_in` and `http://localhost/authors/log_in`. This creates and links the corresponding learner and author records.
+4. Save the YAML above as `/tmp/oauth-local.yaml`, set `target.base_url` to `http://localhost`, and replace all credential placeholders.
+5. Serve the YAML from a separate terminal:
+
+   ```bash
+   python3 -m http.server 8787 --bind 127.0.0.1 --directory /tmp
+   ```
+
+6. From `assets/automation`, run:
+
+   ```bash
+   PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-local.yaml npm run test-oauth-logins
+   ```
+
+#### Running against an already-deployed environment
+
+1. Log in once manually with each dedicated account through the environment's learner and author login pages so Torus creates and links both account classes.
+2. Create a YAML file from the example above using that environment's base URL and dedicated credentials.
+3. Host it at a private HTTP(S) URL. For a quick run from your machine, use the loopback server shown in the local instructions.
+4. From `assets/automation`, run the suite with the URL of that YAML file.
+
+Tokamak example:
+
+```yaml
+target:
+  base_url: https://tokamak.oli.cmu.edu
+```
+
+```bash
+PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-tokamak.yaml npm run test-oauth-logins
+```
+
+Stellarator example:
+
+```yaml
+target:
+  base_url: https://stellarator.oli.cmu.edu
+```
+
+```bash
+PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-stellarator.yaml npm run test-oauth-logins
+```
+
+To target another staging or production deployment, change the base URL and use dedicated accounts linked in that environment. A real Chrome window opens and runs both account-class flows.
 
 ## 🤖 Automated Configurations
 

--- a/assets/automation/README.md
+++ b/assets/automation/README.md
@@ -62,7 +62,7 @@ tests:
         account_label: Author
 ```
 
-The dedicated provider accounts must be linked to the corresponding Torus account class and configured without MFA, CAPTCHA, recovery, or other interactive challenges. Keep them least-privileged and isolated from production data.
+The dedicated provider accounts must be linked to the corresponding Torus account class and configured without MFA, CAPTCHA, recovery, or other interactive challenges. If Google displays the “Verify it’s you” page, the test aborts with a message explaining that the account must have 2FA disabled. Keep the accounts least-privileged and isolated from production data.
 
 #### One-time automation setup
 

--- a/assets/automation/package.json
+++ b/assets/automation/package.json
@@ -7,7 +7,7 @@
     "test-config": "npm run pw config.spec.ts",
     "test-config:headed": "npm run test-config -- --headed",
     "test-dot-smoke": "npm run pw dot-chatbot.spec.ts",
-    "test-oauth-logins": "npm run pw -- --grep @oauth --headed --reporter=line",
+    "test-oauth-logins": "npm run pw oauth-login.spec.ts",
     "test-useraccounts": "npm run pw user-accounts.spec",
     "test-all": "npm run pw user-accounts.spec course-authoring.spec.ts",
     "show-report": "npx playwright show-report",

--- a/assets/automation/package.json
+++ b/assets/automation/package.json
@@ -7,6 +7,7 @@
     "test-config": "npm run pw config.spec.ts",
     "test-config:headed": "npm run test-config -- --headed",
     "test-dot-smoke": "npm run pw dot-chatbot.spec.ts",
+    "test-oauth-logins": "npm run pw -- oauth-login.spec.ts --headed --reporter=line",
     "test-useraccounts": "npm run pw user-accounts.spec",
     "test-all": "npm run pw user-accounts.spec course-authoring.spec.ts",
     "show-report": "npx playwright show-report",

--- a/assets/automation/package.json
+++ b/assets/automation/package.json
@@ -7,7 +7,7 @@
     "test-config": "npm run pw config.spec.ts",
     "test-config:headed": "npm run test-config -- --headed",
     "test-dot-smoke": "npm run pw dot-chatbot.spec.ts",
-    "test-oauth-logins": "npm run pw -- oauth-login.spec.ts --headed --reporter=line",
+    "test-oauth-logins": "npm run pw -- --grep @oauth --headed --reporter=line",
     "test-useraccounts": "npm run pw user-accounts.spec",
     "test-all": "npm run pw user-accounts.spec course-authoring.spec.ts",
     "show-report": "npx playwright show-report",

--- a/assets/automation/tests/torus/oauth_login/oauth-login.spec.ts
+++ b/assets/automation/tests/torus/oauth_login/oauth-login.spec.ts
@@ -1,9 +1,12 @@
 import { loadParameterizedTestConfig } from '@core/parameterizedConfig';
-import { expect, Page, test } from '@playwright/test';
+import { Utils } from '@core/Utils';
+import { expect, Locator, Page, test } from '@playwright/test';
 import {
   OAuthAccountParameters,
   OAUTH_ACCOUNT_CLASSES,
   OAuthLoginParameters,
+  OAUTH_PROVIDER_PARAMETERS,
+  oauthAccountParameters,
   validateOAuthLoginParameters,
 } from './support/oauthLoginConfig';
 import { acceptTorusCookiesIfVisible, completeOAuthProviderLogin } from './support/oauthLogin';
@@ -39,10 +42,10 @@ test.describe('OAuth login @oauth @smoke', () => {
     test(`${accountClass} signs in through the configured OAuth provider`, async ({
       page,
     }, testInfo) => {
-      const account = parameters.accounts[accountClass];
+      const account = oauthAccountParameters(parameters, accountClass);
       const torusOrigin = new URL(baseUrl).origin;
 
-      testInfo.setTimeout(parameters.timeout_ms);
+      testInfo.setTimeout(parameters.timeout_ms * 3);
 
       await page.goto(torusUrl(account.login_path), { waitUntil: 'domcontentloaded' });
       await acceptTorusCookiesIfVisible(page);
@@ -60,11 +63,10 @@ test.describe('OAuth login @oauth @smoke', () => {
         oauthButton.click(),
       ]);
 
-      expect(new URL(page.url()).hostname).toBe(parameters.provider.authorization_hostname);
+      expect(new URL(page.url()).hostname).toBe(OAUTH_PROVIDER_PARAMETERS.authorization_hostname);
 
       const callbackResponse = await completeOAuthProviderLogin(
         page,
-        parameters.provider,
         account,
         (response) => isTorusPath(response.url(), account.callback_path),
         parameters.timeout_ms,
@@ -80,10 +82,23 @@ test.describe('OAuth login @oauth @smoke', () => {
       await assertSignedInWorkspace(page, account);
 
       await page.reload({ waitUntil: 'domcontentloaded' });
-      await assertSignedInWorkspace(page, account);
+      const accountMenu = await assertSignedInWorkspace(page, account);
 
-      const accountMenu = page.locator('#workspace-user-menu-dropdown');
-      const logoutLink = accountMenu.getByRole('link', { name: /sign out/i });
+      await Promise.all([
+        page.waitForURL((url) => isTorusPath(url, account.account_settings_path), {
+          timeout: parameters.timeout_ms,
+          waitUntil: 'domcontentloaded',
+        }),
+        accountSettingsLink(accountMenu, account).click(),
+      ]);
+
+      const accountEmail = page.locator('input[type="email"]');
+
+      await expect(accountEmail).toHaveCount(1);
+      await expect(accountEmail).toHaveValue(account.email);
+
+      const settingsAccountMenu = await openAccountMenu(page);
+      const logoutLink = settingsAccountMenu.getByRole('link', { name: /sign out/i });
 
       await Promise.all([
         page.waitForURL((url) => isTorusPath(url, account.logout_path), {
@@ -106,34 +121,45 @@ async function assertSignedInWorkspace(page: Page, account: OAuthAccountParamete
   ).toBeVisible();
   await expect(page.locator('.alert-danger, .alert-error')).toHaveCount(0);
 
-  const accountMenuButton = page.locator('#workspace-user-menu');
+  const accountMenu = await openAccountMenu(page);
+  const settingsLink = accountSettingsLink(accountMenu, account);
 
-  await expect(accountMenuButton).toHaveAttribute(
-    'aria-label',
-    `${account.torus_account_name} user account menu`,
-  );
-  await accountMenuButton.click();
-
-  const accountMenu = page.locator('#workspace-user-menu-dropdown');
-
-  await expect(accountMenu).toBeVisible();
-
-  const accountSettingsLink = accountMenu.getByRole('link', {
-    name: account.account_settings_link_name,
-    exact: true,
-  });
-
-  await expect(accountSettingsLink).toBeVisible();
-  await expect(accountSettingsLink).toHaveAttribute('href', account.account_settings_path);
+  await expect(settingsLink).toBeVisible();
+  await expect(settingsLink).toHaveAttribute('href', account.account_settings_path);
 
   if (account.account_label) {
     await expect(accountMenu.locator('[role="account label"]')).toHaveText(account.account_label);
   }
+
+  return accountMenu;
+}
+
+async function openAccountMenu(page: Page): Promise<Locator> {
+  const accountMenuButton = page.locator('#workspace-user-menu');
+  const accountMenu = page.locator('#workspace-user-menu-dropdown');
+
+  await expect(accountMenuButton).toBeVisible();
+
+  // LiveView can replace the dropdown after the first click and reset its client-only state.
+  await new Utils(page).forceClick(accountMenuButton, accountMenu);
+
+  return accountMenu;
+}
+
+function accountSettingsLink(accountMenu: Locator, account: OAuthAccountParameters) {
+  // The learner link's trailing chevron adds whitespace to its computed accessible name.
+  return accountMenu.getByRole('link', {
+    name: account.account_settings_link_name,
+    exact: false,
+  });
 }
 
 function oauthLoginButton(page: Page) {
   return page
-    .getByRole('link', { name: `Sign in with ${parameters.provider.name}`, exact: true })
+    .getByRole('link', {
+      name: `Sign in with ${OAUTH_PROVIDER_PARAMETERS.name}`,
+      exact: true,
+    })
     .first();
 }
 

--- a/assets/automation/tests/torus/oauth_login/oauth-login.spec.ts
+++ b/assets/automation/tests/torus/oauth_login/oauth-login.spec.ts
@@ -1,0 +1,148 @@
+import { loadParameterizedTestConfig } from '@core/parameterizedConfig';
+import { expect, Page, test } from '@playwright/test';
+import {
+  OAuthAccountParameters,
+  OAUTH_ACCOUNT_CLASSES,
+  OAuthLoginParameters,
+  validateOAuthLoginParameters,
+} from './support/oauthLoginConfig';
+import { acceptTorusCookiesIfVisible, completeOAuthProviderLogin } from './support/oauthLogin';
+
+const TEST_CASE_NAME = 'oauth_logins';
+
+let baseUrl: string;
+let parameters: OAuthLoginParameters;
+
+// OAuth traces can contain credentials, cookies, and authorization response data.
+// Google rejects Chrome when Blink exposes its automation-controlled feature during sign-in.
+test.use({
+  launchOptions: {
+    args: [
+      '--start-maximized',
+      '--ignore-certificate-errors',
+      '--disable-blink-features=AutomationControlled',
+    ],
+  },
+  screenshot: 'only-on-failure',
+  trace: 'off',
+});
+
+test.beforeAll(async ({ request }) => {
+  const loaded = await loadParameterizedTestConfig<OAuthLoginParameters>(request, TEST_CASE_NAME);
+
+  baseUrl = loaded.baseUrl;
+  parameters = validateOAuthLoginParameters(loaded.parameters);
+});
+
+test.describe('OAuth login @oauth @smoke', () => {
+  OAUTH_ACCOUNT_CLASSES.forEach((accountClass) => {
+    test(`${accountClass} signs in through the configured OAuth provider`, async ({
+      page,
+    }, testInfo) => {
+      const account = parameters.accounts[accountClass];
+      const torusOrigin = new URL(baseUrl).origin;
+
+      testInfo.setTimeout(parameters.timeout_ms);
+
+      await page.goto(torusUrl(account.login_path), { waitUntil: 'domcontentloaded' });
+      await acceptTorusCookiesIfVisible(page);
+
+      const oauthButton = oauthLoginButton(page);
+
+      await expect(oauthButton).toBeVisible();
+      await expect(oauthButton).toHaveAttribute('href', account.authorization_path);
+
+      await Promise.all([
+        page.waitForURL((url) => url.origin !== torusOrigin, {
+          timeout: parameters.timeout_ms,
+          waitUntil: 'domcontentloaded',
+        }),
+        oauthButton.click(),
+      ]);
+
+      expect(new URL(page.url()).hostname).toBe(parameters.provider.authorization_hostname);
+
+      const callbackResponse = await completeOAuthProviderLogin(
+        page,
+        parameters.provider,
+        account,
+        (response) => isTorusPath(response.url(), account.callback_path),
+        parameters.timeout_ms,
+      );
+
+      expect(callbackResponse.status()).toBeLessThan(400);
+      expect(callbackResponse.url()).not.toContain('error=');
+
+      await page.waitForURL((url) => isTorusPath(url, account.landing_path), {
+        timeout: parameters.timeout_ms,
+        waitUntil: 'domcontentloaded',
+      });
+      await assertSignedInWorkspace(page, account);
+
+      await page.reload({ waitUntil: 'domcontentloaded' });
+      await assertSignedInWorkspace(page, account);
+
+      const accountMenu = page.locator('#workspace-user-menu-dropdown');
+      const logoutLink = accountMenu.getByRole('link', { name: /sign out/i });
+
+      await Promise.all([
+        page.waitForURL((url) => isTorusPath(url, account.logout_path), {
+          timeout: parameters.timeout_ms,
+          waitUntil: 'domcontentloaded',
+        }),
+        logoutLink.click(),
+      ]);
+
+      await expect(oauthLoginButton(page)).toBeVisible();
+      await expect(page.locator('#workspace-user-menu')).toHaveCount(0);
+    });
+  });
+});
+
+async function assertSignedInWorkspace(page: Page, account: OAuthAccountParameters) {
+  await expect(page).toHaveURL((url) => isTorusPath(url, account.landing_path));
+  await expect(
+    page.getByRole('heading', { name: account.workspace_heading, exact: true }),
+  ).toBeVisible();
+  await expect(page.locator('.alert-danger, .alert-error')).toHaveCount(0);
+
+  const accountMenuButton = page.locator('#workspace-user-menu');
+
+  await expect(accountMenuButton).toHaveAttribute(
+    'aria-label',
+    `${account.torus_account_name} user account menu`,
+  );
+  await accountMenuButton.click();
+
+  const accountMenu = page.locator('#workspace-user-menu-dropdown');
+
+  await expect(accountMenu).toBeVisible();
+
+  const accountSettingsLink = accountMenu.getByRole('link', {
+    name: account.account_settings_link_name,
+    exact: true,
+  });
+
+  await expect(accountSettingsLink).toBeVisible();
+  await expect(accountSettingsLink).toHaveAttribute('href', account.account_settings_path);
+
+  if (account.account_label) {
+    await expect(accountMenu.locator('[role="account label"]')).toHaveText(account.account_label);
+  }
+}
+
+function oauthLoginButton(page: Page) {
+  return page
+    .getByRole('link', { name: `Sign in with ${parameters.provider.name}`, exact: true })
+    .first();
+}
+
+function torusUrl(path: string) {
+  return new URL(path, baseUrl).toString();
+}
+
+function isTorusPath(value: string | URL, expectedPath: string) {
+  const url = typeof value === 'string' ? new URL(value) : value;
+
+  return url.origin === new URL(baseUrl).origin && url.pathname === expectedPath;
+}

--- a/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
@@ -1,11 +1,10 @@
-import { OAuthAccountParameters, OAuthLoginParameters } from './oauthLoginConfig';
+import { Utils } from '@core/Utils';
 import { expect, Page, Response } from '@playwright/test';
+import { OAuthAccountParameters, OAUTH_PROVIDER_PARAMETERS } from './oauthLoginConfig';
 
 /**
  * Provider interaction and Torus login-page helpers for the live OAuth tests.
  */
-
-type ProviderParameters = OAuthLoginParameters['provider'];
 
 /**
  * Completes the configured provider prompts and returns the Torus callback response.
@@ -13,11 +12,11 @@ type ProviderParameters = OAuthLoginParameters['provider'];
  */
 export async function completeOAuthProviderLogin(
   page: Page,
-  provider: ProviderParameters,
   account: OAuthAccountParameters,
   isCallbackResponse: (response: Response) => boolean,
   timeout: number,
 ): Promise<Response> {
+  const provider = OAUTH_PROVIDER_PARAMETERS;
   const providerError = provider.selectors.error_message
     ? page.locator(provider.selectors.error_message).first()
     : undefined;
@@ -137,7 +136,11 @@ export async function acceptTorusCookiesIfVisible(page: Page) {
     .catch(() => false);
 
   if (appeared) {
-    await acceptButton.click({ force: true });
+    // A normal click waits for the button to settle instead of racing Bootstrap's transition.
+    await acceptButton.click();
     await expect(cookieModal).toBeHidden({ timeout: 5_000 });
+
+    // Recover if the React unmount leaves Bootstrap's backdrop intercepting later clicks.
+    await new Utils(page).modalDisappears();
   }
 }

--- a/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
@@ -1,0 +1,143 @@
+import { OAuthAccountParameters, OAuthLoginParameters } from './oauthLoginConfig';
+import { expect, Page, Response } from '@playwright/test';
+
+/**
+ * Provider interaction and Torus login-page helpers for the live OAuth tests.
+ */
+
+type ProviderParameters = OAuthLoginParameters['provider'];
+
+/**
+ * Completes the configured provider prompts and returns the Torus callback response.
+ * Throws when the provider reports an authentication or consent error.
+ */
+export async function completeOAuthProviderLogin(
+  page: Page,
+  provider: ProviderParameters,
+  account: OAuthAccountParameters,
+  isCallbackResponse: (response: Response) => boolean,
+  timeout: number,
+): Promise<Response> {
+  const providerError = provider.selectors.error_message
+    ? page.locator(provider.selectors.error_message).first()
+    : undefined;
+  const emailInput = page.locator(provider.selectors.email_input);
+
+  await waitForProviderElement(emailInput, providerError, timeout, 'email prompt');
+  await emailInput.fill(account.email);
+  await page.locator(provider.selectors.email_submit).click();
+
+  const passwordInput = page.locator(provider.selectors.password_input);
+
+  await waitForProviderElement(passwordInput, providerError, timeout, 'password prompt');
+  await passwordInput.fill(account.password);
+
+  // Start observing before submit so a fast callback redirect cannot be missed.
+  const callbackResponsePromise = page.waitForResponse(isCallbackResponse, { timeout });
+
+  // Keep an interrupted provider flow from leaving a rejected waiter behind.
+  void callbackResponsePromise.catch(() => undefined);
+
+  await page.locator(provider.selectors.password_submit).click();
+
+  const consentSelector = provider.selectors.consent_submit;
+
+  // Providers may redirect immediately, pause for consent, or reject authentication.
+  const outcome = await Promise.race([
+    callbackResponsePromise.then((response) => ({ kind: 'callback' as const, response })),
+    waitForProviderError(providerError, timeout),
+    ...(consentSelector
+      ? [
+          page
+            .locator(consentSelector)
+            .first()
+            .waitFor({ state: 'visible', timeout })
+            .then(() => ({ kind: 'consent' as const })),
+        ]
+      : []),
+  ]);
+
+  if (outcome.kind === 'error') {
+    return throwProviderError(providerError, 'authentication');
+  }
+
+  if (outcome.kind === 'consent') {
+    if (!consentSelector) {
+      throw new Error('OAuth provider reached consent without a configured consent selector');
+    }
+
+    const consentButton = page.locator(consentSelector).first();
+
+    await consentButton.click();
+
+    const postConsentOutcome = await Promise.race([
+      callbackResponsePromise.then((response) => ({ kind: 'callback' as const, response })),
+      waitForProviderError(providerError, timeout),
+    ]);
+
+    if (postConsentOutcome.kind === 'error') {
+      return throwProviderError(providerError, 'consent');
+    }
+
+    return postConsentOutcome.response;
+  }
+
+  return outcome.response;
+}
+
+async function waitForProviderElement(
+  element: ReturnType<Page['locator']>,
+  providerError: ReturnType<Page['locator']> | undefined,
+  timeout: number,
+  phase: string,
+) {
+  const outcome = await Promise.race([
+    element.waitFor({ state: 'visible', timeout }).then(() => 'element' as const),
+    waitForProviderError(providerError, timeout).then(() => 'error' as const),
+  ]);
+
+  if (outcome === 'error') {
+    await throwProviderError(providerError, phase);
+  }
+}
+
+function waitForProviderError(
+  providerError: ReturnType<Page['locator']> | undefined,
+  timeout: number,
+) {
+  if (!providerError) {
+    return new Promise<{ kind: 'error' }>(() => {});
+  }
+
+  return providerError
+    .waitFor({ state: 'visible', timeout })
+    .then(() => ({ kind: 'error' as const }));
+}
+
+async function throwProviderError(
+  providerError: ReturnType<Page['locator']> | undefined,
+  phase: string,
+): Promise<never> {
+  const message = await providerError?.innerText().catch(() => '');
+
+  throw new Error(
+    `OAuth provider rejected the ${phase}${message?.trim() ? `: ${message.trim()}` : ''}`,
+  );
+}
+
+/**
+ * Dismisses the Torus cookie consent prompt when it is visible.
+ */
+export async function acceptTorusCookiesIfVisible(page: Page) {
+  const cookieModal = page.locator('#cookie_consent_display');
+  const acceptButton = cookieModal.locator('button:has-text("Accept")').first();
+  const appeared = await acceptButton
+    .waitFor({ state: 'visible', timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (appeared) {
+    await acceptButton.click({ force: true });
+    await expect(cookieModal).toBeHidden({ timeout: 5_000 });
+  }
+}

--- a/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLogin.ts
@@ -20,15 +20,28 @@ export async function completeOAuthProviderLogin(
   const providerError = provider.selectors.error_message
     ? page.locator(provider.selectors.error_message).first()
     : undefined;
+  const twoFactorChallenge = page.locator(provider.selectors.two_factor_challenge).first();
   const emailInput = page.locator(provider.selectors.email_input);
 
-  await waitForProviderElement(emailInput, providerError, timeout, 'email prompt');
+  await waitForProviderElement(
+    emailInput,
+    providerError,
+    twoFactorChallenge,
+    timeout,
+    'email prompt',
+  );
   await emailInput.fill(account.email);
   await page.locator(provider.selectors.email_submit).click();
 
   const passwordInput = page.locator(provider.selectors.password_input);
 
-  await waitForProviderElement(passwordInput, providerError, timeout, 'password prompt');
+  await waitForProviderElement(
+    passwordInput,
+    providerError,
+    twoFactorChallenge,
+    timeout,
+    'password prompt',
+  );
   await passwordInput.fill(account.password);
 
   // Start observing before submit so a fast callback redirect cannot be missed.
@@ -45,6 +58,7 @@ export async function completeOAuthProviderLogin(
   const outcome = await Promise.race([
     callbackResponsePromise.then((response) => ({ kind: 'callback' as const, response })),
     waitForProviderError(providerError, timeout),
+    waitForTwoFactorChallenge(twoFactorChallenge, timeout),
     ...(consentSelector
       ? [
           page
@@ -60,6 +74,10 @@ export async function completeOAuthProviderLogin(
     return throwProviderError(providerError, 'authentication');
   }
 
+  if (outcome.kind === 'two-factor') {
+    return throwTwoFactorChallenge();
+  }
+
   if (outcome.kind === 'consent') {
     if (!consentSelector) {
       throw new Error('OAuth provider reached consent without a configured consent selector');
@@ -72,10 +90,15 @@ export async function completeOAuthProviderLogin(
     const postConsentOutcome = await Promise.race([
       callbackResponsePromise.then((response) => ({ kind: 'callback' as const, response })),
       waitForProviderError(providerError, timeout),
+      waitForTwoFactorChallenge(twoFactorChallenge, timeout),
     ]);
 
     if (postConsentOutcome.kind === 'error') {
       return throwProviderError(providerError, 'consent');
+    }
+
+    if (postConsentOutcome.kind === 'two-factor') {
+      return throwTwoFactorChallenge();
     }
 
     return postConsentOutcome.response;
@@ -87,16 +110,22 @@ export async function completeOAuthProviderLogin(
 async function waitForProviderElement(
   element: ReturnType<Page['locator']>,
   providerError: ReturnType<Page['locator']> | undefined,
+  twoFactorChallenge: ReturnType<Page['locator']>,
   timeout: number,
   phase: string,
 ) {
   const outcome = await Promise.race([
     element.waitFor({ state: 'visible', timeout }).then(() => 'element' as const),
     waitForProviderError(providerError, timeout).then(() => 'error' as const),
+    waitForTwoFactorChallenge(twoFactorChallenge, timeout).then(() => 'two-factor' as const),
   ]);
 
   if (outcome === 'error') {
     await throwProviderError(providerError, phase);
+  }
+
+  if (outcome === 'two-factor') {
+    throwTwoFactorChallenge();
   }
 }
 
@@ -111,6 +140,21 @@ function waitForProviderError(
   return providerError
     .waitFor({ state: 'visible', timeout })
     .then(() => ({ kind: 'error' as const }));
+}
+
+function waitForTwoFactorChallenge(
+  twoFactorChallenge: ReturnType<Page['locator']>,
+  timeout: number,
+) {
+  return twoFactorChallenge
+    .waitFor({ state: 'visible', timeout })
+    .then(() => ({ kind: 'two-factor' as const }));
+}
+
+function throwTwoFactorChallenge(): never {
+  throw new Error(
+    'Google displayed the "Verify it\'s you" page. The OAuth test account must have 2FA disabled.',
+  );
 }
 
 async function throwProviderError(

--- a/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
@@ -1,15 +1,18 @@
 /**
- * Runtime parameter contracts and validation for the live OAuth login tests.
+ * Runtime parameter contracts and stable expectations for the live Google OAuth login tests.
  */
 
 export const OAUTH_ACCOUNT_CLASSES = ['learner', 'author'] as const;
 
 type OAuthAccountClass = (typeof OAUTH_ACCOUNT_CLASSES)[number];
 
-export type OAuthAccountParameters = {
+type OAuthAccountRuntimeParameters = {
   email: string;
   password: string;
-  torus_account_name: string;
+  account_label?: string;
+};
+
+type OAuthAccountExpectations = {
   login_path: string;
   authorization_path: string;
   callback_path: string;
@@ -17,25 +20,64 @@ export type OAuthAccountParameters = {
   workspace_heading: string;
   account_settings_link_name: string;
   account_settings_path: string;
-  account_label?: string;
   logout_path: string;
 };
 
+export type OAuthAccountParameters = OAuthAccountRuntimeParameters & OAuthAccountExpectations;
+
 export type OAuthLoginParameters = {
-  provider: {
-    name: string;
-    authorization_hostname: string;
-    selectors: {
-      email_input: string;
-      email_submit: string;
-      password_input: string;
-      password_submit: string;
-      consent_submit?: string;
-      error_message?: string;
-    };
-  };
-  accounts: Record<OAuthAccountClass, OAuthAccountParameters>;
+  accounts: Record<OAuthAccountClass, OAuthAccountRuntimeParameters>;
   timeout_ms: number;
+};
+
+export type OAuthProviderParameters = {
+  name: string;
+  authorization_hostname: string;
+  selectors: {
+    email_input: string;
+    email_submit: string;
+    password_input: string;
+    password_submit: string;
+    consent_submit?: string;
+    error_message?: string;
+  };
+};
+
+export const OAUTH_PROVIDER_PARAMETERS: OAuthProviderParameters = {
+  name: 'Google',
+  authorization_hostname: 'accounts.google.com',
+  selectors: {
+    email_input: 'input[name="identifier"], input#identifierId, input[aria-label="Email or phone"]',
+    email_submit: '#identifierNext',
+    password_input: 'input[type="password"]:not([aria-hidden="true"]):not([name="hiddenPassword"])',
+    password_submit: '#passwordNext',
+    consent_submit: 'button:has-text("Continue")',
+    error_message:
+      'text=/couldn.t find this account|wrong password|browser or app may not be secure|couldn.t sign you in/i',
+  },
+};
+
+const OAUTH_ACCOUNT_EXPECTATIONS: Record<OAuthAccountClass, OAuthAccountExpectations> = {
+  learner: {
+    login_path: '/users/log_in',
+    authorization_path: '/users/auth/google/new',
+    callback_path: '/users/auth/google/callback',
+    landing_path: '/workspaces/student',
+    workspace_heading: 'Courses available',
+    account_settings_link_name: 'Account Settings',
+    account_settings_path: '/users/settings',
+    logout_path: '/',
+  },
+  author: {
+    login_path: '/authors/log_in',
+    authorization_path: '/authors/auth/google/new',
+    callback_path: '/authors/auth/google/callback',
+    landing_path: '/workspaces/course_author',
+    workspace_heading: 'Course Author',
+    account_settings_link_name: 'Edit Account',
+    account_settings_path: '/authors/settings',
+    logout_path: '/authors/log_in',
+  },
 };
 
 const CONFIG_PATH = 'tests.oauth_logins';
@@ -47,26 +89,6 @@ export function validateOAuthLoginParameters(
   parameters: OAuthLoginParameters,
 ): OAuthLoginParameters {
   requirePositiveInteger(parameters?.timeout_ms, 'timeout_ms');
-  requireString(parameters?.provider?.name, 'provider.name');
-  requireHostname(parameters?.provider?.authorization_hostname, 'provider.authorization_hostname');
-  requireString(parameters?.provider?.selectors?.email_input, 'provider.selectors.email_input');
-  requireString(parameters?.provider?.selectors?.email_submit, 'provider.selectors.email_submit');
-  requireString(
-    parameters?.provider?.selectors?.password_input,
-    'provider.selectors.password_input',
-  );
-  requireString(
-    parameters?.provider?.selectors?.password_submit,
-    'provider.selectors.password_submit',
-  );
-  optionalString(
-    parameters?.provider?.selectors?.consent_submit,
-    'provider.selectors.consent_submit',
-  );
-  optionalString(
-    parameters?.provider?.selectors?.error_message,
-    'provider.selectors.error_message',
-  );
 
   OAUTH_ACCOUNT_CLASSES.forEach((accountClass) => {
     const account = parameters?.accounts?.[accountClass];
@@ -74,19 +96,23 @@ export function validateOAuthLoginParameters(
 
     requireRuntimeValue(account?.email, `${path}.email`);
     requireRuntimeValue(account?.password, `${path}.password`);
-    requireRuntimeValue(account?.torus_account_name, `${path}.torus_account_name`);
-    requireLocalPath(account?.login_path, `${path}.login_path`);
-    requireLocalPath(account?.authorization_path, `${path}.authorization_path`);
-    requireLocalPath(account?.callback_path, `${path}.callback_path`);
-    requireLocalPath(account?.landing_path, `${path}.landing_path`);
-    requireString(account?.workspace_heading, `${path}.workspace_heading`);
-    requireString(account?.account_settings_link_name, `${path}.account_settings_link_name`);
-    requireLocalPath(account?.account_settings_path, `${path}.account_settings_path`);
     optionalString(account?.account_label, `${path}.account_label`);
-    requireLocalPath(account?.logout_path, `${path}.logout_path`, true);
   });
 
   return parameters;
+}
+
+/**
+ * Combines environment-specific credentials with the stable expectations for an account class.
+ */
+export function oauthAccountParameters(
+  parameters: OAuthLoginParameters,
+  accountClass: OAuthAccountClass,
+): OAuthAccountParameters {
+  return {
+    ...OAUTH_ACCOUNT_EXPECTATIONS[accountClass],
+    ...parameters.accounts[accountClass],
+  };
 }
 
 function requireString(value: unknown, path: string) {
@@ -112,33 +138,5 @@ function requireRuntimeValue(value: unknown, path: string) {
 function requirePositiveInteger(value: unknown, path: string) {
   if (!Number.isInteger(value) || (value as number) <= 0) {
     throw new Error(`${CONFIG_PATH}.${path} must be a positive integer`);
-  }
-}
-
-function requireHostname(value: unknown, path: string) {
-  requireString(value, path);
-
-  try {
-    const url = new URL(`https://${value}`);
-
-    if (url.hostname !== value || url.pathname !== '/') {
-      throw new Error();
-    }
-  } catch {
-    throw new Error(`${CONFIG_PATH}.${path} must be a hostname without a scheme or path`);
-  }
-}
-
-function requireLocalPath(value: unknown, path: string, allowRoot = false) {
-  requireString(value, path);
-
-  if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) {
-    throw new Error(`${CONFIG_PATH}.${path} must be a local absolute path`);
-  }
-
-  const parsed = new URL(value, 'https://torus.invalid');
-
-  if (parsed.pathname !== value || (!allowRoot && parsed.pathname === '/')) {
-    throw new Error(`${CONFIG_PATH}.${path} must be a local absolute path without a query or hash`);
   }
 }

--- a/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
@@ -38,6 +38,7 @@ export type OAuthProviderParameters = {
     email_submit: string;
     password_input: string;
     password_submit: string;
+    two_factor_challenge: string;
     consent_submit?: string;
     error_message?: string;
   };
@@ -51,6 +52,7 @@ export const OAUTH_PROVIDER_PARAMETERS: OAuthProviderParameters = {
     email_submit: '#identifierNext',
     password_input: 'input[type="password"]:not([aria-hidden="true"]):not([name="hiddenPassword"])',
     password_submit: '#passwordNext',
+    two_factor_challenge: 'text=/verify it.s you/i',
     consent_submit: 'button:has-text("Continue")',
     error_message:
       'text=/couldn.t find this account|wrong password|browser or app may not be secure|couldn.t sign you in/i',

--- a/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
+++ b/assets/automation/tests/torus/oauth_login/support/oauthLoginConfig.ts
@@ -1,0 +1,144 @@
+/**
+ * Runtime parameter contracts and validation for the live OAuth login tests.
+ */
+
+export const OAUTH_ACCOUNT_CLASSES = ['learner', 'author'] as const;
+
+type OAuthAccountClass = (typeof OAUTH_ACCOUNT_CLASSES)[number];
+
+export type OAuthAccountParameters = {
+  email: string;
+  password: string;
+  torus_account_name: string;
+  login_path: string;
+  authorization_path: string;
+  callback_path: string;
+  landing_path: string;
+  workspace_heading: string;
+  account_settings_link_name: string;
+  account_settings_path: string;
+  account_label?: string;
+  logout_path: string;
+};
+
+export type OAuthLoginParameters = {
+  provider: {
+    name: string;
+    authorization_hostname: string;
+    selectors: {
+      email_input: string;
+      email_submit: string;
+      password_input: string;
+      password_submit: string;
+      consent_submit?: string;
+      error_message?: string;
+    };
+  };
+  accounts: Record<OAuthAccountClass, OAuthAccountParameters>;
+  timeout_ms: number;
+};
+
+const CONFIG_PATH = 'tests.oauth_logins';
+
+/**
+ * Validates required OAuth parameters and rejects placeholder runtime values.
+ */
+export function validateOAuthLoginParameters(
+  parameters: OAuthLoginParameters,
+): OAuthLoginParameters {
+  requirePositiveInteger(parameters?.timeout_ms, 'timeout_ms');
+  requireString(parameters?.provider?.name, 'provider.name');
+  requireHostname(parameters?.provider?.authorization_hostname, 'provider.authorization_hostname');
+  requireString(parameters?.provider?.selectors?.email_input, 'provider.selectors.email_input');
+  requireString(parameters?.provider?.selectors?.email_submit, 'provider.selectors.email_submit');
+  requireString(
+    parameters?.provider?.selectors?.password_input,
+    'provider.selectors.password_input',
+  );
+  requireString(
+    parameters?.provider?.selectors?.password_submit,
+    'provider.selectors.password_submit',
+  );
+  optionalString(
+    parameters?.provider?.selectors?.consent_submit,
+    'provider.selectors.consent_submit',
+  );
+  optionalString(
+    parameters?.provider?.selectors?.error_message,
+    'provider.selectors.error_message',
+  );
+
+  OAUTH_ACCOUNT_CLASSES.forEach((accountClass) => {
+    const account = parameters?.accounts?.[accountClass];
+    const path = `accounts.${accountClass}`;
+
+    requireRuntimeValue(account?.email, `${path}.email`);
+    requireRuntimeValue(account?.password, `${path}.password`);
+    requireRuntimeValue(account?.torus_account_name, `${path}.torus_account_name`);
+    requireLocalPath(account?.login_path, `${path}.login_path`);
+    requireLocalPath(account?.authorization_path, `${path}.authorization_path`);
+    requireLocalPath(account?.callback_path, `${path}.callback_path`);
+    requireLocalPath(account?.landing_path, `${path}.landing_path`);
+    requireString(account?.workspace_heading, `${path}.workspace_heading`);
+    requireString(account?.account_settings_link_name, `${path}.account_settings_link_name`);
+    requireLocalPath(account?.account_settings_path, `${path}.account_settings_path`);
+    optionalString(account?.account_label, `${path}.account_label`);
+    requireLocalPath(account?.logout_path, `${path}.logout_path`, true);
+  });
+
+  return parameters;
+}
+
+function requireString(value: unknown, path: string) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${CONFIG_PATH}.${path} must be a non-empty string`);
+  }
+}
+
+function optionalString(value: unknown, path: string) {
+  if (value !== undefined) {
+    requireString(value, path);
+  }
+}
+
+function requireRuntimeValue(value: unknown, path: string) {
+  requireString(value, path);
+
+  if (typeof value === 'string' && value.startsWith('REPLACE_WITH_')) {
+    throw new Error(`${CONFIG_PATH}.${path} still contains a placeholder value`);
+  }
+}
+
+function requirePositiveInteger(value: unknown, path: string) {
+  if (!Number.isInteger(value) || (value as number) <= 0) {
+    throw new Error(`${CONFIG_PATH}.${path} must be a positive integer`);
+  }
+}
+
+function requireHostname(value: unknown, path: string) {
+  requireString(value, path);
+
+  try {
+    const url = new URL(`https://${value}`);
+
+    if (url.hostname !== value || url.pathname !== '/') {
+      throw new Error();
+    }
+  } catch {
+    throw new Error(`${CONFIG_PATH}.${path} must be a hostname without a scheme or path`);
+  }
+}
+
+function requireLocalPath(value: unknown, path: string, allowRoot = false) {
+  requireString(value, path);
+
+  if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) {
+    throw new Error(`${CONFIG_PATH}.${path} must be a local absolute path`);
+  }
+
+  const parsed = new URL(value, 'https://torus.invalid');
+
+  if (parsed.pathname !== value || (!allowRoot && parsed.pathname === '/')) {
+    throw new Error(`${CONFIG_PATH}.${path} must be a local absolute path without a query or hash`);
+  }
+}


### PR DESCRIPTION
## Summary

Adds fully parameterized Playwright smoke tests for Google OAuth login across Torus account classes and deployment environments.

The suite covers:

- Learner login through `/users/log_in`
- Author login through `/authors/log_in`
- Redirect to Google authorization
- Successful callback to Torus without an OAuth error
- Verification of the signed-in account using its email address
- Correct learner or author workspace
- Session persistence after reload
- Logout and return to the public/login state

## Implementation

- Adds one parameterized test case for each account class: `learner` and `author`.
- Reads only environment-specific values from the YAML selected by `PLAYWRIGHT_PARAMETER_CONFIG_URL`:
  - Torus base URL
  - Operation timeout
  - Dedicated learner credentials
  - Dedicated author credentials
  - Optional author account label
- Keeps stable Google selectors, Torus routes, and expected workspace copy in the test code.
- Verifies the exact signed-in email from the Torus account settings page.
- Uses resilient helpers for the cookie modal and LiveView account menu.
- Gives the complete test three times the configured per-operation timeout.
- Runs headed Chrome because Google may reject automated headless authentication.
- Disables tracing to avoid storing credentials, session cookies, and OAuth response data.
- Validates runtime configuration and rejects placeholder values before attempting login.
- Adds `npm run test-oauth-logins`, which selects the suite using the `@oauth` tag.

Full configuration documentation is in [`assets/automation/README.md`](assets/automation/README.md#live-oauth-login-smoke-tests).

## Runtime configuration

```yaml
target:
  base_url: https://torus.example.test
tests:
  oauth_logins:
    timeout_ms: 120000
    accounts:
      learner:
        email: REPLACE_WITH_LEARNER_GOOGLE_EMAIL
        password: REPLACE_WITH_LEARNER_GOOGLE_PASSWORD
      author:
        email: REPLACE_WITH_AUTHOR_GOOGLE_EMAIL
        password: REPLACE_WITH_AUTHOR_GOOGLE_PASSWORD
        account_label: Author
```

Do not commit real credentials or the runtime YAML.

## Prerequisites

Each target environment requires:

- Google OAuth enabled in Torus.
- One dedicated learner Google account.
- One dedicated author Google account.
- Accounts without MFA, CAPTCHA, recovery, or other interactive challenges.
- The Google identities linked to the correct Torus account class.
- A private YAML configuration containing the account credentials and target URL.

Install the automation dependencies once from the repository root:

```bash
cd assets/automation
npm install
npx playwright install --with-deps chrome
```

## Testing locally

1. Configure a Google OAuth web client with these authorized redirect URIs:

   ```text
   http://localhost/users/auth/google/callback
   http://localhost/authors/auth/google/callback
   ```

2. Start or restart Torus with `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` set.

3. Log in manually once with each dedicated account:

   - Learner: `http://localhost/users/log_in`
   - Author: `http://localhost/authors/log_in`

   This creates and links the corresponding Torus learner and author records.

4. Save the runtime configuration as `/tmp/oauth-local.yaml`, set the base URL to `http://localhost`, and replace all credential placeholders.

5. Serve the configuration from a separate terminal:

   ```bash
   python3 -m http.server 8787 --bind 127.0.0.1 --directory /tmp
   ```

6. From `assets/automation`, run:

   ```bash
   PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-local.yaml npm run test-oauth-logins
   ```

## Testing Tokamak

Use dedicated Google accounts already linked to the correct account classes in Tokamak.

Set the YAML target to:

```yaml
target:
  base_url: https://tokamak.oli.cmu.edu
```

Then run from `assets/automation`:

```bash
PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-tokamak.yaml npm run test-oauth-logins
```

## Testing Stellarator

Use dedicated Google accounts already linked to the correct account classes in Stellarator.

Set the YAML target to:

```yaml
target:
  base_url: https://stellarator.oli.cmu.edu
```

Then run from `assets/automation`:

```bash
PLAYWRIGHT_PARAMETER_CONFIG_URL=http://127.0.0.1:8787/oauth-stellarator.yaml npm run test-oauth-logins
```

The same procedure can target another staging or production deployment by changing `target.base_url` and supplying dedicated accounts linked in that environment. A real Chrome window opens and runs both account-class flows.

## Verification

- Prettier passes for the changed files.
- ESLint passes for the OAuth test files.
- Playwright discovers both parameterized cases:
  - Learner OAuth login
  - Author OAuth login

See: https://eliterate.atlassian.net/browse/MER-5850