### PR TITLE
[FEATURE] [MER-5859] Student onboarding text customization

### DIFF
--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -7,6 +7,10 @@ defmodule Oli.Authoring.Course.Project do
   alias Oli.LearningModel.ModelVersion
   alias Oli.Utils.Slug
 
+  import Oli.Utils, only: [validate_word_count: 3]
+
+  @description_word_limit 300
+
   @derive {Phoenix.Param, key: :slug}
   schema "projects" do
     field(:description, :string)
@@ -106,6 +110,7 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
+    |> validate_word_count(:description, @description_word_limit)
     |> Slug.update_never("projects")
   end
 
@@ -131,6 +136,7 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
+    |> validate_word_count(:description, @description_word_limit)
     |> Slug.update_never("projects")
   end
 

--- a/lib/oli/delivery.ex
+++ b/lib/oli/delivery.ex
@@ -81,6 +81,7 @@ defmodule Oli.Delivery do
             has_experiments: has_experiments,
             analytics_version: :v2,
             learning_model_version: project.learning_model_version,
+            description: project.description,
             welcome_title: project.welcome_title,
             encouraging_subtitle: project.encouraging_subtitle,
             certificate: nil

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -19,6 +19,8 @@ defmodule Oli.Delivery.Sections.Section do
     Section
   }
 
+  @description_word_limit 300
+
   @required_fields [
     :type,
     :title,
@@ -256,6 +258,7 @@ defmodule Oli.Delivery.Sections.Section do
     |> check_constraint(:learning_model_version, name: :sections_learning_model_version_check)
     |> Slug.update_never("sections")
     |> validate_length(:title, max: 255)
+    |> validate_word_count(:description, @description_word_limit)
     |> cast_assoc(:certificate)
   end
 

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -194,6 +194,33 @@ defmodule Oli.Utils do
     end
   end
 
+  @doc """
+  Validates that a string field contains no more than the given number of words.
+
+  Words are separated by one or more whitespace characters. Blank values contain zero words.
+  """
+  @spec validate_word_count(Ecto.Changeset.t(), atom(), non_neg_integer()) ::
+          Ecto.Changeset.t()
+  def validate_word_count(changeset, field, max_words) do
+    validate_change(changeset, field, fn ^field, value ->
+      word_count =
+        case value do
+          value when is_binary(value) ->
+            value
+            |> String.split(~r/\s+/, trim: true)
+            |> length()
+
+          _ ->
+            0
+        end
+
+      case word_count > max_words do
+        true -> [{field, "must be #{max_words} words or fewer"}]
+        false -> []
+      end
+    end)
+  end
+
   def validate_number_if(
         changeset,
         field,

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -8,6 +8,58 @@ defmodule OliWeb.Components.Delivery.Student do
   alias OliWeb.Delivery.Student.Utils
   alias OliWeb.Icons
 
+  attr(:title, :map, default: nil)
+  attr(:fallback, :string, default: nil)
+
+  @doc """
+  Renders a rich-text welcome title as inline content, or the given fallback when it is empty.
+  """
+  def welcome_title(assigns) do
+    assigns = assign(assigns, :content, render_welcome_title(assigns.title))
+
+    ~H"""
+    {@content || @fallback}
+    """
+  end
+
+  defp render_welcome_title(welcome_title) when is_map(welcome_title) do
+    children = Map.get(welcome_title, "children") || Map.get(welcome_title, :children) || []
+
+    # Persisted titles retain paragraph wrappers; unwrap them before placing the content in a heading.
+    inline_children =
+      children
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {block, index} ->
+        case block do
+          block when is_map(block) ->
+            case Map.get(block, "children") || Map.get(block, :children) do
+              children when is_list(children) and index == 0 -> children
+              children when is_list(children) -> [%{"text" => " "} | children]
+              _ -> []
+            end
+
+          _ ->
+            []
+        end
+      end)
+
+    case inline_children do
+      [] ->
+        nil
+
+      inline_children ->
+        Phoenix.HTML.raw(
+          Oli.Rendering.Content.render(
+            %Oli.Rendering.Context{},
+            inline_children,
+            Oli.Rendering.Content.Html
+          )
+        )
+    end
+  end
+
+  defp render_welcome_title(_welcome_title), do: nil
+
   attr(:raw_avg_score, :map)
 
   def score_summary(assigns) do

--- a/lib/oli_web/live/common/stepper/stepper.ex
+++ b/lib/oli_web/live/common/stepper/stepper.ex
@@ -126,7 +126,10 @@ defmodule OliWeb.Common.Stepper do
         <h4 class="font-bold text-md md:text-[20px] tracking-[0.02px] md:leading-5 mb-[9px]">
           {@step.title}
         </h4>
-        <p class="font-normal text-sm md:text-[16px] tracking-[0.02px] md:leading-[24px]">
+        <p
+          :if={@step.description not in [nil, ""]}
+          class="font-normal text-sm md:text-[16px] tracking-[0.02px] md:leading-[24px]"
+        >
           {@step.description}
         </p>
       </div>

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -593,7 +593,10 @@ defmodule OliWeb.Delivery.Student.IndexLive do
         </div>
         <div class="flex flex-col items-start gap-2.5">
           <h2 class="text-3xl text-white font-medium">
-            {build_welcome_title(@section.welcome_title)}
+            <Student.welcome_title
+              title={@section.welcome_title}
+              fallback="Welcome to the Course"
+            />
           </h2>
           <div class="text-white/60 text-lg font-semibold">
             {@section.encouraging_subtitle ||
@@ -1572,19 +1575,6 @@ defmodule OliWeb.Delivery.Student.IndexLive do
   end
 
   defp maybe_put_return_to(params, _preview_mode, _preview_return), do: params
-
-  defp build_welcome_title(welcome_title)
-       when welcome_title not in [nil, %{}],
-       do:
-         Phoenix.HTML.raw(
-           Oli.Rendering.Content.render(
-             %Oli.Rendering.Context{},
-             welcome_title["children"],
-             Oli.Rendering.Content.Html
-           )
-         )
-
-  defp build_welcome_title(_), do: "Welcome to the Course"
 
   defp max_attempts(0), do: "∞"
   defp max_attempts(max_attempts), do: max_attempts

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -2,12 +2,13 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
   use Phoenix.Component
 
   import OliWeb.Common.SourceImage
-
-  import OliWeb.Delivery.StudentOnboarding.Wizard,
-    only: [has_required_survey: 1, has_explorations: 1]
+  alias OliWeb.Components.Delivery.Student
 
   attr :section, :map, required: true
 
+  @doc """
+  Renders the section-defined onboarding welcome message or the default course welcome title.
+  """
   def render(assigns) do
     ~H"""
     <img
@@ -15,26 +16,38 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
       src={cover_image(@section)}
     />
     <div class="flex flex-col gap-3 px-[50px] hvsm:px-[70px] hvxl:px-[84px] py-9 dark:text-white">
-      <h2 class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]">
-        Welcome to {@section.title}!
-      </h2>
-      <div class="text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80">
-        <p class="font-bold mb-0">Here's what to expect:</p>
-        <ul class="font-normal list-disc ml-6">
-          <%= if has_required_survey(@section) do %>
-            <li>
-              A short survey to help shape your learning experience and let your instructor get to know you
-            </li>
-          <% end %>
-          <%= if has_explorations(@section) do %>
-            <li>
-              Learning about the new ‘Exploration’ activities that provide real-world examples
-            </li>
-          <% end %>
-          <li>A personalized {@section.title} experience based on your skillsets</li>
-        </ul>
-      </div>
+      <%= if custom_message?(@section.description) do %>
+        <h2
+          id="onboarding-welcome-title"
+          class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
+        >
+          <Student.welcome_title title={@section.welcome_title} />
+        </h2>
+        <p
+          :if={custom_message?(@section.encouraging_subtitle)}
+          id="onboarding-welcome-subtitle"
+          class="font-semibold text-[16px] leading-6 tracking-[0.02px] dark:text-opacity-80"
+        >
+          {@section.encouraging_subtitle}
+        </p>
+        <p
+          id="onboarding-welcome-description"
+          class="whitespace-pre-line text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
+        >
+          {@section.description}
+        </p>
+      <% else %>
+        <h2
+          id="onboarding-welcome-title"
+          class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
+        >
+          Welcome to {@section.title}
+        </h2>
+      <% end %>
     </div>
     """
   end
+
+  defp custom_message?(value) when is_binary(value), do: String.trim(value) != ""
+  defp custom_message?(_value), do: false
 end

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
   alias OliWeb.Components.Delivery.Student
 
   attr :section, :map, required: true
+  attr :id_prefix, :string, default: "onboarding"
 
   @doc """
   Renders the section-defined onboarding welcome message or the default course welcome title.
@@ -18,27 +19,27 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
     <div class="flex flex-col gap-3 px-[50px] hvsm:px-[70px] hvxl:px-[84px] py-9 dark:text-white">
       <%= if custom_message?(@section.description) do %>
         <h2
-          id="onboarding-welcome-title"
+          id={"#{@id_prefix}-welcome-title"}
           class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
         >
           <Student.welcome_title title={@section.welcome_title} />
         </h2>
         <p
           :if={custom_message?(@section.encouraging_subtitle)}
-          id="onboarding-welcome-subtitle"
+          id={"#{@id_prefix}-welcome-subtitle"}
           class="font-semibold text-[16px] leading-6 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.encouraging_subtitle}
         </p>
         <p
-          id="onboarding-welcome-description"
+          id={"#{@id_prefix}-welcome-description"}
           class="whitespace-pre-line text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.description}
         </p>
       <% else %>
         <h2
-          id="onboarding-welcome-title"
+          id={"#{@id_prefix}-welcome-title"}
           class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
         >
           Welcome to {@section.title}

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -27,8 +27,6 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
     introduction_step = %Step{
       title: "Introduction",
-      description:
-        "Welcome to #{section.title}! Here's what you can expect during this set up process.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label:

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -27,6 +27,8 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
     introduction_step = %Step{
       title: "Introduction",
+      description:
+        "Welcome to #{section.title}! Here's what you can expect during this set up process.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label:

--- a/lib/oli_web/live/products/image_preview.ex
+++ b/lib/oli_web/live/products/image_preview.ex
@@ -187,7 +187,7 @@ defmodule OliWeb.Products.ImagePreview do
   attr :section, :map, required: true
   attr :ctx, :map, required: true
   attr :context, :atom, required: true
-  attr :id_prefix, :string, required: true
+  attr :id_prefix, :string, default: "image-preview"
   attr :course_picker_model, :any, default: nil
 
   def preview_content(%{context: :my_course} = assigns) do
@@ -392,6 +392,8 @@ defmodule OliWeb.Products.ImagePreview do
   end
 
   def preview_content(%{context: :student_welcome} = assigns) do
+    assigns = assign_new(assigns, :id_prefix, fn -> "image-preview" end)
+
     ~H"""
     <div
       class="relative h-[628px] w-[1200px] overflow-hidden text-gray-900 dark:text-white"

--- a/lib/oli_web/live/products/image_preview.ex
+++ b/lib/oli_web/live/products/image_preview.ex
@@ -85,6 +85,7 @@ defmodule OliWeb.Products.ImagePreview do
                     section={@preview_section}
                     ctx={@ctx}
                     context={context.id}
+                    id_prefix={"image-preview-thumbnail-#{context_id(context.id)}"}
                     course_picker_model={@course_picker_model}
                   />
                 </div>
@@ -134,6 +135,7 @@ defmodule OliWeb.Products.ImagePreview do
                 section={@preview_section}
                 ctx={@ctx}
                 context={@selected_context}
+                id_prefix="image-preview-modal"
                 course_picker_model={@course_picker_model}
               />
             </div>
@@ -185,6 +187,7 @@ defmodule OliWeb.Products.ImagePreview do
   attr :section, :map, required: true
   attr :ctx, :map, required: true
   attr :context, :atom, required: true
+  attr :id_prefix, :string, required: true
   attr :course_picker_model, :any, default: nil
 
   def preview_content(%{context: :my_course} = assigns) do
@@ -421,7 +424,10 @@ defmodule OliWeb.Products.ImagePreview do
             </div>
             <div class="flex flex-col overflow-hidden bg-white shadow-xl dark:bg-[#0B0C11] dark:shadow-none">
               <div class="flex-1 overflow-hidden [&_img]:!block [&_img]:!h-[150px] [&_img]:!w-full">
-                <Intro.render section={student_welcome_section(@section)} />
+                <Intro.render
+                  section={student_welcome_section(@section)}
+                  id_prefix={@id_prefix}
+                />
               </div>
               <div class="flex items-center justify-end bg-gray-100/50 p-3 dark:bg-black/40">
                 <button class="torus-button primary !py-[10px] !px-5 !rounded-[3px] !text-sm flex items-center justify-center">

--- a/test/oli/delivery/sections/section_test.exs
+++ b/test/oli/delivery/sections/section_test.exs
@@ -89,6 +89,15 @@ defmodule Oli.Delivery.Sections.SectionTest do
       assert changeset.errors[:title] |> elem(0) =~ ~r/should be at most .* character/
     end
 
+    test "validates the description word limit" do
+      section = build(:section, @valid_section_attrs)
+      description = Enum.join(List.duplicate("word", 301), " ")
+
+      changeset = Section.changeset(section, %{description: description})
+
+      assert changeset.errors[:description] == {"must be 300 words or fewer", []}
+    end
+
     test "default assistant_enabled is false" do
       changeset =
         build(:section, @valid_section_attrs)

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -304,6 +304,43 @@ defmodule Oli.DeliveryTest do
       assert Sections.get_section!(section_id).learning_model_version == :lkt_aoa
     end
 
+    test "copies the Project onboarding fields to a new Section", context do
+      welcome_title = %{
+        "type" => "p",
+        "children" => [
+          %{
+            "id" => "project-welcome-title",
+            "type" => "p",
+            "children" => [%{"text" => "Welcome from the project"}]
+          }
+        ]
+      }
+
+      project =
+        context.project
+        |> Project.changeset(%{
+          description: "Project description",
+          welcome_title: welcome_title,
+          encouraging_subtitle: "Project subtitle"
+        })
+        |> Repo.update!()
+
+      user = insert(:user, independent_learner: true)
+
+      assert {:ok, section_id, _slug} =
+               Delivery.create_section(
+                 Sections.change_section(%Section{title: "Project onboarding Section"}),
+                 "project:#{project.id}",
+                 user,
+                 SectionSpecification.direct()
+               )
+
+      section = Sections.get_section!(section_id)
+      assert section.description == "Project description"
+      assert section.welcome_title == welcome_title
+      assert section.encouraging_subtitle == "Project subtitle"
+    end
+
     test "copies the blueprint model even when it differs from its base Project", context do
       product = set_section_learning_model(context.product, :lkt_aoa)
       assert context.project.learning_model_version == :naive

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -60,34 +60,87 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
   describe "Student Onboarding Wizard - Introduction" do
     setup [:user_conn]
 
-    test "the introduction step gets rendered", %{conn: conn, user: student} do
-      %{section: section} = basic_section(nil, %{title: "Chemistry 201"})
+    test "renders the default welcome message when the section description is empty", %{
+      conn: conn,
+      user: student
+    } do
+      %{section: section} =
+        basic_section(nil, %{
+          title: "Chemistry 201",
+          description: nil,
+          welcome_title: %{
+            "type" => "p",
+            "children" => [
+              %{
+                "id" => "unused-custom-title",
+                "type" => "p",
+                "children" => [%{"text" => "This custom title is not displayed"}]
+              }
+            ]
+          },
+          encouraging_subtitle: "This custom subtitle is not displayed"
+        })
+
       enroll_student(student, section)
 
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
-      assert has_element?(view, "h2", "Welcome to Chemistry 201!")
-
-      assert has_element?(
-               view,
-               "li",
-               "A personalized Chemistry 201 experience based on your skillsets"
-             )
-
-      refute has_element?(
-               view,
-               "li",
-               "A short survey to help shape your learning experience and let your instructor get to know yous"
-             )
-
-      refute has_element?(
-               view,
-               "li",
-               "Explorations will bring the course to life, showing its relevance in the real world"
-             )
+      assert has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
+      refute render(view) =~ "This custom title is not displayed"
+      refute has_element?(view, "#onboarding-welcome-subtitle")
+      refute has_element?(view, "#onboarding-welcome-description")
+      refute render(view) =~ "Here's what you can expect during this set up process."
 
       assert has_element?(view, "button", "Go to course")
       assert has_element?(view, "button", "Cancel")
+    end
+
+    test "renders the section welcome fields when the description has content", %{
+      conn: conn,
+      user: student
+    } do
+      welcome_title = %{
+        "type" => "p",
+        "children" => [
+          %{
+            "id" => "custom-welcome-title",
+            "type" => "p",
+            "children" => [
+              %{"text" => "Welcome to "},
+              %{"text" => "Organic Chemistry", "strong" => true}
+            ]
+          }
+        ]
+      }
+
+      section =
+        insert(:section,
+          title: "Chemistry 201",
+          description: "Build a strong foundation for the experiments ahead.",
+          welcome_title: welcome_title,
+          encouraging_subtitle: "Discover how molecules shape our world."
+        )
+
+      enroll_student(student, section)
+
+      {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
+
+      assert has_element?(view, "#onboarding-welcome-title", "Welcome to Organic Chemistry")
+      assert has_element?(view, "#onboarding-welcome-title strong", "Organic Chemistry")
+
+      assert has_element?(
+               view,
+               "#onboarding-welcome-subtitle",
+               "Discover how molecules shape our world."
+             )
+
+      assert has_element?(
+               view,
+               "#onboarding-welcome-description",
+               "Build a strong foundation for the experiments ahead."
+             )
+
+      refute has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
     end
 
     test "renders the section cover image when present", %{conn: conn, user: student} do
@@ -126,16 +179,10 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       conn: conn,
       user: student
     } do
-      section = insert(:section, %{contains_explorations: true})
+      section = insert(:section, %{contains_explorations: true, description: nil})
       enroll_student(student, section)
 
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
-
-      assert has_element?(
-               view,
-               "li",
-               "Learning about the new ‘Exploration’ activities that provide real-world examples"
-             )
 
       assert has_element?(view, "button", "Let's Begin")
     end
@@ -148,12 +195,6 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       enroll_student(student, section)
 
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
-
-      assert has_element?(
-               view,
-               "li",
-               "A short survey to help shape your learning experience and let your instructor get to know you"
-             )
 
       assert has_element?(view, "button", "Start Survey")
     end

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -89,7 +89,12 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       refute render(view) =~ "This custom title is not displayed"
       refute has_element?(view, "#onboarding-welcome-subtitle")
       refute has_element?(view, "#onboarding-welcome-description")
-      refute render(view) =~ "Here's what you can expect during this set up process."
+
+      assert has_element?(
+               view,
+               "p",
+               "Welcome to Chemistry 201! Here's what you can expect during this set up process."
+             )
 
       assert has_element?(view, "button", "Go to course")
       assert has_element?(view, "button", "Cancel")

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -223,6 +223,20 @@ defmodule OliWeb.Sections.EditLiveTest do
       refute html =~ "/authoring/products/#{section.slug}/discounts"
     end
 
+    test "section description cannot exceed 300 words", %{conn: conn, section: section} do
+      description = Enum.join(List.duplicate("word", 301), " ")
+
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+
+      html =
+        view
+        |> element("#section-edit-form")
+        |> render_submit(section: %{description: description})
+
+      assert html =~ "must be 300 words or fewer"
+      assert Oli.Repo.get(Section, section.id).description == section.description
+    end
+
     test "loads open and free section data correctly", %{conn: conn} do
       welcome_title = %{
         type: "p",

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -122,6 +122,20 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       |> hd() =~ "Welcome Title"
     end
 
+    test "project description cannot exceed 300 words", %{conn: conn, author: author} do
+      project = create_project_with_author(author)
+      description = Enum.join(List.duplicate("word", 301), " ")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      element(view, "form[phx-submit='update']")
+      |> render_submit(%{"project" => %{"description" => description}})
+
+      assert has_element?(view, "div.alert-danger", "Project could not be updated.")
+      assert render(view) =~ "must be 300 words or fewer"
+      assert Course.get_project_by_slug(project.slug).description == project.description
+    end
+
     test "publisher dropdown displays publishers sorted alphabetically", %{
       conn: conn,
       author: author


### PR DESCRIPTION
Customize the student onboarding welcome experience using each section’s `welcome title`, `encouraging subtitle`, and `description`.
These values are copied from the source project or template when a section is created, then remain editable.
The existing Introduction guidance remains visible, while the main welcome card displays the section-specific content and falls back to the default course welcome when no description is provided.
Project and section descriptions are limited to 300 words.

Welcome screen:
<p align="middle" >
  <img src="https://github.com/user-attachments/assets/102bc90a-33e8-43b6-b96e-0689c4b46fb3" width="300" />
  <img src="https://github.com/user-attachments/assets/75f509f5-70d4-48e1-b4a0-a79a0e39578d" width="300" /> 
</p>


See: https://eliterate.atlassian.net/browse/MER-5859