### PR TITLE
[BUG FIX] [MER-5894] Handle stale remix breadcrumb targets safely

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -322,14 +322,9 @@ defmodule OliWeb.Delivery.RemixSection do
   def handle_event("set_active", %{"uuid" => uuid}, socket) do
     %{remix_state: state} = socket.assigns
 
-    node = Hierarchy.find_in_hierarchy(state.hierarchy, uuid)
+    {:ok, state} = Remix.select_active(state, uuid)
 
-    if is_container?(node.revision) do
-      {:ok, state} = Remix.select_active(state, uuid)
-      {:noreply, assign(socket, active: state.active, remix_state: state)}
-    else
-      {:noreply, socket}
-    end
+    {:noreply, assign(socket, active: state.active, remix_state: state)}
   end
 
   def handle_event("keydown", %{"key" => key, "shiftKey" => shiftKeyPressed?} = params, socket) do

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -42,6 +42,28 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert html =~ "Your work has been saved."
     end
 
+    test "a stale breadcrumb target does not crash or discard unsaved changes", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/remix")
+
+      initial_entry_ids = curriculum_entry_ids(view)
+
+      render_hook(view, "reorder", %{"sourceIndex" => "0", "dropIndex" => "2"})
+
+      reordered_entry_ids = curriculum_entry_ids(view)
+
+      refute reordered_entry_ids == initial_entry_ids
+      assert has_element?(view, "#curriculum-container[data-saved='false']")
+
+      render_click(view, "set_active", %{"uuid" => "stale-hierarchy-uuid"})
+
+      assert curriculum_entry_ids(view) == reordered_entry_ids
+      assert has_element?(view, "#curriculum-container[data-saved='false']")
+      assert has_element?(view, "#save:not([disabled])")
+    end
+
     test "move modal moves an item into the selected container", %{
       conn: conn,
       section: section,
@@ -1723,6 +1745,14 @@ defmodule OliWeb.RemixSectionLiveTest do
 
       assert_redirect(view, ~p"/sections/#{section.slug}/remix")
     end
+  end
+
+  defp curriculum_entry_ids(view) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find(".curriculum-entries > .curriculum-entry")
+    |> Floki.attribute("id")
   end
 
   defp open_modal_and_confirm_removal([], view), do: view


### PR DESCRIPTION
Fixes [MER-5894](https://eliterate.atlassian.net/browse/MER-5894).

Customize Content breadcrumb events could contain a stale hierarchy UUID after the hierarchy was rebuilt. The LiveView attempted to access `node.revision` when the hierarchy lookup returned `nil`, causing a `BadMapError`. The resulting LiveView remount discarded unsaved curriculum changes.

This change delegates navigation to `Remix.select_active/2`, which safely treats missing or non-container targets as a no-op.

--- 
Added a regression test that:

- Creates an unsaved curriculum reorder.
- Confirms the displayed resource order changed.
- Sends a `set_active` event with a stale UUID.
- Confirms the exact reordered hierarchy remains visible.
- Confirms the unsaved state and enabled Save button are preserved.

---
Manual verification:

https://github.com/user-attachments/assets/86d1b5af-4412-4c64-b4cb-c76324ed2ad2



[MER-5894]: https://eliterate.atlassian.net/browse/MER-5894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ