### PR TITLE
[FEATURE] [MER-5788] Learning Objective search doesn't find subobjectives

### DIFF
--- a/assets/src/phoenix/app.ts
+++ b/assets/src/phoenix/app.ts
@@ -82,24 +82,65 @@ window.addEventListener('phx:page-loading-stop', () => {
 
 type LearningObjectivesScrollDetail = {
   id?: unknown;
-  scroll_delay?: unknown;
+  fallback_id?: unknown;
+  selector?: unknown;
 };
+
+const LEARNING_OBJECTIVES_SCROLL_TIMEOUT = 3000;
+
+// Only one scroll request can be pending: a stale one (a deep link whose panel is still
+// loading) must not yank the page away from a newer one.
+let pendingScrollFrame: number | null = null;
 
 window.addEventListener('phx:learning-objectives-scroll', (event: Event) => {
   const detail = (event as CustomEvent<LearningObjectivesScrollDetail>).detail ?? {};
   const targetId = typeof detail.id === 'string' ? detail.id : null;
-  if (!targetId) return;
+  const fallbackId = typeof detail.fallback_id === 'string' ? detail.fallback_id : null;
+  const selector = typeof detail.selector === 'string' ? detail.selector : null;
 
-  const scrollDelay = typeof detail.scroll_delay === 'number' ? detail.scroll_delay : 0;
+  const findTarget = selector
+    ? () => document.querySelector(selector)
+    : targetId
+    ? () => document.getElementById(targetId)
+    : null;
+
+  if (!findTarget) return;
+
+  if (pendingScrollFrame !== null) {
+    cancelAnimationFrame(pendingScrollFrame);
+    pendingScrollFrame = null;
+  }
+
   const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   const scrollBehavior = prefersReducedMotion ? 'auto' : 'smooth';
-
-  setTimeout(() => {
-    const target = document.getElementById(targetId);
-    if (!target) return;
-
+  const scrollTo = (target: Element) =>
     target.scrollIntoView({ behavior: scrollBehavior, block: 'center' });
-  }, scrollDelay);
+
+  // Expanded objective panels load asynchronously, so the target may not exist yet. Keep
+  // looking until it shows up or the deadline passes; a selector resolves to the first match
+  // in document order. On timeout fall back to an element known to be on the page already.
+  const deadline = performance.now() + LEARNING_OBJECTIVES_SCROLL_TIMEOUT;
+
+  const attempt = () => {
+    const target = findTarget();
+
+    if (target) {
+      pendingScrollFrame = null;
+      scrollTo(target);
+      return;
+    }
+
+    if (performance.now() < deadline) {
+      pendingScrollFrame = requestAnimationFrame(attempt);
+      return;
+    }
+
+    pendingScrollFrame = null;
+    const fallback = fallbackId ? document.getElementById(fallbackId) : null;
+    if (fallback) scrollTo(fallback);
+  };
+
+  attempt();
 });
 
 // Expose React/Redux APIs to server-side rendered templates

--- a/lib/oli_web/components/delivery/learning_objectives/expanded_objective_view.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/expanded_objective_view.ex
@@ -11,6 +11,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ExpandedObjectiveView do
   attr :section_id, :integer, required: true
   attr :section_slug, :string, required: true
   attr :current_user, :map, required: true
+  attr :text_search, :string, default: nil
   attr :sync_load, :boolean, default: false
   attr :is_expanded, :boolean, default: false
 
@@ -243,6 +244,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ExpandedObjectiveView do
                 id={"sub-objectives-list-#{@unique_id}"}
                 sub_objectives_data={@sub_objectives_data}
                 parent_unique_id={@unique_id}
+                text_search={@text_search}
               />
             <% end %>
           </div>

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -1,6 +1,7 @@
 defmodule OliWeb.Components.Delivery.LearningObjectives do
   use OliWeb, :live_component
 
+  alias Oli.Delivery.Sections.SectionResourceDepot
   alias OliWeb.Common.{Params, StripedPagedTable, SearchInput}
   alias OliWeb.Components.Delivery.CardHighlights
   alias OliWeb.Components.Delivery.InstructorDashboard.IntelligentDashboard.Tiles.DraftEmailModal
@@ -42,15 +43,20 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
         socket
       ) do
     params = decode_params(params)
-    params = maybe_adjust_params_for_navigation(objectives_tab.objectives, params)
+    patch_url_type = assigns[:patch_url_type]
+
+    params =
+      maybe_adjust_params_for_navigation(
+        objectives_tab.objectives,
+        params,
+        patch_url_type
+      )
+
     scoped_objectives = scoped_objectives(objectives_tab.objectives, params)
     socket = maybe_handle_tile_navigation(socket, scoped_objectives, params)
 
-    {total_count, rows, _filtered_objectives} =
-      apply_filters(
-        objectives_tab.objectives,
-        params
-      )
+    {total_count, rows, search_expanded_parent_ids} =
+      apply_filters(scoped_objectives, params, patch_url_type)
 
     indexed_rows =
       Enum.with_index(rows)
@@ -59,13 +65,27 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
       end)
 
     {:ok, objectives_table_model} =
-      ObjectivesTableModel.new(indexed_rows, assigns[:patch_url_type])
+      ObjectivesTableModel.new(indexed_rows, patch_url_type)
 
-    expanded_objectives = starting_expanded_objectives(socket, params)
+    # A new search term resets the expansion state to whatever that term dictates. While the
+    # term holds, rows the user collapsed by hand stay collapsed across sorting and paging.
+    # socket.assigns[:params] still holds the previous params here: they are reassigned at the
+    # end of this function.
+    search_changed? = socket.assigns[:params][:text_search] != params.text_search
+
+    expanded_objectives =
+      if search_changed?, do: MapSet.new(), else: starting_expanded_objectives(socket, params)
+
+    manually_collapsed_rows =
+      if search_changed?,
+        do: MapSet.new(),
+        else: socket.assigns[:manually_collapsed_rows] || MapSet.new()
 
     expanded_objectives =
       expanded_objectives
       |> MapSet.union(initial_expanded_rows(scoped_objectives, params))
+      |> MapSet.union(search_expanded_rows(search_expanded_parent_ids, rows))
+      |> MapSet.difference(manually_collapsed_rows)
 
     objectives_table_model =
       Map.merge(objectives_table_model, %{
@@ -82,6 +102,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
             section_title: assigns[:section_title],
             current_user: assigns[:current_user],
             current_params: encode_params_for_url(params),
+            text_search: params.text_search,
             component_target: socket.assigns.myself,
             expanded_rows: expanded_objectives
           })
@@ -136,7 +157,8 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
        selected_proficiency_options: selected_proficiency_options,
        selected_proficiency_ids: selected_proficiency_ids,
        card_props: card_props,
-       expanded_objectives: expanded_objectives
+       expanded_objectives: expanded_objectives,
+       manually_collapsed_rows: manually_collapsed_rows
      )
      |> assign(
        :email_modal_payload,
@@ -340,7 +362,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
           ~p"/sections/#{section_slug}/student_dashboard/#{student_id}/learning_objectives"
       end
 
-    {:noreply, socket |> assign(expanded_objectives: MapSet.new()) |> push_patch(to: path)}
+    {:noreply,
+     socket
+     |> assign(expanded_objectives: MapSet.new(), manually_collapsed_rows: MapSet.new())
+     |> push_patch(to: path)}
   end
 
   def handle_event("filter_by", %{"filter" => filter}, socket) do
@@ -365,7 +390,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
        to:
          route_for(
            socket,
-           %{text_search: objective_name},
+           %{text_search: trim_text_search(objective_name), offset: 0},
            socket.assigns.patch_url_type
          )
      )}
@@ -433,18 +458,19 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   end
 
   def handle_event("toggle_objective_details", %{"objective_id" => objective_id}, socket) do
-    # Get current expanded state
-    expanded_objectives = socket.assigns.expanded_objectives
+    collapsing? = MapSet.member?(socket.assigns.expanded_objectives, objective_id)
 
-    # Toggle the state
     expanded_objectives =
-      if MapSet.member?(expanded_objectives, objective_id) do
-        MapSet.delete(expanded_objectives, objective_id)
-      else
-        MapSet.put(expanded_objectives, objective_id)
-      end
+      if collapsing?,
+        do: MapSet.delete(socket.assigns.expanded_objectives, objective_id),
+        else: MapSet.put(socket.assigns.expanded_objectives, objective_id)
 
-    # Update the table model with the new expanded_rows
+    # Tracked so a later sort or page change does not reopen what the user just closed.
+    manually_collapsed_rows =
+      if collapsing?,
+        do: MapSet.put(socket.assigns.manually_collapsed_rows, objective_id),
+        else: MapSet.delete(socket.assigns.manually_collapsed_rows, objective_id)
+
     updated_table_model =
       Map.update!(socket.assigns.table_model, :data, fn data ->
         Map.put(data, :expanded_rows, expanded_objectives)
@@ -453,6 +479,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     {:noreply,
      socket
      |> assign(expanded_objectives: expanded_objectives)
+     |> assign(manually_collapsed_rows: manually_collapsed_rows)
      |> assign(table_model: updated_table_model)}
   end
 
@@ -512,7 +539,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
           ],
           @default_params.sort_by
         ),
-      text_search: Params.get_param(params, "text_search", @default_params.text_search),
+      text_search:
+        params
+        |> Params.get_param("text_search", @default_params.text_search)
+        |> trim_text_search(),
       filter_by: Params.get_int_param(params, "filter_by", @default_params.filter_by),
       selected_proficiency_ids:
         Params.get_list_param(
@@ -558,6 +588,15 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     end)
   end
 
+  defp trim_text_search(text_search) when is_binary(text_search) do
+    case String.trim(text_search) do
+      "" -> nil
+      text_search -> text_search
+    end
+  end
+
+  defp trim_text_search(_text_search), do: nil
+
   defp encode_params_for_url(params) do
     case Map.fetch(params, :selected_proficiency_ids) do
       {:ok, ids} when is_list(ids) ->
@@ -568,27 +607,49 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     end
   end
 
-  defp apply_filters(objectives, params) do
-    scoped_objectives = scoped_objectives(objectives, params)
-    filtered_objectives = filtered_objectives(scoped_objectives, params)
+  defp apply_filters(scoped_objectives, params, patch_url_type) do
+    {filtered_objectives, search_expanded_parent_ids} =
+      case patch_url_type do
+        :instructor_dashboard -> instructor_dashboard_filter(scoped_objectives, params)
+        _ -> {filtered_objectives(scoped_objectives, params), MapSet.new()}
+      end
 
-    table_objectives =
-      filtered_objectives
-      |> sort_by(params.sort_by, params.sort_order)
+    sorted_objectives = sort_by(filtered_objectives, params.sort_by, params.sort_order)
 
-    total_count = length(table_objectives)
-
-    rows =
-      table_objectives
-      |> Enum.drop(params.offset)
-      |> Enum.take(params.limit)
-
-    {total_count, rows, filtered_objectives}
+    {length(sorted_objectives),
+     sorted_objectives |> Enum.drop(params.offset) |> Enum.take(params.limit),
+     search_expanded_parent_ids}
   end
 
   defp maybe_adjust_params_for_navigation(
          objectives,
-         %{navigation_source: "challenging_objectives_tile"} = params
+         %{navigation_source: "challenging_objectives_tile"} = params,
+         :instructor_dashboard
+       ) do
+    scoped_objectives = scoped_objectives(objectives, params)
+
+    case resolve_deep_link_parent_id(scoped_objectives, params) do
+      nil ->
+        params
+
+      parent_id ->
+        sorted_objectives =
+          scoped_objectives
+          |> instructor_dashboard_filter(params)
+          |> elem(0)
+          |> sort_by(params.sort_by, params.sort_order)
+
+        adjust_offset_to_index(
+          params,
+          Enum.find_index(sorted_objectives, &(&1.resource_id == parent_id))
+        )
+    end
+  end
+
+  defp maybe_adjust_params_for_navigation(
+         objectives,
+         %{navigation_source: "challenging_objectives_tile"} = params,
+         _patch_url_type
        ) do
     scoped_objectives = scoped_objectives(objectives, params)
 
@@ -597,7 +658,13 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
       |> filtered_objectives(params)
       |> sort_by(params.sort_by, params.sort_order)
 
-    case navigation_target_index(sorted_objectives, params) do
+    adjust_offset_to_index(params, navigation_target_index(sorted_objectives, params))
+  end
+
+  defp maybe_adjust_params_for_navigation(_objectives, params, _patch_url_type), do: params
+
+  defp adjust_offset_to_index(params, index) do
+    case index do
       nil ->
         params
 
@@ -609,8 +676,6 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
         end
     end
   end
-
-  defp maybe_adjust_params_for_navigation(_objectives, params), do: params
 
   defp navigation_target_index(objectives, %{subobjective_id: subobjective_id})
        when is_integer(subobjective_id) do
@@ -631,6 +696,28 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
     |> maybe_filter_by_card(params.selected_card_value)
   end
+
+  defp instructor_dashboard_filter(objectives, %{text_search: text_search} = params)
+       when is_binary(text_search) and text_search != "" do
+    search_term = String.downcase(text_search)
+
+    search_matches =
+      objectives
+      |> searchable_objectives()
+      |> maybe_filter_by_text(text_search)
+
+    search_expanded_parent_ids =
+      for match <- search_matches,
+          text_matches?(match.subobjective, search_term),
+          into: MapSet.new(),
+          do: match.objective_resource_id
+
+    {instructor_dashboard_parent_objectives(search_matches, objectives, params),
+     search_expanded_parent_ids}
+  end
+
+  defp instructor_dashboard_filter(objectives, params),
+    do: {instructor_dashboard_parent_objectives(objectives, objectives, params), MapSet.new()}
 
   @doc false
   def initial_expanded_rows(scoped_objectives, params) do
@@ -731,14 +818,18 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
   defp maybe_filter_by_text(objectives, ""), do: objectives
 
   defp maybe_filter_by_text(objectives, text_search) do
-    text = String.downcase(text_search)
+    search_term = String.downcase(text_search)
 
-    objectives
-    |> Enum.filter(fn objective ->
-      String.contains?(String.downcase(objective.objective), text) or
-        String.contains?(String.downcase(to_string(objective.subobjective || "")), text)
-    end)
+    Enum.filter(
+      objectives,
+      &(text_matches?(&1.objective, search_term) or text_matches?(&1.subobjective, search_term))
+    )
   end
+
+  defp text_matches?(nil, _search_term), do: false
+
+  defp text_matches?(text, search_term),
+    do: String.contains?(String.downcase(text), search_term)
 
   defp maybe_filter_by_proficiency(objectives, []), do: objectives
 
@@ -778,6 +869,69 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     do: Enum.filter(objectives, &(&1.student_proficiency_subobj == "Low"))
 
   defp maybe_filter_by_card(objectives, _), do: objectives
+
+  defp parent_resource_id(%{subobjective: nil, resource_id: resource_id}), do: resource_id
+  defp parent_resource_id(objective), do: objective[:objective_resource_id]
+
+  defp searchable_objectives(objectives),
+    do: searchable_child_objectives(missing_child_parent_pairs(objectives)) ++ objectives
+
+  defp missing_child_parent_pairs(objectives) do
+    existing_ids = MapSet.new(objectives, & &1.resource_id)
+
+    for objective <- objectives,
+        top_level_objective?(objective),
+        child_id <- Map.get(objective, :children, []),
+        not MapSet.member?(existing_ids, child_id),
+        do: {child_id, objective}
+  end
+
+  defp searchable_child_objectives(child_parent_pairs) do
+    case Enum.find_value(child_parent_pairs, fn {_child_id, parent} -> parent[:section_id] end) do
+      nil ->
+        []
+
+      section_id ->
+        children_by_id =
+          section_id
+          |> SectionResourceDepot.get_resources_by_ids(
+            for({child_id, _parent} <- child_parent_pairs, uniq: true, do: child_id)
+          )
+          |> Map.new(&{&1.resource_id, &1})
+
+        for {child_id, parent} <- child_parent_pairs,
+            section_resource <- List.wrap(children_by_id[child_id]) do
+          %{
+            resource_id: section_resource.resource_id,
+            objective: parent.objective,
+            objective_resource_id: parent.resource_id,
+            subobjective: section_resource.title,
+            student_proficiency_obj: parent.student_proficiency_obj,
+            student_proficiency_subobj: nil
+          }
+        end
+    end
+  end
+
+  defp instructor_dashboard_parent_objectives(candidates, objectives, params) do
+    matching_parent_ids =
+      candidates
+      |> maybe_filter_by_proficiency(params.selected_proficiency_ids)
+      |> maybe_filter_by_card(params.selected_card_value)
+      |> MapSet.new(&parent_resource_id/1)
+
+    Enum.filter(objectives, fn objective ->
+      top_level_objective?(objective) and
+        MapSet.member?(matching_parent_ids, objective.resource_id)
+    end)
+  end
+
+  defp search_expanded_rows(search_expanded_parent_ids, rows) do
+    for row <- rows,
+        MapSet.member?(search_expanded_parent_ids, row.resource_id),
+        into: MapSet.new(),
+        do: "row_#{row.resource_id}"
+  end
 
   defp route_for(socket, new_params, :instructor_dashboard) do
     base_params =
@@ -947,7 +1101,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
         nil
 
       subobjective ->
-        subobjective.resource_id
+        subobjective.objective_resource_id
     end
   end
 

--- a/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/learning_objectives.ex
@@ -72,6 +72,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     # socket.assigns[:params] still holds the previous params here: they are reassigned at the
     # end of this function.
     search_changed? = socket.assigns[:params][:text_search] != params.text_search
+    new_search_with_results? = search_changed? and rows != []
+
+    socket =
+      maybe_scroll_to_first_search_match(socket, params, new_search_with_results?, patch_url_type)
 
     expanded_objectives =
       if search_changed?, do: MapSet.new(), else: starting_expanded_objectives(socket, params)
@@ -1105,16 +1109,45 @@ defmodule OliWeb.Components.Delivery.LearningObjectives do
     end
   end
 
+  # Only the instructor dashboard highlights matches, so it is the only view with something to
+  # scroll to. The first highlight in document order is the first match, whether it is an
+  # objective row or a subobjective inside an expanded panel; the selector is scoped to the
+  # table so highlights rendered elsewhere on the page cannot win.
+  defp maybe_scroll_to_first_search_match(
+         socket,
+         %{text_search: text_search},
+         true,
+         :instructor_dashboard
+       )
+       when is_binary(text_search) do
+    push_event(socket, "learning-objectives-scroll", %{
+      selector: "#objectives-table .search-highlight"
+    })
+  end
+
+  defp maybe_scroll_to_first_search_match(socket, _params, _new_search_with_results?, _type),
+    do: socket
+
   defp maybe_push_scroll_to_navigation_target(socket, scoped_objectives, params) do
     case resolve_deep_link_parent_id(scoped_objectives, params) do
       nil ->
         socket
 
-      resource_id ->
-        push_event(socket, "learning-objectives-scroll", %{
-          id: "row_#{resource_id}",
-          scroll_delay: 150
-        })
+      parent_id ->
+        push_event(
+          socket,
+          "learning-objectives-scroll",
+          deep_link_scroll_target(params, parent_id)
+        )
     end
   end
+
+  # A subobjective deep link scrolls to the subobjective inside the expanded panel. That panel
+  # loads asynchronously, so the parent row travels along as a fallback for the client to use if
+  # the subobjective never renders.
+  defp deep_link_scroll_target(%{subobjective_id: subobjective_id}, parent_id)
+       when is_integer(subobjective_id),
+       do: %{id: "subobj-#{subobjective_id}", fallback_id: "row_#{parent_id}"}
+
+  defp deep_link_scroll_target(_params, parent_id), do: %{id: "row_#{parent_id}"}
 end

--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -5,6 +5,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.Chip
+  alias OliWeb.Common.Utils
   alias OliWeb.Delivery.InstructorDashboard.HTMLComponents
   alias OliWeb.Icons
   alias Phoenix.LiveView.JS
@@ -174,17 +175,19 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
 
   # OBJECTIVE INSTRUCTOR DASHBOARD
   defp custom_render(assigns, objective, %ColumnSpec{name: :objective_instructor_dashboard}) do
-    objective =
-      case Map.get(objective, :subobjective) do
-        nil -> objective.objective
-        subobjective -> subobjective
-      end
-
-    assigns = Map.merge(assigns, %{objective: objective})
+    assigns =
+      Map.merge(assigns, %{
+        objective: Map.get(objective, :subobjective) || objective.objective,
+        text_search: assigns.model.data[:text_search]
+      })
 
     ~H"""
     <div class="flex items-center gap-x-4">
-      <span class="text-Text-text-high">{@objective}</span>
+      <span class="text-Text-text-high">
+        {Phoenix.HTML.raw(
+          Utils.highlight_search_term(@objective, @text_search, class: "search-highlight")
+        )}
+      </span>
     </div>
     """
   end
@@ -405,6 +408,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
     section_slug = assigns[:section_slug] || assigns.model.data[:section_slug]
     section_id = assigns[:section_id] || assigns.model.data[:section_id]
     section_title = assigns[:section_title] || assigns.model.data[:section_title]
+    text_search = assigns.model.data[:text_search]
 
     proficiency_distribution =
       case Map.get(objective, :student_proficiency_subobj_dist) do
@@ -422,6 +426,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
       |> Map.put(:section_slug, section_slug)
       |> Map.put(:section_id, section_id)
       |> Map.put(:section_title, section_title)
+      |> Map.put(:text_search, text_search)
       |> Map.put(:proficiency_distribution, proficiency_distribution)
       |> Map.put(:current_user, current_user)
       |> Map.put(:is_expanded, is_expanded)
@@ -436,6 +441,7 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
         section_id={@section_id}
         section_slug={@section_slug}
         section_title={@section_title}
+        text_search={@text_search}
         proficiency_distribution={@proficiency_distribution}
         current_user={@current_user}
         is_expanded={@is_expanded}

--- a/lib/oli_web/components/delivery/learning_objectives/sub_objectives_list.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/sub_objectives_list.ex
@@ -6,7 +6,8 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.SubObjectivesList do
     {:ok, sub_objectives_table_model} =
       OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel.new(
         assigns.sub_objectives_data,
-        assigns.parent_unique_id
+        assigns.parent_unique_id,
+        assigns[:text_search]
       )
 
     socket =
@@ -54,7 +55,8 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.SubObjectivesList do
     {:ok, new_table_model} =
       OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel.new(
         sorted_rows,
-        socket.assigns[:parent_unique_id]
+        socket.assigns[:parent_unique_id],
+        socket.assigns[:text_search]
       )
 
     updated_table_model =

--- a/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
@@ -40,7 +40,7 @@ defmodule OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel do
       rows: sub_objectives,
       column_specs: column_specs,
       event_suffix: "",
-      id_field: [:id],
+      id_field: ["subobj", :id],
       data: %{parent_unique_id: parent_unique_id, text_search: text_search}
     )
   end

--- a/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
@@ -3,10 +3,11 @@ defmodule OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel do
 
   alias OliWeb.Common.Table.{ColumnSpec, SortableTableModel}
   alias OliWeb.Common.Chip
+  alias OliWeb.Common.Utils
 
   @proficiency_labels ["Not enough data", "Low", "Medium", "High"]
 
-  def new(sub_objectives, parent_unique_id \\ nil) do
+  def new(sub_objectives, parent_unique_id \\ nil, text_search \\ nil) do
     column_specs = [
       %ColumnSpec{
         name: :sub_objective,
@@ -40,13 +41,23 @@ defmodule OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel do
       column_specs: column_specs,
       event_suffix: "",
       id_field: [:id],
-      data: %{parent_unique_id: parent_unique_id}
+      data: %{parent_unique_id: parent_unique_id, text_search: text_search}
     )
   end
 
   # SUB-OBJECTIVE NAME
-  defp custom_render(_assigns, sub_objective, %ColumnSpec{name: :sub_objective}) do
-    sub_objective.title
+  defp custom_render(assigns, sub_objective, %ColumnSpec{name: :sub_objective}) do
+    assigns =
+      Map.merge(assigns, %{
+        title: sub_objective.title,
+        text_search: assigns.model.data[:text_search]
+      })
+
+    ~H"""
+    <span>
+      {Phoenix.HTML.raw(Utils.highlight_search_term(@title, @text_search, class: "search-highlight"))}
+    </span>
+    """
   end
 
   # STUDENT PROFICIENCY CHIP

--- a/test/oli_web/components/delivery/learning_objectives/learning_objectives_component_test.exs
+++ b/test/oli_web/components/delivery/learning_objectives/learning_objectives_component_test.exs
@@ -73,7 +73,7 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
              )
     end
 
-    test "renders objectives and sub-objectives in the instructor table and counts respect filters",
+    test "renders parent objectives in the instructor table and counts respect subobjective filters",
          %{
            conn: conn
          } do
@@ -184,9 +184,9 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
       assert html =~ "Low Proficiency Learning Objectives"
       assert html =~ "Low Proficiency Sub-Objectives"
       assert html =~ "LO.02"
-      assert html =~ "Sub.LO.2a"
-      assert html =~ "Sub.LO.2b"
-      assert html =~ "Sub.LO.2c"
+      refute html =~ "Sub.LO.2a"
+      refute html =~ "Sub.LO.2b"
+      refute html =~ "Sub.LO.2c"
 
       assert card_text(html, "low_proficiency_outcomes") =~ "1"
       assert card_text(html, "low_proficiency_outcomes") =~ "Learning objective"
@@ -344,13 +344,13 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
              }) == MapSet.new(["row_1"])
     end
 
-    test "initial_expanded_rows expands the subobjective row for a subobjective deep link" do
+    test "initial_expanded_rows expands the parent row for a subobjective deep link" do
       scoped_objectives = objectives_with_subobjective()
 
       assert LearningObjectives.initial_expanded_rows(scoped_objectives, %{
                objective_id: 1,
                subobjective_id: 2
-             }) == MapSet.new(["row_2"])
+             }) == MapSet.new(["row_1"])
     end
 
     test "update seeds expanded rows for subobjective tile navigation handoff" do
@@ -384,10 +384,10 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
       }
 
       assert {:ok, updated_socket} = LearningObjectives.update(assigns, socket)
-      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_2"])
+      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_1"])
 
       assert updated_socket.assigns.table_model.data.expanded_rows ==
-               MapSet.new(["row_2"])
+               MapSet.new(["row_1"])
     end
 
     test "tile navigation adjusts pagination so the targeted objective is present" do
@@ -458,9 +458,117 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
       }
 
       assert {:ok, updated_socket} = LearningObjectives.update(assigns, socket)
-      assert updated_socket.assigns.params.offset == 3
-      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [4]
-      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_4"])
+      assert updated_socket.assigns.params.offset == 2
+      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [3]
+      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_3"])
+    end
+
+    test "tile navigation paginates subobjective links using rendered parent rows" do
+      objectives = objectives_with_prior_subobjective_row()
+
+      socket =
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            __changed__: %{},
+            myself: %Phoenix.LiveComponent.CID{cid: 1}
+          }
+        }
+
+      assigns = %{
+        id: "learning-objectives-update-parent-only-pagination-test",
+        objectives_tab: %{objectives: objectives, navigator_items: []},
+        params: %{
+          "limit" => "1",
+          "offset" => "0",
+          "objective_id" => "3",
+          "subobjective_id" => "4",
+          "navigation_source" => "challenging_objectives_tile"
+        },
+        section_slug: "test-section",
+        section_id: 1,
+        section_title: "Test Section",
+        current_user: %{email: "instructor@example.edu"},
+        patch_url_type: :instructor_dashboard,
+        student_id: nil,
+        view: :insights,
+        v25_migration: :done
+      }
+
+      assert {:ok, updated_socket} = LearningObjectives.update(assigns, socket)
+      assert updated_socket.assigns.params.offset == 1
+      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [3]
+      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_3"])
+    end
+
+    test "search expands only rows matched by subobjective text" do
+      socket =
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            __changed__: %{},
+            myself: %Phoenix.LiveComponent.CID{cid: 1}
+          }
+        }
+
+      assigns = %{
+        id: "learning-objectives-search-expansion-test",
+        objectives_tab: %{
+          objectives: objectives_with_prior_subobjective_row(),
+          navigator_items: []
+        },
+        params: %{"text_search" => "Parent 3"},
+        section_slug: "test-section",
+        section_id: 1,
+        section_title: "Test Section",
+        current_user: %{email: "instructor@example.edu"},
+        patch_url_type: :instructor_dashboard,
+        student_id: nil,
+        view: :insights,
+        v25_migration: :done
+      }
+
+      assert {:ok, updated_socket} = LearningObjectives.update(assigns, socket)
+      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [3]
+      assert updated_socket.assigns.expanded_objectives == MapSet.new()
+
+      assert {:ok, updated_socket} =
+               LearningObjectives.update(
+                 put_in(assigns.params["text_search"], "Child 3.1"),
+                 socket
+               )
+
+      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [3]
+      assert updated_socket.assigns.expanded_objectives == MapSet.new(["row_3"])
+    end
+
+    test "ignores malformed text search params" do
+      socket =
+        %Phoenix.LiveView.Socket{
+          assigns: %{
+            __changed__: %{},
+            myself: %Phoenix.LiveComponent.CID{cid: 1}
+          }
+        }
+
+      assigns = %{
+        id: "learning-objectives-malformed-search-test",
+        objectives_tab: %{
+          objectives: objectives_with_prior_subobjective_row(),
+          navigator_items: []
+        },
+        params: %{"text_search" => ["Parent 3"]},
+        section_slug: "test-section",
+        section_id: 1,
+        section_title: "Test Section",
+        current_user: %{email: "instructor@example.edu"},
+        patch_url_type: :instructor_dashboard,
+        student_id: nil,
+        view: :insights,
+        v25_migration: :done
+      }
+
+      assert {:ok, updated_socket} = LearningObjectives.update(assigns, socket)
+      assert Enum.map(updated_socket.assigns.table_model.rows, & &1.resource_id) == [1, 3]
+      assert updated_socket.assigns.params.text_search == nil
     end
 
     test "initial_expanded_rows ignores unresolved deep-link ids" do
@@ -610,6 +718,59 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.ComponentTest do
         objective: "Objective 3",
         objective_resource_id: 3,
         subobjective: "Sub-Objective 3.1",
+        student_proficiency_obj: "Low",
+        student_proficiency_subobj: "Low",
+        student_proficiency_obj_dist: %{},
+        student_proficiency_subobj_dist: %{},
+        container_ids: [10],
+        related_activities_count: 0
+      }
+    ]
+  end
+
+  defp objectives_with_prior_subobjective_row do
+    [
+      %{
+        resource_id: 1,
+        title: "Objective 1",
+        objective: "Objective 1",
+        subobjective: nil,
+        student_proficiency_obj: "Low",
+        student_proficiency_subobj: nil,
+        student_proficiency_obj_dist: %{},
+        container_ids: [10],
+        related_activities_count: 0
+      },
+      %{
+        resource_id: 2,
+        title: "Sub-Objective 1.1",
+        objective: "Objective 1",
+        objective_resource_id: 1,
+        subobjective: "Sub-Objective 1.1",
+        student_proficiency_obj: "Low",
+        student_proficiency_subobj: "Low",
+        student_proficiency_obj_dist: %{},
+        student_proficiency_subobj_dist: %{},
+        container_ids: [10],
+        related_activities_count: 0
+      },
+      %{
+        resource_id: 3,
+        title: "Parent 3",
+        objective: "Parent 3",
+        subobjective: nil,
+        student_proficiency_obj: "Low",
+        student_proficiency_subobj: nil,
+        student_proficiency_obj_dist: %{},
+        container_ids: [10],
+        related_activities_count: 0
+      },
+      %{
+        resource_id: 4,
+        title: "Child 3.1",
+        objective: "Parent 3",
+        objective_resource_id: 3,
+        subobjective: "Child 3.1",
         student_proficiency_obj: "Low",
         student_proficiency_subobj: "Low",
         student_proficiency_obj_dist: %{},

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -2,12 +2,15 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
   use ExUnit.Case, async: true
   use OliWeb.ConnCase
 
+  import Ecto.Query
   import Phoenix.ConnTest
   import Phoenix.LiveViewTest
   import Oli.Factory
 
   alias Lti_1p3.Roles.ContextRoles
   alias Oli.Delivery.Sections
+  alias Oli.Delivery.Sections.ContainedObjective
+  alias Oli.Repo
 
   defp live_view_learning_objectives_route(section_slug, params \\ %{}) do
     Routes.live_path(
@@ -19,6 +22,16 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       params
     )
   end
+
+  defp search(view, term),
+    do:
+      view
+      |> element("form[phx-change='search_objective']")
+      |> render_change(%{"objective_name" => term})
+
+  # A collapsed row renders no aria-expanded attribute; an expanded one does.
+  defp expanded?(view, resource_id),
+    do: has_element?(view, "[aria-controls='details-row_#{resource_id}'][aria-expanded]")
 
   describe "user" do
     test "can not access page when it is not logged in", %{conn: conn} do
@@ -428,6 +441,127 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       assert has_element?(view, "span", "#{revisions.obj_revision_b.title}")
       assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
     end
+
+    test "searching for a subobjective shows and expands its parent objective", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_learning_objectives_route(section.slug, %{
+            offset: 4
+          })
+        )
+
+      search(view, revisions.obj_revision_c1.title)
+
+      assert_patch(
+        view,
+        live_view_learning_objectives_route(section.slug, %{
+          text_search: revisions.obj_revision_c1.title
+        })
+      )
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      assert expanded?(view, revisions.obj_revision_c.resource_id)
+
+      wait_until(fn ->
+        render(view) =~
+          ~s(<span class="search-highlight">#{revisions.obj_revision_c1.title}</span>)
+      end)
+
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+    end
+
+    test "clearing the search collapses the rows the search expanded", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      search(view, revisions.obj_revision_c1.title)
+      assert expanded?(view, revisions.obj_revision_c.resource_id)
+
+      search(view, "")
+      refute expanded?(view, revisions.obj_revision_c.resource_id)
+    end
+
+    test "a row collapsed by hand stays collapsed while the search term holds", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      search(view, revisions.obj_revision_c1.title)
+      assert expanded?(view, revisions.obj_revision_c.resource_id)
+
+      render_click(
+        element(view, "[aria-controls='details-row_#{revisions.obj_revision_c.resource_id}']")
+      )
+
+      refute expanded?(view, revisions.obj_revision_c.resource_id)
+
+      render_patch(
+        view,
+        live_view_learning_objectives_route(section.slug, %{
+          text_search: revisions.obj_revision_c1.title,
+          sort_order: "desc"
+        })
+      )
+
+      refute expanded?(view, revisions.obj_revision_c.resource_id)
+    end
+
+    test "finds a subobjective that is not a row in the objectives table", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      revisions: revisions
+    } do
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+      Sections.rebuild_contained_objectives(section)
+
+      # Without contained objectives C1 is dropped from the table dataset, but the expanded
+      # panel still lists it, so search has to reach it through its parent.
+      {deleted, _} =
+        Repo.delete_all(
+          from(co in ContainedObjective,
+            where:
+              co.section_id == ^section.id and
+                co.objective_id == ^revisions.obj_revision_c1.resource_id
+          )
+        )
+
+      assert deleted > 0
+
+      {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug))
+
+      search(view, revisions.obj_revision_c1.title)
+
+      assert has_element?(view, "span", "#{revisions.obj_revision_c.title}")
+      refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
+
+      wait_until(fn ->
+        render(view) =~
+          ~s(<span class="search-highlight">#{revisions.obj_revision_c1.title}</span>)
+      end)
+    end
   end
 
   describe "page size change" do
@@ -570,16 +704,13 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       }
 
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
-      expected_row_id = "row_#{revisions.obj_revision_c1.resource_id}"
+      expected_row_id = "row_#{revisions.obj_revision_c.resource_id}"
 
       assert_push_event(view, "learning-objectives-scroll", %{
         id: ^expected_row_id
       })
 
-      assert has_element?(
-               view,
-               "[id^='expanded-objective-row_#{revisions.obj_revision_c1.resource_id}_']"
-             )
+      assert expanded?(view, revisions.obj_revision_c.resource_id)
     end
 
     test "invalid deep-link ids fall back without crashing or forcing expansion", %{

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -472,8 +472,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       assert expanded?(view, revisions.obj_revision_c.resource_id)
 
       wait_until(fn ->
-        render(view) =~
-          ~s(<span class="search-highlight">#{revisions.obj_revision_c1.title}</span>)
+        has_element?(view, ".search-highlight", revisions.obj_revision_c1.title)
       end)
 
       refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
@@ -558,8 +557,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       refute has_element?(view, "span", "#{revisions.obj_revision_f.title}")
 
       wait_until(fn ->
-        render(view) =~
-          ~s(<span class="search-highlight">#{revisions.obj_revision_c1.title}</span>)
+        has_element?(view, ".search-highlight", revisions.obj_revision_c1.title)
       end)
     end
   end
@@ -704,10 +702,10 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       }
 
       {:ok, view, _html} = live(conn, live_view_learning_objectives_route(section.slug, params))
-      expected_row_id = "row_#{revisions.obj_revision_c.resource_id}"
+      expected_id = "subobj-#{revisions.obj_revision_c1.resource_id}"
 
       assert_push_event(view, "learning-objectives-scroll", %{
-        id: ^expected_row_id
+        id: ^expected_id
       })
 
       assert expanded?(view, revisions.obj_revision_c.resource_id)


### PR DESCRIPTION
[MER-5788](https://eliterate.atlassian.net/browse/MER-5788)

## Summary

This PR fixes Learning Objectives search in the instructor dashboard so it also finds sub-objectives, shows the matching parent objective, and expands the row when the match is inside a sub-objective.

### Changes

- Search now considers both objectives and sub-objectives.
- The instructor dashboard main table renders parent objectives only.
- When search matches a sub-objective, the parent objective is shown and expanded automatically.
- When search matches only the parent objective, the row remains collapsed.
- Adds search-term highlighting for objectives and sub-objectives.
- Ignores empty or whitespace-only searches.
- Updates deep-link navigation to resolve the correct parent for sub-objective targets.
- Adds scrolling to the matching search result or targeted deep-linked sub-objective.

### Tests

- Added/updated coverage for:
  - sub-objective search
  - parent objective expansion
  - parent-only rendering in the instructor dashboard
  - sub-objective deep-links
  - deep-link pagination
  - empty or invalid search input
  - result highlighting

### Visual Validation


https://github.com/user-attachments/assets/3668c4c4-ed06-40c0-a980-02f63a7ecbfe




[MER-5788]: https://eliterate.atlassian.net/browse/MER-5788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ