### PR TITLE
[BUG FIX] [MER-5904] Keep corrected multi-input dropdown selection in sync

### DIFF
--- a/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
+++ b/assets/src/components/activities/multi_input/MultiInputDelivery.tsx
@@ -214,6 +214,13 @@ export const MultiInputComponent: React.FC = () => {
     const response = { input: value };
 
     if (part !== undefined) {
+      dispatch(
+        activityDeliverySlice.actions.setStudentInputForPart({
+          partId: input.partId,
+          studentInput: [value],
+        }),
+      );
+
       // Here we handle the case that the student is typing again into an input whose
       // part attempt had already been evaluated. So we must first reset to get a new
       // part attempt, then either submit (if dropdown) or save the input to that part attempt
@@ -243,14 +250,6 @@ export const MultiInputComponent: React.FC = () => {
         }
       } else {
         // Otherwise this is just a change to an existing active part attempt
-
-        dispatch(
-          activityDeliverySlice.actions.setStudentInputForPart({
-            partId: input.partId,
-            studentInput: [value],
-          }),
-        );
-
         const doSave = () =>
           onSaveActivity(uiState.attemptState.attemptGuid, [
             {

--- a/assets/test/multi_input/multi_input_delivery_test.tsx
+++ b/assets/test/multi_input/multi_input_delivery_test.tsx
@@ -3,11 +3,23 @@ import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  DeliveryElementProps,
+  EvaluationResponse,
+  PartActivityResponse,
+} from 'components/activities/DeliveryElement';
 import { DeliveryElementProvider } from 'components/activities/DeliveryElementProvider';
 import { MultiInputComponent } from 'components/activities/multi_input/MultiInputDelivery';
 import { MultiInputActions } from 'components/activities/multi_input/actions';
 import { MultiInputSchema } from 'components/activities/multi_input/schema';
 import { defaultModel } from 'components/activities/multi_input/utils';
+import {
+  makeChoice,
+  makeFeedback,
+  makeHint,
+  makePart,
+  makeResponse,
+} from 'components/activities/types';
 import { activityDeliverySlice } from 'data/activities/DeliveryState';
 import { defaultActivityState } from 'data/activities/utils';
 import { configureStore } from 'state/store';
@@ -44,7 +56,10 @@ describe('multi input delivery', () => {
     window.MathJax = restoreMathJax;
   });
 
-  const renderMultiInput = (model: MultiInputSchema) => {
+  const renderMultiInput = (
+    model: MultiInputSchema,
+    deliveryProps: Partial<DeliveryElementProps<MultiInputSchema>> = {},
+  ) => {
     const props = {
       model,
       activitySlug: 'activity-slug',
@@ -76,7 +91,7 @@ describe('multi input delivery', () => {
 
     return render(
       <Provider store={store}>
-        <DeliveryElementProvider {...defaultDeliveryElementProps} {...props}>
+        <DeliveryElementProvider {...defaultDeliveryElementProps} {...props} {...deliveryProps}>
           <MultiInputComponent />
         </DeliveryElementProvider>
       </Provider>,
@@ -152,5 +167,115 @@ describe('multi input delivery', () => {
 
     expect(container.querySelector('.math-input')).toBeTruthy();
     expect(screen.queryByLabelText('answer submission textbox')).not.toBeInTheDocument();
+  });
+
+  it('keeps a corrected dropdown selected after resetting and resubmitting its part', async () => {
+    const dropdownPartId = 'dropdown-part';
+    const textPartId = 'text-part';
+    const dropdownInputId = 'dropdown-input';
+    const textInputId = 'text-input';
+    const incorrectChoice = makeChoice('Incorrect', 'incorrect-choice');
+    const correctChoice = makeChoice('Correct', 'correct-choice');
+
+    const model: MultiInputSchema = {
+      stem: {
+        id: 'stem',
+        content: [
+          {
+            type: 'p',
+            id: 'paragraph',
+            children: [
+              { text: 'Dropdown: ' },
+              { type: 'input_ref', id: dropdownInputId, children: [{ text: '' }] },
+              { text: ' Text: ' },
+              { type: 'input_ref', id: textInputId, children: [{ text: '' }] },
+            ],
+          },
+        ],
+      },
+      choices: [incorrectChoice, correctChoice],
+      inputs: [
+        {
+          id: dropdownInputId,
+          inputType: 'dropdown',
+          partId: dropdownPartId,
+          choiceIds: [incorrectChoice.id, correctChoice.id],
+        },
+        { id: textInputId, inputType: 'text', partId: textPartId },
+      ],
+      submitPerPart: true,
+      authoring: {
+        parts: [
+          makePart(
+            [makeResponse(`input like {${correctChoice.id}}`, 1)],
+            [makeHint('')],
+            dropdownPartId,
+          ),
+          makePart([makeResponse('input like {text}', 1)], [makeHint('')], textPartId),
+        ],
+        targeted: [],
+        transformations: [],
+        previewText: 'Dropdown and text',
+      },
+    };
+
+    let resetCount = 0;
+    const onResetPart = jest
+      .fn<Promise<PartActivityResponse>, [string, string]>()
+      .mockImplementation(async () => {
+        resetCount += 1;
+        return {
+          type: 'success',
+          attemptState: {
+            attemptGuid: `reset-attempt-${resetCount}`,
+            attemptNumber: resetCount + 1,
+            dateEvaluated: null,
+            dateSubmitted: null,
+            score: null,
+            outOf: null,
+            response: null,
+            feedback: null,
+            explanation: null,
+            hints: [],
+            hasMoreAttempts: true,
+            hasMoreHints: false,
+            partId: dropdownPartId,
+          },
+        };
+      });
+    const onSubmitPart = jest
+      .fn<Promise<EvaluationResponse>, [string, string, { input: string }]>()
+      .mockImplementation(async (_attemptGuid, partAttemptGuid, response) => ({
+        type: 'success',
+        actions: [
+          {
+            type: 'FeedbackAction',
+            attempt_guid: partAttemptGuid,
+            part_id: dropdownPartId,
+            out_of: 1,
+            score: response.input === correctChoice.id ? 1 : 0,
+            show_page: null,
+            feedback: makeFeedback(
+              response.input === correctChoice.id ? 'Correct feedback' : 'Incorrect feedback',
+            ),
+            explanation: null,
+          },
+        ],
+      }));
+
+    renderMultiInput(model, { onResetPart, onSubmitPart });
+
+    const dropdown = screen.getByLabelText('Select answer');
+    fireEvent.change(dropdown, { target: { value: incorrectChoice.id } });
+    await waitFor(() => expect(onSubmitPart).toHaveBeenCalledTimes(1));
+    expect(dropdown).toHaveValue(incorrectChoice.id);
+
+    fireEvent.change(dropdown, { target: { value: correctChoice.id } });
+    await waitFor(() => expect(onResetPart).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onSubmitPart).toHaveBeenCalledTimes(2));
+
+    expect(onSubmitPart.mock.calls[1][2]).toEqual({ input: correctChoice.id });
+    expect(screen.getByText('Correct feedback')).toBeInTheDocument();
+    expect(dropdown).toHaveValue(correctChoice.id);
   });
 });


### PR DESCRIPTION
## Summary

[MER-5904](https://eliterate.atlassian.net/browse/MER-5904)

Fixes multi-input dropdowns on practice pages so that changing an already-evaluated part keeps the newly selected value visible and synchronized with the feedback returned for that submission.

## Root cause

For a multi-input activity with `submitPerPart` enabled, the first dropdown selection followed the normal submission path and updated `partState.studentInput` in Redux. Once that part had been evaluated, a subsequent selection followed the `resetAndSubmitPart` path instead.

That path received the new selection directly in its submission payload, so the server evaluated the new value and returned the appropriate feedback. However, `MultiInputDelivery` did not update `partState.studentInput` before dispatching the reset and submission. The server response and the client state could therefore diverge: feedback described the new selection while Redux still contained the previous one.

The defect was most visible in multi-part activities because an evaluated dropdown remains editable while another part is still incomplete. A single-part activity becomes fully evaluated and disabled after its initial submission.

## Regression source

The stale client state had existed since the evaluated reset-and-submit flow was introduced, but the previous dropdown implementation was effectively uncontrolled and the browser usually retained the student's latest visible selection.

Commit `34386782ad` from May 29, 2026 (`[FEATURE] [MER-5618] Add instructor preview components for supported activities`, PR #6599) converted the shared dropdown to a controlled React `<select value={...}>`. That made Redux authoritative and exposed the latent mismatch: React correctly restored the dropdown to the stale Redux value after the change event.

## Fix

- Move the common `setStudentInputForPart` dispatch above the evaluated/unevaluated submission branches, matching the synchronization pattern already used by `ResponseMultiInputDelivery`.
- Add a regression test with a dropdown part and an unfinished sibling part. The test submits an incorrect choice, changes it to the correct choice, and verifies that the reset submission carries the correct value, correct feedback is shown, and the dropdown remains on the corrected selection.

## Verification

- `cd assets && yarn test test/multi_input/multi_input_delivery_test.tsx --runInBand`
- `cd assets && yarn check-types`
- ESLint on the changed source and test files
- Prettier check on the changed source and test files
- `git diff --check`


[MER-5904]: https://eliterate.atlassian.net/browse/MER-5904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MER-5618]: https://eliterate.atlassian.net/browse/MER-5618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ