### PR TITLE
[ENHANCEMENT] [MER-5801] Add learning objectives CSV export

### DIFF
--- a/lib/oli/authoring/objective_coverage.ex
+++ b/lib/oli/authoring/objective_coverage.ex
@@ -23,6 +23,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   @type row :: %{
           required(:project_id) => pos_integer(),
           required(:publication_id) => pos_integer(),
+          optional(:root_resource_id) => pos_integer() | nil,
           required(:revision_id) => pos_integer(),
           required(:resource_id) => pos_integer(),
           required(:resource_type_id) => pos_integer(),
@@ -31,6 +32,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
           optional(:deleted) => boolean(),
           optional(:objectives) => map() | nil,
           optional(:children) => list() | nil,
+          optional(:ordered_children) => list() | nil,
           optional(:graded) => boolean() | nil,
           optional(:activity_refs) => list() | nil,
           optional(:scope) => atom() | String.t() | nil,
@@ -40,6 +42,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   @type t :: %{
           project_id: pos_integer() | nil,
           publication_id: pos_integer() | nil,
+          root_resource_id: pos_integer() | nil,
           rows_by_type: %{pos_integer() => [row()]},
           objectives_by_id: %{pos_integer() => map()},
           parents_by_child: %{pos_integer() => [pos_integer()]},
@@ -103,7 +106,12 @@ defmodule Oli.Authoring.ObjectiveCoverage do
               {:error, :multiple_working_publications}
 
             {_project_id, [publication_id]} ->
-              build_context = %{project_id: context.project_id, publication_id: publication_id}
+              build_context = %{
+                project_id: context.project_id,
+                publication_id: publication_id,
+                root_resource_id: context.root_resource_id
+              }
+
               {:ok, build(Enum.filter(rows, &is_integer(&1.resource_id)), build_context)}
           end
         end
@@ -201,6 +209,8 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     model = %{
       project_id: context[:project_id] || first_value(normalized_rows, :project_id),
       publication_id: context[:publication_id] || first_value(normalized_rows, :publication_id),
+      root_resource_id:
+        context[:root_resource_id] || first_value(normalized_rows, :root_resource_id),
       rows_by_type: rows_by_type,
       objectives_by_id: objectives_by_id,
       parents_by_child: parents_by_child,
@@ -305,6 +315,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
       select: %{
         project_id: project.id,
         publication_id: pub.id,
+        root_resource_id: pub.root_resource_id,
         revision_id: revision.id,
         resource_id: revision.resource_id,
         resource_type_id: revision.resource_type_id,
@@ -329,6 +340,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   defp context_from_rows(rows) when is_list(rows) do
     %{
       project_id: first_value(rows, :project_id),
+      root_resource_id: first_value(rows, :root_resource_id),
       publication_ids:
         rows
         |> Enum.map(&Map.get(&1, :publication_id))
@@ -342,6 +354,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     %{
       project_id: Map.get(row, :project_id),
       publication_id: Map.get(row, :publication_id),
+      root_resource_id: Map.get(row, :root_resource_id),
       revision_id: Map.get(row, :revision_id),
       resource_id: Map.get(row, :resource_id),
       resource_type_id: Map.get(row, :resource_type_id),
@@ -350,6 +363,7 @@ defmodule Oli.Authoring.ObjectiveCoverage do
       deleted: Map.get(row, :deleted, false) == true,
       objectives: normalize_map(Map.get(row, :objectives)),
       children: normalize_ids(Map.get(row, :children)),
+      ordered_children: normalize_ordered_ids(Map.get(row, :children)),
       graded: Map.get(row, :graded, false) == true,
       activity_refs: normalize_ids(Map.get(row, :activity_refs)),
       scope: Map.get(row, :scope),
@@ -387,7 +401,15 @@ defmodule Oli.Authoring.ObjectiveCoverage do
   end
 
   defp curriculum_summary(row) do
-    Map.take(row, [:resource_id, :revision_id, :slug, :title, :children])
+    Map.take(row, [
+      :resource_id,
+      :resource_type_id,
+      :revision_id,
+      :slug,
+      :title,
+      :children,
+      :ordered_children
+    ])
   end
 
   defp direct_page_ids_by_objective(pages) do
@@ -896,6 +918,11 @@ defmodule Oli.Authoring.ObjectiveCoverage do
     do: value |> Enum.filter(&is_integer/1) |> Enum.uniq() |> Enum.sort()
 
   defp normalize_ids(_), do: []
+
+  defp normalize_ordered_ids(value) when is_list(value),
+    do: value |> Enum.filter(&is_integer/1) |> Enum.uniq()
+
+  defp normalize_ordered_ids(_), do: []
 
   defp first_value([row | _], key), do: Map.get(row, key)
   defp first_value([], _key), do: nil

--- a/lib/oli/authoring/objective_coverage/csv_export.ex
+++ b/lib/oli/authoring/objective_coverage/csv_export.ex
@@ -1,0 +1,339 @@
+defmodule Oli.Authoring.ObjectiveCoverage.CsvExport do
+  @moduledoc """
+  Produces the authoring learning-objective map CSV from the compact
+  `Oli.Authoring.ObjectiveCoverage` snapshot.
+
+  Activity data comes from the snapshot's projection, which deliberately omits
+  revision content. Curriculum locations are derived once from its precomputed
+  page paths and then reused for every exported relationship.
+  """
+
+  alias Oli.Activities
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.ObjectiveCoverage
+  alias Oli.Branding.CustomLabels
+  alias Oli.Resources.Numbering
+  alias Oli.Resources.ResourceType
+
+  @headers [
+    "LO Label",
+    "LO Title",
+    "Sub-Objective",
+    "Activity Type",
+    "Activity Name",
+    "Page Name",
+    "Course Location"
+  ]
+
+  @type export_row :: [String.t()]
+
+  @doc "Returns the ordered CSV column headers."
+  @spec headers() :: [String.t()]
+  def headers, do: @headers
+
+  @doc "Loads a project's compact coverage snapshot and encodes its CSV."
+  @spec generate(%Project{}, map()) :: {:ok, String.t()} | {:error, atom()}
+  def generate(%Project{} = project, params \\ %{}) do
+    with {:ok, model} <- ObjectiveCoverage.load(project) do
+      activity_types_by_id =
+        Activities.list_activity_registrations()
+        |> Map.new(&{&1.id, &1.title})
+
+      {:ok, encode(model, project.customizations, activity_types_by_id, params)}
+    end
+  end
+
+  @doc "Encodes a previously loaded coverage snapshot as CSV."
+  @spec encode(ObjectiveCoverage.t(), %CustomLabels{} | nil, map(), map()) :: String.t()
+  def encode(model, customizations, activity_types_by_id, params \\ %{}) do
+    model
+    |> rows(customizations, activity_types_by_id, params)
+    |> then(&[@headers | &1])
+    |> CSV.encode()
+    |> Enum.join()
+  end
+
+  @doc "Builds ordered, spreadsheet-safe export rows without encoding them."
+  @spec rows(ObjectiveCoverage.t(), %CustomLabels{} | nil, map(), map()) :: [export_row()]
+  def rows(model, customizations, activity_types_by_id, params \\ %{}) do
+    activities_by_objective = activities_by_objective(model.activities_by_id)
+    pages_by_activity = pages_by_activity(model.pages_by_id)
+    course_locations = course_locations(model, customizations)
+
+    model
+    |> filtered_and_sorted_objectives(params, activities_by_objective)
+    |> Enum.with_index(1)
+    |> Enum.flat_map(fn {objective, index} ->
+      relationship_rows(
+        model,
+        objective,
+        index,
+        activities_by_objective,
+        pages_by_activity,
+        course_locations,
+        activity_types_by_id
+      )
+    end)
+    |> Enum.map(fn row -> Enum.map(row, &spreadsheet_safe/1) end)
+  end
+
+  defp filtered_and_sorted_objectives(model, params, activities_by_objective) do
+    query = params |> param("query", "") |> normalize_text()
+
+    objectives =
+      model
+      |> ObjectiveCoverage.objectives()
+      |> Enum.filter(fn objective ->
+        query == "" or String.contains?(normalize_text(objective.title), query)
+      end)
+
+    sort_by = param(params, "sort_by", "title")
+    sort_order = if param(params, "sort_order", "asc") == "desc", do: :desc, else: :asc
+
+    Enum.sort_by(
+      objectives,
+      &objective_sort_value(model, &1, sort_by, activities_by_objective),
+      sort_order
+    )
+  end
+
+  defp objective_sort_value(_model, objective, "title", _activities_by_objective),
+    do: {normalize_text(objective.title), objective.resource_id}
+
+  defp objective_sort_value(model, objective, "sub_objectives_count", _activities_by_objective) do
+    coverage = ObjectiveCoverage.coverage(model, objective.resource_id)
+    {coverage.sub_objective_count, normalize_text(objective.title), objective.resource_id}
+  end
+
+  defp objective_sort_value(model, objective, "page_attachments_count", _activities_by_objective) do
+    page_count =
+      [objective.resource_id | Map.get(model.children_by_parent, objective.resource_id, [])]
+      |> Enum.flat_map(&Map.get(model.direct_page_ids_by_objective, &1, []))
+      |> Enum.uniq()
+      |> length()
+
+    {page_count, normalize_text(objective.title), objective.resource_id}
+  end
+
+  defp objective_sort_value(
+         _model,
+         objective,
+         "activity_attachments_count",
+         activities_by_objective
+       ) do
+    activity_count =
+      activities_by_objective
+      |> Map.get(objective.resource_id, [])
+      |> Enum.map(& &1.resource_id)
+      |> Enum.uniq()
+      |> length()
+
+    {activity_count, normalize_text(objective.title), objective.resource_id}
+  end
+
+  defp objective_sort_value(_model, objective, _sort_by, _activities_by_objective),
+    do: {normalize_text(objective.title), objective.resource_id}
+
+  defp relationship_rows(
+         model,
+         objective,
+         index,
+         activities_by_objective,
+         pages_by_activity,
+         course_locations,
+         activity_types_by_id
+       ) do
+    model.objective_scope_by_id
+    |> Map.get(objective.resource_id, [objective.resource_id])
+    |> Enum.filter(&Map.has_key?(model.objectives_by_id, &1))
+    |> Enum.sort_by(fn objective_id ->
+      related_objective = Map.fetch!(model.objectives_by_id, objective_id)
+
+      {
+        if(objective_id == objective.resource_id, do: 0, else: 1),
+        normalize_text(related_objective.title),
+        objective_id
+      }
+    end)
+    |> Enum.flat_map(fn related_objective_id ->
+      sub_objective_title =
+        if related_objective_id == objective.resource_id do
+          ""
+        else
+          model.objectives_by_id[related_objective_id].title || ""
+        end
+
+      activities_by_objective
+      |> Map.get(related_objective_id, [])
+      |> Enum.sort_by(&{normalize_text(&1.title), &1.resource_id})
+      |> Enum.flat_map(fn activity ->
+        activity_pages = Map.get(pages_by_activity, activity.resource_id, [])
+        activity_pages = if activity_pages == [], do: [nil], else: activity_pages
+
+        Enum.map(activity_pages, fn page ->
+          [
+            "LO #{index}",
+            objective.title || "",
+            sub_objective_title,
+            Map.get(activity_types_by_id, activity.activity_type_id, ""),
+            activity.title || "",
+            page_title(page),
+            page_location(page, course_locations)
+          ]
+        end)
+      end)
+    end)
+  end
+
+  defp activities_by_objective(activities_by_id) do
+    Enum.reduce(activities_by_id, %{}, fn {_activity_id, activity}, acc ->
+      activity.objectives
+      |> objective_ids()
+      |> Enum.reduce(acc, fn objective_id, acc ->
+        Map.update(acc, objective_id, [activity], &[activity | &1])
+      end)
+    end)
+  end
+
+  defp pages_by_activity(pages_by_id) do
+    Enum.reduce(pages_by_id, %{}, fn {_page_id, page}, acc ->
+      Enum.reduce(page.activity_refs, acc, fn activity_id, acc ->
+        Map.update(acc, activity_id, [page], &[page | &1])
+      end)
+    end)
+    |> Map.new(fn {activity_id, pages} ->
+      {activity_id, Enum.sort_by(pages, &{normalize_text(&1.title), &1.resource_id})}
+    end)
+  end
+
+  defp course_locations(model, customizations) do
+    labels = custom_labels(customizations)
+    numberings = curriculum_numberings(model, labels)
+    container_type_id = ResourceType.id_for_container()
+
+    Map.new(model.pages_by_id, fn {page_id, _page} ->
+      location =
+        model.curriculum_paths_by_id
+        |> Map.get(page_id, [])
+        |> course_path(model.root_resource_id)
+        |> Enum.flat_map(fn resource_id ->
+          with %{resource_type_id: ^container_type_id} = container <-
+                 Map.get(model.curriculum_by_id, resource_id),
+               %Numbering{} = numbering <- Map.get(numberings, resource_id) do
+            ["#{Numbering.prefix(numbering)}: #{container.title}"]
+          else
+            _ -> []
+          end
+        end)
+        |> Enum.join(" > ")
+
+      {page_id, location}
+    end)
+  end
+
+  defp course_path(paths, root_resource_id) do
+    Enum.find(paths, &(List.first(&1) == root_resource_id)) || List.first(paths) || []
+  end
+
+  defp curriculum_numberings(model, labels) do
+    root_ids = curriculum_root_ids(model)
+
+    {_tracker, numberings} =
+      Enum.reduce(root_ids, {Numbering.init_numbering_tracker(), %{}}, fn root_id, acc ->
+        number_children(model.curriculum_by_id, root_id, 1, labels, acc, MapSet.new())
+      end)
+
+    numberings
+  end
+
+  defp curriculum_root_ids(model) do
+    case Map.fetch(model.curriculum_by_id, model.root_resource_id) do
+      {:ok, _root} ->
+        [model.root_resource_id]
+
+      :error ->
+        model.curriculum_by_id
+        |> Map.keys()
+        |> Enum.reject(&Map.has_key?(model.curriculum_parents_by_child, &1))
+        |> Enum.sort()
+    end
+  end
+
+  defp number_children(curriculum_by_id, parent_id, level, labels, acc, visiting) do
+    parent = Map.fetch!(curriculum_by_id, parent_id)
+    visiting = MapSet.put(visiting, parent_id)
+
+    parent.ordered_children
+    |> Enum.filter(&Map.has_key?(curriculum_by_id, &1))
+    |> Enum.reduce(acc, fn child_id, acc ->
+      case MapSet.member?(visiting, child_id) do
+        true ->
+          acc
+
+        false ->
+          child = Map.fetch!(curriculum_by_id, child_id)
+          {tracker, numberings} = acc
+          {index, tracker} = Numbering.next_index(tracker, level, child)
+          numbering = %Numbering{level: level, index: index, labels: labels}
+
+          number_children(
+            curriculum_by_id,
+            child_id,
+            level + 1,
+            labels,
+            {tracker, Map.put(numberings, child_id, numbering)},
+            visiting
+          )
+      end
+    end)
+  end
+
+  defp custom_labels(nil), do: CustomLabels.default_map()
+
+  defp custom_labels(%CustomLabels{} = customizations) do
+    defaults = CustomLabels.default_map()
+
+    customizations
+    |> Map.from_struct()
+    |> Map.take([:unit, :module, :section])
+    |> Map.merge(defaults, fn _key, custom, default -> custom || default end)
+  end
+
+  defp objective_ids(objectives) when is_map(objectives) do
+    objectives
+    |> Map.values()
+    |> Enum.flat_map(&List.wrap/1)
+    |> Enum.filter(&is_integer/1)
+    |> Enum.uniq()
+  end
+
+  defp objective_ids(_), do: []
+
+  defp page_title(nil), do: ""
+  defp page_title(page), do: page.title || ""
+
+  defp page_location(nil, _course_locations), do: ""
+  defp page_location(page, course_locations), do: Map.get(course_locations, page.resource_id, "")
+
+  defp param(params, key, default),
+    do: Map.get(params, key, Map.get(params, String.to_existing_atom(key), default))
+
+  defp normalize_text(value) when is_binary(value),
+    do: value |> String.downcase() |> String.trim()
+
+  defp normalize_text(_), do: ""
+
+  # Prevent user-authored titles from being interpreted as formulas by common
+  # spreadsheet applications while preserving their visible text.
+  defp spreadsheet_safe(value) when is_binary(value) do
+    case String.trim_leading(value) do
+      <<prefix::binary-size(1), _::binary>> when prefix in ["=", "+", "-", "@"] ->
+        "'" <> value
+
+      _ ->
+        value
+    end
+  end
+
+  defp spreadsheet_safe(value), do: to_string(value || "")
+end

--- a/lib/oli_web/controllers/objectives_csv_controller.ex
+++ b/lib/oli_web/controllers/objectives_csv_controller.ex
@@ -1,0 +1,25 @@
+defmodule OliWeb.ObjectivesCsvController do
+  @moduledoc "Downloads the filtered learning-objective coverage map for an authoring project."
+
+  use OliWeb, :controller
+
+  alias Oli.Authoring.ObjectiveCoverage.CsvExport
+
+  @spec download(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def download(conn, params) do
+    project = conn.assigns.project
+
+    case CsvExport.generate(project, params) do
+      {:ok, contents} ->
+        conn
+        |> put_resp_header("cache-control", "private, no-store")
+        |> put_resp_header("content-type", "text/csv")
+        |> send_download({:binary, contents},
+          filename: "#{project.slug}_learning_objectives.csv"
+        )
+
+      {:error, _reason} ->
+        send_resp(conn, :not_found, "Learning objective data is unavailable")
+    end
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/objectives_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/objectives_live.ex
@@ -89,7 +89,21 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
       <Filter.render change="change_search" reset="reset_search" apply="apply_search" query={@query} />
     </FilterBox.render>
 
-    <div class="flex justify-end">
+    <div class="flex flex-wrap justify-end gap-3">
+      <.link
+        id="download-objectives-csv"
+        href={
+          ~p"/workspaces/course_author/#{@project.slug}/objectives.csv?#{csv_export_params(@params)}"
+        }
+        download={"#{@project.slug}_learning_objectives.csv"}
+        class="inline-flex min-h-8 items-center justify-center gap-2 rounded-md border border-Fill-Buttons-fill-primary bg-Background-bg-secondary px-4 py-2 text-sm font-semibold leading-4 text-Text-text-button transition hover:bg-Fill-Buttons-fill-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
+      >
+        <span class="inline-flex size-4 items-center justify-center text-current [&_svg]:size-4">
+          <Icons.download stroke_class="stroke-current" />
+        </span>
+        Download CSV
+      </.link>
+
       <button
         type="button"
         class="inline-flex min-h-8 items-center justify-center gap-2 rounded-md bg-Fill-Buttons-fill-primary px-4 py-2 text-sm font-semibold leading-4 text-Text-text-white shadow-[0px_2px_4px_rgba(0,52,99,0.10)] transition hover:bg-Fill-Buttons-fill-primary-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-Fill-Buttons-fill-primary"
@@ -222,6 +236,10 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLive do
     </a>
     to learn more about the importance of attaching learning objectives to pages and activities.
     """
+  end
+
+  defp csv_export_params(params) do
+    Map.take(params, ["query", "filter", "sort_by", "sort_order"])
   end
 
   defp new_modal(form, socket) do

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1209,6 +1209,12 @@ defmodule OliWeb.Router do
     end
   end
 
+  scope "/workspaces/course_author", OliWeb do
+    pipe_through([:browser, :authoring_protected, :authorize_project])
+
+    get("/:project_id/objectives.csv", ObjectivesCsvController, :download)
+  end
+
   scope "/workspaces", OliWeb.Workspaces do
     pipe_through([:browser, :delivery_protected])
 

--- a/test/oli/authoring/objective_coverage/csv_export_test.exs
+++ b/test/oli/authoring/objective_coverage/csv_export_test.exs
@@ -1,0 +1,219 @@
+defmodule Oli.Authoring.ObjectiveCoverage.CsvExportTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Authoring.ObjectiveCoverage
+  alias Oli.Authoring.ObjectiveCoverage.CsvExport
+  alias Oli.Branding.CustomLabels
+  alias Oli.Resources.ResourceType
+
+  test "exports one row per objective/activity/page relationship with custom course locations" do
+    model =
+      ObjectiveCoverage.build([
+        row(:objective, 1, title: "Alpha Objective", children: [2]),
+        row(:objective, 2, title: "Alpha Sub-Objective"),
+        row(:container, 100, title: "Root", children: [110]),
+        row(:container, 110, title: "Foundations", children: [120]),
+        row(:container, 120, title: "Motion", children: [200, 201]),
+        row(:page, 200, title: "Vectors", activity_refs: [300, 301]),
+        row(:page, 201, title: "Acceleration", activity_refs: [300]),
+        row(:activity, 300,
+          title: "Direct Quiz",
+          objectives: %{"part" => [1]},
+          activity_type_id: 11
+        ),
+        row(:activity, 301,
+          title: "Child Check",
+          objectives: %{"part" => [2]},
+          activity_type_id: 2
+        ),
+        row(:activity, 302,
+          title: "Banked Practice",
+          objectives: %{"part" => [2]},
+          activity_type_id: 15,
+          scope: :banked
+        )
+      ])
+
+    customizations = %CustomLabels{unit: "Book", module: "Chapter", section: "Lesson"}
+
+    assert CsvExport.rows(model, customizations, %{
+             11 => "Multiple Choice",
+             2 => "CATA",
+             15 => "Input"
+           }) == [
+             [
+               "LO 1",
+               "Alpha Objective",
+               "",
+               "Multiple Choice",
+               "Direct Quiz",
+               "Acceleration",
+               "Book 1: Foundations > Chapter 1: Motion"
+             ],
+             [
+               "LO 1",
+               "Alpha Objective",
+               "",
+               "Multiple Choice",
+               "Direct Quiz",
+               "Vectors",
+               "Book 1: Foundations > Chapter 1: Motion"
+             ],
+             [
+               "LO 1",
+               "Alpha Objective",
+               "Alpha Sub-Objective",
+               "Input",
+               "Banked Practice",
+               "",
+               ""
+             ],
+             [
+               "LO 1",
+               "Alpha Objective",
+               "Alpha Sub-Objective",
+               "CATA",
+               "Child Check",
+               "Vectors",
+               "Book 1: Foundations > Chapter 1: Motion"
+             ]
+           ]
+  end
+
+  test "preserves authored curriculum order when numbering locations" do
+    model =
+      ObjectiveCoverage.build(
+        [
+          row(:container, 50, title: "Unattached Container", children: [400]),
+          row(:objective, 1, title: "Objective"),
+          row(:container, 100, title: "Root", children: [300, 200]),
+          row(:container, 200, title: "Second Book", children: [400]),
+          row(:container, 300, title: "First Book"),
+          row(:page, 400, title: "Page", activity_refs: [500]),
+          row(:activity, 500,
+            title: "Activity",
+            objectives: %{"part" => [1]},
+            activity_type_id: 11
+          )
+        ],
+        %{root_resource_id: 100}
+      )
+
+    [row] = CsvExport.rows(model, nil, %{11 => "Multiple Choice"})
+
+    assert List.last(row) == "Unit 2: Second Book"
+  end
+
+  test "applies the current search and sort before assigning LO labels" do
+    model =
+      ObjectiveCoverage.build([
+        row(:objective, 1, title: "Alpha Objective"),
+        row(:objective, 2, title: "Beta Objective"),
+        row(:activity, 10,
+          title: "Alpha Activity",
+          objectives: %{"part" => [1]},
+          activity_type_id: 11
+        ),
+        row(:activity, 20,
+          title: "Beta Activity",
+          objectives: %{"part" => [2]},
+          activity_type_id: 11
+        )
+      ])
+
+    assert [["LO 1", "Alpha Objective" | _]] =
+             CsvExport.rows(model, nil, %{11 => "Multiple Choice"}, %{"query" => "alpha"})
+
+    assert [
+             ["LO 1", "Beta Objective" | _],
+             ["LO 2", "Alpha Objective" | _]
+           ] =
+             CsvExport.rows(model, nil, %{11 => "Multiple Choice"}, %{
+               "sort_by" => "title",
+               "sort_order" => "desc"
+             })
+  end
+
+  test "matches the objective table's attachment count sorting" do
+    model =
+      ObjectiveCoverage.build([
+        row(:objective, 1, title: "Parent", children: [2]),
+        row(:objective, 2, title: "Child"),
+        row(:objective, 3, title: "Direct"),
+        row(:page, 20, title: "Child Page", objectives: %{"attached" => [2]}),
+        row(:activity, 30,
+          title: "Child Activity",
+          objectives: %{"part" => [2]},
+          activity_type_id: 11
+        ),
+        row(:activity, 31,
+          title: "Direct Activity",
+          objectives: %{"part" => [3]},
+          activity_type_id: 11
+        )
+      ])
+
+    assert [["LO 1", "Parent" | _], ["LO 2", "Direct" | _]] =
+             CsvExport.rows(model, nil, %{11 => "Multiple Choice"}, %{
+               "sort_by" => "page_attachments_count",
+               "sort_order" => "desc"
+             })
+
+    assert [["LO 1", "Direct" | _], ["LO 2", "Parent" | _]] =
+             CsvExport.rows(model, nil, %{11 => "Multiple Choice"}, %{
+               "sort_by" => "activity_attachments_count",
+               "sort_order" => "desc"
+             })
+  end
+
+  test "encodes headers for an empty result and neutralizes spreadsheet formulas" do
+    model =
+      ObjectiveCoverage.build([
+        row(:objective, 1, title: "=FORMULA"),
+        row(:activity, 10,
+          title: "+FORMULA",
+          objectives: %{"part" => [1]},
+          activity_type_id: 11
+        )
+      ])
+
+    encoded = CsvExport.encode(model, nil, %{11 => "Multiple Choice"})
+    headers = CsvExport.headers()
+
+    assert [
+             ^headers,
+             ["LO 1", "'=FORMULA", "", "Multiple Choice", "'+FORMULA", "", ""]
+           ] =
+             NimbleCSV.RFC4180.parse_string(encoded, skip_headers: false)
+
+    header_only =
+      CsvExport.encode(model, nil, %{11 => "Multiple Choice"}, %{"query" => "no match"})
+
+    assert [headers] ==
+             NimbleCSV.RFC4180.parse_string(header_only, skip_headers: false)
+  end
+
+  defp row(type, resource_id, attrs) do
+    %{
+      project_id: 1,
+      publication_id: 2,
+      revision_id: resource_id + 1_000,
+      resource_id: resource_id,
+      resource_type_id: resource_type_id(type),
+      slug: "resource-#{resource_id}",
+      title: Keyword.get(attrs, :title, "Resource #{resource_id}"),
+      deleted: false,
+      objectives: Keyword.get(attrs, :objectives, %{}),
+      children: Keyword.get(attrs, :children, []),
+      graded: Keyword.get(attrs, :graded, false),
+      activity_refs: Keyword.get(attrs, :activity_refs, []),
+      scope: Keyword.get(attrs, :scope, :embedded),
+      activity_type_id: Keyword.get(attrs, :activity_type_id)
+    }
+  end
+
+  defp resource_type_id(:objective), do: ResourceType.id_for_objective()
+  defp resource_type_id(:container), do: ResourceType.id_for_container()
+  defp resource_type_id(:page), do: ResourceType.id_for_page()
+  defp resource_type_id(:activity), do: ResourceType.id_for_activity()
+end

--- a/test/oli/authoring/objective_coverage_test.exs
+++ b/test/oli/authoring/objective_coverage_test.exs
@@ -123,10 +123,16 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
         row(ResourceType.id_for_container(), nested_container_id, children: [page_id])
       ]
 
-      model = ObjectiveCoverage.build(rows, %{project_id: 1, publication_id: 2})
+      model =
+        ObjectiveCoverage.build(rows, %{
+          project_id: 1,
+          publication_id: 2,
+          root_resource_id: container_id
+        })
 
       assert model.project_id == 1
       assert model.publication_id == 2
+      assert model.root_resource_id == container_id
       assert model.objectives_by_id[objective_id].children == [child_id]
       assert model.children_by_parent == %{objective_id => [child_id], child_id => []}
       assert model.parents_by_child == %{child_id => [objective_id]}
@@ -209,6 +215,7 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       assert {:ok, model} = ObjectiveCoverage.load(project.slug)
       assert model.project_id == project.id
       assert is_integer(model.publication_id)
+      assert is_integer(model.root_resource_id)
       assert model.rows_by_type != %{}
     end
 
@@ -290,6 +297,7 @@ defmodule Oli.Authoring.ObjectiveCoverageTest do
       assert {:ok, empty_model} = ObjectiveCoverage.load(project.slug)
       assert empty_model.project_id == project.id
       assert empty_model.publication_id == model.publication_id
+      assert empty_model.root_resource_id == model.root_resource_id
       assert empty_model.rows_by_type == %{}
     end
 

--- a/test/oli_web/controllers/objectives_csv_controller_test.exs
+++ b/test/oli_web/controllers/objectives_csv_controller_test.exs
@@ -1,0 +1,121 @@
+defmodule OliWeb.ObjectivesCsvControllerTest do
+  use OliWeb.ConnCase
+
+  import Oli.Factory
+
+  alias Oli.Activities
+  alias Oli.Repo
+  alias Oli.Resources.ResourceType
+  alias Oli.Seeder
+
+  describe "download/2" do
+    setup [:admin_conn]
+
+    test "downloads the current project's objective map", %{conn: conn} do
+      seed = Seeder.base_project_with_resource2()
+      objective = create_objective(seed, "Objective, with comma")
+      activity = create_activity(seed, objective.resource_id, "Practice Activity")
+
+      seed.revision1
+      |> Ecto.Changeset.change(activity_refs: [activity.resource_id])
+      |> Repo.update!()
+
+      conn =
+        get(
+          conn,
+          ~p"/workspaces/course_author/#{seed.project.slug}/objectives.csv?sort_by=title&sort_order=asc"
+        )
+
+      assert response_content_type(conn, :csv) == "text/csv"
+
+      assert get_resp_header(conn, "content-disposition") == [
+               "attachment; filename=\"#{seed.project.slug}_learning_objectives.csv\""
+             ]
+
+      assert [
+               [
+                 "LO Label",
+                 "LO Title",
+                 "Sub-Objective",
+                 "Activity Type",
+                 "Activity Name",
+                 "Page Name",
+                 "Course Location"
+               ],
+               [
+                 "LO 1",
+                 "Objective, with comma",
+                 "",
+                 "Multiple Choice",
+                 "Practice Activity",
+                 "Page one",
+                 ""
+               ]
+             ] = NimbleCSV.RFC4180.parse_string(conn.resp_body, skip_headers: false)
+    end
+  end
+
+  test "requires an authenticated author", %{conn: conn} do
+    seed = Seeder.base_project_with_resource2()
+
+    conn = get(conn, ~p"/workspaces/course_author/#{seed.project.slug}/objectives.csv")
+
+    assert redirected_to(conn) == ~p"/authors/log_in"
+  end
+
+  test "requires access to the requested project", %{conn: conn} do
+    {:ok, context} = author_conn(%{conn: conn})
+    seed = Seeder.base_project_with_resource2()
+
+    conn = get(context[:conn], ~p"/workspaces/course_author/#{seed.project.slug}/objectives.csv")
+
+    assert redirected_to(conn) == ~p"/workspaces/course_author"
+  end
+
+  defp create_objective(seed, title) do
+    resource = insert(:resource)
+
+    revision =
+      insert(:revision,
+        resource: resource,
+        resource_type_id: ResourceType.id_for_objective(),
+        objectives: %{},
+        children: [],
+        title: title,
+        deleted: false
+      )
+
+    attach_to_project(seed, resource, revision)
+    revision
+  end
+
+  defp create_activity(seed, objective_id, title) do
+    resource = insert(:resource)
+    activity_type = Activities.get_registration_by_slug("oli_multiple_choice")
+
+    revision =
+      insert(:revision,
+        resource: resource,
+        resource_type_id: ResourceType.id_for_activity(),
+        activity_type_id: activity_type.id,
+        objectives: %{"part" => [objective_id]},
+        scope: :embedded,
+        title: title,
+        deleted: false
+      )
+
+    attach_to_project(seed, resource, revision)
+    revision
+  end
+
+  defp attach_to_project(seed, resource, revision) do
+    insert(:project_resource, project_id: seed.project.id, resource_id: resource.id)
+
+    insert(:published_resource,
+      publication: seed.publication,
+      resource: resource,
+      revision: revision,
+      author: seed.author
+    )
+  end
+end

--- a/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/objectives_live_test.exs
@@ -211,6 +211,12 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
 
       assert has_element?(view, "p", "None exist")
 
+      assert has_element?(
+               view,
+               "#download-objectives-csv[download='#{project.slug}_learning_objectives.csv']",
+               "Download CSV"
+             )
+
       assert_receive {:finish_attachments, {_attachments, _flash_fn}}
       assert_receive {:DOWN, _ref, :process, _pid, :normal}
     end
@@ -268,6 +274,50 @@ defmodule OliWeb.Workspaces.CourseAuthor.ObjectivesLiveTest do
              |> element("#accordion article:first-child")
              |> render() =~
                "Second Objective"
+
+      assert_receive {:finish_attachments, {_attachments, _flash_fn}}
+      assert_receive {:DOWN, _ref, :process, _pid, :normal}
+    end
+
+    test "download link preserves the applied search and sort without pagination", %{
+      conn: conn,
+      project: project,
+      publication: publication
+    } do
+      create_objective(project, publication, "first_obj", "First Objective")
+      create_objective(project, publication, "second_obj", "Second Objective")
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      view
+      |> element("input[phx-blur='change_search']")
+      |> render_blur(%{value: "first"})
+
+      view
+      |> element("button[phx-click='apply_search']")
+      |> render_click()
+
+      view
+      |> element("form[phx-change='sort']")
+      |> render_change(%{sort_by: "title"})
+
+      href =
+        view
+        |> element("#download-objectives-csv")
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.attribute("href")
+        |> hd()
+
+      assert href |> URI.parse() |> Map.fetch!(:path) ==
+               "/workspaces/course_author/#{project.slug}/objectives.csv"
+
+      export_params = href |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()
+
+      assert export_params["query"] == "first"
+      assert export_params["sort_by"] == "title"
+      assert export_params["sort_order"] == "desc"
+      refute Map.has_key?(export_params, "offset")
 
       assert_receive {:finish_attachments, {_attachments, _flash_fn}}
       assert_receive {:DOWN, _ref, :process, _pid, :normal}


### PR DESCRIPTION

Implements [MER-5801](https://eliterate.atlassian.net/browse/MER-5801) by adding a **Download CSV** action to the Learning Objectives authoring page.

The export:

- Respects the currently applied search and sorting.
- Produces one row per objective/activity/page relationship.
- Includes LO, Sub-Objective, activity, page, and curriculum-location details.
- Uses custom Unit/Module/Section labels.
- Returns headers only when no objectives match.

<img width="1085" height="814" alt="image" src="https://github.com/user-attachments/assets/ead839cc-3f47-4916-8c0c-3f41fde04da1" />

[MER-5801]: https://eliterate.atlassian.net/browse/MER-5801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ