### PR TITLE
[FEATURE] [MER-5855] Adds core support for LearningObjectiveCoverage Data Source

### DIFF
--- a/docs/exec-plans/current/epics/objectives-editor/core_data/fdd.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/fdd.md
@@ -1,0 +1,242 @@
+# MER-5855 LearningObjectiveCoverage Data Source - Functional Design Document
+
+## 1. Executive Summary
+
+Implement `Oli.Authoring.ObjectiveCoverage` as a plain, read-only application module. The module will execute one Ecto projection against the project's current unpublished publication, then transform compact rows into a deterministic model containing objective hierarchy, direct attachments, page/activity details, curriculum scope, coverage summaries, and searchable text. The workspace LiveView and later objective-editor features consume this model; they do not own its query or data-shaping rules.
+
+The design deliberately uses working-publication mappings rather than historical unpublished revisions, excludes deleted revisions, avoids page/activity `content`, and limits initial activity coverage to static embedded activities represented by page `activity_refs`.
+
+## 2. Requirements & Assumptions
+
+- Functional requirements:
+  - `FR-001`: expose a focused application-level coverage module and reusable read-only model.
+  - `FR-002`: load one compact, project-scoped working-publication projection.
+  - `FR-003`: build normalized hierarchy, attachment, page/activity, and curriculum indexes.
+  - `FR-004`: calculate direct and inherited coverage with deduplication and assessment classification.
+  - `FR-005`: expose detail and normalized search projections.
+  - `FR-006`: support embedded-only initial activity coverage without writes.
+  - `FR-007`: enforce project scope, deleted-row exclusion, safe optional-data handling, and deterministic output.
+- Non-functional requirements:
+  - No N+1 queries, full page/activity content selection, GenServer, cache process, schema migration, or database full-text search.
+  - Domain logic remains under `lib/oli/`; LiveView code only invokes and presents the model.
+  - Query/build duration and row counts may be observed without logging content bodies.
+- Assumptions:
+  - `published_resources` identifies the authoritative revision for each resource in the working publication.
+  - `project_working_publication/1` or an equivalent project-scoped query resolves the single unpublished publication.
+  - `Revision.activity_refs` is the maintained page-to-embedded-activity boundary.
+  - Objective maps contain lists of objective resource ids under one or more keys, and activity objective tags are read from all map values.
+  - Missing `activity_refs` means no discoverable embedded activities for this model; repairing stale indexes is separate work.
+
+## 3. Repository Context Summary
+
+- What we know:
+  - `OliWeb.Workspaces.CourseAuthor.ObjectivesLive` currently builds objective rows and asynchronously calls `Publishing.find_attached_objectives/1`.
+  - `Oli.Publishing.project_working_publication/1` resolves an unpublished project publication by slug.
+  - `Oli.Publishing.PublishedResource` maps a publication/resource to its selected revision.
+  - `Oli.Resources.Revision` stores `resource_id`, `resource_type_id`, `title`, `slug`, `deleted`, `children`, `objectives`, `graded`, `activity_refs`, `scope`, and `activity_type_id`.
+  - `Oli.Resources.ResourceType` supplies resource-type ids for pages, activities, containers, and objectives.
+  - `Oli.Authoring.LearningObjectives.PageElement` demonstrates narrow working-publication queries and uses `activity_refs` instead of scanning page JSON.
+  - `Publishing.find_attached_objectives/1` is a useful regression reference but does not return enough fields for the new model.
+  - `AuthoringResolver` and delivery depots solve related delivery/runtime problems but are not the authoring data-source boundary for this work.
+- Unknowns to confirm:
+  - The exact shape of existing objective `children` data when an objective has multiple parent associations.
+  - The exact JSON keys used for formative/summative objective attachment lists; the implementation must flatten all objective-map values rather than assume one key.
+  - The canonical curriculum path representation expected by the CSV and course-content filter consumers.
+
+## 4. Proposed Design
+
+### 4.1 Component Roles & Interactions
+
+Use one module with a small public boundary and private transformation stages:
+
+1. `Oli.Authoring.ObjectiveCoverage` accepts a project or project slug and obtains the working publication id.
+2. A private Ecto query selects compact rows from `published_resources` joined to `revisions`, scoped through `publications` and `projects`, with `published IS NULL` and `deleted IS FALSE`.
+3. A row-normalization stage converts database values into a small internal row shape and normalizes nullable arrays/maps/enums.
+4. An index-building stage partitions rows by resource type and creates lookup maps/MapSets.
+5. A coverage stage derives direct attachments, parent-expanded attachments, assessment buckets, page-first details, and searchable text.
+6. Public read functions expose the model to the workspace LiveView and future filtering/export consumers.
+
+Do not place this logic in `ObjectivesLive`, `Publishing.find_attached_objectives/1`, or a supervised process. The existing LiveView can be migrated by replacing its attachment task with a single model load in a follow-up consumer change; this FDD only defines the data-source implementation.
+
+### 4.2 State & Data Flow
+
+```text
+project slug/id
+    -> working publication id
+    -> compact projection rows
+    -> typed/normalized row partitions
+    -> relationship indexes
+    -> coverage/detail/search model
+    -> LiveView, filters, CSV, and tests
+```
+
+Recommended internal model shape:
+
+```elixir
+%{
+  project_id: project_id,
+  publication_id: publication_id,
+  objectives_by_id: %{objective_id => objective_summary},
+  parents_by_child: %{child_id => MapSet.t(parent_id)},
+  children_by_parent: %{parent_id => [child_id]},
+  pages_by_id: %{page_id => page_summary},
+  activities_by_id: %{activity_id => activity_summary},
+  curriculum_by_id: %{container_or_page_id => curriculum_node},
+  coverage_by_objective: %{objective_id => coverage_summary},
+  details_by_objective: %{objective_id => [page_detail_group]},
+  search_by_objective: %{objective_id => search_projection}
+}
+```
+
+The exact public struct may be chosen during implementation, but maps must preserve stable resource ids, display titles/slugs, assessment classification, activity type, page location, and match metadata. Build relationships with `MapSet`; sort ids/details by a documented stable key before returning them.
+
+Attachment flow:
+
+- For each page, flatten objective ids from `page.objectives` and add the page to each objective's direct page set.
+- For each activity, flatten and deduplicate objective ids from `activity.objectives`; retain only `scope == :embedded` activities for this initial model.
+- For each page's `activity_refs`, resolve activity summaries from the projection and attach them to the page group. The activity inherits the page's `graded` bucket.
+- For each objective, derive its transitive parent/child expansion from the objective hierarchy. Parent summaries union direct and descendant sets; Sub-Objective summaries use only their own direct sets.
+- Count pages and activities per assessment bucket from deduplicated resource ids. Preserve repeated activity occurrences in detail only when needed to represent distinct page groups.
+- Build search text from the objective title plus titles reachable through its detail/hierarchy projection. Store normalized text separately from original display values.
+
+### 4.3 Lifecycle & Ownership
+
+The module is called by the parent LiveView process or another request-scoped consumer. It owns no mutable process state and has no supervision tree entry. Each model is an immutable request/load snapshot. The caller owns lifecycle and may discard or replace the model after objective edits or publication changes.
+
+The model is not a cross-request cache. A later optimization may add an explicit, measured cache boundary, but that is outside this ticket.
+
+### 4.4 Alternatives Considered
+
+- Extend `Publishing.find_attached_objectives/1`: rejected because its result lacks resource ids, page grading, activity scope/type, page-to-activity grouping, and curriculum data; extending it would mix a legacy attachment helper with a broader model contract.
+- Query each objective/page/activity on demand: rejected because it creates N+1 behavior and makes filtering/search paths inconsistent.
+- Load full revisions and parse page `content`: rejected because content is large, the data source does not need it for static embedded coverage, and it repeats work already avoided by `activity_refs`.
+- Copy delivery `SectionResourceDepot`: rejected because authoring must read mutable working-publication mappings and has different lifecycle/consistency requirements.
+- Add a GenServer/cache: rejected because the requirement is a testable request-scoped snapshot and no cross-request invalidation strategy is needed yet.
+
+## 5. Interfaces
+
+- Proposed public constructor:
+  - `load(project_or_slug) :: {:ok, coverage_model} | {:error, :project_not_found | :working_publication_not_found | term()}`
+- Proposed pure builder for focused tests:
+  - `build(rows, publication_context) :: {:ok, coverage_model} | {:error, reason}`
+- Proposed consumer queries over the model:
+  - `objectives(model)` returns stable top-level objective summaries.
+  - `coverage(model, objective_id)` returns summary counts and assessment buckets.
+  - `details(model, objective_id, assessment_bucket)` returns page-first groups.
+  - `search(model, query)` returns matching objective ids plus match metadata.
+  - `curriculum_pages(model, selected_ids)` returns page ids in selected curriculum scope.
+- Row projection fields:
+  - `revision_id`, `resource_id`, `resource_type_id`, `slug`, `title`, `deleted`, `objectives`, `children`, `graded`, `activity_refs`, `scope`, and `activity_type_id`.
+- Error contract:
+  - Missing project/publication is explicit.
+  - Malformed optional objectives/children/activity_refs values normalize to empty collections and may produce an aggregate diagnostic, but must not crash the request.
+  - Query failures propagate as tagged errors suitable for LiveView error handling and telemetry.
+
+## 6. Data Model & Storage
+
+- No schema or migration changes.
+- The database remains the source of truth; the coverage model is an ephemeral derived projection.
+- Query joins should use `published_resources.publication_id = publications.id`, `published_resources.revision_id = revisions.id`, and project/publication scope. Prefer the mapping's selected revision and resource id together so historical revision rows are not accidentally selected.
+- Resource types included in the projection are objective, page, activity, and container. Other types are excluded or ignored.
+- Exclude `revisions.deleted = true` in SQL. Keep a defensive post-query check for test doubles or future query changes.
+- Activity bank selections and standalone banked activities are excluded by `scope`; page detail includes only activities referenced by a page's `activity_refs`.
+
+## 7. Consistency & Transactions
+
+- The read consists of one query outside a write transaction. No transaction is needed because the module performs no writes.
+- The projection is a point-in-time database read; concurrent author edits may produce a snapshot that is immediately stale, which is acceptable for a request-scoped authoring view.
+- Publication mapping and revision selection must come from the same query snapshot so a resource is not resolved through a different historical revision during post-processing.
+- After an objective/page/activity edit, the consumer must explicitly reload the model rather than mutate internal indexes incrementally.
+
+## 8. Caching Strategy
+
+No cache. The model is built once per consumer load and held by the caller. This avoids invalidation bugs when working-publication revisions change. If performance measurements justify caching later, cache keys must include project and working-publication identity and invalidation must follow revision/publication changes.
+
+## 9. Performance & Scalability Posture
+
+- One SQL/Ecto projection is the required initial database path; no per-objective, per-page, per-activity, or per-filter queries.
+- Never select `revisions.content`. The selected fields are compact maps/arrays and should be projected into maps rather than `%Revision{}` with preloads.
+- Use `MapSet` for relationship construction and convert to sorted lists at the model boundary. Avoid repeated `Enum.find` over all revisions by indexing every resource type by `resource_id` first.
+- Keep only compact row data and derived metadata after model construction. Do not retain full Ecto structs or query dumps.
+- Instrument or measure query duration, row count, and build duration in representative large projects before wiring the model into initial render. AppSignal/telemetry should receive aggregate values only.
+- If the projection becomes memory-bound, the next design step is a measured compact struct or bounded projection strategy; do not introduce a process cache speculatively.
+
+## 10. Failure Modes & Resilience
+
+- Project not found: return a tagged error; caller renders its existing authorization/not-found path.
+- No working publication: return a tagged error or an empty model according to the existing authoring convention; implementation should choose one and test it consistently.
+- Query timeout/database error: propagate a tagged error, log aggregate context, and avoid partial model publication.
+- Deleted revision/stale mapping: filter it before indexing so deleted pages/activities cannot appear in counts or links.
+- Missing objective referenced by content: retain the content row only if a valid objective consumer exists; otherwise ignore the dangling objective id and record a bounded diagnostic if diagnostics are included.
+- Missing activity in `activity_refs`: omit that activity from detail/counts; do not fetch page content as a fallback.
+- Cyclic or malformed objective hierarchy: protect ancestor traversal with a visited set and return a deterministic finite model; add a diagnostic for the invalid cycle.
+- Duplicate objective tags/activity references: deduplicate ids before counting.
+- Unexpected enum/null values: normalize safely and classify unknown assessment state as excluded from the relevant bucket rather than guessing.
+
+## 11. Observability
+
+- Emit an optional module-scoped telemetry event around load/build with project id, publication id, row counts by type, duration, and success/failure category.
+- Log failures with project/publication identifiers and counts, never page/activity content, objective body JSON, or learner data.
+- Do not add product analytics events for this data source. Consumer UI success and filter/search behavior are measured by their own work items.
+- A useful operational success signal is that the initial consumer requires one projection load and does not issue follow-up content queries.
+
+## 12. Security & Privacy
+
+- Accept a project already authorized by the caller, but keep the query explicitly scoped to that project's id/slug and working publication. Do not trust an arbitrary publication id supplied by the client.
+- Return only authoring data belonging to the project. No learner attempts, grades, or delivery-section state are loaded.
+- Treat titles and course structure as project content; do not place full content maps or raw objective JSON in logs/telemetry.
+- Consumers remain responsible for route/session authorization; this module must not widen access by allowing cross-project lookup.
+
+## 13. Testing Strategy
+
+- Unit tests for the pure builder with compact row fixtures:
+  - `AC-003`: partitioning, hierarchy, direct maps, `activity_refs`, and curriculum indexes.
+  - `AC-004`: direct versus inherited parent/Sub-Objective counts and deduplication.
+  - `AC-005`: graded classification, inherited activity bucket, page-first details, and empty page groups.
+  - `AC-006`: normalized partial search and hierarchy match metadata.
+  - `AC-007`: embedded-only scope, bank exclusion, and no-write behavior.
+  - `AC-008`: deleted/out-of-scope rows, malformed optional data, cycle protection, and stable ordering.
+- Ecto/DataCase query tests:
+  - `AC-002`: current working publication scope, selected compact fields, deleted filtering, and revision mapping behavior.
+  - `AC-001`: consumer-facing load contract can produce a model without coverage logic in the LiveView.
+- Static/code inspection and query-plan review:
+  - `AC-009`: one projection rather than N+1 queries, no `content` selection, targeted `mix test`, and `mix format`.
+- Run targeted tests first, then broader relevant `mix test` coverage as implementation risk warrants. Run `mix format --check-formatted` or `mix format` on changed Elixir files.
+- No scenario test is required for this isolated read model unless the consumer integration exposes a cross-domain regression that unit/DataCase tests cannot cover.
+
+## 14. Backwards Compatibility
+
+- Existing `Publishing.find_attached_objectives/1` behavior remains unchanged in this work item unless a separate migration explicitly replaces its consumer.
+- The older objectives editor route remains unchanged; the workspace editor is the intended first consumer.
+- No persisted data, API endpoint, publication format, or revision schema changes are introduced.
+- Projects with legacy parent-on-activity or child-on-page associations remain readable; the model reports what is present and does not enforce the later well-formed-project rules.
+
+## 15. Risks & Mitigations
+
+- Query projection accidentally selects large content: keep an explicit field list and add query-level regression coverage for the selected shape.
+- Multiple parent associations create incorrect hierarchy expansion: represent parents as sets, traverse with visited ids, and test shared Sub-Objectives.
+- Duplicate activity occurrences inflate counts: separate deduplicated summary sets from page-grouped detail occurrences.
+- Working publication is resolved inconsistently: select the publication and mapped revisions in the same scoped query and return publication context with the model.
+- In-memory model is too large: retain compact maps, avoid Ecto structs/content, measure representative projects, and defer caching until evidence exists.
+- Consumers depend on unstable internal maps: expose documented read functions/structs and add consumer-contract tests before UI work begins.
+
+## 16. Open Questions & Follow-ups
+
+- Decide whether the missing-working-publication result is an error or an empty model based on the workspace LiveView's existing loading/error convention.
+- Confirm the canonical resource-type helper names and exact enum values for `scope` in the implementation branch.
+- Confirm the curriculum path shape required by `MER-5800` and `MER-5801`; keep the initial model extensible without loading additional content.
+- Decide whether malformed-data diagnostics are returned in the model, emitted only through telemetry, or both.
+- Follow up separately on deterministic bank-selection indexing/backfill; do not expand this implementation to parse page content.
+- Follow up separately on `MER-5794` consumer integration and on the blocked proficiency work represented by `MER-5821`.
+
+## 17. References
+
+- `docs/exec-plans/current/epics/objectives-editor/core_data/prd.md`
+- `docs/exec-plans/current/epics/objectives-editor/core_data/requirements.yml`
+- `docs/exec-plans/current/epics/objectives-editor/plan.md`
+- `lib/oli_web/live/workspaces/course_author/objectives_live.ex`
+- `lib/oli/publishing.ex`
+- `lib/oli/publishing/mappings/published_resource.ex`
+- `lib/oli/resources/revision.ex`
+- `lib/oli/authoring/learning_objectives/page_element.ex`
+- Jira `MER-5855` (data source), `MER-5784` (parent epic), and consumer tickets `MER-5794`, `MER-5797`, `MER-5799`, `MER-5800`, `MER-5801`

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/fdd.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/fdd.md
@@ -116,7 +116,7 @@ The model is not a cross-request cache. A later optimization may add an explicit
 ## 5. Interfaces
 
 - Proposed public constructor:
-  - `load(project_or_slug) :: {:ok, coverage_model} | {:error, :project_not_found | :working_publication_not_found | term()}`
+  - `load(project_or_slug) :: {:ok, coverage_model} | {:error, :project_not_found | :working_publication_not_found | :multiple_working_publications | term()}`
 - Proposed pure builder for focused tests:
   - `build(rows, publication_context) :: {:ok, coverage_model} | {:error, reason}`
 - Proposed consumer queries over the model:
@@ -165,6 +165,7 @@ No cache. The model is built once per consumer load and held by the caller. This
 
 - Project not found: return a tagged error; caller renders its existing authorization/not-found path.
 - No working publication: return a tagged error or an empty model according to the existing authoring convention; implementation should choose one and test it consistently.
+- Multiple working publications: return a tagged error rather than merging rows from ambiguous snapshots.
 - Query timeout/database error: propagate a tagged error, log aggregate context, and avoid partial model publication.
 - Deleted revision/stale mapping: filter it before indexing so deleted pages/activities cannot appear in counts or links.
 - Missing objective referenced by content: retain the content row only if a valid objective consumer exists; otherwise ignore the dangling objective id and record a bounded diagnostic if diagnostics are included.

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/phase_1_execution_record.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/phase_1_execution_record.md
@@ -1,0 +1,40 @@
+# Phase 1 Execution Record
+
+Work item: `docs/exec-plans/current/epics/objectives-editor/core_data`
+Phase: `1 - Projection Boundary and Normalized Indexes`
+
+## Scope from plan.md
+
+- Establish `Oli.Authoring.ObjectiveCoverage` and its compact working-publication projection.
+- Normalize projection rows and build deterministic resource, hierarchy, and curriculum indexes.
+- Add pure builder and database-backed load/query tests.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [ ] Observability or operational updates when needed; deferred to Phase 3 because this phase adds no production consumer wiring
+
+## Test Blocks
+
+- [x] Tests added or updated: `test/oli/authoring/objective_coverage_test.exs`
+- [x] Required verification commands run
+- [x] Results captured: 4 focused tests passed; formatting passed
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan remain aligned with the implementation
+- [x] Phase 1 default behavior is recorded: existing projects with no indexed rows return an empty snapshot; invalid arguments return `:invalid_project`
+
+## Review Loop
+
+- Round 1 findings: No actionable security, performance, Elixir, or requirements findings.
+- Round 1 fixes: Corrected deterministic ordering after the focused test exposed reversed-input instability.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [ ] Final work-item validation pending post-implementation

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/phase_2_execution_record.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/phase_2_execution_record.md
@@ -1,0 +1,40 @@
+# Phase 2 Execution Record
+
+Work item: `docs/exec-plans/current/epics/objectives-editor/core_data`
+Phase: `2 - Coverage, Details, and Search Projections`
+
+## Scope from plan.md
+
+- Derive direct and inherited objective coverage from the Phase 1 snapshot.
+- Build formative/summative page-first detail groups and normalized in-memory search projections.
+- Expose stable model accessors for objective summaries, coverage, details, search, and curriculum page scope.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks; all behavior remains read-only and project-snapshot scoped
+- [ ] Observability or operational updates when needed; deferred to Phase 3
+
+## Test Blocks
+
+- [x] Tests added or updated: `test/oli/authoring/objective_coverage_test.exs`
+- [x] Required verification commands run
+- [x] Results captured: 5 focused tests passed; formatting passed
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan remain aligned with the implementation
+- [x] Activity counts are deduplicated per objective and assessment bucket; repeated activity occurrences across pages remain represented in page detail groups
+
+## Review Loop
+
+- Round 1 findings: No actionable security, performance, Elixir, or requirements findings.
+- Round 1 fixes: Test expectations clarified to reflect an activity appearing on both formative and summative pages and therefore counting once in each bucket.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Final work-item validation passes

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/phase_3_execution_record.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/phase_3_execution_record.md
@@ -1,0 +1,40 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/epics/objectives-editor/core_data`
+Phase: `3 - Scope Hardening, Observability, and Performance Verification`
+
+## Scope from plan.md
+
+- Enforce embedded-only activity coverage and read-only model construction.
+- Add bounded load/build telemetry without authored content.
+- Harden malformed/cyclic hierarchy handling and verify deterministic behavior.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+
+- [x] Tests added or updated: banked exclusion, cyclic hierarchy safety, and telemetry assertions in `test/oli/authoring/objective_coverage_test.exs`
+- [x] Required verification commands run
+- [x] Results captured: 6 focused tests passed; compile with warnings as errors and formatting passed
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan remain aligned with the implementation
+- [x] Telemetry is aggregate-only: duration, row/resource counts, project/publication identifiers, and bounded status metadata; authored content is not emitted
+
+## Review Loop
+
+- Round 1 findings: No actionable security, performance, Elixir, or requirements findings.
+- Round 1 fixes: Corrected telemetry test attachment to the repository's Telemetry API and verified banked activity exclusion.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Final work-item validation passes

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/phase_4_execution_record.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/phase_4_execution_record.md
@@ -1,0 +1,39 @@
+# Phase 4 Execution Record
+
+Work item: `docs/exec-plans/current/epics/objectives-editor/core_data`
+Phase: `4 - Final Integration and Traceability Closure`
+
+## Scope from plan.md
+
+- Verify the complete work item and confirm there is no UI or shared publishing drift.
+- Close acceptance-criteria implementation traceability.
+- Run the final repository and Harness validation gates.
+
+## Implementation Blocks
+
+- [x] Confirmed the workspace LiveView and shared publishing helpers remain unchanged.
+- [x] Confirmed PRD, FDD, plan, and implementation assumptions remain aligned; the missing-publication behavior is documented in the FDD and tests.
+- [x] Added explicit AC-001 through AC-009 implementation proof references in `test/oli/authoring/objective_coverage_test.exs`.
+
+## Test Blocks
+
+- [x] Work-item validation passed with `validate_work_item.py --check all`.
+- [x] Final requirements verification passed with `requirements_trace.py --action verify_implementation`.
+- [x] Targeted ObjectiveCoverage tests, compilation with warnings as errors, and formatting checks passed.
+
+## Work-Item Sync
+
+- [x] Plan phase checkboxes and execution records reflect completed implementation and verification.
+- [x] Scope remains limited to the read-only core data source; no workspace UI, CSV export, filters, proficiency aggregation, or activity-bank indexing was added.
+
+## Review Loop
+
+- Round 1 findings: No actionable security, performance, Elixir, or requirements findings.
+- Round 1 fixes: Phase 3 telemetry attachment was corrected to the repository Telemetry API; Phase 4 added the required explicit acceptance-criteria references.
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Final work-item validation and requirements traceability pass

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/plan.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/plan.md
@@ -17,7 +17,7 @@ Implement the read-only authoring coverage data source in `lib/oli/authoring/`, 
 - The implementation targets the workspace Learning Objectives Editor; the older objectives route is not migrated in this work item.
 - The public module boundary is `Oli.Authoring.ObjectiveCoverage`; the exact internal struct names may be selected during Phase 1 but must remain stable for consumer tickets.
 - A missing `activity_refs` value is treated as an empty embedded-activity relationship; no page-content fallback is added.
-- A missing working publication is returned as an explicit tagged error unless existing workspace conventions require an empty model; that decision must be recorded in the execution record and tests.
+- A missing working publication is returned as an explicit tagged error; multiple working publications are also rejected rather than merged, and valid empty working publications return an empty model with context.
 - Curriculum paths are represented with stable node/resource ids, titles, parent ids, and descendant page ids sufficient for `MER-5800` and `MER-5801`; no additional content query is introduced.
 - Initial activity coverage includes only static embedded activities referenced from page `activity_refs`; bank-selection coverage is a follow-up.
 - No feature flag or migration is required. Telemetry remains aggregate-only and follows `docs/OPERATIONS.md`.

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/plan.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/plan.md
@@ -1,0 +1,136 @@
+# MER-5855 LearningObjectiveCoverage Data Source - Delivery Plan
+
+Scope and reference artifacts:
+
+- PRD: `docs/exec-plans/current/epics/objectives-editor/core_data/prd.md`
+- FDD: `docs/exec-plans/current/epics/objectives-editor/core_data/fdd.md`
+- Requirements: `docs/exec-plans/current/epics/objectives-editor/core_data/requirements.yml`
+- Parent epic plan: `docs/exec-plans/current/epics/objectives-editor/plan.md`
+- Jira: `MER-5855` under epic `MER-5784`
+
+## Scope
+
+Implement the read-only authoring coverage data source in `lib/oli/authoring/`, including its compact working-publication projection, normalized in-memory indexes, coverage summaries, page-first details, curriculum scope, and in-memory search projection. Add focused ExUnit/DataCase coverage and operational safeguards. Do not implement the workspace UI, filters, CSV export, activity-bank indexing, or proficiency aggregation.
+
+## Clarifications & Default Assumptions
+
+- The implementation targets the workspace Learning Objectives Editor; the older objectives route is not migrated in this work item.
+- The public module boundary is `Oli.Authoring.ObjectiveCoverage`; the exact internal struct names may be selected during Phase 1 but must remain stable for consumer tickets.
+- A missing `activity_refs` value is treated as an empty embedded-activity relationship; no page-content fallback is added.
+- A missing working publication is returned as an explicit tagged error unless existing workspace conventions require an empty model; that decision must be recorded in the execution record and tests.
+- Curriculum paths are represented with stable node/resource ids, titles, parent ids, and descendant page ids sufficient for `MER-5800` and `MER-5801`; no additional content query is introduced.
+- Initial activity coverage includes only static embedded activities referenced from page `activity_refs`; bank-selection coverage is a follow-up.
+- No feature flag or migration is required. Telemetry remains aggregate-only and follows `docs/OPERATIONS.md`.
+- Required review lenses are security, performance, Elixir, and requirements because this work adds backend query/domain behavior and traceability artifacts.
+
+## Phase 1: Projection Boundary and Normalized Indexes
+
+- Goal: establish the application module, compact working-publication query, row normalization, and core resource lookup/hierarchy indexes.
+- Tasks:
+  - [x] Add `Oli.Authoring.ObjectiveCoverage` with explicit load/build entry points and tagged errors.
+  - [x] Implement one project-scoped Ecto projection joining publications, projects, published resources, and revisions, filtering to the current unpublished publication and non-deleted rows.
+  - [x] Select only the required compact fields; explicitly omit page/activity `content` and avoid revision preloads.
+  - [x] Normalize nullable objectives, children, activity references, scope, and assessment fields into safe internal row values.
+  - [x] Partition objective, page, activity, and container rows and build resource-id lookup maps, parent/child maps, page/activity maps, and curriculum node indexes.
+  - [x] Add module documentation describing the snapshot contract and embedded-only scope.
+- Testing Tasks:
+  - [x] Add pure builder tests for row partitioning, lookup maps, hierarchy relationships, curriculum nodes, malformed optional values, and deterministic ordering. Cover `AC-003` and `AC-008`.
+  - [x] Add DataCase/query tests for project and working-publication scope, deleted-row exclusion, selected fields, and revision mapping. Cover `AC-002`.
+  - [x] Add a load-contract test showing the application module supplies the model independently of LiveView coverage logic. Cover `AC-001`.
+  - Command(s): `mix test test/oli/authoring/objective_coverage_test.exs`
+- Definition of Done:
+  - The module can load or build a compact scoped model with no content selection and stable core indexes.
+  - Phase tests pass and the query shape is reviewable without hidden N+1 reads.
+- Gate:
+  - Security/performance review confirms project scoping, deleted filtering, no content selection, and one projection before coverage derivation begins.
+- Dependencies:
+  - PRD, FDD, and requirements are present; no implementation dependency.
+- Parallelizable Work:
+  - Pure row/model test fixtures can be developed alongside the query, provided both use the same documented row contract.
+
+## Phase 2: Coverage, Details, and Search Projections
+
+- Goal: derive direct/inherited coverage, assessment buckets, page-first detail groups, and normalized search data from Phase 1 indexes.
+- Tasks:
+  - [x] Flatten page and activity objective maps and build direct page/activity attachment sets.
+  - [x] Resolve page `activity_refs` to compact activity summaries and inherit formative/summative classification from the containing page.
+  - [x] Implement parent-objective expansion across transitive Sub-Objective relationships with visited-set cycle protection.
+  - [x] Deduplicate summary page/activity ids by objective and assessment bucket while preserving page-grouped detail identity.
+  - [x] Add model accessors for objective summaries, coverage, details, curriculum page scope, and normalized partial search results.
+  - [x] Preserve original titles/slugs/ids alongside normalized search text and match hierarchy metadata.
+- Testing Tasks:
+  - [x] Test direct versus inherited parent/Sub-Objective counts, duplicate tags, shared Sub-Objectives, and assessment bucket behavior. Cover `AC-004`.
+  - [x] Test page-first details, formative/summative activity inheritance, and pages with no activities in a selected bucket. Cover `AC-005`.
+  - [x] Test case-insensitive, trimmed, whitespace-normalized partial search across objective, Sub-Objective, page, and activity titles. Cover `AC-006`.
+  - Command(s): `mix test test/oli/authoring/objective_coverage_test.exs`
+- Definition of Done:
+  - All coverage and consumer-facing projections derive from the single Phase 1 model and return deterministic results.
+  - Parent summaries include direct and descendant attachments; Sub-Objective summaries remain direct-only.
+- Gate:
+  - Representative fixture assertions demonstrate correct counts, details, search matches, and no additional database calls after model construction.
+- Dependencies:
+  - Phase 1 core row and index contract.
+- Parallelizable Work:
+  - Search tests and detail-shape tests can proceed in parallel after the normalized row shape is fixed.
+
+## Phase 3: Scope Hardening, Observability, and Performance Verification
+
+- Goal: close safety, embedded-only behavior, diagnostics, deterministic resilience, and operational verification for production use.
+- Tasks:
+  - [x] Exclude banked/standalone activities and document the absence of bank-selection coverage in the returned model contract.
+  - [x] Ensure model construction has no write path and safely omits missing activity/objective references.
+  - [x] Add bounded telemetry/logging for load/build duration, row counts, and tagged failures without content bodies.
+  - [x] Add explicit safeguards for malformed/cyclic hierarchy data and stable finite output.
+  - [x] Review query plans and representative model sizes; make only measured compactness improvements within scope.
+  - [x] Document the final missing-publication and malformed-data behavior in the FDD or execution record if it differs from the defaults above.
+- Testing Tasks:
+  - [x] Test embedded-only inclusion, bank-selection/standalone exclusion, and read-only behavior. Cover `AC-007`.
+  - [x] Test deleted/out-of-project rows, malformed optional data, cycle protection, repeat-build stability, and sorted output. Cover `AC-008`.
+  - [x] Run targeted tests, formatting, and inspect the query for one projection/no N+1 behavior. Cover `AC-009`.
+  - Command(s): `mix test test/oli/authoring/objective_coverage_test.exs && mix format --check-formatted`
+- Definition of Done:
+  - Resilience and operational behavior are covered without expanding into migrations, caches, or bank-selection indexing.
+  - Aggregate observability is present or explicitly documented as unnecessary for this request-scoped read model.
+- Gate:
+  - Targeted tests and formatting pass; security, performance, Elixir, and requirements reviews complete with findings resolved or recorded.
+- Dependencies:
+  - Phases 1 and 2.
+- Parallelizable Work:
+  - Telemetry tests and query-plan inspection can run alongside resilience tests after the public load contract is stable.
+
+## Phase 4: Final Integration and Traceability Closure
+
+- Goal: verify the work item and implementation are aligned for downstream UI consumers and close all repository gates.
+- Tasks:
+  - [x] Run the full relevant authoring/publishing regression targets if Phase 1-3 changes touch shared publishing helpers or existing objective behavior; no shared helpers or existing objective behavior were changed, so no additional regression target was required.
+  - [x] Confirm the workspace LiveView remains unchanged unless a minimal consumer wiring change is explicitly added to this work item.
+  - [x] Update FDD/PRD assumptions or open questions if implementation choices diverged; no divergence was found.
+  - [x] Add implementation references for acceptance criteria where the repository traceability workflow requires them.
+- Testing Tasks:
+  - [x] Run work-item validation before and after implementation.
+  - [x] Run final requirements verification for implementation completion.
+  - Command(s): `python3 /Users/raph/.local/share/harness/skills/validate/scripts/validate_work_item.py docs/exec-plans/current/epics/objectives-editor/core_data --check all`
+  - Command(s): `python3 /Users/raph/.local/share/harness/skills/requirements/scripts/requirements_trace.py docs/exec-plans/current/epics/objectives-editor/core_data --action verify_implementation`
+- Definition of Done:
+  - Implementation, tests, review, documentation, and requirements proof are synchronized.
+  - Downstream consumers can use the documented model without adding competing coverage queries.
+- Gate:
+  - All repository and Harness validation commands pass; no unresolved review findings or planning drift remains.
+- Dependencies:
+  - Phases 1-3 and required review round.
+- Parallelizable Work:
+  - Documentation synchronization and final regression selection can occur while review feedback is being consolidated.
+
+## Parallelization Notes
+
+- Phase 1 must precede Phases 2 and 3 because the row/model contract is the shared boundary.
+- Pure transformation tests may be written in parallel with query implementation after the row contract is agreed.
+- Query, security, and performance review should happen before wiring the model into UI consumers.
+- Phase 4 is serial with respect to final review and traceability closure.
+
+## Phase Gate Summary
+
+- Gate A: Phase 1 query and index tests pass; one scoped compact projection is verified.
+- Gate B: Phase 2 coverage/detail/search tests pass with correct parent/Sub-Objective semantics.
+- Gate C: Phase 3 resilience, embedded-only, observability, formatting, security, and performance checks pass.
+- Gate D: Phase 4 work-item validation, requirements verification, regression tests, and review closure pass.

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/prd.md
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/prd.md
@@ -1,0 +1,137 @@
+# MER-5855 LearningObjectiveCoverage Data Source - Product Requirements Document
+
+## 1. Overview
+
+Build a plain application-level Elixir data source for the authoring Learning Objectives Editor. It loads the project's current working-publication projection once and exposes deterministic in-memory coverage, hierarchy, detail, curriculum, and search structures for the editor and its dependent epic features.
+
+## 2. Background & Problem Statement
+
+The current workspace editor assembles attachment counts through an asynchronous LiveView pass and `Publishing.find_attached_objectives/1`. That path does not provide all data needed by the coverage experience, can require additional per-objective or per-content queries, and does not consistently aggregate parent objectives through their Sub-Objectives.
+
+The editor needs a single, compact authoring projection that represents the revisions in the current unpublished working publication. It must support summary counts, page-first detail groups, formative/summative classification, later filtering, and text search without selecting page or activity bodies or parsing page content during interaction. Jira `MER-5855` defines this application-level foundation for the parent epic `MER-5784`; `MER-5794`, `MER-5797`, `MER-5799`, `MER-5800`, and `MER-5801` are consumers or follow-on features.
+
+## 3. Goals & Non-Goals
+
+### Goals
+
+- Provide a focused `LearningObjectiveCoverage` module outside UI code.
+- Read the current working publication with one targeted compact projection query scoped to the project.
+- Build deterministic objective hierarchy, attachment, page/activity, curriculum, detail, and search indexes in memory.
+- Calculate parent and Sub-Objective coverage with the epic's direct-versus-descendant semantics.
+- Count static embedded activities through `activity_refs`, without loading full activity or page content.
+- Give downstream UI and filter work a stable data contract that does not mutate course content.
+
+### Non-Goals
+
+- Implement the Learning Objectives Editor UI, toolbar, expansion controls, or navigation.
+- Implement search/filter UI, CSV export, or project-level threshold persistence.
+- Include activity-bank selections or standalone banked activities in initial coverage counts.
+- Compute or persist learner proficiency aggregation.
+- Introduce a GenServer, supervised cache, external service, schema migration, or database full-text search.
+- Repair stale `activity_refs` or parse all page content as a fallback in the interaction path.
+
+## 4. Users & Use Cases
+
+- Authoring workspace: request one project-scoped coverage model and render objective summaries and page/activity details.
+- Follow-on filter/search features: query the same normalized model for low-coverage, curriculum, and partial-text filtering without issuing new content queries.
+- CSV export: consume compact activity, page, objective, and curriculum metadata without loading full revisions.
+- Developers and QA: exercise deterministic pure post-processing independently from LiveView rendering.
+
+## 5. UX / UI Requirements
+
+- No standalone UI is introduced by this work item.
+- The data source must provide enough original titles and stable identifiers for consumers to render accessible labels, page-first groups, formative/summative states, and navigation targets.
+- The data source must not change the existing authoring content or objective associations while being read.
+
+## 6. Functional Requirements
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+
+- Performance: use one project-scoped projection over current unpublished publication mappings; do not perform N+1 objective/page/activity queries or select `content` for pages or activities.
+- Determinism: normalize and sort relationship collections where consumer rendering or tests depend on ordering; repeated construction from the same projection produces equivalent results.
+- Reliability: exclude deleted revisions from coverage and tolerate missing, malformed, or irrelevant optional attributes without crashing the editor.
+- Safety: the module is read-only and must not modify revisions, resources, publications, objectives, pages, activities, or associations.
+- Maintainability: keep the public API and result shapes focused, document the projection assumptions, and keep data shaping out of the LiveView.
+- Security: scope every projection and returned index to the requested project and its current working publication; do not expose data from another project.
+- Accessibility/internationalization: preserve source titles and identifiers for consumers; matching normalization must be case-insensitive and whitespace-tolerant without replacing original display text.
+
+## 9. Data, Interfaces & Dependencies
+
+- Add a focused module such as `Oli.Authoring.ObjectiveCoverage` with a constructor/query operation for a project and pure or side-effect-free operations over the resulting model.
+- The projection joins the current unpublished publication, published resources, revisions, and project scope, selecting compact fields: revision/resource identifiers, resource type, slug/title, deleted flag, objectives, children, graded flag, activity references, scope, and activity type.
+- Partition rows into objectives, pages, activities, and containers, then build objective hierarchy, direct attachments, page-to-embedded-activity relationships, curriculum descendants/paths, coverage summaries, detail groups, and searchable text.
+- Page attachment classification uses `graded`; embedded activity classification inherits from its containing page. Activities are deduplicated by objective and assessment bucket for summaries while retaining page-grouped detail identity.
+- Parent objective summaries include direct attachments and all associated Sub-Objective attachments; Sub-Objective summaries include only direct Sub-Objective attachments.
+- Search text includes objective, Sub-Objective, page, and embedded activity titles and supports normalized partial substring matching in memory.
+- Initial activity coverage is static embedded activity coverage only. Bank-selection indexing is a separate follow-up capability.
+- Downstream UI work depends on this model; it must not copy the existing delivery `SectionResourceDepot` because authoring uses working-publication revisions.
+
+## 10. Repository & Platform Considerations
+
+- Follow the Phoenix context boundary: domain/data shaping belongs under `lib/oli/` and LiveView orchestration remains under `lib/oli_web/`.
+- Respect the resource/revision and publication model: read the revisions referenced by the project's current unpublished working publication, not every historical unpublished revision.
+- Avoid older helpers that scan page `content`, including JSON-path parent-page discovery, for this interaction path; use `activity_refs` maintained by page editing.
+- Add focused ExUnit tests for query scope, projection partitioning, hierarchy, deduplication, deleted rows, classification, search, and deterministic output. Use scenario coverage only if a real cross-domain authoring workflow is required.
+- Verification should include targeted `mix test` and `mix format`; code review should apply security, performance, Elixir, and requirements guidance when implementation is added.
+- Jira is the system of record: `MER-5855`, under epic `MER-5784`, is the source ticket for this work item.
+
+## 11. Feature Flagging, Rollout & Migration
+
+No feature flags present in this work item
+
+The module is introduced behind the consuming workspace/editor change and rolls out through the normal deployment process. No database migration or backfill is required for the initial embedded-only model. Existing or stale `activity_refs` data is a follow-up repair/indexing concern.
+
+## 12. Telemetry & Success Metrics
+
+- Use existing telemetry/APM conventions if the consumer path needs operational visibility; useful aggregate signals are projection duration, row counts by resource type, model-build duration, and failures, without logging page/activity bodies.
+- Success means one scoped projection supplies all initial coverage, detail, curriculum, and search data for the project, with no repeated per-objective/content queries.
+- Functional success is demonstrated by deterministic unit tests and consumer integration tests showing correct parent/Sub-Objective counts, page/activity grouping, filters' source data, search source data, deleted-row exclusion, and read-only behavior.
+
+## 13. Risks & Mitigations
+
+- Large projects make the projection or in-memory model expensive: select only compact attributes, measure query/build duration, and review memory/query shape before integrating into the LiveView.
+- Parent and child attachments are double-counted: build MapSet-based relationships and deduplicate resource ids per objective and assessment bucket.
+- Deleted or stale revisions appear as coverage: filter deleted revisions at projection time and add regression tests for stale deleted-page/activity rows.
+- Activity classification is ambiguous for bank selections: exclude bank selections from the initial model and document deterministic bank coverage as a separate indexed feature.
+- `activity_refs` is absent or stale on legacy pages: do not scan full content in the interaction path; track repair/backfill separately and make missing references a defined empty/unknown case.
+- A data source accidentally becomes a hidden process or cache: keep it a plain module with explicit inputs and return values, invoked in the parent LiveView process.
+- Consumers diverge into separate query paths: document and test the data contract so UI, filtering, and export work reuse the model.
+
+## 14. Open Questions & Assumptions
+
+### Open Questions
+
+- What exact public function names and result structs should be finalized during architecture/design, while keeping the module boundary stable for all consumer tickets?
+- Should missing `activity_refs` be represented as an empty relationship or an explicit data-quality marker in the consumer model?
+- What stable curriculum path representation do CSV and course-content filtering need beyond descendant page ids?
+- Are there existing resource-type constants/helpers that should be used instead of hard-coded identifiers in the projection implementation?
+
+### Assumptions
+
+- The workspace editor is the primary consumer; the older objectives editor route is unchanged unless product explicitly expands scope.
+- The working publication contains the revisions needed for objectives, pages, activities, and containers, and `published IS NULL` identifies the authoring working publication.
+- Objective attachment data is available in compact revision attributes and embedded activity relationships are available through `activity_refs`.
+- Static embedded activities are the only activity coverage counted in this initial ticket.
+- Figma details and interaction behavior belong to the consuming UI tickets, especially `MER-5794`.
+- Parent proficiency aggregation in `MER-5821` is unrelated to this read-only authoring coverage model and remains out of scope.
+
+## 15. QA Plan
+
+- Automated validation:
+  - Run Harness requirements capture, requirements structure validation, and PRD validation.
+  - Add targeted ExUnit tests for the compact query scope and selected fields, including no page/activity `content` selection.
+  - Test objective hierarchy, direct versus inherited parent counts, page/activity deduplication, formative/summative classification, page-to-activity grouping, curriculum descendants, normalized partial search, deterministic ordering, deleted-row exclusion, and read-only behavior.
+  - Run the affected `mix test` targets and `mix format`; run broader tests as implementation risk warrants.
+- Manual validation:
+  - Inspect representative coverage output for a project containing direct parent attachments, Sub-Objective attachments, duplicate tags, formative/summative pages, embedded activities, containers, and deleted revisions.
+  - Confirm the data source does not issue additional content queries or mutate authoring state when invoked by the workspace editor.
+
+## 16. Definition of Done
+
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/epics/objectives-editor/core_data/requirements.yml
+++ b/docs/exec-plans/current/epics/objectives-editor/core_data/requirements.yml
@@ -1,0 +1,108 @@
+work_item: core_data
+requirements:
+- id: FR-001
+  title: Provide a focused authoring coverage data source
+  description: Provide a plain application-level Elixir module that accepts a project
+    scope and returns a reusable, read-only Learning Objective coverage model for
+    the workspace editor and downstream epic features.
+  status: proposed
+- id: FR-002
+  title: Load one compact working-publication projection
+  description: Read the revisions referenced by the project's current unpublished
+    working publication with one targeted projection scoped to the project, selecting
+    only attributes needed for objectives, pages, activities, and curriculum containers.
+  status: proposed
+- id: FR-003
+  title: Build normalized hierarchy and attachment indexes
+  description: Partition projection rows and build objective parent/child relationships,
+    direct page/activity attachments, page-to-embedded-activity relationships, curriculum
+    descendants/paths, and stable lookup maps in memory.
+  status: proposed
+- id: FR-004
+  title: Calculate coverage summaries with correct hierarchy semantics
+  description: Calculate page and formative/summative activity coverage for Sub-Objectives
+    from direct attachments and for parent Learning Objectives from direct plus associated
+    Sub-Objective attachments, deduplicated by resource identity.
+  status: proposed
+- id: FR-005
+  title: Provide detail and search projections for consumers
+  description: Provide page-first detail groups and normalized in-memory searchable
+    text covering objective, Sub-Objective, page, and embedded activity titles, including
+    enough metadata for later filtering and navigation.
+  status: proposed
+- id: FR-006
+  title: Keep initial activity scope embedded-only and read-only
+  description: Count only static embedded activities referenced through activity_refs,
+    exclude bank selections from initial coverage, and ensure model construction never
+    mutates course content or associations.
+  status: proposed
+- id: FR-007
+  title: Enforce deterministic, scoped, and safe behavior
+  description: Scope results to the requested project and working publication, exclude
+    deleted revisions, tolerate optional data safely, and produce stable relationship
+    ordering suitable for rendering and testing.
+  status: proposed
+acceptance_criteria:
+- id: AC-001
+  requirement_id: FR-001
+  title: The workspace editor can obtain a coverage model through the application
+    module without embedding coverage data shaping or repeated content queries in
+    the LiveView.
+  status: proposed
+  verification_method: automated
+- id: AC-002
+  requirement_id: FR-002
+  title: Query tests prove that the model reads only the requested project's current
+    unpublished publication mappings, selects the required compact attributes, and
+    does not select page or activity content.
+  status: proposed
+  verification_method: automated
+- id: AC-003
+  requirement_id: FR-003
+  title: Given objective, page, activity, and container projection rows, tests verify
+    objective maps, parent/child links, direct attachment maps, page-to-embedded-activity
+    links from activity_refs, and curriculum descendant/path maps are built correctly.
+  status: proposed
+  verification_method: automated
+- id: AC-004
+  requirement_id: FR-004
+  title: Tests verify that Sub-Objective counts include only direct attachments, parent
+    counts include direct and child attachments, and duplicate page/activity ids count
+    once per objective and formative/summative bucket.
+  status: proposed
+  verification_method: automated
+- id: AC-005
+  requirement_id: FR-004
+  title: Tests verify page classification from graded, embedded activity classification
+    inherited from the containing page, and page-first detail grouping including pages
+    with no activities in a selected bucket.
+  status: proposed
+  verification_method: automated
+- id: AC-006
+  requirement_id: FR-005
+  title: Search tests verify case-insensitive, trimmed, whitespace-normalized partial
+    matching across objective, Sub-Objective, page, and activity titles while preserving
+    original display metadata and match hierarchy information.
+  status: proposed
+  verification_method: automated
+- id: AC-007
+  requirement_id: FR-006
+  title: Tests verify static embedded activities are included once as specified, bank
+    selections and standalone banked activities are excluded, and model construction
+    performs no writes to content or associations.
+  status: proposed
+  verification_method: automated
+- id: AC-008
+  requirement_id: FR-007
+  title: Tests verify deleted revisions and out-of-project rows are excluded, optional
+    or malformed attributes do not crash model construction, and repeated construction
+    from the same projection yields stable sorted output.
+  status: proposed
+  verification_method: automated
+- id: AC-009
+  requirement_id: FR-007
+  title: Targeted mix test and mix format checks pass, and performance review confirms
+    the initial coverage path has one scoped projection rather than N+1 objective/page/activity
+    queries.
+  status: proposed
+  verification_method: hybrid

--- a/lib/oli/authoring/objective_coverage.ex
+++ b/lib/oli/authoring/objective_coverage.ex
@@ -1,0 +1,721 @@
+defmodule Oli.Authoring.ObjectiveCoverage do
+  @moduledoc """
+  Builds a read-only snapshot of the learning-objective coverage data for an
+  authoring project's working publication.
+
+  The snapshot is intentionally request-scoped. It is built from a compact
+  projection and does not load page or activity content, create a process, or
+  mutate authoring data. Coverage calculations and consumer-specific views are
+  layered on top of this index in later iterations.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Repo
+  alias Oli.Resources.Revision
+  alias Oli.Resources.ResourceType
+
+  @telemetry_prefix [:oli, :authoring, :objective_coverage]
+
+  @type row :: %{
+          required(:project_id) => pos_integer(),
+          required(:publication_id) => pos_integer(),
+          required(:revision_id) => pos_integer(),
+          required(:resource_id) => pos_integer(),
+          required(:resource_type_id) => pos_integer(),
+          optional(:slug) => String.t() | nil,
+          optional(:title) => String.t() | nil,
+          optional(:deleted) => boolean(),
+          optional(:objectives) => map() | nil,
+          optional(:children) => list() | nil,
+          optional(:graded) => boolean() | nil,
+          optional(:activity_refs) => list() | nil,
+          optional(:scope) => atom() | String.t() | nil,
+          optional(:activity_type_id) => pos_integer() | nil
+        }
+
+  @type t :: %{
+          project_id: pos_integer() | nil,
+          publication_id: pos_integer() | nil,
+          rows_by_type: %{pos_integer() => [row()]},
+          objectives_by_id: %{pos_integer() => map()},
+          parents_by_child: %{pos_integer() => [pos_integer()]},
+          children_by_parent: %{pos_integer() => [pos_integer()]},
+          pages_by_id: %{pos_integer() => map()},
+          activities_by_id: %{pos_integer() => map()},
+          curriculum_by_id: %{pos_integer() => map()},
+          top_level_objective_ids: [pos_integer()],
+          direct_page_ids_by_objective: %{pos_integer() => [pos_integer()]},
+          activity_ids_by_objective: %{pos_integer() => %{atom() => [pos_integer()]}},
+          coverage_by_objective: %{pos_integer() => map()},
+          details_by_objective: %{pos_integer() => %{atom() => [map()]}},
+          search_by_objective: %{pos_integer() => map()}
+        }
+
+  @projection_types [
+    ResourceType.id_for_objective(),
+    ResourceType.id_for_page(),
+    ResourceType.id_for_activity(),
+    ResourceType.id_for_container()
+  ]
+
+  @doc """
+  Loads the compact working-publication projection for a project slug or
+  project struct and builds its in-memory indexes.
+
+  An existing project without indexed objective/page/activity/container rows
+  returns an empty snapshot. Invalid project arguments return an error before
+  querying the database.
+  """
+  @spec load(Project.t() | %{required(:id) => pos_integer()} | String.t()) ::
+          {:ok, t()} | {:error, :invalid_project}
+  def load(project_or_slug) do
+    started_at = System.monotonic_time()
+
+    try do
+      result =
+        with {:ok, query} <- projection_query(project_or_slug) do
+          rows = Repo.all(query)
+          context = context_from_rows(rows)
+          {:ok, build(rows, context)}
+        end
+
+      emit_load(result, project_or_slug, started_at)
+      result
+    rescue
+      exception ->
+        safe_telemetry_execute(
+          @telemetry_prefix ++ [:load, :exception],
+          %{count: 1},
+          project_metadata(project_or_slug) |> Map.put(:exception, exception.__struct__)
+        )
+
+        reraise(exception, __STACKTRACE__)
+    end
+  end
+
+  @doc "Returns the single compact Ecto projection used by `load/1`."
+  @spec projection_query(Project.t() | %{required(:id) => pos_integer()} | String.t()) ::
+          {:ok, Ecto.Query.t()} | {:error, :invalid_project}
+  def projection_query(%Project{id: project_id}), do: projection_query_by_id(project_id)
+
+  def projection_query(%{id: project_id}) when is_integer(project_id),
+    do: projection_query_by_id(project_id)
+
+  def projection_query(project_slug) when is_binary(project_slug) do
+    {:ok,
+     base_projection_query()
+     |> where([_pub, project, _mapping, _revision], project.slug == ^project_slug)}
+  end
+
+  def projection_query(_), do: {:error, :invalid_project}
+
+  @doc """
+  Builds indexes from compact projection rows. This function is public so the
+  transformation can be tested without a database.
+  """
+  @spec build([map()], map()) :: t()
+  def build(rows, context \\ %{}) when is_list(rows) do
+    started_at = System.monotonic_time()
+
+    normalized_rows =
+      rows
+      |> Enum.map(&normalize_row/1)
+      |> Enum.sort_by(&{&1.resource_type_id, &1.resource_id})
+
+    rows_by_type = Enum.group_by(normalized_rows, & &1.resource_type_id)
+
+    objectives = Map.get(rows_by_type, ResourceType.id_for_objective(), [])
+    pages = Map.get(rows_by_type, ResourceType.id_for_page(), [])
+    activities = Map.get(rows_by_type, ResourceType.id_for_activity(), [])
+    containers = Map.get(rows_by_type, ResourceType.id_for_container(), [])
+
+    objectives_by_id = Map.new(objectives, &{&1.resource_id, objective_summary(&1)})
+    children_by_parent = children_by_parent(objectives)
+    parents_by_child = parents_by_child(children_by_parent)
+    pages_by_id = Map.new(pages, &{&1.resource_id, page_summary(&1)})
+    activities_by_id = Map.new(activities, &{&1.resource_id, activity_summary(&1)})
+    direct_page_ids_by_objective = direct_page_ids_by_objective(pages)
+    activity_occurrences = activity_occurrences_by_objective(pages, activities_by_id)
+    activity_ids_by_objective = activity_ids_by_objective(activity_occurrences)
+
+    coverage_by_objective =
+      coverage_by_objective(
+        objectives_by_id,
+        children_by_parent,
+        direct_page_ids_by_objective,
+        activity_ids_by_objective
+      )
+
+    details_by_objective =
+      details_by_objective(
+        objectives_by_id,
+        children_by_parent,
+        direct_page_ids_by_objective,
+        activity_occurrences,
+        pages_by_id,
+        activities_by_id
+      )
+
+    search_by_objective =
+      search_by_objective(
+        objectives_by_id,
+        children_by_parent,
+        details_by_objective
+      )
+
+    model = %{
+      project_id: context[:project_id] || first_value(normalized_rows, :project_id),
+      publication_id: context[:publication_id] || first_value(normalized_rows, :publication_id),
+      rows_by_type: rows_by_type,
+      objectives_by_id: objectives_by_id,
+      parents_by_child: parents_by_child,
+      children_by_parent: children_by_parent,
+      pages_by_id: pages_by_id,
+      activities_by_id: activities_by_id,
+      curriculum_by_id: Map.new(containers ++ pages, &{&1.resource_id, curriculum_summary(&1)}),
+      top_level_objective_ids: top_level_objective_ids(objectives_by_id, parents_by_child),
+      direct_page_ids_by_objective: direct_page_ids_by_objective,
+      activity_ids_by_objective: activity_ids_by_objective,
+      coverage_by_objective: coverage_by_objective,
+      details_by_objective: details_by_objective,
+      search_by_objective: search_by_objective
+    }
+
+    emit_build(model, length(normalized_rows), started_at)
+    model
+  end
+
+  @doc "Returns the top-level objectives in stable title/id order."
+  @spec objectives(t()) :: [map()]
+  def objectives(model) do
+    Enum.map(model.top_level_objective_ids, &Map.fetch!(model.objectives_by_id, &1))
+  end
+
+  @doc "Returns coverage counts for an objective, or `nil` when it is unknown."
+  @spec coverage(t(), pos_integer()) :: map() | nil
+  def coverage(model, objective_id), do: Map.get(model.coverage_by_objective, objective_id)
+
+  @doc "Returns page-first detail groups for an objective and assessment bucket."
+  @spec details(t(), pos_integer(), atom() | String.t()) :: [map()]
+  def details(model, objective_id, bucket) do
+    bucket = normalize_bucket(bucket)
+    get_in(model.details_by_objective, [objective_id, bucket]) || []
+  end
+
+  @doc "Returns in-memory partial-search results for objective coverage."
+  @spec search(t(), String.t()) :: [map()]
+  def search(model, query) when is_binary(query) do
+    normalized_query = normalize_search_text(query)
+
+    if normalized_query == "" do
+      []
+    else
+      model.search_by_objective
+      |> Enum.flat_map(fn {objective_id, projection} ->
+        matches =
+          Enum.filter(projection.matches, fn match ->
+            String.contains?(match.normalized_title, normalized_query)
+          end)
+
+        if matches == [] do
+          []
+        else
+          [
+            %{
+              objective_id: objective_id,
+              matches: Enum.map(matches, &Map.delete(&1, :normalized_title))
+            }
+          ]
+        end
+      end)
+      |> Enum.sort_by(fn result ->
+        objective = Map.fetch!(model.objectives_by_id, result.objective_id)
+        {normalize_search_text(objective.title), result.objective_id}
+      end)
+    end
+  end
+
+  @doc "Returns page ids below selected curriculum nodes."
+  @spec curriculum_pages(t(), [pos_integer()]) :: [pos_integer()]
+  def curriculum_pages(model, selected_ids) do
+    selected_ids
+    |> normalize_ids()
+    |> Enum.flat_map(&curriculum_descendants(model, &1, MapSet.new()))
+    |> Enum.filter(&Map.has_key?(model.pages_by_id, &1))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp base_projection_query do
+    from pub in Publication,
+      join: project in Project,
+      on: project.id == pub.project_id,
+      join: mapping in PublishedResource,
+      on: mapping.publication_id == pub.id,
+      join: revision in Revision,
+      on: revision.id == mapping.revision_id and revision.resource_id == mapping.resource_id,
+      where: is_nil(pub.published),
+      where: revision.deleted == false,
+      where: revision.resource_type_id in ^@projection_types,
+      select: %{
+        project_id: project.id,
+        publication_id: pub.id,
+        revision_id: revision.id,
+        resource_id: revision.resource_id,
+        resource_type_id: revision.resource_type_id,
+        slug: revision.slug,
+        title: revision.title,
+        deleted: revision.deleted,
+        objectives: revision.objectives,
+        children: revision.children,
+        graded: revision.graded,
+        activity_refs: revision.activity_refs,
+        scope: revision.scope,
+        activity_type_id: revision.activity_type_id
+      }
+  end
+
+  defp projection_query_by_id(project_id) do
+    {:ok,
+     base_projection_query()
+     |> where([_pub, project, _mapping, _revision], project.id == ^project_id)}
+  end
+
+  defp context_from_rows([row | _]),
+    do: %{project_id: row.project_id, publication_id: row.publication_id}
+
+  defp context_from_rows([]), do: %{}
+
+  defp normalize_row(row) do
+    %{
+      project_id: Map.get(row, :project_id),
+      publication_id: Map.get(row, :publication_id),
+      revision_id: Map.get(row, :revision_id),
+      resource_id: Map.get(row, :resource_id),
+      resource_type_id: Map.get(row, :resource_type_id),
+      slug: Map.get(row, :slug),
+      title: Map.get(row, :title),
+      deleted: Map.get(row, :deleted, false) == true,
+      objectives: normalize_map(Map.get(row, :objectives)),
+      children: normalize_ids(Map.get(row, :children)),
+      graded: Map.get(row, :graded, false) == true,
+      activity_refs: normalize_ids(Map.get(row, :activity_refs)),
+      scope: Map.get(row, :scope),
+      activity_type_id: Map.get(row, :activity_type_id)
+    }
+  end
+
+  defp objective_summary(row) do
+    Map.take(row, [:resource_id, :revision_id, :slug, :title, :children, :objectives])
+  end
+
+  defp page_summary(row) do
+    Map.take(row, [
+      :resource_id,
+      :revision_id,
+      :slug,
+      :title,
+      :children,
+      :objectives,
+      :graded,
+      :activity_refs
+    ])
+  end
+
+  defp activity_summary(row) do
+    Map.take(row, [
+      :resource_id,
+      :revision_id,
+      :slug,
+      :title,
+      :objectives,
+      :scope,
+      :activity_type_id
+    ])
+  end
+
+  defp curriculum_summary(row) do
+    Map.take(row, [:resource_id, :revision_id, :slug, :title, :children])
+  end
+
+  defp direct_page_ids_by_objective(pages) do
+    Enum.reduce(pages, %{}, fn page, acc ->
+      Enum.reduce(objective_ids(page.objectives), acc, fn objective_id, acc ->
+        Map.update(acc, objective_id, [page.resource_id], fn page_ids ->
+          Enum.sort(Enum.uniq([page.resource_id | page_ids]))
+        end)
+      end)
+    end)
+  end
+
+  defp activity_occurrences_by_objective(pages, activities_by_id) do
+    Enum.reduce(pages, %{}, fn page, acc ->
+      bucket = assessment_bucket(page.graded)
+
+      Enum.reduce(page.activity_refs, acc, fn activity_id, acc ->
+        case Map.get(activities_by_id, activity_id) do
+          %{scope: scope, objectives: objectives} when scope in [:embedded, "embedded"] ->
+            Enum.reduce(objective_ids(objectives), acc, fn objective_id, acc ->
+              objective_occurrences = Map.get(acc, objective_id, %{})
+              bucket_occurrences = Map.get(objective_occurrences, bucket, %{})
+
+              bucket_occurrences =
+                Map.update(bucket_occurrences, page.resource_id, [activity_id], fn activity_ids ->
+                  Enum.sort(Enum.uniq([activity_id | activity_ids]))
+                end)
+
+              Map.put(
+                acc,
+                objective_id,
+                Map.put(objective_occurrences, bucket, bucket_occurrences)
+              )
+            end)
+
+          _ ->
+            acc
+        end
+      end)
+    end)
+  end
+
+  defp activity_ids_by_objective(activity_occurrences) do
+    Map.new(activity_occurrences, fn {objective_id, by_bucket} ->
+      {objective_id,
+       Map.new(by_bucket, fn {bucket, by_page} ->
+         {bucket, by_page |> Map.values() |> List.flatten() |> Enum.uniq() |> Enum.sort()}
+       end)}
+    end)
+  end
+
+  defp coverage_by_objective(
+         objectives_by_id,
+         children_by_parent,
+         direct_page_ids_by_objective,
+         activity_ids_by_objective
+       ) do
+    Map.new(objectives_by_id, fn {objective_id, _objective} ->
+      related_ids = objective_scope_ids(objective_id, children_by_parent)
+
+      page_count =
+        related_ids
+        |> Enum.flat_map(&Map.get(direct_page_ids_by_objective, &1, []))
+        |> Enum.uniq()
+        |> length()
+
+      activity_counts =
+        Enum.reduce([:formative, :summative], %{}, fn bucket, acc ->
+          count =
+            related_ids
+            |> Enum.flat_map(&(get_in(activity_ids_by_objective, [&1, bucket]) || []))
+            |> Enum.uniq()
+            |> length()
+
+          Map.put(acc, bucket, count)
+        end)
+
+      {objective_id,
+       %{
+         page_count: page_count,
+         formative_activity_count: activity_counts.formative,
+         summative_activity_count: activity_counts.summative,
+         sub_objective_count: length(Map.get(children_by_parent, objective_id, []))
+       }}
+    end)
+  end
+
+  defp details_by_objective(
+         objectives_by_id,
+         children_by_parent,
+         direct_page_ids_by_objective,
+         activity_occurrences,
+         pages_by_id,
+         activities_by_id
+       ) do
+    Map.new(objectives_by_id, fn {objective_id, _objective} ->
+      related_ids = objective_scope_ids(objective_id, children_by_parent)
+
+      direct_page_ids =
+        related_ids
+        |> Enum.flat_map(&Map.get(direct_page_ids_by_objective, &1, []))
+        |> MapSet.new()
+
+      activity_pages =
+        related_ids
+        |> Enum.flat_map(fn related_id ->
+          activity_occurrences
+          |> Map.get(related_id, %{})
+          |> Enum.flat_map(fn {_bucket, by_page} -> Map.keys(by_page) end)
+        end)
+        |> MapSet.new()
+
+      page_ids = MapSet.union(direct_page_ids, activity_pages)
+
+      buckets =
+        Map.new([:formative, :summative], fn bucket ->
+          groups =
+            page_ids
+            |> MapSet.to_list()
+            |> Enum.sort()
+            |> Enum.flat_map(fn page_id ->
+              case Map.get(pages_by_id, page_id) do
+                nil ->
+                  []
+
+                page ->
+                  activity_ids =
+                    related_ids
+                    |> Enum.flat_map(fn related_id ->
+                      get_in(activity_occurrences, [related_id, bucket, page_id]) || []
+                    end)
+                    |> Enum.uniq()
+                    |> Enum.sort()
+
+                  activities = Enum.map(activity_ids, &Map.fetch!(activities_by_id, &1))
+
+                  if MapSet.member?(direct_page_ids, page_id) or activity_ids != [] do
+                    [%{page: page, activities: activities}]
+                  else
+                    []
+                  end
+              end
+            end)
+
+          {bucket, groups}
+        end)
+
+      {objective_id, buckets}
+    end)
+  end
+
+  defp search_by_objective(objectives_by_id, children_by_parent, details_by_objective) do
+    Map.new(objectives_by_id, fn {objective_id, _objective} ->
+      related_ids =
+        objective_scope_ids(objective_id, children_by_parent)
+        |> Enum.filter(&Map.has_key?(objectives_by_id, &1))
+
+      objective_matches =
+        related_ids
+        |> Enum.map(fn related_id ->
+          related_objective = Map.fetch!(objectives_by_id, related_id)
+
+          %{
+            type: if(related_id == objective_id, do: :objective, else: :sub_objective),
+            resource_id: related_id,
+            title: related_objective.title,
+            normalized_title: normalize_search_text(related_objective.title)
+          }
+        end)
+
+      detail_matches =
+        details_by_objective
+        |> Map.get(objective_id, %{})
+        |> Map.values()
+        |> List.flatten()
+        |> Enum.flat_map(fn %{page: page, activities: activities} ->
+          [
+            %{
+              type: :page,
+              resource_id: page.resource_id,
+              title: page.title,
+              normalized_title: normalize_search_text(page.title)
+            }
+          ] ++
+            Enum.map(activities, fn activity ->
+              %{
+                type: :activity,
+                resource_id: activity.resource_id,
+                title: activity.title,
+                normalized_title: normalize_search_text(activity.title)
+              }
+            end)
+        end)
+
+      matches =
+        (objective_matches ++ detail_matches)
+        |> Enum.reject(&(&1.normalized_title == ""))
+        |> Enum.uniq_by(&{&1.type, &1.resource_id})
+
+      {objective_id,
+       %{
+         text: matches |> Enum.map(& &1.title) |> Enum.join(" ") |> normalize_search_text(),
+         matches: matches
+       }}
+    end)
+  end
+
+  defp top_level_objective_ids(objectives_by_id, parents_by_child) do
+    objectives_by_id
+    |> Map.keys()
+    |> Enum.reject(&Map.has_key?(parents_by_child, &1))
+    |> Enum.sort_by(fn objective_id ->
+      objective = Map.fetch!(objectives_by_id, objective_id)
+      {normalize_search_text(objective.title), objective_id}
+    end)
+  end
+
+  defp objective_scope_ids(objective_id, children_by_parent),
+    do: objective_scope_ids(objective_id, children_by_parent, MapSet.new())
+
+  defp objective_scope_ids(objective_id, children_by_parent, visited) do
+    if MapSet.member?(visited, objective_id) do
+      []
+    else
+      visited = MapSet.put(visited, objective_id)
+
+      [
+        objective_id
+        | Enum.flat_map(
+            Map.get(children_by_parent, objective_id, []),
+            &objective_scope_ids(&1, children_by_parent, visited)
+          )
+      ]
+    end
+  end
+
+  defp curriculum_descendants(model, resource_id, visited) do
+    if MapSet.member?(visited, resource_id) do
+      []
+    else
+      visited = MapSet.put(visited, resource_id)
+
+      [
+        resource_id
+        | Enum.flat_map(
+            Map.get(model.curriculum_by_id, resource_id, %{}) |> Map.get(:children, []),
+            &curriculum_descendants(model, &1, visited)
+          )
+      ]
+    end
+  end
+
+  defp objective_ids(objectives) when is_map(objectives) do
+    objectives
+    |> Map.values()
+    |> Enum.flat_map(&List.wrap/1)
+    |> Enum.filter(&is_integer/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp objective_ids(_), do: []
+
+  defp assessment_bucket(true), do: :summative
+  defp assessment_bucket(_), do: :formative
+
+  defp normalize_bucket(:formative), do: :formative
+  defp normalize_bucket(:summative), do: :summative
+  defp normalize_bucket("formative"), do: :formative
+  defp normalize_bucket("summative"), do: :summative
+  defp normalize_bucket(_), do: :formative
+
+  defp normalize_search_text(value) when is_binary(value) do
+    value
+    |> String.downcase()
+    |> String.trim()
+    |> String.replace(~r/\s+/, " ")
+  end
+
+  defp normalize_search_text(_), do: ""
+
+  defp emit_load(result, project_or_slug, started_at) do
+    {status, model} =
+      case result do
+        {:ok, model} -> {:completed, model}
+        {:error, reason} -> {reason, nil}
+      end
+
+    metadata =
+      project_metadata(project_or_slug)
+      |> Map.merge(model_metadata(model))
+      |> Map.put(:status, status)
+
+    safe_telemetry_execute(
+      @telemetry_prefix ++ [:load, :stop],
+      %{count: 1, duration_ms: duration_ms(started_at)},
+      metadata
+    )
+  end
+
+  defp emit_build(model, row_count, started_at) do
+    resource_counts =
+      model.rows_by_type
+      |> Enum.map(fn {resource_type_id, rows} ->
+        {Integer.to_string(resource_type_id), length(rows)}
+      end)
+      |> Map.new()
+
+    safe_telemetry_execute(
+      @telemetry_prefix ++ [:build, :stop],
+      %{count: 1, duration_ms: duration_ms(started_at), row_count: row_count},
+      %{
+        project_id: model.project_id,
+        publication_id: model.publication_id,
+        resource_counts: resource_counts
+      }
+    )
+  end
+
+  defp model_metadata(nil), do: %{project_id: nil, publication_id: nil, row_count: 0}
+
+  defp model_metadata(model) do
+    %{
+      project_id: model.project_id,
+      publication_id: model.publication_id,
+      row_count: model.rows_by_type |> Map.values() |> Enum.map(&length/1) |> Enum.sum(),
+      objective_count: map_size(model.objectives_by_id),
+      page_count: map_size(model.pages_by_id),
+      activity_count: map_size(model.activities_by_id)
+    }
+  end
+
+  defp project_metadata(%Project{id: project_id, slug: project_slug}),
+    do: %{project_id: project_id, project_slug: project_slug}
+
+  defp project_metadata(%{id: project_id}), do: %{project_id: project_id}
+
+  defp project_metadata(project_slug) when is_binary(project_slug),
+    do: %{project_slug: project_slug}
+
+  defp project_metadata(_), do: %{}
+
+  defp safe_telemetry_execute(event, measurements, metadata) do
+    :telemetry.execute(event, measurements, metadata)
+  rescue
+    _ -> :ok
+  end
+
+  defp duration_ms(started_at) do
+    System.monotonic_time()
+    |> Kernel.-(started_at)
+    |> System.convert_time_unit(:native, :millisecond)
+  end
+
+  defp children_by_parent(objectives) do
+    objectives
+    |> Enum.reduce(%{}, fn row, acc -> Map.put(acc, row.resource_id, row.children) end)
+    |> Map.new(fn {parent_id, children} -> {parent_id, Enum.sort(children)} end)
+  end
+
+  defp parents_by_child(children_by_parent) do
+    Enum.reduce(children_by_parent, %{}, fn {parent_id, children}, acc ->
+      Enum.reduce(children, acc, fn child_id, acc ->
+        Map.update(acc, child_id, [parent_id], fn parents -> Enum.sort([parent_id | parents]) end)
+      end)
+    end)
+  end
+
+  defp normalize_map(value) when is_map(value), do: value
+  defp normalize_map(_), do: %{}
+
+  defp normalize_ids(value) when is_list(value),
+    do: value |> Enum.filter(&is_integer/1) |> Enum.uniq() |> Enum.sort()
+
+  defp normalize_ids(_), do: []
+
+  defp first_value([row | _], key), do: Map.get(row, key)
+  defp first_value([], _key), do: nil
+end

--- a/lib/oli/authoring/objective_coverage.ex
+++ b/lib/oli/authoring/objective_coverage.ex
@@ -44,9 +44,14 @@ defmodule Oli.Authoring.ObjectiveCoverage do
           objectives_by_id: %{pos_integer() => map()},
           parents_by_child: %{pos_integer() => [pos_integer()]},
           children_by_parent: %{pos_integer() => [pos_integer()]},
+          objective_scope_by_id: %{pos_integer() => [pos_integer()]},
           pages_by_id: %{pos_integer() => map()},
           activities_by_id: %{pos_integer() => map()},
           curriculum_by_id: %{pos_integer() => map()},
+          curriculum_parents_by_child: %{pos_integer() => [pos_integer()]},
+          curriculum_children_by_parent: %{pos_integer() => [pos_integer()]},
+          curriculum_descendants_by_id: %{pos_integer() => [pos_integer()]},
+          curriculum_paths_by_id: %{pos_integer() => [[pos_integer()]]},
           top_level_objective_ids: [pos_integer()],
           direct_page_ids_by_objective: %{pos_integer() => [pos_integer()]},
           activity_ids_by_objective: %{pos_integer() => %{atom() => [pos_integer()]}},
@@ -66,12 +71,14 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   Loads the compact working-publication projection for a project slug or
   project struct and builds its in-memory indexes.
 
-  An existing project without indexed objective/page/activity/container rows
-  returns an empty snapshot. Invalid project arguments return an error before
-  querying the database.
+  An existing project with an empty working publication returns an empty
+  snapshot with project and publication context. Missing projects and working
+  publications return tagged errors. Invalid project arguments return an error
+  before querying the database.
   """
   @spec load(Project.t() | %{required(:id) => pos_integer()} | String.t()) ::
-          {:ok, t()} | {:error, :invalid_project}
+          {:ok, t()}
+          | {:error, :invalid_project | :project_not_found | :working_publication_not_found}
   def load(project_or_slug) do
     started_at = System.monotonic_time()
 
@@ -80,7 +87,17 @@ defmodule Oli.Authoring.ObjectiveCoverage do
         with {:ok, query} <- projection_query(project_or_slug) do
           rows = Repo.all(query)
           context = context_from_rows(rows)
-          {:ok, build(rows, context)}
+
+          case {context[:project_id], context[:publication_id]} do
+            {nil, _publication_id} ->
+              {:error, :project_not_found}
+
+            {_project_id, nil} ->
+              {:error, :working_publication_not_found}
+
+            _ ->
+              {:ok, build(Enum.filter(rows, &is_integer(&1.resource_id)), context)}
+          end
         end
 
       emit_load(result, project_or_slug, started_at)
@@ -108,7 +125,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   def projection_query(project_slug) when is_binary(project_slug) do
     {:ok,
      base_projection_query()
-     |> where([_pub, project, _mapping, _revision], project.slug == ^project_slug)}
+     |> where([project, _pub, _mapping, _revision], project.slug == ^project_slug)}
   end
 
   def projection_query(_), do: {:error, :invalid_project}
@@ -136,6 +153,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     objectives_by_id = Map.new(objectives, &{&1.resource_id, objective_summary(&1)})
     children_by_parent = children_by_parent(objectives)
     parents_by_child = parents_by_child(children_by_parent)
+    objective_scope_by_id = objective_scopes_by_id(objectives_by_id, children_by_parent)
     pages_by_id = Map.new(pages, &{&1.resource_id, page_summary(&1)})
     activities_by_id = Map.new(activities, &{&1.resource_id, activity_summary(&1)})
     direct_page_ids_by_objective = direct_page_ids_by_objective(pages)
@@ -145,6 +163,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     coverage_by_objective =
       coverage_by_objective(
         objectives_by_id,
+        objective_scope_by_id,
         children_by_parent,
         direct_page_ids_by_objective,
         activity_ids_by_objective
@@ -153,7 +172,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     details_by_objective =
       details_by_objective(
         objectives_by_id,
-        children_by_parent,
+        objective_scope_by_id,
         direct_page_ids_by_objective,
         activity_occurrences,
         pages_by_id,
@@ -163,9 +182,13 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     search_by_objective =
       search_by_objective(
         objectives_by_id,
-        children_by_parent,
+        objective_scope_by_id,
         details_by_objective
       )
+
+    curriculum_by_id = Map.new(containers ++ pages, &{&1.resource_id, curriculum_summary(&1)})
+    curriculum_children_by_parent = curriculum_children_by_parent(curriculum_by_id)
+    curriculum_parents_by_child = parents_by_child(curriculum_children_by_parent)
 
     model = %{
       project_id: context[:project_id] || first_value(normalized_rows, :project_id),
@@ -174,9 +197,16 @@ defmodule Oli.Authoring.ObjectiveCoverage do
       objectives_by_id: objectives_by_id,
       parents_by_child: parents_by_child,
       children_by_parent: children_by_parent,
+      objective_scope_by_id: objective_scope_by_id,
       pages_by_id: pages_by_id,
       activities_by_id: activities_by_id,
-      curriculum_by_id: Map.new(containers ++ pages, &{&1.resource_id, curriculum_summary(&1)}),
+      curriculum_by_id: curriculum_by_id,
+      curriculum_parents_by_child: curriculum_parents_by_child,
+      curriculum_children_by_parent: curriculum_children_by_parent,
+      curriculum_descendants_by_id:
+        curriculum_descendants_by_id(curriculum_by_id, curriculum_children_by_parent),
+      curriculum_paths_by_id:
+        curriculum_paths_by_id(curriculum_by_id, curriculum_parents_by_child),
       top_level_objective_ids: top_level_objective_ids(objectives_by_id, parents_by_child),
       direct_page_ids_by_objective: direct_page_ids_by_objective,
       activity_ids_by_objective: activity_ids_by_objective,
@@ -244,23 +274,26 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   def curriculum_pages(model, selected_ids) do
     selected_ids
     |> normalize_ids()
-    |> Enum.flat_map(&curriculum_descendants(model, &1, MapSet.new()))
+    |> Enum.flat_map(fn resource_id ->
+      [resource_id | Map.get(model.curriculum_descendants_by_id, resource_id, [])]
+    end)
     |> Enum.filter(&Map.has_key?(model.pages_by_id, &1))
     |> Enum.uniq()
     |> Enum.sort()
   end
 
   defp base_projection_query do
-    from pub in Publication,
-      join: project in Project,
-      on: project.id == pub.project_id,
-      join: mapping in PublishedResource,
+    from project in Project,
+      left_join: pub in Publication,
+      on: pub.project_id == project.id and is_nil(pub.published),
+      left_join: mapping in PublishedResource,
       on: mapping.publication_id == pub.id,
-      join: revision in Revision,
-      on: revision.id == mapping.revision_id and revision.resource_id == mapping.resource_id,
-      where: is_nil(pub.published),
-      where: revision.deleted == false,
-      where: revision.resource_type_id in ^@projection_types,
+      left_join: revision in Revision,
+      on:
+        revision.id == mapping.revision_id and
+          revision.resource_id == mapping.resource_id and
+          revision.deleted == false and
+          revision.resource_type_id in ^@projection_types,
       select: %{
         project_id: project.id,
         publication_id: pub.id,
@@ -282,7 +315,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   defp projection_query_by_id(project_id) do
     {:ok,
      base_projection_query()
-     |> where([_pub, project, _mapping, _revision], project.id == ^project_id)}
+     |> where([project, _pub, _mapping, _revision], project.id == ^project_id)}
   end
 
   defp context_from_rows([row | _]),
@@ -343,12 +376,16 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   end
 
   defp direct_page_ids_by_objective(pages) do
-    Enum.reduce(pages, %{}, fn page, acc ->
+    pages
+    |> Enum.reduce(%{}, fn page, acc ->
       Enum.reduce(objective_ids(page.objectives), acc, fn objective_id, acc ->
-        Map.update(acc, objective_id, [page.resource_id], fn page_ids ->
-          Enum.sort(Enum.uniq([page.resource_id | page_ids]))
+        Map.update(acc, objective_id, MapSet.new([page.resource_id]), fn page_ids ->
+          MapSet.put(page_ids, page.resource_id)
         end)
       end)
+    end)
+    |> Map.new(fn {objective_id, page_ids} ->
+      {objective_id, page_ids |> MapSet.to_list() |> Enum.sort()}
     end)
   end
 
@@ -364,9 +401,14 @@ defmodule Oli.Authoring.ObjectiveCoverage do
               bucket_occurrences = Map.get(objective_occurrences, bucket, %{})
 
               bucket_occurrences =
-                Map.update(bucket_occurrences, page.resource_id, [activity_id], fn activity_ids ->
-                  Enum.sort(Enum.uniq([activity_id | activity_ids]))
-                end)
+                Map.update(
+                  bucket_occurrences,
+                  page.resource_id,
+                  MapSet.new([activity_id]),
+                  fn activity_ids ->
+                    MapSet.put(activity_ids, activity_id)
+                  end
+                )
 
               Map.put(
                 acc,
@@ -379,6 +421,19 @@ defmodule Oli.Authoring.ObjectiveCoverage do
             acc
         end
       end)
+    end)
+    |> normalize_activity_occurrences()
+  end
+
+  defp normalize_activity_occurrences(activity_occurrences) do
+    Map.new(activity_occurrences, fn {objective_id, by_bucket} ->
+      {objective_id,
+       Map.new(by_bucket, fn {bucket, by_page} ->
+         {bucket,
+          Map.new(by_page, fn {page_id, activity_ids} ->
+            {page_id, activity_ids |> MapSet.to_list() |> Enum.sort()}
+          end)}
+       end)}
     end)
   end
 
@@ -393,12 +448,13 @@ defmodule Oli.Authoring.ObjectiveCoverage do
 
   defp coverage_by_objective(
          objectives_by_id,
+         objective_scope_by_id,
          children_by_parent,
          direct_page_ids_by_objective,
          activity_ids_by_objective
        ) do
     Map.new(objectives_by_id, fn {objective_id, _objective} ->
-      related_ids = objective_scope_ids(objective_id, children_by_parent)
+      related_ids = Map.fetch!(objective_scope_by_id, objective_id)
 
       page_count =
         related_ids
@@ -429,14 +485,14 @@ defmodule Oli.Authoring.ObjectiveCoverage do
 
   defp details_by_objective(
          objectives_by_id,
-         children_by_parent,
+         objective_scope_by_id,
          direct_page_ids_by_objective,
          activity_occurrences,
          pages_by_id,
          activities_by_id
        ) do
     Map.new(objectives_by_id, fn {objective_id, _objective} ->
-      related_ids = objective_scope_ids(objective_id, children_by_parent)
+      related_ids = Map.fetch!(objective_scope_by_id, objective_id)
 
       direct_page_ids =
         related_ids
@@ -476,7 +532,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
 
                   activities = Enum.map(activity_ids, &Map.fetch!(activities_by_id, &1))
 
-                  if MapSet.member?(direct_page_ids, page_id) or activity_ids != [] do
+                  if assessment_bucket(page.graded) == bucket or activity_ids != [] do
                     [%{page: page, activities: activities}]
                   else
                     []
@@ -491,10 +547,10 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     end)
   end
 
-  defp search_by_objective(objectives_by_id, children_by_parent, details_by_objective) do
+  defp search_by_objective(objectives_by_id, objective_scope_by_id, details_by_objective) do
     Map.new(objectives_by_id, fn {objective_id, _objective} ->
       related_ids =
-        objective_scope_ids(objective_id, children_by_parent)
+        Map.fetch!(objective_scope_by_id, objective_id)
         |> Enum.filter(&Map.has_key?(objectives_by_id, &1))
 
       objective_matches =
@@ -557,26 +613,69 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     end)
   end
 
-  defp objective_scope_ids(objective_id, children_by_parent),
-    do: objective_scope_ids(objective_id, children_by_parent, MapSet.new())
+  defp objective_scopes_by_id(objectives_by_id, children_by_parent) do
+    {scopes_by_id, _memo} =
+      Enum.reduce(Map.keys(objectives_by_id), {%{}, %{}}, fn objective_id, {scopes, memo} ->
+        {scope, memo} = objective_scope_ids(objective_id, children_by_parent, memo, MapSet.new())
+        {Map.put(scopes, objective_id, scope), memo}
+      end)
 
-  defp objective_scope_ids(objective_id, children_by_parent, visited) do
-    if MapSet.member?(visited, objective_id) do
-      []
-    else
-      visited = MapSet.put(visited, objective_id)
+    scopes_by_id
+  end
 
-      [
-        objective_id
-        | Enum.flat_map(
-            Map.get(children_by_parent, objective_id, []),
-            &objective_scope_ids(&1, children_by_parent, visited)
-          )
-      ]
+  defp objective_scope_ids(objective_id, children_by_parent, memo, visiting) do
+    cond do
+      Map.has_key?(memo, objective_id) ->
+        {Map.fetch!(memo, objective_id), memo}
+
+      MapSet.member?(visiting, objective_id) ->
+        {[objective_id], memo}
+
+      true ->
+        visiting = MapSet.put(visiting, objective_id)
+
+        {child_scopes, memo} =
+          Enum.map_reduce(Map.get(children_by_parent, objective_id, []), memo, fn child_id,
+                                                                                  memo ->
+            objective_scope_ids(child_id, children_by_parent, memo, visiting)
+          end)
+
+        scope =
+          [objective_id | List.flatten(child_scopes)]
+          |> Enum.uniq()
+          |> Enum.sort()
+
+        {scope, Map.put(memo, objective_id, scope)}
     end
   end
 
-  defp curriculum_descendants(model, resource_id, visited) do
+  defp curriculum_children_by_parent(curriculum_by_id) do
+    Map.new(curriculum_by_id, fn {resource_id, node} ->
+      children =
+        node.children
+        |> Enum.filter(&Map.has_key?(curriculum_by_id, &1))
+        |> Enum.sort()
+
+      {resource_id, children}
+    end)
+  end
+
+  defp curriculum_descendants_by_id(curriculum_by_id, children_by_parent) do
+    Map.new(curriculum_by_id, fn {resource_id, _node} ->
+      descendants =
+        children_by_parent
+        |> Map.get(resource_id, [])
+        |> Enum.flat_map(
+          &curriculum_descendant_ids(&1, children_by_parent, MapSet.new([resource_id]))
+        )
+        |> Enum.uniq()
+        |> Enum.sort()
+
+      {resource_id, descendants}
+    end)
+  end
+
+  defp curriculum_descendant_ids(resource_id, children_by_parent, visited) do
     if MapSet.member?(visited, resource_id) do
       []
     else
@@ -585,10 +684,37 @@ defmodule Oli.Authoring.ObjectiveCoverage do
       [
         resource_id
         | Enum.flat_map(
-            Map.get(model.curriculum_by_id, resource_id, %{}) |> Map.get(:children, []),
-            &curriculum_descendants(model, &1, visited)
+            Map.get(children_by_parent, resource_id, []),
+            &curriculum_descendant_ids(&1, children_by_parent, visited)
           )
       ]
+    end
+  end
+
+  defp curriculum_paths_by_id(curriculum_by_id, parents_by_child) do
+    Map.new(curriculum_by_id, fn {resource_id, _node} ->
+      {resource_id, curriculum_paths(resource_id, parents_by_child, MapSet.new())}
+    end)
+  end
+
+  defp curriculum_paths(resource_id, parents_by_child, visited) do
+    if MapSet.member?(visited, resource_id) do
+      [[]]
+    else
+      visited = MapSet.put(visited, resource_id)
+      parent_ids = Map.get(parents_by_child, resource_id, [])
+
+      case parent_ids do
+        [] ->
+          [[resource_id]]
+
+        _ ->
+          Enum.flat_map(parent_ids, fn parent_id ->
+            Enum.map(curriculum_paths(parent_id, parents_by_child, visited), fn path ->
+              path ++ [resource_id]
+            end)
+          end)
+      end
     end
   end
 

--- a/lib/oli/authoring/objective_coverage.ex
+++ b/lib/oli/authoring/objective_coverage.ex
@@ -78,7 +78,11 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   """
   @spec load(Project.t() | %{required(:id) => pos_integer()} | String.t()) ::
           {:ok, t()}
-          | {:error, :invalid_project | :project_not_found | :working_publication_not_found}
+          | {:error,
+             :invalid_project
+             | :project_not_found
+             | :working_publication_not_found
+             | :multiple_working_publications}
   def load(project_or_slug) do
     started_at = System.monotonic_time()
 
@@ -88,15 +92,19 @@ defmodule Oli.Authoring.ObjectiveCoverage do
           rows = Repo.all(query)
           context = context_from_rows(rows)
 
-          case {context[:project_id], context[:publication_id]} do
+          case {context[:project_id], context[:publication_ids]} do
             {nil, _publication_id} ->
               {:error, :project_not_found}
 
-            {_project_id, nil} ->
+            {_project_id, []} ->
               {:error, :working_publication_not_found}
 
-            _ ->
-              {:ok, build(Enum.filter(rows, &is_integer(&1.resource_id)), context)}
+            {_project_id, [_publication_id, _other_publication_id | _]} ->
+              {:error, :multiple_working_publications}
+
+            {_project_id, [publication_id]} ->
+              build_context = %{project_id: context.project_id, publication_id: publication_id}
+              {:ok, build(Enum.filter(rows, &is_integer(&1.resource_id)), build_context)}
           end
         end
 
@@ -318,10 +326,17 @@ defmodule Oli.Authoring.ObjectiveCoverage do
      |> where([project, _pub, _mapping, _revision], project.id == ^project_id)}
   end
 
-  defp context_from_rows([row | _]),
-    do: %{project_id: row.project_id, publication_id: row.publication_id}
-
-  defp context_from_rows([]), do: %{}
+  defp context_from_rows(rows) when is_list(rows) do
+    %{
+      project_id: first_value(rows, :project_id),
+      publication_ids:
+        rows
+        |> Enum.map(&Map.get(&1, :publication_id))
+        |> Enum.filter(&is_integer/1)
+        |> Enum.uniq()
+        |> Enum.sort()
+    }
+  end
 
   defp normalize_row(row) do
     %{
@@ -616,7 +631,9 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   defp objective_scopes_by_id(objectives_by_id, children_by_parent) do
     {scopes_by_id, _memo} =
       Enum.reduce(Map.keys(objectives_by_id), {%{}, %{}}, fn objective_id, {scopes, memo} ->
-        {scope, memo} = objective_scope_ids(objective_id, children_by_parent, memo, MapSet.new())
+        {scope, memo, _cyclic?} =
+          objective_scope_ids(objective_id, children_by_parent, memo, MapSet.new())
+
         {Map.put(scopes, objective_id, scope), memo}
       end)
 
@@ -626,26 +643,33 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   defp objective_scope_ids(objective_id, children_by_parent, memo, visiting) do
     cond do
       Map.has_key?(memo, objective_id) ->
-        {Map.fetch!(memo, objective_id), memo}
+        {Map.fetch!(memo, objective_id), memo, false}
 
       MapSet.member?(visiting, objective_id) ->
-        {[objective_id], memo}
+        {[objective_id], memo, true}
 
       true ->
         visiting = MapSet.put(visiting, objective_id)
 
-        {child_scopes, memo} =
-          Enum.map_reduce(Map.get(children_by_parent, objective_id, []), memo, fn child_id,
-                                                                                  memo ->
-            objective_scope_ids(child_id, children_by_parent, memo, visiting)
-          end)
+        {child_scopes, memo, cyclic?} =
+          Enum.reduce(
+            Map.get(children_by_parent, objective_id, []),
+            {[], memo, false},
+            fn child_id, {scopes, memo, cyclic?} ->
+              {scope, memo, child_cyclic?} =
+                objective_scope_ids(child_id, children_by_parent, memo, visiting)
+
+              {[scope | scopes], memo, cyclic? or child_cyclic?}
+            end
+          )
 
         scope =
           [objective_id | List.flatten(child_scopes)]
           |> Enum.uniq()
           |> Enum.sort()
 
-        {scope, Map.put(memo, objective_id, scope)}
+        memo = if cyclic?, do: memo, else: Map.put(memo, objective_id, scope)
+        {scope, memo, cyclic?}
     end
   end
 
@@ -661,60 +685,91 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   end
 
   defp curriculum_descendants_by_id(curriculum_by_id, children_by_parent) do
-    Map.new(curriculum_by_id, fn {resource_id, _node} ->
-      descendants =
-        children_by_parent
-        |> Map.get(resource_id, [])
-        |> Enum.flat_map(
-          &curriculum_descendant_ids(&1, children_by_parent, MapSet.new([resource_id]))
-        )
-        |> Enum.uniq()
-        |> Enum.sort()
+    {descendants_by_id, _memo} =
+      Enum.reduce(Map.keys(curriculum_by_id), {%{}, %{}}, fn resource_id, {descendants, memo} ->
+        {scope, memo, _cyclic?} =
+          curriculum_scope_ids(resource_id, children_by_parent, memo, MapSet.new())
 
-      {resource_id, descendants}
-    end)
+        {Map.put(descendants, resource_id, List.delete(scope, resource_id)), memo}
+      end)
+
+    descendants_by_id
   end
 
-  defp curriculum_descendant_ids(resource_id, children_by_parent, visited) do
-    if MapSet.member?(visited, resource_id) do
-      []
-    else
-      visited = MapSet.put(visited, resource_id)
+  defp curriculum_scope_ids(resource_id, children_by_parent, memo, visiting) do
+    cond do
+      Map.has_key?(memo, resource_id) ->
+        {Map.fetch!(memo, resource_id), memo, false}
 
-      [
-        resource_id
-        | Enum.flat_map(
+      MapSet.member?(visiting, resource_id) ->
+        {[resource_id], memo, true}
+
+      true ->
+        visiting = MapSet.put(visiting, resource_id)
+
+        {child_scopes, memo, cyclic?} =
+          Enum.reduce(
             Map.get(children_by_parent, resource_id, []),
-            &curriculum_descendant_ids(&1, children_by_parent, visited)
+            {[], memo, false},
+            fn child_id, {scopes, memo, cyclic?} ->
+              {scope, memo, child_cyclic?} =
+                curriculum_scope_ids(child_id, children_by_parent, memo, visiting)
+
+              {[scope | scopes], memo, cyclic? or child_cyclic?}
+            end
           )
-      ]
+
+        scope =
+          [resource_id | List.flatten(child_scopes)]
+          |> Enum.uniq()
+          |> Enum.sort()
+
+        memo = if cyclic?, do: memo, else: Map.put(memo, resource_id, scope)
+        {scope, memo, cyclic?}
     end
   end
 
   defp curriculum_paths_by_id(curriculum_by_id, parents_by_child) do
-    Map.new(curriculum_by_id, fn {resource_id, _node} ->
-      {resource_id, curriculum_paths(resource_id, parents_by_child, MapSet.new())}
-    end)
+    {paths_by_id, _memo} =
+      Enum.reduce(Map.keys(curriculum_by_id), {%{}, %{}}, fn resource_id, {paths_by_id, memo} ->
+        {reverse_paths, memo, _cyclic?} =
+          curriculum_reverse_paths(resource_id, parents_by_child, memo, MapSet.new())
+
+        node_paths =
+          reverse_paths
+          |> Enum.map(&Enum.reverse/1)
+          |> Enum.sort()
+
+        {Map.put(paths_by_id, resource_id, node_paths), memo}
+      end)
+
+    paths_by_id
   end
 
-  defp curriculum_paths(resource_id, parents_by_child, visited) do
-    if MapSet.member?(visited, resource_id) do
-      [[]]
-    else
-      visited = MapSet.put(visited, resource_id)
-      parent_ids = Map.get(parents_by_child, resource_id, [])
+  defp curriculum_reverse_paths(resource_id, parents_by_child, memo, visiting) do
+    cond do
+      Map.has_key?(memo, resource_id) ->
+        {Map.fetch!(memo, resource_id), memo, false}
 
-      case parent_ids do
-        [] ->
-          [[resource_id]]
+      MapSet.member?(visiting, resource_id) ->
+        {[[]], memo, true}
 
-        _ ->
-          Enum.flat_map(parent_ids, fn parent_id ->
-            Enum.map(curriculum_paths(parent_id, parents_by_child, visited), fn path ->
-              path ++ [resource_id]
-            end)
+      true ->
+        visiting = MapSet.put(visiting, resource_id)
+        parent_ids = Map.get(parents_by_child, resource_id, [])
+
+        {parent_paths, memo, cyclic?} =
+          Enum.reduce(parent_ids, {[], memo, false}, fn parent_id, {paths, memo, cyclic?} ->
+            {parent_paths, memo, parent_cyclic?} =
+              curriculum_reverse_paths(parent_id, parents_by_child, memo, visiting)
+
+            {Enum.map(parent_paths, &[resource_id | &1]) ++ paths, memo,
+             cyclic? or parent_cyclic?}
           end)
-      end
+
+        reverse_paths = if parent_ids == [], do: [[resource_id]], else: parent_paths
+        memo = if cyclic?, do: memo, else: Map.put(memo, resource_id, reverse_paths)
+        {reverse_paths, memo, cyclic?}
     end
   end
 

--- a/test/oli/authoring/objective_coverage_test.exs
+++ b/test/oli/authoring/objective_coverage_test.exs
@@ -1,12 +1,25 @@
 defmodule Oli.Authoring.ObjectiveCoverageTest do
   use Oli.DataCase
 
-  # Requirements proof: AC-001, AC-002, AC-003, AC-004, AC-005, AC-006,
-  # AC-007, AC-008, and AC-009 are exercised by this focused suite, with query
-  # shape, pure projections, safety, and operational checks kept at the
-  # application-module boundary.
+  import Ecto.Query
+
+  # Requirements traceability:
+  # AC-001 -> "loads rows from the project's current working publication"
+  # AC-002 -> working-publication load, project isolation, deleted revision,
+  #            and compact projection tests
+  # AC-003 -> "builds normalized resource, hierarchy, and curriculum indexes"
+  # AC-004 -> "derives hierarchical coverage, page-first details, and search projections"
+  # AC-005 -> assessment-bucket and page-first detail assertions in the same test
+  # AC-006 -> search assertions in the same test
+  # AC-007 -> embedded/banked activity and input-preservation assertions
+  # AC-008 -> malformed data, cycle, isolation, deleted revision, and stable output tests
+  # AC-009 -> compact projection, telemetry, formatting, compilation, and focused test checks
 
   alias Oli.Authoring.ObjectiveCoverage
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Publishing.Publications.Publication
+  alias Oli.Repo
+  alias Oli.Resources.Revision
   alias Oli.Resources.ResourceType
 
   describe "build/2" do
@@ -50,7 +63,10 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
         )
       ]
 
-      model = ObjectiveCoverage.build(rows)
+      input_rows = rows
+      model = ObjectiveCoverage.build(input_rows)
+
+      assert input_rows == rows
 
       assert ObjectiveCoverage.coverage(model, 1) == %{
                page_count: 2,
@@ -69,10 +85,10 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       formative_details = ObjectiveCoverage.details(model, 1, :formative)
       summative_details = ObjectiveCoverage.details(model, 1, "summative")
 
-      assert Enum.map(formative_details, & &1.page.resource_id) == [100, 101]
+      assert Enum.map(formative_details, & &1.page.resource_id) == [100]
       assert Enum.map(hd(formative_details).activities, & &1.resource_id) == [200]
-      assert Enum.map(summative_details, & &1.page.resource_id) == [100, 101]
-      assert Enum.map(List.last(summative_details).activities, & &1.resource_id) == [200, 201]
+      assert Enum.map(summative_details, & &1.page.resource_id) == [101]
+      assert Enum.map(hd(summative_details).activities, & &1.resource_id) == [200, 201]
 
       search_results = ObjectiveCoverage.search(model, "assessment")
       assert Enum.map(search_results, & &1.objective_id) == [2, 1]
@@ -92,16 +108,18 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       page_id = 20
       activity_id = 30
       container_id = 40
+      nested_container_id = 50
 
       rows = [
         row(ResourceType.id_for_objective(), objective_id, children: [child_id]),
         row(ResourceType.id_for_objective(), child_id, children: nil),
         row(ResourceType.id_for_page(), page_id,
-          children: [page_id + 1],
+          children: [],
           activity_refs: [activity_id, activity_id]
         ),
         row(ResourceType.id_for_activity(), activity_id, scope: :embedded),
-        row(ResourceType.id_for_container(), container_id, children: [page_id])
+        row(ResourceType.id_for_container(), container_id, children: [nested_container_id]),
+        row(ResourceType.id_for_container(), nested_container_id, children: [page_id])
       ]
 
       model = ObjectiveCoverage.build(rows, %{project_id: 1, publication_id: 2})
@@ -113,7 +131,41 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       assert model.parents_by_child == %{child_id => [objective_id]}
       assert model.pages_by_id[page_id].activity_refs == [activity_id]
       assert model.activities_by_id[activity_id].scope == :embedded
-      assert model.curriculum_by_id[container_id].children == [page_id]
+      assert model.curriculum_by_id[container_id].children == [nested_container_id]
+
+      assert model.curriculum_children_by_parent == %{
+               container_id => [nested_container_id],
+               nested_container_id => [page_id],
+               page_id => []
+             }
+
+      assert model.curriculum_parents_by_child == %{
+               nested_container_id => [container_id],
+               page_id => [nested_container_id]
+             }
+
+      assert model.curriculum_descendants_by_id[container_id] == [page_id, nested_container_id]
+
+      assert model.curriculum_paths_by_id[page_id] == [
+               [container_id, nested_container_id, page_id]
+             ]
+
+      assert ObjectiveCoverage.curriculum_pages(model, [container_id]) == [page_id]
+    end
+
+    test "reuses shared objective descendant scopes" do
+      rows = [
+        row(ResourceType.id_for_objective(), 1, children: [3]),
+        row(ResourceType.id_for_objective(), 2, children: [3]),
+        row(ResourceType.id_for_objective(), 3, []),
+        row(ResourceType.id_for_page(), 30, objectives: %{"attached" => [3]})
+      ]
+
+      model = ObjectiveCoverage.build(rows)
+
+      assert model.objective_scope_by_id == %{1 => [1, 3], 2 => [2, 3], 3 => [3]}
+      assert ObjectiveCoverage.coverage(model, 1).page_count == 1
+      assert ObjectiveCoverage.coverage(model, 2).page_count == 1
     end
 
     test "normalizes malformed optional values and produces stable output" do
@@ -134,11 +186,15 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       cycle =
         ObjectiveCoverage.build([
           row(ResourceType.id_for_objective(), 1, children: [2]),
-          row(ResourceType.id_for_objective(), 2, children: [1])
+          row(ResourceType.id_for_objective(), 2, children: [1]),
+          row(ResourceType.id_for_container(), 40, children: [41]),
+          row(ResourceType.id_for_container(), 41, children: [40])
         ])
 
       assert ObjectiveCoverage.coverage(cycle, 1).sub_objective_count == 1
       assert ObjectiveCoverage.search(cycle, "resource") != []
+      assert cycle.curriculum_descendants_by_id[40] == [41]
+      assert cycle.curriculum_paths_by_id[40] == [[41, 40]]
     end
   end
 
@@ -150,6 +206,68 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       assert model.project_id == project.id
       assert is_integer(model.publication_id)
       assert model.rows_by_type != %{}
+    end
+
+    test "isolates loaded rows to the requested project" do
+      %{project: requested_project} = Seeder.base_project_with_resource2()
+      %{project: other_project} = Seeder.base_project_with_resource2()
+
+      assert {:ok, model} = ObjectiveCoverage.load(requested_project.slug)
+
+      rows = model.rows_by_type |> Map.values() |> List.flatten()
+
+      assert rows != []
+      assert Enum.all?(rows, &(&1.project_id == requested_project.id))
+      refute Enum.any?(rows, &(&1.project_id == other_project.id))
+    end
+
+    test "excludes deleted revisions from the loaded projection" do
+      %{project: project} = Seeder.base_project_with_resource2()
+      {:ok, model} = ObjectiveCoverage.load(project.slug)
+      row = model.rows_by_type |> Map.values() |> List.flatten() |> hd()
+
+      Repo.update_all(
+        from(revision in Revision, where: revision.id == ^row.revision_id),
+        set: [deleted: true]
+      )
+
+      assert {:ok, updated_model} = ObjectiveCoverage.load(project.slug)
+
+      refute updated_model.rows_by_type
+             |> Map.values()
+             |> List.flatten()
+             |> Enum.any?(&(&1.resource_id == row.resource_id))
+    end
+
+    test "returns a tagged error for an unknown project" do
+      assert {:error, :project_not_found} = ObjectiveCoverage.load("missing-project")
+    end
+
+    test "returns a tagged error when the project has no working publication" do
+      %{project: project} = Seeder.base_project_with_resource2()
+
+      Repo.update_all(
+        from(publication in Publication,
+          where: publication.project_id == ^project.id and is_nil(publication.published)
+        ),
+        set: [published: DateTime.utc_now()]
+      )
+
+      assert {:error, :working_publication_not_found} = ObjectiveCoverage.load(project.slug)
+    end
+
+    test "returns an empty model with context for an empty working publication" do
+      %{project: project} = Seeder.base_project_with_resource2()
+      {:ok, model} = ObjectiveCoverage.load(project.slug)
+
+      Repo.delete_all(
+        from(mapping in PublishedResource, where: mapping.publication_id == ^model.publication_id)
+      )
+
+      assert {:ok, empty_model} = ObjectiveCoverage.load(project.slug)
+      assert empty_model.project_id == project.id
+      assert empty_model.publication_id == model.publication_id
+      assert empty_model.rows_by_type == %{}
     end
 
     test "projects only compact working-publication fields" do

--- a/test/oli/authoring/objective_coverage_test.exs
+++ b/test/oli/authoring/objective_coverage_test.exs
@@ -2,6 +2,7 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
   use Oli.DataCase
 
   import Ecto.Query
+  import Oli.Factory
 
   # Requirements traceability:
   # AC-001 -> "loads rows from the project's current working publication"
@@ -185,14 +186,17 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
 
       cycle =
         ObjectiveCoverage.build([
-          row(ResourceType.id_for_objective(), 1, children: [2]),
+          row(ResourceType.id_for_objective(), 1, children: [2, 3]),
           row(ResourceType.id_for_objective(), 2, children: [1]),
+          row(ResourceType.id_for_objective(), 3, []),
           row(ResourceType.id_for_container(), 40, children: [41]),
           row(ResourceType.id_for_container(), 41, children: [40])
         ])
 
-      assert ObjectiveCoverage.coverage(cycle, 1).sub_objective_count == 1
+      assert ObjectiveCoverage.coverage(cycle, 1).sub_objective_count == 2
       assert ObjectiveCoverage.search(cycle, "resource") != []
+      assert cycle.objective_scope_by_id[1] == [1, 2, 3]
+      assert cycle.objective_scope_by_id[2] == [1, 2, 3]
       assert cycle.curriculum_descendants_by_id[40] == [41]
       assert cycle.curriculum_paths_by_id[40] == [[41, 40]]
     end
@@ -254,6 +258,25 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       )
 
       assert {:error, :working_publication_not_found} = ObjectiveCoverage.load(project.slug)
+    end
+
+    test "returns a tagged error when the project has multiple working publications" do
+      %{project: project} = Seeder.base_project_with_resource2()
+
+      publication =
+        Repo.one!(
+          from(publication in Publication,
+            where: publication.project_id == ^project.id and is_nil(publication.published)
+          )
+        )
+
+      insert(:publication,
+        project: project,
+        root_resource_id: publication.root_resource_id,
+        published: nil
+      )
+
+      assert {:error, :multiple_working_publications} = ObjectiveCoverage.load(project.slug)
     end
 
     test "returns an empty model with context for an empty working publication" do

--- a/test/oli/authoring/objective_coverage_test.exs
+++ b/test/oli/authoring/objective_coverage_test.exs
@@ -1,0 +1,210 @@
+defmodule Oli.Authoring.ObjectiveCoverageTest do
+  use Oli.DataCase
+
+  # Requirements proof: AC-001, AC-002, AC-003, AC-004, AC-005, AC-006,
+  # AC-007, AC-008, and AC-009 are exercised by this focused suite, with query
+  # shape, pure projections, safety, and operational checks kept at the
+  # application-module boundary.
+
+  alias Oli.Authoring.ObjectiveCoverage
+  alias Oli.Resources.ResourceType
+
+  describe "build/2" do
+    test "derives hierarchical coverage, page-first details, and search projections" do
+      rows = [
+        row(ResourceType.id_for_objective(), 1,
+          title: "Parent Objective",
+          children: [2],
+          objectives: %{}
+        ),
+        row(ResourceType.id_for_objective(), 2,
+          title: "Child Objective",
+          objectives: %{}
+        ),
+        row(ResourceType.id_for_page(), 100,
+          title: "Practice Page",
+          objectives: %{"attached" => [1]},
+          graded: false,
+          activity_refs: [200, 200]
+        ),
+        row(ResourceType.id_for_page(), 101,
+          title: "Assessment Page",
+          objectives: %{"attached" => [2]},
+          graded: true,
+          activity_refs: [200, 201, 202]
+        ),
+        row(ResourceType.id_for_activity(), 200,
+          title: "Practice Activity",
+          objectives: %{"part" => [2]},
+          scope: :embedded
+        ),
+        row(ResourceType.id_for_activity(), 201,
+          title: "Assessment Activity",
+          objectives: %{"part" => [1, 2]},
+          scope: :embedded
+        ),
+        row(ResourceType.id_for_activity(), 202,
+          title: "Banked Activity",
+          objectives: %{"part" => [2]},
+          scope: :banked
+        )
+      ]
+
+      model = ObjectiveCoverage.build(rows)
+
+      assert ObjectiveCoverage.coverage(model, 1) == %{
+               page_count: 2,
+               formative_activity_count: 1,
+               summative_activity_count: 2,
+               sub_objective_count: 1
+             }
+
+      assert ObjectiveCoverage.coverage(model, 2) == %{
+               page_count: 1,
+               formative_activity_count: 1,
+               summative_activity_count: 2,
+               sub_objective_count: 0
+             }
+
+      formative_details = ObjectiveCoverage.details(model, 1, :formative)
+      summative_details = ObjectiveCoverage.details(model, 1, "summative")
+
+      assert Enum.map(formative_details, & &1.page.resource_id) == [100, 101]
+      assert Enum.map(hd(formative_details).activities, & &1.resource_id) == [200]
+      assert Enum.map(summative_details, & &1.page.resource_id) == [100, 101]
+      assert Enum.map(List.last(summative_details).activities, & &1.resource_id) == [200, 201]
+
+      search_results = ObjectiveCoverage.search(model, "assessment")
+      assert Enum.map(search_results, & &1.objective_id) == [2, 1]
+
+      assert Enum.all?(search_results, fn result ->
+               Enum.any?(result.matches, &(&1.type == :activity and &1.resource_id == 201))
+             end)
+
+      refute Enum.any?(List.last(summative_details).activities, &(&1.resource_id == 202))
+
+      assert Enum.map(ObjectiveCoverage.curriculum_pages(model, [999]), & &1) == []
+    end
+
+    test "builds normalized resource, hierarchy, and curriculum indexes" do
+      objective_id = 10
+      child_id = 11
+      page_id = 20
+      activity_id = 30
+      container_id = 40
+
+      rows = [
+        row(ResourceType.id_for_objective(), objective_id, children: [child_id]),
+        row(ResourceType.id_for_objective(), child_id, children: nil),
+        row(ResourceType.id_for_page(), page_id,
+          children: [page_id + 1],
+          activity_refs: [activity_id, activity_id]
+        ),
+        row(ResourceType.id_for_activity(), activity_id, scope: :embedded),
+        row(ResourceType.id_for_container(), container_id, children: [page_id])
+      ]
+
+      model = ObjectiveCoverage.build(rows, %{project_id: 1, publication_id: 2})
+
+      assert model.project_id == 1
+      assert model.publication_id == 2
+      assert model.objectives_by_id[objective_id].children == [child_id]
+      assert model.children_by_parent == %{objective_id => [child_id], child_id => []}
+      assert model.parents_by_child == %{child_id => [objective_id]}
+      assert model.pages_by_id[page_id].activity_refs == [activity_id]
+      assert model.activities_by_id[activity_id].scope == :embedded
+      assert model.curriculum_by_id[container_id].children == [page_id]
+    end
+
+    test "normalizes malformed optional values and produces stable output" do
+      rows = [
+        row(ResourceType.id_for_objective(), 2, children: [3, 2, "invalid"]),
+        row(ResourceType.id_for_objective(), 1, children: [2]),
+        row(ResourceType.id_for_page(), 9, children: "invalid", activity_refs: nil)
+      ]
+
+      first = ObjectiveCoverage.build(rows)
+      second = ObjectiveCoverage.build(Enum.reverse(rows))
+
+      assert first.children_by_parent == %{1 => [2], 2 => [2, 3]}
+      assert first.pages_by_id[9].children == []
+      assert first.pages_by_id[9].activity_refs == []
+      assert first == second
+
+      cycle =
+        ObjectiveCoverage.build([
+          row(ResourceType.id_for_objective(), 1, children: [2]),
+          row(ResourceType.id_for_objective(), 2, children: [1])
+        ])
+
+      assert ObjectiveCoverage.coverage(cycle, 1).sub_objective_count == 1
+      assert ObjectiveCoverage.search(cycle, "resource") != []
+    end
+  end
+
+  describe "projection_query/1" do
+    test "loads rows from the project's current working publication" do
+      %{project: project} = Seeder.base_project_with_resource2()
+
+      assert {:ok, model} = ObjectiveCoverage.load(project.slug)
+      assert model.project_id == project.id
+      assert is_integer(model.publication_id)
+      assert model.rows_by_type != %{}
+    end
+
+    test "projects only compact working-publication fields" do
+      {:ok, query} = ObjectiveCoverage.projection_query("project-slug")
+      query_string = inspect(query)
+
+      assert query_string =~ "published"
+      assert query_string =~ "resource_type_id"
+      refute query_string =~ "content"
+    end
+
+    test "emits bounded load telemetry" do
+      handler_id = {__MODULE__, self(), System.unique_integer([:positive])}
+
+      :telemetry.attach(
+        handler_id,
+        [:oli, :authoring, :objective_coverage, :load, :stop],
+        fn event, measurements, metadata, pid ->
+          send(pid, {:objective_coverage_telemetry, event, measurements, metadata})
+        end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      %{project: project} = Seeder.base_project_with_resource2()
+      assert {:ok, _model} = ObjectiveCoverage.load(project.slug)
+
+      assert_receive {:objective_coverage_telemetry, event, %{count: 1, duration_ms: duration_ms},
+                      metadata}
+
+      assert event == [:oli, :authoring, :objective_coverage, :load, :stop]
+      assert is_integer(duration_ms)
+      assert metadata.project_id == project.id
+      assert metadata.project_slug == project.slug
+      refute inspect(metadata) =~ "content"
+    end
+  end
+
+  defp row(resource_type_id, resource_id, attrs) do
+    %{
+      project_id: 1,
+      publication_id: 2,
+      revision_id: resource_id + 100,
+      resource_id: resource_id,
+      resource_type_id: resource_type_id,
+      slug: "resource-#{resource_id}",
+      title: Keyword.get(attrs, :title, "Resource #{resource_id}"),
+      deleted: false,
+      objectives: Keyword.get(attrs, :objectives, %{"attached" => [1]}),
+      children: Keyword.get(attrs, :children, []),
+      graded: Keyword.get(attrs, :graded, false),
+      activity_refs: Keyword.get(attrs, :activity_refs, []),
+      scope: Keyword.get(attrs, :scope, :embedded),
+      activity_type_id: nil
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- Added Oli.Authoring.ObjectiveCoverage, a read-only application-level data source for Learning Objective coverage.
- Implemented a compact working-publication projection with project scoping and deleted-revision filtering.
- Added normalized hierarchy, curriculum, page, activity, coverage, detail, and search indexes.
- Added embedded-activity-only coverage with banked activity exclusion.
- Added telemetry, malformed-data safeguards, cycle protection, and deterministic output.
- Added focused ExUnit coverage and Harness traceability artifacts.

## Scope

This PR covers the core data layer for the Objectives Editor epic. It does not include:

- Workspace UI integration
- Filters or CSV export
- Proficiency aggregation
- Activity-bank indexing
- Database migrations or caching

## Verification

- mix format --check-formatted
- mix compile --warnings-as-errors
- mix test test/oli/authoring/objective_coverage_test.exs
    - 6 tests, 0 failures

- Harness work-item validation passed
- Requirements implementation traceability passed