### PR TITLE
[BUG FIX] [MER-5820] Harden DOT GenAI failure handling

### DIFF
--- a/lib/oli/encrypted/binary.ex
+++ b/lib/oli/encrypted/binary.ex
@@ -1,3 +1,12 @@
 defmodule Oli.Encrypted.Binary do
   use Cloak.Ecto.Binary, vault: Oli.Vault
+
+  require Logger
+
+  def after_decrypt(:error) do
+    Logger.error("Unable to decrypt an encrypted value; check CLOAK_VAULT_KEY configuration")
+    nil
+  end
+
+  def after_decrypt(value), do: value
 end

--- a/lib/oli/gen_ai/completions.ex
+++ b/lib/oli/gen_ai/completions.ex
@@ -20,6 +20,15 @@ defmodule Oli.GenAI.Completions do
     |> apply(:stream, [messages, functions, registered_model, response_handler_fn])
   end
 
+  def validate_registered_model(%RegisteredModel{provider: :null}), do: :ok
+
+  def validate_registered_model(%RegisteredModel{api_key: api_key})
+      when is_binary(api_key) and byte_size(api_key) > 0,
+      do: :ok
+
+  def validate_registered_model(%RegisteredModel{}),
+    do: {:error, {:invalid_model_configuration, :missing_api_key}}
+
   defp get_provider(%RegisteredModel{} = registered_model) do
     case registered_model.provider do
       :null -> Oli.GenAI.Completions.NullProvider

--- a/lib/oli/gen_ai/completions/open_ai_compliant_provider.ex
+++ b/lib/oli/gen_ai/completions/open_ai_compliant_provider.ex
@@ -217,7 +217,8 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
     |> add_beta_header(config)
   end
 
-  def bearer(config), do: {"Authorization", "Bearer #{config.api_key || Config.api_key()}"}
+  def bearer(%{api_key: api_key}) when is_binary(api_key) and byte_size(api_key) > 0,
+    do: {"Authorization", "Bearer #{api_key}"}
 
   def request_options(config), do: config.http_options || Config.http_options()
 

--- a/lib/oli/gen_ai/completions/open_ai_compliant_provider.ex
+++ b/lib/oli/gen_ai/completions/open_ai_compliant_provider.ex
@@ -45,7 +45,6 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
            config
          ) do
       {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.error("OpenAI Provider HTTP failure: #{inspect(reason)}")
         {:error, reason}
 
       stream ->
@@ -53,7 +52,7 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
         |> Elixir.Stream.transform(:ok, fn chunk, :ok ->
           case process_stream_chunk(chunk) do
             {:error} ->
-              response_handler_fn.({:error})
+              response_handler_fn.({:error, stream_error_details(chunk)})
               {:halt, {:error}}
 
             :ignore ->
@@ -320,7 +319,7 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
         {:ok, content}
 
       _ ->
-        Logger.error("Unexpected OpenAI response format: #{inspect(response)}")
+        Logger.warning("OpenAI response normalization failed error_category=unexpected_response")
         {:error, :unexpected_response}
     end
   end
@@ -682,7 +681,7 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
       [Jason.decode!(payload)]
     rescue
       error in Jason.DecodeError ->
-        Logger.error("GenAI raw stream payload decode failure: #{inspect(payload)}")
+        Logger.error("GenAI stream payload decode failure error_category=invalid_json")
         reraise error, __STACKTRACE__
     end
   end
@@ -715,4 +714,22 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProvider do
   defp accumulate_error_body(state, chunk) do
     %{state | error_body: state.error_body <> chunk}
   end
+
+  defp stream_error_details(%{"status" => :error} = chunk) do
+    status = Map.get(chunk, "code")
+
+    %{http_status: status, error_category: stream_error_category(status, Map.get(chunk, "body"))}
+  end
+
+  defp stream_error_details(_), do: %{error_category: :invalid_response}
+
+  defp stream_error_category(429, body) do
+    case Jason.decode(body || "") do
+      {:ok, %{"error" => %{"code" => "credit_balance_exhausted"}}} -> :insufficient_quota
+      _ -> :rate_limited
+    end
+  end
+
+  defp stream_error_category(status, _body) when is_integer(status), do: :http_error
+  defp stream_error_category(_, _body), do: :network_error
 end

--- a/lib/oli/gen_ai/dialogue/configuration.ex
+++ b/lib/oli/gen_ai/dialogue/configuration.ex
@@ -9,7 +9,8 @@ defmodule Oli.GenAI.Dialogue.Configuration do
     :service_config,
     :messages,
     :functions,
-    :reply_to_pid
+    :reply_to_pid,
+    :execution_fn
   ]
 
   def new(service_config, messages, functions, reply_to_pid) do
@@ -17,7 +18,8 @@ defmodule Oli.GenAI.Dialogue.Configuration do
       service_config: service_config,
       messages: messages,
       functions: functions,
-      reply_to_pid: reply_to_pid
+      reply_to_pid: reply_to_pid,
+      execution_fn: nil
     }
   end
 end

--- a/lib/oli/gen_ai/dialogue/server.ex
+++ b/lib/oli/gen_ai/dialogue/server.ex
@@ -329,6 +329,10 @@ defmodule Oli.GenAI.Dialogue.Server do
     {:noreply, %{state | engagement_task: nil}}
   end
 
+  # A task can complete just before its engagement is replaced. Demonitoring
+  # suppresses its :DOWN message but does not flush an already-delivered reply.
+  def handle_info({ref, _result}, state) when is_reference(ref), do: {:noreply, state}
+
   def handle_info(
         {:DOWN, ref, :process, _pid, reason},
         %{engagement_task: %Task{ref: ref}} = state

--- a/lib/oli/gen_ai/dialogue/server.ex
+++ b/lib/oli/gen_ai/dialogue/server.ex
@@ -159,6 +159,9 @@ defmodule Oli.GenAI.Dialogue.Server do
         {:error} ->
           notify_server_fn.({:stream_chunk, {:error}})
 
+        {:error, _details} ->
+          notify_server_fn.({:stream_chunk, {:error}})
+
         {:function_call, function_call} ->
           notify_server_fn.({:stream_chunk, {:function_call, function_call}})
 
@@ -208,11 +211,7 @@ defmodule Oli.GenAI.Dialogue.Server do
         {:noreply, state}
 
       {:error, error} ->
-        Logger.info(
-          "Encountered completions http error for client #{inspect(configuration.reply_to_pid)}: #{inspect(error)}"
-        )
-
-        Logger.warning("Failed without backup for client #{inspect(configuration.reply_to_pid)}")
+        log_dialogue_failure(state, :execution_failed, error)
 
         notify_client_fn.(
           {:dialogue_server, {:error, "An error occurred while processing the request"}}
@@ -242,7 +241,6 @@ defmodule Oli.GenAI.Dialogue.Server do
   def handle_info({:stream_chunk, _stale_engagement_id, _chunk}, state), do: {:noreply, state}
 
   def handle_info({:stream_chunk, {:error}}, state) do
-    Logger.warning("Streaming error for client #{inspect(state.configuration.reply_to_pid)}")
     notify_error(state)
 
     {:noreply, %{state | messages: discard_last_assistant_message(state.messages)}}
@@ -297,13 +295,18 @@ defmodule Oli.GenAI.Dialogue.Server do
             {:noreply, state, {:continue, :execute_function}}
 
           {:error, reason} ->
-            Logger.error("Failed to execute function #{name}: #{reason}")
+            log_dialogue_failure(
+              state,
+              :tool_execution_failed,
+              safe_function_error_category(reason)
+            )
+
             notify_error(state)
             {:noreply, state}
         end
 
       {:error, _} ->
-        Logger.error("Failed to decode function arguments: #{args}")
+        log_dialogue_failure(state, :tool_arguments_invalid_json, :invalid_json)
         notify_error(state)
         {:noreply, state}
     end
@@ -330,9 +333,7 @@ defmodule Oli.GenAI.Dialogue.Server do
         {:DOWN, ref, :process, _pid, reason},
         %{engagement_task: %Task{ref: ref}} = state
       ) do
-    Logger.error(
-      "Dialogue engagement task terminated unexpectedly: #{task_exit_category(reason)}"
-    )
+    log_dialogue_failure(state, :engagement_task_terminated, task_exit_category(reason))
 
     notify_error(state)
     {:noreply, %{state | engagement_task: nil}}
@@ -408,6 +409,35 @@ defmodule Oli.GenAI.Dialogue.Server do
       {:dialogue_server, {:error, "An error occurred while processing the request"}}
     )
   end
+
+  defp log_dialogue_failure(state, event, error_category) do
+    %Configuration{service_config: service_config} = state.configuration
+
+    Logger.warning(
+      "Dialogue engagement failed event=#{event} error_category=#{safe_error_category(error_category)} " <>
+        "service_config_id=#{service_config.id}"
+    )
+  end
+
+  defp safe_error_category(reason)
+       when reason in [
+              :all_breakers_open,
+              :exception,
+              :invalid_json,
+              :missing_api_key,
+              :stream_error
+            ],
+       do: reason
+
+  defp safe_error_category({:invalid_model_configuration, :missing_api_key}), do: :missing_api_key
+  defp safe_error_category({:http_error, status}) when is_integer(status), do: :http_error
+  defp safe_error_category(_), do: :unknown
+
+  defp safe_function_error_category(reason)
+       when reason in [:invalid_arguments, :invalid_function_name],
+       do: reason
+
+  defp safe_function_error_category(_), do: :unknown
 
   defp discard_last_assistant_message(messages) do
     case messages do

--- a/lib/oli/gen_ai/dialogue/server.ex
+++ b/lib/oli/gen_ai/dialogue/server.ex
@@ -77,8 +77,16 @@ defmodule Oli.GenAI.Dialogue.Server do
     GenServer.cast(server, {:engage, message})
   end
 
+  def engage(server, %Message{} = message, engagement_id) when is_pid(server) do
+    GenServer.cast(server, {:engage, message, engagement_id})
+  end
+
   def remember(server, %Message{} = message) when is_pid(server) do
     GenServer.cast(server, {:remember, message})
+  end
+
+  def cancel_engagement(server) when is_pid(server) do
+    GenServer.cast(server, :cancel_engagement)
   end
 
   def init(%Configuration{} = static_configuration) do
@@ -92,34 +100,49 @@ defmodule Oli.GenAI.Dialogue.Server do
   def handle_cast({:engage, message}, %State{} = state) do
     %{configuration: cfg} = state
 
-    # spawn a Task so we don’t block the GenServer loop
-    server = self()
-
-    Task.start(fn ->
-      build_notify_fns(server, state)
-      |> do_engage(state, message)
-    end)
-
     Logger.debug(
       "Engaging dialogue for client #{inspect(cfg.reply_to_pid)} with message: #{inspect(message)}"
     )
 
-    {:noreply, %State{state | messages: [message | state.messages]}}
+    {:noreply, state |> start_engagement(message, nil) |> prepend_message(message)}
+  end
+
+  def handle_cast({:engage, message, engagement_id}, %State{} = state) do
+    {:noreply, state |> start_engagement(message, engagement_id) |> prepend_message(message)}
   end
 
   def handle_cast({:remember, message}, %State{} = state) do
     {:noreply, remember_message(state, message)}
   end
 
-  defp build_notify_fns(server_pid, %State{
-         configuration: %Configuration{reply_to_pid: reply_to_pid}
-       }) do
+  def handle_cast(:cancel_engagement, state), do: {:noreply, cancel_engagement_task(state)}
+
+  defp build_notify_fns(
+         server_pid,
+         %State{
+           configuration: %Configuration{reply_to_pid: reply_to_pid}
+         },
+         nil
+       ) do
     {
       fn message ->
         send(server_pid, message)
       end,
       fn message ->
         send(reply_to_pid, message)
+      end
+    }
+  end
+
+  defp build_notify_fns(
+         server_pid,
+         %State{configuration: %Configuration{reply_to_pid: reply_to_pid}},
+         engagement_id
+       ) do
+    {
+      fn {:stream_chunk, chunk} -> send(server_pid, {:stream_chunk, engagement_id, chunk}) end,
+      fn {:dialogue_server, event} ->
+        send(reply_to_pid, {:dialogue_server, engagement_id, event})
       end
     }
   end
@@ -167,17 +190,19 @@ defmodule Oli.GenAI.Dialogue.Server do
       service_config_id: configuration.service_config.id
     }
 
-    case Execution.stream(
+    on_plan = fn plan ->
+      notify_client_fn.({:dialogue_server, {:llm_routing, routing_metadata(plan.selected_model)}})
+    end
+
+    execution_fn = configuration.execution_fn || (&execute_stream/6)
+
+    case execution_fn.(
            request_ctx,
            messages_for_execution(state.messages, state.adaptive_runtime_message, message),
            configuration.functions,
            configuration.service_config,
            response_handler_fn,
-           on_plan: fn plan ->
-             notify_client_fn.(
-               {:dialogue_server, {:llm_routing, routing_metadata(plan.selected_model)}}
-             )
-           end
+           on_plan
          ) do
       :ok ->
         {:noreply, state}
@@ -197,14 +222,28 @@ defmodule Oli.GenAI.Dialogue.Server do
     end
   end
 
+  defp send_to_listener(
+         %State{engagement_id: engagement_id, configuration: %Configuration{reply_to_pid: pid}},
+         message
+       )
+       when not is_nil(engagement_id) do
+    send(pid, {:dialogue_server, engagement_id, elem(message, 1)})
+  end
+
   defp send_to_listener(%State{configuration: %Configuration{reply_to_pid: pid}}, message) do
     send(pid, message)
   end
 
   # All stream chunks come back here
 
+  def handle_info({:stream_chunk, engagement_id, chunk}, %{engagement_id: engagement_id} = state),
+    do: handle_info({:stream_chunk, chunk}, state)
+
+  def handle_info({:stream_chunk, _stale_engagement_id, _chunk}, state), do: {:noreply, state}
+
   def handle_info({:stream_chunk, {:error}}, state) do
     Logger.warning("Streaming error for client #{inspect(state.configuration.reply_to_pid)}")
+    notify_error(state)
 
     {:noreply, %{state | messages: discard_last_assistant_message(state.messages)}}
   end
@@ -259,11 +298,13 @@ defmodule Oli.GenAI.Dialogue.Server do
 
           {:error, reason} ->
             Logger.error("Failed to execute function #{name}: #{reason}")
+            notify_error(state)
             {:noreply, state}
         end
 
       {:error, _} ->
         Logger.error("Failed to decode function arguments: #{args}")
+        notify_error(state)
         {:noreply, state}
     end
   end
@@ -276,14 +317,25 @@ defmodule Oli.GenAI.Dialogue.Server do
   # This is the entry point for engaging the dialogue server from within the server itself
   # (e.g., when the server sends a message to itself after executing a function call)
   def handle_info({:engage, message}, %State{} = state) do
-    server = self()
+    {:noreply,
+     state |> start_engagement(message, state.engagement_id) |> prepend_message(message)}
+  end
 
-    Task.start(fn ->
-      build_notify_fns(server, state)
-      |> do_engage(state, message)
-    end)
+  def handle_info({ref, _result}, %{engagement_task: %Task{ref: ref}} = state) do
+    Process.demonitor(ref, [:flush])
+    {:noreply, %{state | engagement_task: nil}}
+  end
 
-    {:noreply, %State{state | messages: [message | state.messages]}}
+  def handle_info(
+        {:DOWN, ref, :process, _pid, reason},
+        %{engagement_task: %Task{ref: ref}} = state
+      ) do
+    Logger.error(
+      "Dialogue engagement task terminated unexpectedly: #{task_exit_category(reason)}"
+    )
+
+    notify_error(state)
+    {:noreply, %{state | engagement_task: nil}}
   end
 
   def handle_continue(:execute_function, %{function_message: message} = state) do
@@ -302,6 +354,59 @@ defmodule Oli.GenAI.Dialogue.Server do
         # If the newest message is not from the assistant, start a new assistant draft.
         [Message.new(:assistant, token) | messages]
     end
+  end
+
+  defp start_engagement(state, message, engagement_id) do
+    state = cancel_engagement_task(state)
+    server = self()
+
+    task =
+      Task.Supervisor.async_nolink(Oli.TaskSupervisor, fn ->
+        build_notify_fns(server, state, engagement_id)
+        |> do_engage(state, message)
+      end)
+
+    %{state | engagement_task: task, engagement_id: engagement_id}
+  end
+
+  defp prepend_message(state, message), do: %{state | messages: [message | state.messages]}
+
+  defp cancel_engagement_task(%{engagement_task: nil} = state), do: state
+
+  defp cancel_engagement_task(%{engagement_task: %Task{} = task} = state) do
+    Process.demonitor(task.ref, [:flush])
+    Process.exit(task.pid, :kill)
+    %{state | engagement_task: nil}
+  end
+
+  defp task_exit_category(:normal), do: "normal"
+  defp task_exit_category(:killed), do: "killed"
+  defp task_exit_category({exception, _stacktrace}) when is_exception(exception), do: "exception"
+  defp task_exit_category(_), do: "error"
+
+  defp execute_stream(
+         request_ctx,
+         messages,
+         functions,
+         service_config,
+         response_handler_fn,
+         on_plan
+       ) do
+    Execution.stream(
+      request_ctx,
+      messages,
+      functions,
+      service_config,
+      response_handler_fn,
+      on_plan: on_plan
+    )
+  end
+
+  defp notify_error(state) do
+    send_to_listener(
+      state,
+      {:dialogue_server, {:error, "An error occurred while processing the request"}}
+    )
   end
 
   defp discard_last_assistant_message(messages) do

--- a/lib/oli/gen_ai/dialogue/state.ex
+++ b/lib/oli/gen_ai/dialogue/state.ex
@@ -19,7 +19,9 @@ defmodule Oli.GenAI.Dialogue.State do
     :function_name,
     :function_args,
     :function_id,
-    :function_message
+    :function_message,
+    :engagement_task,
+    :engagement_id
   ]
 
   def new(%Configuration{messages: messages, service_config: service_config} = configuration) do
@@ -35,7 +37,9 @@ defmodule Oli.GenAI.Dialogue.State do
       function_name: nil,
       function_args: nil,
       function_id: nil,
-      function_message: nil
+      function_message: nil,
+      engagement_task: nil,
+      engagement_id: nil
     }
   end
 end

--- a/lib/oli/gen_ai/execution.ex
+++ b/lib/oli/gen_ai/execution.ex
@@ -11,6 +11,7 @@ defmodule Oli.GenAI.Execution do
   alias Oli.GenAI.Telemetry
   alias Oli.GenAI.Completions
   alias Oli.GenAI.Completions.ServiceConfig
+  require Logger
 
   @doc """
   Executes a synchronous completion request with routing.
@@ -39,20 +40,24 @@ defmodule Oli.GenAI.Execution do
       notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
-        with :ok <- Completions.validate_registered_model(plan.selected_model) do
-          execute_with_fallback(
-            :generate,
-            completer,
-            messages,
-            functions,
-            plan,
-            service_config,
-            request_ctx,
-            request_type,
-            true,
-            provider_opts
-          )
-        end
+        result =
+          with :ok <- Completions.validate_registered_model(plan.selected_model) do
+            execute_with_fallback(
+              :generate,
+              completer,
+              messages,
+              functions,
+              plan,
+              service_config,
+              request_ctx,
+              request_type,
+              true,
+              provider_opts
+            )
+          end
+
+        log_validation_failure(result, plan, request_type, service_config)
+        result
       after
         release_admission!(plan)
       end
@@ -76,20 +81,24 @@ defmodule Oli.GenAI.Execution do
       notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
-        with :ok <- Completions.validate_registered_model(plan.selected_model) do
-          execute_with_fallback(
-            :stream,
-            completer,
-            messages,
-            functions,
-            plan,
-            service_config,
-            request_ctx,
-            request_type,
-            false,
-            response_handler_fn
-          )
-        end
+        result =
+          with :ok <- Completions.validate_registered_model(plan.selected_model) do
+            execute_with_fallback(
+              :stream,
+              completer,
+              messages,
+              functions,
+              plan,
+              service_config,
+              request_ctx,
+              request_type,
+              false,
+              response_handler_fn
+            )
+          end
+
+        log_validation_failure(result, plan, request_type, service_config)
+        result
       after
         release_admission!(plan)
       end
@@ -158,6 +167,7 @@ defmodule Oli.GenAI.Execution do
     latency_ms = System.monotonic_time(:millisecond) - start_ms
 
     report_breaker(result, plan.selected_model, latency_ms)
+    log_failure(result, plan, request_type, service_config)
     emit_provider_telemetry(result, latency_ms, plan, request_type, service_config)
 
     case {include_metadata?, result} do
@@ -180,11 +190,24 @@ defmodule Oli.GenAI.Execution do
        ) do
     start_ms = System.monotonic_time(:millisecond)
     error_key = {:genai_stream_error, make_ref()}
-    Process.put(error_key, false)
+    Process.put(error_key, nil)
 
     wrapped_handler = fn chunk ->
-      if chunk == :error or match?({:error, _}, chunk) or chunk == {:error} do
-        Process.put(error_key, true)
+      case chunk do
+        {:error, reason} ->
+          log_failure({:error, reason}, plan, request_type, service_config)
+          Process.put(error_key, reason)
+
+        :error ->
+          log_failure({:error, :stream_error}, plan, request_type, service_config)
+          Process.put(error_key, :stream_error)
+
+        {:error} ->
+          log_failure({:error, :stream_error}, plan, request_type, service_config)
+          Process.put(error_key, :stream_error)
+
+        _ ->
+          :ok
       end
 
       response_handler_fn.(chunk)
@@ -193,17 +216,22 @@ defmodule Oli.GenAI.Execution do
     result = completer.stream(messages, functions, plan.selected_model, wrapped_handler)
     latency_ms = System.monotonic_time(:millisecond) - start_ms
 
-    error_seen? = Process.get(error_key, false)
+    stream_error = Process.get(error_key)
     Process.delete(error_key)
 
     result =
-      if error_seen? do
-        {:error, :stream_error}
+      if stream_error do
+        {:error, stream_error}
       else
         result
       end
 
     report_breaker(result, plan.selected_model, latency_ms)
+
+    if is_nil(stream_error) do
+      log_failure(result, plan, request_type, service_config)
+    end
+
     emit_provider_telemetry(result, latency_ms, plan, request_type, service_config)
     result
   end
@@ -235,6 +263,10 @@ defmodule Oli.GenAI.Execution do
   defp error_details(:connect_timeout), do: {nil, :timeout}
   defp error_details(:recv_timeout), do: {nil, :timeout}
   defp error_details({:timeout, _}), do: {nil, :timeout}
+
+  defp error_details(%{http_status: status, error_category: category}) when is_integer(status) do
+    {status, category}
+  end
 
   defp error_details(%{status: status}) when is_integer(status) do
     {status, http_status_category(status)}
@@ -310,6 +342,29 @@ defmodule Oli.GenAI.Execution do
       }
     )
   end
+
+  defp log_failure({:error, reason}, plan, request_type, service_config) do
+    {http_status, error_category} = error_details(reason)
+
+    Logger.warning(
+      "GenAI request failed service_config_id=#{service_config.id} " <>
+        "registered_model_id=#{plan.selected_model.id} provider=#{plan.selected_model.provider} " <>
+        "request_type=#{request_type} http_status=#{http_status || "none"} " <>
+        "error_category=#{error_category}"
+    )
+  end
+
+  defp log_failure(_, _, _, _), do: :ok
+
+  defp log_validation_failure(
+         {:error, {:invalid_model_configuration, _}} = result,
+         plan,
+         request_type,
+         service_config
+       ),
+       do: log_failure(result, plan, request_type, service_config)
+
+  defp log_validation_failure(_, _, _, _), do: :ok
 
   defp notify_plan(nil, _plan), do: :ok
   defp notify_plan(callback, plan) when is_function(callback, 1), do: callback.(plan)

--- a/lib/oli/gen_ai/execution.ex
+++ b/lib/oli/gen_ai/execution.ex
@@ -39,18 +39,20 @@ defmodule Oli.GenAI.Execution do
       notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
-        execute_with_fallback(
-          :generate,
-          completer,
-          messages,
-          functions,
-          plan,
-          service_config,
-          request_ctx,
-          request_type,
-          true,
-          provider_opts
-        )
+        with :ok <- Completions.validate_registered_model(plan.selected_model) do
+          execute_with_fallback(
+            :generate,
+            completer,
+            messages,
+            functions,
+            plan,
+            service_config,
+            request_ctx,
+            request_type,
+            true,
+            provider_opts
+          )
+        end
       after
         release_admission!(plan)
       end
@@ -74,18 +76,20 @@ defmodule Oli.GenAI.Execution do
       notify_plan(Keyword.get(opts, :on_plan), plan)
 
       try do
-        execute_with_fallback(
-          :stream,
-          completer,
-          messages,
-          functions,
-          plan,
-          service_config,
-          request_ctx,
-          request_type,
-          false,
-          response_handler_fn
-        )
+        with :ok <- Completions.validate_registered_model(plan.selected_model) do
+          execute_with_fallback(
+            :stream,
+            completer,
+            messages,
+            functions,
+            plan,
+            service_config,
+            request_ctx,
+            request_type,
+            false,
+            response_handler_fn
+          )
+        end
       after
         release_admission!(plan)
       end

--- a/lib/oli/gen_ai/router.ex
+++ b/lib/oli/gen_ai/router.ex
@@ -333,11 +333,16 @@ defmodule Oli.GenAI.Router do
         )
 
       {:error, reason} ->
-        Logger.warning("GenAI routing rejected",
-          service_config_id: service_config.id,
-          reason: reason,
-          request_type: request_type
+        Logger.warning(
+          "GenAI routing rejected service_config_id=#{service_config.id} " <>
+            "request_type=#{request_type} reason=#{routing_error_category(reason)}"
         )
     end
   end
+
+  defp routing_error_category(reason)
+       when reason in [:all_breakers_open, :over_capacity, :secondary_over_capacity],
+       do: reason
+
+  defp routing_error_category(_), do: :unknown
 end

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -25,6 +25,7 @@ defmodule OliWeb.Dialogue.WindowLive do
 
   @adaptive_runtime_update_name "adaptive_runtime_update"
   @activity_attempt_guid_pattern ~r/\A[a-zA-Z0-9_-]+\z/
+  @watchdog_margin_ms 5_000
 
   defp realize_prompt_template(nil, _), do: ""
 
@@ -228,6 +229,9 @@ defmodule OliWeb.Dialogue.WindowLive do
       trigger_queue: [],
       active_message: nil,
       current_llm_metadata: nil,
+      engagement_id: nil,
+      watchdog_timer: nil,
+      watchdog_timeout_ms: watchdog_timeout_ms(dialogue),
       title: "Dot",
       current_user: Oli.Accounts.get_user!(user_id),
       height: 500,
@@ -706,10 +710,15 @@ defmodule OliWeb.Dialogue.WindowLive do
 
     persist_message(message, socket)
 
-    # This asynchronously engages the dialogue server with the new message
-    Server.engage(dialogue, message)
+    engagement_id = make_ref()
 
-    {:noreply, assign(socket, streaming: true, messages: messages, allow_submission?: false)}
+    # This asynchronously engages the dialogue server with the new message
+    Server.engage(dialogue, message, engagement_id)
+
+    {:noreply,
+     socket
+     |> assign(messages: messages)
+     |> start_streaming(engagement_id)}
   end
 
   def handle_event(
@@ -733,25 +742,28 @@ defmodule OliWeb.Dialogue.WindowLive do
   # If we encounter any type of error from the server, have DOT post a message indicating
   # that there was an error, and basically stop responding (until the user refreshes the page)
   def handle_info({:dialogue_server, {:error, _error}}, socket) do
-    messages = socket.assigns.messages
-
-    message =
-      Message.new(
-        :assistant,
-        "<span class='text-red-500'>Hmmm, we encountered a problem while processing your last message. Maybe try again later.</span>"
-      )
-
-    messages = messages ++ [message]
-
-    {:noreply,
-     assign(socket,
-       streaming: false,
-       messages: messages,
-       allow_submission?: true,
-       active_message: nil,
-       current_llm_metadata: nil
-     )}
+    {:noreply, fail_dialogue(socket)}
   end
+
+  def handle_info(
+        {:dialogue_server, engagement_id, event},
+        %{assigns: %{engagement_id: engagement_id}} = socket
+      ) do
+    handle_info({:dialogue_server, event}, socket)
+  end
+
+  def handle_info({:dialogue_server, _stale_engagement_id, _event}, socket),
+    do: {:noreply, socket}
+
+  def handle_info(
+        {:dialogue_timeout, engagement_id},
+        %{assigns: %{engagement_id: engagement_id}} = socket
+      ) do
+    Logger.error("Dialogue engagement timed out")
+    {:noreply, fail_dialogue(socket)}
+  end
+
+  def handle_info({:dialogue_timeout, _stale_engagement_id}, socket), do: {:noreply, socket}
 
   def handle_info({:dialogue_server, {:llm_routing, metadata}}, socket) do
     {:noreply, assign(socket, current_llm_metadata: metadata)}
@@ -775,18 +787,25 @@ defmodule OliWeb.Dialogue.WindowLive do
     case socket.assigns.trigger_queue do
       [] ->
         {:noreply,
-         assign(socket,
+         socket
+         |> cancel_watchdog()
+         |> assign(
            streaming: false,
            allow_submission?: true,
            active_message: nil,
            current_llm_metadata: nil,
-           messages: socket.assigns.messages ++ [message]
+           messages: socket.assigns.messages ++ [message],
+           engagement_id: nil
          )}
 
       [trigger | rest] ->
         prompt = Oli.Conversation.Triggers.assemble_trigger_prompt(trigger)
 
-        Server.engage(socket.assigns.dialogue, Message.new(:system, prompt))
+        Server.engage(
+          socket.assigns.dialogue,
+          Message.new(:system, prompt),
+          socket.assigns.engagement_id
+        )
 
         {:noreply,
          assign(socket,
@@ -826,22 +845,44 @@ defmodule OliWeb.Dialogue.WindowLive do
         prompt = Triggers.assemble_trigger_prompt(trigger)
         message = Message.new(:system, prompt)
 
-        Server.engage(socket.assigns.dialogue, message)
+        engagement_id = make_ref()
+        Server.engage(socket.assigns.dialogue, message, engagement_id)
 
         socket =
           push_event(socket, "wakeup-dot", %{
             to: "#ai_bot_collapsed"
           })
 
-        {:noreply,
-         assign(socket,
-           streaming: true
-         )}
+        {:noreply, start_streaming(socket, engagement_id)}
     end
   end
 
   def handle_info(_item, socket) do
     {:noreply, socket}
+  end
+
+  defp fail_dialogue(socket) do
+    Server.cancel_engagement(socket.assigns.dialogue)
+    messages = socket.assigns.messages
+
+    message =
+      Message.new(
+        :assistant,
+        "<span class='text-red-500'>Hmmm, we encountered a problem while processing your last message. Maybe try again later.</span>"
+      )
+
+    messages = messages ++ [message]
+
+    socket
+    |> cancel_watchdog()
+    |> assign(
+      streaming: false,
+      messages: messages,
+      allow_submission?: true,
+      active_message: nil,
+      current_llm_metadata: nil,
+      engagement_id: nil
+    )
   end
 
   def persist_message(message, socket) do
@@ -937,4 +978,44 @@ defmodule OliWeb.Dialogue.WindowLive do
   end
 
   defp normalize_activity_attempt_guid(_), do: {:error, :invalid_activity_attempt_guid}
+
+  defp start_streaming(socket, engagement_id) do
+    socket = cancel_watchdog(socket)
+
+    timer =
+      Process.send_after(
+        self(),
+        {:dialogue_timeout, engagement_id},
+        socket.assigns.watchdog_timeout_ms
+      )
+
+    assign(socket,
+      streaming: true,
+      allow_submission?: false,
+      engagement_id: engagement_id,
+      watchdog_timer: timer
+    )
+  end
+
+  defp cancel_watchdog(%{assigns: %{watchdog_timer: nil}} = socket), do: socket
+
+  defp cancel_watchdog(socket) do
+    Process.cancel_timer(socket.assigns.watchdog_timer)
+    assign(socket, watchdog_timer: nil)
+  end
+
+  defp watchdog_timeout_ms(dialogue) do
+    recv_timeout =
+      dialogue
+      |> :sys.get_state()
+      |> then(& &1.configuration.service_config)
+      |> then(fn config ->
+        [config.primary_model, config.secondary_model, config.backup_model]
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&Map.get(&1, :recv_timeout, 60_000))
+      |> Enum.max(fn -> 60_000 end)
+
+    recv_timeout + Application.get_env(:oli, :dialogue_watchdog_margin_ms, @watchdog_margin_ms)
+  end
 end

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -809,12 +809,14 @@ defmodule OliWeb.Dialogue.WindowLive do
         )
 
         {:noreply,
-         assign(socket,
+         socket
+         |> assign(
            active_message: socket.assigns.active_message <> "\n\n",
            messages: socket.assigns.messages ++ [message],
            trigger_queue: rest,
            current_llm_metadata: nil
-         )}
+         )
+         |> start_streaming(socket.assigns.engagement_id)}
     end
   end
 

--- a/lib/oli_web/live/dialogue/window_live.ex
+++ b/lib/oli_web/live/dialogue/window_live.ex
@@ -759,7 +759,8 @@ defmodule OliWeb.Dialogue.WindowLive do
         {:dialogue_timeout, engagement_id},
         %{assigns: %{engagement_id: engagement_id}} = socket
       ) do
-    Logger.error("Dialogue engagement timed out")
+    Logger.error("Dialogue engagement timed out section_id=#{socket.assigns.section.id}")
+
     {:noreply, fail_dialogue(socket)}
   end
 

--- a/test/oli/encrypted/binary_test.exs
+++ b/test/oli/encrypted/binary_test.exs
@@ -1,0 +1,18 @@
+defmodule Oli.Encrypted.BinaryTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias Oli.Encrypted.Binary
+
+  test "converts Cloak authentication failures to nil and logs an operator-facing error" do
+    log = capture_log(fn -> assert Binary.after_decrypt(:error) == nil end)
+
+    assert log =~ "Unable to decrypt an encrypted value"
+    assert log =~ "CLOAK_VAULT_KEY"
+  end
+
+  test "preserves successfully decrypted binary values" do
+    assert Binary.after_decrypt("secret") == "secret"
+  end
+end

--- a/test/oli/gen_ai/completions/open_ai_compliant_provider_test.exs
+++ b/test/oli/gen_ai/completions/open_ai_compliant_provider_test.exs
@@ -5,6 +5,19 @@ defmodule Oli.GenAI.Completions.OpenAICompliantProviderTest do
   alias Oli.GenAI.Completions.OpenAICompliantProvider
   alias HTTPoison.{AsyncEnd, Error}
 
+  describe "bearer/1" do
+    test "uses only the registered model API key" do
+      assert OpenAICompliantProvider.bearer(%{api_key: "registered-model-key"}) ==
+               {"Authorization", "Bearer registered-model-key"}
+    end
+
+    test "rejects a missing API key instead of falling back to global OpenAI configuration" do
+      assert_raise FunctionClauseError, fn ->
+        OpenAICompliantProvider.bearer(%{api_key: nil})
+      end
+    end
+  end
+
   describe "decode_stream_chunk/2" do
     test "buffers partial SSE payloads until a full event is available" do
       {data, buffer} =

--- a/test/oli/gen_ai/completions_test.exs
+++ b/test/oli/gen_ai/completions_test.exs
@@ -1,0 +1,17 @@
+defmodule Oli.GenAI.CompletionsTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.GenAI.Completions
+  alias Oli.GenAI.Completions.RegisteredModel
+
+  test "rejects a non-binary API key for providers that require credentials" do
+    model = %RegisteredModel{provider: :open_ai, api_key: :error}
+
+    assert {:error, {:invalid_model_configuration, :missing_api_key}} =
+             Completions.validate_registered_model(model)
+  end
+
+  test "permits the null provider without an API key" do
+    assert :ok = Completions.validate_registered_model(%RegisteredModel{provider: :null})
+  end
+end

--- a/test/oli/gen_ai/dialogue/server_test.exs
+++ b/test/oli/gen_ai/dialogue/server_test.exs
@@ -69,6 +69,41 @@ defmodule Oli.GenAI.Dialogue.ServerTest do
     refute log =~ "secret response body"
   end
 
+  test "ignores a stale task reply after replacing an engagement" do
+    test_pid = self()
+
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 1, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: test_pid,
+      messages: [Message.new(:system, "base system prompt")],
+      execution_fn: fn _, _, _, _, _, _ ->
+        send(test_pid, {:execution_started, self()})
+
+        receive do
+          :finish -> :ok
+        end
+      end
+    }
+
+    {:ok, server} = Server.new(config)
+    on_exit(fn -> if Process.alive?(server), do: GenServer.stop(server) end)
+
+    Server.engage(server, Message.new(:user, "first"))
+    assert_receive {:execution_started, _first_task_pid}
+    %{engagement_task: %{ref: stale_ref}} = :sys.get_state(server)
+
+    Server.engage(server, Message.new(:user, "second"))
+    assert_receive {:execution_started, second_task_pid}
+
+    send(server, {stale_ref, {:noreply, :stale_state}})
+
+    assert %{engagement_task: %{pid: ^second_task_pid}} = :sys.get_state(server)
+    assert Process.alive?(server)
+
+    send(second_task_pid, :finish)
+  end
+
   @tag capture_log: true
   test "notifies the client when tool arguments are invalid JSON" do
     config = %Configuration{

--- a/test/oli/gen_ai/dialogue/server_test.exs
+++ b/test/oli/gen_ai/dialogue/server_test.exs
@@ -1,6 +1,8 @@
 defmodule Oli.GenAI.Dialogue.ServerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Oli.GenAI.Completions.{Message, ServiceConfig}
   alias Oli.GenAI.Dialogue.{Configuration, Server}
 
@@ -44,6 +46,29 @@ defmodule Oli.GenAI.Dialogue.ServerTest do
                    1_000
   end
 
+  test "logs a safe execution failure with service configuration context" do
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 42, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: self(),
+      messages: [Message.new(:system, "base system prompt")],
+      execution_fn: fn _, _, _, _, _, _ -> {:error, %{body: "secret response body"}} end
+    }
+
+    log =
+      capture_log(fn ->
+        {:ok, server} = Server.new(config)
+        Server.engage(server, Message.new(:user, "hello"))
+
+        assert_receive {:dialogue_server,
+                        {:error, "An error occurred while processing the request"}}
+      end)
+
+    assert log =~ "event=execution_failed"
+    assert log =~ "service_config_id=42"
+    refute log =~ "secret response body"
+  end
+
   @tag capture_log: true
   test "notifies the client when tool arguments are invalid JSON" do
     config = %Configuration{
@@ -63,6 +88,35 @@ defmodule Oli.GenAI.Dialogue.ServerTest do
     send(server, {:stream_chunk, {:function_call_finished}})
 
     assert_receive {:dialogue_server, {:error, "An error occurred while processing the request"}}
+  end
+
+  test "logs invalid tool arguments without exposing their contents" do
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 7, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: self(),
+      messages: [Message.new(:system, "base system prompt")]
+    }
+
+    log =
+      capture_log(fn ->
+        {:ok, server} = Server.new(config)
+
+        send(
+          server,
+          {:stream_chunk,
+           {:function_call,
+            %{"name" => "lookup", "arguments" => "secret-invalid-json", "id" => "1"}}}
+        )
+
+        send(server, {:stream_chunk, {:function_call_finished}})
+
+        assert_receive {:dialogue_server,
+                        {:error, "An error occurred while processing the request"}}
+      end)
+
+    assert log =~ "event=tool_arguments_invalid_json"
+    refute log =~ "secret-invalid-json"
   end
 
   @tag capture_log: true

--- a/test/oli/gen_ai/dialogue/server_test.exs
+++ b/test/oli/gen_ai/dialogue/server_test.exs
@@ -25,4 +25,64 @@ defmodule Oli.GenAI.Dialogue.ServerTest do
 
     assert state.adaptive_runtime_message.name == "adaptive_runtime_update"
   end
+
+  @tag capture_log: true
+  test "notifies the client when an engagement task crashes" do
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 1, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: self(),
+      messages: [Message.new(:system, "base system prompt")],
+      execution_fn: fn _, _, _, _, _, _ -> raise "provider initialization failed" end
+    }
+
+    {:ok, server} = Server.new(config)
+
+    Server.engage(server, Message.new(:user, "hello"))
+
+    assert_receive {:dialogue_server, {:error, "An error occurred while processing the request"}},
+                   1_000
+  end
+
+  @tag capture_log: true
+  test "notifies the client when tool arguments are invalid JSON" do
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 1, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: self(),
+      messages: [Message.new(:system, "base system prompt")]
+    }
+
+    {:ok, server} = Server.new(config)
+
+    send(
+      server,
+      {:stream_chunk, {:function_call, %{"name" => "lookup", "arguments" => "{", "id" => "1"}}}
+    )
+
+    send(server, {:stream_chunk, {:function_call_finished}})
+
+    assert_receive {:dialogue_server, {:error, "An error occurred while processing the request"}}
+  end
+
+  @tag capture_log: true
+  test "notifies the client when tool execution fails" do
+    config = %Configuration{
+      service_config: %ServiceConfig{id: 1, primary_model: %{id: 1}},
+      functions: [],
+      reply_to_pid: self(),
+      messages: [Message.new(:system, "base system prompt")]
+    }
+
+    {:ok, server} = Server.new(config)
+
+    send(
+      server,
+      {:stream_chunk, {:function_call, %{"name" => "lookup", "arguments" => "{}", "id" => "1"}}}
+    )
+
+    send(server, {:stream_chunk, {:function_call_finished}})
+
+    assert_receive {:dialogue_server, {:error, "An error occurred while processing the request"}}
+  end
 end

--- a/test/oli/gen_ai/execution_test.exs
+++ b/test/oli/gen_ai/execution_test.exs
@@ -1,6 +1,8 @@
 defmodule Oli.GenAI.ExecutionTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias Oli.GenAI.{AdmissionControl, BreakerSupervisor, Execution, HackneyPool}
   alias Oli.GenAI.Completions.{RegisteredModel, ServiceConfig}
 
@@ -216,6 +218,28 @@ defmodule Oli.GenAI.ExecutionTest do
            end)
   end
 
+  test "logs safe status and category for streaming provider failures" do
+    service_config = build_service_config(61, secondary_model: nil, backup_model: nil)
+
+    log =
+      capture_log(fn ->
+        assert {:error, %{http_status: 429, error_category: :insufficient_quota}} =
+                 Execution.stream(
+                   %{request_type: :stream},
+                   [],
+                   [],
+                   service_config,
+                   fn _ -> :ok end,
+                   completions_mod: __MODULE__.StreamingQuotaCompletions
+                 )
+      end)
+
+    assert log =~ "service_config_id=61"
+    assert log =~ "registered_model_id=#{service_config.primary_model.id}"
+    assert log =~ "http_status=429"
+    assert log =~ "error_category=insufficient_quota"
+  end
+
   test "kill switch always uses primary and bypasses admission controls" do
     Process.put(:execution_test_pid, self())
 
@@ -361,6 +385,15 @@ defmodule Oli.GenAI.ExecutionTest do
     end
 
     def stream(_messages, _functions, _registered_model, _response_handler_fn) do
+      :ok
+    end
+  end
+
+  defmodule StreamingQuotaCompletions do
+    def generate(_messages, _functions, _registered_model, _opts \\ []), do: :ok
+
+    def stream(_messages, _functions, _registered_model, response_handler_fn) do
+      response_handler_fn.({:error, %{http_status: 429, error_category: :insufficient_quota}})
       :ok
     end
   end

--- a/test/oli_web/live/dialogue/window_live_test.exs
+++ b/test/oli_web/live/dialogue/window_live_test.exs
@@ -504,6 +504,46 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
       assert socket_assigns(view).allow_submission?
     end
 
+    test "restarts the watchdog for a queued trigger continuation", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Dialogue.WindowLive,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => user.id,
+            "service_config" => stub_service_config()
+          }
+        )
+
+      trigger = %Oli.Conversation.Trigger{
+        trigger_type: :page,
+        data: %{},
+        prompt: "Offer help with the current page."
+      }
+
+      send(view.pid, {:trigger, trigger})
+      %{engagement_id: engagement_id, watchdog_timer: first_watchdog} = socket_assigns(view)
+
+      send(view.pid, {:trigger, trigger})
+      send(view.pid, {:dialogue_server, engagement_id, {:tokens_received, "First response."}})
+      send(view.pid, {:dialogue_server, engagement_id, {:tokens_finished}})
+
+      %{
+        engagement_id: ^engagement_id,
+        trigger_queue: [],
+        watchdog_timer: second_watchdog
+      } = socket_assigns(view)
+
+      assert second_watchdog != first_watchdog
+    end
+
     test "ignores dialogue events from a stale engagement", %{
       conn: conn,
       user: user,

--- a/test/oli_web/live/dialogue/window_live_test.exs
+++ b/test/oli_web/live/dialogue/window_live_test.exs
@@ -11,7 +11,7 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
   alias Oli.Repo
   alias Oli.Resources.ResourceType
   alias Oli.Delivery.Sections
-  alias Oli.GenAI.Completions.ServiceConfig
+  alias Oli.GenAI.Completions.{RegisteredModel, ServiceConfig}
 
   defp create_project(_) do
     author = insert(:author)
@@ -446,6 +446,87 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
       assert assistant_message.llm_model == "gpt-4.1-mini"
       assert assistant_message.content =~ "assistant reply"
     end
+
+    test "ends streaming and shows a generic error when dialogue processing fails", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Dialogue.WindowLive,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => user.id,
+            "service_config" => stub_service_config()
+          }
+        )
+
+      render_submit(view, "update", %{"user_input" => %{"content" => "help"}})
+      send(view.pid, {:dialogue_server, {:error, :provider_failure}})
+
+      assert render(view) =~ "Hmmm, we encountered a problem"
+      assert socket_assigns(view).streaming == false
+      assert socket_assigns(view).allow_submission?
+      assert has_element?(view, "#ai_bot_input:not([disabled])")
+      assert has_element?(view, "#bot_submit_button:not([disabled])")
+    end
+
+    @tag capture_log: true
+    test "ends a stalled engagement when its watchdog expires", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Dialogue.WindowLive,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => user.id,
+            "service_config" => stub_service_config()
+          }
+        )
+
+      render_submit(view, "update", %{"user_input" => %{"content" => "help"}})
+      engagement_id = socket_assigns(view).engagement_id
+
+      send(view.pid, {:dialogue_timeout, engagement_id})
+
+      assert render(view) =~ "Hmmm, we encountered a problem"
+      assert socket_assigns(view).streaming == false
+      assert socket_assigns(view).allow_submission?
+    end
+
+    test "ignores dialogue events from a stale engagement", %{
+      conn: conn,
+      user: user,
+      section: section
+    } do
+      Sections.enroll(user.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      {:ok, view, _html} =
+        live_isolated(
+          conn,
+          OliWeb.Dialogue.WindowLive,
+          session: %{
+            "section_slug" => section.slug,
+            "current_user_id" => user.id,
+            "service_config" => stub_service_config()
+          }
+        )
+
+      send(view.pid, {:dialogue_server, make_ref(), {:error, :stale_provider_failure}})
+
+      refute render(view) =~ "Hmmm, we encountered a problem"
+      assert socket_assigns(view).messages == []
+    end
   end
 
   defp function_names(view) do
@@ -463,6 +544,10 @@ defmodule OliWeb.Dialogue.WindowLiveTest do
   end
 
   defp stub_service_config do
-    %ServiceConfig{id: 1, name: "test-service-config", primary_model: %{id: 1}}
+    %ServiceConfig{
+      id: 1,
+      name: "test-service-config",
+      primary_model: %RegisteredModel{id: 1, name: "null", provider: :null}
+    }
   end
 end


### PR DESCRIPTION
## Jira
https://eliterate.atlassian.net/browse/MER-5820

## Summary
Fixes DOT failure paths that could leave students on an infinite loading spinner.

- Reject invalid or undecryptable registered-model credentials before invoking a provider; OpenAI no longer falls back to the global API key.
- Monitor and cancel dialogue tasks, and translate task crashes, stream failures, invalid tool JSON, and tool failures into the existing generic DOT error.
- Add a request-scoped watchdog based on configured model timeouts.
- Correlate dialogue events with an engagement ID so late events from a timed-out request cannot affect the next response.
- Emit safe, actionable failure logs with model/service context and normalized categories (for example, `429 insufficient_quota`), without provider bodies, prompts, tool arguments, or credentials.

## Failure mode and fix
A bad encrypted credential previously reached provider execution (or silently used the global OpenAI key), while a stalled task could outlive the UI watchdog. The UI could then re-enable submission and receive stale stream events from the old task. This change fails invalid credentials explicitly, bounds the task lifecycle, and ignores stale events.

## Video
Video: DOT tested with an OpenAI API key that has no remaining credits. The request fails gracefully, the chat displays the generic error and correctly re-enables input for another message. At the same time, the server logs the failure safely and actionably as `429 insufficient_quota`, without exposing credentials or sensitive content.

https://github.com/user-attachments/assets/ef9e3140-585a-45f6-966d-5518d811535b

```
[warning] GenAI request failed service_config_id=1 registered_model_id=4 provider=open_ai request_type=stream http_status=429 error_category=insufficient_quota
```


## Validation
- `mix format`
- `mix compile`
- `yarn --cwd assets run format`
- `yarn --cwd assets run check-types`
- `yarn --cwd assets run deploy`
- `mix test test/oli/gen_ai/dialogue/server_test.exs test/oli/gen_ai/execution_test.exs test/oli/gen_ai/completions_test.exs test/oli/gen_ai/completions/open_ai_compliant_provider_test.exs test/oli/encrypted/binary_test.exs test/oli_web/live/dialogue/window_live_test.exs` (66 tests, 0 failures)