### PR TITLE
[BUG FIX] [MER-5837] Fix course page navigation bar icon alignment

### DIFF
--- a/lib/oli_web/components/delivery/layouts.ex
+++ b/lib/oli_web/components/delivery/layouts.ex
@@ -1310,16 +1310,16 @@ defmodule OliWeb.Components.Delivery.Layouts do
             class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-end items-center z-10"
             role="next_page"
           >
-            <div class="hidden sm:flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 w-0 flex-1 min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap">
-              {maybe_add_icon(@next_page, @pages_progress)}
-              <span
-                class="block w-0 min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap"
-                title={@next_page["title"]}
-              >
-                {@next_page["title"]}
-              </span>
-            </div>
-            <div class="px-2 lg:px-6 py-2 rounded justify-end items-center gap-2 flex">
+            <div class="px-2 lg:px-6 py-2 rounded flex items-center justify-end gap-6 min-w-0">
+              <div class="hidden sm:flex flex-row gap-x-1 justify-end items-center min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap">
+                {maybe_add_icon(@next_page, @pages_progress)}
+                <span
+                  class="block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
+                  title={@next_page["title"]}
+                >
+                  {@next_page["title"]}
+                </span>
+              </div>
               <.link
                 aria-label="next"
                 href={

--- a/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
+++ b/test/oli_web/components/delivery/layouts_previous_next_nav_test.exs
@@ -41,7 +41,13 @@ defmodule OliWeb.Components.Delivery.LayoutsPreviousNextNavTest do
                ~s(class="hidden lg:flex grow shrink basis-0 min-w-0 h-10 justify-end items-center z-10")
 
       assert html =~
-               ~s(class="hidden sm:flex flex-row gap-x-1 justify-end items-center grow shrink basis-0 w-0 flex-1 min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap")
+               ~s(class="px-2 lg:px-6 py-2 rounded flex items-center justify-end gap-6 min-w-0")
+
+      assert html =~
+               ~s(class="hidden sm:flex flex-row gap-x-1 justify-end items-center min-w-0 text-right dark:text-white text-xs font-normal overflow-hidden whitespace-nowrap")
+
+      assert html =~
+               ~s(class="block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap")
     end
   end
 end


### PR DESCRIPTION
[MER-5837](https://eliterate.atlassian.net/browse/MER-5837)

### Summary

Fixes the visual separation between the next page label and its navigation button in the course page bottom navigation bar.

### Changes

- Groups the next page label and navigation button within the same flex container.
- Adjusts spacing between the label and button to visually match the previous-page side.
- Updates the existing component test to reflect the new layout while preserving truncation coverage.

### Tests

- mix test test/oli_web/components/delivery/layouts_previous_next_nav_test.exs

### Risks / notes

- Change is limited to markup/classes in the bottom navigation component.
- Does not modify routing, navigation logic, or progress state.

### Visual Validation

- Check a course page with both previous and next navigation visible and confirm the next page label sits next to its button with spacing consistent with the previous side.

<img width="977" height="87" alt="Captura de pantalla 2026-08-10 a la(s) 2 34 50 p  m" src="https://github.com/user-attachments/assets/3ecde997-8d6b-4799-9344-f78ea12c33db" />
<img width="938" height="101" alt="Captura de pantalla 2026-08-10 a la(s) 2 34 35 p  m" src="https://github.com/user-attachments/assets/ed4d5d8f-99e8-4293-8fe5-d0546d557aa9" />
<img width="946" height="99" alt="Captura de pantalla 2026-08-10 a la(s) 2 34 09 p  m" src="https://github.com/user-attachments/assets/a45352b7-98a4-4d63-8a80-8c407da8aed8" />


[MER-5837]: https://eliterate.atlassian.net/browse/MER-5837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ