### PR TITLE
[ENHANCEMENT] [MER-5689] Add Play/Pause Functionality for GIFs

### DIFF
--- a/assets/src/components/parts/janus-image/GifPlayer.tsx
+++ b/assets/src/components/parts/janus-image/GifPlayer.tsx
@@ -72,7 +72,13 @@ const GifPlayer: React.FC<GifPlayerProps> = ({
   return (
     <span
       className={className}
-      style={{ position: 'relative', display: 'inline-block', lineHeight: 0, ...style }}
+      style={{
+        position: 'relative',
+        display: 'block',
+        maxWidth: '100%',
+        lineHeight: 0,
+        ...style,
+      }}
       onClick={onClick}
       data-janus-type={dataJanusType}
       data-testid="janus-image-gif"
@@ -86,11 +92,12 @@ const GifPlayer: React.FC<GifPlayerProps> = ({
       `}</style>
       <canvas
         ref={canvasRef}
+        className="janus-image-gif-canvas"
         data-testid="janus-image-gif-canvas"
         role={decorative ? 'presentation' : 'img'}
         aria-label={decorative ? undefined : alt}
         aria-hidden={decorative || undefined}
-        style={{ width: '100%', height: '100%', display: 'block' }}
+        style={{ width: '100%', height: 'auto', display: 'block' }}
       />
       {status === 'ready' && (
         <button

--- a/assets/styles/common/responsive-layout.scss
+++ b/assets/styles/common/responsive-layout.scss
@@ -176,21 +176,42 @@
   ------------------------------*/
 
   // Only scaleContent is true: width 100%, height from model
+  .responsive-image-scale-only,
   img.responsive-image-scale-only {
     width: 100% !important;
     height: var(--image-height) !important;
+
+    canvas {
+      width: 100% !important;
+      height: var(--image-height) !important;
+      display: block;
+    }
   }
 
   // Only lockAspectRatio is true: maintain aspect ratio - use original width, height auto
+  .responsive-image-lock-ratio-only,
   img.responsive-image-lock-ratio-only {
     width: var(--image-width) !important;
     height: auto !important;
+
+    canvas {
+      width: 100% !important;
+      height: auto !important;
+      display: block;
+    }
   }
 
   // Both scaleContent and lockAspectRatio are true: width 100%, height auto
+  .responsive-image-scale-lock-both,
   img.responsive-image-scale-lock-both {
     width: 100% !important;
     height: auto !important;
+
+    canvas {
+      width: 100% !important;
+      height: auto !important;
+      display: block;
+    }
   }
 
   janus-number-slider,


### PR DESCRIPTION
Hey @bsparks, could you please review the PR? Thanks

Fixed the responsive GIF sizing in adaptive layout.

After the GIF player change, GIFs were rendered on a <span>/<canvas> instead of <img>, so the existing responsive image CSS (scaleContent / lockAspectRatio) no longer applied. GIFs failed to fill the column width or keep the correct aspect ratio in responsive mode.

This extends the same responsive-image rules to the GIF wrapper and canvas, and updates GifPlayer to use width: 100% / height: auto (block layout). Static images are unchanged.