### PR TITLE
[BUG FIX] [MER-5884] Lambda ETL does not insert experiment attribution records into click house

### DIFF
--- a/cloud/xapi-etl-processor/README.md
+++ b/cloud/xapi-etl-processor/README.md
@@ -66,6 +66,7 @@ cloud/xapi-etl-processor/
 | `MIN_REMAINING_TIME_TO_START_INSERT_MS`   | Minimum remaining Lambda time required before concat/serialize/insert work may start (default `15000`).                                        |
 | `LAMBDA_TIMEOUT_SAFETY_MARGIN_MS`         | Milliseconds reserved after deriving the request timeout from remaining Lambda budget (default `5000`).                                        |
 | `MAX_MESSAGES_PER_INVOCATION_TO_PROCESS`  | Optional code-level cap on how many SQS messages one invocation should prepare before leaving the rest for retry.                              |
+| `MAX_EXPERIMENT_ATTRIBUTIONS_PER_STATEMENT` | Maximum experiment attribution entries accepted on one statement (default `100`).                                                           |
 | `DRY_RUN`                                 | `true` skips the ClickHouse insert but still reads/parses objects (useful for validation).                                                     |
 | `LOG_LEVEL`                               | Override logging verbosity (`DEBUG`, `INFO`, `WARN`, etc.).                                                                                    |
 | `S3_CONNECT_TIMEOUT_SECONDS`              | S3 client connect timeout (seconds, default `5`).                                                                                              |
@@ -147,7 +148,7 @@ aws lambda update-function-code \
   --zip-file fileb://dist/xapi-etl-processor-handler.zip
 ```
 
-If you prefer staging in S3, replace the last command with the
+If you prefer uploading the artifact through S3, replace the last command with the
 `--s3-bucket/--s3-key` variant.
 
 ### Diagnostics & observability
@@ -189,7 +190,8 @@ point than the older tiny-Lambda configuration:
 - Lambda memory: `1024 MB`
 - Lambda timeout: `60s`
 - Event source mapping maximum concurrency: `2`
-- SQS visibility timeout: at least `300s`
+- SQS visibility timeout: at least `420s` for a 60s Lambda timeout and 60s
+  batching window
 
 At low traffic, expect smaller inserts. The implementation flushes smaller
 sub-batches when freshness or remaining Lambda budget makes waiting for a
@@ -200,6 +202,164 @@ sub-batches when freshness or remaining Lambda budget makes waiting for a
 The following steps assume you have permissions to manage S3, SQS, Lambda, and
 IAM within your AWS account. Replace names with values that suit your
 environment.
+
+### Environment deployment template
+
+Use the following configuration as the baseline for each environment:
+
+| Setting | Recommended value |
+| --- | --- |
+| Runtime/architecture | Python `3.12` / `x86_64` |
+| Handler | `lambda_function.lambda_handler` |
+| Memory/timeout/ephemeral storage | `1024 MB` / `60s` / `512 MB` |
+| S3 notification | `s3:ObjectCreated:*`, prefix `section/`, suffix `.jsonl` |
+| Event mapping | batch `50`, window `60s`, maximum concurrency `2`, partial batch responses enabled |
+| Main queue | 420s visibility, four-day retention, long polling, managed SSE |
+| DLQ | 14-day retention, managed SSE, redrive after five receives |
+
+Run these commands from the repository root after replacing every placeholder.
+Use a file for environment variables so the ClickHouse password does not appear
+in shell history or process arguments.
+
+```bash
+AWS_REGION="REPLACE_WITH_AWS_REGION"
+AWS_ACCOUNT_ID="REPLACE_WITH_AWS_ACCOUNT_ID"
+ENVIRONMENT="REPLACE_WITH_ENVIRONMENT_NAME"
+LAMBDA_NAME="xapi-etl-processor-$ENVIRONMENT"
+LAMBDA_ROLE_NAME="xapi-etl-processor-$ENVIRONMENT"
+MAIN_QUEUE_NAME="clickhouse-etl-events-$ENVIRONMENT"
+DLQ_NAME="clickhouse-etl-events-$ENVIRONMENT-dlq"
+SOURCE_BUCKET="REPLACE_WITH_XAPI_SOURCE_BUCKET"
+LAYER_ARN="REPLACE_WITH_DEPENDENCY_LAYER_ARN"
+SUBNET_IDS="REPLACE_WITH_COMMA_SEPARATED_SUBNET_IDS"
+SECURITY_GROUP_IDS="REPLACE_WITH_COMMA_SEPARATED_SECURITY_GROUP_IDS"
+CLICKHOUSE_HOST="REPLACE_WITH_CLICKHOUSE_HOST"
+CLICKHOUSE_PORT=8443
+CLICKHOUSE_PROTOCOL=https
+CLICKHOUSE_DATABASE="REPLACE_WITH_CLICKHOUSE_DATABASE"
+CLICKHOUSE_USER="REPLACE_WITH_CLICKHOUSE_USER"
+```
+
+Create encrypted queues and configure redrive:
+
+```bash
+aws sqs create-queue \
+  --region "$AWS_REGION" \
+  --queue-name "$DLQ_NAME" \
+  --attributes MessageRetentionPeriod=1209600,SqsManagedSseEnabled=true
+
+aws sqs create-queue \
+  --region "$AWS_REGION" \
+  --queue-name "$MAIN_QUEUE_NAME" \
+  --attributes VisibilityTimeout=420,MessageRetentionPeriod=345600,ReceiveMessageWaitTimeSeconds=20,SqsManagedSseEnabled=true
+
+DLQ_URL="https://sqs.$AWS_REGION.amazonaws.com/$AWS_ACCOUNT_ID/$DLQ_NAME"
+MAIN_QUEUE_URL="https://sqs.$AWS_REGION.amazonaws.com/$AWS_ACCOUNT_ID/$MAIN_QUEUE_NAME"
+DLQ_ARN="arn:aws:sqs:$AWS_REGION:$AWS_ACCOUNT_ID:$DLQ_NAME"
+MAIN_QUEUE_ARN="arn:aws:sqs:$AWS_REGION:$AWS_ACCOUNT_ID:$MAIN_QUEUE_NAME"
+
+aws sqs set-queue-attributes \
+  --region "$AWS_REGION" \
+  --queue-url "$MAIN_QUEUE_URL" \
+  --attributes "RedrivePolicy={\"deadLetterTargetArn\":\"$DLQ_ARN\",\"maxReceiveCount\":\"5\"}"
+```
+
+Apply a queue access policy that grants `sqs:SendMessage` only to the source
+bucket and account. The policy must scope `Resource` to `$MAIN_QUEUE_ARN`,
+`aws:SourceAccount` to `$AWS_ACCOUNT_ID`, and `aws:SourceArn` to
+`arn:aws:s3:::$SOURCE_BUCKET`.
+
+Build the layer and handler as described in [Packaging for Lambda](#packaging-for-lambda).
+Create a restricted temporary environment file, substitute the environment
+values, and insert the ClickHouse password locally. The trap removes the file
+when the shell exits. Never commit this file:
+
+```bash
+ENV_FILE="$(mktemp /tmp/xapi-etl-environment.XXXXXX)"
+chmod 600 "$ENV_FILE"
+trap 'rm -f "$ENV_FILE"' EXIT
+```
+
+```json
+{
+  "Variables": {
+    "DRY_RUN": "false",
+    "CLICKHOUSE_PROTOCOL": "<clickhouse-protocol>",
+    "CLICKHOUSE_USER": "<clickhouse-user>",
+    "CLICKHOUSE_TABLE": "raw_events",
+    "CLICKHOUSE_HOST": "<clickhouse-host>",
+    "CLICKHOUSE_PORT": "<clickhouse-port>",
+    "CLICKHOUSE_PASSWORD": "<clickhouse-password>",
+    "LOG_LEVEL": "INFO",
+    "CLICKHOUSE_DATABASE": "<clickhouse-database>"
+  }
+}
+```
+
+Before creating a VPC-attached function, verify that the execution role has the
+logging, source-object, queue-consumer, and network-interface permissions listed
+in [Create the Lambda execution role](#4-create-the-lambda-execution-role).
+Use an environment-scoped least-privilege role rather than copying broad legacy
+managed policies.
+
+```bash
+aws lambda create-function \
+  --region "$AWS_REGION" \
+  --function-name "$LAMBDA_NAME" \
+  --runtime python3.12 \
+  --architectures x86_64 \
+  --role "arn:aws:iam::$AWS_ACCOUNT_ID:role/$LAMBDA_ROLE_NAME" \
+  --handler lambda_function.lambda_handler \
+  --zip-file fileb://cloud/xapi-etl-processor/dist/xapi-etl-processor-handler.zip \
+  --layers "$LAYER_ARN" \
+  --memory-size 1024 \
+  --timeout 60 \
+  --ephemeral-storage Size=512 \
+  --vpc-config SubnetIds="$SUBNET_IDS",SecurityGroupIds="$SECURITY_GROUP_IDS" \
+  --environment file://"$ENV_FILE"
+```
+
+Use HTTPS for ClickHouse because the Lambda sends Basic Auth credentials and
+learner analytics in transit. Plain HTTP is acceptable only when a reviewed,
+isolated network path provides equivalent transport encryption. Prefer a
+deployment secret integration such as AWS Secrets Manager over a temporary
+credential file when the surrounding deployment system supports it.
+
+Create the event source mapping with partial batch responses enabled. This is
+required for the handler's `batchItemFailures` response to retry only failed or
+untouched messages:
+
+```bash
+aws lambda create-event-source-mapping \
+  --region "$AWS_REGION" \
+  --function-name "$LAMBDA_NAME" \
+  --event-source-arn "$MAIN_QUEUE_ARN" \
+  --batch-size 50 \
+  --maximum-batching-window-in-seconds 60 \
+  --function-response-types ReportBatchItemFailures \
+  --scaling-config MaximumConcurrency=2
+```
+
+Configure the bucket notification with a unique ID, the main queue ARN,
+`s3:ObjectCreated:*`, prefix `section/`, and suffix `.jsonl`. Because
+`put-bucket-notification-configuration` replaces the entire bucket
+configuration, read the current configuration and merge the queue entry without
+removing existing queue, topic, or Lambda notifications.
+
+Finally, verify the environment without printing secret values:
+
+```bash
+aws lambda get-function-configuration \
+  --function-name "$LAMBDA_NAME" \
+  --query '{Runtime:Runtime,Role:Role,Handler:Handler,Timeout:Timeout,MemorySize:MemorySize,VpcConfig:VpcConfig,Layers:Layers,Architectures:Architectures,EnvironmentKeys:keys(Environment.Variables)}'
+
+aws lambda list-event-source-mappings \
+  --function-name "$LAMBDA_NAME"
+
+aws sqs get-queue-attributes \
+  --queue-url "$MAIN_QUEUE_URL" \
+  --attribute-names VisibilityTimeout RedrivePolicy Policy SqsManagedSseEnabled
+```
 
 ### 1. Create / configure the S3 bucket
 
@@ -213,8 +373,9 @@ environment.
 2. Create a second queue, e.g. `xapi-etl-processor-dlq`, to serve as the DLQ.
 3. Configure the main queue with a redrive policy that points to the DLQ (choose
    a `maxReceiveCount` suitable for your retry tolerance, e.g. `5`).
-4. Set the main queue visibility timeout to at least **5×** the Lambda timeout.
-   Example: Lambda timeout 60s ⇒ Visibility timeout ≥ 300s.
+4. Set the main queue visibility timeout to at least **6×** the Lambda timeout
+   plus the maximum batching window. Example: Lambda timeout 60s and batching
+   window 60s ⇒ Visibility timeout ≥ 420s.
 5. Update the main queue **Access policy** to allow the S3 bucket to call
    `sqs:SendMessage`. Example statement:
 
@@ -248,6 +409,10 @@ environment.
    - Inline policy allowing `s3:GetObject` on the bucket/prefix you ingest.
    - Inline policy allowing `sqs:ReceiveMessage`, `sqs:DeleteMessage`,
      `sqs:GetQueueAttributes` on the main queue.
+   - For a VPC-attached Lambda, allow `ec2:CreateNetworkInterface`,
+     `ec2:DescribeNetworkInterfaces`, and `ec2:DeleteNetworkInterface`. AWS's
+     managed `AWSLambdaVPCAccessExecutionRole` policy provides the standard
+     Lambda VPC permissions, or define an equivalent controlled policy.
    - If using a DLQ with `sqs:SendMessage` from Lambda, add permission for it as
      well.
 
@@ -306,8 +471,26 @@ Run as a ClickHouse admin user:
 CREATE USER IF NOT EXISTS xapi_etl_processor
   IDENTIFIED WITH sha256_password BY '<strong-random-password>';
 
-GRANT INSERT ON oli_analytics.raw_events TO xapi_etl_processor;
+GRANT INSERT ON oli_analytics.* TO xapi_etl_processor;
 ```
+
+Grant `INSERT` at the database level rather than on `raw_events` alone. The
+Lambda writes both `raw_events` and `experiment_attributions`, and the wildcard
+also authorizes inserts into future ETL tables created in the same database.
+Keep the grant scoped to the database configured by `CLICKHOUSE_DATABASE`.
+
+For another environment, create a distinct service user and scope it to that
+environment's analytics database:
+
+```sql
+CREATE USER IF NOT EXISTS <environment_service_user>
+  IDENTIFIED WITH sha256_password BY '<strong-random-password>';
+
+GRANT INSERT ON <environment_database>.* TO <environment_service_user>;
+```
+
+If the same service user intentionally writes to multiple environments, grant each
+database explicitly; do not broaden the permission to `*.*`.
 
 Optional hardening (adjust to your cluster baseline):
 
@@ -333,6 +516,9 @@ Set these Lambda environment variables:
 - `CLICKHOUSE_DATABASE=oli_analytics`
 - `CLICKHOUSE_TABLE=raw_events`
 
+Use a distinct `CLICKHOUSE_USER` and `CLICKHOUSE_DATABASE` for each environment
+as shown in the environment deployment template above.
+
 If you manage env vars via CLI, note that `update-function-configuration`
 replaces the entire `Variables` object. Merge with existing values before
 updating.
@@ -347,7 +533,7 @@ updating.
 
 2. Update Lambda env vars to the new secret.
 3. Validate ingestion with a test JSONL upload and confirm inserts in
-   `raw_events`.
+   `raw_events` and, for attributed statements, `experiment_attributions`.
 4. If rotation used a temporary user, remove the old user after validation:
 
    ```sql

--- a/cloud/xapi-etl-processor/lambda_function.py
+++ b/cloud/xapi-etl-processor/lambda_function.py
@@ -185,7 +185,7 @@ EXPERIMENT_ATTRIBUTION_INSERT_COLUMNS: List[str] = [
     "raw_event_hash", "attribution_hash", "source_file", "source_etag", "source_line",
     "host_event_type", "timestamp", "section_id", "project_id", "publication_id",
     "enrollment_id", "experiment_role", "attribution_type", "experiment_id",
-    "experiment_uuid", "decision_point_id", "decision_point_key", "condition_id",
+    "experiment_uuid", "condition_id",
     "condition_code", "assignment_id", "assignment_key", "algorithm", "policy_version",
     "content_revision_id", "reward_value", "reward_source", "intervention_id",
     "intervention_key", "assessment_binding_id", "assessment_page_resource_id",
@@ -1050,12 +1050,12 @@ def _get_experiment_attribution_type_map() -> Dict[str, "pa.DataType"]:
     string_columns = {
         "raw_event_hash", "attribution_hash", "source_file", "source_etag",
         "host_event_type", "experiment_role", "attribution_type", "experiment_uuid",
-        "decision_point_key", "condition_code", "assignment_key", "algorithm",
+        "condition_code", "assignment_key", "algorithm",
         "policy_version", "reward_source", "intervention_key", "disposition",
     }
     uint64_columns = {
         "section_id", "project_id", "publication_id", "enrollment_id", "experiment_id",
-        "decision_point_id", "condition_id", "assignment_id", "content_revision_id",
+        "condition_id", "assignment_id", "content_revision_id",
         "intervention_id", "assessment_binding_id", "assessment_page_resource_id",
         "resource_attempt_id", "page_revision_id",
     }
@@ -1315,8 +1315,6 @@ def transform_experiment_attributions(
                 "attribution_type": _safe_str(attribution.get("attribution_type")),
                 "experiment_id": _safe_int(attribution.get("experiment_id")),
                 "experiment_uuid": _safe_str(attribution.get("experiment_uuid")),
-                "decision_point_id": _safe_int(attribution.get("decision_point_id")),
-                "decision_point_key": _safe_str(attribution.get("decision_point_key")),
                 "condition_id": _safe_int(attribution.get("condition_id")),
                 "condition_code": _safe_str(attribution.get("condition_code")),
                 "assignment_id": _safe_int(attribution.get("assignment_id")),

--- a/cloud/xapi-etl-processor/lambda_function.py
+++ b/cloud/xapi-etl-processor/lambda_function.py
@@ -25,6 +25,9 @@ CLICKHOUSE_TIMEOUT_SECONDS Request timeout for HTTP insert (default 30)
 MAX_S3_OBJECT_BYTES        Soft cap per S3 object (bytes); raises if exceeded
 TARGET_ROWS_PER_INSERT     Preferred row target before flushing (default 10000)
 MAX_ROWS_PER_INSERT        Hard row ceiling for a sub-batch (default 30000)
+MAX_EXPERIMENT_ATTRIBUTIONS_PER_STATEMENT
+                           Maximum attribution entries accepted on one xAPI
+                           statement (default 100)
 MAX_PARQUET_BYTES_PER_INSERT
                            Soft payload-size ceiling in bytes (default 16777216)
 MIN_REMAINING_TIME_TO_START_INSERT_MS
@@ -178,6 +181,18 @@ DEFAULT_CLICKHOUSE_INSERT_COLUMNS: List[str] = [
     "source_line",
 ]
 
+EXPERIMENT_ATTRIBUTION_INSERT_COLUMNS: List[str] = [
+    "raw_event_hash", "attribution_hash", "source_file", "source_etag", "source_line",
+    "host_event_type", "timestamp", "section_id", "project_id", "publication_id",
+    "enrollment_id", "experiment_role", "attribution_type", "experiment_id",
+    "experiment_uuid", "decision_point_id", "decision_point_key", "condition_id",
+    "condition_code", "assignment_id", "assignment_key", "algorithm", "policy_version",
+    "content_revision_id", "reward_value", "reward_source", "intervention_id",
+    "intervention_key", "assessment_binding_id", "assessment_page_resource_id",
+    "resource_attempt_id", "disposition", "reward_threshold", "normalized_score",
+    "page_revision_id",
+]
+
 _CLICKHOUSE_TYPE_MAP: Optional[Dict[str, "pa.DataType"]] = None
 
 
@@ -191,6 +206,7 @@ class S3ObjectRef:
 class PreparedMessage:
     message_id: str
     table: "pa.Table"
+    experiment_attributions: Optional["pa.Table"]
     object_count: int
 
 
@@ -198,6 +214,7 @@ class PreparedMessage:
 class BatchAccumulator:
     prepared_messages: List[PreparedMessage] = field(default_factory=list)
     total_rows: int = 0
+    total_attribution_rows: int = 0
     total_objects: int = 0
     estimated_bytes: int = 0
 
@@ -206,6 +223,11 @@ class BatchAccumulator:
         self.total_rows += prepared_message.table.num_rows
         self.total_objects += prepared_message.object_count
         self.estimated_bytes += estimate_table_size_bytes(prepared_message.table)
+        if prepared_message.experiment_attributions is not None:
+            self.total_attribution_rows += prepared_message.experiment_attributions.num_rows
+            self.estimated_bytes += estimate_table_size_bytes(
+                prepared_message.experiment_attributions
+            )
 
     def is_empty(self) -> bool:
         return not self.prepared_messages
@@ -216,9 +238,18 @@ class BatchAccumulator:
     def tables(self) -> List["pa.Table"]:
         return [prepared.table for prepared in self.prepared_messages]
 
+    def experiment_attribution_tables(self) -> List["pa.Table"]:
+        return [
+            prepared.experiment_attributions
+            for prepared in self.prepared_messages
+            if prepared.experiment_attributions is not None
+            and prepared.experiment_attributions.num_rows > 0
+        ]
+
     def reset(self) -> None:
         self.prepared_messages.clear()
         self.total_rows = 0
+        self.total_attribution_rows = 0
         self.total_objects = 0
         self.estimated_bytes = 0
 
@@ -301,7 +332,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
             )
 
             fetch_started = time.perf_counter()
-            table = build_arrow_table_from_s3_objects(s3_refs)
+            table, experiment_attributions = build_arrow_tables_from_s3_objects(s3_refs)
             fetch_elapsed = time.perf_counter() - fetch_started
             logger.info(
                 "Completed fetch for message %s in %.2fs",
@@ -320,6 +351,7 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 PreparedMessage(
                     message_id=message_id,
                     table=table,
+                    experiment_attributions=experiment_attributions,
                     object_count=len(s3_refs),
                 )
             )
@@ -454,6 +486,10 @@ def flush_current_batch(
 
     concat_started = time.perf_counter()
     combined_table = concatenate_tables(current_batch.tables())
+    attribution_tables = current_batch.experiment_attribution_tables()
+    combined_attributions = (
+        concatenate_tables(attribution_tables) if attribution_tables else None
+    )
     concat_duration_ms = elapsed_ms(concat_started)
     log_stage(
         "sub_batch_concatenated",
@@ -466,6 +502,11 @@ def flush_current_batch(
 
     parquet_started = time.perf_counter()
     parquet_payload = table_to_parquet(combined_table)
+    attribution_payload = (
+        table_to_parquet(combined_attributions)
+        if combined_attributions is not None
+        else None
+    )
     parquet_duration_ms = elapsed_ms(parquet_started)
     payload_bytes = len(parquet_payload)
     log_stage(
@@ -520,7 +561,19 @@ def flush_current_batch(
             combined_table.num_rows,
             timeout_seconds=request_timeout_seconds,
             insert_token=insert_token,
+            table=os.getenv("CLICKHOUSE_TABLE") or "raw_events",
+            columns=resolve_clickhouse_insert_columns(),
         )
+        if combined_attributions is not None and attribution_payload is not None:
+            attribution_timeout_seconds = derive_clickhouse_timeout_seconds(context)
+            insert_into_clickhouse(
+                attribution_payload,
+                combined_attributions.num_rows,
+                timeout_seconds=attribution_timeout_seconds,
+                insert_token=f"{insert_token}-experiment-attributions",
+                table="experiment_attributions",
+                columns=EXPERIMENT_ATTRIBUTION_INSERT_COLUMNS,
+            )
     except Exception as exc:  # pylint: disable=broad-except
         logger.exception("ClickHouse insert failed for sub-batch %s: %s", insert_token, exc)
         log_stage(
@@ -615,14 +668,28 @@ def _extract_from_s3_event_record(s3_record: Dict[str, Any]) -> Iterable[S3Objec
 
 def build_arrow_table_from_s3_objects(objects: Iterable[S3ObjectRef]) -> Optional[pa.Table]:
     """Load JSONL objects from S3 and convert to a single Arrow table."""
+    table, _experiment_attributions = build_arrow_tables_from_s3_objects(objects)
+    return table
+
+
+def build_arrow_tables_from_s3_objects(
+    objects: Iterable[S3ObjectRef],
+) -> tuple[Optional[pa.Table], Optional[pa.Table]]:
+    """Load JSONL objects into raw-event and experiment-attribution tables."""
     tables: List[pa.Table] = []
+    attribution_tables: List[pa.Table] = []
     for ref in objects:
-        table = load_json_lines_as_table(ref)
+        table, attributions = load_json_lines_as_tables(ref)
         if table is not None:
             tables.append(table)
+        if attributions is not None:
+            attribution_tables.append(attributions)
     if not tables:
-        return None
-    return concatenate_tables(tables)
+        return None, None
+    return (
+        concatenate_tables(tables),
+        concatenate_tables(attribution_tables) if attribution_tables else None,
+    )
 
 
 def forward_failure_to_dlq(record: Optional[Dict[str, Any]], *, reason: str) -> None:
@@ -663,6 +730,14 @@ def find_record_by_id(records: Iterable[Dict[str, Any]], message_id: str) -> Opt
 
 def load_json_lines_as_table(ref: S3ObjectRef) -> Optional[pa.Table]:
     """Read a JSON Lines object from S3 into an Arrow table."""
+    table, _experiment_attributions = load_json_lines_as_tables(ref)
+    return table
+
+
+def load_json_lines_as_tables(
+    ref: S3ObjectRef,
+) -> tuple[Optional[pa.Table], Optional[pa.Table]]:
+    """Read a JSON Lines object into raw-event and attribution Arrow tables."""
     ensure_pyarrow_available()
     max_bytes_env = os.getenv("MAX_S3_OBJECT_BYTES")
     max_bytes = int(max_bytes_env) if max_bytes_env else None
@@ -690,6 +765,7 @@ def load_json_lines_as_table(ref: S3ObjectRef) -> Optional[pa.Table]:
             )
 
     rows: List[Dict[str, Any]] = []
+    attribution_rows: List[Dict[str, Any]] = []
     log_interval_seconds = float(os.getenv("ITER_LOG_INTERVAL_SECONDS", "5"))
     next_log_deadline = fetch_started + log_interval_seconds
 
@@ -710,6 +786,16 @@ def load_json_lines_as_table(ref: S3ObjectRef) -> Optional[pa.Table]:
                 line_number=processed_rows,
             )
             rows.append(transformed)
+            attribution_rows.extend(
+                transform_experiment_attributions(
+                    statement,
+                    raw_bytes=raw_line,
+                    bucket=ref.bucket,
+                    key=ref.key,
+                    etag=response.get("ETag"),
+                    line_number=processed_rows,
+                )
+            )
         except json.JSONDecodeError as exc:
             raise ValueError(
                 f"Invalid JSON in s3://{ref.bucket}/{ref.key}: {raw_line[:200]!r}"
@@ -733,7 +819,7 @@ def load_json_lines_as_table(ref: S3ObjectRef) -> Optional[pa.Table]:
 
     if not rows:
         logger.info("S3 object s3://%s/%s contained no JSON rows", ref.bucket, ref.key)
-        return None
+        return None, None
 
     try:
         table = pa.Table.from_pylist(rows)
@@ -752,7 +838,13 @@ def load_json_lines_as_table(ref: S3ObjectRef) -> Optional[pa.Table]:
             ref.key,
             time.perf_counter() - fetch_started,
         )
-        return table
+        attribution_table = None
+        if attribution_rows:
+            attribution_table = pa.Table.from_pylist(attribution_rows)
+            attribution_table = normalize_experiment_attribution_table_schema(
+                attribution_table
+            )
+        return table, attribution_table
     except Exception as exc:  # pylint: disable=broad-except
         raise ValueError(f"Unable to convert rows from s3://{ref.bucket}/{ref.key} into Arrow table") from exc
 
@@ -792,6 +884,23 @@ def normalize_table_schema(table: pa.Table) -> pa.Table:
                     exc,
                 )
     return _project_table_to_clickhouse_columns(table)
+
+
+def normalize_experiment_attribution_table_schema(table: pa.Table) -> pa.Table:
+    """Apply the ClickHouse experiment_attributions projection and types."""
+    timestamp_idx = table.schema.get_field_index("timestamp")
+    if timestamp_idx != -1 and pa.types.is_string(table.column(timestamp_idx).type):
+        converted = _coerce_iso8601_timestamp_column(table.column(timestamp_idx))
+        table = table.set_column(
+            timestamp_idx,
+            table.schema.field(timestamp_idx).with_type(converted.type),
+            converted,
+        )
+    return _project_table(
+        table,
+        EXPERIMENT_ATTRIBUTION_INSERT_COLUMNS,
+        _get_experiment_attribution_type_map(),
+    )
 
 
 def _coerce_iso8601_timestamp_column(column: pa.ChunkedArray) -> pa.Array:
@@ -848,7 +957,13 @@ def _project_table_to_clickhouse_columns(table: pa.Table) -> pa.Table:
     if not columns:
         return table
 
-    type_map = _get_clickhouse_type_map()
+    return _project_table(table, columns, _get_clickhouse_type_map())
+
+
+def _project_table(
+    table: pa.Table, columns: List[str], type_map: Mapping[str, "pa.DataType"]
+) -> pa.Table:
+
     arrays = []
     names: List[str] = []
     row_count = table.num_rows
@@ -929,6 +1044,33 @@ def _get_clickhouse_type_map() -> Dict[str, "pa.DataType"]:
             "source_line": pa.uint32(),
         }
     return _CLICKHOUSE_TYPE_MAP
+
+
+def _get_experiment_attribution_type_map() -> Dict[str, "pa.DataType"]:
+    string_columns = {
+        "raw_event_hash", "attribution_hash", "source_file", "source_etag",
+        "host_event_type", "experiment_role", "attribution_type", "experiment_uuid",
+        "decision_point_key", "condition_code", "assignment_key", "algorithm",
+        "policy_version", "reward_source", "intervention_key", "disposition",
+    }
+    uint64_columns = {
+        "section_id", "project_id", "publication_id", "enrollment_id", "experiment_id",
+        "decision_point_id", "condition_id", "assignment_id", "content_revision_id",
+        "intervention_id", "assessment_binding_id", "assessment_page_resource_id",
+        "resource_attempt_id", "page_revision_id",
+    }
+    result = {column: pa.string() for column in string_columns}
+    result.update({column: pa.uint64() for column in uint64_columns})
+    result.update(
+        {
+            "source_line": pa.uint32(),
+            "timestamp": pa.timestamp("ms", tz="UTC"),
+            "reward_value": pa.float64(),
+            "reward_threshold": pa.float64(),
+            "normalized_score": pa.float64(),
+        }
+    )
+    return result
 
 
 def transform_xapi_statement(
@@ -1185,9 +1327,26 @@ def transform_experiment_attributions(
                 "policy_version": _safe_str(attribution.get("policy_version")),
                 "content_revision_id": _safe_int(attribution.get("content_revision_id")),
                 "reward_value": _safe_float(
-                    attribution.get("reward_value") or _get_nested(result, ["score", "raw"])
+                    attribution.get("reward_value")
+                    if attribution.get("reward_value") is not None
+                    else _get_nested(result, ["score", "raw"])
                 ),
                 "reward_source": _safe_str(attribution.get("reward_source")),
+                "intervention_id": _safe_int(attribution.get("intervention_id")),
+                "intervention_key": _safe_str(attribution.get("intervention_key")),
+                "assessment_binding_id": _safe_int(
+                    attribution.get("assessment_binding_id")
+                ),
+                "assessment_page_resource_id": _safe_int(
+                    attribution.get("assessment_page_resource_id")
+                ),
+                "resource_attempt_id": _safe_int(
+                    attribution.get("resource_attempt_id")
+                ),
+                "disposition": _safe_str(attribution.get("disposition")),
+                "reward_threshold": _safe_float(attribution.get("reward_threshold")),
+                "normalized_score": _safe_float(attribution.get("normalized_score")),
+                "page_revision_id": _safe_int(attribution.get("page_revision_id")),
                 "source_file": f"s3://{bucket}/{key}",
                 "source_etag": etag.strip('"') if isinstance(etag, str) else etag,
                 "source_line": line_number,
@@ -1203,6 +1362,15 @@ def _experiment_attributions(statement: Mapping[str, Any]) -> List[Mapping[str, 
 
     if not isinstance(attributions, list):
         return []
+
+    max_attributions = max(
+        1, int(os.getenv("MAX_EXPERIMENT_ATTRIBUTIONS_PER_STATEMENT", "100"))
+    )
+    if len(attributions) > max_attributions:
+        raise ValueError(
+            "experiment attribution count "
+            f"{len(attributions)} exceeds configured maximum {max_attributions}"
+        )
 
     return [attribution for attribution in attributions if isinstance(attribution, Mapping)]
 
@@ -1323,9 +1491,15 @@ def insert_into_clickhouse(
     *,
     timeout_seconds: Optional[float] = None,
     insert_token: Optional[str] = None,
+    table: Optional[str] = None,
+    columns: Optional[List[str]] = None,
 ) -> None:
     url = resolve_clickhouse_url()
-    query = build_insert_query()
+    query = (
+        build_insert_query(table=table, columns=columns, allow_override=False)
+        if table == "experiment_attributions"
+        else build_insert_query()
+    )
     params = {"query": query}
     params.update(parse_clickhouse_settings())
 
@@ -1391,18 +1565,23 @@ def resolve_clickhouse_url() -> str:
     return f"{protocol}://{host}:{port}{path}".rstrip("/")
 
 
-def build_insert_query() -> str:
-    override = os.getenv("CLICKHOUSE_INSERT_SQL")
+def build_insert_query(
+    *,
+    table: Optional[str] = None,
+    columns: Optional[List[str]] = None,
+    allow_override: bool = True,
+) -> str:
+    override = os.getenv("CLICKHOUSE_INSERT_SQL") if allow_override else None
     if override:
         return override
 
     database = os.getenv("CLICKHOUSE_DATABASE")
-    table = os.getenv("CLICKHOUSE_TABLE")
+    table = table or os.getenv("CLICKHOUSE_TABLE")
     if not database or not table:
         raise ValueError(
             "CLICKHOUSE_DATABASE and CLICKHOUSE_TABLE must be set when CLICKHOUSE_INSERT_SQL is not provided"
         )
-    columns = resolve_clickhouse_insert_columns()
+    columns = columns if columns is not None else resolve_clickhouse_insert_columns()
     column_clause = ""
     if columns:
         column_clause = " (" + ", ".join(quote_identifier(col) for col in columns) + ")"
@@ -1515,11 +1694,12 @@ def estimate_table_size_bytes(table: "pa.Table") -> int:
 def determine_flush_reason(current_batch: BatchAccumulator, *, force: bool) -> Optional[str]:
     if current_batch.is_empty():
         return None
-    if current_batch.total_rows >= resolve_max_rows_per_insert():
+    payload_rows = current_batch.total_rows + current_batch.total_attribution_rows
+    if payload_rows >= resolve_max_rows_per_insert():
         return "max_rows_reached"
     if current_batch.estimated_bytes >= resolve_max_parquet_bytes_per_insert():
         return "payload_ceiling_reached"
-    if current_batch.total_rows >= resolve_target_rows_per_insert():
+    if payload_rows >= resolve_target_rows_per_insert():
         return "target_rows_reached"
     if force:
         return "forced_flush"

--- a/cloud/xapi-etl-processor/tests/lambda_function_test.py
+++ b/cloud/xapi-etl-processor/tests/lambda_function_test.py
@@ -65,6 +65,7 @@ class LambdaFunctionTests(TestCase):
             "LAMBDA_TIMEOUT_SAFETY_MARGIN_MS",
             "CLICKHOUSE_TIMEOUT_SECONDS",
             "MAX_MESSAGES_PER_INVOCATION_TO_PROCESS",
+            "MAX_EXPERIMENT_ATTRIBUTIONS_PER_STATEMENT",
         ]:
             self.addCleanup(lambda name=env_var: os.environ.pop(name, None))
 
@@ -76,6 +77,9 @@ class LambdaFunctionTests(TestCase):
         return lambda_function.pa.Table.from_pylist(
             [{"event_hash": f"hash-{index}", "source_line": index + 1} for index in range(row_count)]
         )
+
+    def _event_tables_with_rows(self, row_count):
+        return self._table_with_rows(row_count), None
 
     def _experiment_attributed_part_attempt_fixture(self):
         raw_line = next(
@@ -145,6 +149,62 @@ class LambdaFunctionTests(TestCase):
         self.assertEqual(args[1], 1)
         self.assertIn("timeout_seconds", kwargs)
         self.assertIn("insert_token", kwargs)
+
+    def test_lambda_handler_inserts_experiment_attributions_with_raw_events(self):
+        raw_line, _statement = self._experiment_attributed_part_attempt_fixture()
+        event = {"Records": [self._message("msg-1")]}
+        self.mock_s3.get_object.return_value = {
+            "Body": FakeBody([raw_line.decode("utf-8")]),
+            "ETag": '"etag-value"',
+        }
+
+        with mock.patch.object(lambda_function, "insert_into_clickhouse") as insert_mock:
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "CLICKHOUSE_DATABASE": "db",
+                    "CLICKHOUSE_TABLE": "raw_events",
+                    "TARGET_ROWS_PER_INSERT": "10",
+                },
+                clear=False,
+            ):
+                result = lambda_function.lambda_handler(
+                    event, FakeContext(remaining_time_ms=60000)
+                )
+
+        self.assertEqual(result["batchItemFailures"], [])
+        self.assertEqual(insert_mock.call_count, 2)
+        self.assertEqual(insert_mock.call_args_list[0].args[1], 1)
+        self.assertEqual(insert_mock.call_args_list[0].kwargs["table"], "raw_events")
+        self.assertEqual(insert_mock.call_args_list[1].args[1], 1)
+        self.assertEqual(
+            insert_mock.call_args_list[1].kwargs["table"],
+            "experiment_attributions",
+        )
+
+    def test_rejects_statements_exceeding_attribution_limit(self):
+        raw_line, statement = self._experiment_attributed_part_attempt_fixture()
+        attribution = statement["context"]["extensions"][
+            "http://oli.cmu.edu/extensions/experiment_attributions"
+        ][0]
+        statement["context"]["extensions"][
+            "http://oli.cmu.edu/extensions/experiment_attributions"
+        ] = [attribution, attribution]
+
+        with mock.patch.dict(
+            os.environ,
+            {"MAX_EXPERIMENT_ATTRIBUTIONS_PER_STATEMENT": "1"},
+            clear=False,
+        ):
+            with self.assertRaisesRegex(ValueError, "exceeds configured maximum 1"):
+                lambda_function.transform_experiment_attributions(
+                    statement,
+                    raw_bytes=raw_line,
+                    bucket="bucket",
+                    key="events/file.jsonl",
+                    etag='"etag"',
+                    line_number=1,
+                )
 
     def test_lambda_handler_respects_dry_run(self):
         body = json.dumps(
@@ -301,6 +361,36 @@ class LambdaFunctionTests(TestCase):
         self.assertNotIn("reward_id", rows[0])
         self.assertNotIn("previous_policy_state_hash", rows[0])
         self.assertNotIn("next_policy_state_hash", rows[0])
+
+        attribution = statement["context"]["extensions"][
+            "http://oli.cmu.edu/extensions/experiment_attributions"
+        ][0]
+        attribution.update(
+            {
+                "intervention_id": 14,
+                "intervention_key": "807288:3765579404",
+                "assessment_binding_id": 3,
+                "assessment_page_resource_id": 807288,
+                "resource_attempt_id": 7936916,
+                "disposition": "accepted",
+                "reward_threshold": 1,
+                "normalized_score": 0,
+                "page_revision_id": 1955463,
+            }
+        )
+        evidence_row = lambda_function.transform_experiment_attributions(
+            statement,
+            raw_bytes=raw_line,
+            bucket="bucket",
+            key="events/file.jsonl",
+            etag='"etag"',
+            line_number=1,
+        )[0]
+        self.assertEqual(evidence_row["intervention_id"], 14)
+        self.assertEqual(evidence_row["assessment_page_resource_id"], 807288)
+        self.assertEqual(evidence_row["resource_attempt_id"], 7936916)
+        self.assertEqual(evidence_row["normalized_score"], 0.0)
+        self.assertEqual(evidence_row["page_revision_id"], 1955463)
 
         statement["context"]["extensions"][
             "http://oli.cmu.edu/extensions/experiment_attributions"
@@ -461,8 +551,8 @@ class LambdaFunctionTests(TestCase):
             with mock.patch.object(lambda_function, "_sqs_client") as sqs_mock:
                 with mock.patch.object(
                     lambda_function,
-                    "build_arrow_table_from_s3_objects",
-                    side_effect=[self._table_with_rows(2), self._table_with_rows(2)],
+                    "build_arrow_tables_from_s3_objects",
+                    side_effect=[self._event_tables_with_rows(2), self._event_tables_with_rows(2)],
                 ):
                     with mock.patch.object(
                         lambda_function,
@@ -501,11 +591,11 @@ class LambdaFunctionTests(TestCase):
 
         with mock.patch.object(
             lambda_function,
-            "build_arrow_table_from_s3_objects",
+            "build_arrow_tables_from_s3_objects",
             side_effect=[
-                self._table_with_rows(2),
-                self._table_with_rows(2),
-                self._table_with_rows(2),
+                self._event_tables_with_rows(2),
+                self._event_tables_with_rows(2),
+                self._event_tables_with_rows(2),
             ],
         ):
             with mock.patch.object(lambda_function, "insert_into_clickhouse", side_effect=capture_insert):
@@ -532,11 +622,11 @@ class LambdaFunctionTests(TestCase):
 
         with mock.patch.object(
             lambda_function,
-            "build_arrow_table_from_s3_objects",
+            "build_arrow_tables_from_s3_objects",
             side_effect=[
-                self._table_with_rows(2),
-                self._table_with_rows(2),
-                self._table_with_rows(2),
+                self._event_tables_with_rows(2),
+                self._event_tables_with_rows(2),
+                self._event_tables_with_rows(2),
             ],
         ):
             with mock.patch.object(
@@ -564,11 +654,11 @@ class LambdaFunctionTests(TestCase):
 
         def prepare_then_exhaust_time(_refs):
             context.remaining_time_ms = 500
-            return self._table_with_rows(2)
+            return self._event_tables_with_rows(2)
 
         with mock.patch.object(
             lambda_function,
-            "build_arrow_table_from_s3_objects",
+            "build_arrow_tables_from_s3_objects",
             side_effect=prepare_then_exhaust_time,
         ):
             with mock.patch.object(lambda_function, "insert_into_clickhouse") as insert_mock:
@@ -596,8 +686,8 @@ class LambdaFunctionTests(TestCase):
 
         with mock.patch.object(
             lambda_function,
-            "build_arrow_table_from_s3_objects",
-            return_value=self._table_with_rows(2),
+            "build_arrow_tables_from_s3_objects",
+            return_value=self._event_tables_with_rows(2),
         ):
             with mock.patch.object(
                 lambda_function,
@@ -636,8 +726,8 @@ class LambdaFunctionTests(TestCase):
 
         with mock.patch.object(
             lambda_function,
-            "build_arrow_table_from_s3_objects",
-            return_value=self._table_with_rows(2),
+            "build_arrow_tables_from_s3_objects",
+            return_value=self._event_tables_with_rows(2),
         ):
             with mock.patch.object(lambda_function, "insert_into_clickhouse") as insert_mock:
                 with mock.patch.dict(

--- a/cloud/xapi-etl-processor/tests/lambda_function_test.py
+++ b/cloud/xapi-etl-processor/tests/lambda_function_test.py
@@ -181,6 +181,9 @@ class LambdaFunctionTests(TestCase):
             insert_mock.call_args_list[1].kwargs["table"],
             "experiment_attributions",
         )
+        attribution_columns = insert_mock.call_args_list[1].kwargs["columns"]
+        self.assertNotIn("decision_point_id", attribution_columns)
+        self.assertNotIn("decision_point_key", attribution_columns)
 
     def test_rejects_statements_exceeding_attribution_limit(self):
         raw_line, statement = self._experiment_attributed_part_attempt_fixture()
@@ -347,6 +350,8 @@ class LambdaFunctionTests(TestCase):
         self.assertEqual(rows[0]["attribution_type"], "reward")
         self.assertEqual(rows[0]["experiment_id"], 101)
         self.assertEqual(rows[0]["experiment_uuid"], "11111111-2222-3333-4444-555555555555")
+        self.assertNotIn("decision_point_id", rows[0])
+        self.assertNotIn("decision_point_key", rows[0])
         self.assertEqual(rows[0]["condition_code"], "condition-a")
         self.assertEqual(rows[0]["reward_value"], 1.0)
         self.assertEqual(rows[0]["reward_source"], "activity_attempt:full_credit")


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5884

This PR fixes an issue with the ETL lambda not properly processing experiment_attributes into clickhouse.

It does not change any torus functionality per-se, but the lambda code that executes as part of the ETL.

These changes were tested and verified using stellarator the clickhouse staging DB with the xapi-etl-processor-staging lambda.