### PR TITLE
[ENHANCEMENT] [MER-5790] Populate page level learning objectives based on activities

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -55,7 +55,14 @@ defmodule Oli.Delivery.Sections do
   alias OliWeb.Common.FormatDateTime
   alias Oli.Delivery.PreviousNextIndex
   alias Ecto.Multi
-  alias Oli.Delivery.Attempts.Core.{ResourceAccess, ResourceAttempt}
+
+  alias Oli.Delivery.Attempts.Core.{
+    ActivityAttempt,
+    PartAttempt,
+    ResourceAccess,
+    ResourceAttempt
+  }
+
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Paywall
   alias Oli.Delivery.Sections.PostProcessing
@@ -6141,9 +6148,14 @@ defmodule Oli.Delivery.Sections do
   * `:student_id` - If provided, filters proficiency results for a specific student
   * `:exclude_sub_objectives` - If true, only returns top-level objectives (default: false)
   * `:include_related_activities_count` - If true, includes `related_activities_count` field for each objective. A related activity is any activity that has the objective attached to it in its objectives map (default: false)
+
+  Container scopes union objectives statically attached to pages and embedded activities with
+  objectives from submitted or evaluated learner activity results. The latter allows realized
+  activity-bank selections to contribute their exact objectives after learners encounter them.
   """
   def get_objectives_and_subobjectives(%Section{slug: section_slug} = section, opts \\ []) do
     student_id = if opts[:student_id], do: opts[:student_id], else: nil
+    enrolled_student_ids = Sections.enrolled_student_ids(section_slug)
 
     exclude_sub_objectives = if opts[:exclude_sub_objectives], do: true, else: false
     include_related_activities_count = opts[:include_related_activities_count] || false
@@ -6201,16 +6213,11 @@ defmodule Oli.Delivery.Sections do
         }
       end)
 
-    # Only the two containment fields are needed, and both consumers of `container_ids` are
-    # membership checks, so the grouped lists are prepended and never reversed.
+    # Include both statically contained objectives and objectives realized by enrolled learners.
+    # Building this before the proficiency queries keeps objectives outside delivered content out
+    # of the more expensive metrics work.
     objective_to_container_ids_map =
-      from(co in ContainedObjective)
-      |> where([co], co.section_id == ^section.id)
-      |> select([co], {co.objective_id, co.container_id})
-      |> Repo.all()
-      |> Enum.reduce(%{}, fn {objective_id, container_id}, acc ->
-        Map.update(acc, objective_id, [container_id], &[container_id | &1])
-      end)
+      objective_to_container_ids_map(section.id, enrolled_student_ids)
 
     # Section resources outlive the content that referenced them, so containment - not the
     # `deleted` flag - decides whether an objective still belongs to the delivered course.
@@ -6291,8 +6298,6 @@ defmodule Oli.Delivery.Sections do
 
     {student_ids, proficiency_dist_for_objectives} =
       if is_nil(student_id) do
-        student_ids = Sections.enrolled_student_ids(section_slug)
-
         proficiency_dist_for_objectives =
           objectives
           |> Enum.reduce(%{}, fn objective, acc ->
@@ -6300,7 +6305,7 @@ defmodule Oli.Delivery.Sections do
               Metrics.evidence_resource_ids(objective.resource_id, objective.children)
 
             student_proficiency =
-              Enum.into(student_ids, %{}, fn enrolled_student_id ->
+              Enum.into(enrolled_student_ids, %{}, fn enrolled_student_id ->
                 {enrolled_student_id,
                  Metrics.proficiency_bucket_for_student(
                    resource_ids,
@@ -6316,7 +6321,7 @@ defmodule Oli.Delivery.Sections do
 
             {proficiency_mode, proficiency_dist} =
               if map_size(proficiency_dist) == 0 do
-                {"Not enough data", %{"Not enough data" => length(student_ids)}}
+                {"Not enough data", %{"Not enough data" => length(enrolled_student_ids)}}
               else
                 proficiency_mode =
                   proficiency_dist
@@ -6344,7 +6349,7 @@ defmodule Oli.Delivery.Sections do
             )
           end)
 
-        {student_ids, proficiency_dist_for_objectives}
+        {enrolled_student_ids, proficiency_dist_for_objectives}
       else
         {[], %{}}
       end
@@ -6458,6 +6463,66 @@ defmodule Oli.Delivery.Sections do
       end
     end)
   end
+
+  defp objective_to_container_ids_map(section_id, enrolled_student_ids) do
+    from(co in ContainedObjective,
+      where: co.section_id == ^section_id,
+      select: {co.objective_id, co.container_id}
+    )
+    |> Repo.all()
+    |> Enum.concat(realized_objective_container_pairs(section_id, enrolled_student_ids))
+    |> Enum.reduce(%{}, fn {objective_id, container_id}, acc ->
+      Map.update(acc, objective_id, MapSet.new([container_id]), &MapSet.put(&1, container_id))
+    end)
+    |> Map.new(fn {objective_id, container_ids} ->
+      {objective_id, container_ids |> MapSet.to_list() |> Enum.sort()}
+    end)
+  end
+
+  defp realized_objective_container_pairs(_section_id, []), do: []
+
+  # Bank selections are only realized when learners receive them. Use the exact activity revision
+  # recorded by each submitted result so its objectives augment the static container index.
+  defp realized_objective_container_pairs(section_id, enrolled_student_ids) do
+    from(pa in PartAttempt,
+      join: aa in ActivityAttempt,
+      on: aa.id == pa.activity_attempt_id,
+      join: activity_revision in Revision,
+      on: activity_revision.id == aa.revision_id,
+      join: resource_attempt in ResourceAttempt,
+      on: resource_attempt.id == aa.resource_attempt_id,
+      join: access in ResourceAccess,
+      on: access.id == resource_attempt.resource_access_id,
+      join: contained_page in ContainedPage,
+      on:
+        contained_page.section_id == access.section_id and
+          contained_page.page_id == access.resource_id,
+      where:
+        access.section_id == ^section_id and
+          access.user_id in ^enrolled_student_ids and
+          pa.lifecycle_state in [:submitted, :evaluated],
+      distinct: [contained_page.container_id, activity_revision.id, pa.part_id],
+      select: %{
+        container_id: contained_page.container_id,
+        objectives: activity_revision.objectives,
+        part_id: pa.part_id
+      }
+    )
+    |> Repo.all()
+    |> Enum.flat_map(fn result ->
+      result_objective_ids(result.objectives, result.part_id)
+      |> Enum.map(&{&1, result.container_id})
+    end)
+  end
+
+  defp result_objective_ids(objectives, part_id) when is_map(objectives) do
+    objectives
+    |> Map.get(part_id, [])
+    |> List.wrap()
+    |> Enum.filter(&is_integer/1)
+  end
+
+  defp result_objective_ids(_objectives, _part_id), do: []
 
   @doc """
   Returns the container label and numbering for a given container.

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -55,13 +55,8 @@ defmodule Oli.Delivery.Sections do
   alias OliWeb.Common.FormatDateTime
   alias Oli.Delivery.PreviousNextIndex
   alias Ecto.Multi
-
-  alias Oli.Delivery.Attempts.Core.{
-    ActivityAttempt,
-    PartAttempt,
-    ResourceAccess,
-    ResourceAttempt
-  }
+  alias Oli.Analytics.Summary.{ResourcePartResponse, ResourceSummary, StudentResponse}
+  alias Oli.Delivery.Attempts.Core.{ResourceAccess, ResourceAttempt}
 
   alias Oli.Delivery.Metrics
   alias Oli.Delivery.Paywall
@@ -6150,12 +6145,12 @@ defmodule Oli.Delivery.Sections do
   * `:include_related_activities_count` - If true, includes `related_activities_count` field for each objective. A related activity is any activity that has the objective attached to it in its objectives map (default: false)
 
   Container scopes union objectives statically attached to pages and embedded activities with
-  objectives from submitted or evaluated learner activity results. The latter allows realized
-  activity-bank selections to contribute their exact objectives after learners encounter them.
+  objectives from answered activities recorded in per-student analytics summaries. The latter
+  allows realized activity-bank selections to contribute their objectives after learners encounter
+  them.
   """
   def get_objectives_and_subobjectives(%Section{slug: section_slug} = section, opts \\ []) do
     student_id = if opts[:student_id], do: opts[:student_id], else: nil
-    enrolled_student_ids = Sections.enrolled_student_ids(section_slug)
 
     exclude_sub_objectives = if opts[:exclude_sub_objectives], do: true, else: false
     include_related_activities_count = opts[:include_related_activities_count] || false
@@ -6217,7 +6212,7 @@ defmodule Oli.Delivery.Sections do
     # Building this before the proficiency queries keeps objectives outside delivered content out
     # of the more expensive metrics work.
     objective_to_container_ids_map =
-      objective_to_container_ids_map(section.id, enrolled_student_ids)
+      objective_to_container_ids_map(section.id)
 
     # Section resources outlive the content that referenced them, so containment - not the
     # `deleted` flag - decides whether an objective still belongs to the delivered course.
@@ -6298,6 +6293,8 @@ defmodule Oli.Delivery.Sections do
 
     {student_ids, proficiency_dist_for_objectives} =
       if is_nil(student_id) do
+        student_ids = Sections.enrolled_student_ids(section_slug)
+
         proficiency_dist_for_objectives =
           objectives
           |> Enum.reduce(%{}, fn objective, acc ->
@@ -6305,7 +6302,7 @@ defmodule Oli.Delivery.Sections do
               Metrics.evidence_resource_ids(objective.resource_id, objective.children)
 
             student_proficiency =
-              Enum.into(enrolled_student_ids, %{}, fn enrolled_student_id ->
+              Enum.into(student_ids, %{}, fn enrolled_student_id ->
                 {enrolled_student_id,
                  Metrics.proficiency_bucket_for_student(
                    resource_ids,
@@ -6321,7 +6318,7 @@ defmodule Oli.Delivery.Sections do
 
             {proficiency_mode, proficiency_dist} =
               if map_size(proficiency_dist) == 0 do
-                {"Not enough data", %{"Not enough data" => length(enrolled_student_ids)}}
+                {"Not enough data", %{"Not enough data" => length(student_ids)}}
               else
                 proficiency_mode =
                   proficiency_dist
@@ -6349,7 +6346,7 @@ defmodule Oli.Delivery.Sections do
             )
           end)
 
-        {enrolled_student_ids, proficiency_dist_for_objectives}
+        {student_ids, proficiency_dist_for_objectives}
       else
         {[], %{}}
       end
@@ -6464,13 +6461,13 @@ defmodule Oli.Delivery.Sections do
     end)
   end
 
-  defp objective_to_container_ids_map(section_id, enrolled_student_ids) do
+  defp objective_to_container_ids_map(section_id) do
     from(co in ContainedObjective,
       where: co.section_id == ^section_id,
       select: {co.objective_id, co.container_id}
     )
     |> Repo.all()
-    |> Enum.concat(realized_objective_container_pairs(section_id, enrolled_student_ids))
+    |> Enum.concat(realized_objective_container_pairs(section_id))
     |> Enum.reduce(%{}, fn {objective_id, container_id}, acc ->
       Map.update(acc, objective_id, MapSet.new([container_id]), &MapSet.put(&1, container_id))
     end)
@@ -6479,50 +6476,73 @@ defmodule Oli.Delivery.Sections do
     end)
   end
 
-  defp realized_objective_container_pairs(_section_id, []), do: []
+  # Student response summaries retain the page on which an activity was answered. Pair them with
+  # per-student resource summaries to scope realized bank objectives without scanning attempts.
+  defp realized_objective_container_pairs(section_id) do
+    activity_type_id = ResourceType.id_for_activity()
 
-  # Bank selections are only realized when learners receive them. Use the exact activity revision
-  # recorded by each submitted result so its objectives augment the static container index.
-  defp realized_objective_container_pairs(section_id, enrolled_student_ids) do
-    from(pa in PartAttempt,
-      join: aa in ActivityAttempt,
-      on: aa.id == pa.activity_attempt_id,
-      join: activity_revision in Revision,
-      on: activity_revision.id == aa.revision_id,
-      join: resource_attempt in ResourceAttempt,
-      on: resource_attempt.id == aa.resource_attempt_id,
-      join: access in ResourceAccess,
-      on: access.id == resource_attempt.resource_access_id,
+    from(summary in ResourceSummary,
+      join: enrollment in Enrollment,
+      on:
+        enrollment.section_id == summary.section_id and
+          enrollment.user_id == summary.user_id,
+      join: enrollment_context_role in EnrollmentContextRole,
+      on: enrollment_context_role.enrollment_id == enrollment.id,
+      join: resource_part_response in ResourcePartResponse,
+      on:
+        resource_part_response.resource_id == summary.resource_id and
+          resource_part_response.part_id == summary.part_id,
+      join: student_response in StudentResponse,
+      on:
+        student_response.section_id == summary.section_id and
+          student_response.user_id == summary.user_id and
+          student_response.resource_part_response_id == resource_part_response.id,
       join: contained_page in ContainedPage,
       on:
-        contained_page.section_id == access.section_id and
-          contained_page.page_id == access.resource_id,
+        contained_page.section_id == student_response.section_id and
+          contained_page.page_id == student_response.page_id,
+      join: spp in SectionsProjectsPublications,
+      on: spp.section_id == summary.section_id,
+      join: published_resource in PublishedResource,
+      on:
+        published_resource.publication_id == spp.publication_id and
+          published_resource.resource_id == summary.resource_id,
+      join: activity_revision in Revision,
+      on: activity_revision.id == published_resource.revision_id,
       where:
-        access.section_id == ^section_id and
-          access.user_id in ^enrolled_student_ids and
-          pa.lifecycle_state in [:submitted, :evaluated],
-      distinct: [contained_page.container_id, activity_revision.id, pa.part_id],
+        summary.project_id == -1 and
+          summary.section_id == ^section_id and
+          summary.resource_type_id == ^activity_type_id and
+          summary.num_attempts > 0 and
+          enrollment.status == :enrolled and
+          enrollment_context_role.context_role_id == ^@student_role_id and
+          activity_revision.deleted == false,
+      distinct: [contained_page.container_id, activity_revision.id, summary.part_id],
       select: %{
         container_id: contained_page.container_id,
         objectives: activity_revision.objectives,
-        part_id: pa.part_id
+        part_id: summary.part_id
       }
     )
     |> Repo.all()
     |> Enum.flat_map(fn result ->
-      result_objective_ids(result.objectives, result.part_id)
+      objective_ids_for_part(result.objectives, result.part_id)
       |> Enum.map(&{&1, result.container_id})
     end)
   end
 
-  defp result_objective_ids(objectives, part_id) when is_map(objectives) do
+  defp objective_ids_for_part(objectives, part_id) when is_map(objectives) do
     objectives
     |> Map.get(part_id, [])
     |> List.wrap()
     |> Enum.filter(&is_integer/1)
   end
 
-  defp result_objective_ids(_objectives, _part_id), do: []
+  defp objective_ids_for_part(objectives, _part_id) when is_list(objectives) do
+    Enum.filter(objectives, &is_integer/1)
+  end
+
+  defp objective_ids_for_part(_objectives, _part_id), do: []
 
   @doc """
   Returns the container label and numbering for a given container.

--- a/lib/oli/scenarios/directive_parser.ex
+++ b/lib/oli/scenarios/directive_parser.ex
@@ -1212,6 +1212,7 @@ defmodule Oli.Scenarios.DirectiveParser do
       "activity_customization",
       "page_objectives",
       "activity_objectives",
+      "learning_objectives",
       "insights",
       "discussion",
       "annotation",
@@ -1241,6 +1242,8 @@ defmodule Oli.Scenarios.DirectiveParser do
       page_objectives: parse_page_objectives_assertion(assert_data["page_objectives"]),
       activity_objectives:
         parse_activity_objectives_assertion(assert_data["activity_objectives"]),
+      learning_objectives:
+        parse_learning_objectives_assertion(assert_data["learning_objectives"]),
       insights: parse_insights_assertion(assert_data["insights"]),
       discussion: parse_discussion_assertion(assert_data["discussion"]),
       annotation: parse_annotation_assertion(assert_data["annotation"]),
@@ -1763,6 +1766,31 @@ defmodule Oli.Scenarios.DirectiveParser do
 
       {:error, msg} ->
         raise msg
+    end
+  end
+
+  defp parse_learning_objectives_assertion(nil), do: nil
+
+  defp parse_learning_objectives_assertion(data) when is_map(data) do
+    with :ok <-
+           DirectiveValidator.validate_assertion_attributes(:learning_objectives, data),
+         :ok <- require_learning_objective_expectation(data) do
+      %{
+        section: data["section"],
+        container: data["container"] || "course",
+        includes: data["includes"] || [],
+        excludes: data["excludes"] || []
+      }
+    else
+      {:error, msg} -> raise msg
+    end
+  end
+
+  defp require_learning_objective_expectation(data) do
+    if Enum.any?(["includes", "excludes"], &(is_list(data[&1]) and data[&1] != [])) do
+      :ok
+    else
+      {:error, "learning_objectives assertion requires a non-empty includes or excludes list"}
     end
   end
 

--- a/lib/oli/scenarios/directive_types.ex
+++ b/lib/oli/scenarios/directive_types.ex
@@ -107,7 +107,7 @@ defmodule Oli.Scenarios.DirectiveTypes do
   end
 
   defmodule AssertDirective do
-    @moduledoc "Asserts the structure, resource properties, progress, proficiency, or general assertions"
+    @moduledoc "Holds one parsed assertion specification."
     defstruct [
       :structure,
       :resource,
@@ -122,6 +122,7 @@ defmodule Oli.Scenarios.DirectiveTypes do
       :activity_customization,
       :page_objectives,
       :activity_objectives,
+      :learning_objectives,
       :insights,
       :discussion,
       :annotation,

--- a/lib/oli/scenarios/directive_validator.ex
+++ b/lib/oli/scenarios/directive_validator.ex
@@ -227,6 +227,9 @@ defmodule Oli.Scenarios.DirectiveValidator do
         :activity_objectives ->
           ["project", "activity_virtual_id", "expected"]
 
+        :learning_objectives ->
+          ["section", "container", "includes", "excludes"]
+
         :instructor_dashboard_summary ->
           [
             "section",

--- a/lib/oli/scenarios/directives/assert/learning_objectives_assertion.ex
+++ b/lib/oli/scenarios/directives/assert/learning_objectives_assertion.ex
@@ -1,0 +1,92 @@
+defmodule Oli.Scenarios.Directives.Assert.LearningObjectivesAssertion do
+  @moduledoc """
+  Verifies learning objectives available in a course or container scope for a section.
+  """
+
+  alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.SectionResourceDepot
+  alias Oli.Scenarios.DirectiveTypes.{AssertDirective, VerificationResult}
+  alias Oli.Scenarios.Directives.Assert.Helpers
+
+  @doc """
+  Verifies that the configured objective titles are present or absent in the requested scope.
+  """
+  def assert(%AssertDirective{learning_objectives: spec}, state) when is_map(spec) do
+    verification =
+      with {:ok, section} <- Helpers.get_section(state, spec.section),
+           {:ok, container_id} <- resolve_container_id(section.id, spec.container) do
+        actual = objective_titles(section, container_id)
+        missing = MapSet.difference(MapSet.new(spec.includes), actual)
+        unexpected = MapSet.intersection(MapSet.new(spec.excludes), actual)
+
+        verification(spec, actual, missing, unexpected)
+      else
+        {:error, reason} -> failed(spec, "Could not verify learning objectives: #{reason}", nil)
+      end
+
+    {:ok, state, verification}
+  end
+
+  def assert(%AssertDirective{learning_objectives: nil}, state), do: {:ok, state, nil}
+
+  defp resolve_container_id(_section_id, container) when container in [nil, "course"],
+    do: {:ok, nil}
+
+  defp resolve_container_id(section_id, container) when is_binary(container) do
+    case Enum.find(SectionResourceDepot.containers(section_id), &(&1.title == container)) do
+      nil -> {:error, "Container '#{container}' not found in section"}
+      section_resource -> {:ok, section_resource.resource_id}
+    end
+  end
+
+  defp objective_titles(section, container_id) do
+    section
+    |> Sections.get_objectives_and_subobjectives(exclude_sub_objectives: false)
+    |> Enum.filter(&(container_id in List.wrap(&1.container_ids)))
+    |> Enum.map(&(Map.get(&1, :subobjective) || &1.objective))
+    |> MapSet.new()
+  end
+
+  defp verification(spec, actual, missing, unexpected) do
+    actual = actual |> MapSet.to_list() |> Enum.sort()
+
+    if MapSet.size(missing) == 0 and MapSet.size(unexpected) == 0 do
+      %VerificationResult{
+        to: spec.section,
+        passed: true,
+        message: "Learning objectives match the expected scope",
+        expected: expected(spec),
+        actual: actual
+      }
+    else
+      details =
+        [
+          set_message("missing", missing),
+          set_message("unexpected", unexpected)
+        ]
+        |> Enum.reject(&is_nil/1)
+        |> Enum.join("; ")
+
+      failed(spec, "Learning objectives mismatch: #{details}", actual)
+    end
+  end
+
+  defp set_message(label, set) do
+    case set |> MapSet.to_list() |> Enum.sort() do
+      [] -> nil
+      values -> "#{label} #{inspect(values)}"
+    end
+  end
+
+  defp failed(spec, message, actual) do
+    %VerificationResult{
+      to: spec.section,
+      passed: false,
+      message: message,
+      expected: expected(spec),
+      actual: actual
+    }
+  end
+
+  defp expected(spec), do: %{includes: spec.includes, excludes: spec.excludes}
+end

--- a/lib/oli/scenarios/directives/assert_handler.ex
+++ b/lib/oli/scenarios/directives/assert_handler.ex
@@ -19,6 +19,7 @@ defmodule Oli.Scenarios.Directives.AssertHandler do
     ActivityCustomizationAssertion,
     PageObjectivesAssertion,
     ActivityObjectivesAssertion,
+    LearningObjectivesAssertion,
     InsightsAssertion,
     DiscussionAssertion,
     AnnotationAssertion,
@@ -68,6 +69,9 @@ defmodule Oli.Scenarios.Directives.AssertHandler do
 
       directive.activity_objectives != nil ->
         ActivityObjectivesAssertion.assert(directive, state)
+
+      directive.learning_objectives != nil ->
+        LearningObjectivesAssertion.assert(directive, state)
 
       directive.insights != nil ->
         InsightsAssertion.assert(directive, state)

--- a/priv/schemas/v0-1-0/scenario.schema.json
+++ b/priv/schemas/v0-1-0/scenario.schema.json
@@ -1284,6 +1284,49 @@
           }
         }
       },
+      "learningObjectivesAssertion": {
+        "type": "object",
+        "required": [
+          "section"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "section": {
+            "type": "string"
+          },
+          "container": {
+            "type": "string"
+          },
+          "includes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          },
+          "excludes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "uniqueItems": true
+          }
+        },
+        "anyOf": [
+          {
+            "required": ["includes"],
+            "properties": {
+              "includes": { "minItems": 1 }
+            }
+          },
+          {
+            "required": ["excludes"],
+            "properties": {
+              "excludes": { "minItems": 1 }
+            }
+          }
+        ]
+      },
       "insightsExpected": {
         "type": "object",
         "additionalProperties": false,
@@ -1412,6 +1455,9 @@
           "activity_objectives": {
             "$ref": "#/definitions/activityObjectivesAssertion"
           },
+          "learning_objectives": {
+            "$ref": "#/definitions/learningObjectivesAssertion"
+          },
           "insights": {
             "$ref": "#/definitions/insightsAssertion"
           },
@@ -1484,6 +1530,9 @@
           },
           "activity_objectives": {
             "$ref": "#/definitions/activityObjectivesAssertion"
+          },
+          "learning_objectives": {
+            "$ref": "#/definitions/learningObjectivesAssertion"
           },
           "insights": {
             "$ref": "#/definitions/insightsAssertion"

--- a/test/scenarios/learning_objectives/bank_result_container_scope.scenario.yaml
+++ b/test/scenarios/learning_objectives/bank_result_container_scope.scenario.yaml
@@ -11,6 +11,9 @@
         - container: "Unit 1"
           children:
             - page: "Bank Practice"
+        - container: "Unit 2"
+          children:
+            - page: "Other Bank Practice"
 
 - create_activity:
     project: "bank_objective_scope_course"
@@ -56,6 +59,23 @@
                 score: 0
         - type: bank-selection
           id: "bank_result_selection"
+          count: 1
+          points: 1
+          clauses:
+            - field: "tags"
+              op: "includes"
+              value:
+                - "bank-result"
+
+- edit_page:
+    project: "bank_objective_scope_course"
+    page: "Other Bank Practice"
+    content: |
+      title: "Other Bank Practice"
+      graded: false
+      blocks:
+        - type: bank-selection
+          id: "other_bank_result_selection"
           count: 1
           points: 1
           clauses:
@@ -149,4 +169,11 @@
       section: "bank_objective_scope_section"
       includes:
         - "Static objective"
+        - "Bank result objective"
+
+- assert:
+    learning_objectives:
+      section: "bank_objective_scope_section"
+      container: "Unit 2"
+      excludes:
         - "Bank result objective"

--- a/test/scenarios/learning_objectives/bank_result_container_scope.scenario.yaml
+++ b/test/scenarios/learning_objectives/bank_result_container_scope.scenario.yaml
@@ -1,0 +1,152 @@
+- project:
+    name: "bank_objective_scope_course"
+    title: "Bank Objective Scope Course"
+    tags:
+      - "bank-result"
+    objectives:
+      - "Static objective"
+      - "Bank result objective"
+    root:
+      children:
+        - container: "Unit 1"
+          children:
+            - page: "Bank Practice"
+
+- create_activity:
+    project: "bank_objective_scope_course"
+    title: "Bank Result Question"
+    virtual_id: "bank_result_question"
+    scope: "banked"
+    type: "oli_multiple_choice"
+    tags:
+      - "bank-result"
+    objectives:
+      - "Bank result objective"
+    content: |
+      stem_md: "Which option is correct?"
+      choices:
+        - id: "a"
+          body_md: "Incorrect"
+          score: 0
+        - id: "b"
+          body_md: "Correct"
+          score: 1
+
+- edit_page:
+    project: "bank_objective_scope_course"
+    page: "Bank Practice"
+    content: |
+      title: "Bank Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "static_question"
+          activity:
+            type: oli_multiple_choice
+            title: "Static Question"
+            objectives:
+              - "Static objective"
+            stem_md: "Select the static answer."
+            choices:
+              - id: "a"
+                body_md: "Static answer"
+                score: 1
+              - id: "b"
+                body_md: "Other answer"
+                score: 0
+        - type: bank-selection
+          id: "bank_result_selection"
+          count: 1
+          points: 1
+          clauses:
+            - field: "tags"
+              op: "includes"
+              value:
+                - "bank-result"
+
+- publish:
+    to: "bank_objective_scope_course"
+    description: "Publish bank objective scope regression"
+
+- section:
+    name: "bank_objective_scope_section"
+    title: "Bank Objective Scope Section"
+    from: "bank_objective_scope_course"
+
+- dashboard_analytics_ready:
+    section: "bank_objective_scope_section"
+
+- assert:
+    learning_objectives:
+      section: "bank_objective_scope_section"
+      container: "Unit 1"
+      includes:
+        - "Static objective"
+      excludes:
+        - "Bank result objective"
+
+- user:
+    name: "instructor"
+    type: "instructor"
+
+- enroll:
+    user: "instructor"
+    section: "bank_objective_scope_section"
+    role: "instructor"
+
+- visit_page:
+    student: "instructor"
+    section: "bank_objective_scope_section"
+    page: "Bank Practice"
+
+- answer_question:
+    student: "instructor"
+    section: "bank_objective_scope_section"
+    page: "Bank Practice"
+    activity_virtual_id: "bank_result_question"
+    response: "b"
+
+- assert:
+    learning_objectives:
+      section: "bank_objective_scope_section"
+      container: "Unit 1"
+      includes:
+        - "Static objective"
+      excludes:
+        - "Bank result objective"
+
+- user:
+    name: "student"
+    type: "student"
+
+- enroll:
+    user: "student"
+    section: "bank_objective_scope_section"
+    role: "student"
+
+- visit_page:
+    student: "student"
+    section: "bank_objective_scope_section"
+    page: "Bank Practice"
+
+- answer_question:
+    student: "student"
+    section: "bank_objective_scope_section"
+    page: "Bank Practice"
+    activity_virtual_id: "bank_result_question"
+    response: "b"
+
+- assert:
+    learning_objectives:
+      section: "bank_objective_scope_section"
+      container: "Unit 1"
+      includes:
+        - "Static objective"
+        - "Bank result objective"
+
+- assert:
+    learning_objectives:
+      section: "bank_objective_scope_section"
+      includes:
+        - "Static objective"
+        - "Bank result objective"

--- a/test/scenarios/learning_objectives/bank_result_container_scope_test.exs
+++ b/test/scenarios/learning_objectives/bank_result_container_scope_test.exs
@@ -14,7 +14,7 @@ defmodule Oli.Scenarios.LearningObjectives.BankResultContainerScopeTest do
     result = Scenarios.execute_file(@scenario_path, RuntimeOpts.build())
 
     assert result.errors == []
-    assert length(result.verifications) == 4
+    assert length(result.verifications) == 5
     assert Enum.all?(result.verifications, & &1.passed)
   end
 

--- a/test/scenarios/learning_objectives/bank_result_container_scope_test.exs
+++ b/test/scenarios/learning_objectives/bank_result_container_scope_test.exs
@@ -1,0 +1,40 @@
+defmodule Oli.Scenarios.LearningObjectives.BankResultContainerScopeTest do
+  use Oli.DataCase
+
+  alias Oli.Scenarios
+  alias Oli.Scenarios.DirectiveTypes.AssertDirective
+  alias Oli.Scenarios.Directives.Assert.LearningObjectivesAssertion
+  alias Oli.Scenarios.RuntimeOpts
+
+  @scenario_path Path.join(__DIR__, "bank_result_container_scope.scenario.yaml")
+
+  test "unions static and realized bank activity objectives in container scopes" do
+    assert :ok = Scenarios.validate_file(@scenario_path)
+
+    result = Scenarios.execute_file(@scenario_path, RuntimeOpts.build())
+
+    assert result.errors == []
+    assert length(result.verifications) == 4
+    assert Enum.all?(result.verifications, & &1.passed)
+  end
+
+  test "reports an unknown container as a failed verification" do
+    result = Scenarios.execute_file(@scenario_path, RuntimeOpts.build())
+    assert result.errors == []
+
+    directive = %AssertDirective{
+      learning_objectives: %{
+        section: "bank_objective_scope_section",
+        container: "Missing Unit",
+        includes: ["Bank result objective"],
+        excludes: []
+      }
+    }
+
+    assert {:ok, _state, verification} =
+             LearningObjectivesAssertion.assert(directive, result.state)
+
+    refute verification.passed
+    assert verification.message =~ "Container 'Missing Unit' not found"
+  end
+end

--- a/test/scenarios/validation/invalid_attributes_test.exs
+++ b/test/scenarios/validation/invalid_attributes_test.exs
@@ -348,6 +348,23 @@ defmodule Oli.Scenarios.Validation.InvalidAttributesTest do
                    end
     end
 
+    test "learning_objectives assertion with unknown attribute fails" do
+      yaml = """
+      - assert:
+          learning_objectives:
+            section: "section1"
+            includes:
+              - "Objective"
+            hidden: false
+      """
+
+      assert_raise RuntimeError,
+                   ~r/Unknown attributes in 'learning_objectives assertion' directive: \["hidden"\]/,
+                   fn ->
+                     DirectiveParser.parse_yaml!(yaml)
+                   end
+    end
+
     test "wait directive with unknown attribute fails" do
       yaml = """
       - wait:

--- a/test/scenarios/validation/schema_validation_test.exs
+++ b/test/scenarios/validation/schema_validation_test.exs
@@ -387,6 +387,46 @@ defmodule Oli.Scenarios.Validation.SchemaValidationTest do
     assert length(directives) == 5
   end
 
+  test "schema and parser accept scoped learning objective assertions" do
+    yaml = """
+    - assert:
+        learning_objectives:
+          section: "demo_section"
+          container: "Unit 1"
+          includes:
+            - "Understand systems"
+          excludes:
+            - "Unrelated objective"
+    """
+
+    assert :ok = Scenarios.validate_yaml(yaml)
+    [directive] = DirectiveParser.parse_yaml!(yaml)
+
+    assert directive.learning_objectives == %{
+             section: "demo_section",
+             container: "Unit 1",
+             includes: ["Understand systems"],
+             excludes: ["Unrelated objective"]
+           }
+  end
+
+  test "schema and parser reject learning objective assertions without expectations" do
+    yaml = """
+    - assert:
+        learning_objectives:
+          section: "demo_section"
+          container: "Unit 1"
+    """
+
+    assert {:error, _errors} = Scenarios.validate_yaml(yaml)
+
+    assert_raise RuntimeError,
+                 ~r/learning_objectives assertion requires a non-empty includes or excludes list/,
+                 fn ->
+                   DirectiveParser.parse_yaml!(yaml)
+                 end
+  end
+
   test "schema accepts finalize_attempt and gradebook assertions" do
     yaml = """
     - project:

--- a/test/support/scenarios/README.md
+++ b/test/support/scenarios/README.md
@@ -129,6 +129,7 @@ All directives are documented in detail in the linked documentation files.
 | | `assert.activity_customization` | Assert persisted instructor activity customization state | [instructor_customizations.md](docs/instructor_customizations.md#activity-customization-assertions) |
 | | `assert.page_objectives` | Assert delivery page learning objective titles | [content_authoring.md](docs/content_authoring.md#page-objective-assertions) |
 | | `assert.activity_objectives` | Assert objective titles attached to a scenario activity | [content_authoring.md](docs/content_authoring.md#activity-objective-assertions) |
+| | `assert.learning_objectives` | Assert section learning objectives within course or container scope | [analytics.md](docs/analytics.md#scoped-learning-objective-assertions) |
 | | `assert.insights` | Assert authoring analytics for pages, activities, and objectives | [analytics.md](docs/analytics.md#insights-assertions) |
 | **Instructor Dashboard** | | | |
 | | `dashboard_analytics_ready` | Prepare analytics-backed instructor dashboard data after learner activity | [instructor_dashboard.md](docs/instructor_dashboard.md#dashboard_analytics_ready) |

--- a/test/support/scenarios/docs/analytics.md
+++ b/test/support/scenarios/docs/analytics.md
@@ -1,4 +1,28 @@
-# Authoring Analytics
+# Analytics
+
+## Scoped learning objective assertions
+
+`assert.learning_objectives` verifies the objective titles available to a section at course scope
+or within a named curriculum container. This exercises the same section learning-objective data
+used by instructor and student dashboards.
+
+- `section`: Scenario section name (required)
+- `container`: Container title; omit or use `course` for the full course
+- `includes`: Objective titles that must be present
+- `excludes`: Objective titles that must not be present
+
+At least one of `includes` or `excludes` must be non-empty.
+
+```yaml
+- assert:
+    learning_objectives:
+      section: "analytics_section"
+      container: "Unit 1"
+      includes:
+        - "Apply feedback principles"
+      excludes:
+        - "Unrelated objective"
+```
 
 ## Insights assertions
 


### PR DESCRIPTION
## Summary

- Include learning objectives from activities that enrolled students have actually answered, including dynamically selected activity-bank questions that are not statically attached to a page.
- Union those realized objectives with the existing statically contained objectives for course and unit/module scopes.
- Preserve the exact page containment relationship so a shared bank candidate appears only beneath the unit where a learner encountered it.
- Read from `ResourceSummary`, `ResourcePartResponse`, and `StudentResponse` instead of traversing the attempt hierarchy.

## Why

Activity-bank selections store selection criteria rather than every activity that may eventually be chosen. Static containment therefore cannot know which banked activity appeared on a particular page.

Once an enrolled learner answers an activity, the analytics summary records provide the realized learner/page/activity relationship. Instructor responses are excluded, and activity objectives are resolved from the current publication.

## Verification

The regression scenario covers:

- Static objectives are available before any learner response.
- An instructor response does not add a realized bank objective.
- An enrolled learner response adds the bank objective to Unit 1 and the entire course.
- The same eligible bank activity does not leak into Unit 2 when it was not answered there.

## Ticket

[MER-5790](https://eliterate.atlassian.net/browse/MER-5790)

[MER-5790]: https://eliterate.atlassian.net/browse/MER-5790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ