### PR TITLE
[BUG FIX] [MER-5894] Fix stale Curriculum breadcrumb after saving Remix changes

### DIFF
--- a/lib/oli_web/live/delivery/remix_section.ex
+++ b/lib/oli_web/live/delivery/remix_section.ex
@@ -1181,13 +1181,11 @@ defmodule OliWeb.Delivery.RemixSection do
 
       <%= for {breadcrumb, index} <- Enum.with_index(@breadcrumbs) do %>
         {render_breadcrumb_item(
-          Enum.into(
-            %{
-              breadcrumb: breadcrumb,
-              show_short: length(@breadcrumbs) > 3,
-              is_last: length(@breadcrumbs) - 1 == index
-            },
-            assigns
+          assign(
+            assigns,
+            breadcrumb: breadcrumb,
+            show_short: length(@breadcrumbs) > 3,
+            is_last: length(@breadcrumbs) - 1 == index
           )
         )}
       <% end %>

--- a/test/oli_web/live/remix_section_test.exs
+++ b/test/oli_web/live/remix_section_test.exs
@@ -64,6 +64,48 @@ defmodule OliWeb.RemixSectionLiveTest do
       assert has_element?(view, "#save:not([disabled])")
     end
 
+    test "Curriculum breadcrumb returns to the root after saving a nested removal", %{
+      conn: conn,
+      section: section,
+      unit_1: unit_1,
+      unit_2: unit_2,
+      module_1: module_1
+    } do
+      {:ok, view, _html} = live(conn, ~p"/sections/#{section.slug}/remix")
+
+      root_entry_ids = curriculum_entry_ids(view)
+
+      view
+      |> element(~s{#entry-#{unit_1.resource_id} button[phx-click="set_active"]})
+      |> render_click()
+
+      view
+      |> element(~s{#entry-#{module_1.resource_id} button[phx-click="show_remove_modal"]})
+      |> render_click()
+
+      view
+      |> element(~s{button[phx-click="RemoveModal.remove"]})
+      |> render_click()
+
+      view
+      |> element("#save")
+      |> render_click()
+
+      assert curriculum_entry_ids(view) == root_entry_ids
+
+      view
+      |> element(~s{#entry-#{unit_2.resource_id} button[phx-click="set_active"]})
+      |> render_click()
+
+      refute curriculum_entry_ids(view) == root_entry_ids
+
+      view
+      |> element("button.breadcrumb-item", "Curriculum")
+      |> render_click()
+
+      assert curriculum_entry_ids(view) == root_entry_ids
+    end
+
     test "move modal moves an item into the selected container", %{
       conn: conn,
       section: section,


### PR DESCRIPTION
Fixes an issue on section Remix pages where the Curriculum breadcrumb became unresponsive after removing an item, saving the curriculum, and entering another module.

## Cause
Breadcrumb assigns were built using Enum.into(..., assigns). This preserved stale Phoenix LiveView __changed__ metadata after the hierarchy was refreshed during save.
As a result, LiveView did not rerender the Curriculum breadcrumb with the updated hierarchy UUID, leaving it with a stale navigation target. The back arrow continued working because it was rendered from correctly refreshed assigns.

## Fix
Build the breadcrumb state with Phoenix’s assign/2, ensuring the new breadcrumb values are properly tracked as changed and rerendered after saving.

See: https://eliterate.atlassian.net/browse/MER-5894