### PR TITLE
[DEVOPS] [MER-5849] Apply CI E2E review follow-up

### DIFF
--- a/.github/workflows/pr-playwright.yml
+++ b/.github/workflows/pr-playwright.yml
@@ -3,7 +3,7 @@ name: PR Playwright Suite
 # Runs Playwright tests against a dedicated Torus instance built and torn
 # down for this job only, with an isolated database, Swoosh.Adapters.Local
 # for email, and the /test/scenario-yaml and /test/emails endpoints enabled
-# (MIX_ENV=playwright). This is the counterpart to nightly-playwright.yml,
+# (MIX_ENV=ci_e2e). This is the counterpart to nightly-playwright.yml,
 # which targets a real, persistent Torus deployment and must never gain
 # access to those endpoints.
 #
@@ -47,7 +47,7 @@ jobs:
           --health-retries 5
 
     env:
-      MIX_ENV: playwright
+      MIX_ENV: ci_e2e
       DB_NAME: oli_playwright_ci
       DB_HOST: localhost
       # HOST and PLAYWRIGHT_BASE_URL must name the same host: the server
@@ -95,9 +95,9 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-playwright-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-ci-e2e-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            ${{ runner.os }}-mix-playwright-
+            ${{ runner.os }}-mix-ci-e2e-
 
       - name: Install Gleam Mix archive
         run: |
@@ -115,7 +115,7 @@ jobs:
       - name: Build dependencies
         run: mix deps.compile
 
-      - name: Compile (MIX_ENV=playwright)
+      - name: Compile (MIX_ENV=ci_e2e)
         run: set -a && source oli.env && mix compile --warnings-as-errors
 
       # mix.exs's ecto.setup alias runs create, migrate, and
@@ -132,7 +132,7 @@ jobs:
         working-directory: assets
         run: yarn install --frozen-lockfile
 
-      # Watchers are disabled for MIX_ENV=playwright (config/playwright.exs),
+      # Watchers are disabled for MIX_ENV=ci_e2e (config/ci_e2e.exs),
       # so the JS/CSS bundles the app serves must be built once, upfront,
       # rather than relying on the dev watcher process to build them live.
       - name: Build frontend assets
@@ -147,7 +147,7 @@ jobs:
         working-directory: assets/automation
         run: npx playwright install --with-deps chrome
 
-      - name: Start Torus (MIX_ENV=playwright)
+      - name: Start Torus (MIX_ENV=ci_e2e)
         run: |
           set -a
           source oli.env
@@ -172,7 +172,7 @@ jobs:
         run: npx playwright test --grep @pr --reporter=line
 
       - name: Upload Playwright report
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: pr-playwright-report
@@ -180,7 +180,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Playwright test results
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: pr-playwright-test-results
@@ -188,7 +188,7 @@ jobs:
           retention-days: 14
 
       - name: Upload Torus server log
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: pr-playwright-torus-server-log

--- a/config/ci_e2e.exs
+++ b/config/ci_e2e.exs
@@ -2,16 +2,16 @@ import Config
 
 import_config "dev.exs"
 
-# This environment is reserved for the ephemeral Torus instance used by the
-# credential-account Playwright suite. It must never be used for a persistent
-# staging or production deployment.
+# This environment is reserved for an ephemeral Torus instance used by CI E2E
+# suites. It must never be used for a persistent staging or production deployment.
 config :oli,
-  env: :playwright,
+  env: :ci_e2e,
   enable_playwright_scenarios: true,
+  enable_e2e_mailbox: true,
   playwright_scenario_token: System.fetch_env!("PLAYWRIGHT_SCENARIO_TOKEN"),
   recaptcha_module: Oli.Playwright.Recaptcha
 
-config :oli, Oli.Repo, database: System.get_env("DB_NAME", "oli_playwright")
+config :oli, Oli.Repo, database: System.get_env("DB_NAME", "oli_ci_e2e")
 
 config :oli, OliWeb.Endpoint,
   code_reloader: false,

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -205,6 +205,7 @@ config :logger, :console, format: "[$level] $message\n"
 
 config :oli,
   enable_playwright_scenarios: true,
+  enable_e2e_mailbox: false,
   playwright_scenario_token: System.get_env("PLAYWRIGHT_SCENARIO_TOKEN"),
   playwright_assets_bucket: System.get_env("PLAYWRIGHT_ASSETS_BUCKET"),
   # runtime.exs points ex_aws at real AWS even in dev, so the playwright

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,6 +19,7 @@ config :logger, level: :info
 
 config :oli,
   enable_playwright_scenarios: false,
+  enable_e2e_mailbox: false,
   playwright_scenario_token: System.get_env("PLAYWRIGHT_SCENARIO_TOKEN")
 
 # Configure email for production

--- a/config/test.exs
+++ b/config/test.exs
@@ -145,6 +145,7 @@ config :logger, level: :warning
 
 config :oli,
   enable_playwright_scenarios: true,
+  enable_e2e_mailbox: true,
   playwright_scenario_token: System.get_env("PLAYWRIGHT_SCENARIO_TOKEN"),
   # never hits real S3 in :test (Oli.Test.MockAws intercepts the request), so
   # a fixed name here carries none of the bucket-squatting risk that a

--- a/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
+++ b/docs/exec-plans/current/epics/automated_testing/mer-5849/approach.md
@@ -10,8 +10,9 @@ depending on real inboxes or the nightly suite's persistent deployments.
 ### Reuse the existing Playwright environment gate
 
 The email-inspection routes will be mounted only when
-`Application.compile_env(:oli, :enable_playwright_scenarios, false)` is enabled.
-They will use the existing `OliWeb.PlaywrightAuth` token check.
+`Application.compile_env(:oli, :enable_e2e_mailbox, false)` is enabled in the
+dedicated E2E environment. They will use the existing `OliWeb.PlaywrightAuth`
+token check.
 
 This deliberately extends the test-only boundary established by MER-5171:
 `/test/scenario-yaml` already uses this compile-time gate and the same secret to
@@ -158,7 +159,7 @@ registration flows.
   `pgvector/pgvector:pg18` service-container database (destroyed with the
   runner, satisfying the ticket's "reset the CI test database after the run"
   without an explicit teardown step), compiles and boots Torus under
-  `MIX_ENV=playwright`, polls `/` until ready, then runs every `@pr`-tagged
+  `MIX_ENV=ci_e2e`, polls `/` until ready, then runs every `@pr`-tagged
   test. Named and worded generically on purpose (no MER-5849/credential
   wording in the workflow file itself): it is meant to be the durable,
   reusable home for any future Playwright test that can run against a bare,
@@ -169,10 +170,10 @@ registration flows.
   (`ci-ephemeral-token`) rather than a GitHub secret: the instance it protects
   is unreachable outside the job and destroyed when it ends, so the token has
   no value to protect beyond this one run.
-- On completion (success or failure), the job uploads the Playwright
-  report/trace/test-results (as `nightly-playwright.yml` already does) *and*
+- When the job fails, it uploads the Playwright report/trace/test-results and
   the Torus server's stdout/stderr, redirected to a file when the server is
-  started — nightly-playwright does not need this because it targets an
+  started. Successful runs do not retain redundant diagnostics;
+  `nightly-playwright` does not need the server log because it targets an
   already-running, separately-logged deployment.
 - Test selection uses an explicit Playwright tag, `@pr`, applied to both
   `credential-account-flows.spec.ts` and
@@ -188,7 +189,7 @@ registration flows.
   Argo CD in a private GitOps repository not present in this codebase, and
   every Plasma preview is currently built as a shared, human-reviewable
   `MIX_ENV=prod` image (real AWS SES mailer, no scenario/mailbox routes) —
-  changing that for all previews to get this suite's `MIX_ENV=playwright`
+  changing that for all previews to get this suite's `MIX_ENV=ci_e2e`
   behavior is out of this repo's reach and out of this ticket's scope. A
   fully self-contained job satisfies the ticket's own step-by-step "CI/CD
   Integration" section without depending on that external infrastructure.
@@ -216,13 +217,13 @@ production systems.
   test missing and invalid-token responses.
 - **Parallel interference:** use a generated address per test and server-side
   recipient filtering.
-- **Environment drift:** verify the routes are present only when the existing
-  Playwright compile-time flag is enabled and run the suite only against the
+- **Environment drift:** verify mailbox routes are present only when the
+  dedicated E2E mailbox flag is enabled, and run the suite only against the
   dedicated CI deployment.
 - **`PLAYWRIGHT_BASE_URL` must match the server's `HOST`:** Playwright resolves
   every relative `page.goto(...)` against `PLAYWRIGHT_BASE_URL`, but the
   server builds the absolute confirmation/reset links embedded in emails from
-  `HOST` (`config/dev.exs:108`, inherited by `config/playwright.exs`). If the
+  `HOST` (`config/dev.exs:108`, inherited by `config/ci_e2e.exs`). If the
   two values name different hosts (e.g. `PLAYWRIGHT_BASE_URL=127.0.0.1` with
   `HOST=localhost`), the browser reaches the emailed link on an origin it has
   never visited, so no cookie set earlier in the flow (including the

--- a/lib/oli/playwright/recaptcha.ex
+++ b/lib/oli/playwright/recaptcha.ex
@@ -3,7 +3,7 @@ defmodule Oli.Playwright.Recaptcha do
   Deterministic reCAPTCHA implementation for the isolated Playwright environment.
 
   The credential-account browser suite exercises Torus registration flows but
-  must not depend on the external reCAPTCHA service. `config/playwright.exs`
+  must not depend on the external reCAPTCHA service. `config/ci_e2e.exs`
   selects this module only for that ephemeral environment.
   """
 

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -354,8 +354,6 @@ defmodule OliWeb.Router do
       pipe_through [:api]
 
       post "/scenario-yaml", PlaywrightScenarioController, :run
-      get "/emails", PlaywrightMailboxController, :index
-      get "/emails/:id", PlaywrightMailboxController, :show
     end
 
     scope "/test", OliWeb do
@@ -373,6 +371,15 @@ defmodule OliWeb.Router do
       pipe_through [:browser]
 
       get "/embedded/index.html", PlaywrightSupportAssetController, :embedded_runtime
+    end
+  end
+
+  if Application.compile_env(:oli, :enable_e2e_mailbox, false) do
+    scope "/test", OliWeb do
+      pipe_through [:api]
+
+      get "/emails", PlaywrightMailboxController, :index
+      get "/emails/:id", PlaywrightMailboxController, :show
     end
   end
 


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5849

## Summary

Follow-up to PR #6787 implementing Gastón Abella’s review suggestions for the ephemeral CI E2E environment.

- Rename the dedicated Mix environment from `playwright` to `ci_e2e`.
- Retain Playwright diagnostics only when the CI job fails.
- Restrict the test mailbox API to the dedicated E2E environment and ExUnit.

## Technical Notes

- Keep the existing Playwright scenario support available in development, while gating `/test/emails*` behind a separate `enable_e2e_mailbox` compile-time flag.
- Configure the mailbox only for `ci_e2e` and `test`; it remains unavailable in development and production.
- Update CI cache keys and operational documentation to use `MIX_ENV=ci_e2e`.

## Validation

- `mix format --check-formatted` on touched Elixir/config files.
- `mix test test/oli_web/controllers/playwright_mailbox_controller_test.exs` — 6 tests, 0 failures.
- Verified `/test/emails*` routes are present with `MIX_ENV=ci_e2e` and absent with `MIX_ENV=dev`.