### PR TITLE
[ENHANCEMENT] [MER-5670] Queue automation project teardown with Oban

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ update this file accordingly.
 | GOOGLE_DOCS_IMPORT_FILE_ID    | No       | Google Docs file ID used by Google Docs import Playwright automation            |
 | DUMMY_LTI_TOOL_ADMIN_PASSWORD | No       | Admin password used to register Torus with the dummy LTI tool                   |
 | DUMMY_LTI_TOOL_BASE_URL       | No       | Dummy LTI tool base URL used by LTI external tool Playwright automation         |
+| OBAN_QUEUE_SIZE_AUTOMATION_TEARDOWN | No | Automation project teardown queue concurrency (Default: 1)                     |
 
 - `CANVAS_*` environment variables configure the Canvas-to-Torus grade passback Playwright
   smoke test. They are not required by the Torus application runtime. The student credentials

--- a/config/config.exs
+++ b/config/config.exs
@@ -269,7 +269,8 @@ config :oli, Oban,
     mailer: 10,
     certificate_pdf: 3,
     certificate_mailer: 3,
-    certificate_eligibility: 10
+    certificate_eligibility: 10,
+    automation_teardown: 1
   ]
 
 config :ex_money,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -741,7 +741,9 @@ if runtime_env == :prod do
       objectives: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_OBJECTIVES", "3")),
       mailer: String.to_integer(System.get_env("OBAN_QUEUE_SIZE_MAILER", "10")),
       certificate_eligibility:
-        String.to_integer(System.get_env("OBAN_QUEUE_SIZE_CERTIFICATE_ELIGIBILITY", "10"))
+        String.to_integer(System.get_env("OBAN_QUEUE_SIZE_CERTIFICATE_ELIGIBILITY", "10")),
+      automation_teardown:
+        String.to_integer(System.get_env("OBAN_QUEUE_SIZE_AUTOMATION_TEARDOWN", "1"))
     ]
 
   config :oli, Oli.Vault,

--- a/lib/oli/automation_setup.ex
+++ b/lib/oli/automation_setup.ex
@@ -5,17 +5,18 @@ defmodule Oli.AutomationSetup do
   """
   alias Lti_1p3.Roles.ContextRoles
 
-  alias Oli.Repo
   alias Oli.Accounts.User
   alias Oli.Analytics.Summary.ResourcePartResponse
   alias Oli.Analytics.Summary.ResourceSummary
   alias Oli.Analytics.Summary.ResponseSummary
   alias Oli.Analytics.Summary.StudentResponse
+  alias Oli.AutomationSetup.ProjectTeardownWorker
   alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Course.ProjectResource
   alias Oli.Authoring.MediaLibrary.MediaItem
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionsProjectsPublications
+  alias Oli.Repo
   alias Oli.Resources.Resource
 
   alias Ecto.Multi
@@ -74,6 +75,37 @@ defmodule Oli.AutomationSetup do
     end
   end
 
+  @doc """
+  Validates an automation project and queues its full teardown.
+  """
+  @spec enqueue_project_teardown(String.t()) ::
+          %{success: true, queued: true, job_id: pos_integer()}
+          | %{success: false, message: String.t()}
+  def enqueue_project_teardown(slug) do
+    with {:ok, project} <-
+           Repo.one(from p in Project, where: p.slug == ^slug, preload: [:authors])
+           |> validate_project_for_teardown(),
+         {:ok, job} <-
+           %{project_slug: project.slug}
+           |> ProjectTeardownWorker.new()
+           |> Oban.insert() do
+      %{success: true, queued: true, job_id: job.id}
+    else
+      {:error, %Ecto.Changeset{} = changeset} ->
+        Logger.error(
+          "Could not enqueue automation project teardown: #{inspect(changeset.errors)}"
+        )
+
+        %{success: false, message: "Could not queue project teardown"}
+
+      {:error, message} ->
+        %{success: false, message: message}
+
+      _ ->
+        %{success: false, message: "Unknown Reason"}
+    end
+  end
+
   # Tears down a test project, including publications, project-resource
   # associations, revisions, analytics rollups with non-cascading resource
   # references, resources, and imported media.
@@ -93,12 +125,7 @@ defmodule Oli.AutomationSetup do
                  :publications
                ]
            )
-           |> has_project(),
-         # Only tear down projects where duplicates are not allowed
-         {:ok} <- no_duplicates(project),
-         # Only tear down projects with no authors
-         {:ok} <-
-           has_no_authors(project.authors) do
+           |> validate_project_for_teardown() do
       resource_ids = for r <- project.resources, do: r.id
       publication_ids = for p <- project.publications, do: p.id
 
@@ -374,6 +401,14 @@ defmodule Oli.AutomationSetup do
 
   defp has_project(project) do
     {:ok, project}
+  end
+
+  defp validate_project_for_teardown(project) do
+    with {:ok, project} <- has_project(project),
+         {:ok} <- no_duplicates(project),
+         {:ok} <- has_no_authors(project.authors) do
+      {:ok, project}
+    end
   end
 
   defp has_no_authors([]) do

--- a/lib/oli/automation_setup/project_teardown_worker.ex
+++ b/lib/oli/automation_setup/project_teardown_worker.ex
@@ -20,6 +20,11 @@ defmodule Oli.AutomationSetup.ProjectTeardownWorker do
 
   alias Oli.AutomationSetup
 
+  @non_retryable_messages [
+    "Can only delete projects with no authors",
+    "Project allows duplicates"
+  ]
+
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"project_slug" => project_slug}}) do
     started_at = System.monotonic_time(:millisecond)
@@ -37,6 +42,14 @@ defmodule Oli.AutomationSetup.ProjectTeardownWorker do
       %{success: false, message: "Project not found"} ->
         Logger.info("automation_project_teardown already_completed project=#{project_slug}")
         :ok
+
+      %{success: false, message: message} when message in @non_retryable_messages ->
+        Logger.error(
+          "automation_project_teardown cancelled project=#{project_slug} " <>
+            "duration_ms=#{System.monotonic_time(:millisecond) - started_at} message=#{message}"
+        )
+
+        {:cancel, message}
 
       %{success: false} = result ->
         message = Map.get(result, :message, "Could not delete project")

--- a/lib/oli/automation_setup/project_teardown_worker.ex
+++ b/lib/oli/automation_setup/project_teardown_worker.ex
@@ -1,0 +1,52 @@
+defmodule Oli.AutomationSetup.ProjectTeardownWorker do
+  @moduledoc """
+  Performs complete automation-project cleanup outside the teardown request.
+
+  Jobs run on a single-concurrency queue because deleting a full course can be
+  database-intensive.
+  """
+
+  use Oban.Worker,
+    queue: :automation_teardown,
+    max_attempts: 3,
+    unique: [
+      fields: [:args, :worker],
+      keys: [:project_slug],
+      period: :infinity,
+      states: [:available, :scheduled, :executing, :retryable]
+    ]
+
+  require Logger
+
+  alias Oli.AutomationSetup
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"project_slug" => project_slug}}) do
+    started_at = System.monotonic_time(:millisecond)
+    Logger.info("automation_project_teardown started project=#{project_slug}")
+
+    case AutomationSetup.teardown_project(project_slug) do
+      %{success: true} ->
+        Logger.info(
+          "automation_project_teardown completed project=#{project_slug} " <>
+            "duration_ms=#{System.monotonic_time(:millisecond) - started_at}"
+        )
+
+        :ok
+
+      %{success: false, message: "Project not found"} ->
+        Logger.info("automation_project_teardown already_completed project=#{project_slug}")
+        :ok
+
+      %{success: false} = result ->
+        message = Map.get(result, :message, "Could not delete project")
+
+        Logger.error(
+          "automation_project_teardown failed project=#{project_slug} " <>
+            "duration_ms=#{System.monotonic_time(:millisecond) - started_at} message=#{message}"
+        )
+
+        {:error, message}
+    end
+  end
+end

--- a/lib/oli_web/controllers/api/automation_setup_controller.ex
+++ b/lib/oli_web/controllers/api/automation_setup_controller.ex
@@ -2,9 +2,11 @@ defmodule OliWeb.Api.AutomationSetupController do
   use OliWeb, :controller
   use OpenApiSpex.Controller
   import OliWeb.Api.Helpers
+  require Logger
   alias Oli.AutomationSetup
 
   @moduledoc tags: ["Automated Test Data Setup Service"]
+  @automation_idle_timeout_ms 300_000
 
   alias OpenApiSpex.Schema
 
@@ -100,21 +102,39 @@ defmodule OliWeb.Api.AutomationSetupController do
   defmodule AutomationTeardownResponse do
     require OpenApiSpex
 
+    success_response = %Schema{
+      type: :object,
+      properties: %{
+        success: %Schema{type: :boolean, enum: [true]}
+      },
+      required: [:success]
+    }
+
+    error_response = %Schema{
+      type: :object,
+      properties: %{
+        success: %Schema{type: :boolean, enum: [false]},
+        message: %Schema{type: :string}
+      },
+      required: [:success, :message]
+    }
+
     teardown_response = %Schema{
+      oneOf: [success_response, error_response]
+    }
+
+    project_teardown_response = %Schema{
       oneOf: [
         %Schema{
           type: :object,
           properties: %{
-            success: true
-          }
+            success: %Schema{type: :boolean, enum: [true]},
+            queued: %Schema{type: :boolean, description: "Whether teardown was queued"},
+            job_id: %Schema{type: :integer, description: "Queued Oban job ID"}
+          },
+          required: [:success, :queued, :job_id]
         },
-        %Schema{
-          type: :object,
-          properties: %{
-            success: false,
-            message: %Schema{type: :string}
-          }
-        }
+        error_response
       ]
     }
 
@@ -126,7 +146,7 @@ defmodule OliWeb.Api.AutomationSetupController do
         educator_deleted: teardown_response,
         learner_deleted: teardown_response,
         section_deleted: teardown_response,
-        project_deleted: teardown_response
+        project_deleted: project_teardown_response
       },
       example: %{
         author_deleted: %{
@@ -139,7 +159,9 @@ defmodule OliWeb.Api.AutomationSetupController do
           success: true
         },
         project_deleted: %{
-          success: true
+          success: true,
+          queued: true,
+          job_id: 12_345
         },
         section_deleted: %{
           success: true
@@ -212,6 +234,8 @@ defmodule OliWeb.Api.AutomationSetupController do
         "create_educator" => create_educator,
         "project_archive" => project_archive
       }) do
+    conn = extend_automation_idle_timeout(conn)
+
     case setup_data(
            project_archive,
            create_learner,
@@ -258,12 +282,38 @@ defmodule OliWeb.Api.AutomationSetupController do
         "section_slug" => section_slug,
         "project_slug" => project_slug
       }) do
+    teardown_started_at = System.monotonic_time(:millisecond)
+
+    Logger.info("automation_teardown started project=#{project_slug} section=#{section_slug}")
+
     # The order these happen in matters
-    author_deleted = AutomationSetup.teardown_author(author_email, author_password)
-    educator_deleted = AutomationSetup.teardown_educator(educator_email, educator_password)
-    learner_deleted = AutomationSetup.teardown_learner(learner_email, learner_password)
-    section_deleted = AutomationSetup.teardown_section(section_slug)
-    project_deleted = AutomationSetup.teardown_project(project_slug)
+    author_deleted =
+      timed_teardown_step(:author, fn ->
+        AutomationSetup.teardown_author(author_email, author_password)
+      end)
+
+    educator_deleted =
+      timed_teardown_step(:educator, fn ->
+        AutomationSetup.teardown_educator(educator_email, educator_password)
+      end)
+
+    learner_deleted =
+      timed_teardown_step(:learner, fn ->
+        AutomationSetup.teardown_learner(learner_email, learner_password)
+      end)
+
+    section_deleted =
+      timed_teardown_step(:section, fn -> AutomationSetup.teardown_section(section_slug) end)
+
+    project_deleted =
+      timed_teardown_step(:project_enqueue, fn ->
+        AutomationSetup.enqueue_project_teardown(project_slug)
+      end)
+
+    Logger.info(
+      "automation_teardown completed project=#{project_slug} section=#{section_slug} " <>
+        "duration_ms=#{System.monotonic_time(:millisecond) - teardown_started_at}"
+    )
 
     json(conn, %{
       author_deleted: author_deleted,
@@ -272,6 +322,46 @@ defmodule OliWeb.Api.AutomationSetupController do
       section_deleted: section_deleted,
       project_deleted: project_deleted
     })
+  end
+
+  # Importing a full course can take longer than Cowboy's default HTTP/1 idle
+  # timeout. Scope the extension to automation setup requests.
+  defp extend_automation_idle_timeout(
+         %Plug.Conn{adapter: {Plug.Cowboy.Conn, cowboy_request}} = conn
+       ) do
+    :cowboy_req.cast(
+      {:set_options, %{idle_timeout: @automation_idle_timeout_ms}},
+      cowboy_request
+    )
+
+    conn
+  end
+
+  defp extend_automation_idle_timeout(conn), do: conn
+
+  defp timed_teardown_step(step, teardown_fn) do
+    started_at = System.monotonic_time(:millisecond)
+    Logger.info("automation_teardown step_started step=#{step}")
+
+    try do
+      result = teardown_fn.()
+
+      Logger.info(
+        "automation_teardown step_completed step=#{step} success=#{Map.get(result, :success)} " <>
+          "duration_ms=#{System.monotonic_time(:millisecond) - started_at}"
+      )
+
+      result
+    rescue
+      error ->
+        Logger.error(
+          "automation_teardown step_failed step=#{step} " <>
+            "duration_ms=#{System.monotonic_time(:millisecond) - started_at} " <>
+            "error=#{Exception.message(error)}"
+        )
+
+        reraise error, __STACKTRACE__
+    end
   end
 
   defp format_project(project) do

--- a/test/oli/automation_setup/project_teardown_worker_test.exs
+++ b/test/oli/automation_setup/project_teardown_worker_test.exs
@@ -2,6 +2,8 @@ defmodule Oli.AutomationSetup.ProjectTeardownWorkerTest do
   use Oli.DataCase
   use Oban.Testing, repo: Oli.Repo
 
+  import Oli.Factory
+
   @moduletag capture_log: true
 
   alias Oli.AutomationSetup.ProjectTeardownWorker
@@ -10,6 +12,24 @@ defmodule Oli.AutomationSetup.ProjectTeardownWorkerTest do
     assert :ok =
              perform_job(ProjectTeardownWorker, %{
                "project_slug" => "missing-automation-project"
+             })
+  end
+
+  test "cancels teardown when the project still has authors" do
+    project = insert(:project, allow_duplication: false)
+
+    assert {:cancel, "Can only delete projects with no authors"} =
+             perform_job(ProjectTeardownWorker, %{
+               "project_slug" => project.slug
+             })
+  end
+
+  test "cancels teardown when the project allows duplicates" do
+    project = insert(:project, authors: [], allow_duplication: true)
+
+    assert {:cancel, "Project allows duplicates"} =
+             perform_job(ProjectTeardownWorker, %{
+               "project_slug" => project.slug
              })
   end
 end

--- a/test/oli/automation_setup/project_teardown_worker_test.exs
+++ b/test/oli/automation_setup/project_teardown_worker_test.exs
@@ -1,0 +1,15 @@
+defmodule Oli.AutomationSetup.ProjectTeardownWorkerTest do
+  use Oli.DataCase
+  use Oban.Testing, repo: Oli.Repo
+
+  @moduletag capture_log: true
+
+  alias Oli.AutomationSetup.ProjectTeardownWorker
+
+  test "treats an already deleted project as a successful retry" do
+    assert :ok =
+             perform_job(ProjectTeardownWorker, %{
+               "project_slug" => "missing-automation-project"
+             })
+  end
+end

--- a/test/oli_web/controllers/api/automation/automation_setup_controller_test.exs
+++ b/test/oli_web/controllers/api/automation/automation_setup_controller_test.exs
@@ -1,5 +1,10 @@
 defmodule OliWeb.Api.AutomationSetupControllerTest do
   use OliWeb.ConnCase
+  use Oban.Testing, repo: Oli.Repo
+  @moduletag capture_log: true
+
+  alias Oli.AutomationSetup
+  alias Oli.AutomationSetup.ProjectTeardownWorker
   alias OliWeb.Api.AutomationSetupController
   alias Oli.Resources.Revision
   alias Oli.Accounts
@@ -140,9 +145,34 @@ defmodule OliWeb.Api.AutomationSetupControllerTest do
         "author_deleted" => %{"success" => true},
         "educator_deleted" => %{"success" => true},
         "learner_deleted" => %{"success" => true},
-        "project_deleted" => %{"success" => true},
+        "project_deleted" => %{
+          "success" => true,
+          "queued" => true,
+          "job_id" => project_teardown_job_id
+        },
         "section_deleted" => %{"success" => true}
       } = response
+
+      assert is_integer(project_teardown_job_id)
+
+      assert_enqueued(
+        worker: ProjectTeardownWorker,
+        args: %{"project_slug" => project_slug}
+      )
+
+      assert %{success: true, queued: true, job_id: ^project_teardown_job_id} =
+               AutomationSetup.enqueue_project_teardown(project_slug)
+
+      assert [_job] = all_enqueued(worker: ProjectTeardownWorker)
+
+      # Project cleanup is intentionally asynchronous. In test mode Oban jobs
+      # run manually, so the project remains until the worker is performed.
+      assert Oli.Authoring.Course.get_project_by_slug(project_slug)
+
+      assert :ok =
+               perform_job(ProjectTeardownWorker, %{
+                 "project_slug" => project_slug
+               })
 
       refute Accounts.get_author_by_email(author_email)
       refute Accounts.get_author_by_email(author_email)
@@ -158,7 +188,7 @@ defmodule OliWeb.Api.AutomationSetupControllerTest do
                  where: spp.project_id == ^project_id or spp.publication_id == ^publication.id
              )
 
-      # Make sure we cleaned up all the records
+      # Make sure the asynchronous job cleaned up all the records.
       assert revision_count_before == Repo.one(from r in Revision, select: count(r.id))
       assert resource_count_before == Repo.one(from r in Resource, select: count(r.id))
     end
@@ -198,6 +228,11 @@ defmodule OliWeb.Api.AutomationSetupControllerTest do
                },
                "section_deleted" => %{"success" => false, "message" => "No section slug provided"}
              } = response
+
+      refute_enqueued(
+        worker: ProjectTeardownWorker,
+        args: %{"project_slug" => project.slug}
+      )
     end
   end
 


### PR DESCRIPTION
## Summary

Moves full automation-project teardown to an asynchronous Oban job while keeping user and section cleanup synchronous.

## Why this is needed

Deleting a full imported course can take several minutes. In one observed run:

- Revision deletion took approximately **186 seconds**.
- Resource deletion took approximately **96 seconds**.
- Total project teardown took approximately **283 seconds**.

The slowdown comes primarily from PostgreSQL foreign-key validation and cascading behavior. Several tables that reference revisions and resources do not have supporting indexes on their foreign-key columns.

When a revision or resource is deleted, PostgreSQL must check the referencing tables for dependent rows. Without an index, this can require sequential table scans. Since a full course contains thousands of resources, those scans may be repeated many times during teardown.

The cost therefore depends not only on the course being deleted, but also on the overall size and state of the database. As shared test tables grow, the scans become longer, causing the same Playwright test to have significantly different teardown times across runs and environments.

Waiting for this work inside the HTTP request caused request timeouts, socket hang-ups, and otherwise successful Playwright runs to report teardown warnings.

## What changed

- User, learner, educator, and section cleanup remains synchronous.
- Full project cleanup is queued as an Oban job.
- The original complete deletion behavior is preserved, including publications, revisions, resources, analytics records, and imported media.
- Added a dedicated `automation_teardown` queue with concurrency `1` so multiple expensive teardown jobs do not overload PostgreSQL.
- Teardown jobs are unique per project while active and retry failures up to three times.
- Repeated execution after a project has already been deleted is treated as successful.
- Added timing logs for the request and background project cleanup.
- Extended the Cowboy idle timeout only for full-course imports.