### PR TITLE
[ENHANCEMENT] [MER-5689] Add Play/Pause Functionality for GIFs

### DIFF
--- a/assets/src/components/parts/janus-image/GifPlayer.tsx
+++ b/assets/src/components/parts/janus-image/GifPlayer.tsx
@@ -26,6 +26,17 @@ const playPauseButtonStyle: CSSProperties = {
   color: '#fff',
   cursor: 'pointer',
   padding: 0,
+  zIndex: 1,
+};
+
+const skeletonOverlayStyle: CSSProperties = {
+  position: 'absolute',
+  inset: 0,
+  borderRadius: 4,
+  background: 'linear-gradient(90deg, rgba(229,231,235,0.9) 0%, rgba(243,244,246,0.95) 50%, rgba(229,231,235,0.9) 100%)',
+  backgroundSize: '200% 100%',
+  animation: 'janus-image-gif-skeleton 1.2s ease-in-out infinite',
+  pointerEvents: 'none',
 };
 
 const GifPlayer: React.FC<GifPlayerProps> = ({
@@ -65,6 +76,13 @@ const GifPlayer: React.FC<GifPlayerProps> = ({
       data-janus-type={dataJanusType}
       data-testid="janus-image-gif"
     >
+      {status === 'loading' && <span aria-hidden="true" style={skeletonOverlayStyle} />}
+      <style type="text/css">{`
+        @keyframes janus-image-gif-skeleton {
+          0% { background-position: 200% 0; }
+          100% { background-position: -200% 0; }
+        }
+      `}</style>
       <canvas
         ref={canvasRef}
         data-testid="janus-image-gif-canvas"

--- a/assets/src/components/parts/janus-image/GifPlayer.tsx
+++ b/assets/src/components/parts/janus-image/GifPlayer.tsx
@@ -33,7 +33,8 @@ const skeletonOverlayStyle: CSSProperties = {
   position: 'absolute',
   inset: 0,
   borderRadius: 4,
-  background: 'linear-gradient(90deg, rgba(229,231,235,0.9) 0%, rgba(243,244,246,0.95) 50%, rgba(229,231,235,0.9) 100%)',
+  background:
+    'linear-gradient(90deg, rgba(229,231,235,0.9) 0%, rgba(243,244,246,0.95) 50%, rgba(229,231,235,0.9) 100%)',
   backgroundSize: '200% 100%',
   animation: 'janus-image-gif-skeleton 1.2s ease-in-out infinite',
   pointerEvents: 'none',

--- a/assets/src/components/parts/janus-image/ImageAuthor.tsx
+++ b/assets/src/components/parts/janus-image/ImageAuthor.tsx
@@ -2,6 +2,8 @@ import React, { CSSProperties, useCallback, useEffect, useRef, useState } from '
 import debounce from 'lodash/debounce';
 import { clone } from 'utils/common';
 import { AuthorPartComponentProps } from '../types/parts';
+import GifPlayer from './GifPlayer';
+import { isGifSrc } from './hooks/useGifPlayer';
 import { ImageModel } from './schema';
 
 // 🔹 Module-level variable persists across re-renders and re-mounts
@@ -140,24 +142,37 @@ const ImageAuthor: React.FC<AuthorPartComponentProps<ImageModel>> = (props) => {
       onSaveConfigure({ id, snapshot: modelClone });
     }
   };
+  const isGif = isGifSrc(src);
+
   return ready ? (
-    <img
-      ref={imageContainerRef}
-      onLoad={() => {
-        // Only manipulate size if lockAspectRatio is checked AND we're not in responsive layout with scaleContent
-        // When scaleContent is true (including when both flags are checked), CSS handles sizing
-        if (lockAspectRatio && !(isResponsiveLayout && scaleContent === true)) {
-          manipulateImageSize(model, false);
-        }
-      }}
-      draggable="false"
-      alt={decorative ? '' : alt}
-      aria-hidden={decorative ? true : undefined}
-      role={decorative ? 'presentation' : undefined}
-      src={src}
-      className={imageClasses || undefined}
-      style={imageStyles}
-    />
+    isGif ? (
+      <GifPlayer
+        src={src}
+        alt={alt}
+        decorative={decorative}
+        className={imageClasses || undefined}
+        style={imageStyles}
+        dataJanusType={tagName}
+      />
+    ) : (
+      <img
+        ref={imageContainerRef}
+        onLoad={() => {
+          // Only manipulate size if lockAspectRatio is checked AND we're not in responsive layout with scaleContent
+          // When scaleContent is true (including when both flags are checked), CSS handles sizing
+          if (lockAspectRatio && !(isResponsiveLayout && scaleContent === true)) {
+            manipulateImageSize(model, false);
+          }
+        }}
+        draggable="false"
+        alt={decorative ? '' : alt}
+        aria-hidden={decorative ? true : undefined}
+        role={decorative ? 'presentation' : undefined}
+        src={src}
+        className={imageClasses || undefined}
+        style={imageStyles}
+      />
+    )
   ) : null;
 };
 

--- a/assets/src/components/parts/janus-image/hooks/useGifPlayer.ts
+++ b/assets/src/components/parts/janus-image/hooks/useGifPlayer.ts
@@ -21,7 +21,7 @@ async function loadGifBytes(src: string): Promise<ArrayBuffer> {
       return direct.arrayBuffer();
     }
   } catch {
-    // Fall through to same-origin proxy for external hosts without CORS.
+    // Fall through to same-origin proxy for external hosts without CORS
   }
 
   const proxied = await fetch(`/api/v1/media/proxy?url=${encodeURIComponent(src)}`, {

--- a/assets/src/components/parts/janus-image/hooks/useGifPlayer.ts
+++ b/assets/src/components/parts/janus-image/hooks/useGifPlayer.ts
@@ -14,6 +14,27 @@ interface UseGifPlayerOptions {
 
 type Status = 'idle' | 'loading' | 'ready' | 'error';
 
+async function loadGifBytes(src: string): Promise<ArrayBuffer> {
+  try {
+    const direct = await fetch(src, { mode: 'cors', credentials: 'omit' });
+    if (direct.ok) {
+      return direct.arrayBuffer();
+    }
+  } catch {
+    // Fall through to same-origin proxy for external hosts without CORS.
+  }
+
+  const proxied = await fetch(`/api/v1/media/proxy?url=${encodeURIComponent(src)}`, {
+    credentials: 'include',
+  });
+
+  if (!proxied.ok) {
+    throw new Error(`GIF fetch failed with status ${proxied.status}`);
+  }
+
+  return proxied.arrayBuffer();
+}
+
 export function useGifPlayer(src: string, options: UseGifPlayerOptions = {}) {
   const { autoPlay = true, respectReducedMotion = true } = options;
 
@@ -123,9 +144,7 @@ export function useGifPlayer(src: string, options: UseGifPlayerOptions = {}) {
 
     (async () => {
       try {
-        const res = await fetch(src, { mode: 'cors', credentials: 'omit' });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const buffer = await res.arrayBuffer();
+        const buffer = await loadGifBytes(src);
         if (cancelled) return;
 
         const gif = parseGIF(buffer);

--- a/lib/oli_web/controllers/api/media_proxy_controller.ex
+++ b/lib/oli_web/controllers/api/media_proxy_controller.ex
@@ -1,0 +1,135 @@
+defmodule OliWeb.Api.MediaProxyController do
+  @moduledoc """
+  Proxies external GIF bytes for the janus-image GIF player when browser CORS blocks direct fetch.
+  """
+
+  use OliWeb, :controller
+
+  @max_bytes 10 * 1024 * 1024
+  @request_timeout_ms 15_000
+
+  @blocked_hosts ~w(
+    localhost
+    metadata.google.internal
+    metadata.goog
+  )
+
+  def show(conn, %{"url" => url}) when is_binary(url) do
+    with true <- authenticated?(conn),
+         {:ok, body} <- fetch_gif(url) do
+      conn
+      |> put_resp_content_type("image/gif")
+      |> put_resp_header("cache-control", "private, max-age=300")
+      |> send_resp(200, body)
+    else
+      false -> send_resp(conn, 401, "")
+      {:error, :forbidden} -> send_resp(conn, 403, "")
+      {:error, :bad_request} -> send_resp(conn, 400, "")
+      {:error, _} -> send_resp(conn, 502, "")
+    end
+  end
+
+  def show(conn, _params), do: send_resp(conn, 400, "")
+
+  defp authenticated?(conn),
+    do: not is_nil(conn.assigns[:current_author]) or not is_nil(conn.assigns[:current_user])
+
+  defp fetch_gif(url) when is_binary(url) do
+    with {:ok, uri} <- parse_url(url),
+         :ok <- validate_gif_url(uri),
+         :ok <- validate_host(uri),
+         :ok <- validate_resolved_ips(uri.host),
+         {:ok, body} <- http_get(uri),
+         :ok <- validate_size(body),
+         :ok <- validate_gif_bytes(body) do
+      {:ok, body}
+    else
+      {:error, reason} when reason in [:blocked_host, :blocked_ip] -> {:error, :forbidden}
+      {:error, reason} when reason in [:request_failed, :upstream_error] -> {:error, :upstream}
+      {:error, _} -> {:error, :bad_request}
+    end
+  end
+
+  defp fetch_gif(_), do: {:error, :bad_request}
+
+  defp parse_url(url) do
+    case URI.parse(String.trim(url)) do
+      %URI{scheme: scheme, host: host} = uri when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        {:ok, uri}
+
+      _ ->
+        {:error, :invalid_url}
+    end
+  end
+
+  defp validate_gif_url(%URI{path: path}) when is_binary(path) do
+    if Regex.match?(~r/\.gif(?:[?#].*)?$/i, path), do: :ok, else: {:error, :not_gif_url}
+  end
+
+  defp validate_gif_url(_), do: {:error, :not_gif_url}
+
+  defp validate_host(%URI{host: host}) when is_binary(host) do
+    normalized = String.downcase(host)
+
+    cond do
+      normalized in @blocked_hosts -> {:error, :blocked_host}
+      String.ends_with?(normalized, ".localhost") -> {:error, :blocked_host}
+      true -> :ok
+    end
+  end
+
+  defp validate_resolved_ips(host) do
+    host
+    |> resolve_ips()
+    |> Enum.reduce_while(:ok, fn ip, :ok ->
+      if blocked_ip?(ip), do: {:halt, {:error, :blocked_ip}}, else: {:cont, :ok}
+    end)
+  end
+
+  defp validate_size(body) when byte_size(body) <= @max_bytes, do: :ok
+  defp validate_size(_), do: {:error, :too_large}
+
+  defp validate_gif_bytes(<<"GIF87a", _::binary>>), do: :ok
+  defp validate_gif_bytes(<<"GIF89a", _::binary>>), do: :ok
+  defp validate_gif_bytes(_), do: {:error, :invalid_gif}
+
+  defp resolve_ips(host) do
+    case :inet.gethostbyname(String.to_charlist(host)) do
+      {:ok, {:hostent, _name, _aliases, _addrtype, _length, addresses}} -> addresses
+      {:error, _} -> []
+    end
+  end
+
+  defp blocked_ip?({127, _, _, _}), do: true
+  defp blocked_ip?({0, _, _, _}), do: true
+  defp blocked_ip?({10, _, _, _}), do: true
+  defp blocked_ip?({172, b, _, _}) when b in 16..31, do: true
+  defp blocked_ip?({192, 168, _, _}), do: true
+  defp blocked_ip?({169, 254, _, _}), do: true
+  defp blocked_ip?({_, _, _, _} = ip), do: ip_in_cgnat?(ip)
+  defp blocked_ip?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp blocked_ip?({0xFE, 0x80, _, _, _, _, _, _}), do: true
+  defp blocked_ip?({0xFC, _, _, _, _, _, _, _}), do: true
+  defp blocked_ip?({0xFD, _, _, _, _, _, _, _}), do: true
+  defp blocked_ip?(_), do: false
+
+  defp ip_in_cgnat?({100, b, _, _}) when b in 64..127, do: true
+  defp ip_in_cgnat?(_), do: false
+
+  defp http_get(%URI{} = uri) do
+    case HTTPoison.get(URI.to_string(uri), [],
+           follow_redirect: false,
+           recv_timeout: @request_timeout_ms,
+           timeout: @request_timeout_ms
+         ) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        {:ok, body}
+
+      {:ok, %HTTPoison.Response{status_code: status_code}} when status_code in 400..599 ->
+        {:error, :upstream_error}
+
+      {:error, %HTTPoison.Error{}} ->
+        {:error, :request_failed}
+    end
+  end
+end

--- a/lib/oli_web/controllers/api/media_proxy_controller.ex
+++ b/lib/oli_web/controllers/api/media_proxy_controller.ex
@@ -54,7 +54,8 @@ defmodule OliWeb.Api.MediaProxyController do
 
   defp parse_url(url) do
     case URI.parse(String.trim(url)) do
-      %URI{scheme: scheme, host: host} = uri when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+      %URI{scheme: scheme, host: host} = uri
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
         {:ok, uri}
 
       _ ->

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -763,6 +763,12 @@ defmodule OliWeb.Router do
     get("/", Api.MediaController, :index)
   end
 
+  scope "/api/v1/media", OliWeb do
+    pipe_through([:api])
+
+    get("/proxy", Api.MediaProxyController, :show)
+  end
+
   # Activity Bank Service
   scope "/api/v1/bank/project/:project", OliWeb do
     pipe_through([:api, :authoring_protected])


### PR DESCRIPTION
Hey @bsparks, could you please look at the PR? Thanks

This is continuation of https://github.com/Simon-Initiative/oli-torus/pull/6772

Added GET /api/v1/media/proxy so the GIF player can load external GIFs when CORS blocks a direct fetch. Auth required; URL must be an http(s) .gif; SSRF guards (no private/metadata hosts, no redirects); 10MB/15s limits; body must be a real GIF. Used as a fallback in useGifPlayer after a direct fetch fails.

