### PR TITLE
[BUG FIX] [MER-5859] Rework for student onboarding text customization

### DIFF
--- a/lib/oli_web/live/delivery/student_onboarding/intro.ex
+++ b/lib/oli_web/live/delivery/student_onboarding/intro.ex
@@ -2,6 +2,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
   use Phoenix.Component
 
   import OliWeb.Common.SourceImage
+  alias Oli.Rendering.Content
   alias Oli.Rendering.Context
   alias OliWeb.Components.Delivery.Student
 
@@ -12,13 +13,19 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
   Renders the section-defined onboarding welcome message or the default course welcome title.
   """
   def render(assigns) do
+    assigns =
+      assigns
+      |> assign(:has_welcome_title, rich_text_content?(assigns.section.welcome_title))
+      |> assign(:has_encouraging_subtitle, text_content?(assigns.section.encouraging_subtitle))
+      |> assign(:has_description, text_content?(assigns.section.description))
+
     ~H"""
     <img
       class="object-cover hidden hvxl:block hvxl:h-[150px] hv2xl:h-[300px] w-full"
       src={cover_image(@section)}
     />
     <div class="flex flex-col gap-3 px-[50px] hvsm:px-[70px] hvxl:px-[84px] py-9 dark:text-white">
-      <%= if custom_message?(@section.description) do %>
+      <%= if @has_welcome_title or @has_encouraging_subtitle or @has_description do %>
         <div
           id={"#{@id_prefix}-welcome-title"}
           role="heading"
@@ -26,6 +33,7 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
           class="min-w-0 max-w-full [overflow-wrap:anywhere] text-[16px] leading-6 tracking-[0.02px] [&_ol]:!pl-6 [&_ul]:!pl-6 [&>*:first-child]:font-semibold [&>*:first-child]:text-[18xl] [&>*:first-child]:leading-[24px] hvsm:[&>*:first-child]:text-[30px] hvsm:[&>*:first-child]:leading-[40px] hvxl:[&>*:first-child]:text-[40px] hvxl:[&>*:first-child]:leading-[54px]"
         >
           <Student.welcome_title
+            :if={@has_welcome_title}
             title={@section.welcome_title}
             render_context={
               %Context{
@@ -36,15 +44,17 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
             }
             id_prefix={@id_prefix}
           />
+          <span :if={!@has_welcome_title}>Welcome to {@section.title}</span>
         </div>
         <p
-          :if={custom_message?(@section.encouraging_subtitle)}
+          :if={@has_encouraging_subtitle}
           id={"#{@id_prefix}-welcome-subtitle"}
           class="min-w-0 max-w-full [overflow-wrap:anywhere] font-semibold text-[16px] leading-6 tracking-[0.02px] dark:text-opacity-80"
         >
           {@section.encouraging_subtitle}
         </p>
         <p
+          :if={@has_description}
           id={"#{@id_prefix}-welcome-description"}
           class="min-w-0 max-w-full whitespace-pre-line [overflow-wrap:anywhere] text-[14px] leading-5 tracking-[0.02px] dark:text-opacity-80"
         >
@@ -62,6 +72,18 @@ defmodule OliWeb.Delivery.StudentOnboarding.Intro do
     """
   end
 
-  defp custom_message?(value) when is_binary(value), do: String.trim(value) != ""
-  defp custom_message?(_value), do: false
+  defp rich_text_content?(welcome_title) when is_map(welcome_title) do
+    children =
+      Map.get(welcome_title, "children") || Map.get(welcome_title, :children) || []
+
+    %Context{}
+    |> Content.render(children, Content.Plaintext)
+    |> IO.iodata_to_binary()
+    |> text_content?()
+  end
+
+  defp rich_text_content?(_welcome_title), do: false
+
+  defp text_content?(value) when is_binary(value), do: String.trim(value) != ""
+  defp text_content?(_value), do: false
 end

--- a/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
+++ b/test/oli_web/live/delivery/onboarding_wizard/student_onboarding_wizard_test.exs
@@ -60,7 +60,7 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
   describe "Student Onboarding Wizard - Introduction" do
     setup [:user_conn]
 
-    test "renders the default welcome message when the section description is empty", %{
+    test "renders the default welcome message when all section welcome fields are empty", %{
       conn: conn,
       user: student
     } do
@@ -72,13 +72,13 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
             "type" => "p",
             "children" => [
               %{
-                "id" => "unused-custom-title",
+                "id" => "empty-custom-title",
                 "type" => "p",
-                "children" => [%{"text" => "This custom title is not displayed"}]
+                "children" => [%{"text" => "  "}]
               }
             ]
           },
-          encouraging_subtitle: "This custom subtitle is not displayed"
+          encouraging_subtitle: ""
         })
 
       enroll_student(student, section)
@@ -86,7 +86,6 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
       {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
 
       assert has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
-      refute render(view) =~ "This custom title is not displayed"
       refute has_element?(view, "#onboarding-welcome-subtitle")
       refute has_element?(view, "#onboarding-welcome-description")
 
@@ -98,6 +97,91 @@ defmodule OliWeb.Deliver.StudentOnboarding.WizardTest do
 
       assert has_element?(view, "button", "Go to course")
       assert has_element?(view, "button", "Cancel")
+    end
+
+    for {has_description, has_welcome_title, has_encouraging_subtitle} <- [
+          {false, false, false},
+          {false, false, true},
+          {false, true, false},
+          {false, true, true},
+          {true, false, false},
+          {true, false, true},
+          {true, true, false},
+          {true, true, true}
+        ] do
+      test "renders welcome field combination has_description=#{has_description}, has_welcome_title=#{has_welcome_title}, has_encouraging_subtitle=#{has_encouraging_subtitle}",
+           %{
+             conn: conn,
+             user: student
+           } do
+        has_description = unquote(has_description)
+        has_welcome_title = unquote(has_welcome_title)
+        has_encouraging_subtitle = unquote(has_encouraging_subtitle)
+
+        fallback_title_selector =
+          unquote(
+            if has_description or has_encouraging_subtitle,
+              do: "#onboarding-welcome-title > span:first-child",
+              else: "h2#onboarding-welcome-title"
+          )
+
+        welcome_title =
+          if has_welcome_title do
+            %{
+              "type" => "p",
+              "children" => [
+                %{
+                  "id" => "custom-title",
+                  "type" => "p",
+                  "children" => [%{"text" => "Start exploring chemistry"}]
+                }
+              ]
+            }
+          else
+            %{}
+          end
+
+        %{section: section} =
+          basic_section(nil, %{
+            title: "Chemistry 201",
+            description: if(has_description, do: "Custom course description", else: nil),
+            welcome_title: welcome_title,
+            encouraging_subtitle:
+              if(has_encouraging_subtitle, do: "Custom encouraging subtitle", else: nil)
+          })
+
+        enroll_student(student, section)
+
+        {:ok, view, _html} = live(conn, onboarding_wizard_route(section.slug))
+
+        if has_welcome_title do
+          assert has_element?(view, "#onboarding-welcome-title", "Start exploring chemistry")
+          refute has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
+        else
+          assert has_element?(view, "#onboarding-welcome-title", "Welcome to Chemistry 201")
+          assert has_element?(view, fallback_title_selector)
+        end
+
+        if has_encouraging_subtitle do
+          assert has_element?(
+                   view,
+                   "#onboarding-welcome-subtitle",
+                   "Custom encouraging subtitle"
+                 )
+        else
+          refute has_element?(view, "#onboarding-welcome-subtitle")
+        end
+
+        if has_description do
+          assert has_element?(
+                   view,
+                   "#onboarding-welcome-description",
+                   "Custom course description"
+                 )
+        else
+          refute has_element?(view, "#onboarding-welcome-description")
+        end
+      end
     end
 
     test "renders the section welcome fields when the description has content", %{


### PR DESCRIPTION
Uses the section’s Description, Welcome Title, and Encouraging Subtitle independently.
Falls back to “Welcome to [Course Title]” when no custom Welcome Title exists.

| # | Description | Welcome Title | Encouraging Subtitle |                                                   Decision A                                                   |
| - | ----------- | ------------- | -------------------- | -------------------------------------------------------------------------------------------------------------- |
| 1 |      ❌      |       ❌       |          ❌           |                               Show “Welcome to [Course Title]” as Welcome Title                                |
| 2 |      ❌      |       ❌       |          ✅           |             Show “Welcome to [Course Title]” as Welcome Title, and the custom Encouraging Subtitle             |
| 3 |      ❌      |       ✅       |          ❌           |                                           Show custom Welcome Title                                            |
| 4 |      ❌      |       ✅       |          ✅           |                           Show custom Welcome Title and custom Encouraging Subtitle                            |
| 5 |      ✅      |       ❌       |          ❌           |                    Show “Welcome to [Course Title]” as Welcome Title and custom Description                    |
| 6 |      ✅      |       ❌       |          ✅           | Show “Welcome to [Course Title]” as Welcome Title, the custom Description, and the custom Encouraging Subtitle |
| 7 |      ✅      |       ✅       |          ❌           |                                Show custom Welcome Title and custom Description                                |
| 8 |      ✅      |       ✅       |          ✅           |                 Show custom Welcome Title, custom Description, and custom Encouraging Subtitle                 |

See: https://eliterate.atlassian.net/browse/MER-5859