### PR TITLE
[FEATURE] [MER-5849] Add Playwright coverage for credential-based account flows

### DIFF
--- a/.github/workflows/pr-playwright.yml
+++ b/.github/workflows/pr-playwright.yml
@@ -69,6 +69,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # Provides sane, non-secret defaults (e.g. CLOAK_VAULT_KEY) the same
+      # way nightly-scenarios does, so this job doesn't have to hand-list
+      # every variable the app reads at boot.
+      - name: Configure
+        run: cp oli.example.env oli.env
+
       - name: Setup BEAM toolchain
         uses: erlef/setup-beam@v1
         with:
@@ -110,7 +116,7 @@ jobs:
         run: mix deps.compile
 
       - name: Compile (MIX_ENV=playwright)
-        run: mix compile --warnings-as-errors
+        run: set -a && source oli.env && mix compile --warnings-as-errors
 
       - name: Create and migrate the ephemeral database
         run: |
@@ -126,7 +132,11 @@ jobs:
         run: npx playwright install --with-deps chrome
 
       - name: Start Torus (MIX_ENV=playwright)
-        run: nohup mix phx.server > /tmp/torus-server.log 2>&1 &
+        run: |
+          set -a
+          source oli.env
+          set +a
+          nohup mix phx.server > /tmp/torus-server.log 2>&1 &
 
       - name: Wait for Torus to be ready
         run: |

--- a/.github/workflows/pr-playwright.yml
+++ b/.github/workflows/pr-playwright.yml
@@ -1,0 +1,173 @@
+name: PR Playwright Suite
+
+# Runs Playwright tests against a dedicated Torus instance built and torn
+# down for this job only, with an isolated database, Swoosh.Adapters.Local
+# for email, and the /test/scenario-yaml and /test/emails endpoints enabled
+# (MIX_ENV=playwright). This is the counterpart to nightly-playwright.yml,
+# which targets a real, persistent Torus deployment and must never gain
+# access to those endpoints.
+#
+# To include a Playwright test here, tag its title (or its
+# test.describe title) with "@pr", the same way existing suites use
+# "@nightly" or "@smoke". The database starts out freshly created and empty
+# on every run - a test can (and, if it needs data, should) seed exactly
+# what it needs via /test/scenario-yaml, but only add "@pr" to a test that
+# doesn't depend on fixture data already present from elsewhere, or on real
+# third-party credentials (Canvas, Google, LTI tools, etc.) - this instance
+# has none of that.
+on:
+  pull_request:
+    branches:
+      - master
+      - hotfix-*
+      - prerelease-*
+      - nextgen-ux
+
+jobs:
+  pr-playwright:
+    name: PR Playwright Suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_DB: oli_playwright_ci
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d oli_playwright_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      MIX_ENV: playwright
+      DB_NAME: oli_playwright_ci
+      DB_HOST: localhost
+      # HOST and PLAYWRIGHT_BASE_URL must name the same host: the server
+      # builds absolute confirmation/reset links in emails from HOST, while
+      # Playwright resolves every relative page.goto(...) against
+      # PLAYWRIGHT_BASE_URL. A mismatch (e.g. 127.0.0.1 vs localhost) sends
+      # the browser to an origin it never visited, with none of the earlier
+      # cookies (including cookie consent) present there.
+      HOST: localhost
+      SCHEME: http
+      HTTP_PORT: 4002
+      PORT: 4002
+      PLAYWRIGHT_BASE_URL: http://localhost:4002
+      # Scoped to this ephemeral, unreachable-from-outside-the-job instance
+      # only; it never needs to be a real secret.
+      PLAYWRIGHT_SCENARIO_TOKEN: ci-ephemeral-token
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup BEAM toolchain
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: 1.19.2
+          otp-version: 28.1.1
+          gleam-version: '1.16.0'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 'lts/*'
+          cache: npm
+          cache-dependency-path: assets/automation/package-lock.json
+
+      - name: Restore deps cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-playwright-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-playwright-
+
+      - name: Install Gleam Mix archive
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix archive.install hex mix_gleam 0.6.2 --force
+
+      - name: Install Elixir dependencies
+        run: mix deps.get
+
+      - name: Build Gleam project
+        run: gleam build --target erlang
+        working-directory: gleam
+
+      - name: Build dependencies
+        run: mix deps.compile
+
+      - name: Compile (MIX_ENV=playwright)
+        run: mix compile --warnings-as-errors
+
+      - name: Create and migrate the ephemeral database
+        run: |
+          mix ecto.create
+          mix ecto.migrate
+
+      - name: Install Playwright dependencies
+        working-directory: assets/automation
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: assets/automation
+        run: npx playwright install --with-deps chrome
+
+      - name: Start Torus (MIX_ENV=playwright)
+        run: nohup mix phx.server > /tmp/torus-server.log 2>&1 &
+
+      - name: Wait for Torus to be ready
+        run: |
+          for _ in $(seq 1 60); do
+            if curl --silent --fail --output /dev/null "http://localhost:4002/"; then
+              echo "Torus is ready."
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Torus did not become ready in time." >&2
+          cat /tmp/torus-server.log
+          exit 1
+
+      - name: Run @pr-tagged Playwright tests
+        working-directory: assets/automation
+        run: npx playwright test --grep @pr --reporter=line
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-playwright-report
+          path: assets/automation/playwright-report/
+          retention-days: 14
+
+      - name: Upload Playwright test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-playwright-test-results
+          path: assets/automation/test-results/
+          retention-days: 14
+
+      - name: Upload Torus server log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-playwright-torus-server-log
+          path: /tmp/torus-server.log
+          retention-days: 14
+
+    # The postgres service container (and its `oli_playwright_ci` database)
+    # is destroyed with the job's runner; no manual cleanup step is needed.

--- a/.github/workflows/pr-playwright.yml
+++ b/.github/workflows/pr-playwright.yml
@@ -123,6 +123,17 @@ jobs:
           mix ecto.create
           mix ecto.migrate
 
+      - name: Install frontend dependencies
+        working-directory: assets
+        run: yarn install --frozen-lockfile
+
+      # Watchers are disabled for MIX_ENV=playwright (config/playwright.exs),
+      # so the JS/CSS bundles the app serves must be built once, upfront,
+      # rather than relying on the dev watcher process to build them live.
+      - name: Build frontend assets
+        working-directory: assets
+        run: yarn run deploy
+
       - name: Install Playwright dependencies
         working-directory: assets/automation
         run: npm ci

--- a/.github/workflows/pr-playwright.yml
+++ b/.github/workflows/pr-playwright.yml
@@ -118,10 +118,15 @@ jobs:
       - name: Compile (MIX_ENV=playwright)
         run: set -a && source oli.env && mix compile --warnings-as-errors
 
-      - name: Create and migrate the ephemeral database
-        run: |
-          mix ecto.create
-          mix ecto.migrate
+      # mix.exs's ecto.setup alias runs create, migrate, and
+      # priv/repo/seeds.exs. Seeding is required, not optional: the
+      # `system_roles` rows an Author's system_role_id foreign key points
+      # at (ids 1/2) are only ever inserted by seeds.exs, not by any
+      # migration - a fresh database with no seed data can migrate cleanly
+      # and still reject every author insert with a foreign_key_constraint
+      # error.
+      - name: Create, migrate, and seed the ephemeral database
+        run: set -a && source oli.env && mix ecto.setup
 
       - name: Install frontend dependencies
         working-directory: assets

--- a/assets/automation/src/core/mailbox.ts
+++ b/assets/automation/src/core/mailbox.ts
@@ -81,3 +81,20 @@ async function getMailboxEmail(
 function authHeaders(token: string) {
   return { 'x-playwright-scenario-token': token };
 }
+
+export function extractAccountLink(
+  htmlBody: string | null,
+  textBody: string | null,
+  segment: 'authors' | 'users',
+  action: 'confirm' | 'reset_password',
+): string {
+  const path = `/${segment}/${action}/`;
+  const source = [htmlBody, textBody].filter(Boolean).join(' ');
+  const match = source.match(new RegExp(`https?:\\/\\/[^\\s"'<]+${path}[^\\s"'<]+`));
+
+  if (!match) {
+    throw new Error(`Expected an account ${action} URL under ${path} in the email.`);
+  }
+
+  return match[0].replace(/&amp;/g, '&');
+}

--- a/assets/automation/src/core/mailbox.ts
+++ b/assets/automation/src/core/mailbox.ts
@@ -1,0 +1,83 @@
+import { APIRequestContext } from '@playwright/test';
+
+type MailboxMessage = {
+  id: string;
+  subject: string;
+  to: string[];
+  sent_at: string;
+};
+
+type MailboxMessageDetail = MailboxMessage & {
+  html_body: string | null;
+  text_body: string | null;
+};
+
+type WaitForEmailOptions = {
+  baseUrl: string;
+  recipient: string;
+  subject: string;
+  token: string;
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 250;
+
+export async function waitForMailboxEmail(
+  request: APIRequestContext,
+  options: WaitForEmailOptions,
+): Promise<MailboxMessageDetail> {
+  const deadline = Date.now() + (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  while (Date.now() < deadline) {
+    const messages = await listMailboxEmails(request, options);
+
+    if (messages.length > 0) {
+      return getMailboxEmail(request, options, messages[0].id);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  throw new Error(
+    `Timed out waiting for '${options.subject}' email sent to '${options.recipient}'.`,
+  );
+}
+
+async function listMailboxEmails(
+  request: APIRequestContext,
+  options: WaitForEmailOptions,
+): Promise<MailboxMessage[]> {
+  const url = new URL('/test/emails', options.baseUrl);
+  url.searchParams.set('to', options.recipient);
+  url.searchParams.set('subject', options.subject);
+
+  const response = await request.get(url.toString(), { headers: authHeaders(options.token) });
+
+  if (!response.ok()) {
+    throw new Error(`Mailbox list request failed (${response.status()}): ${await response.text()}`);
+  }
+
+  return ((await response.json()) as { emails: MailboxMessage[] }).emails;
+}
+
+async function getMailboxEmail(
+  request: APIRequestContext,
+  options: WaitForEmailOptions,
+  id: string,
+): Promise<MailboxMessageDetail> {
+  const url = new URL(`/test/emails/${encodeURIComponent(id)}`, options.baseUrl);
+  const response = await request.get(url.toString(), { headers: authHeaders(options.token) });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Mailbox detail request failed (${response.status()}): ${await response.text()}`,
+    );
+  }
+
+  return ((await response.json()) as { email: MailboxMessageDetail }).email;
+}
+
+function authHeaders(token: string) {
+  return { 'x-playwright-scenario-token': token };
+}

--- a/assets/automation/src/core/runtimeConfig.ts
+++ b/assets/automation/src/core/runtimeConfig.ts
@@ -51,7 +51,7 @@ export function hasRuntimeBaseUrl(): boolean {
 }
 
 export function getScenarioToken(): string {
-  return runtimeConfig.scenarioToken || 'my-token';
+  return runtimeConfig.scenarioToken || process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
 }
 
 export function shouldAutoCloseBrowser(): boolean {

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -62,8 +62,8 @@ export class CredentialAccountPO {
     await expect(this.page.getByText('Password reset successfully.')).toBeVisible();
   }
 
-  async login(email: string, password: string) {
-    await this.page.goto(`/${this.pathSegment()}/log_in`);
+  async login(email: string, password: string, loginPath?: string) {
+    await this.page.goto(loginPath ?? `/${this.pathSegment()}/log_in`);
 
     const form = this.page.locator('#login_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
@@ -77,8 +77,12 @@ export class CredentialAccountPO {
     await expect(this.page.getByText('Invalid email or password')).toBeVisible();
   }
 
-  async expectLoginSuccess() {
-    await this.page.waitForURL(this.destinationPath());
+  async expectLoginSuccess(destination?: string) {
+    await this.page.waitForURL(destination ?? this.destinationPath());
+  }
+
+  async expectAccountLabel(label: string) {
+    await expect(this.page.locator('[role="account label"]')).toHaveText(label);
   }
 
   private formName() {

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -27,12 +27,14 @@ export class CredentialAccountPO {
       .locator(`input[name="${this.formName()}[password_confirmation]"]`)
       .fill(account.password);
 
+    await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Create account', exact: true }).click();
     await this.page.waitForURL(`/${this.pathSegment()}/confirm`);
   }
 
   async confirm(url: string) {
     await this.page.goto(url);
+    await this.acceptCookieConsentIfVisible();
     await this.page.getByRole('button', { name: 'Confirm', exact: true }).click();
     await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
     await expect(this.page.getByText('Email successfully confirmed.')).toBeVisible();
@@ -43,6 +45,7 @@ export class CredentialAccountPO {
 
     const form = this.page.locator('#reset_password_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
+    await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Send password reset instructions' }).click();
     await this.page.waitForURL(this.resetRequestDestination());
   }
@@ -53,6 +56,7 @@ export class CredentialAccountPO {
     const form = this.page.locator('#reset_password_form');
     await form.locator(`input[name="${this.formName()}[password]"]`).fill(password);
     await form.locator(`input[name="${this.formName()}[password_confirmation]"]`).fill(password);
+    await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Reset Password', exact: true }).click();
     await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
     await expect(this.page.getByText('Password reset successfully.')).toBeVisible();
@@ -64,6 +68,7 @@ export class CredentialAccountPO {
     const form = this.page.locator('#login_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
     await form.locator(`input[name="${this.formName()}[password]"]`).fill(password);
+    await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Sign in', exact: true }).click();
   }
 
@@ -90,5 +95,15 @@ export class CredentialAccountPO {
 
   private resetRequestDestination() {
     return this.type === 'author' ? '/authors/log_in' : '/';
+  }
+
+  private async acceptCookieConsentIfVisible() {
+    const consent = this.page.locator('#cookie_consent_display');
+    const acceptButton = consent.getByRole('button', { name: 'Accept', exact: true });
+
+    if (await acceptButton.isVisible({ timeout: 1_000 }).catch(() => false)) {
+      await acceptButton.click({ force: true });
+      await expect(consent).toBeHidden();
+    }
   }
 }

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -36,7 +36,7 @@ export class CredentialAccountPO {
     await this.page.goto(url);
     await this.acceptCookieConsentIfVisible();
     await this.page.getByRole('button', { name: 'Confirm', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
+    await this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' });
     await expect(this.page.getByText('Email successfully confirmed.')).toBeVisible();
   }
 
@@ -58,7 +58,7 @@ export class CredentialAccountPO {
     await form.locator(`input[name="${this.formName()}[password_confirmation]"]`).fill(password);
     await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Reset Password', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
+    await this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' });
     await expect(this.page.getByText('Password reset successfully.')).toBeVisible();
   }
 

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -29,7 +29,7 @@ export class CredentialAccountPO {
 
     await this.acceptCookieConsentIfVisible();
     await form.getByRole('button', { name: 'Create account', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/confirm`);
+    await this.page.waitForURL(`/${this.pathSegment()}/confirm`, { waitUntil: 'commit' });
   }
 
   async confirm(url: string) {

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -1,0 +1,94 @@
+import { expect, Page } from '@playwright/test';
+
+export type CredentialAccountType = 'author' | 'user';
+
+type AccountDetails = {
+  email: string;
+  familyName: string;
+  givenName: string;
+  password: string;
+};
+
+export class CredentialAccountPO {
+  constructor(
+    private readonly page: Page,
+    private readonly type: CredentialAccountType,
+  ) {}
+
+  async register(account: AccountDetails) {
+    await this.page.goto(`/${this.pathSegment()}/register`);
+
+    const form = this.page.locator('#registration_form');
+    await form.locator(`input[name="${this.formName()}[email]"]`).fill(account.email);
+    await form.locator(`input[name="${this.formName()}[given_name]"]`).fill(account.givenName);
+    await form.locator(`input[name="${this.formName()}[family_name]"]`).fill(account.familyName);
+    await form.locator(`input[name="${this.formName()}[password]"]`).fill(account.password);
+    await form
+      .locator(`input[name="${this.formName()}[password_confirmation]"]`)
+      .fill(account.password);
+
+    await form.getByRole('button', { name: 'Create account', exact: true }).click();
+    await this.page.waitForURL(`/${this.pathSegment()}/confirm`);
+  }
+
+  async confirm(url: string) {
+    await this.page.goto(url);
+    await this.page.getByRole('button', { name: 'Confirm', exact: true }).click();
+    await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
+    await expect(this.page.getByText('Email successfully confirmed.')).toBeVisible();
+  }
+
+  async requestPasswordReset(email: string) {
+    await this.page.goto(`/${this.pathSegment()}/reset_password`);
+
+    const form = this.page.locator('#reset_password_form');
+    await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
+    await form.getByRole('button', { name: 'Send password reset instructions' }).click();
+    await this.page.waitForURL(this.resetRequestDestination());
+  }
+
+  async resetPassword(url: string, password: string) {
+    await this.page.goto(url);
+
+    const form = this.page.locator('#reset_password_form');
+    await form.locator(`input[name="${this.formName()}[password]"]`).fill(password);
+    await form.locator(`input[name="${this.formName()}[password_confirmation]"]`).fill(password);
+    await form.getByRole('button', { name: 'Reset Password', exact: true }).click();
+    await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
+    await expect(this.page.getByText('Password reset successfully.')).toBeVisible();
+  }
+
+  async login(email: string, password: string) {
+    await this.page.goto(`/${this.pathSegment()}/log_in`);
+
+    const form = this.page.locator('#login_form');
+    await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
+    await form.locator(`input[name="${this.formName()}[password]"]`).fill(password);
+    await form.getByRole('button', { name: 'Sign in', exact: true }).click();
+  }
+
+  async expectLoginFailure() {
+    await this.page.waitForURL(`/${this.pathSegment()}/log_in`);
+    await expect(this.page.getByText('Invalid email or password')).toBeVisible();
+  }
+
+  async expectLoginSuccess() {
+    await this.page.waitForURL(this.destinationPath());
+  }
+
+  private formName() {
+    return this.type;
+  }
+
+  private pathSegment() {
+    return this.type === 'author' ? 'authors' : 'users';
+  }
+
+  private destinationPath() {
+    return this.type === 'author' ? '/workspaces/course_author' : '/workspaces/student';
+  }
+
+  private resetRequestDestination() {
+    return this.type === 'author' ? '/authors/log_in' : '/';
+  }
+}

--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { BrowserContext, expect, Page } from '@playwright/test';
 
 export type CredentialAccountType = 'author' | 'user';
 
@@ -85,12 +85,19 @@ export class CredentialAccountPO {
     await expect(this.page.locator('[role="account label"]')).toHaveText(label);
   }
 
-  private formName() {
-    return this.type;
+  // Clears only the session cookie so a confirmation/reset link is followed
+  // anonymously, without wiping the cookie-consent choice and re-triggering
+  // the consent modal on the next navigation.
+  async clearSessionCookie(context: BrowserContext) {
+    await context.clearCookies({ name: '_oli_key' });
   }
 
-  private pathSegment() {
+  pathSegment(): 'authors' | 'users' {
     return this.type === 'author' ? 'authors' : 'users';
+  }
+
+  private formName() {
+    return this.type;
   }
 
   private destinationPath() {

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -1,0 +1,111 @@
+import { waitForMailboxEmail } from '@core/mailbox';
+import { test } from '@fixture/my-fixture';
+import { CredentialAccountPO, CredentialAccountType } from '@pom/home/CredentialAccountPO';
+import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
+
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
+const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
+
+test.describe('credential-based account flows', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test('author self-service lifecycle', async ({ context, page, request }, testInfo) => {
+    await exerciseSelfServiceLifecycle('author', context, page, request, testInfo.parallelIndex);
+  });
+
+  test('independent learner self-service lifecycle', async ({
+    context,
+    page,
+    request,
+  }, testInfo) => {
+    await exerciseSelfServiceLifecycle('user', context, page, request, testInfo.parallelIndex);
+  });
+});
+
+async function exerciseSelfServiceLifecycle(
+  type: CredentialAccountType,
+  context: BrowserContext,
+  page: Page,
+  request: APIRequestContext,
+  parallelIndex: number,
+) {
+  const suffix = `${Date.now()}-${parallelIndex}-${type}`;
+  const email = `pw-${suffix}@example.test`;
+  const initialPassword = `Initial-${suffix}-password`;
+  const newPassword = `Reset-${suffix}-password`;
+  const account = new CredentialAccountPO(page, type);
+
+  await setCookieConsent(context);
+  await account.register({
+    email,
+    givenName: 'Playwright',
+    familyName: type === 'author' ? 'Author' : 'Learner',
+    password: initialPassword,
+  });
+
+  const confirmation = await waitForMailboxEmail(request, {
+    baseUrl,
+    recipient: email,
+    subject: 'Confirm your email',
+    token: scenarioToken,
+  });
+
+  await context.clearCookies();
+  await setCookieConsent(context);
+  await account.confirm(
+    extractAccountLink(confirmation.html_body, confirmation.text_body, type, 'confirm'),
+  );
+
+  await account.login(email, initialPassword);
+  await account.expectLoginSuccess();
+
+  await context.clearCookies();
+  await setCookieConsent(context);
+  await account.requestPasswordReset(email);
+
+  const reset = await waitForMailboxEmail(request, {
+    baseUrl,
+    recipient: email,
+    subject: 'Reset password',
+    token: scenarioToken,
+  });
+
+  await account.resetPassword(
+    extractAccountLink(reset.html_body, reset.text_body, type, 'reset_password'),
+    newPassword,
+  );
+
+  await account.login(email, initialPassword);
+  await account.expectLoginFailure();
+
+  await account.login(email, newPassword);
+  await account.expectLoginSuccess();
+}
+
+function setCookieConsent(context: BrowserContext) {
+  return context.addCookies([
+    {
+      name: '_cky_opt_in',
+      value: 'true',
+      url: baseUrl,
+    },
+  ]);
+}
+
+function extractAccountLink(
+  htmlBody: string | null,
+  textBody: string | null,
+  type: CredentialAccountType,
+  action: 'confirm' | 'reset_password',
+) {
+  const segment = type === 'author' ? 'authors' : 'users';
+  const path = `/${segment}/${action}/`;
+  const source = [htmlBody, textBody].filter(Boolean).join(' ');
+  const match = source.match(new RegExp(`https?:\\/\\/[^\\s"'<]+${path}[^\\s"'<]+`));
+
+  if (!match) {
+    throw new Error(`Expected an account ${action} URL for ${type} in the email.`);
+  }
+
+  return match[0].replace(/&amp;/g, '&');
+}

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -35,7 +35,6 @@ async function exerciseSelfServiceLifecycle(
   const newPassword = `Reset-${suffix}-password`;
   const account = new CredentialAccountPO(page, type);
 
-  await setCookieConsent(context);
   await account.register({
     email,
     givenName: 'Playwright',
@@ -51,7 +50,6 @@ async function exerciseSelfServiceLifecycle(
   });
 
   await context.clearCookies();
-  await setCookieConsent(context);
   await account.confirm(
     extractAccountLink(confirmation.html_body, confirmation.text_body, type, 'confirm'),
   );
@@ -60,7 +58,6 @@ async function exerciseSelfServiceLifecycle(
   await account.expectLoginSuccess();
 
   await context.clearCookies();
-  await setCookieConsent(context);
   await account.requestPasswordReset(email);
 
   const reset = await waitForMailboxEmail(request, {
@@ -80,16 +77,6 @@ async function exerciseSelfServiceLifecycle(
 
   await account.login(email, newPassword);
   await account.expectLoginSuccess();
-}
-
-function setCookieConsent(context: BrowserContext) {
-  return context.addCookies([
-    {
-      name: '_cky_opt_in',
-      value: 'true',
-      url: baseUrl,
-    },
-  ]);
 }
 
 function extractAccountLink(

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -1,4 +1,4 @@
-import { waitForMailboxEmail } from '@core/mailbox';
+import { extractAccountLink, waitForMailboxEmail } from '@core/mailbox';
 import { test } from '@fixture/my-fixture';
 import { CredentialAccountPO, CredentialAccountType } from '@pom/home/CredentialAccountPO';
 import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
@@ -54,7 +54,7 @@ async function exerciseSelfServiceLifecycle(
   // the consent modal on the next navigation.
   await context.clearCookies({ name: '_oli_key' });
   await account.confirm(
-    extractAccountLink(confirmation.html_body, confirmation.text_body, type, 'confirm'),
+    extractAccountLink(confirmation.html_body, confirmation.text_body, segment(type), 'confirm'),
   );
 
   await account.login(email, initialPassword);
@@ -74,7 +74,7 @@ async function exerciseSelfServiceLifecycle(
   });
 
   await account.resetPassword(
-    extractAccountLink(reset.html_body, reset.text_body, type, 'reset_password'),
+    extractAccountLink(reset.html_body, reset.text_body, segment(type), 'reset_password'),
     newPassword,
   );
 
@@ -85,20 +85,6 @@ async function exerciseSelfServiceLifecycle(
   await account.expectLoginSuccess();
 }
 
-function extractAccountLink(
-  htmlBody: string | null,
-  textBody: string | null,
-  type: CredentialAccountType,
-  action: 'confirm' | 'reset_password',
-) {
-  const segment = type === 'author' ? 'authors' : 'users';
-  const path = `/${segment}/${action}/`;
-  const source = [htmlBody, textBody].filter(Boolean).join(' ');
-  const match = source.match(new RegExp(`https?:\\/\\/[^\\s"'<]+${path}[^\\s"'<]+`));
-
-  if (!match) {
-    throw new Error(`Expected an account ${action} URL for ${type} in the email.`);
-  }
-
-  return match[0].replace(/&amp;/g, '&');
+function segment(type: CredentialAccountType): 'authors' | 'users' {
+  return type === 'author' ? 'authors' : 'users';
 }

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -1,10 +1,8 @@
 import { extractAccountLink, waitForMailboxEmail } from '@core/mailbox';
+import { getBaseUrl, getScenarioToken } from '@core/runtimeConfig';
 import { test } from '@fixture/my-fixture';
 import { CredentialAccountPO, CredentialAccountType } from '@pom/home/CredentialAccountPO';
 import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
-
-const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
 
 test.describe('credential-based account flows @pr', () => {
   test.describe.configure({ timeout: 120_000 });
@@ -43,38 +41,37 @@ async function exerciseSelfServiceLifecycle(
   });
 
   const confirmation = await waitForMailboxEmail(request, {
-    baseUrl,
+    baseUrl: getBaseUrl(),
     recipient: email,
     subject: 'Confirm your email',
-    token: scenarioToken,
+    token: getScenarioToken(),
   });
 
-  // Clear only the session cookie so the confirmation/reset links are followed
-  // anonymously, without wiping the cookie-consent choice and re-triggering
-  // the consent modal on the next navigation.
-  await context.clearCookies({ name: '_oli_key' });
+  await account.clearSessionCookie(context);
   await account.confirm(
-    extractAccountLink(confirmation.html_body, confirmation.text_body, segment(type), 'confirm'),
+    extractAccountLink(
+      confirmation.html_body,
+      confirmation.text_body,
+      account.pathSegment(),
+      'confirm',
+    ),
   );
 
   await account.login(email, initialPassword);
   await account.expectLoginSuccess();
 
-  // Clear only the session cookie so the confirmation/reset links are followed
-  // anonymously, without wiping the cookie-consent choice and re-triggering
-  // the consent modal on the next navigation.
-  await context.clearCookies({ name: '_oli_key' });
+  await account.clearSessionCookie(context);
   await account.requestPasswordReset(email);
 
   const reset = await waitForMailboxEmail(request, {
-    baseUrl,
+    baseUrl: getBaseUrl(),
     recipient: email,
     subject: 'Reset password',
-    token: scenarioToken,
+    token: getScenarioToken(),
   });
 
   await account.resetPassword(
-    extractAccountLink(reset.html_body, reset.text_body, segment(type), 'reset_password'),
+    extractAccountLink(reset.html_body, reset.text_body, account.pathSegment(), 'reset_password'),
     newPassword,
   );
 
@@ -83,8 +80,4 @@ async function exerciseSelfServiceLifecycle(
 
   await account.login(email, newPassword);
   await account.expectLoginSuccess();
-}
-
-function segment(type: CredentialAccountType): 'authors' | 'users' {
-  return type === 'author' ? 'authors' : 'users';
 }

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -49,7 +49,10 @@ async function exerciseSelfServiceLifecycle(
     token: scenarioToken,
   });
 
-  await context.clearCookies();
+  // Clear only the session cookie so the confirmation/reset links are followed
+  // anonymously, without wiping the cookie-consent choice and re-triggering
+  // the consent modal on the next navigation.
+  await context.clearCookies({ name: '_oli_key' });
   await account.confirm(
     extractAccountLink(confirmation.html_body, confirmation.text_body, type, 'confirm'),
   );
@@ -57,7 +60,10 @@ async function exerciseSelfServiceLifecycle(
   await account.login(email, initialPassword);
   await account.expectLoginSuccess();
 
-  await context.clearCookies();
+  // Clear only the session cookie so the confirmation/reset links are followed
+  // anonymously, without wiping the cookie-consent choice and re-triggering
+  // the consent modal on the next navigation.
+  await context.clearCookies({ name: '_oli_key' });
   await account.requestPasswordReset(email);
 
   const reset = await waitForMailboxEmail(request, {

--- a/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-flows.spec.ts
@@ -6,7 +6,7 @@ import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
 const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
 
-test.describe('credential-based account flows', () => {
+test.describe('credential-based account flows @pr', () => {
   test.describe.configure({ timeout: 120_000 });
 
   test('author self-service lifecycle', async ({ context, page, request }, testInfo) => {

--- a/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
@@ -9,7 +9,7 @@ const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
 const scenarioPath = path.resolve(__dirname, './playwright_credential_roles.yaml');
 const seededPassword = 'changeme123456';
 
-test.describe('credential-based account flows - provisioned roles', () => {
+test.describe('credential-based account flows - provisioned roles @pr', () => {
   test.describe.configure({ timeout: 120_000 });
 
   test('system admin author credential lifecycle', async ({

--- a/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
@@ -1,11 +1,10 @@
 import path from 'node:path';
 import { extractAccountLink, waitForMailboxEmail } from '@core/mailbox';
+import { getBaseUrl, getScenarioToken } from '@core/runtimeConfig';
 import { test } from '@fixture/my-fixture';
 import { CredentialAccountPO, CredentialAccountType } from '@pom/home/CredentialAccountPO';
 import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
 
-const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
 const scenarioPath = path.resolve(__dirname, './playwright_credential_roles.yaml');
 const seededPassword = 'changeme123456';
 
@@ -78,7 +77,6 @@ async function exerciseProvisionedRoleLifecycle({
   page: Page;
   request: APIRequestContext;
 }) {
-  const segment = type === 'author' ? 'authors' : 'users';
   const newPassword = `Reset-${Date.now()}-${type}-password`;
   const account = new CredentialAccountPO(page, type);
 
@@ -86,21 +84,18 @@ async function exerciseProvisionedRoleLifecycle({
   await account.expectLoginSuccess(destination);
   await account.expectAccountLabel(accountLabel);
 
-  // Clear only the session cookie so the reset link is followed anonymously,
-  // without wiping the cookie-consent choice and re-triggering the consent
-  // modal on the next navigation.
-  await context.clearCookies({ name: '_oli_key' });
+  await account.clearSessionCookie(context);
   await account.requestPasswordReset(email);
 
   const reset = await waitForMailboxEmail(request, {
-    baseUrl,
+    baseUrl: getBaseUrl(),
     recipient: email,
     subject: 'Reset password',
-    token: scenarioToken,
+    token: getScenarioToken(),
   });
 
   await account.resetPassword(
-    extractAccountLink(reset.html_body, reset.text_body, segment, 'reset_password'),
+    extractAccountLink(reset.html_body, reset.text_body, account.pathSegment(), 'reset_password'),
     newPassword,
   );
 

--- a/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
+++ b/assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts
@@ -1,0 +1,113 @@
+import path from 'node:path';
+import { extractAccountLink, waitForMailboxEmail } from '@core/mailbox';
+import { test } from '@fixture/my-fixture';
+import { CredentialAccountPO, CredentialAccountType } from '@pom/home/CredentialAccountPO';
+import { APIRequestContext, BrowserContext, Page } from '@playwright/test';
+
+const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
+const scenarioToken = process.env.PLAYWRIGHT_SCENARIO_TOKEN || 'my-token';
+const scenarioPath = path.resolve(__dirname, './playwright_credential_roles.yaml');
+const seededPassword = 'changeme123456';
+
+test.describe('credential-based account flows - provisioned roles', () => {
+  test.describe.configure({ timeout: 120_000 });
+
+  test('system admin author credential lifecycle', async ({
+    context,
+    page,
+    request,
+    seedScenario,
+  }, testInfo) => {
+    const suffix = `${Date.now()}-${testInfo.parallelIndex}-admin`;
+    await seedScenario(scenarioPath, { RUN_ID: `-${suffix}` });
+
+    await exerciseProvisionedRoleLifecycle({
+      type: 'author',
+      email: `admin-${suffix}@example.test`,
+      destination: '/workspaces/course_author',
+      accountLabel: 'Admin',
+      context,
+      page,
+      request,
+    });
+  });
+
+  test('instructor user credential lifecycle', async ({
+    context,
+    page,
+    request,
+    seedScenario,
+  }, testInfo) => {
+    const suffix = `${Date.now()}-${testInfo.parallelIndex}-instructor`;
+    await seedScenario(scenarioPath, { RUN_ID: `-${suffix}` });
+
+    await exerciseProvisionedRoleLifecycle({
+      type: 'user',
+      email: `instructor-${suffix}@example.test`,
+      destination: '/workspaces/instructor',
+      accountLabel: 'Instructor',
+      // A plain /users/log_in submission always lands on /workspaces/student,
+      // regardless of can_create_sections: the redirect target is computed
+      // before current_user is assigned onto the conn. Only /instructors/log_in
+      // carries an explicit request_path=/workspaces/instructor in its form
+      // action, so it must be used to reach the instructor destination.
+      loginPath: '/instructors/log_in',
+      context,
+      page,
+      request,
+    });
+  });
+});
+
+async function exerciseProvisionedRoleLifecycle({
+  type,
+  email,
+  destination,
+  accountLabel,
+  loginPath,
+  context,
+  page,
+  request,
+}: {
+  type: CredentialAccountType;
+  email: string;
+  destination: string;
+  accountLabel: string;
+  loginPath?: string;
+  context: BrowserContext;
+  page: Page;
+  request: APIRequestContext;
+}) {
+  const segment = type === 'author' ? 'authors' : 'users';
+  const newPassword = `Reset-${Date.now()}-${type}-password`;
+  const account = new CredentialAccountPO(page, type);
+
+  await account.login(email, seededPassword, loginPath);
+  await account.expectLoginSuccess(destination);
+  await account.expectAccountLabel(accountLabel);
+
+  // Clear only the session cookie so the reset link is followed anonymously,
+  // without wiping the cookie-consent choice and re-triggering the consent
+  // modal on the next navigation.
+  await context.clearCookies({ name: '_oli_key' });
+  await account.requestPasswordReset(email);
+
+  const reset = await waitForMailboxEmail(request, {
+    baseUrl,
+    recipient: email,
+    subject: 'Reset password',
+    token: scenarioToken,
+  });
+
+  await account.resetPassword(
+    extractAccountLink(reset.html_body, reset.text_body, segment, 'reset_password'),
+    newPassword,
+  );
+
+  await account.login(email, seededPassword, loginPath);
+  await account.expectLoginFailure();
+
+  await account.login(email, newPassword, loginPath);
+  await account.expectLoginSuccess(destination);
+  await account.expectAccountLabel(accountLabel);
+}

--- a/assets/automation/tests/torus/user_accounts/playwright_credential_roles.yaml
+++ b/assets/automation/tests/torus/user_accounts/playwright_credential_roles.yaml
@@ -1,0 +1,23 @@
+# Scenario for provisioned-role credential-flow coverage. Torus has no
+# self-service registration for a system admin Author or an instructor User,
+# so these accounts must be seeded directly.
+# Parameters:
+#   RUN_ID - suffix to make emails unique per test run.
+
+- user:
+    name: 'credential_admin'
+    type: 'author'
+    system_role: 'system_admin'
+    email: 'admin${RUN_ID}@example.test'
+    given_name: 'Playwright'
+    family_name: 'Admin'
+    password: 'changeme123456'
+
+- user:
+    name: 'credential_instructor'
+    type: 'instructor'
+    can_create_sections: true
+    email: 'instructor${RUN_ID}@example.test'
+    given_name: 'Playwright'
+    family_name: 'Instructor'
+    password: 'changeme123456'

--- a/config/playwright.exs
+++ b/config/playwright.exs
@@ -1,0 +1,12 @@
+import Config
+
+# This environment is reserved for the ephemeral Torus instance used by the
+# credential-account Playwright suite. It must never be used for a persistent
+# staging or production deployment.
+config :oli,
+  env: :playwright,
+  enable_playwright_scenarios: true,
+  playwright_scenario_token: System.fetch_env!("PLAYWRIGHT_SCENARIO_TOKEN"),
+  recaptcha_module: Oli.Playwright.Recaptcha
+
+config :oli, Oli.Mailer, adapter: Swoosh.Adapters.Local

--- a/config/playwright.exs
+++ b/config/playwright.exs
@@ -1,5 +1,7 @@
 import Config
 
+import_config "dev.exs"
+
 # This environment is reserved for the ephemeral Torus instance used by the
 # credential-account Playwright suite. It must never be used for a persistent
 # staging or production deployment.
@@ -8,5 +10,11 @@ config :oli,
   enable_playwright_scenarios: true,
   playwright_scenario_token: System.fetch_env!("PLAYWRIGHT_SCENARIO_TOKEN"),
   recaptcha_module: Oli.Playwright.Recaptcha
+
+config :oli, Oli.Repo, database: System.get_env("DB_NAME", "oli_playwright")
+
+config :oli, OliWeb.Endpoint,
+  code_reloader: false,
+  live_reload: []
 
 config :oli, Oli.Mailer, adapter: Swoosh.Adapters.Local

--- a/config/playwright.exs
+++ b/config/playwright.exs
@@ -15,6 +15,7 @@ config :oli, Oli.Repo, database: System.get_env("DB_NAME", "oli_playwright")
 
 config :oli, OliWeb.Endpoint,
   code_reloader: false,
-  live_reload: []
+  live_reload: [],
+  watchers: []
 
 config :oli, Oli.Mailer, adapter: Swoosh.Adapters.Local

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -84,11 +84,16 @@ non-existent registration feature.
 existing Playwright token, and a browser test has a deterministic path to
 wait for a Local-adapter email.
 
-### Phase 2: Self-service lifecycle coverage
+### Phase 2: Self-service lifecycle coverage — complete
 
 - Add credential-account page objects or focused task helpers.
 - Add complete Author and independent-learner browser flows: registration,
   confirmation, login, reset, old-password rejection, and new-password login.
+- Generate a unique recipient per flow, select the message by recipient and
+  subject, and extract only the expected account-action URL (rather than an
+  unrelated link such as the email logo).
+- Preconfigure cookie consent in the test browser context so an unrelated
+  consent modal cannot obscure the credential-flow controls.
 
 **Exit criterion:** both self-service account types complete their lifecycle
 against a Playwright environment without a real inbox or external reCAPTCHA.

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -150,12 +150,59 @@ against a Playwright environment without a real inbox or external reCAPTCHA.
 credential reset behavior without pretending that they have self-service
 registration flows.
 
-### Phase 4: CI/CD integration and operational closure
+### Phase 4: CI/CD integration and operational closure — complete
 
-- Configure a dedicated CI job to start an isolated Torus instance with the
-  Local adapter, wait for readiness, and run only this suite.
-- Retain Playwright artifacts and server logs on failure.
-- Document required environment variables and the separation from Nightly.
+- Added `.github/workflows/pr-playwright.yml`, triggered on `pull_request` to
+  the same branches as the main `build.yml` CI (`master`, `hotfix-*`,
+  `prerelease-*`, `nextgen-ux`). It starts an ephemeral
+  `pgvector/pgvector:pg18` service-container database (destroyed with the
+  runner, satisfying the ticket's "reset the CI test database after the run"
+  without an explicit teardown step), compiles and boots Torus under
+  `MIX_ENV=playwright`, polls `/` until ready, then runs every `@pr`-tagged
+  test. Named and worded generically on purpose (no MER-5849/credential
+  wording in the workflow file itself): it is meant to be the durable,
+  reusable home for any future Playwright test that can run against a bare,
+  freshly created database, not a one-off tied to this ticket.
+  `HOST` and `PLAYWRIGHT_BASE_URL` are both set to `localhost` — see the
+  Phase 2 note above on why they must match.
+- `PLAYWRIGHT_SCENARIO_TOKEN` is a fixed, non-secret string
+  (`ci-ephemeral-token`) rather than a GitHub secret: the instance it protects
+  is unreachable outside the job and destroyed when it ends, so the token has
+  no value to protect beyond this one run.
+- On completion (success or failure), the job uploads the Playwright
+  report/trace/test-results (as `nightly-playwright.yml` already does) *and*
+  the Torus server's stdout/stderr, redirected to a file when the server is
+  started — nightly-playwright does not need this because it targets an
+  already-running, separately-logged deployment.
+- Test selection uses an explicit Playwright tag, `@pr`, applied to both
+  `credential-account-flows.spec.ts` and
+  `credential-account-provisioned-roles.spec.ts` describe blocks, run via
+  `npx playwright test --grep @pr`. This mirrors the existing `@nightly`/
+  `@smoke` tagging convention (single lowercase word naming *when/where* a
+  test runs, not what it tests) rather than inventing a new mechanism, and is
+  the semantic inverse of `@nightly` the ticket asked about, extensible to
+  future non-nightly, non-smoke suites without editing the workflow file.
+- **Rejected:** reusing the "Plasma" per-PR preview deployment
+  (`build-preview-image.yml`, `plasma.oli.cmu.edu`) that a ticket comment
+  suggested investigating. Plasma's actual deployment step is reconciled by
+  Argo CD in a private GitOps repository not present in this codebase, and
+  every Plasma preview is currently built as a shared, human-reviewable
+  `MIX_ENV=prod` image (real AWS SES mailer, no scenario/mailbox routes) —
+  changing that for all previews to get this suite's `MIX_ENV=playwright`
+  behavior is out of this repo's reach and out of this ticket's scope. A
+  fully self-contained job satisfies the ticket's own step-by-step "CI/CD
+  Integration" section without depending on that external infrastructure.
+- **Deferred, not built:** flipping test selection from opt-in (`@pr`) to
+  opt-out (`--grep-invert "@nightly|@smoke"`, so any newly added spec runs
+  here by default) is mechanically possible but not done. Several existing
+  suites under `assets/automation/tests/torus/` (LTI external tool, course
+  authoring, Google Docs import, Canvas) assume a persistent, pre-seeded
+  environment and real third-party credentials that this minimal, empty
+  ephemeral instance does not provide; inverting the grep today would run
+  them here and fail them for environment reasons unrelated to real bugs.
+  Doing this safely later requires first auditing and tagging (e.g.
+  `@requires-persistent-env`) every suite that cannot run against a bare
+  ephemeral instance.
 
 **Exit criterion:** pull-request or equivalent CI can run the suite on an
 ephemeral Playwright deployment without touching persistent staging or

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -111,11 +111,40 @@ wait for a Local-adapter email.
 **Exit criterion:** both self-service account types complete their lifecycle
 against a Playwright environment without a real inbox or external reCAPTCHA.
 
-### Phase 3: Provisioned-role credential coverage
+### Phase 3: Provisioned-role credential coverage — complete
 
-- Add scenario YAML bootstrap for a system admin and an instructor.
-- Add browser login/reset coverage for both and assert their role-specific
-  post-login destinations.
+- Seed a system admin Author (`system_role: system_admin`) and an instructor
+  User (`type: instructor`, `can_create_sections: true`) via the existing
+  scenario-YAML mechanism
+  (`assets/automation/tests/torus/user_accounts/playwright_credential_roles.yaml`),
+  reusing `seedScenario`/`/test/scenario-yaml` rather than factories or direct
+  database writes. Seeded accounts are pre-confirmed
+  (`email_verified` defaults to `true`), so no confirmation step is exercised
+  for these roles — only login, reset, old-password rejection, and
+  new-password login.
+- Cover both roles in
+  `assets/automation/tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts`,
+  reusing `CredentialAccountPO` from Phase 2 rather than the older
+  `HomeTask`/`LoginPO` role-picker stack.
+- Assert the role-specific destination and an account-menu role label
+  (`[role="account label"]`, e.g. "Admin"/"Instructor") after each successful
+  login, not just a successful authentication.
+- A plain `/users/log_in` submission always redirects to
+  `/workspaces/student`, even for a `can_create_sections: true` user: the
+  redirect target is computed before `current_user` is assigned onto the
+  `conn` (`lib/oli_web/user_auth.ex:23-41`). Reaching `/workspaces/instructor`
+  requires logging in through `/instructors/log_in`, whose form action embeds
+  `request_path=/workspaces/instructor` directly
+  (`lib/oli_web/live/user_login_live.ex:47`). `CredentialAccountPO.login`
+  therefore takes an optional `loginPath` override used only for the
+  instructor case; the system-admin Author already lands on the regular
+  `/workspaces/course_author` via `/authors/log_in`, distinguished only by the
+  "Admin" account-menu label.
+- Do not run both credential-flow spec files concurrently against the same
+  Playwright server/`test-results` directory (e.g. one from a terminal, one
+  from `--ui`); a single observed hang and a single unrelated trace-file
+  `ENOENT` both coincided with concurrent runs and did not reproduce across
+  22 clean, sequential runs.
 
 **Exit criterion:** Authoring and Delivery privileged roles prove their
 credential reset behavior without pretending that they have self-service

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -1,0 +1,134 @@
+# MER-5849 Credential-Based Account Flow Playwright Coverage
+
+## Purpose
+
+Add deterministic Playwright coverage for email/password account lifecycles without
+depending on real inboxes or the nightly suite's persistent deployments.
+
+## Decision Summary
+
+### Reuse the existing Playwright environment gate
+
+The email-inspection routes will be mounted only when
+`Application.compile_env(:oli, :enable_playwright_scenarios, false)` is enabled.
+They will use the existing `OliWeb.PlaywrightAuth` token check.
+
+This deliberately extends the test-only boundary established by MER-5171:
+`/test/scenario-yaml` already uses this compile-time gate and the same secret to
+let a Playwright-enabled deployment construct its own isolated test state. A
+separate email-specific flag would duplicate that deployment contract without
+providing an additional security boundary.
+
+Production and ordinary staging deployments keep this flag disabled. A
+Playwright-specific ephemeral deployment must enable it, use an isolated
+database, and supply its scenario token.
+
+### Reuse the local mailbox, not the mailbox-preview UI
+
+The Playwright environment will configure `Oli.Mailer` with
+`Swoosh.Adapters.Local`. A small JSON controller under `/test` will read the
+same local mailbox data. It is a machine contract for browser tests; it does
+not automate or change `/dev/mailbox`, which remains a human-oriented
+development preview.
+
+The API will support a recipient filter and stable message detail lookup. The
+list response will include enough metadata to select a message by recipient
+and subject; the detail response will expose the HTML and text bodies needed
+to extract a confirmation or reset URL.
+
+### Select emails by recipient and purpose, never by arrival order
+
+Each test creates a unique address. A single lifecycle produces both
+`Confirm your email` and `Reset password` messages, delivered asynchronously
+through Oban. The TypeScript mailbox helper will poll by the unique recipient
+and exact subject, then request the selected message by identifier. It must
+not assume that the newest message is the intended one.
+
+## Coverage Contract
+
+| Account case | Provisioning | Browser-driven coverage |
+| --- | --- | --- |
+| Standard Author | Self-service `/authors/register` | Registration, confirmation, login, reset, old-password rejection, new-password login, Authoring destination |
+| Independent learner | Self-service `/users/register` | Registration, confirmation, login, reset, old-password rejection, new-password login, Delivery destination |
+| System admin | Scenario-seeded Author with admin role | Login, reset, old-password rejection, new-password login, admin/Authoring destination |
+| Instructor | Scenario-seeded User with instructor capability | Login, reset, old-password rejection, new-password login, Instructor destination |
+
+Admin and instructor accounts are seeded because Torus has no public
+self-service registration flow for either privilege. They extend credential
+coverage across the Authoring and Delivery role boundaries without testing a
+non-existent registration feature.
+
+## Boundaries And Non-Goals
+
+- Do not add a public mailbox endpoint, runtime adapter switching, or a second
+  automation authorization mechanism.
+- Do not put these tests in the `@nightly` suite, which targets persistent
+  environments.
+- Do not change the credential lifecycle semantics, authorization rules, or
+  production email delivery adapter.
+- Do not automate `/dev/mailbox` HTML.
+- The registration flows require deterministic E2E handling of reCAPTCHA; the
+  approach must avoid a real external challenge during CI.
+
+## Implementation Outline
+
+### Phase 1: E2E foundation
+
+- Add guarded mailbox JSON endpoints and focused controller/authorization
+  tests, reusing `OliWeb.PlaywrightAuth`.
+- Configure the dedicated Playwright environment with the Local adapter and
+  deterministic reCAPTCHA handling for both account types.
+- Add the TypeScript mailbox polling helper.
+
+**Exit criterion:** the application exposes no mailbox data without the
+existing Playwright token, and a browser test has a deterministic path to
+wait for a Local-adapter email.
+
+### Phase 2: Self-service lifecycle coverage
+
+- Add credential-account page objects or focused task helpers.
+- Add complete Author and independent-learner browser flows: registration,
+  confirmation, login, reset, old-password rejection, and new-password login.
+
+**Exit criterion:** both self-service account types complete their lifecycle
+against a Playwright environment without a real inbox or external reCAPTCHA.
+
+### Phase 3: Provisioned-role credential coverage
+
+- Add scenario YAML bootstrap for a system admin and an instructor.
+- Add browser login/reset coverage for both and assert their role-specific
+  post-login destinations.
+
+**Exit criterion:** Authoring and Delivery privileged roles prove their
+credential reset behavior without pretending that they have self-service
+registration flows.
+
+### Phase 4: CI/CD integration and operational closure
+
+- Configure a dedicated CI job to start an isolated Torus instance with the
+  Local adapter, wait for readiness, and run only this suite.
+- Retain Playwright artifacts and server logs on failure.
+- Document required environment variables and the separation from Nightly.
+
+**Exit criterion:** pull-request or equivalent CI can run the suite on an
+ephemeral Playwright deployment without touching persistent staging or
+production systems.
+
+## Risks And Verification
+
+- **Async delivery:** poll the mailbox with bounded timeouts and include the
+  mailbox response in failure diagnostics where safe.
+- **Secret exposure:** require the existing token for every mailbox route;
+  test missing and invalid-token responses.
+- **Parallel interference:** use a generated address per test and server-side
+  recipient filtering.
+- **Environment drift:** verify the routes are present only when the existing
+  Playwright compile-time flag is enabled and run the suite only against the
+  dedicated CI deployment.
+- **Role drift:** assert role-specific post-login destinations for admin and
+  instructor, not merely successful authentication.
+
+Verification will include focused ExUnit controller tests, TypeScript linting
+and formatting, the targeted Playwright account-flow suite against the
+dedicated environment, and CI artifact checks for a forced or captured
+failure path.

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -94,6 +94,19 @@ wait for a Local-adapter email.
   unrelated link such as the email logo).
 - Dismiss the cookie-consent modal when it is present before a credential-flow
   action, so an unrelated asynchronous UI overlay cannot obscure its control.
+- Wait for the confirm/reset LiveViews' post-submit redirect using
+  `waitUntil: 'commit'` rather than the default `'load'`. These redirects are
+  pushed by LiveView over the existing WebSocket
+  (`Phoenix.LiveView.redirect/2`, a cross-document navigation), and Chrome did
+  not reliably report the resulting `load` event to Playwright even though the
+  navigation and render completed; waiting for `'commit'` avoids depending on
+  that event.
+- When simulating an anonymous confirmation or reset-password click (i.e. not
+  as the just-registered, auto-logged-in account), clear only the session
+  cookie (`context.clearCookies({ name: '_oli_key' })`) instead of every
+  cookie. Clearing all cookies also discarded the cookie-consent choice,
+  re-triggering the consent modal on the next navigation and racing with the
+  credential-flow submit it was meant to protect.
 
 **Exit criterion:** both self-service account types complete their lifecycle
 against a Playwright environment without a real inbox or external reCAPTCHA.
@@ -130,6 +143,18 @@ production systems.
 - **Environment drift:** verify the routes are present only when the existing
   Playwright compile-time flag is enabled and run the suite only against the
   dedicated CI deployment.
+- **`PLAYWRIGHT_BASE_URL` must match the server's `HOST`:** Playwright resolves
+  every relative `page.goto(...)` against `PLAYWRIGHT_BASE_URL`, but the
+  server builds the absolute confirmation/reset links embedded in emails from
+  `HOST` (`config/dev.exs:108`, inherited by `config/playwright.exs`). If the
+  two values name different hosts (e.g. `PLAYWRIGHT_BASE_URL=127.0.0.1` with
+  `HOST=localhost`), the browser reaches the emailed link on an origin it has
+  never visited, so no cookie set earlier in the flow (including the
+  cookie-consent choice) is present there. The consent modal then has to
+  mount fresh, asynchronously, on that page, racing the credential-flow
+  submit and intermittently blocking it — reproducible headed or in `--ui`
+  mode, not just headless. Keep `PLAYWRIGHT_BASE_URL` and `HOST` set to the
+  same hostname for any local or CI Playwright run.
 - **Role drift:** assert role-specific post-login destinations for admin and
   instructor, not merely successful authentication.
 

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -92,8 +92,8 @@ wait for a Local-adapter email.
 - Generate a unique recipient per flow, select the message by recipient and
   subject, and extract only the expected account-action URL (rather than an
   unrelated link such as the email logo).
-- Preconfigure cookie consent in the test browser context so an unrelated
-  consent modal cannot obscure the credential-flow controls.
+- Dismiss the cookie-consent modal when it is present before a credential-flow
+  action, so an unrelated asynchronous UI overlay cannot obscure its control.
 
 **Exit criterion:** both self-service account types complete their lifecycle
 against a Playwright environment without a real inbox or external reCAPTCHA.

--- a/lib/oli/playwright/recaptcha.ex
+++ b/lib/oli/playwright/recaptcha.ex
@@ -1,0 +1,15 @@
+defmodule Oli.Playwright.Recaptcha do
+  @moduledoc """
+  Deterministic reCAPTCHA implementation for the isolated Playwright environment.
+
+  The credential-account browser suite exercises Torus registration flows but
+  must not depend on the external reCAPTCHA service. `config/playwright.exs`
+  selects this module only for that ephemeral environment.
+  """
+
+  @behaviour Oli.Recaptcha
+
+  @impl true
+  @doc "Returns a successful verification without contacting reCAPTCHA."
+  def verify(_response), do: {:success, true}
+end

--- a/lib/oli_web/controllers/playwright_mailbox_controller.ex
+++ b/lib/oli_web/controllers/playwright_mailbox_controller.ex
@@ -1,0 +1,77 @@
+defmodule OliWeb.PlaywrightMailboxController do
+  @moduledoc """
+  Token-protected access to messages captured by `Swoosh.Adapters.Local`.
+
+  These routes are mounted only in Playwright-enabled builds. They provide a
+  stable JSON contract for browser tests without exposing or automating the
+  development mailbox preview UI.
+  """
+
+  use OliWeb, :controller
+
+  alias OliWeb.PlaywrightAuth
+  alias Swoosh.Adapters.Local.Storage.Memory
+
+  def index(conn, params) do
+    with :ok <- PlaywrightAuth.authorize(conn),
+         {:ok, recipient} <- fetch_recipient(params) do
+      subject = Map.get(params, "subject")
+
+      emails =
+        Memory.all()
+        |> Enum.filter(&sent_to?(&1, recipient))
+        |> maybe_filter_subject(subject)
+        |> Enum.map(&email_summary/1)
+
+      json(conn, %{emails: emails})
+    else
+      {:error, :unauthorized} -> send_resp(conn, :unauthorized, "unauthorized")
+      {:error, :missing_recipient} -> send_resp(conn, :bad_request, "missing_recipient")
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    with :ok <- PlaywrightAuth.authorize(conn),
+         %Swoosh.Email{} = email <- Memory.get(id) do
+      json(conn, %{email: email_detail(email)})
+    else
+      {:error, :unauthorized} -> send_resp(conn, :unauthorized, "unauthorized")
+      nil -> send_resp(conn, :not_found, "not_found")
+    end
+  end
+
+  defp fetch_recipient(%{"to" => recipient}) when is_binary(recipient) and recipient != "",
+    do: {:ok, recipient}
+
+  defp fetch_recipient(_), do: {:error, :missing_recipient}
+
+  defp sent_to?(email, recipient) do
+    Enum.any?(email.to, &(recipient_address(&1) == recipient))
+  end
+
+  defp recipient_address({_name, address}), do: address
+  defp recipient_address(address) when is_binary(address), do: address
+
+  defp maybe_filter_subject(emails, subject) when is_binary(subject) and subject != "" do
+    Enum.filter(emails, &(&1.subject == subject))
+  end
+
+  defp maybe_filter_subject(emails, _subject), do: emails
+
+  defp email_summary(email) do
+    %{
+      id: message_id(email),
+      to: Enum.map(email.to, &recipient_address/1),
+      subject: email.subject,
+      sent_at: Map.get(email.private, :sent_at)
+    }
+  end
+
+  defp email_detail(email) do
+    email
+    |> email_summary()
+    |> Map.merge(%{html_body: email.html_body, text_body: email.text_body})
+  end
+
+  defp message_id(%{headers: %{"Message-ID" => id}}), do: id
+end

--- a/lib/oli_web/live/author_registration_live.ex
+++ b/lib/oli_web/live/author_registration_live.ex
@@ -5,7 +5,7 @@ defmodule OliWeb.AuthorRegistrationLive do
 
   alias Oli.Accounts
   alias Oli.Accounts.Author
-  alias Oli.Utils.Recaptcha
+  alias Oli.Recaptcha
 
   def render(assigns) do
     ~H"""

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -354,6 +354,8 @@ defmodule OliWeb.Router do
       pipe_through [:api]
 
       post "/scenario-yaml", PlaywrightScenarioController, :run
+      get "/emails", PlaywrightMailboxController, :index
+      get "/emails/:id", PlaywrightMailboxController, :show
     end
 
     scope "/test", OliWeb do

--- a/test/oli_web/controllers/playwright_mailbox_controller_test.exs
+++ b/test/oli_web/controllers/playwright_mailbox_controller_test.exs
@@ -1,0 +1,98 @@
+defmodule OliWeb.PlaywrightMailboxControllerTest do
+  use OliWeb.ConnCase
+
+  alias Swoosh.Adapters.Local.Storage.Memory
+
+  @token "playwright-mailbox-controller-test-token"
+
+  setup do
+    previous_token = Application.get_env(:oli, :playwright_scenario_token)
+    Application.put_env(:oli, :playwright_scenario_token, @token)
+    Memory.delete_all()
+
+    on_exit(fn ->
+      Memory.delete_all()
+      Application.put_env(:oli, :playwright_scenario_token, previous_token)
+    end)
+
+    :ok
+  end
+
+  test "lists only messages for the requested recipient and subject", %{conn: conn} do
+    confirmation = deliver("pw-author@example.test", "Confirm your email", "confirm link")
+    _reset = deliver("pw-author@example.test", "Reset password", "reset link")
+    _other = deliver("other@example.test", "Confirm your email", "other link")
+
+    conn =
+      conn
+      |> authorized()
+      |> get("/test/emails", %{
+        "to" => "pw-author@example.test",
+        "subject" => "Confirm your email"
+      })
+
+    assert %{"emails" => [email]} = json_response(conn, 200)
+    assert email["id"] == message_id(confirmation)
+    assert email["to"] == ["pw-author@example.test"]
+    assert email["subject"] == "Confirm your email"
+    assert is_binary(email["sent_at"])
+  end
+
+  test "returns message detail by id", %{conn: conn} do
+    email = deliver("pw-user@example.test", "Reset password", "reset link")
+
+    conn = conn |> authorized() |> get("/test/emails/#{message_id(email)}")
+
+    assert %{
+             "email" => %{
+               "id" => id,
+               "html_body" => "<p>reset link</p>",
+               "text_body" => "reset link"
+             }
+           } = json_response(conn, 200)
+
+    assert id == message_id(email)
+  end
+
+  test "requires the Playwright token", %{conn: conn} do
+    conn = get(conn, "/test/emails", %{"to" => "pw-user@example.test"})
+
+    assert response(conn, 401) == "unauthorized"
+  end
+
+  test "requires the Playwright token to retrieve message detail", %{conn: conn} do
+    email = deliver("pw-user@example.test", "Reset password", "reset link")
+
+    conn = get(conn, "/test/emails/#{message_id(email)}")
+
+    assert response(conn, 401) == "unauthorized"
+  end
+
+  test "requires a recipient when listing messages", %{conn: conn} do
+    conn = conn |> authorized() |> get("/test/emails")
+
+    assert response(conn, 400) == "missing_recipient"
+  end
+
+  test "returns not found for an unknown message", %{conn: conn} do
+    conn = conn |> authorized() |> get("/test/emails/not-a-message")
+
+    assert response(conn, 404) == "not_found"
+  end
+
+  defp deliver(to, subject, text_body) do
+    email =
+      Swoosh.Email.new()
+      |> Swoosh.Email.from({"Torus", "no-reply@example.test"})
+      |> Swoosh.Email.to(to)
+      |> Swoosh.Email.subject(subject)
+      |> Swoosh.Email.html_body("<p>#{text_body}</p>")
+      |> Swoosh.Email.text_body(text_body)
+
+    Memory.push(email)
+  end
+
+  defp message_id(%{headers: %{"Message-ID" => id}}), do: id
+
+  defp authorized(conn), do: put_req_header(conn, "x-playwright-scenario-token", @token)
+end

--- a/test/oli_web/live/author_registration_live_test.exs
+++ b/test/oli_web/live/author_registration_live_test.exs
@@ -2,6 +2,8 @@ defmodule OliWeb.AuthorRegistrationLiveTest do
   use OliWeb.ConnCase
 
   import Phoenix.LiveViewTest
+  alias Oli.Accounts
+  alias Oli.Utils.Seeder.AccountsFixtures
 
   describe "Registration page" do
     test "renders registration page", %{conn: conn} do
@@ -46,6 +48,33 @@ defmodule OliWeb.AuthorRegistrationLiveTest do
         |> follow_redirect(conn, ~p"/authors/log_in")
 
       assert html_response(conn, 200) =~ "Sign in"
+    end
+  end
+
+  describe "register author" do
+    test "creates an author through the configured recaptcha implementation", %{conn: conn} do
+      Oli.TestHelpers.stub_recaptcha()
+
+      {:ok, lv, _html} = live(conn, ~p"/authors/register")
+
+      email = AccountsFixtures.unique_author_email()
+
+      form =
+        form(lv, "#registration_form",
+          author: %{
+            "email" => email,
+            "given_name" => "Andrew",
+            "family_name" => "Carnegie",
+            "password" => "valid_password",
+            "password_confirmation" => "valid_password"
+          }
+        )
+
+      render_submit(form)
+      conn = follow_trigger_action(form, conn)
+
+      assert redirected_to(conn) == ~p"/workspaces/course_author"
+      assert Accounts.get_author_by_email(email)
     end
   end
 end


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5849

## Summary

Adds end-to-end Playwright coverage for the full email/password account
lifecycle (registration, email confirmation, login, password reset,
old-password rejection, new-password login) across both Authoring (Author)
and Delivery (User) accounts, including provisioned system-admin and
instructor roles, plus the CI machinery to run this suite against a
dedicated ephemeral Torus instance on every pull request.

## What Was Added

- Guarded `/test/emails` mailbox JSON endpoints and `/test/scenario-yaml`
  scenario seeding, reusing the existing `enable_playwright_scenarios`
  compile-time flag and `PlaywrightAuth` token, backed by
  `Swoosh.Adapters.Local` (never mounted outside the dedicated
  `MIX_ENV=playwright` build).
- `config/playwright.exs`: the dedicated ephemeral environment configuration
  (Local mailer, deterministic reCAPTCHA, scenario/mailbox routes enabled).
- `CredentialAccountPO` + two Playwright specs: self-service Author /
  independent-learner registration→confirm→login→reset→login lifecycle, and
  provisioned system-admin Author / instructor User login→reset→login
  lifecycle (seeded via scenario YAML, since neither role has self-service
  registration).
- `.github/workflows/pr-playwright.yml`: a new CI job, separate from
  `nightly-playwright.yml`, that boots an ephemeral Postgres + Torus instance
  under `MIX_ENV=playwright` and runs every Playwright test tagged `@pr`,
  uploading Playwright artifacts and the server log on every run.
- Durable design record and decision log at
  `docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md`.

## Validation

- `mix format --check-formatted`, `mix compile --warnings-as-errors`
  (`MIX_ENV=playwright`) pass.
- `mix test test/oli_web/controllers/playwright_mailbox_controller_test.exs
  test/oli_web/live/author_registration_live_test.exs` — 11 tests, 0 failures.
- `npx playwright test tests/torus/user_accounts/credential-account-flows.spec.ts
  tests/torus/user_accounts/credential-account-provisioned-roles.spec.ts` —
  passing consistently across 20+ clean local runs.
- ESLint/Prettier clean on all changed TypeScript/YAML files.
- `pr-playwright.yml` has not yet run in real GitHub Actions — opening this
  PR is the first real validation of that job; follow-up fixes may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)