### PR TITLE
[CHORE] [MER-000] Generate AI review PR diffs locally to avoid fatal error if github throttles download

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -159,16 +159,18 @@ jobs:
           echo "Running reviewer role: ${{ matrix.role }}"
           echo "Filter outputs: elixir=${{ needs.changes.outputs.elixir }}, gleam=${{ needs.changes.outputs.gleam }}, ts=${{ needs.changes.outputs.typescript }}, ui=${{ needs.changes.outputs.ui }}, perf=${{ needs.changes.outputs.performance }}, sec=${{ needs.changes.outputs.security }}, req=${{ needs.changes.outputs.requirements }}"
 
-      - name: Generate PR diff (exactly what GitHub shows)
+      - name: Generate full PR diff
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         env:
-          PATCH_URL: ${{ github.event.pull_request.patch_url }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          curl -sSL --fail-with-body "${PATCH_URL}" -o diff.patch
+          MB=$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")
+          git diff --unified=0 "${MB}" "${HEAD_SHA}" > diff.patch
           if ! head -n 1 diff.patch | grep -qE '^(From [0-9a-f]{7,40} |diff --git )'; then
-            echo "::error::downloaded content does not look like a git patch; refusing to review it"
+            echo "::error::generated content does not look like a git patch; refusing to review it"
             exit 1
           fi
 


### PR DESCRIPTION
## Problem

Each AI review matrix job downloads the pull request patch from the unauthenticated GitHub web patch endpoint before role-specific processing. GitHub has intermittently returned HTTP 429 for this request. Because the download is a required step and the matrix uses fail-fast behavior, one throttled request fails its reviewer and cancels the remaining AI review jobs.

The downloaded patch is retained only by the requirements reviewer. All other reviewers replace it downstream with a role-specific diff generated from the checked-out repository.

## Change

Replace the full PR patch download with a local merge-base diff between the pull request base and head SHAs. This preserves the existing diff.patch contract and leaves all downstream role-specific narrowing, validation, prompting, and review processing unchanged.

Requirements continues to receive the complete PR diff, while other roles continue to replace it with their filtered local diff.

## Verification

- parsed .github/workflows/ai-review.yml successfully as YAML
- git diff --check
- verified the change is limited to the full PR diff generation step