### PR TITLE
[BUG FIX] [MER-5795] Fix persistent experiment errors and decision point insertion

### DIFF
--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -9,7 +9,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
   require Logger
 
   alias Oli.Authoring.{Locks, Course}
-  alias Oli.Resources.{Collaboration, Revision}
+  alias Oli.Resources.{Collaboration, Revision, ResourceType}
   alias Oli.Resources
   alias Oli.Publishing
   alias Oli.Publishing.AuthoringResolver
@@ -26,6 +26,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
   alias Oli.Authoring.Editing.ActivityEditor
   alias Oli.Resources.ContentMigrator
   alias Oli.Features
+
+  @alternatives_type_id ResourceType.id_for_alternatives()
 
   @doc """
   Attempts to process an edit for a resource specified by a given
@@ -124,17 +126,60 @@ defmodule Oli.Authoring.Editing.PageEditor do
         previous_alternatives = alternatives_by_identity(previous_content)
         updated_alternatives = alternatives_by_identity(updated_content)
 
-        updated_alternatives
-        |> Enum.reject(fn {identity, count} ->
-          Map.get(previous_alternatives, identity, 0) >= count
-        end)
-        |> Enum.reduce_while(:ok, fn {{_id, strategy}, _count}, :ok ->
+        added_alternatives =
+          Enum.reject(updated_alternatives, fn {identity, count} ->
+            Map.get(previous_alternatives, identity, 0) >= count
+          end)
+
+        validate_added_alternatives(added_alternatives, project)
+    end
+  end
+
+  defp validate_added_alternatives([], _project), do: :ok
+
+  defp validate_added_alternatives(added_alternatives, project) do
+    resource_ids = Enum.map(added_alternatives, &elem(&1, 0))
+
+    case Enum.all?(resource_ids, &(is_integer(&1) and &1 > 0)) do
+      true -> validate_added_alternatives_resources(added_alternatives, resource_ids, project)
+      false -> {:error, {:not_found}}
+    end
+  end
+
+  defp validate_added_alternatives_resources(added_alternatives, resource_ids, project) do
+    strategies_by_resource_id =
+      project.slug
+      |> AuthoringResolver.from_resource_id(resource_ids)
+      |> Enum.reduce(%{}, fn
+        %Revision{
+          resource_id: resource_id,
+          resource_type_id: @alternatives_type_id,
+          content: content
+        },
+        strategies
+        when is_map(content) ->
+          Map.put(
+            strategies,
+            resource_id,
+            Map.get(content, "strategy", "user_section_preference")
+          )
+
+        _revision, strategies ->
+          strategies
+      end)
+
+    Enum.reduce_while(added_alternatives, :ok, fn {resource_id, _count}, :ok ->
+      case Map.fetch(strategies_by_resource_id, resource_id) do
+        {:ok, strategy} ->
           case feature_enabled_for_strategy?(strategy, project) do
             true -> {:cont, :ok}
             false -> {:halt, {:error, feature_for_strategy(strategy)}}
           end
-        end)
-    end
+
+        :error ->
+          {:halt, {:error, {:not_found}}}
+      end
+    end)
   end
 
   defp alternatives_by_identity(%{"model" => model}) when is_list(model) do
@@ -144,7 +189,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
   defp alternatives_by_identity(_content), do: %{}
 
   defp collect_alternatives(%{"type" => "alternatives"} = content, counts) do
-    identity = {Map.get(content, "id"), Map.get(content, "strategy")}
+    identity = Map.get(content, "alternatives_id")
     counts = Map.update(counts, identity, 1, &(&1 + 1))
 
     collect_child_alternatives(content, counts)

--- a/lib/oli_web/author_auth.ex
+++ b/lib/oli_web/author_auth.ex
@@ -34,6 +34,7 @@ defmodule OliWeb.AuthorAuth do
         signed_in_path(conn)
 
     conn
+    |> delete_session(:author_return_to)
     |> put_token_in_session(token)
     |> put_author_id_in_session(author.id)
     |> maybe_write_remember_me_cookie(token, params)

--- a/lib/oli_web/components/layouts/workspace.html.heex
+++ b/lib/oli_web/components/layouts/workspace.html.heex
@@ -73,7 +73,7 @@
             data-bs-dismiss="alert"
             aria-label="Close"
             phx-click="lv:clear-flash"
-            phx-value-key="danger"
+            phx-value-key="error"
           >
             <i class="fa-solid fa-xmark fa-lg"></i>
           </button>

--- a/test/oli/editing/page_editor_test.exs
+++ b/test/oli/editing/page_editor_test.exs
@@ -3,7 +3,7 @@ defmodule Oli.EditingTest do
 
   alias Oli.Resources
   alias Oli.Resources.Revision
-  alias Oli.Authoring.Editing.{PageEditor, ActivityEditor}
+  alias Oli.Authoring.Editing.{PageEditor, ActivityEditor, ResourceEditor}
   alias Oli.Publishing
   alias Oli.Accounts.Author
   alias Oli.Accounts.SystemRole
@@ -93,6 +93,7 @@ defmodule Oli.EditingTest do
              project: project
            } do
         {:ok, project} = Course.update_project(project, unquote(Macro.escape(project_settings)))
+        group = create_alternatives_group(project, author, unquote(strategy))
 
         content = %{
           "version" => "0.1.0",
@@ -100,8 +101,7 @@ defmodule Oli.EditingTest do
             %{
               "type" => "alternatives",
               "id" => "new-alternatives",
-              "strategy" => unquote(strategy),
-              "alternatives_id" => 123,
+              "alternatives_id" => group.resource_id,
               "children" => []
             }
           ]
@@ -117,6 +117,42 @@ defmodule Oli.EditingTest do
       end
     end
 
+    test "edit/4 uses the referenced Alternatives resource strategy for feature validation", %{
+      author: author,
+      revision1: revision1,
+      project: project
+    } do
+      {:ok, project} =
+        Course.update_project(project, %{
+          alternatives_enabled: false,
+          experiments_enabled: true
+        })
+
+      decision_point = create_alternatives_group(project, author, "experiment_controlled")
+
+      content = %{
+        "version" => "0.1.0",
+        "model" => [
+          %{
+            "type" => "alternatives",
+            "id" => "new-decision-point",
+            "alternatives_id" => decision_point.resource_id,
+            "children" => []
+          }
+        ]
+      }
+
+      assert {:acquired} =
+               PageEditor.acquire_lock(project.slug, revision1.slug, author.email)
+
+      assert {:ok, updated_revision} =
+               PageEditor.edit(project.slug, revision1.slug, author.email, %{
+                 "content" => content
+               })
+
+      refute get_in(updated_revision.content, ["model", Access.at(0), "strategy"])
+    end
+
     test "edit/4 rejects newly inserted alternatives nested in child-bearing content", %{
       author: author,
       revision1: revision1,
@@ -128,6 +164,8 @@ defmodule Oli.EditingTest do
           experiments_enabled: true
         })
 
+      group = create_alternatives_group(project, author, "user_section_preference")
+
       content = %{
         "version" => "0.1.0",
         "model" => [
@@ -138,8 +176,7 @@ defmodule Oli.EditingTest do
               %{
                 "type" => "alternatives",
                 "id" => "nested-alternatives",
-                "strategy" => "user_section_preference",
-                "alternatives_id" => 123,
+                "alternatives_id" => group.resource_id,
                 "children" => []
               }
             ]
@@ -167,14 +204,15 @@ defmodule Oli.EditingTest do
           experiments_enabled: false
         })
 
+      group = create_alternatives_group(project, author, "user_section_preference")
+
       content = %{
         "version" => "0.1.0",
         "model" => [
           %{
             "type" => "alternatives",
             "id" => "existing-alternatives",
-            "strategy" => "user_section_preference",
-            "alternatives_id" => 123,
+            "alternatives_id" => group.resource_id,
             "children" => []
           }
         ]
@@ -735,5 +773,20 @@ defmodule Oli.EditingTest do
       assert hd(result).parentIds == nil
       assert hd(result).title == objective1_title
     end
+  end
+
+  defp create_alternatives_group(project, author, strategy) do
+    {:ok, revision} =
+      ResourceEditor.create(
+        project.slug,
+        author,
+        Oli.Resources.ResourceType.id_for_alternatives(),
+        %{
+          title: "Alternatives Group",
+          content: %{"options" => [], "strategy" => strategy}
+        }
+      )
+
+    revision
   end
 end

--- a/test/oli_web/author_auth_test.exs
+++ b/test/oli_web/author_auth_test.exs
@@ -36,6 +36,7 @@ defmodule OliWeb.AuthorAuthTest do
     test "redirects to the configured path", %{conn: conn, author: author} do
       conn = conn |> put_session(:author_return_to, "/hello") |> AuthorAuth.log_in_author(author)
       assert redirected_to(conn) == "/hello"
+      refute get_session(conn, :author_return_to)
     end
 
     test "ignores an unsafe configured session path", %{conn: conn, author: author} do

--- a/test/oli_web/controllers/api/resource_controller_test.exs
+++ b/test/oli_web/controllers/api/resource_controller_test.exs
@@ -4,6 +4,7 @@ defmodule OliWeb.Api.ResourceControllerTest do
   import Oli.Factory
 
   alias Oli.Authoring.Course
+  alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Publishing
   alias Oli.Utils.Time
 
@@ -70,6 +71,17 @@ defmodule OliWeb.Api.ResourceControllerTest do
           experiments_enabled: true
         })
 
+      {:ok, alternatives_group} =
+        ResourceEditor.create(
+          project.slug,
+          author,
+          Oli.Resources.ResourceType.id_for_alternatives(),
+          %{
+            title: "Alternatives Group",
+            content: %{"options" => [], "strategy" => "user_section_preference"}
+          }
+        )
+
       project.slug
       |> Publishing.project_working_publication()
       |> then(&Publishing.get_published_resource!(&1.id, page.resource_id))
@@ -87,8 +99,7 @@ defmodule OliWeb.Api.ResourceControllerTest do
                 %{
                   "type" => "alternatives",
                   "id" => "new-alternatives",
-                  "strategy" => "user_section_preference",
-                  "alternatives_id" => 123,
+                  "alternatives_id" => alternatives_group.resource_id,
                   "children" => []
                 }
               ]

--- a/test/oli_web/live/workspaces/course_author/experiments_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/experiments_live_test.exs
@@ -358,6 +358,47 @@ defmodule OliWeb.Workspaces.CourseAuthor.ExperimentsLiveTest do
       refute render(view) =~ "Cancelled condition"
     end
 
+    test "dismissed condition errors stay dismissed after subsequent actions", %{
+      view: _view,
+      conn: conn,
+      admin: admin,
+      project: project,
+      publication: publication
+    } do
+      decision_point = insert_legacy_experiment(publication, admin)
+      [first_condition, second_condition] = decision_point.content["options"]
+      {:ok, view, _html} = live(conn, live_view_experiments_route(project.slug))
+
+      view
+      |> element(
+        "button[phx-click='show_edit_option_modal'][phx-value-option-id='#{first_condition["id"]}']"
+      )
+      |> render_click()
+
+      view
+      |> form("#edit_modal-form", %{
+        "params" => %{
+          "id" => first_condition["id"],
+          "resource_id" => decision_point.resource_id,
+          "name" => second_condition["name"]
+        }
+      })
+      |> render_submit()
+
+      error_message = "duplicate options have been found"
+      assert has_element?(view, ".alert-danger", error_message)
+
+      view
+      |> element(".alert-danger button[phx-click='lv:clear-flash'][phx-value-key='error']")
+      |> render_click()
+
+      view
+      |> element("#show-archived-experiments")
+      |> render_click()
+
+      refute has_element?(view, ".alert-danger", error_message)
+    end
+
     test "deletes a decision point after confirmation", %{
       view: _view,
       conn: conn,


### PR DESCRIPTION
## Summary

- Fix dismissed experiment errors reappearing after subsequent LiveView actions.
- Resolve an inserted Alternatives group’s strategy from its authoritative resource instead of the page placement.
- Allow A/B decision points when experiments are enabled but ordinary content alternatives are disabled.
- Reject missing, malformed, cross-project, and non-Alternatives resource references.
- Consume stored author return paths after login so stale redirects do not recur.

## Root cause

The experiments error alert dismissed the wrong LiveView flash key, leaving the server-side error in place. The page editor also classified newly inserted decision points from placement content, even though strategy was intentionally removed from the persistence model and belongs to the referenced Alternatives resource.

[New Page (3).webm](https://github.com/user-attachments/assets/70c7a9af-9c21-4da7-a09f-9e794ca1369d)


## Impact

Authors can dismiss experiment errors without them returning, and can insert A/B Test decision points into projects where experiments are enabled independently of ordinary content alternatives.

## Validation

- `mix test test/oli_web/live/workspaces/course_author/experiments_live_test.exs` — 28 tests, 0 failures
- `mix test test/oli/editing/page_editor_test.exs test/oli_web/controllers/api/resource_controller_test.exs test/oli_web/author_auth_test.exs` — 49 tests, 0 failures
- `mix format`
- `git diff --check`
