### PR TITLE
[BUG FIX] [MER-5795] Rework 3 - Fix alternatives rendering in instructor preview

### DIFF
--- a/cloud/xapi-etl-processor/Dockerfile
+++ b/cloud/xapi-etl-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11 AS build
+FROM public.ecr.aws/lambda/python:3.12 AS build
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
@@ -9,11 +9,11 @@ WORKDIR /tmp/work
 COPY requirements.txt ./
 
 RUN pip install --upgrade pip \
- && pip install --target /opt/package -r requirements.txt
+ && python -m pip install --only-binary=:all: --target /opt/package -r requirements.txt
 
 COPY lambda_function.py /opt/package/
 
-RUN yum install -y zip \
+RUN dnf install -y zip \
  && cd /opt/package \
  && zip -r9 /tmp/xapi-etl-processor.zip .
 

--- a/cloud/xapi-etl-processor/README.md
+++ b/cloud/xapi-etl-processor/README.md
@@ -96,19 +96,19 @@ ls dist/
 Publish the layer and note the returned ARN:
 
 ```bash
-LAYER_NAME=xapi-etl-processor-deps
+LAYER_NAME=oli-xapi-etl-processor-layers
 aws lambda publish-layer-version \
   --layer-name "$LAYER_NAME" \
-  --compatible-runtimes python3.11 \
+  --compatible-runtimes python3.12 \
   --zip-file fileb://dist/xapi-etl-processor-layer.zip
 
 # If the layer archive exceeds the direct upload limit (~70 MB), stage it in S3:
-S3_BUCKET=my-layer-artifacts
+S3_BUCKET=oli-xapi-etl-processor-layers
 S3_DEPS_LAYER_KEY=lambda/xapi-etl-processor-layer.zip
 aws s3 cp dist/xapi-etl-processor-layer.zip s3://$S3_BUCKET/$S3_DEPS_LAYER_KEY
 aws lambda publish-layer-version \
   --layer-name "$LAYER_NAME" \
-  --compatible-runtimes python3.11 \
+  --compatible-runtimes python3.12 \
   --content S3Bucket=$S3_BUCKET,S3Key=$S3_DEPS_LAYER_KEY
 
 # Optionally add permissions for other accounts
@@ -253,7 +253,7 @@ environment.
 
 ### 5. Deploy the Lambda function
 
-1. Create a Lambda function (Python 3.11 runtime recommended).
+1. Create a Lambda function using the Python 3.12 runtime.
 2. Upload the deployment package created above or point to the S3 artifact.
 3. Set the handler to `lambda_function.lambda_handler`.
 4. Start with memory `1024 MB` and timeout `60s`, then tune after observing
@@ -390,7 +390,7 @@ drop or disable the old user after validation.
 
 ## Local tests
 
-Install dev dependencies and run the unit tests (Python 3.11 recommended so
+Install dev dependencies and run the unit tests (Python 3.12 recommended so
 `pyarrow` wheels are available):
 
 ```bash

--- a/cloud/xapi-etl-processor/layer/Dockerfile
+++ b/cloud/xapi-etl-processor/layer/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=public.ecr.aws/lambda/python:3.11
+ARG BASE_IMAGE=public.ecr.aws/lambda/python:3.12
 
 FROM ${BASE_IMAGE} AS build
 
@@ -11,9 +11,9 @@ WORKDIR /opt
 COPY requirements.txt /tmp/requirements.txt
 
 RUN pip install --upgrade pip \
-    && python -m pip install --target /opt/python -r /tmp/requirements.txt
+    && python -m pip install --only-binary=:all: --target /opt/python -r /tmp/requirements.txt
 
-RUN yum install -y zip
+RUN dnf install -y zip
 
 RUN cd /opt \
     && zip -r9 /tmp/xapi-etl-processor-layer.zip python

--- a/lib/oli/rendering/alternatives.ex
+++ b/lib/oli/rendering/alternatives.ex
@@ -41,6 +41,7 @@ defmodule Oli.Rendering.Alternatives do
         writer
       ) do
     by_id = alternative_groups_by_id || load_alternative_groups_by_id(groups_fn)
+    context = %Context{context | alternative_groups_by_id: by_id}
 
     enrollment_id =
       case enrollment do

--- a/lib/oli/rendering/alternatives/html.ex
+++ b/lib/oli/rendering/alternatives/html.ex
@@ -49,6 +49,7 @@ defmodule Oli.Rendering.Alternatives.Html do
 
     [
       ~s|<div id="preview-alternatives-#{placement_id}" phx-hook="PreviewAlternativesTabs">|,
+      preview_notice(context, element, :tabs),
       ~s|<div role="tablist" aria-label="Alternative content options">|,
       tabs,
       "</div>",
@@ -123,7 +124,41 @@ defmodule Oli.Rendering.Alternatives.Html do
         id: "alternatives-selector-#{alternatives_id}"
       )
 
-    preference_selector
+    [
+      preview_notice(context, %{"alternatives_id" => alternatives_id}, :preference),
+      preference_selector
+    ]
+  end
+
+  defp preview_notice(%Context{mode: mode} = context, element, presentation)
+       when mode in [:author_preview, :instructor_preview] do
+    strategy =
+      (context.alternative_groups_by_id || %{})
+      |> Map.get(element["alternatives_id"], %{})
+      |> Map.get(:strategy)
+
+    message = preview_notice_message(strategy, presentation)
+
+    ~s|<div data-preview-alternatives-notice class="mb-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100">#{message}</div>|
+  end
+
+  defp preview_notice(_context, _element, _presentation), do: ""
+
+  defp preview_notice_message(strategy, :tabs)
+       when strategy in ["experiment_controlled", "upgrade_decision_point"] do
+    "Preview mode shows every alternative. Use the tabs to switch between them. In delivery, the experiment policy selects one alternative for each learner, and that assignment stays with the learner for this intervention."
+  end
+
+  defp preview_notice_message("user_section_preference", :preference) do
+    "Preview mode lets you test each preference. In delivery, each learner's preference determines which alternative they see."
+  end
+
+  defp preview_notice_message(_strategy, :tabs) do
+    "Preview mode shows every alternative. Use the tabs to switch between them. In delivery, this group's policy determines which content is shown."
+  end
+
+  defp preview_notice_message(_strategy, :preference) do
+    "Preview mode lets you test each preference. In delivery, the learner's preference determines which alternative is shown."
   end
 
   defp user_section_preference(

--- a/lib/oli/rendering/alternatives/html.ex
+++ b/lib/oli/rendering/alternatives/html.ex
@@ -146,15 +146,15 @@ defmodule Oli.Rendering.Alternatives.Html do
 
   defp preview_notice_message(strategy, :tabs)
        when strategy in ["experiment_controlled", "upgrade_decision_point"] do
-    "Preview mode shows every alternative. Use the tabs to switch between them. In delivery, the experiment policy selects one alternative for each learner, and that assignment stays with the learner for this intervention."
+    "Preview each alternative using the tabs below to switch between them. The experiment policy assigns one alternative to each learner, and that assignment stays with the learner for this intervention."
   end
 
   defp preview_notice_message("user_section_preference", :preference) do
-    "Preview mode lets you test each preference. In delivery, each learner's preference determines which alternative they see."
+    "Preview each alternative by selecting it from the list below. A learner's selection will be stored as their preference for the section."
   end
 
   defp preview_notice_message(_strategy, :tabs) do
-    "Preview mode shows every alternative. Use the tabs to switch between them. In delivery, this group's policy determines which content is shown."
+    "Preview each alternative using the tabs below to switch between them. In delivery, this group's policy determines which content is shown."
   end
 
   defp preview_notice_message(_strategy, :preference) do

--- a/lib/oli_web/delivery/instructor/preview_page_context.ex
+++ b/lib/oli_web/delivery/instructor/preview_page_context.ex
@@ -435,6 +435,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         navigation_params
       )
 
+    alternative_groups_by_id = alternative_groups_by_id(content, section_slug)
+
     activity_bank_selection_previews =
       Map.new(activity_bank_selection_previews, fn {selection_id, preview} ->
         criteria_presentation = Map.get(preview, :criteria, %{})
@@ -463,7 +465,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         bib_entries,
         all_activities,
         navigation_params,
-        activity_bank_selection_previews
+        activity_bank_selection_previews,
+        alternative_groups_by_id
       )
 
     html = Page.render(render_context, content, Page.Html)
@@ -516,10 +519,12 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
          bib_entries,
          all_activities,
          navigation_params,
-         activity_bank_selection_previews
+         activity_bank_selection_previews,
+         alternative_groups_by_id
        ) do
     section_slug = section.slug
     base_project_attributes = Sections.get_section_attributes(section)
+    alternative_groups = Map.values(alternative_groups_by_id)
 
     %Context{
       user: user,
@@ -543,6 +548,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
         activity_bank_selections: activity_bank_selection_previews
       },
       resource_summary_fn: &Resources.resource_summary(&1, section_slug, Resolver),
+      alternatives_groups_fn: fn -> {:ok, alternative_groups} end,
+      alternative_groups_by_id: alternative_groups_by_id,
       alternatives_selector_fn: &Resources.Alternatives.select/2,
       extrinsic_read_section_fn: &Oli.Delivery.ExtrinsicState.read_section/3,
       activity_types_map: Map.new(all_activities, fn activity -> {activity.id, activity} end),
@@ -550,6 +557,17 @@ defmodule OliWeb.Delivery.Instructor.PreviewPageContext do
       learning_language: base_project_attributes.learning_language,
       submitted_surveys: %{}
     }
+  end
+
+  defp alternative_groups_by_id(content, section_slug) do
+    case PageContent.alternatives_placements(content) do
+      [] ->
+        %{}
+
+      _placements ->
+        {:ok, groups} = Resources.alternatives_groups(section_slug, Resolver)
+        Map.new(groups, fn group -> {group.id, group} end)
+    end
   end
 
   defp activity_summary(

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -230,6 +230,11 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
       assert rendered =~ ~s|phx-hook="PreviewAlternativesTabs"|
       assert rendered =~ "Alternative 1"
       assert rendered =~ "Alternative 2"
+
+      assert rendered =~
+               "the experiment policy selects one alternative for each learner"
+
+      assert rendered =~ "assignment stays with the learner for this intervention"
       refute rendered =~ "AlternativesPreferenceSelector"
       refute rendered =~ "alternatives-selector-1"
     end
@@ -278,6 +283,7 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       assert rendered =~ "AlternativesPreferenceSelector"
       assert rendered =~ "alternatives-selector-1"
+      assert rendered =~ "preference determines which alternative they see"
       refute rendered =~ ~s|phx-hook="PreviewAlternativesTabs"|
       refute rendered =~ ~s|role="tablist"|
     end

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -230,9 +230,10 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
       assert rendered =~ ~s|phx-hook="PreviewAlternativesTabs"|
       assert rendered =~ "Alternative 1"
       assert rendered =~ "Alternative 2"
+      assert rendered =~ "Preview each alternative using the tabs below to switch between them"
 
       assert rendered =~
-               "the experiment policy selects one alternative for each learner"
+               "experiment policy assigns one alternative to each learner"
 
       assert rendered =~ "assignment stays with the learner for this intervention"
       refute rendered =~ "AlternativesPreferenceSelector"
@@ -283,7 +284,8 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
 
       assert rendered =~ "AlternativesPreferenceSelector"
       assert rendered =~ "alternatives-selector-1"
-      assert rendered =~ "preference determines which alternative they see"
+      assert rendered =~ "Preview each alternative by selecting it from the list below"
+      assert rendered =~ "stored as their preference for the section"
       refute rendered =~ ~s|phx-hook="PreviewAlternativesTabs"|
       refute rendered =~ ~s|role="tablist"|
     end

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -177,6 +177,122 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
       )
     end
 
+    test "renders all decision point alternatives in instructor preview", %{
+      conn: conn,
+      section: section,
+      project: project,
+      publication: publication,
+      page_revision: page_revision
+    } do
+      alternatives_revision =
+        insert(:revision,
+          author_id: page_revision.author_id,
+          resource_type_id: Oli.Resources.ResourceType.id_for_alternatives(),
+          content: %{
+            "strategy" => "upgrade_decision_point",
+            "options" => [
+              %{"id" => "control", "name" => "Control"},
+              %{"id" => "treatment", "name" => "Treatment"}
+            ]
+          }
+        )
+
+      insert(:project_resource,
+        project_id: project.id,
+        resource_id: alternatives_revision.resource_id
+      )
+
+      insert(:published_resource,
+        publication: publication,
+        resource: alternatives_revision.resource,
+        revision: alternatives_revision
+      )
+
+      insert(:section_resource,
+        section: section,
+        project: project,
+        resource_id: alternatives_revision.resource_id
+      )
+
+      {:ok, page_revision} =
+        Oli.Resources.update_revision(page_revision, %{
+          content: %{
+            "model" => [
+              %{
+                "id" => "decision-point",
+                "type" => "alternatives",
+                "alternatives_id" => alternatives_revision.resource_id,
+                "strategy" => "upgrade_decision_point",
+                "children" => [
+                  %{
+                    "id" => "control-alternative",
+                    "type" => "alternative",
+                    "value" => "control",
+                    "children" => [
+                      %{
+                        "id" => "control-content",
+                        "type" => "content",
+                        "children" => [
+                          %{
+                            "id" => "control-copy",
+                            "type" => "p",
+                            "children" => [%{"text" => "Control copy"}]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  %{
+                    "id" => "treatment-alternative",
+                    "type" => "alternative",
+                    "value" => "treatment",
+                    "children" => [
+                      %{
+                        "id" => "treatment-content",
+                        "type" => "content",
+                        "children" => [
+                          %{
+                            "id" => "treatment-copy",
+                            "type" => "p",
+                            "children" => [%{"text" => "Treatment copy"}]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        })
+
+      {:ok, view, html} = live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert html =~ "Control copy"
+      assert html =~ "Treatment copy"
+      assert html =~ "the experiment policy selects one alternative for each learner"
+      assert has_element?(view, ~s|[phx-hook="PreviewAlternativesTabs"]|)
+
+      {:ok, _alternatives_revision} =
+        Oli.Resources.update_revision(alternatives_revision, %{
+          content: %{
+            "strategy" => "user_section_preference",
+            "options" => alternatives_revision.content["options"]
+          }
+        })
+
+      {:ok, preference_view, _html} =
+        live(conn, PreviewRoutes.lesson_path(section.slug, page_revision.slug))
+
+      assert has_element?(
+               preference_view,
+               "#alternatives-selector-#{alternatives_revision.resource_id}"
+             )
+
+      assert render(preference_view) =~
+               "preference determines which alternative they see"
+    end
+
     test "back link falls back to preview schedule request_path when return_to is absent", %{
       conn: conn,
       section: section,
@@ -1326,6 +1442,8 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
     {:ok,
      conn: log_in_user(conn, user),
      user: user,
+     project: map.project,
+     publication: publication,
      section: map.section,
      page_revision: map.page.revision,
      next_page_revision: map.next_page.revision,

--- a/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
+++ b/test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs
@@ -270,7 +270,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
 
       assert html =~ "Control copy"
       assert html =~ "Treatment copy"
-      assert html =~ "the experiment policy selects one alternative for each learner"
+      assert html =~ "experiment policy assigns one alternative to each learner"
       assert has_element?(view, ~s|[phx-hook="PreviewAlternativesTabs"]|)
 
       {:ok, _alternatives_revision} =
@@ -290,7 +290,7 @@ defmodule OliWeb.Delivery.Instructor.PreviewLessonLiveTest do
              )
 
       assert render(preference_view) =~
-               "preference determines which alternative they see"
+               "stored as their preference for the section"
     end
 
     test "back link falls back to preview schedule request_path when return_to is absent", %{


### PR DESCRIPTION
## Summary

- Fixes a 500 error when instructor preview renders pages containing Alternatives or experiment decision points.
- Loads section-scoped Alternatives groups once and shares them across the preview render context.
- Preserves preview behavior for both experiment-controlled and learner-preference Alternatives.
- Adds policy-specific guidance explaining how to preview alternatives and how learner selections or experiment assignments behave in delivery.
- Adds regression coverage for experiment tabs, learner-preference controls, and instructor preview rendering.
- Updates the xAPI ETL Lambda and dependency layer builds to Python 3.12.
- Requires binary dependency wheels and updates deployment documentation for the new runtime.

## Root cause

Instructor preview did not provide either a preloaded Alternatives group map or the fallback group resolver required by `Oli.Rendering.Alternatives`. Rendering an Alternatives element therefore attempted to invoke a nil function and returned a 500 response.

## User impact

Instructors can preview pages containing learner-preference Alternatives and experiment decision points without a crash. Preview notices clarify how to inspect each alternative and how the corresponding delivery policy behaves for learners.

## Testing

- `mix test test/oli/rendering/alternatives/html_test.exs test/oli_web/live/delivery/instructor/preview_lesson_live_test.exs`
  - 44 tests, 0 failures
- `mix test test/oli/resources/alternatives_test.exs`
  - 14 tests, 0 failures

## Related issues

- [TRIAGE-2462](https://eliterate.atlassian.net/browse/TRIAGE-2462)
- [MER-5795](https://eliterate.atlassian.net/browse/MER-5795)

[TRIAGE-2462]: https://eliterate.atlassian.net/browse/TRIAGE-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ