### PR TITLE
[ENHANCEMENT] [MER-5859] Rework for student onboarding text customization

### DIFF
--- a/assets/src/components/editing/toolbar/buttons/DescriptiveButton.tsx
+++ b/assets/src/components/editing/toolbar/buttons/DescriptiveButton.tsx
@@ -13,7 +13,8 @@ export const DescriptiveButton = (props: DescriptiveButtonProps) => {
   const { context, closeSubmenus } = useToolbar();
 
   const onMouseDown = React.useCallback(
-    (_e) => {
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.preventDefault();
       props.description.command.execute(context, editor);
       closeSubmenus();
     },
@@ -31,6 +32,7 @@ export const DescriptiveButton = (props: DescriptiveButtonProps) => {
 
   return (
     <button
+      type="button"
       className={classNames(styles.toolbarButton, styles.descriptive, active && styles.active)}
       onMouseDown={onMouseDown}
     >

--- a/assets/test/components/editing/descriptive_button_test.tsx
+++ b/assets/test/components/editing/descriptive_button_test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { Descendant, createEditor } from 'slate';
+import { Slate, withReact } from 'slate-react';
+import { CommandDescription } from 'components/editing/elements/commands/interfaces';
+import { DescriptiveButton } from 'components/editing/toolbar/buttons/DescriptiveButton';
+import { ToolbarContext } from 'components/editing/toolbar/hooks/useToolbar';
+
+describe('DescriptiveButton', () => {
+  it('executes a formatting command without submitting its surrounding form', () => {
+    const execute = jest.fn();
+    const closeSubmenus = jest.fn();
+    const onSubmit = jest.fn((event) => event.preventDefault());
+    const editor = withReact(createEditor());
+    const value: Descendant[] = [{ type: 'p', children: [{ text: 'Welcome' }] } as any];
+    const description: CommandDescription = {
+      type: 'CommandDesc',
+      icon: () => undefined,
+      description: () => 'Bulleted List',
+      command: {
+        precondition: () => true,
+        execute,
+      },
+    };
+
+    render(
+      <form onSubmit={onSubmit}>
+        <Slate editor={editor} initialValue={value} onChange={jest.fn()}>
+          <ToolbarContext.Provider
+            value={{
+              context: { projectSlug: 'project' },
+              submenu: null,
+              openSubmenu: jest.fn(),
+              closeSubmenus,
+            }}
+          >
+            <DescriptiveButton description={description} />
+          </ToolbarContext.Provider>
+        </Slate>
+      </form>,
+    );
+
+    const button = screen.getByRole('button', { name: 'Bulleted List' });
+
+    expect(button).toHaveAttribute('type', 'button');
+    fireEvent.mouseDown(button);
+
+    expect(execute).toHaveBeenCalledWith({ projectSlug: 'project' }, editor);
+    expect(closeSubmenus).toHaveBeenCalled();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -7,9 +7,7 @@ defmodule Oli.Authoring.Course.Project do
   alias Oli.LearningModel.ModelVersion
   alias Oli.Utils.Slug
 
-  import Oli.Utils, only: [validate_word_count: 3]
-
-  @description_word_limit 300
+  @description_character_limit 300
 
   @derive {Phoenix.Param, key: :slug}
   schema "projects" do
@@ -110,7 +108,10 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
-    |> validate_word_count(:description, @description_word_limit)
+    |> validate_length(:description,
+      max: @description_character_limit,
+      message: "must be %{count} characters or fewer"
+    )
     |> Slug.update_never("projects")
   end
 
@@ -136,7 +137,10 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
-    |> validate_word_count(:description, @description_word_limit)
+    |> validate_length(:description,
+      max: @description_character_limit,
+      message: "must be %{count} characters or fewer"
+    )
     |> Slug.update_never("projects")
   end
 

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -19,7 +19,7 @@ defmodule Oli.Delivery.Sections.Section do
     Section
   }
 
-  @description_word_limit 300
+  @description_character_limit 300
 
   @required_fields [
     :type,
@@ -258,7 +258,10 @@ defmodule Oli.Delivery.Sections.Section do
     |> check_constraint(:learning_model_version, name: :sections_learning_model_version_check)
     |> Slug.update_never("sections")
     |> validate_length(:title, max: 255)
-    |> validate_word_count(:description, @description_word_limit)
+    |> validate_length(:description,
+      max: @description_character_limit,
+      message: "must be %{count} characters or fewer"
+    )
     |> cast_assoc(:certificate)
   end
 

--- a/lib/oli/rendering/content/html.ex
+++ b/lib/oli/rendering/content/html.ex
@@ -425,7 +425,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def ol(%Context{} = _context, next, _) do
-    ["<ol class=\"list-inside pl-2\">", next.(), "</ol>\n"]
+    ["<ol class=\"list-decimal list-inside pl-2\">", next.(), "</ol>\n"]
   end
 
   def dl(%Context{}, next, title, %{}) do
@@ -452,7 +452,7 @@ defmodule Oli.Rendering.Content.Html do
   end
 
   def ul(%Context{} = _context, next, _) do
-    ["<ul class=\"list-inside pl-2\">", next.(), "</ul>\n"]
+    ["<ul class=\"list-disc list-inside pl-2\">", next.(), "</ul>\n"]
   end
 
   def li(%Context{} = context, next, attrs) do

--- a/lib/oli/utils.ex
+++ b/lib/oli/utils.ex
@@ -194,33 +194,6 @@ defmodule Oli.Utils do
     end
   end
 
-  @doc """
-  Validates that a string field contains no more than the given number of words.
-
-  Words are separated by one or more whitespace characters. Blank values contain zero words.
-  """
-  @spec validate_word_count(Ecto.Changeset.t(), atom(), non_neg_integer()) ::
-          Ecto.Changeset.t()
-  def validate_word_count(changeset, field, max_words) do
-    validate_change(changeset, field, fn ^field, value ->
-      word_count =
-        case value do
-          value when is_binary(value) ->
-            value
-            |> String.split(~r/\s+/, trim: true)
-            |> length()
-
-          _ ->
-            0
-        end
-
-      case word_count > max_words do
-        true -> [{field, "must be #{max_words} words or fewer"}]
-        false -> []
-      end
-    end)
-  end
-
   def validate_number_if(
         changeset,
         field,

--- a/lib/oli_web/common/react.ex
+++ b/lib/oli_web/common/react.ex
@@ -8,6 +8,9 @@ defmodule OliWeb.Common.React do
 
   <%= React.component(@ctx, "Components.MyComponent", %{name: "Bob"}, id: "my-component-1") %>
 
+  Rendering contexts may set `render_opts.react_component_id_prefix` to scope component IDs when
+  the same rendered content can appear more than once in a LiveView.
+
   Remember to import and register the component in assets/src/apps/Components.tsx
   """
 
@@ -19,9 +22,20 @@ defmodule OliWeb.Common.React do
   def component(_, name, props),
     do: ReactPhoenix.ClientSide.react_component(name, props)
 
-  def component(%{is_liveview: true}, name, props, opts),
-    do: live_react_component(name, props, opts)
+  def component(%{is_liveview: true} = context, name, props, opts),
+    do: live_react_component(name, props, prefix_component_id(context, opts))
 
-  def component(_, name, props, opts),
-    do: ReactPhoenix.ClientSide.react_component(name, props, opts)
+  def component(context, name, props, opts),
+    do: ReactPhoenix.ClientSide.react_component(name, props, prefix_component_id(context, opts))
+
+  defp prefix_component_id(context, opts) do
+    with %{render_opts: render_opts} when is_map(render_opts) <- context,
+         prefix when is_binary(prefix) and prefix != "" <-
+           Map.get(render_opts, :react_component_id_prefix),
+         id when is_binary(id) and id != "" <- Keyword.get(opts, :id) do
+      Keyword.put(opts, :id, "#{prefix}-#{id}")
+    else
+      _ -> opts
+    end
+  end
 end

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -1344,7 +1344,7 @@ defmodule OliWeb.Components.Common do
             editMode: true,
             value: @value,
             fixedToolbar: true,
-            allowBlockElements: false
+            allowBlockElements: true
           },
           id: "rich_text_editor_react_component"
         )}

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -4,25 +4,34 @@ defmodule OliWeb.Components.Delivery.Student do
   alias OliWeb.Common.FormatDateTime
   alias Oli.Delivery.Attempts.HistoricalGradedAttemptSummary
   alias Oli.Delivery.Attempts.Core.ResourceAttempt
+  alias Oli.Rendering.Context
   alias OliWeb.Components.Common
   alias OliWeb.Delivery.Student.Utils
   alias OliWeb.Icons
 
   attr(:title, :map, default: nil)
   attr(:fallback, :string, default: nil)
+  attr(:render_context, :map, required: true)
+  attr(:id_prefix, :string, required: true)
 
   @doc """
   Renders rich-text welcome content, or the given fallback when it is empty.
+
+  The rendering context determines whether embedded React content uses LiveReact. The ID prefix
+  scopes those React mounts when the same welcome content appears in multiple previews.
   """
   def welcome_title(assigns) do
-    assigns = assign(assigns, :content, render_welcome_title(assigns.title))
+    render_context = with_react_component_id_prefix(assigns.render_context, assigns.id_prefix)
+
+    assigns =
+      assign(assigns, :content, render_welcome_title(assigns.title, render_context))
 
     ~H"""
     {@content || @fallback}
     """
   end
 
-  defp render_welcome_title(welcome_title) when is_map(welcome_title) do
+  defp render_welcome_title(welcome_title, %Context{} = context) when is_map(welcome_title) do
     children = Map.get(welcome_title, "children") || Map.get(welcome_title, :children) || []
 
     case children do
@@ -32,7 +41,7 @@ defmodule OliWeb.Components.Delivery.Student do
       children ->
         Phoenix.HTML.raw(
           Oli.Rendering.Content.render(
-            %Oli.Rendering.Context{},
+            context,
             children,
             Oli.Rendering.Content.Html
           )
@@ -40,7 +49,14 @@ defmodule OliWeb.Components.Delivery.Student do
     end
   end
 
-  defp render_welcome_title(_welcome_title), do: nil
+  defp render_welcome_title(_welcome_title, %Context{}), do: nil
+
+  defp with_react_component_id_prefix(%Context{} = context, id_prefix) do
+    %{
+      context
+      | render_opts: Map.put(context.render_opts, :react_component_id_prefix, id_prefix)
+    }
+  end
 
   attr(:raw_avg_score, :map)
 

--- a/lib/oli_web/components/delivery/student.ex
+++ b/lib/oli_web/components/delivery/student.ex
@@ -12,7 +12,7 @@ defmodule OliWeb.Components.Delivery.Student do
   attr(:fallback, :string, default: nil)
 
   @doc """
-  Renders a rich-text welcome title as inline content, or the given fallback when it is empty.
+  Renders rich-text welcome content, or the given fallback when it is empty.
   """
   def welcome_title(assigns) do
     assigns = assign(assigns, :content, render_welcome_title(assigns.title))
@@ -25,33 +25,15 @@ defmodule OliWeb.Components.Delivery.Student do
   defp render_welcome_title(welcome_title) when is_map(welcome_title) do
     children = Map.get(welcome_title, "children") || Map.get(welcome_title, :children) || []
 
-    # Persisted titles retain paragraph wrappers; unwrap them before placing the content in a heading.
-    inline_children =
-      children
-      |> Enum.with_index()
-      |> Enum.flat_map(fn {block, index} ->
-        case block do
-          block when is_map(block) ->
-            case Map.get(block, "children") || Map.get(block, :children) do
-              children when is_list(children) and index == 0 -> children
-              children when is_list(children) -> [%{"text" => " "} | children]
-              _ -> []
-            end
-
-          _ ->
-            []
-        end
-      end)
-
-    case inline_children do
+    case children do
       [] ->
         nil
 
-      inline_children ->
+      children ->
         Phoenix.HTML.raw(
           Oli.Rendering.Content.render(
             %Oli.Rendering.Context{},
-            inline_children,
+            children,
             Oli.Rendering.Content.Html
           )
         )

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -592,10 +592,23 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           Hi, {user_given_name(@ctx)} !
         </div>
         <div class="flex flex-col items-start gap-2.5">
-          <div role="heading" aria-level="2" class="text-3xl text-white font-medium">
+          <div
+            role="heading"
+            aria-level="2"
+            class="min-w-0 max-w-full [overflow-wrap:anywhere] text-base leading-6 text-white font-normal [&_ol]:!pl-6 [&_ul]:!pl-6 [&>*:first-child]:text-3xl [&>*:first-child]:leading-9 [&>*:first-child]:font-medium"
+          >
             <Student.welcome_title
               title={@section.welcome_title}
               fallback="Welcome to the Course"
+              render_context={
+                %Oli.Rendering.Context{
+                  is_liveview: true,
+                  section_id: @section.id,
+                  section_slug: @section.slug,
+                  user: @ctx.user
+                }
+              }
+              id_prefix="student-home"
             />
           </div>
           <div class="text-white/60 text-lg font-semibold">

--- a/lib/oli_web/live/delivery/student/index_live.ex
+++ b/lib/oli_web/live/delivery/student/index_live.ex
@@ -592,12 +592,12 @@ defmodule OliWeb.Delivery.Student.IndexLive do
           Hi, {user_given_name(@ctx)} !
         </div>
         <div class="flex flex-col items-start gap-2.5">
-          <h2 class="text-3xl text-white font-medium">
+          <div role="heading" aria-level="2" class="text-3xl text-white font-medium">
             <Student.welcome_title
               title={@section.welcome_title}
               fallback="Welcome to the Course"
             />
-          </h2>
+          </div>
           <div class="text-white/60 text-lg font-semibold">
             {@section.encouraging_subtitle ||
               "Dive Into Discovery. Begin Your Learning Adventure Now!"}

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -18,12 +18,14 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
     />
     <div class="flex flex-col gap-3 px-[50px] hvsm:px-[70px] hvxl:px-[84px] py-9 dark:text-white">
       <%= if custom_message?(@section.description) do %>
-        <h2
+        <div
           id={"#{@id_prefix}-welcome-title"}
+          role="heading"
+          aria-level="2"
           class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
         >
           <Student.welcome_title title={@section.welcome_title} />
-        </h2>
+        </div>
         <p
           :if={custom_message?(@section.encouraging_subtitle)}
           id={"#{@id_prefix}-welcome-subtitle"}
@@ -33,7 +35,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
         </p>
         <p
           id={"#{@id_prefix}-welcome-description"}
-          class="whitespace-pre-line text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
+          class="whitespace-pre-line break-words text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.description}
         </p>

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -22,7 +22,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
           id={"#{@id_prefix}-welcome-title"}
           role="heading"
           aria-level="2"
-          class="min-w-0 max-w-full [overflow-wrap:anywhere] font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
+          class="min-w-0 max-w-full [overflow-wrap:anywhere] text-[16px] leading-6 tracking-[0.02px] [&>*:first-child]:font-semibold [&>*:first-child]:text-[18xl] [&>*:first-child]:leading-[24px] hvsm:[&>*:first-child]:text-[30px] hvsm:[&>*:first-child]:leading-[40px] hvxl:[&>*:first-child]:text-[40px] hvxl:[&>*:first-child]:leading-[54px]"
         >
           <Student.welcome_title title={@section.welcome_title} />
         </div>

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
   use Phoenix.Component
 
   import OliWeb.Common.SourceImage
+  alias Oli.Rendering.Context
   alias OliWeb.Components.Delivery.Student
 
   attr :section, :map, required: true
@@ -22,9 +23,19 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
           id={"#{@id_prefix}-welcome-title"}
           role="heading"
           aria-level="2"
-          class="min-w-0 max-w-full [overflow-wrap:anywhere] text-[16px] leading-6 tracking-[0.02px] [&>*:first-child]:font-semibold [&>*:first-child]:text-[18xl] [&>*:first-child]:leading-[24px] hvsm:[&>*:first-child]:text-[30px] hvsm:[&>*:first-child]:leading-[40px] hvxl:[&>*:first-child]:text-[40px] hvxl:[&>*:first-child]:leading-[54px]"
+          class="min-w-0 max-w-full [overflow-wrap:anywhere] text-[16px] leading-6 tracking-[0.02px] [&_ol]:!pl-6 [&_ul]:!pl-6 [&>*:first-child]:font-semibold [&>*:first-child]:text-[18xl] [&>*:first-child]:leading-[24px] hvsm:[&>*:first-child]:text-[30px] hvsm:[&>*:first-child]:leading-[40px] hvxl:[&>*:first-child]:text-[40px] hvxl:[&>*:first-child]:leading-[54px]"
         >
-          <Student.welcome_title title={@section.welcome_title} />
+          <Student.welcome_title
+            title={@section.welcome_title}
+            render_context={
+              %Context{
+                is_liveview: true,
+                section_id: @section.id,
+                section_slug: @section.slug
+              }
+            }
+            id_prefix={@id_prefix}
+          />
         </div>
         <p
           :if={custom_message?(@section.encouraging_subtitle)}

--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -22,20 +22,20 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
           id={"#{@id_prefix}-welcome-title"}
           role="heading"
           aria-level="2"
-          class="font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
+          class="min-w-0 max-w-full [overflow-wrap:anywhere] font-semibold text-[18xl] leading-[24px] hvsm:text-[30px] hvsm:leading-[40px] hvxl:text-[40px] hvxl:leading-[54px] tracking-[0.02px]"
         >
           <Student.welcome_title title={@section.welcome_title} />
         </div>
         <p
           :if={custom_message?(@section.encouraging_subtitle)}
           id={"#{@id_prefix}-welcome-subtitle"}
-          class="font-semibold text-[16px] leading-6 tracking-[0.02px] dark:text-opacity-80"
+          class="min-w-0 max-w-full [overflow-wrap:anywhere] font-semibold text-[16px] leading-6 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.encouraging_subtitle}
         </p>
         <p
           id={"#{@id_prefix}-welcome-description"}
-          class="whitespace-pre-line break-words text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
+          class="min-w-0 max-w-full whitespace-pre-line [overflow-wrap:anywhere] text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.description}
         </p>

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -27,8 +27,6 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
     introduction_step = %Step{
       title: "Introduction",
-      description:
-        "Welcome to #{section.title}! Here's what you can expect during this set up process.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label:

--- a/lib/oli_web/live/delivery/student_onboarding/wizard.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/wizard.ex
@@ -27,6 +27,8 @@ defmodule OliWeb.Delivery.StudentOnboarding.Wizard do
 
     introduction_step = %Step{
       title: "Introduction",
+      description:
+        "Welcome to #{section.title}! Here's what you can expect during this set up process.",
       render_fn: &render_step/1,
       data: %{},
       next_button_label:

--- a/lib/oli_web/live/products/details/edit.ex
+++ b/lib/oli_web/live/products/details/edit.ex
@@ -49,7 +49,7 @@ defmodule OliWeb.Products.Details.Edit do
 
         <div class="form-group mb-2">
           {label(f, :description)}
-          {text_input(f, :description, class: "form-control")}
+          {text_input(f, :description, class: "form-control", maxlength: 300)}
           <div>{error_tag(f, :description)}</div>
         </div>
 

--- a/lib/oli_web/live/products/details_view.ex
+++ b/lib/oli_web/live/products/details_view.ex
@@ -342,7 +342,7 @@ defmodule OliWeb.Products.DetailsView do
   def handle_event("validate", %{"section" => params}, socket) do
     changeset =
       socket.assigns.product
-      |> Sections.change_section(params)
+      |> Sections.change_section(decode_welcome_title(params))
 
     {:noreply, assign(socket, changeset: changeset)}
   end

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -177,6 +177,7 @@ defmodule OliWeb.Sections.EditView do
       params
       |> can_change_payment?(socket.assigns.is_admin)
       |> convert_dates(socket.assigns.ctx)
+      |> decode_welcome_title()
 
     {:noreply, assign(socket, changeset: Sections.change_section(socket.assigns.section, params))}
   end

--- a/lib/oli_web/live/sections/main_details.ex
+++ b/lib/oli_web/live/sections/main_details.ex
@@ -22,6 +22,7 @@ defmodule OliWeb.Sections.MainDetails do
           field={@form[:description]}
           label="Description"
           class="form-control"
+          maxlength="300"
           disabled={@disabled}
         />
       </div>

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -162,6 +162,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
               label="Project Description"
               type="textarea"
               class="form-control"
+              maxlength="300"
               placeholder="A brief description of your project..."
               error_position={:top}
               errors={f.errors}

--- a/lib/oli_web/live/workspaces/course_author/products/details_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/products/details_live.ex
@@ -364,9 +364,14 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLive do
   end
 
   def handle_event("validate", %{"section" => params}, socket) do
+    params =
+      params
+      |> decode_welcome_title()
+      |> filter_paywall_params(socket.assigns.is_admin)
+
     changeset =
       socket.assigns.product
-      |> Sections.change_section(filter_paywall_params(params, socket.assigns.is_admin))
+      |> Sections.change_section(params)
 
     {:noreply, assign(socket, changeset: changeset)}
   end

--- a/lib/oli_web/live/workspaces/instructor/index_live.ex
+++ b/lib/oli_web/live/workspaces/instructor/index_live.ex
@@ -312,9 +312,10 @@ defmodule OliWeb.Workspaces.Instructor.IndexLive do
           <% end %>
           {list_instructors(Sections.get_instructors_for_section(@section.id))}
         </div>
-        <div class="text-black text-base font-normal leading-normal h-[100px] overflow-hidden">
+        <div class="self-stretch min-w-0 text-black text-base font-normal leading-normal h-[100px] overflow-hidden">
           <p
             role="course description"
+            class="break-words"
             style="display: -webkit-box; -webkit-line-clamp: 4; -webkit-box-orient: vertical;"
           >
             {@section.description}

--- a/lib/oli_web/templates/delivery/enroll.html.heex
+++ b/lib/oli_web/templates/delivery/enroll.html.heex
@@ -10,7 +10,7 @@
         <img src={cover_image(@section)} class="card-img-top" alt="course image" />
         <div class="text-center">
           <h5 class="text-lg font-semibold my-1">{@section.title}</h5>
-          <p class="text-sm my-1">{@section.description}</p>
+          <p class="text-sm my-1 break-words">{@section.description}</p>
         </div>
       </div>
 

--- a/test/oli/delivery/sections/section_test.exs
+++ b/test/oli/delivery/sections/section_test.exs
@@ -89,13 +89,15 @@ defmodule Oli.Delivery.Sections.SectionTest do
       assert changeset.errors[:title] |> elem(0) =~ ~r/should be at most .* character/
     end
 
-    test "validates the description word limit" do
+    test "validates the description character limit" do
       section = build(:section, @valid_section_attrs)
-      description = Enum.join(List.duplicate("word", 301), " ")
+      description = String.duplicate("a", 301)
 
       changeset = Section.changeset(section, %{description: description})
 
-      assert changeset.errors[:description] == {"must be 300 words or fewer", []}
+      assert changeset.errors[:description] ==
+               {"must be %{count} characters or fewer",
+                [count: 300, validation: :length, kind: :max, type: :string]}
     end
 
     test "default assistant_enabled is false" do

--- a/test/oli/rendering/content/html_test.exs
+++ b/test/oli/rendering/content/html_test.exs
@@ -40,10 +40,10 @@ defmodule Oli.Content.Content.HtmlTest do
       assert rendered_html_string =~ "<h4 class=\"h3\">1651–1748: Early seeds</h4>"
 
       assert rendered_html_string =~
-               "<ol class=\"list-inside pl-2\"><li data-point-marker=\"1896247178\">one</li>\n<li data-point-marker=\"1896247178\"><em>two</em></li>\n<li data-point-marker=\"1896247178\"><em><strong>three</strong></em></li>\n</ol>"
+               "<ol class=\"list-decimal list-inside pl-2\"><li data-point-marker=\"1896247178\">one</li>\n<li data-point-marker=\"1896247178\"><em>two</em></li>\n<li data-point-marker=\"1896247178\"><em><strong>three</strong></em></li>\n</ol>"
 
       assert rendered_html_string =~
-               "<ul class=\"list-inside pl-2\"><li data-point-marker=\"18868465\">alpha</li>\n<li data-point-marker=\"18868465\">beta</li>\n<li data-point-marker=\"18868465\">gamma</li>\n</ul>"
+               "<ul class=\"list-disc list-inside pl-2\"><li data-point-marker=\"18868465\">alpha</li>\n<li data-point-marker=\"18868465\">beta</li>\n<li data-point-marker=\"18868465\">gamma</li>\n</ul>"
 
       assert rendered_html_string =~
                ~r/<div data-react-class="Components.YoutubePlayer"/

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -168,7 +168,10 @@ defmodule OliWeb.DeliveryControllerTest do
       enrollment_path = ~p"/sections/#{section.slug}/enroll"
       conn = get(conn, enrollment_path)
 
-      assert response(conn, 200) =~ "Enroll in Course Section"
+      html = response(conn, 200)
+
+      assert html =~ "Enroll in Course Section"
+      assert html =~ ~s(class="text-sm my-1 break-words")
     end
 
     test "redirect to requested path after login", %{conn: conn, section: section} do

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -178,6 +178,12 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
                 ]
               }
             ]
+          },
+          %{
+            "id" => "welcome-video",
+            "type" => "youtube",
+            "src" => "RpnEyBIkdMc",
+            "children" => [%{"text" => ""}]
           }
         ]
       }
@@ -207,6 +213,16 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       assert has_element?(
                view,
                ~s(#onboarding-welcome-title[class*="text-[16px]"][class*="first-child]:text-[18xl]"])
+             )
+
+      assert has_element?(
+               view,
+               ~s(#onboarding-welcome-title[class*="[&_ul]:!pl-6"])
+             )
+
+      assert has_element?(
+               view,
+               ~s(#onboarding-youtube--welcome-video[phx-hook="LiveReact"])
              )
     end
 

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -158,6 +158,11 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
         "type" => "p",
         "children" => [
           %{
+            "id" => "welcome-heading",
+            "type" => "p",
+            "children" => [%{"text" => "Welcome to the course"}]
+          },
+          %{
             "id" => "welcome-list",
             "type" => "ul",
             "children" => [
@@ -189,8 +194,19 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
 
       assert has_element?(
                view,
+               "#onboarding-welcome-title > p:first-child",
+               "Welcome to the course"
+             )
+
+      assert has_element?(
+               view,
                "#onboarding-welcome-title ul.list-disc li",
                "Review the course goals"
+             )
+
+      assert has_element?(
+               view,
+               ~s(#onboarding-welcome-title[class*="text-[16px]"][class*="first-child]:text-[18xl]"])
              )
     end
 

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -89,7 +89,6 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       refute render(view) =~ "This custom title is not displayed"
       refute has_element?(view, "#onboarding-welcome-subtitle")
       refute has_element?(view, "#onboarding-welcome-description")
-
       assert has_element?(
                view,
                "p",

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -89,6 +89,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       refute render(view) =~ "This custom title is not displayed"
       refute has_element?(view, "#onboarding-welcome-subtitle")
       refute has_element?(view, "#onboarding-welcome-description")
+
       assert has_element?(
                view,
                "p",
@@ -145,6 +146,47 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
              )
 
       refute has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
+    end
+
+    test "renders welcome title block formatting", %{conn: conn, user: student} do
+      welcome_title = %{
+        "type" => "p",
+        "children" => [
+          %{
+            "id" => "welcome-list",
+            "type" => "ul",
+            "children" => [
+              %{
+                "id" => "welcome-list-item",
+                "type" => "li",
+                "children" => [
+                  %{
+                    "id" => "welcome-list-paragraph",
+                    "type" => "p",
+                    "children" => [%{"text" => "Review the course goals"}]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      section =
+        insert(:section,
+          description: "Prepare for the course.",
+          welcome_title: welcome_title
+        )
+
+      enroll_student(student, section)
+
+      {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
+
+      assert has_element?(
+               view,
+               "#onboarding-welcome-title ul.list-disc li",
+               "Review the course goals"
+             )
     end
 
     test "renders the section cover image when present", %{conn: conn, user: student} do

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -135,6 +135,11 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
 
       assert has_element?(
                view,
+               ~s(#onboarding-welcome-title.min-w-0.max-w-full[class*="overflow-wrap:anywhere"])
+             )
+
+      assert has_element?(
+               view,
                "#onboarding-welcome-subtitle",
                "Discover how molecules shape our world."
              )

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1036,7 +1036,7 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(view, "div", "Hi, #{user.given_name} !")
 
       # Shows welcome title respecting the strong tag
-      assert has_element?(view, "h2", "Welcome to")
+      assert has_element?(view, ~s(div[role="heading"][aria-level="2"]), "Welcome to")
       assert has_element?(view, "strong", "the best course ever!")
 
       # Shows encouraging subtitle
@@ -1085,7 +1085,11 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       assert has_element?(view, "div", "Hi, #{user.given_name} !")
 
       # Shows welcome title respecting the strong tag
-      assert has_element?(view, "h2", "Welcome to the Course")
+      assert has_element?(
+               view,
+               ~s(div[role="heading"][aria-level="2"]),
+               "Welcome to the Course"
+             )
 
       # Shows encouraging subtitle
       assert has_element?(view, "div", "Dive Into Discovery. Begin Your Learning Adventure Now!")

--- a/test/oli_web/live/delivery/student/index_live_test.exs
+++ b/test/oli_web/live/delivery/student/index_live_test.exs
@@ -1019,6 +1019,29 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
             id: "2748906063",
             type: "p",
             children: [%{text: "Welcome to "}, %{text: "the best course ever!", strong: true}]
+          },
+          %{
+            id: "home-welcome-list",
+            type: "ol",
+            children: [
+              %{
+                id: "home-welcome-list-item",
+                type: "li",
+                children: [
+                  %{
+                    id: "home-welcome-list-paragraph",
+                    type: "p",
+                    children: [%{text: "Review the course goals"}]
+                  }
+                ]
+              }
+            ]
+          },
+          %{
+            id: "home-welcome-video",
+            type: "youtube",
+            src: "RpnEyBIkdMc",
+            children: [%{text: ""}]
           }
         ]
       }
@@ -1038,6 +1061,17 @@ defmodule OliWeb.Delivery.Student.IndexLiveTest do
       # Shows welcome title respecting the strong tag
       assert has_element?(view, ~s(div[role="heading"][aria-level="2"]), "Welcome to")
       assert has_element?(view, "strong", "the best course ever!")
+
+      assert has_element?(
+               view,
+               ~s(div[role="heading"][aria-level="2"][class*="text-base"][class*="first-child]:text-3xl"][class*="[&_ol]:!pl-6"] ol.list-decimal li),
+               "Review the course goals"
+             )
+
+      assert has_element?(
+               view,
+               ~s(#student-home-youtube--home-welcome-video[phx-hook="LiveReact"])
+             )
 
       # Shows encouraging subtitle
       assert has_element?(view, "div", encouraging_subtitle)

--- a/test/oli_web/live/products/details_view_test.exs
+++ b/test/oli_web/live/products/details_view_test.exs
@@ -56,6 +56,8 @@ defmodule OliWeb.Products.DetailsViewTest do
     } do
       {:ok, _view, html} = live(conn, product_route(product.slug))
 
+      assert html =~ ~s(maxlength="300")
+
       {description_index, _} = :binary.match(html, "Description")
       {tags_index, _} = :binary.match(html, "Tags")
       {welcome_title_index, _} = :binary.match(html, "Welcome Message Title")

--- a/test/oli_web/live/products/image_preview_test.exs
+++ b/test/oli_web/live/products/image_preview_test.exs
@@ -65,7 +65,19 @@ defmodule OliWeb.Products.ImagePreviewTest do
         insert(:section,
           type: :blueprint,
           title: "Preview Biology",
-          cover_image: nil
+          cover_image: nil,
+          description: "Prepare for the course.",
+          welcome_title: %{
+            "type" => "p",
+            "children" => [
+              %{
+                "id" => "preview-welcome-video",
+                "type" => "youtube",
+                "src" => "RpnEyBIkdMc",
+                "children" => [%{"text" => ""}]
+              }
+            ]
+          }
         )
         |> Map.put(:required_survey_resource_id, nil)
         |> Map.put(:contains_explorations, false)
@@ -82,6 +94,8 @@ defmodule OliWeb.Products.ImagePreviewTest do
       refute html =~ "Learning about the new ‘Exploration’ activities"
       assert html =~ "Go to course"
       assert html =~ "/images/course_default.png"
+      assert html =~ ~s(id="image-preview-youtube--preview-welcome-video")
+      assert html =~ ~s(phx-hook="LiveReact")
     end
 
     test "gallery renders the full uploaded image above the three shared runtime contexts" do

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -223,17 +223,19 @@ defmodule OliWeb.Sections.EditLiveTest do
       refute html =~ "/authoring/products/#{section.slug}/discounts"
     end
 
-    test "section description cannot exceed 300 words", %{conn: conn, section: section} do
-      description = Enum.join(List.duplicate("word", 301), " ")
+    test "section description cannot exceed 300 characters", %{conn: conn, section: section} do
+      description = String.duplicate("a", 301)
 
-      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+      {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
+
+      assert html =~ ~s(maxlength="300")
 
       html =
         view
         |> element("#section-edit-form")
         |> render_submit(section: %{description: description})
 
-      assert html =~ "must be 300 words or fewer"
+      assert html =~ "must be 300 characters or fewer"
       assert Oli.Repo.get(Section, section.id).description == section.description
     end
 
@@ -268,13 +270,17 @@ defmodule OliWeb.Sections.EditLiveTest do
       assert has_element?(view, "input[value='#{section.description}']")
       assert has_element?(view, "input[value='#{section.encouraging_subtitle}']")
 
-      # Loads the welcome title
-      view
-      |> render()
-      |> Floki.parse_fragment!()
-      |> Floki.find(~s{div[data-live-react-class="Components.RichTextEditor"]})
-      |> Floki.attribute("data-live-react-props")
-      |> hd() =~ "Welcome Title"
+      # Loads the welcome title with block formatting enabled.
+      editor_props =
+        view
+        |> render()
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{div[data-live-react-class="Components.RichTextEditor"]})
+        |> Floki.attribute("data-live-react-props")
+        |> hd()
+
+      assert editor_props =~ "Welcome Title"
+      assert editor_props =~ ~s("allowBlockElements":true)
 
       assert view
              |> element(
@@ -287,6 +293,56 @@ defmodule OliWeb.Sections.EditLiveTest do
                "select[id=section_institution_id] option[selected][value='#{section.institution_id}']"
              )
              |> has_element?()
+    end
+
+    test "preserves welcome title block formatting when another field changes", %{
+      conn: conn,
+      section: section
+    } do
+      welcome_title = %{
+        "type" => "p",
+        "children" => [
+          %{
+            "id" => "welcome-list",
+            "type" => "ul",
+            "children" => [
+              %{
+                "id" => "welcome-list-item",
+                "type" => "li",
+                "children" => [
+                  %{
+                    "id" => "welcome-list-paragraph",
+                    "type" => "p",
+                    "children" => [%{"text" => "Review the syllabus"}]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+
+      html =
+        view
+        |> element("#section-edit-form")
+        |> render_change(%{
+          section: %{
+            description: "An updated description",
+            welcome_title: Poison.encode!(welcome_title)
+          }
+        })
+
+      hidden_welcome_title =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{input[name="section[welcome_title]"]})
+        |> Floki.attribute("value")
+        |> hd()
+        |> Poison.decode!()
+
+      assert hidden_welcome_title == welcome_title
     end
 
     test "institution dropdown is disabled for LTI sections", %{conn: conn} do

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -122,17 +122,19 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       |> hd() =~ "Welcome Title"
     end
 
-    test "project description cannot exceed 300 words", %{conn: conn, author: author} do
+    test "project description cannot exceed 300 characters", %{conn: conn, author: author} do
       project = create_project_with_author(author)
-      description = Enum.join(List.duplicate("word", 301), " ")
+      description = String.duplicate("a", 301)
 
-      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+      {:ok, view, html} = live(conn, live_view_route(project.slug))
+
+      assert html =~ ~s(maxlength="300")
 
       element(view, "form[phx-submit='update']")
       |> render_submit(%{"project" => %{"description" => description}})
 
       assert has_element?(view, "div.alert-danger", "Project could not be updated.")
-      assert render(view) =~ "must be 300 words or fewer"
+      assert render(view) =~ "must be 300 characters or fewer"
       assert Course.get_project_by_slug(project.slug).description == project.description
     end
 

--- a/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/products/details_live_test.exs
@@ -237,6 +237,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.Products.DetailsLiveTest do
 
       {:ok, _live, html} = live(conn, live_view_route(project.slug, product.slug, %{}))
 
+      assert html =~ ~s(maxlength="300")
+
       {description_index, _} = :binary.match(html, "Description")
       {tags_index, _} = :binary.match(html, "Tags")
       {welcome_title_index, _} = :binary.match(html, "Welcome Message Title")

--- a/test/oli_web/live/workspaces/instructor_test.exs
+++ b/test/oli_web/live/workspaces/instructor_test.exs
@@ -393,6 +393,24 @@ defmodule OliWeb.Workspaces.InstructorTest do
                ~r/Instructors:\s*#{instructor.name},\s*Lionel Messi,\s*Angel Di Maria/
              )
     end
+
+    test "constrains long descriptions within the course card padding", %{
+      conn: conn,
+      instructor: instructor
+    } do
+      description = String.duplicate("a", 300)
+      section = insert(:section, open_and_free: true, description: description)
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      {:ok, view, _html} = live(conn, ~p"/workspaces/instructor")
+
+      assert has_element?(
+               view,
+               "div.self-stretch.min-w-0 > p[role='course description'].break-words",
+               description
+             )
+    end
   end
 
   describe "user logged in as hidden instructor" do


### PR DESCRIPTION
Rework for MER-5859.

- Enforces a 300-character limit for project and section descriptions in forms and schemas.
- Wraps long descriptions correctly on enrollment, instructor course cards, and onboarding screens.
- Prevents rich-text toolbar actions from submitting the surrounding form.
- Preserves rich-text block formatting while validating and editing other fields.
- Renders bulleted and numbered lists with correct marker alignment and indentation.
- Preserves saved rich-text block structure in student welcome displays.
- Keeps the first welcome block at heading size while displaying subsequent content at body size.
- Renders embedded content, including YouTube videos, on onboarding and student home screens.
- Uses uniquely prefixed React mount IDs across runtime and preview contexts to prevent duplicate DOM IDs.

https://github.com/user-attachments/assets/394e58b4-097d-4d71-a28c-311904cc9d15

<img width="1440" height="779" alt="image" src="https://github.com/user-attachments/assets/808bdbe9-db13-441a-b8cb-dd41d3a7084a" />



See: https://eliterate.atlassian.net/browse/MER-5859