### PR TITLE
[FEATURE] [MER-5821] Aggregate child Learning Objective proficiency into parent Learning Objectives

### DIFF
--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/informal.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/informal.md
@@ -1,0 +1,192 @@
+# MER-5821: Aggregate Child Learning Objective Proficiency into Parent Learning Objectives
+
+This work item is the second of the three `learning_model_v2` "usage" concerns identified in
+`docs/exec-plans/current/epics/learning_model_v2/usage/informal.md`: parent-LO/sub-objective
+aggregation. It is tracked in Jira as `MER-5821`, linked under epic `MER-5843`
+("Learning Proficiency Model Improvements").
+
+## Why the original Jira ticket text is stale
+
+The Jira description for `MER-5821` originally asked for "equal weighting" across Sub-LOs and
+was ambiguous about whether aggregation should move from a runtime projection to a persisted,
+write-time calculation. Darren Siegel's review comments on the ticket (2026-07-29 through
+2026-08-04) resolved both points:
+
+- Timing does not change. Aggregation stays a **runtime projection** computed when proficiency
+  is read (e.g. the Instructor Dashboard Learning Objectives tab, or a student-facing page),
+  not persisted when a learner submits an attempt.
+- The formula changes from equal-weighting to a **weighted average, weighted by the amount of
+  evidence available per Sub-LO** (Darren: "weighted by the number of completed attempts
+  present in each Sub Objective attached activity"). This matches epic `MER-5843`'s own
+  "Learning Objective Aggregation" section ("weighted by number of attempts"), though that
+  epic's Scope section still has a stale "equal-weight aggregation" line that should be
+  disregarded in favor of the more specific and more recent aggregation section.
+- Darren also asked that the ticket audit and update **every** place in the system, both
+  authoring and delivery, that performs this rollup today, rather than patching a single call
+  site.
+
+## Decoupling from the algorithm (naive vs. LKT-AOA)
+
+Epic `MER-5843` is running two parallel tracks: `MER-5846` implements the new LKT-AOA learner
+model (an "Implement the LKT-AOA Learner Model" story whose own Negative AC states "Learning
+Objective proficiency aggregation is not implemented as part of this ticket"), and `MER-5845`
+adds a `learning_model_version` switch (already implemented in code today, see
+`Oli.LearningModel.ModelVersion` and the `learning_model_version` field on
+`Oli.Authoring.Course.Project` / `Oli.Delivery.Sections.Section`) that lets a project/section
+run on `:naive` or `:lkt_aoa`.
+
+`MER-5821` owns the aggregation layer used by **both** algorithms. It must not assume which
+algorithm computed a given child's proficiency; the aggregation function only combines already-
+computed `(proficiency, evidence_count)` pairs into a parent score. This was confirmed directly
+with the ticket owner during PRD drafting.
+
+## Confirmed weighting semantics per algorithm
+
+- **Naive/legacy** (`lib/oli/delivery/metrics.ex`): a Sub-LO's own score is computed from first
+  attempts only (`num_first_attempts` / `num_first_attempts_correct`), never `num_attempts`
+  total. Therefore the weight passed into the shared aggregation function for a naive child
+  **must** be `num_first_attempts` — using total attempts here would weight by evidence that
+  never contributed to that child's score.
+- **LKT-AOA**: `docs/exec-plans/current/epics/learning_model_v2/lkt_technical_notes.docx.md`
+  section 6 ("Learning Objective Aggregation") is the authoritative technical definition
+  referenced by `usage/informal.md`. Section 6.2 states the rule directly: "Sub-objective
+  scores aggregate to the LO level using a weighted average, weighted by number of tagged
+  opportunities per sub-objective," i.e. `LO_score = Σ(sub_objective_score × opportunities) /
+  Σ opportunities`, where "opportunities" is the sub-objective's total attempt count (section
+  6.1 defines the sub-objective score itself as the mean over all attempts, not just the
+  first). This **confirms** — rather than merely assumes — that the LKT-AOA caller must pass
+  total attempt count as `count`, resolving what was an open question earlier in PRD drafting.
+  The exact API Torus will expose to read that count is a dependency on `MER-5846`, which is
+  still in progress; the aggregation *rule* is settled, the concrete data access is not yet
+  built.
+- Section 6.4 of the same technical notes ("Tagging Hierarchy: Double-Counting Prevention")
+  defines the same de-duplication rule already present in the original Jira AC: an activity
+  tagged to both a parent LO and one of its Sub-LOs counts only at the more specific
+  (Sub-LO) level.
+- Section 6.3 ("Coverage Gaps") describes a **coverage gap indicator** shown alongside the
+  score for thin Sub-LOs, rather than suppressing the parent score outright. The visual
+  treatment of that indicator needs UX design (per the notes, "UX support needed from Jess")
+  and is out of scope for this ticket; this PRD only needs the aggregation function to avoid
+  silently dropping low-evidence children from the weighted average, consistent with both the
+  original Jira AC ("reflects the incomplete coverage") and this technical note.
+- `docs/exec-plans/current/epics/learning_model_v2/usage/informal.md` separately notes that a
+  single shared `proficiency_range/2`-style bucketing function is **not** sufficient across both
+  models ("The shared current `proficiency_range/2` cannot determine both models from a score
+  and naive attempt count alone"), because each model's "not enough data" eligibility rule
+  differs. This work item's shared function therefore returns a weighted **score** (and the
+  total evidence count), and leaves bucketing/eligibility to the caller — the naive caller
+  continues to call the existing `proficiency_range/2`; a future LKT-AOA caller applies its own
+  rule (section 6.5).
+
+## Data model
+
+- `Oli.Resources.Revision`: `children` (objective revisions) is the LO → Sub-LO hierarchy;
+  `objectives` (activity revisions) maps `part_id => [objective_ids]`, i.e. which LO/Sub-LO an
+  activity part is tagged to.
+- `Oli.Analytics.Summary.ResourceSummary`: per `(project_id, section_id, user_id, resource_id,
+  part_id)` counts — `num_attempts`, `num_correct`, `num_first_attempts`,
+  `num_first_attempts_correct`. No row is created for a parent LO purely because its Sub-LO has
+  activity — a parent only has its own row if an activity is tagged to it directly.
+- Bucket thresholds for the naive model live in `Metrics.proficiency_range/2`
+  (`lib/oli/delivery/metrics.ex:1180-1184`): `< 3` first attempts or nil score → "Not enough
+  data"; `<= 0.4` → "Low"; `<= 0.8` → "Medium"; else "High".
+
+## Call sites audited (must all consume the new shared function)
+
+1. **`Metrics.aggregate_raw_proficiency/1` + `proficiency_for_student_per_learning_objective/3`**
+   (`lib/oli/delivery/metrics.ex:761-823`) — delivery, student-facing: `prologue_live.ex:634`,
+   `lesson_live.ex:1660`, `review_live.ex:131`. Already pools numerator/denominator across
+   children before dividing, so it already behaves like a weighted average — but it is coded
+   directly against naive first-attempt semantics and needs to be generalized/extracted behind
+   the new shared function rather than reimplemented per algorithm.
+2. **`Sections.get_objectives_and_subobjectives/2`** (`lib/oli/delivery/sections.ex:5914-6185`,
+   backed by `Metrics.proficiency_per_student_for_objective/3`,
+   `lib/oli/delivery/metrics.ex:1509-1556`) — Instructor Dashboard Learning Objectives tab
+   (`instructor_dashboard_live.ex:120`), the instructor's per-student view
+   (`student_dashboard_live.ex:54`), and the CSV export
+   (`delivery_controller.ex:471`, `download_learning_objectives/2`). Today a parent LO's
+   proficiency comes **only** from its own direct `ResourceSummary` row; Sub-LOs are never
+   combined in. Test `test/oli/delivery/sections_test.exs:3450-3498` documents and asserts this
+   gap today and must be updated once the aggregation lands.
+3. **`Oli.Delivery.LearningObjectives.PageElement.maybe_proficiency/5`**
+   (`lib/oli/delivery/learning_objectives/page_element.ex:135-147`), consumed by
+   `lib/oli/rendering/content/learning_objectives.ex` (the new `"learning_objectives"` page
+   element). Also does not combine Sub-LOs today.
+
+Useful fixture: `setup_objectives_and_activities_test/0`
+(`test/oli/delivery/sections_test.exs:3711`) already builds a 2-level hierarchy with activities
+tagged at both parent and Sub-LO level.
+
+Out of scope / adjacent, noted but not touched by this ticket:
+
+- Whole-class ("Average Class Proficiency") aggregation in
+  `lib/oli/instructor_dashboard/data_snapshot/projections/summary/projector.ex` and
+  `csv_export/serializers/helpers.ex` — these aggregate proficiency across *students*, not
+  across a LO hierarchy, and use two different bucket-to-score weight scales (30/60/90 vs.
+  20/60/100) that are already an inconsistency independent of this ticket.
+- `Oli.InstructorDashboard.Oracles.ProgressProficiency`
+  (`lib/oli/instructor_dashboard/oracles/progress_proficiency.ex`) computes page/container-scoped
+  proficiency directly against `ResourceSummary`, not LO parent/Sub-LO rollup; it is flagged
+  elsewhere in the epic as a naive-model shortcut to remove, but that is `learning_model_v2`
+  dispatch work, not this ticket's aggregation-function scope.
+
+## Agreed function contract
+
+A single algorithm-agnostic weighted-average function. Conceptually:
+
+```elixir
+@doc """
+Aggregates a parent Learning Objective's proficiency from the proficiency
+estimates of its Sub-LOs (and, optionally, its own directly-tagged evidence),
+producing a single weighted average.
+
+Each child is passed as `{proficiency, count}`, where `count` is a measure
+of how much evidence backs that child's proficiency estimate. This function
+is agnostic to which learner model produced `proficiency` — it is the
+CALLER's responsibility to supply a `count` that is consistent with how
+that proficiency value was calculated:
+
+  * Legacy (naive, first-attempt-only) algorithm: `count` MUST be the
+    number of FIRST attempts (`num_first_attempts`), since only first
+    attempts contribute to that model's proficiency estimate. Passing a
+    total attempt count here would over-weight children whose score was
+    computed from a smaller subset of evidence than their attempt count
+    implies.
+
+  * Learning Proficiency Framework v2 (LKT-AOA): `count` must reflect the
+    total evidence count used by that model (all attempts / "tagged
+    opportunities"), per the LKT-AOA technical definition
+    (`docs/exec-plans/current/epics/learning_model_v2/lkt_technical_notes.docx.md`,
+    section 6.2), since LKT-AOA's own Sub-LO score is a mean over every
+    attempt rather than only the first.
+
+Mismatching `count` semantics across children (e.g. mixing first-attempt
+counts with total-attempt counts within the same aggregation call) will
+silently skew the weighted average — this function has no way to detect
+that on its own.
+"""
+```
+
+This `@doc` text must be preserved as written (not rewritten) when this function is implemented.
+
+Functional rules the function/its callers must preserve:
+
+- No double-counting: an activity tagged to both a parent LO and one of its Sub-LOs is counted
+  once, at the Sub-LO.
+- Incomplete coverage: a Sub-LO with insufficient evidence is not silently excluded from the
+  denominator — it must still be represented so the parent reflects incomplete coverage rather
+  than behaving as if only the attempted Sub-LOs existed.
+- The weighted score is what downstream bucketing (naive: `proficiency_range/2`; a future
+  LKT-AOA provider: its own rule) consumes — the aggregation function does not bucket.
+
+## Explicit scope boundary
+
+In scope: the shared aggregation function and its documented contract; auditing and updating
+call sites 1–3 above to consume it instead of duplicating or omitting the rollup; updating the
+existing test(s) that assert today's non-aggregating behavior.
+
+Out of scope: changing aggregation timing (stays a runtime projection); implementing LKT-AOA
+itself (`MER-5846`); implementing/changing the `learning_model_version` switch (`MER-5845`,
+already implemented); implementing the Confidence metric (`MER-5847`); the coverage-gap-indicator
+UI treatment (needs UX design); the whole-class "Average Class Proficiency" aggregation and its
+weight-scale inconsistency; `ProgressProficiency`'s page/container-scoped calculation.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/informal.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/informal.md
@@ -171,8 +171,18 @@ This `@doc` text must be preserved as written (not rewritten) when this function
 
 Functional rules the function/its callers must preserve:
 
-- No double-counting: an activity tagged to both a parent LO and one of its Sub-LOs is counted
-  once, at the Sub-LO.
+- Always combine: whenever a parent LO has evidence of its own (an activity tagged directly to
+  it), that evidence is always included in the weighted average alongside every Sub-LO's evidence
+  — never excluded just because the parent has Sub-LOs, and never used as a fallback only when
+  Sub-LOs lack evidence. This is a deliberate product decision, not an oversight: **Darren Siegel
+  confirmed on Slack (2026-09-01) that this ("Option B") is "the simplest thing that we can (and
+  should) do."** It explicitly supersedes the original Jira ticket's own AC that an activity
+  tagged to both a parent LO and one of its Sub-LOs must be counted only once, at the Sub-LO —
+  under Option B that specific activity's evidence is double-counted (once via the parent's own
+  row, once via the Sub-LO's row) when this occurs. Three alternatives that would avoid or reduce
+  that double-counting were considered and rejected in favor of Option B's simplicity; see
+  `parent_evidence_aggregation_options.md` in this directory for the full comparison, including
+  worked numeric examples of each alternative's trade-offs.
 - Incomplete coverage: a Sub-LO with insufficient evidence is not silently excluded from the
   denominator — it must still be represented so the parent reflects incomplete coverage rather
   than behaving as if only the attempted Sub-LOs existed.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md
@@ -1,0 +1,125 @@
+# Parent LO Proficiency: How Should a Parent's Own Directly-Tagged Evidence Be Combined With Its Sub-LOs?
+
+## Context
+
+When a parent Learning Objective has one or more Sub-LOs, how should proficiency be aggregated at
+the parent level? Depending on how we choose to weigh the effect of tagging an activity directly to
+the parent (rather than to one of its Sub-LOs), we arrive at different possible results — and each
+approach carries its own difficulties and/or trade-offs, laid out below.
+
+This question specifically matters for **existing** course content. A separate, already-filed
+ticket will restrict authors from tagging activities directly to a parent LO once it has Sub-LOs,
+for newly authored course packages going forward. That upcoming restriction does not apply
+retroactively, so any course that has already tagged activities directly to a parent LO will keep
+that tagging as-is. This discussion is about how proficiency should be aggregated for that existing
+content, not about the tagging rules for new courses.
+
+All four options below rely on `Oli.Analytics.Summary.ResourceSummary`, which stores one row per
+`(project_id, section_id, user_id, resource_id, resource_type_id, part_id)`, with running totals
+(`num_attempts`, `num_correct`, `num_first_attempts`, `num_first_attempts_correct`) incremented as
+attempts occur. Critically, **this row does not retain which specific activity contributed to a
+given increment** — counts from every activity ever tagged to that `resource_id` are folded
+together at write time. As the options below show, this is the central constraint driving the
+difficulty and trade-offs of each approach.
+
+## Option A — Exact reconciliation (activity-level exclusion)
+
+**Logic:** For the parent, determine which activities are tagged *only* to the parent (not to any
+of its Sub-LOs), and compute the parent's own contribution using only attempts on those activities.
+Any activity tagged to both the parent and a Sub-LO is attributed entirely to the Sub-LO and
+excluded from the parent's own contribution. The parent's final proficiency is then the weighted
+average of:
+- Attempts on activities tagged only to the parent, and
+- Each Sub-LO's own proficiency (computed normally, since a Sub-LO is always the most specific tag
+  and never needs this exclusion itself).
+
+**Implementation difficulty:** This cannot be computed from the existing `ResourceSummary` rows,
+because those rows have already summed every contributing activity's counts together with no way
+to subtract out a specific activity's contribution after the fact. Reconciling at the activity
+level requires abandoning the pre-aggregated `ResourceSummary` read for the parent's own
+contribution and instead querying the much larger raw attempt tables
+(`ResourceAttempt` / `ActivityAttempt` / `PartAttempt`) directly, filtered down to the specific set
+of activity resource_ids tagged only to the parent (a set difference computed from each
+objective's tagged-activity list, e.g. the existing `related_activities` field). This is a
+materially larger and more expensive computation than reading one pre-summed row per objective,
+and is the only option of the four that cannot reuse the aggregation this ticket's other call
+sites already rely on.
+
+## Option B — Always combine parent and children (unconditional sum) — ✅ CHOSEN
+
+**Decision:** Darren Siegel confirmed on Slack (2026-09-01) that this is "the simplest thing that
+we can (and should) do." This is the option implemented.
+
+**Logic:** Always include the parent's own full `ResourceSummary` row alongside every Sub-LO's row
+in the weighted average, regardless of whether any Sub-LO has evidence and regardless of whether
+any activity is tagged to both levels.
+
+**Risk:** If an activity is tagged to both the parent and a Sub-LO, its evidence is double-counted
+— it contributes once via the parent's row and again via the Sub-LO's row, inflating (or
+deflating) the parent's evidence weight relative to what those attempts actually represent.
+
+## Option C — Prefer children; fall back to the parent's own evidence only when children have none
+
+**Logic:** Compute the weighted average of the Sub-LOs' evidence first. If that produces zero total
+evidence (i.e., not a single Sub-LO has any attempts at all), fall back to using the parent's own
+evidence alone instead. If any Sub-LO has evidence, use only the Sub-LOs' combined evidence — never
+blended with the parent's own row.
+
+**Behavior:** Because this is an either/or choice (never a blend of parent + children), it carries
+no double-counting risk: the parent's own evidence is only ever used in the one situation where
+there is no Sub-LO evidence to double-count against.
+
+**Trade-off:** The moment any Sub-LO accumulates even a single attempt, the parent's own evidence —
+however substantial — stops contributing entirely, and the parent's proficiency is driven solely by
+that (possibly much thinner) Sub-LO evidence.
+
+For example: Activity A is tagged only to the parent, and is answered by 20 students with 18
+correct first attempts (a strong, well-evidenced signal — on its own, this would show as **High**).
+Activity B is tagged to Sub-LO A.1 (1 of 3 first attempts correct) and Activity C is tagged to
+Sub-LO A.2 (0 of 3 first attempts correct). Once all three activities have been completed, both
+Sub-LOs now have evidence, so the parent's proficiency is computed from A.1 and A.2 alone: a
+combined score of 0.33 from just 6 thin attempts, displaying as **Low**. Activity A's 20 attempts —
+a much larger and stronger body of evidence — no longer contribute to the parent's displayed
+proficiency at all, permanently, once every Sub-LO has any evidence of its own.
+
+## Option D — Always use children only, with no fallback
+
+**Logic:** The parent's proficiency is always the weighted average of its Sub-LOs' evidence. The
+parent's own directly-tagged evidence never contributes once the parent has any Sub-LOs, regardless
+of how much (or how little) evidence those Sub-LOs have accumulated.
+
+**Behavior:** If none of a parent's Sub-LOs have ever been tagged to any activity, the parent shows
+"Not enough data" indefinitely, even if the parent itself has substantial directly-tagged evidence.
+
+---
+
+## Worked Examples
+
+### Example 1: A Sub-LO has evidence, and one activity is tagged to both the parent and that Sub-LO
+
+Setup:
+- Parent LO, with Sub-LO A.1 and Sub-LO A.2.
+- Activity 1: tagged **only** to the parent. Result: 8 of 10 first attempts correct.
+- Activity 2: tagged **only** to Sub-LO A.1. Result: 10 of 10 first attempts correct.
+- Activity 3: tagged to **both** the parent and Sub-LO A.1. Result: 0 of 40 first attempts correct.
+- Sub-LO A.2: no activity ever tagged to it.
+
+| Option | How it's computed | Score | Displayed proficiency |
+|---|---|---|---|
+| A — Exact reconciliation | Parent's exclusive evidence (Activity 1 only) + A.1 (Activity 2 + Activity 3) + A.2 (none) | 0.44 | **Medium** |
+| B — Always combine | Parent's full row (Activity 1 + Activity 3) + A.1's full row (Activity 2 + Activity 3) | 0.344 | **Low** (Activity 3 is counted twice, pulling the score down) |
+| C — Prefer children, fallback if empty | A.1 has evidence, so only A.1 + A.2 are used | 0.36 | **Low** |
+| D — Always children | Only A.1 + A.2 are used (same as C here, since A.1 has evidence) | 0.36 | **Low** |
+
+### Example 2: Neither Sub-LO has ever been tagged to any activity
+
+Setup:
+- Same parent LO, with Sub-LO A.1 and Sub-LO A.2, neither ever used.
+- Activity 1: tagged **only** to the parent. Result: 8 of 10 first attempts correct.
+
+| Option | How it's computed | Score | Displayed proficiency |
+|---|---|---|---|
+| A — Exact reconciliation | Parent's exclusive evidence (Activity 1, nothing to exclude) + A.1/A.2 (none) | 0.84 | **High** |
+| B — Always combine | Same as A here, since there is no overlapping activity to double-count | 0.84 | **High** |
+| C — Prefer children, fallback if empty | Both Sub-LOs have zero evidence, so falls back to the parent's own evidence | 0.84 | **High** |
+| D — Always children | Both Sub-LOs have zero evidence, and there is no fallback | — | **Not enough data** |

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -83,21 +83,21 @@ implementation, no `learning_model_version` switch changes — those are explici
   behaves like a weighted average today, so this phase is a refactor-in-place, not a functional
   change).
 - Tasks:
-  - [ ] Replace the inline pooling logic in `aggregate_raw_proficiency/1`
+  - [x] Replace the inline pooling logic in `aggregate_raw_proficiency/1`
     (`lib/oli/delivery/metrics.ex:804-823`) with a call to the Phase 1 shared function, passing
     `num_first_attempts` as `count` for each child (PRD Assumptions).
-  - [ ] Confirm `proficiency_for_student_per_learning_objective/3`
+  - [x] Confirm `proficiency_for_student_per_learning_objective/3`
     (`lib/oli/delivery/metrics.ex:761-802`) still bucket via `proficiency_range/2` on the
     aggregated score (FR-007).
-  - [ ] Leave `raw_proficiency_per_learning_objective/2`'s SQL-embedded formula
+  - [x] Leave `raw_proficiency_per_learning_objective/2`'s SQL-embedded formula
     (`lib/oli/delivery/metrics.ex:1522-1546`) untouched in this phase; it feeds
     `proficiency_per_student_for_objective/3`, which Phase 3 addresses separately.
 - Testing Tasks:
-  - [ ] Update/extend existing coverage in `test/oli/analytics/summary/metrics_v2_test.exs` for
+  - [x] Update/extend existing coverage in `test/oli/analytics/summary/metrics_v2_test.exs` for
     `aggregate_raw_proficiency/1` and `proficiency_for_student_per_learning_objective/3` to assert
     unchanged output for current fixtures, plus a new case with an activity tagged to both a
     parent and a Sub-LO to confirm no double count (AC-004).
-  - [ ] Run the targeted `Phoenix.LiveViewTest` suites for `prologue_live_test.exs`,
+  - [x] Run the targeted `Phoenix.LiveViewTest` suites for `prologue_live_test.exs`,
     `lesson_live_test.exs`, and `review_live_test.exs` to confirm no visible regression
     (AC-007, AC-008).
   - Command(s): `mix test test/oli/analytics/summary/metrics_v2_test.exs test/oli_web/live/delivery/student/`

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -118,26 +118,29 @@ implementation, no `learning_model_version` switch changes — those are explici
   into its displayed/exported proficiency, closing the gap the ticket exists to fix, without
   regressing to per-learner or per-objective query loops.
 - Tasks:
-  - [ ] Extend the query backing `get_objectives_and_subobjectives/2`
+  - [x] Extend the query backing `get_objectives_and_subobjectives/2`
     (`lib/oli/delivery/sections.ex:5914-6185`) and/or
     `Metrics.proficiency_per_student_for_objective/3` (`lib/oli/delivery/metrics.ex:1509-1556`) to
     fetch each parent LO's own evidence and its Sub-LOs' evidence in the same set-based pass
     (resolve the Clarification above), then call the Phase 1 shared function per parent LO per
-    student.
-  - [ ] Ensure double-counting prevention: an activity tagged to both a parent LO and a Sub-LO
+    student. Implemented via new `Metrics.raw_proficiency_per_student_for_objective/3` (raw,
+    not-yet-bucketed extraction of the existing query) and a new `Sections.aggregated_proficiency_bucket/3`.
+  - [x] Ensure double-counting prevention: an activity tagged to both a parent LO and a Sub-LO
     contributes once, at the Sub-LO (FR-003, AC-004) — reuse whatever tagging-resolution logic
-    Phase 2 established if applicable, rather than re-deriving it.
-  - [ ] Ensure a leaf LO (no `children`) takes the same path it does today and is unaffected
+    Phase 2 established if applicable, rather than re-deriving it. Implemented via
+    `Sections.objective_evidence_resource_ids/1`, mirroring `Metrics.proficiency_for_student_per_learning_objective/3`'s
+    exclusion of a parent's own evidence whenever it has Sub-LOs.
+  - [x] Ensure a leaf LO (no `children`) takes the same path it does today and is unaffected
     (AC-008).
 - Testing Tasks:
-  - [ ] Update `test/oli/delivery/sections_test.exs:3450-3498` (the test that currently asserts
+  - [x] Update `test/oli/delivery/sections_test.exs:3450-3498` (the test that currently asserts
     the un-aggregated behavior) to assert the new combined result using
     `setup_objectives_and_activities_test/0` (`test/oli/delivery/sections_test.exs:3711`)
     (AC-006).
-  - [ ] Add a case for a parent LO with one attempted Sub-LO and one unattempted/under-evidenced
+  - [x] Add a case for a parent LO with one attempted Sub-LO and one unattempted/under-evidenced
     Sub-LO, asserting incomplete coverage is reflected rather than treated as fully attempted
     (AC-005).
-  - [ ] Run `Phoenix.LiveViewTest` coverage for `instructor_dashboard_live_test.exs` and
+  - [x] Run `Phoenix.LiveViewTest` coverage for `instructor_dashboard_live_test.exs` and
     `student_dashboard_live_test.exs`, and controller tests covering
     `delivery_controller.ex`'s `download_learning_objectives/2` CSV export (AC-006).
   - Command(s): `mix test test/oli/delivery/sections_test.exs test/oli_web/live/delivery/instructor_dashboard/ test/oli_web/live/delivery/student_dashboard/ test/oli_web/controllers/delivery_controller_test.exs`

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -1,0 +1,234 @@
+# MER-5821: Aggregate Child Learning Objective Proficiency into Parent Learning Objectives - Delivery Plan
+
+Scope and reference artifacts:
+- PRD: `docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md`
+- FDD: none. This work item intentionally skips a separate FDD (`harness-architect`). The
+  technical design (function contract, `count` semantics per algorithm, call-site audit, and
+  bucketing ownership) was resolved during PRD drafting and is captured directly in
+  `prd.md` sections 2, 9, 13, and 14, and in `informal.md` in this same directory. This plan
+  treats those sections as the design source of record in place of an `fdd.md`.
+- Requirements: `docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml`
+  (FR-001 through FR-007, AC-001 through AC-010)
+
+## Scope
+
+Introduce a single, algorithm-agnostic weighted-aggregation function for parent Learning
+Objective proficiency, and migrate the three audited runtime call sites (naive delivery-side
+pooling, the Instructor Dashboard/CSV export authoring-side path, and the new
+`"learning_objectives"` page element) onto it, so a parent LO's proficiency always reflects a
+weighted combination of its Sub-LOs (and any directly-tagged evidence) instead of being
+inconsistent or absent across surfaces. No timing change (stays a runtime projection), no LKT-AOA
+implementation, no `learning_model_version` switch changes — those are explicit PRD non-goals.
+
+## Clarifications & Default Assumptions
+
+- The shared function's exact module and name are decided in Phase 1, not fixed in advance; the
+  default assumption is that it lives near `Oli.Delivery.Metrics` (e.g. as a new function on
+  `Metrics`, or a small new module it delegates to) since all three call sites already depend on
+  `Metrics` today, and the PRD's Data/Interfaces section lists `Metrics.aggregate_raw_proficiency/1`
+  as the closest existing analog to generalize from.
+- Default assumption: the naive caller passes `num_first_attempts` as `count`; this is a firm
+  requirement (PRD Assumptions), not a per-phase decision.
+- Default assumption: bucketing is not part of the shared function. The naive caller continues
+  calling `Metrics.proficiency_range/2` after aggregating. No phase below introduces a second
+  bucketing implementation.
+- Default assumption: `test/oli/delivery/sections_test.exs:3450-3498` is updated in place (not
+  deleted) to assert the new aggregated behavior, since it is the test that currently documents
+  the gap this work item closes.
+- Clarification needed during Phase 3: whether `Sections.get_objectives_and_subobjectives/2`
+  should call the shared function per-objective in a loop or extend its existing set-based query
+  to fetch all Sub-LO evidence for a section in one pass and aggregate in memory. Default
+  assumption: extend the existing set-based query (per PRD Non-Functional Requirements — this
+  function already serves full-roster Instructor Dashboard reads and must not regress to N+1
+  query behavior).
+
+## Phase 1: Shared aggregation function
+
+- Goal: Introduce the algorithm-agnostic weighted-aggregation function with its documented
+  `count` contract, fully unit-tested in isolation, with no call site wired to it yet.
+- Tasks:
+  - [ ] Decide the function's home module/name (default assumption above) and add it with the
+    exact `@doc` text agreed in `prd.md` / `informal.md` (must be preserved verbatim, not
+    rewritten).
+  - [ ] Implement `score = Σ(proficiency_i × count_i) / Σ(count_i)` over a list of
+    `(proficiency, count)` pairs, including a parent's own direct `(proficiency, count)` pair
+    when present (FR-001).
+  - [ ] Handle a child with `count == 0` or unset/`nil` proficiency without excluding it from the
+    aggregation's evidence accounting (FR-004) — it must still be representable so the caller can
+    detect incomplete coverage, not silently vanish from the computation.
+  - [ ] Do not implement bucketing inside this function; it returns the weighted score (and total
+    evidence count) only (FR-007, PRD Assumptions).
+- Testing Tasks:
+  - [ ] ExUnit unit tests: multiple Sub-LOs with different counts (AC-001); parent with both
+    direct evidence and Sub-LOs (AC-002); a Sub-LO with zero/insufficient evidence not silently
+    dropped (AC-005); deterministic output for repeated calls with the same inputs (PRD
+    Non-Functional Requirements).
+  - Command(s): `mix test <new test file path>`
+- Definition of Done:
+  - Function exists, is unit-tested per the cases above, and its `@doc` matches the agreed text
+    exactly.
+  - No existing call site has been modified yet.
+- Gate:
+  - `mix test` targeted at the new module passes; `mix format` clean.
+- Dependencies:
+  - None. This phase has no dependency on Phases 2-4.
+- Parallelizable Work:
+  - None within this phase; it is the prerequisite for Phases 2-4.
+
+## Phase 2: Naive delivery-side integration (student prologue/lesson/review)
+
+- Goal: Generalize `Metrics.aggregate_raw_proficiency/1` /
+  `proficiency_for_student_per_learning_objective/3` to call the Phase 1 function instead of its
+  own inline pooling, with no behavior change for existing sections (this call site already
+  behaves like a weighted average today, so this phase is a refactor-in-place, not a functional
+  change).
+- Tasks:
+  - [ ] Replace the inline pooling logic in `aggregate_raw_proficiency/1`
+    (`lib/oli/delivery/metrics.ex:804-823`) with a call to the Phase 1 shared function, passing
+    `num_first_attempts` as `count` for each child (PRD Assumptions).
+  - [ ] Confirm `proficiency_for_student_per_learning_objective/3`
+    (`lib/oli/delivery/metrics.ex:761-802`) still bucket via `proficiency_range/2` on the
+    aggregated score (FR-007).
+  - [ ] Leave `raw_proficiency_per_learning_objective/2`'s SQL-embedded formula
+    (`lib/oli/delivery/metrics.ex:1522-1546`) untouched in this phase; it feeds
+    `proficiency_per_student_for_objective/3`, which Phase 3 addresses separately.
+- Testing Tasks:
+  - [ ] Update/extend existing coverage in `test/oli/analytics/summary/metrics_v2_test.exs` for
+    `aggregate_raw_proficiency/1` and `proficiency_for_student_per_learning_objective/3` to assert
+    unchanged output for current fixtures, plus a new case with an activity tagged to both a
+    parent and a Sub-LO to confirm no double count (AC-004).
+  - [ ] Run the targeted `Phoenix.LiveViewTest` suites for `prologue_live_test.exs`,
+    `lesson_live_test.exs`, and `review_live_test.exs` to confirm no visible regression
+    (AC-007, AC-008).
+  - Command(s): `mix test test/oli/analytics/summary/metrics_v2_test.exs test/oli_web/live/delivery/student/`
+- Definition of Done:
+  - `aggregate_raw_proficiency/1` and its caller delegate to the Phase 1 function.
+  - Existing naive fixtures produce identical output to pre-change behavior.
+- Gate:
+  - Targeted `mix test` above passes; `mix format` clean.
+- Dependencies:
+  - Phase 1.
+- Parallelizable Work:
+  - Can run concurrently with Phase 3 and Phase 4 once Phase 1 is merged; none of the three call
+    sites depend on each other.
+
+## Phase 3: Instructor Dashboard / CSV export integration (the main gap)
+
+- Goal: Make `Sections.get_objectives_and_subobjectives/2` actually combine a parent LO's Sub-LOs
+  into its displayed/exported proficiency, closing the gap the ticket exists to fix, without
+  regressing to per-learner or per-objective query loops.
+- Tasks:
+  - [ ] Extend the query backing `get_objectives_and_subobjectives/2`
+    (`lib/oli/delivery/sections.ex:5914-6185`) and/or
+    `Metrics.proficiency_per_student_for_objective/3` (`lib/oli/delivery/metrics.ex:1509-1556`) to
+    fetch each parent LO's own evidence and its Sub-LOs' evidence in the same set-based pass
+    (resolve the Clarification above), then call the Phase 1 shared function per parent LO per
+    student.
+  - [ ] Ensure double-counting prevention: an activity tagged to both a parent LO and a Sub-LO
+    contributes once, at the Sub-LO (FR-003, AC-004) — reuse whatever tagging-resolution logic
+    Phase 2 established if applicable, rather than re-deriving it.
+  - [ ] Ensure a leaf LO (no `children`) takes the same path it does today and is unaffected
+    (AC-008).
+- Testing Tasks:
+  - [ ] Update `test/oli/delivery/sections_test.exs:3450-3498` (the test that currently asserts
+    the un-aggregated behavior) to assert the new combined result using
+    `setup_objectives_and_activities_test/0` (`test/oli/delivery/sections_test.exs:3711`)
+    (AC-006).
+  - [ ] Add a case for a parent LO with one attempted Sub-LO and one unattempted/under-evidenced
+    Sub-LO, asserting incomplete coverage is reflected rather than treated as fully attempted
+    (AC-005).
+  - [ ] Run `Phoenix.LiveViewTest` coverage for `instructor_dashboard_live_test.exs` and
+    `student_dashboard_live_test.exs`, and controller tests covering
+    `delivery_controller.ex`'s `download_learning_objectives/2` CSV export (AC-006).
+  - Command(s): `mix test test/oli/delivery/sections_test.exs test/oli_web/live/delivery/instructor_dashboard/ test/oli_web/live/delivery/student_dashboard/ test/oli_web/controllers/delivery_controller_test.exs`
+- Definition of Done:
+  - Instructor Dashboard tab, per-student instructor view, and CSV export all show a combined
+    parent LO proficiency for sections with Sub-LO-only tagged evidence.
+  - The previously-passing assertion of non-aggregated behavior is gone, replaced by an assertion
+    of the new behavior.
+- Gate:
+  - Targeted `mix test` above passes; query plan/shape reviewed against PRD Non-Functional
+    Requirements (no N+1 introduced); `mix format` clean.
+- Dependencies:
+  - Phase 1. Not dependent on Phase 2.
+- Parallelizable Work:
+  - Can run concurrently with Phase 2 and Phase 4 once Phase 1 is merged.
+
+## Phase 4: Learning-objectives page element integration
+
+- Goal: Make `PageElement.maybe_proficiency/5` combine Sub-LOs for the
+  `"learning_objectives"` page element, consistent with Phases 2 and 3.
+- Tasks:
+  - [ ] Update `maybe_proficiency/5`
+    (`lib/oli/delivery/learning_objectives/page_element.ex:135-147`) to call the Phase 1 shared
+    function (directly, or via whichever `Metrics`/`Sections` entry point Phase 2/3 expose) for
+    LOs with `children`, instead of returning only the LO's own direct proficiency.
+  - [ ] Confirm `lib/oli/rendering/content/learning_objectives.ex`'s `proficiency_for/2` still
+    renders the same bucket labels it does today; no rendering change should be needed if the
+    upstream data now already reflects the aggregated value.
+- Testing Tasks:
+  - [ ] Add/extend tests for `page_element.ex` covering a parent LO with Sub-LOs and no direct
+    evidence (AC-007).
+  - [ ] Run existing rendering tests for `learning_objectives.ex` to confirm no regression in
+    label/bucket rendering.
+  - Command(s): `mix test test/oli/delivery/learning_objectives/ test/oli/rendering/content/learning_objectives_test.exs`
+- Definition of Done:
+  - The page element shows a combined parent LO proficiency consistent with Phase 3's Instructor
+    Dashboard value for the same student and section.
+- Gate:
+  - Targeted `mix test` above passes; `mix format` clean.
+- Dependencies:
+  - Phase 1. Not dependent on Phase 2 or Phase 3.
+- Parallelizable Work:
+  - Can run concurrently with Phase 2 and Phase 3 once Phase 1 is merged.
+
+## Phase 5: Cross-cutting verification, review, and closeout
+
+- Goal: Confirm the three integrated call sites agree with each other, run full regression, and
+  close out review/requirements/issue-tracking obligations before this work item is considered
+  done.
+- Tasks:
+  - [ ] Manual QA per PRD QA Plan: for one section fixture with a parent LO with Sub-LOs and no
+    direct evidence, confirm the Instructor Dashboard tab, its CSV export, the per-student
+    instructor view, and student prologue/lesson/review views all show the same combined value
+    for the same student; confirm a leaf LO is unchanged.
+  - [ ] Update Jira `MER-5821` with implementation notes/status per `docs/ISSUE_TRACKING.md`.
+  - [ ] Run code review per `docs/CODEREVIEW.md`: `.review/security.md` and `.review/performance.md`
+    always; `.review/elixir.md` (backend Elixir/Ecto/LiveView changes) and `.review/requirements.md`
+    (this PRD's traceability) since both apply to this work item; `.review/ui.md` and
+    `.review/typescript.md` are not expected to apply (no frontend/TypeScript changes).
+- Testing Tasks:
+  - [ ] Run the full affected-area suite: `mix test test/oli/delivery/ test/oli/analytics/summary/ test/oli_web/live/delivery/ test/oli_web/controllers/delivery_controller_test.exs`.
+  - [ ] Run `mix format --check-formatted` across all touched files.
+  - Command(s): `mix test test/oli/delivery/ test/oli/analytics/summary/ test/oli_web/live/delivery/ test/oli_web/controllers/delivery_controller_test.exs`, `mix format --check-formatted`
+- Definition of Done:
+  - All PRD acceptance criteria (AC-001 through AC-010) are demonstrably satisfied by passing
+    automated tests plus the manual QA above.
+  - Code review findings from the applicable `.review/` guides are resolved or explicitly
+    accepted.
+- Gate:
+  - Full targeted test run above is green; code review has no unresolved findings.
+- Dependencies:
+  - Phases 2, 3, and 4 all complete.
+- Parallelizable Work:
+  - None; this phase is the closeout gate after Phases 2-4 converge.
+
+## Parallelization Notes
+
+- Phase 1 is a strict prerequisite for everything else and should be done first, alone.
+- Phases 2, 3, and 4 touch three independent call sites (naive delivery-side pooling, the
+  Instructor Dashboard/Sections path, and the page element) with no code overlap between them, and
+  can be implemented in parallel once Phase 1 is merged.
+- Phase 3 is the largest and most product-visible phase (it is the gap the ticket exists to
+  close) and should not be blocked on Phases 2 or 4 finishing first.
+- Phase 5 must wait for all of Phases 2-4 to land, since its cross-site consistency check requires
+  all three surfaces to already reflect the new aggregation.
+
+## Phase Gate Summary
+
+- Gate A (end of Phase 1): shared aggregation function exists, is unit-tested, and its `@doc`
+  contract is final.
+- Gate B (end of Phases 2-4, in any order): each of the three call sites independently passes its
+  own targeted tests and shows the aggregated value in its own surface.
+- Gate C (end of Phase 5): cross-site consistency confirmed manually, full regression suite green,
+  applicable code review guides clean, Jira `MER-5821` updated.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -125,13 +125,17 @@ implementation, no `learning_model_version` switch changes — those are explici
     fetch each parent LO's own evidence and its Sub-LOs' evidence in the same set-based pass
     (resolve the Clarification above), then call the Phase 1 shared function per parent LO per
     student. Implemented via new `Metrics.raw_proficiency_per_student_for_objective/3` (raw,
-    not-yet-bucketed extraction of the existing query) and a new `Sections.aggregated_proficiency_bucket/3`.
-  - [x] ~~Ensure double-counting prevention...~~ **Superseded after Phase 4** — see the
-    Post-Phase-4 Correction note below. Originally implemented as exclusion of a parent's own
-    evidence whenever it has Sub-LOs (mirroring `Metrics.proficiency_for_student_per_learning_objective/3`'s
-    pre-existing 2024 behavior); Darren Siegel confirmed on Slack (2026-09-01) that the parent's
-    own evidence should always be combined with its Sub-LOs' evidence instead (FR-003, AC-004),
-    accepting the resulting double-counting risk when an activity is tagged to both levels.
+    not-yet-bucketed extraction of the existing query); the bucketing helper was later relocated
+    to the shared `Metrics.proficiency_bucket_for_student/3` (see the Post-Phase-4 Correction note
+    below).
+  - [ ] ~~Ensure double-counting prevention...~~ **NOT done — deliberately superseded after
+    Phase 4**, see the Post-Phase-4 Correction note below. This task, as originally written, was
+    initially implemented (exclusion of a parent's own evidence whenever it has Sub-LOs, mirroring
+    `Metrics.proficiency_for_student_per_learning_objective/3`'s pre-existing 2024 behavior), then
+    explicitly reversed: Darren Siegel confirmed on Slack (2026-09-01) that the parent's own
+    evidence should always be combined with its Sub-LOs' evidence instead (FR-003, AC-004),
+    accepting the resulting double-counting risk when an activity is tagged to both levels. Left
+    unchecked because double-counting prevention is not what the shipped code does.
   - [x] Ensure a leaf LO (no `children`) takes the same path it does today and is unaffected
     (AC-008).
 - Testing Tasks:
@@ -243,6 +247,35 @@ Retrofit applied across all phases already implemented:
 No further phase renumbering was needed — Phase 5 (below) still applies to the corrected
 implementation.
 
+## Post-Correction Cleanup: consolidating the student-facing call site onto shared primitives
+
+A branch-wide `/simplify`-style review (reuse, simplification, efficiency, altitude lenses)
+surfaced that `Metrics.proficiency_for_student_per_learning_objective/3` (Phase 2's call site)
+still used its own private raw-fetch/aggregate pair — `raw_proficiency_per_learning_objective/2`
+plus `aggregate_raw_proficiency/1` and `naive_child_proficiency/2` — instead of the
+`raw_proficiency_per_student_for_objective/3` + `evidence_resource_ids/2` +
+`proficiency_bucket_for_student/3` pipeline the Instructor Dashboard and page element call sites
+already shared. This was accumulated phasing debt (Phase 2 predates the cleaner primitives Phase 3
+introduced), not a deliberate design choice, and duplicated the naive proficiency formula
+byte-for-byte in both Elixir and SQL.
+
+`proficiency_for_student_per_learning_objective/3` was refactored to call
+`raw_proficiency_per_student_for_objective/3` and `proficiency_bucket_for_student/3` directly, and
+the now-fully-unused private helpers `aggregate_raw_proficiency/1` and `naive_child_proficiency/2`
+were deleted. `raw_proficiency_per_learning_objective/2` itself was **not** removed — it remains a
+public function used independently by `Oli.Scenarios.Directives.Assert.ProficiencyAssertion` and
+covered by its own dedicated test in `metrics_v2_test.exs`, outside this ticket's scope. Verified
+mathematically equivalent (every objective-type `ResourceSummary` row uses a fixed `part_id`, so
+`GROUP BY`+`SUM` over that one row equals reading it directly) and confirmed by the full existing
+test suite plus the `Oli.Scenarios` suite (which exercises `raw_proficiency_per_learning_objective/2`
+via the assertion directive above) — no test changes were required for this refactor.
+
+Also fixed in the same pass: a genuinely dead `aggregate_raw_proficiency([])` clause (the general
+clause already produced the identical result), an unnecessary defensive `List.wrap/1` in
+`page_element.ex` (the depot always normalizes `children` to a list, never `nil`), and this file's
+own stale reference to `Sections.aggregated_proficiency_bucket/3` (see the Phase 3 task note
+above, corrected to point at its final home).
+
 ## Phase 5: Cross-cutting verification, review, and closeout
 
 - Goal: Confirm the three integrated call sites agree with each other, run full regression, and
@@ -252,7 +285,12 @@ implementation.
   - [ ] Manual QA per PRD QA Plan: for one section fixture with a parent LO with Sub-LOs and no
     direct evidence, confirm the Instructor Dashboard tab, its CSV export, the per-student
     instructor view, and student prologue/lesson/review views all show the same combined value
-    for the same student; confirm a leaf LO is unchanged.
+    for the same student; confirm a leaf LO is unchanged. **Also** cover the scenario that
+    actually changed behavior under the Post-Phase-4 Correction (Option B): a parent LO that has
+    *both* its own directly-tagged evidence *and* a Sub-LO with evidence — confirm all four
+    surfaces show the same combined value (not the parent's own value alone, and not "not enough
+    data"). The "no direct evidence" scenario alone behaves identically whether or not the
+    parent's own evidence is combined, so it does not exercise Option B on its own.
   - [ ] Update Jira `MER-5821` with implementation notes/status per `docs/ISSUE_TRACKING.md`.
   - [ ] Run code review per `docs/CODEREVIEW.md`: `.review/security.md` and `.review/performance.md`
     always; `.review/elixir.md` (backend Elixir/Ecto/LiveView changes) and `.review/requirements.md`

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -47,23 +47,23 @@ implementation, no `learning_model_version` switch changes — those are explici
 - Goal: Introduce the algorithm-agnostic weighted-aggregation function with its documented
   `count` contract, fully unit-tested in isolation, with no call site wired to it yet.
 - Tasks:
-  - [ ] Decide the function's home module/name (default assumption above) and add it with the
+  - [x] Decide the function's home module/name (default assumption above) and add it with the
     exact `@doc` text agreed in `prd.md` / `informal.md` (must be preserved verbatim, not
-    rewritten).
-  - [ ] Implement `score = Σ(proficiency_i × count_i) / Σ(count_i)` over a list of
+    rewritten). Implemented as `Oli.Delivery.Metrics.aggregate_weighted_proficiency/1`.
+  - [x] Implement `score = Σ(proficiency_i × count_i) / Σ(count_i)` over a list of
     `(proficiency, count)` pairs, including a parent's own direct `(proficiency, count)` pair
     when present (FR-001).
-  - [ ] Handle a child with `count == 0` or unset/`nil` proficiency without excluding it from the
+  - [x] Handle a child with `count == 0` or unset/`nil` proficiency without excluding it from the
     aggregation's evidence accounting (FR-004) — it must still be representable so the caller can
     detect incomplete coverage, not silently vanish from the computation.
-  - [ ] Do not implement bucketing inside this function; it returns the weighted score (and total
+  - [x] Do not implement bucketing inside this function; it returns the weighted score (and total
     evidence count) only (FR-007, PRD Assumptions).
 - Testing Tasks:
-  - [ ] ExUnit unit tests: multiple Sub-LOs with different counts (AC-001); parent with both
+  - [x] ExUnit unit tests: multiple Sub-LOs with different counts (AC-001); parent with both
     direct evidence and Sub-LOs (AC-002); a Sub-LO with zero/insufficient evidence not silently
     dropped (AC-005); deterministic output for repeated calls with the same inputs (PRD
     Non-Functional Requirements).
-  - Command(s): `mix test <new test file path>`
+  - Command(s): `mix test test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs`
 - Definition of Done:
   - Function exists, is unit-tested per the cases above, and its `@doc` matches the agreed text
     exactly.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/plan.md
@@ -95,8 +95,9 @@ implementation, no `learning_model_version` switch changes — those are explici
 - Testing Tasks:
   - [x] Update/extend existing coverage in `test/oli/analytics/summary/metrics_v2_test.exs` for
     `aggregate_raw_proficiency/1` and `proficiency_for_student_per_learning_objective/3` to assert
-    unchanged output for current fixtures, plus a new case with an activity tagged to both a
-    parent and a Sub-LO to confirm no double count (AC-004).
+    unchanged output for current fixtures, plus a new case covering a parent LO that has both its
+    own directly-tagged evidence and a Sub-LO (AC-004; the double-counting outcome for this case
+    was revised after Phase 4 — see the Post-Phase-4 Correction note below).
   - [x] Run the targeted `Phoenix.LiveViewTest` suites for `prologue_live_test.exs`,
     `lesson_live_test.exs`, and `review_live_test.exs` to confirm no visible regression
     (AC-007, AC-008).
@@ -125,11 +126,12 @@ implementation, no `learning_model_version` switch changes — those are explici
     (resolve the Clarification above), then call the Phase 1 shared function per parent LO per
     student. Implemented via new `Metrics.raw_proficiency_per_student_for_objective/3` (raw,
     not-yet-bucketed extraction of the existing query) and a new `Sections.aggregated_proficiency_bucket/3`.
-  - [x] Ensure double-counting prevention: an activity tagged to both a parent LO and a Sub-LO
-    contributes once, at the Sub-LO (FR-003, AC-004) — reuse whatever tagging-resolution logic
-    Phase 2 established if applicable, rather than re-deriving it. Implemented via
-    `Sections.objective_evidence_resource_ids/1`, mirroring `Metrics.proficiency_for_student_per_learning_objective/3`'s
-    exclusion of a parent's own evidence whenever it has Sub-LOs.
+  - [x] ~~Ensure double-counting prevention...~~ **Superseded after Phase 4** — see the
+    Post-Phase-4 Correction note below. Originally implemented as exclusion of a parent's own
+    evidence whenever it has Sub-LOs (mirroring `Metrics.proficiency_for_student_per_learning_objective/3`'s
+    pre-existing 2024 behavior); Darren Siegel confirmed on Slack (2026-09-01) that the parent's
+    own evidence should always be combined with its Sub-LOs' evidence instead (FR-003, AC-004),
+    accepting the resulting double-counting risk when an activity is tagged to both levels.
   - [x] Ensure a leaf LO (no `children`) takes the same path it does today and is unaffected
     (AC-008).
 - Testing Tasks:
@@ -162,17 +164,24 @@ implementation, no `learning_model_version` switch changes — those are explici
 - Goal: Make `PageElement.maybe_proficiency/5` combine Sub-LOs for the
   `"learning_objectives"` page element, consistent with Phases 2 and 3.
 - Tasks:
-  - [ ] Update `maybe_proficiency/5`
+  - [x] Update `maybe_proficiency/5`
     (`lib/oli/delivery/learning_objectives/page_element.ex:135-147`) to call the Phase 1 shared
     function (directly, or via whichever `Metrics`/`Sections` entry point Phase 2/3 expose) for
-    LOs with `children`, instead of returning only the LO's own direct proficiency.
-  - [ ] Confirm `lib/oli/rendering/content/learning_objectives.ex`'s `proficiency_for/2` still
+    LOs with `children`, instead of returning only the LO's own direct proficiency. Implemented
+    as `maybe_proficiency/6` (gained an `objectives_with_children` param, shared with
+    `do_included_objectives/3` to avoid a duplicate depot fetch), consuming two functions
+    extracted from `Sections` into `Metrics` for reuse across all three call sites:
+    `Metrics.evidence_resource_ids/2` and `Metrics.proficiency_bucket_for_student/3`.
+  - [x] Confirm `lib/oli/rendering/content/learning_objectives.ex`'s `proficiency_for/2` still
     renders the same bucket labels it does today; no rendering change should be needed if the
-    upstream data now already reflects the aggregated value.
+    upstream data now already reflects the aggregated value. Confirmed unchanged; the module was
+    not touched by this phase.
 - Testing Tasks:
-  - [ ] Add/extend tests for `page_element.ex` covering a parent LO with Sub-LOs and no direct
-    evidence (AC-007).
-  - [ ] Run existing rendering tests for `learning_objectives.ex` to confirm no regression in
+  - [x] Add/extend tests for `page_element.ex` covering a parent LO with Sub-LOs and no direct
+    evidence (AC-007). Includes a case where the Sub-LO has no activity within the page
+    element's own render scope, cross-checked directly against
+    `Sections.get_objectives_and_subobjectives/2` for the same student/section.
+  - [x] Run existing rendering tests for `learning_objectives.ex` to confirm no regression in
     label/bucket rendering.
   - Command(s): `mix test test/oli/delivery/learning_objectives/ test/oli/rendering/content/learning_objectives_test.exs`
 - Definition of Done:
@@ -184,6 +193,55 @@ implementation, no `learning_model_version` switch changes — those are explici
   - Phase 1. Not dependent on Phase 2 or Phase 3.
 - Parallelizable Work:
   - Can run concurrently with Phase 2 and Phase 3 once Phase 1 is merged.
+
+## Post-Phase-4 Correction: parent's own evidence is always combined, not excluded
+
+After Phase 4 was implemented and committed, further review of the case where a parent LO has
+Sub-LOs but neither the parent nor its Sub-LOs necessarily have overlapping evidence surfaced a
+genuine open question the PRD/requirements.yml had not resolved precisely: should a parent LO's
+own directly-tagged evidence ever be excluded from its aggregated proficiency, and if so, when?
+
+Phases 2–4 as originally implemented answered this by excluding a parent's own evidence entirely
+whenever it had any Sub-LOs (mirroring `Metrics.proficiency_for_student_per_learning_objective/3`'s
+pre-existing 2024 behavior from ticket NG23-252). This avoided double-counting an activity tagged
+to both a parent and a Sub-LO, but it also meant a parent with substantial, genuinely independent
+direct evidence could show "Not enough data" indefinitely if its Sub-LOs were never tagged to any
+activity — a real regression risk for existing course content, since a separate, already-filed
+ticket will restrict this kind of parent-level tagging only for **new** courses going forward, not
+retroactively.
+
+Four alternatives (exact activity-level reconciliation, always combining, prefer-Sub-LOs-with-a-
+fallback, and always-Sub-LOs-only) were compared, with worked numeric examples, in
+`parent_evidence_aggregation_options.md` in this directory. **Darren Siegel confirmed on Slack
+(2026-09-01)** that always combining a parent's own evidence with its Sub-LOs' evidence ("Option
+B") is "the simplest thing that we can (and should) do" — explicitly accepting the resulting
+double-counting risk when an activity happens to be tagged to both a parent and one of its
+Sub-LOs, rather than building the more expensive exact-reconciliation approach or the fallback
+approach. This decision supersedes the original Jira ticket's own AC that such an activity's
+evidence must count only once, at the Sub-LO.
+
+Retrofit applied across all phases already implemented:
+
+- `Metrics.evidence_resource_ids/2` (introduced in Phase 4, shared by all three call sites) now
+  unconditionally returns `[resource_id | children]` instead of excluding `resource_id` whenever
+  `children` is non-empty.
+- `Metrics.proficiency_for_student_per_learning_objective/3` (Phase 2's call site, and the
+  pre-existing 2024 logic it was refactored from) now delegates to `evidence_resource_ids/2` as
+  well, replacing its own separate `if rev.children == [] do ... else ... end` exclusion with the
+  same always-combine rule — unifying all three call sites onto one shared implementation of this
+  rule instead of two independent copies.
+- `Sections.get_objectives_and_subobjectives/2` and `PageElement.maybe_proficiency/6` required no
+  code changes themselves, since both already delegated to `Metrics.evidence_resource_ids/2`.
+- Every test asserting the old exclusion behavior was recomputed and updated for the new combined
+  result: `test/oli/analytics/summary/metrics_v2_test.exs`, `test/oli/delivery/sections_test.exs`
+  ("filters by student_id when provided"), and
+  `test/oli/delivery/learning_objectives/page_element_test.exs` (both the resource_ids-fetched
+  assertion and the combined-proficiency assertion).
+- `informal.md`, `prd.md`, and `requirements.yml` (FR-003/AC-004) were updated to describe the new
+  rule and record the decision and its rationale.
+
+No further phase renumbering was needed — Phase 5 (below) still applies to the corrected
+implementation.
 
 ## Phase 5: Cross-cutting verification, review, and closeout
 

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
@@ -1,0 +1,268 @@
+# MER-5821: Aggregate Child Learning Objective Proficiency into Parent Learning Objectives - Product Requirements Document
+
+## 1. Overview
+
+Torus calculates learner proficiency at the Sub-Objective (Sub-LO) level from tagged activity
+evidence. When a Learning Objective (LO) has one or more Sub-LOs, its own proficiency should
+reflect a weighted combination of its Sub-LOs' proficiency (and any evidence tagged directly to
+the parent), rather than only its own directly-tagged evidence. Today this rollup either behaves
+inconsistently across the codebase or does not happen at all in some surfaces, so a parent LO with
+only Sub-LO-tagged activity shows "not enough data" even when its Sub-LOs have ample evidence.
+
+This work item introduces a single, algorithm-agnostic weighted-aggregation function and unifies
+the authoring- and delivery-side call sites that need it, so that parent LO proficiency reflects
+its Sub-LOs consistently everywhere it is shown, while remaining a runtime projection (not a
+persisted, write-time calculation) and remaining reusable by both the current naive proficiency
+algorithm and the forthcoming LKT-AOA learner model (`MER-5846`).
+
+## 2. Background & Problem Statement
+
+The Jira ticket `MER-5821` originally asked for equal-weight aggregation and was ambiguous about
+whether aggregation should move from a runtime projection to a persisted calculation. Review
+comments from Darren Siegel resolved both points: timing stays a runtime projection, and the
+formula is a weighted average, weighted by the amount of evidence available per Sub-LO — not
+equal weighting. Darren also asked that every place in the system performing this rollup, both
+authoring and delivery, be found and updated together, rather than patched one at a time.
+
+A code audit (see `informal.md` in this directory) found that the rollup is inconsistent today:
+
+- Delivery, student-facing proficiency (`Metrics.aggregate_raw_proficiency/1`) already pools
+  evidence across a parent's children before dividing, so it already behaves like a weighted
+  average, but it is coded directly against the naive first-attempt formula.
+- The Instructor Dashboard Learning Objectives tab, the instructor's per-student view, and the
+  Learning Objectives CSV export (`Sections.get_objectives_and_subobjectives/2`) do not combine a
+  parent's Sub-LOs at all — a parent LO's displayed proficiency comes only from its own direct
+  evidence, which is usually absent because authors tag activities at the Sub-LO level.
+  Existing test coverage (`test/oli/delivery/sections_test.exs:3450-3498`) documents and asserts
+  this gap as current behavior.
+- A new delivery-side page element (`PageElement.maybe_proficiency/5`) also does not combine
+  Sub-LOs.
+
+Separately, epic `MER-5843` ("Learning Proficiency Model Improvements") is replacing the naive
+proficiency algorithm with LKT-AOA (`MER-5846`) behind a `learning_model_version` switch already
+implemented in code (`MER-5845`). `MER-5846`'s own acceptance criteria explicitly exclude LO
+aggregation from its scope, and the LKT-AOA technical definition
+(`docs/exec-plans/current/epics/learning_model_v2/lkt_technical_notes.docx.md`, section 6) already
+specifies its own weighted-average rollup rule. This work item's aggregation function must serve
+both the current naive algorithm and this future LKT-AOA rollup without depending on either one's
+internals.
+
+## 3. Goals & Non-Goals
+
+### Goals
+- Provide a single, algorithm-agnostic weighted-aggregation function that produces a parent LO's
+  proficiency score from `(proficiency, count)` pairs contributed by its Sub-LOs (and, when
+  present, its own directly-tagged evidence).
+- Make the function's `count` contract explicit: the caller supplies a count consistent with
+  whichever algorithm computed that child's proficiency (naive: first-attempt count; LKT-AOA:
+  total/opportunity count), and the function documents this responsibility rather than guessing.
+- Audit and update every runtime call site that rolls up (or should roll up) Sub-LO proficiency
+  into a parent LO — both authoring-facing and delivery-facing — so they all consume the shared
+  function instead of duplicating or omitting the rollup.
+- Preserve the existing double-counting rule: an activity tagged to both a parent LO and one of
+  its Sub-LOs counts once, at the Sub-LO.
+- Preserve incomplete-coverage semantics: a Sub-LO with insufficient evidence is represented in
+  the aggregation rather than silently excluded, so the parent reflects incomplete coverage
+  instead of behaving as though only the attempted Sub-LOs exist.
+- Keep the aggregated result flowing through the same bucketing behavior naive callers use today
+  (`Metrics.proficiency_range/2`), so the Not Enough Information / Low / Medium / High
+  distribution shown for a parent LO reflects its combined evidence.
+
+### Non-Goals
+- Changing when aggregation happens. It remains a runtime projection computed when proficiency is
+  read, not persisted at attempt-evaluation time.
+- Implementing the LKT-AOA learner model itself (`MER-5846`) or its `learning_state` data path.
+- Implementing or changing the `learning_model_version` project/section switch (`MER-5845`); it
+  already exists in code and this work item only needs to be safe to call regardless of which
+  version is active.
+- Implementing the Confidence metric (`MER-5847`).
+- Designing or building the coverage-gap-indicator UI described in the LKT-AOA technical notes
+  (section 6.3); that needs separate UX design work.
+- Reworking the whole-class "Average Class Proficiency" aggregation
+  (`data_snapshot/projections/summary/projector.ex` and its CSV helper) or its pre-existing
+  20/60/100 vs. 30/60/90 bucket-weight inconsistency; that aggregates across students, not across
+  an LO hierarchy, and is a separate concern.
+- Changing `Oli.InstructorDashboard.Oracles.ProgressProficiency`'s page/container-scoped
+  proficiency calculation; it does not perform LO parent/Sub-LO rollup.
+
+## 4. Users & Use Cases
+
+- Instructor: views the Learning Objectives tab of the Instructor Dashboard and expects a parent
+  LO's proficiency distribution to reflect the combined evidence of all its Sub-LOs, not just
+  activity tagged directly to the parent.
+- Instructor: exports the Learning Objectives CSV and expects the same combined proficiency values
+  as the on-screen tab.
+- Instructor: views a single student's proficiency on the per-student instructor view and expects
+  the same combined parent-LO behavior.
+- Student: views their own proficiency (prologue, lesson, and review pages) for a parent LO and
+  expects it to reflect their performance across that LO's Sub-LOs.
+- Author/researcher (indirect, future): the LKT-AOA implementation (`MER-5846`) will call the same
+  aggregation function once it exists, so it does not need to reimplement parent-LO rollup.
+
+## 5. UX / UI Requirements
+
+- No new UI. Existing surfaces (Instructor Dashboard Learning Objectives tab, per-student
+  instructor view, Learning Objectives CSV export, student prologue/lesson/review proficiency
+  displays, and the `"learning_objectives"` page element) should start showing a combined parent
+  LO value where they previously showed "not enough data" or an un-aggregated direct-only value.
+- No copy changes are required by this work item. If the resulting values differ visibly from
+  today's (e.g., a parent LO that previously showed "Not enough data" now shows a computed
+  proficiency), no additional UI treatment is required beyond what each surface already renders
+  for that bucket.
+
+## 6. Functional Requirements
+
+Requirements are found in requirements.yml
+
+## 7. Acceptance Criteria (Testable)
+
+Requirements are found in requirements.yml
+
+## 8. Non-Functional Requirements
+
+- Reliability: the aggregation function must produce a deterministic result for a given set of
+  `(proficiency, count)` inputs and must not raise on the boundary cases already covered by
+  existing tests (no children, all children below the minimum-evidence threshold, a child with a
+  `nil`/unset proficiency).
+- Performance: updated call sites (in particular the Instructor Dashboard tab and its CSV export,
+  which operate over a full section roster) must continue to use set-based, per-section queries
+  rather than issuing one query per learner or per objective, consistent with
+  `docs/BACKEND.md` and the existing query shape in `Sections.get_objectives_and_subobjectives/2`.
+- Compatibility: the change must not alter the meaning of `Metrics.proficiency_range/2`'s existing
+  thresholds or the naive model's current behavior for LOs that have no Sub-LOs (i.e., leaf LOs
+  keep their current single-node calculation unchanged).
+
+## 9. Data, Interfaces & Dependencies
+
+- `Oli.Resources.Revision.children` (objective hierarchy) and `Oli.Resources.Revision.objectives`
+  (activity-to-objective tagging) are the source of the parent/Sub-LO relationship and evidence
+  attribution; no schema changes are introduced by this work item.
+- `Oli.Analytics.Summary.ResourceSummary` remains the source of naive-model evidence counts
+  (`num_first_attempts`, `num_first_attempts_correct`).
+- New shared function (exact module/function name to be decided during planning/implementation)
+  consumed by:
+  - `Oli.Delivery.Metrics.aggregate_raw_proficiency/1` /
+    `proficiency_for_student_per_learning_objective/3` (`lib/oli/delivery/metrics.ex`)
+  - `Oli.Delivery.Sections.get_objectives_and_subobjectives/2` (`lib/oli/delivery/sections.ex`),
+    via `Metrics.proficiency_per_student_for_objective/3`
+  - `Oli.Delivery.LearningObjectives.PageElement.maybe_proficiency/5`
+    (`lib/oli/delivery/learning_objectives/page_element.ex`)
+- Depends on (does not implement): `Oli.LearningModel.ModelVersion` and the
+  `learning_model_version` field on `Oli.Authoring.Course.Project` /
+  `Oli.Delivery.Sections.Section` (already implemented via `MER-5845`/the `data_model` work item).
+- Depends on, does not block on: `MER-5846` (LKT-AOA learner model) for the eventual LKT-AOA
+  caller of this function; `MER-5847` (Confidence) for any future coverage/confidence signal.
+- Reference: `docs/exec-plans/current/epics/learning_model_v2/lkt_technical_notes.docx.md`
+  section 6 is the authoritative source for the LKT-AOA-side weighting rule this function's
+  contract is designed to also support.
+
+## 10. Repository & Platform Considerations
+
+- Backend-only change in Elixir (`lib/oli/delivery/`), per `docs/BACKEND.md` domain boundaries;
+  no `assets/src` (React/TypeScript) changes are expected since no aggregation logic exists on the
+  frontend today (all call sites consume already-aggregated backend data).
+- Follows `docs/TESTING.md`: cover the new aggregation function with ExUnit unit tests, and cover
+  the updated call sites with the existing test types already used for them (ExUnit for
+  `Sections`/`Metrics`, `Phoenix.LiveViewTest` for the LiveView-driven surfaces where behavior
+  changes are user-visible).
+- `test/oli/delivery/sections_test.exs:3450-3498` currently asserts the pre-aggregation behavior
+  for `get_objectives_and_subobjectives/2` and must be updated to reflect the new aggregated
+  result rather than deleted or ignored.
+- `setup_objectives_and_activities_test/0` (`test/oli/delivery/sections_test.exs:3711`) already
+  builds a 2-level Sub-LO hierarchy with parent- and child-tagged activities and is the expected
+  fixture base for new aggregation test coverage.
+
+## 11. Feature Flagging, Rollout & Migration
+
+No feature flags present in this work item
+
+## 12. Telemetry & Success Metrics
+
+- No new telemetry events are introduced by this work item. Existing AppSignal/Phoenix telemetry
+  around the updated LiveViews and controller action (`delivery_controller.ex`'s
+  `download_learning_objectives/2`) continues to apply unchanged.
+- Success signal: the Instructor Dashboard Learning Objectives tab, its CSV export, the per-student
+  instructor view, and student-facing proficiency displays show a non-"not enough data" parent LO
+  value whenever its Sub-LOs collectively have sufficient evidence, even when the parent itself has
+  no directly-tagged activity.
+
+## 13. Risks & Mitigations
+
+- Risk: mismatching `count` semantics between the naive and a future LKT-AOA caller could silently
+  skew the weighted average. Mitigation: the function's documentation states the contract
+  explicitly and assigns responsibility to the caller; naive callers are updated in this work item
+  to supply `num_first_attempts` consistently.
+- Risk: unifying three call sites that currently behave differently (one already
+  weighted-average-like, two with no aggregation at all) could change displayed values for
+  existing sections in ways instructors notice. Mitigation: this is the intended, requested
+  behavior change (per Darren Siegel's ticket comments); no additional mitigation beyond correct
+  implementation and test coverage is in scope here.
+- Risk: `Sections.get_objectives_and_subobjectives/2` is used for full-roster, per-section
+  Instructor Dashboard reads; adding aggregation could reintroduce N+1 query behavior if
+  implemented naively per-learner/per-objective. Mitigation: keep the aggregation set-based,
+  consistent with the function's existing query shape (see Non-Functional Requirements).
+- Risk: the exact API LKT-AOA (`MER-5846`) will use to supply its `count` value is not yet built,
+  so this work item cannot add a real LKT-AOA caller yet. Mitigation: the shared function's
+  contract is designed against the confirmed LKT-AOA technical specification (section 6.2) so that
+  wiring in the eventual LKT-AOA caller is additive once `MER-5846` exists.
+
+## 14. Open Questions & Assumptions
+
+### Open Questions
+- The exact data-access API `MER-5846` (LKT-AOA) will expose for a Sub-LO's total
+  "opportunity"/attempt count is not yet defined, since that model has not been implemented. The
+  aggregation rule itself (weighted by opportunities) is confirmed by the LKT-AOA technical notes
+  section 6.2; only the concrete Elixir interface to read that count from the eventual
+  `learning_state`-backed implementation remains open, and is `MER-5846`'s responsibility to
+  expose, not this work item's to guess.
+- Whether the shared aggregation function should also return enough information (e.g., per-child
+  coverage) for a future coverage-gap indicator (LKT-AOA technical notes section 6.3), or whether
+  that is added later when the indicator's UX is designed, is not yet decided. This work item
+  assumes the minimal contract (aggregate score + total count) is sufficient for now, since the
+  indicator's visual design is explicitly not ready.
+
+### Assumptions
+- The naive algorithm's per-child weight is `num_first_attempts`, matching that algorithm's own
+  proficiency calculation, which already uses only first attempts.
+- The LKT-AOA algorithm's per-child weight will be its total attempt ("opportunity") count, per
+  the LKT-AOA technical notes section 6.2 (`Σ opportunities`), once `MER-5846` exists.
+- Bucketing (mapping a weighted score to Not Enough Information / Low / Medium / High) stays
+  owned by each algorithm's caller rather than being embedded in the shared aggregation function,
+  because the two algorithms' minimum-evidence eligibility rules differ (naive: 3 first attempts
+  on the pooled result; LKT-AOA per its technical notes: 3 attempts per Sub-LO). The naive caller
+  continues to use the existing `Metrics.proficiency_range/2`.
+- No database schema changes are required; this is a pure computation/query-composition change
+  over existing data.
+
+## 15. QA Plan
+
+- Automated validation:
+  - Run Harness requirements capture, requirements structure validation, and PRD validation.
+  - New ExUnit unit tests for the shared aggregation function covering: multiple Sub-LOs with
+    different evidence counts, a parent with both directly-tagged evidence and Sub-LOs, a Sub-LO
+    with zero/insufficient evidence (coverage not silently dropped), and an activity tagged to
+    both parent and Sub-LO (counted once).
+  - Updated/added ExUnit coverage in `test/oli/delivery/sections_test.exs` for
+    `get_objectives_and_subobjectives/2`, replacing the assertion at lines 3450-3498 that
+    currently documents the un-aggregated behavior.
+  - Updated/added coverage for `Metrics.aggregate_raw_proficiency/1` and
+    `proficiency_for_student_per_learning_objective/3` if their signature or behavior changes
+    during extraction to the shared function.
+  - `Phoenix.LiveViewTest` coverage for `instructor_dashboard_live.ex`, `student_dashboard_live.ex`,
+    `prologue_live.ex`, `lesson_live.ex`, and `review_live.ex` where the rendered proficiency value
+    is user-visible and expected to change for fixtures with Sub-LOs.
+  - Run the affected `mix test` targets and `mix format`; run the broader `mix test` suite as
+    implementation risk warrants, per `docs/TESTING.md`.
+- Manual validation:
+  - Inspect the Instructor Dashboard Learning Objectives tab and its CSV export for a section with
+    a parent LO that has Sub-LOs and no direct evidence, confirming a combined value now appears
+    instead of "not enough data".
+  - Inspect student prologue/lesson/review proficiency displays for the same fixture from the
+    student's perspective.
+  - Confirm a leaf LO (no Sub-LOs) is unaffected and shows the same value as before.
+
+## 16. Definition of Done
+
+- [ ] PRD sections complete
+- [ ] requirements.yml captured and valid
+- [ ] validation passes

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
@@ -145,13 +145,14 @@ Requirements are found in requirements.yml
   attribution; no schema changes are introduced by this work item.
 - `Oli.Analytics.Summary.ResourceSummary` remains the source of naive-model evidence counts
   (`num_first_attempts`, `num_first_attempts_correct`).
-- New shared function (exact module/function name to be decided during planning/implementation)
-  consumed by:
-  - `Oli.Delivery.Metrics.aggregate_raw_proficiency/1` /
-    `proficiency_for_student_per_learning_objective/3` (`lib/oli/delivery/metrics.ex`)
+- Shared functions, implemented as `Metrics.aggregate_weighted_proficiency/1`,
+  `Metrics.evidence_resource_ids/2`, and `Metrics.proficiency_bucket_for_student/3`
+  (`lib/oli/delivery/metrics.ex`), consumed identically by all three call sites:
+  - `Oli.Delivery.Metrics.proficiency_for_student_per_learning_objective/3`
+    (`lib/oli/delivery/metrics.ex`)
   - `Oli.Delivery.Sections.get_objectives_and_subobjectives/2` (`lib/oli/delivery/sections.ex`),
-    via `Metrics.proficiency_per_student_for_objective/3`
-  - `Oli.Delivery.LearningObjectives.PageElement.maybe_proficiency/5`
+    via `Metrics.raw_proficiency_per_student_for_objective/3`
+  - `Oli.Delivery.LearningObjectives.PageElement.maybe_proficiency/6`
     (`lib/oli/delivery/learning_objectives/page_element.ex`)
 - Depends on (does not implement): `Oli.LearningModel.ModelVersion` and the
   `learning_model_version` field on `Oli.Authoring.Course.Project` /
@@ -257,15 +258,15 @@ No feature flags present in this work item
 - Automated validation:
   - Run Harness requirements capture, requirements structure validation, and PRD validation.
   - New ExUnit unit tests for the shared aggregation function covering: multiple Sub-LOs with
-    different evidence counts, a parent with both directly-tagged evidence and Sub-LOs, a Sub-LO
-    with zero/insufficient evidence (coverage not silently dropped), and an activity tagged to
-    both parent and Sub-LO (counted once).
+    different evidence counts, a parent with both directly-tagged evidence and Sub-LOs (always
+    combined, per the confirmed "Option B" decision — see `parent_evidence_aggregation_options.md`;
+    an activity tagged to both a parent and a Sub-LO is deliberately NOT deduplicated), and a
+    Sub-LO with zero/insufficient evidence (coverage not silently dropped).
   - Updated/added ExUnit coverage in `test/oli/delivery/sections_test.exs` for
     `get_objectives_and_subobjectives/2`, replacing the assertion at lines 3450-3498 that
     currently documents the un-aggregated behavior.
-  - Updated/added coverage for `Metrics.aggregate_raw_proficiency/1` and
-    `proficiency_for_student_per_learning_objective/3` if their signature or behavior changes
-    during extraction to the shared function.
+  - Updated/added coverage for `Metrics.proficiency_for_student_per_learning_objective/3` if its
+    signature or behavior changes during extraction to the shared function.
   - `Phoenix.LiveViewTest` coverage for `instructor_dashboard_live.ex`, `student_dashboard_live.ex`,
     `prologue_live.ex`, `lesson_live.ex`, and `review_live.ex` where the rendered proficiency value
     is user-visible and expected to change for fixtures with Sub-LOs.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/prd.md
@@ -59,8 +59,14 @@ internals.
 - Audit and update every runtime call site that rolls up (or should roll up) Sub-LO proficiency
   into a parent LO — both authoring-facing and delivery-facing — so they all consume the shared
   function instead of duplicating or omitting the rollup.
-- Preserve the existing double-counting rule: an activity tagged to both a parent LO and one of
-  its Sub-LOs counts once, at the Sub-LO.
+- Always combine a parent LO's own directly-tagged evidence with its Sub-LOs' evidence in the
+  weighted average whenever the parent has evidence of its own — never excluding it because the
+  parent has Sub-LOs, and never treating it as a fallback used only when Sub-LOs lack evidence.
+  This supersedes the original Jira ticket's own AC (an activity tagged to both a parent LO and
+  one of its Sub-LOs must count only once, at the Sub-LO); Darren Siegel confirmed on Slack
+  (2026-09-01) that always combining ("Option B") is "the simplest thing that we can (and should)
+  do," accepting the resulting double-counting risk when an activity is tagged to both levels. See
+  `parent_evidence_aggregation_options.md` for the alternatives considered and their trade-offs.
 - Preserve incomplete-coverage semantics: a Sub-LO with insufficient evidence is represented in
   the aggregation rather than silently excluded, so the parent reflects incomplete coverage
   instead of behaving as though only the attempted Sub-LOs exist.
@@ -188,6 +194,18 @@ No feature flags present in this work item
 
 ## 13. Risks & Mitigations
 
+- Risk: an activity tagged to both a parent LO and one of its Sub-LOs is double-counted (its
+  evidence contributes once via the parent's own row and again via the Sub-LO's row), since the
+  parent's own evidence and its Sub-LOs' evidence are always combined (Option B). Mitigation:
+  **none — this is an accepted risk, not mitigated by this work item.** Darren Siegel confirmed on
+  Slack (2026-09-01) that always combining is "the simplest thing that we can (and should) do,"
+  explicitly choosing this over three alternatives that would avoid or reduce the double-counting
+  (see `parent_evidence_aggregation_options.md`) because those alternatives either require
+  materially more engineering effort (querying raw attempt data instead of the pre-aggregated
+  `ResourceSummary` rows this work item's other call sites rely on) or their own worse trade-offs
+  (silently discarding a parent's real evidence in other scenarios). How common double-tagging
+  actually is in existing OLI/Torus courses remains unknown; if it turns out to be prevalent, this
+  risk may need to be revisited in a follow-up work item.
 - Risk: mismatching `count` semantics between the naive and a future LKT-AOA caller could silently
   skew the weighted average. Mitigation: the function's documentation states the contract
   explicitly and assigns responsibility to the caller; naive callers are updated in this work item

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -53,7 +53,11 @@ requirements:
       once, attributed to the Sub-LO, and not also counted directly against the parent.
     status: proposed
     verification_method: automated
-    proofs: []
+    proofs:
+      - "Partially covered (Phase 2, naive delivery-side call site only):
+        test/oli/analytics/summary/metrics_v2_test.exs. Status stays proposed until
+        Phase 3 (Instructor Dashboard/CSV export) and Phase 4 (page element) verify
+        the same invariant for their own call sites."
 - id: FR-004
   title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
     is represented in the aggregation rather than silently excluded from it.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -4,7 +4,7 @@ requirements:
   title: Provide a single, algorithm-agnostic weighted-aggregation function that computes
     a parent Learning Objective's proficiency score from (proficiency, count) pairs
     contributed by its Sub-LOs and, when present, its own directly-tagged evidence.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-001
     title: "Given a parent LO with multiple Sub-LOs each having a (proficiency, count)\
@@ -28,7 +28,7 @@ requirements:
   title: Document the aggregation function's count contract explicitly, making it
     the caller's responsibility to supply a count consistent with whichever algorithm
     computed that child's proficiency.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-003
     title: The function's documentation states that a naive/legacy child's count must
@@ -79,7 +79,7 @@ requirements:
 - id: FR-004
   title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
     is represented in the aggregation rather than silently excluded from it.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-005
     title: Given a parent LO with one Sub-LO that has sufficient evidence and another
@@ -96,7 +96,7 @@ requirements:
   title: Audit and update every runtime call site that rolls up (or should roll up)
     Sub-LO proficiency into a parent LO, across both authoring and delivery surfaces,
     so all of them consume the shared aggregation function.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-006
     title: Given a section with a parent LO that has Sub-LOs and no direct evidence,
@@ -157,27 +157,39 @@ requirements:
 - id: FR-006
   title: Keep Learning Objective proficiency aggregation a runtime projection computed
     at read time rather than a persisted, write-time calculation.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-009
     title: Given a learner submits a new attempt on an activity tagged to a Sub-LO,
       when that attempt is evaluated, then no parent LO proficiency value is persisted
       or recalculated as part of that evaluation; the parent's aggregated value is
       computed only when subsequently read.
-    status: proposed
+    status: verified
     verification_method: manual
-    proofs: []
+    proofs:
+      - "This work item's entire diff (git diff master...HEAD) touches only
+        read-side aggregation functions in lib/oli/delivery/metrics.ex,
+        lib/oli/delivery/sections.ex, and
+        lib/oli/delivery/learning_objectives/page_element.ex; no file under
+        lib/oli/delivery/attempts/ (attempt submission/evaluation) is
+        modified, confirming aggregation stays a runtime projection with no
+        new write-time persistence introduced."
 - id: FR-007
   title: Route the naive algorithm's aggregated score through the existing Metrics.proficiency_range/2
     bucketing so parent LO Not Enough Information/Low/Medium/High distributions reflect
     combined evidence without duplicating threshold logic.
-  status: proposed
+  status: verified
   acceptance_criteria:
   - id: AC-010
     title: Given a parent LO's aggregated naive score and total evidence count, when
       it is bucketed for display, then Metrics.proficiency_range/2's existing thresholds
       are used unchanged rather than a second, duplicated set of thresholds.
-    status: proposed
+    status: verified
     verification_method: automated
-    proofs: []
+    proofs:
+      - "lib/oli/delivery/metrics.ex (Metrics.proficiency_bucket_for_student/3
+        and proficiency_for_student_per_learning_objective/3) both call
+        proficiency_range/2 directly on the aggregated (score, total_count)
+        pair; no second bucketing implementation exists anywhere in this
+        work item's diff."
 acceptance_criteria: []

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -42,26 +42,40 @@ requirements:
       - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1 @doc,
         verified verbatim against informal.md's "Agreed function contract")
 - id: FR-003
-  title: Preserve the existing no-double-counting rule so an activity tagged to both
-    a parent LO and one of its Sub-LOs contributes to the aggregation once, at the
-    Sub-LO.
-  status: proposed
+  title: "SUPERSEDED (Darren Siegel, Slack, 2026-09-01, \"Option B\"): always combine\
+    \ a parent LO's own directly-tagged evidence with its Sub-LOs' evidence in the\
+    \ weighted average, whenever the parent has evidence of its own. This replaces\
+    \ the original Jira AC requiring that an activity tagged to both a parent LO and\
+    \ one of its Sub-LOs contribute to the aggregation only once, at the Sub-LO —\
+    \ that de-duplication is explicitly NOT implemented; see\
+    \ parent_evidence_aggregation_options.md for the alternatives considered and why\
+    \ Option B was chosen over them."
+  status: verified
   acceptance_criteria:
   - id: AC-004
-    title: Given an activity tagged to both a parent LO and one of its Sub-LOs, when
-      parent LO proficiency is aggregated, then that activity's evidence is counted
-      once, attributed to the Sub-LO, and not also counted directly against the parent.
-    status: proposed
+    title: Given a parent LO with one or more Sub-LOs, when parent LO proficiency is
+      aggregated, then the parent's own directly-tagged evidence (when present) is
+      always combined with each Sub-LO's evidence into the weighted average. An
+      activity tagged to both a parent LO and one of its Sub-LOs is NOT deduplicated
+      under this rule — its evidence contributes once via the parent's own row and
+      again via the Sub-LO's row. This double-counting is a deliberate, accepted
+      trade-off (see FR-003), not a defect.
+    status: verified
     verification_method: automated
     proofs:
-      - "Partially covered (Phase 2 naive delivery-side, and Phase 3
-        Instructor Dashboard/CSV export call sites): test/oli/analytics/summary/metrics_v2_test.exs,
-        test/oli/delivery/sections_test.exs ('filters by student_id when
-        provided' — objective_a's own directly-tagged evidence is excluded
-        from its aggregated proficiency once it has Sub-LOs, via
-        Sections.objective_evidence_resource_ids/1). Status stays proposed
-        until Phase 4 (page element) verifies the same invariant for its own
-        call site."
+      - "lib/oli/delivery/metrics.ex (Metrics.evidence_resource_ids/2) — the
+        shared always-combine rule now used by all three call sites: Metrics
+        (naive delivery-side), Sections.get_objectives_and_subobjectives/2
+        (Instructor Dashboard/CSV export), and
+        PageElement.maybe_proficiency/6 (the 'learning_objectives' page
+        element)."
+      - test/oli/analytics/summary/metrics_v2_test.exs
+      - "test/oli/delivery/sections_test.exs ('filters by student_id when
+        provided')"
+      - "test/oli/delivery/learning_objectives/page_element_test.exs
+        ('combines a parent's Sub-LO evidence, including a Sub-LO outside
+        this page element's own scope, consistent with the Instructor
+        Dashboard')"
 - id: FR-004
   title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
     is represented in the aggregation rather than silently excluded from it.
@@ -94,8 +108,9 @@ requirements:
     verification_method: automated
     proofs:
       - "lib/oli/delivery/sections.ex (Sections.get_objectives_and_subobjectives/2,
-        aggregated_proficiency_bucket/3) — the Instructor Dashboard tab
-        (instructor_dashboard_live.ex:120), per-student instructor view
+        via the shared Metrics.evidence_resource_ids/2 and
+        Metrics.proficiency_bucket_for_student/3) — the Instructor Dashboard
+        tab (instructor_dashboard_live.ex:120), per-student instructor view
         (student_dashboard_live.ex:54), and CSV export
         (delivery_controller.ex:471) all route through this same function."
       - test/oli/delivery/sections_test.exs ("filters by student_id when
@@ -107,28 +122,38 @@ requirements:
       page element renders that LO, then the displayed proficiency reflects the same
       combined Sub-LO evidence, consistent with the Instructor Dashboard's value for
       that student.
-    status: proposed
+    status: verified
     verification_method: automated
     proofs:
-      - "Partially covered: student prologue/lesson/review pages (Phase 2, see
-        test/oli/analytics/summary/metrics_v2_test.exs) and the Instructor
-        Dashboard side of the comparison (Phase 3, see AC-006 proofs above).
-        Status stays proposed until Phase 4 (the 'learning_objectives' page
-        element) verifies the same invariant, and until Phase 5 confirms
-        cross-site consistency."
+      - "lib/oli/delivery/learning_objectives/page_element.ex
+        (PageElement.maybe_proficiency/6) — resolves evidence resource_ids
+        from the section's authoritative objective hierarchy (not the page
+        element's own narrow render scope), so a Sub-LO with no activity on
+        the current page still contributes to its parent's aggregated
+        proficiency."
+      - "test/oli/delivery/learning_objectives/page_element_test.exs
+        ('combines a parent's Sub-LO evidence, including a Sub-LO outside
+        this page element's own scope, consistent with the Instructor
+        Dashboard') — directly cross-checks
+        PageElement.prepare_render_payload/5's result against
+        Sections.get_objectives_and_subobjectives/2's result for the same
+        student/section and asserts they match."
+      - test/oli/analytics/summary/metrics_v2_test.exs (student
+        prologue/lesson/review side, Phase 2)
   - id: AC-008
     title: Given a leaf Learning Objective with no Sub-LOs, when its proficiency is
       read from any of the updated call sites, then its value is unchanged from current
       behavior.
-    status: proposed
+    status: verified
     verification_method: automated
     proofs:
-      - "Partially covered (Phase 2 naive delivery-side call site, and Phase 3
-        Instructor Dashboard/CSV export call site): test/oli/analytics/summary/metrics_v2_test.exs
-        (o3, a leaf objective), test/oli/delivery/sections_test.exs ('a leaf
-        Learning Objective with no Sub-LOs uses only its own evidence,
-        unaffected by aggregation'). Status stays proposed until Phase 4 (page
-        element) verifies the same invariant for its own call site."
+      - test/oli/analytics/summary/metrics_v2_test.exs (o3, a leaf objective)
+      - "test/oli/delivery/sections_test.exs ('a leaf Learning Objective with
+        no Sub-LOs uses only its own evidence, unaffected by aggregation')"
+      - "test/oli/delivery/learning_objectives/page_element_test.exs
+        ('queries proficiency only when a Summary element exists' —
+        obj_resource_c1/obj_resource_d, both leaves, are queried by their own
+        resource_id)"
 - id: FR-006
   title: Keep Learning Objective proficiency aggregation a runtime projection computed
     at read time rather than a persisted, write-time calculation.

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -10,16 +10,20 @@ requirements:
     title: "Given a parent LO with multiple Sub-LOs each having a (proficiency, count)\
       \ pair, when the aggregation function is called, then it returns score = \u03A3\
       (proficiency_i \xD7 count_i) / \u03A3(count_i) over all supplied children."
-    status: proposed
+    status: verified
     verification_method: automated
-    proofs: []
+    proofs:
+      - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1)
+      - test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
   - id: AC-002
     title: Given a parent LO that has both directly-tagged evidence and one or more
       Sub-LOs, when the aggregation function is called, then the parent's own (proficiency,
       count) pair is combined into the same weighted average as its Sub-LOs' pairs.
-    status: proposed
+    status: verified
     verification_method: automated
-    proofs: []
+    proofs:
+      - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1)
+      - test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
 - id: FR-002
   title: Document the aggregation function's count contract explicitly, making it
     the caller's responsibility to supply a count consistent with whichever algorithm
@@ -32,9 +36,11 @@ requirements:
       ("opportunity") count per the LKT-AOA technical notes section 6.2, and states
       that the function itself has no way to detect mismatched count semantics across
       children.
-    status: proposed
+    status: verified
     verification_method: manual
-    proofs: []
+    proofs:
+      - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1 @doc,
+        verified verbatim against informal.md's "Agreed function contract")
 - id: FR-003
   title: Preserve the existing no-double-counting rule so an activity tagged to both
     a parent LO and one of its Sub-LOs contributes to the aggregation once, at the
@@ -59,9 +65,11 @@ requirements:
       LO proficiency is aggregated, then the result reflects the incomplete coverage
       of the unattempted or under-evidenced Sub-LO rather than being calculated as
       if only the attempted Sub-LO existed.
-    status: proposed
+    status: verified
     verification_method: automated
-    proofs: []
+    proofs:
+      - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1)
+      - test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
 - id: FR-005
   title: Audit and update every runtime call site that rolls up (or should roll up)
     Sub-LO proficiency into a parent LO, across both authoring and delivery surfaces,

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -1,0 +1,122 @@
+work_item: lo_aggregation
+requirements:
+- id: FR-001
+  title: Provide a single, algorithm-agnostic weighted-aggregation function that computes
+    a parent Learning Objective's proficiency score from (proficiency, count) pairs
+    contributed by its Sub-LOs and, when present, its own directly-tagged evidence.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-001
+    title: "Given a parent LO with multiple Sub-LOs each having a (proficiency, count)\
+      \ pair, when the aggregation function is called, then it returns score = \u03A3\
+      (proficiency_i \xD7 count_i) / \u03A3(count_i) over all supplied children."
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-002
+    title: Given a parent LO that has both directly-tagged evidence and one or more
+      Sub-LOs, when the aggregation function is called, then the parent's own (proficiency,
+      count) pair is combined into the same weighted average as its Sub-LOs' pairs.
+    status: proposed
+    verification_method: automated
+    proofs: []
+- id: FR-002
+  title: Document the aggregation function's count contract explicitly, making it
+    the caller's responsibility to supply a count consistent with whichever algorithm
+    computed that child's proficiency.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-003
+    title: The function's documentation states that a naive/legacy child's count must
+      be num_first_attempts and that an LKT-AOA child's count must be its total attempt
+      ("opportunity") count per the LKT-AOA technical notes section 6.2, and states
+      that the function itself has no way to detect mismatched count semantics across
+      children.
+    status: proposed
+    verification_method: manual
+    proofs: []
+- id: FR-003
+  title: Preserve the existing no-double-counting rule so an activity tagged to both
+    a parent LO and one of its Sub-LOs contributes to the aggregation once, at the
+    Sub-LO.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-004
+    title: Given an activity tagged to both a parent LO and one of its Sub-LOs, when
+      parent LO proficiency is aggregated, then that activity's evidence is counted
+      once, attributed to the Sub-LO, and not also counted directly against the parent.
+    status: proposed
+    verification_method: automated
+    proofs: []
+- id: FR-004
+  title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
+    is represented in the aggregation rather than silently excluded from it.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-005
+    title: Given a parent LO with one Sub-LO that has sufficient evidence and another
+      Sub-LO that has not been attempted or has insufficient evidence, when parent
+      LO proficiency is aggregated, then the result reflects the incomplete coverage
+      of the unattempted or under-evidenced Sub-LO rather than being calculated as
+      if only the attempted Sub-LO existed.
+    status: proposed
+    verification_method: automated
+    proofs: []
+- id: FR-005
+  title: Audit and update every runtime call site that rolls up (or should roll up)
+    Sub-LO proficiency into a parent LO, across both authoring and delivery surfaces,
+    so all of them consume the shared aggregation function.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-006
+    title: Given a section with a parent LO that has Sub-LOs and no direct evidence,
+      when an instructor views the Instructor Dashboard Learning Objectives tab, the
+      per-student instructor view, or downloads the Learning Objectives CSV export,
+      then the parent LO's displayed/exported proficiency reflects its Sub-LOs' combined
+      evidence instead of "not enough data".
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-007
+    title: Given the same section and parent LO, when a student views their proficiency
+      on the prologue, lesson, or review pages, or when the "learning_objectives"
+      page element renders that LO, then the displayed proficiency reflects the same
+      combined Sub-LO evidence, consistent with the Instructor Dashboard's value for
+      that student.
+    status: proposed
+    verification_method: automated
+    proofs: []
+  - id: AC-008
+    title: Given a leaf Learning Objective with no Sub-LOs, when its proficiency is
+      read from any of the updated call sites, then its value is unchanged from current
+      behavior.
+    status: proposed
+    verification_method: automated
+    proofs: []
+- id: FR-006
+  title: Keep Learning Objective proficiency aggregation a runtime projection computed
+    at read time rather than a persisted, write-time calculation.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-009
+    title: Given a learner submits a new attempt on an activity tagged to a Sub-LO,
+      when that attempt is evaluated, then no parent LO proficiency value is persisted
+      or recalculated as part of that evaluation; the parent's aggregated value is
+      computed only when subsequently read.
+    status: proposed
+    verification_method: manual
+    proofs: []
+- id: FR-007
+  title: Route the naive algorithm's aggregated score through the existing Metrics.proficiency_range/2
+    bucketing so parent LO Not Enough Information/Low/Medium/High distributions reflect
+    combined evidence without duplicating threshold logic.
+  status: proposed
+  acceptance_criteria:
+  - id: AC-010
+    title: Given a parent LO's aggregated naive score and total evidence count, when
+      it is bucketed for display, then Metrics.proficiency_range/2's existing thresholds
+      are used unchanged rather than a second, duplicated set of thresholds.
+    status: proposed
+    verification_method: automated
+    proofs: []
+acceptance_criteria: []

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -73,9 +73,21 @@ requirements:
       - "test/oli/delivery/sections_test.exs ('filters by student_id when
         provided')"
       - "test/oli/delivery/learning_objectives/page_element_test.exs
-        ('combines a parent's Sub-LO evidence, including a Sub-LO outside
+        ('combines a parent's own evidence with a Sub-LO's evidence, including a Sub-LO outside
         this page element's own scope, consistent with the Instructor
         Dashboard')"
+      - "test/scenarios/proficiency/parent_combines_own_and_subobjective_evidence.scenario.yaml
+        and test/scenarios/instructor_dashboard/lo_aggregation_weighted_and_combined.scenario.yaml
+        — exercise the real attempt-submission pipeline (Oli.Scenarios'
+        answer_question/finalize_attempt directives, not factory-inserted
+        ResourceSummary rows) so this behavior is verified end to end, not
+        just at the Metrics function boundary."
+      - "test/scenarios/proficiency/parent_double_counts_activity_tagged_to_both_parent_and_subobjective.scenario.yaml
+        — the literal double-counting case named in this AC's title: one
+        real activity tagged to both the parent and a Sub-LO is answered
+        once, and the parent's aggregation counts it twice (once via its
+        own row, again via the Sub-LO's row), which is what pushes a
+        2-real-attempt section past the 3-attempt 'enough data' minimum."
 - id: FR-004
   title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
     is represented in the aggregation rather than silently excluded from it.
@@ -92,6 +104,10 @@ requirements:
     proofs:
       - lib/oli/delivery/metrics.ex (Metrics.aggregate_weighted_proficiency/1)
       - test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
+      - "test/scenarios/proficiency/parent_reflects_incomplete_subobjective_coverage.scenario.yaml
+        — a Sub-LO with a single (incorrect) real attempt still shifts the
+        parent's bucket from what it would be if that Sub-LO's thin evidence
+        were ignored (High) to the correct combined value (Medium)."
 - id: FR-005
   title: Audit and update every runtime call site that rolls up (or should roll up)
     Sub-LO proficiency into a parent LO, across both authoring and delivery surfaces,
@@ -116,6 +132,14 @@ requirements:
       - test/oli/delivery/sections_test.exs ("filters by student_id when
         provided", "reflects incomplete coverage instead of ignoring an
         under-evidenced Sub-LO")
+      - "test/oli_web/live/delivery/instructor_dashboard/insights/lo_aggregation_ui_test.exs
+        — logs in as a real instructor and checks the actual rendered
+        Instructor Dashboard Learning Objectives tab, the per-student
+        instructor view, and the Learning Objectives CSV export, seeded via
+        Oli.Scenarios (real attempt pipeline). Closes a coverage gap: no
+        prior automated test exercised
+        Sections.get_objectives_and_subobjectives/2 through these three UI
+        surfaces rather than by calling the function directly."
   - id: AC-007
     title: Given the same section and parent LO, when a student views their proficiency
       on the prologue, lesson, or review pages, or when the "learning_objectives"
@@ -132,7 +156,7 @@ requirements:
         the current page still contributes to its parent's aggregated
         proficiency."
       - "test/oli/delivery/learning_objectives/page_element_test.exs
-        ('combines a parent's Sub-LO evidence, including a Sub-LO outside
+        ('combines a parent's own evidence with a Sub-LO's evidence, including a Sub-LO outside
         this page element's own scope, consistent with the Instructor
         Dashboard') — directly cross-checks
         PageElement.prepare_render_payload/5's result against
@@ -140,6 +164,10 @@ requirements:
         student/section and asserts they match."
       - test/oli/analytics/summary/metrics_v2_test.exs (student
         prologue/lesson/review side, Phase 2)
+      - "test/oli_web/live/delivery/instructor_dashboard/insights/lo_aggregation_ui_test.exs
+        — the same seeded student/section is checked against both the
+        Instructor Dashboard tab and the per-student instructor view and
+        asserts the same bucket in both."
   - id: AC-008
     title: Given a leaf Learning Objective with no Sub-LOs, when its proficiency is
       read from any of the updated call sites, then its value is unchanged from current

--- a/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
+++ b/docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/requirements.yml
@@ -54,10 +54,14 @@ requirements:
     status: proposed
     verification_method: automated
     proofs:
-      - "Partially covered (Phase 2, naive delivery-side call site only):
-        test/oli/analytics/summary/metrics_v2_test.exs. Status stays proposed until
-        Phase 3 (Instructor Dashboard/CSV export) and Phase 4 (page element) verify
-        the same invariant for their own call sites."
+      - "Partially covered (Phase 2 naive delivery-side, and Phase 3
+        Instructor Dashboard/CSV export call sites): test/oli/analytics/summary/metrics_v2_test.exs,
+        test/oli/delivery/sections_test.exs ('filters by student_id when
+        provided' — objective_a's own directly-tagged evidence is excluded
+        from its aggregated proficiency once it has Sub-LOs, via
+        Sections.objective_evidence_resource_ids/1). Status stays proposed
+        until Phase 4 (page element) verifies the same invariant for its own
+        call site."
 - id: FR-004
   title: Preserve incomplete-coverage semantics so a Sub-LO with insufficient evidence
     is represented in the aggregation rather than silently excluded from it.
@@ -86,9 +90,17 @@ requirements:
       per-student instructor view, or downloads the Learning Objectives CSV export,
       then the parent LO's displayed/exported proficiency reflects its Sub-LOs' combined
       evidence instead of "not enough data".
-    status: proposed
+    status: verified
     verification_method: automated
-    proofs: []
+    proofs:
+      - "lib/oli/delivery/sections.ex (Sections.get_objectives_and_subobjectives/2,
+        aggregated_proficiency_bucket/3) — the Instructor Dashboard tab
+        (instructor_dashboard_live.ex:120), per-student instructor view
+        (student_dashboard_live.ex:54), and CSV export
+        (delivery_controller.ex:471) all route through this same function."
+      - test/oli/delivery/sections_test.exs ("filters by student_id when
+        provided", "reflects incomplete coverage instead of ignoring an
+        under-evidenced Sub-LO")
   - id: AC-007
     title: Given the same section and parent LO, when a student views their proficiency
       on the prologue, lesson, or review pages, or when the "learning_objectives"
@@ -97,14 +109,26 @@ requirements:
       that student.
     status: proposed
     verification_method: automated
-    proofs: []
+    proofs:
+      - "Partially covered: student prologue/lesson/review pages (Phase 2, see
+        test/oli/analytics/summary/metrics_v2_test.exs) and the Instructor
+        Dashboard side of the comparison (Phase 3, see AC-006 proofs above).
+        Status stays proposed until Phase 4 (the 'learning_objectives' page
+        element) verifies the same invariant, and until Phase 5 confirms
+        cross-site consistency."
   - id: AC-008
     title: Given a leaf Learning Objective with no Sub-LOs, when its proficiency is
       read from any of the updated call sites, then its value is unchanged from current
       behavior.
     status: proposed
     verification_method: automated
-    proofs: []
+    proofs:
+      - "Partially covered (Phase 2 naive delivery-side call site, and Phase 3
+        Instructor Dashboard/CSV export call site): test/oli/analytics/summary/metrics_v2_test.exs
+        (o3, a leaf objective), test/oli/delivery/sections_test.exs ('a leaf
+        Learning Objective with no Sub-LOs uses only its own evidence,
+        unaffected by aggregation'). Status stays proposed until Phase 4 (page
+        element) verifies the same invariant for its own call site."
 - id: FR-006
   title: Keep Learning Objective proficiency aggregation a runtime projection computed
     at read time rather than a persisted, write-time calculation.

--- a/lib/oli/delivery/learning_objectives/page_element.ex
+++ b/lib/oli/delivery/learning_objectives/page_element.ex
@@ -61,8 +61,13 @@ defmodule Oli.Delivery.LearningObjectives.PageElement do
         container_resource_id =
           current_container_resource_id(section, current_page_resource_id, schedule)
 
-        {:ok, objectives} =
-          included_objectives(
+        # objectives_with_children (only fetched when there are any in-scope
+        # activities, see do_included_objectives/3) is reused by
+        # maybe_proficiency/6 below for the same authoritative (not
+        # page-scoped) hierarchy it needs to resolve a parent's Sub-LOs for
+        # aggregation, instead of each independently re-fetching it.
+        {:ok, objectives, objectives_with_children} =
+          do_included_objectives(
             section,
             container_resource_id,
             Keyword.put(opts, :schedule, schedule)
@@ -75,7 +80,14 @@ defmodule Oli.Delivery.LearningObjectives.PageElement do
           objectives: objectives,
           objectives_by_id: Map.new(objectives, &{&1.resource_id, &1}),
           performance_by_objective_id:
-            maybe_proficiency(section, objective_ids, user, summary_element?(elements), opts)
+            maybe_proficiency(
+              section,
+              objective_ids,
+              objectives_with_children,
+              user,
+              summary_element?(elements),
+              opts
+            )
         }
     end
   end
@@ -95,22 +107,31 @@ defmodule Oli.Delivery.LearningObjectives.PageElement do
 
   @doc false
   def included_objectives(%Section{} = section, container_resource_id, opts) do
+    {:ok, objectives, _objectives_with_children} =
+      do_included_objectives(section, container_resource_id, opts)
+
+    {:ok, objectives}
+  end
+
+  # Returns `{:ok, objectives, objectives_with_children}`, where
+  # `objectives_with_children` is the section's authoritative objective
+  # hierarchy fetched to build `objectives` (empty, and the depot left
+  # unqueried, when there are no in-scope activities) — the caller can reuse
+  # it (e.g. for proficiency aggregation) instead of re-fetching.
+  defp do_included_objectives(%Section{} = section, container_resource_id, opts) do
     schedule = schedule(section.id, opts)
     container = container_section_resource(section, container_resource_id, schedule)
 
     pages = descendant_page_section_resources(container, schedule)
     activity_ids = in_scope_activity_ids(pages, opts)
 
-    objectives =
-      if MapSet.size(activity_ids) == 0 do
-        []
-      else
-        section.id
-        |> objectives_with_effective_children(opts)
-        |> included_objectives_for_activity_ids(activity_ids)
-      end
-
-    {:ok, objectives}
+    if MapSet.size(activity_ids) == 0 do
+      {:ok, [], []}
+    else
+      objectives_with_children = objectives_with_effective_children(section.id, opts)
+      objectives = included_objectives_for_activity_ids(objectives_with_children, activity_ids)
+      {:ok, objectives, objectives_with_children}
+    end
   end
 
   defp learning_objectives_elements(%{"model" => model}) when is_list(model) do
@@ -129,21 +150,86 @@ defmodule Oli.Delivery.LearningObjectives.PageElement do
     end)
   end
 
-  defp maybe_proficiency(_section, [], _user, _summary?, _opts), do: %{}
-  defp maybe_proficiency(_section, _objective_ids, _user, false, _opts), do: %{}
-  defp maybe_proficiency(_section, _objective_ids, nil, true, _opts), do: %{}
+  defp maybe_proficiency(_section, [], _objectives_with_children, _user, _summary?, _opts),
+    do: %{}
 
-  defp maybe_proficiency(%Section{id: section_id}, objective_ids, %User{id: user_id}, true, opts) do
-    proficiency_fun =
-      Keyword.get(opts, :proficiency_fun, &Metrics.proficiency_per_student_for_objective/3)
+  defp maybe_proficiency(
+         _section,
+         _objective_ids,
+         _objectives_with_children,
+         _user,
+         false,
+         _opts
+       ),
+       do: %{}
 
-    proficiency_fun.(section_id, objective_ids, student_id: user_id)
-    |> Enum.into(%{}, fn {objective_id, proficiency_by_user_id} ->
-      {objective_id, Map.get(proficiency_by_user_id, user_id)}
+  defp maybe_proficiency(_section, _objective_ids, _objectives_with_children, nil, true, _opts),
+    do: %{}
+
+  defp maybe_proficiency(
+         %Section{id: section_id},
+         objective_ids,
+         objectives_with_children,
+         %User{id: user_id},
+         true,
+         opts
+       ) do
+    # A parent objective's proficiency must combine its Sub-LOs' evidence
+    # (Metrics.evidence_resource_ids/2), which can include a Sub-LO that has no
+    # activity in this page element's own scope (e.g. attempted elsewhere in
+    # the course). `objectives_with_children` is the section's authoritative
+    # objective hierarchy (not page-scoped), so this matches the same rule the
+    # Instructor Dashboard uses (Sections.get_objectives_and_subobjectives/2)
+    # for the same student.
+    children_by_resource_id =
+      Map.new(objectives_with_children, &{&1.resource_id, List.wrap(&1.children)})
+
+    evidence_resource_ids_by_objective_id =
+      Map.new(objective_ids, fn objective_id ->
+        {objective_id,
+         Metrics.evidence_resource_ids(
+           objective_id,
+           Map.get(children_by_resource_id, objective_id, [])
+         )}
+      end)
+
+    all_evidence_resource_ids =
+      evidence_resource_ids_by_objective_id
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.uniq()
+
+    raw_proficiency_fun =
+      Keyword.get(
+        opts,
+        :raw_proficiency_fun,
+        &Metrics.raw_proficiency_per_student_for_objective/3
+      )
+
+    raw_proficiency_by_resource_id =
+      raw_proficiency_fun.(section_id, all_evidence_resource_ids, student_id: user_id)
+
+    Map.new(objective_ids, fn objective_id ->
+      resource_ids = Map.fetch!(evidence_resource_ids_by_objective_id, objective_id)
+
+      {objective_id,
+       Metrics.proficiency_bucket_for_student(
+         resource_ids,
+         raw_proficiency_by_resource_id,
+         user_id
+       )}
     end)
   end
 
-  defp maybe_proficiency(_section, _objective_ids, _non_delivery_user, true, _opts), do: %{}
+  defp maybe_proficiency(
+         _section,
+         _objective_ids,
+         _objectives_with_children,
+         _non_delivery_user,
+         true,
+         _opts
+       ),
+       do: %{}
 
   defp schedule(section_id, opts) do
     Keyword.get_lazy(opts, :schedule, fn ->

--- a/lib/oli/delivery/learning_objectives/page_element.ex
+++ b/lib/oli/delivery/learning_objectives/page_element.ex
@@ -182,7 +182,7 @@ defmodule Oli.Delivery.LearningObjectives.PageElement do
     # Instructor Dashboard uses (Sections.get_objectives_and_subobjectives/2)
     # for the same student.
     children_by_resource_id =
-      Map.new(objectives_with_children, &{&1.resource_id, List.wrap(&1.children)})
+      Map.new(objectives_with_children, &{&1.resource_id, &1.children})
 
     evidence_resource_ids_by_objective_id =
       Map.new(objective_ids, fn objective_id ->

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -737,7 +737,9 @@ defmodule Oli.Delivery.Metrics do
   }
 
   This implementation considers that an objective may have sub-objectives.
-  In that case, the proficiency for the given objectives will result from the aggregated raw proficiency of its contained sub-objectives.
+  In that case, the proficiency for the given objectives will result from the aggregated raw
+  proficiency of its contained sub-objectives, combined with the objective's own directly-tagged
+  evidence when it has any (see `evidence_resource_ids/2`).
 
   Example:
     Given the following parent-child learning objectives relationship:
@@ -769,7 +771,7 @@ defmodule Oli.Delivery.Metrics do
         section
       ) do
     unique_objective_and_subobjective_ids =
-      Enum.flat_map(learning_objectives, fn rev -> [rev.resource_id | rev.children] end)
+      Enum.flat_map(learning_objectives, &evidence_resource_ids(&1.resource_id, &1.children))
       |> Enum.uniq()
 
     raw_proficiency_per_learning_objective =
@@ -781,19 +783,8 @@ defmodule Oli.Delivery.Metrics do
 
     Enum.into(learning_objectives, %{}, fn rev ->
       aggregated_proficiency =
-        if rev.children == [] do
-          [
-            Map.get(
-              raw_proficiency_per_learning_objective,
-              rev.resource_id,
-              nil
-            )
-          ]
-        else
-          Enum.map(rev.children, fn subobjective_id ->
-            Map.get(raw_proficiency_per_learning_objective, subobjective_id)
-          end)
-        end
+        evidence_resource_ids(rev.resource_id, rev.children)
+        |> Enum.map(&Map.get(raw_proficiency_per_learning_objective, &1))
         |> Enum.reject(&is_nil/1)
         |> aggregate_raw_proficiency()
 
@@ -1630,6 +1621,57 @@ defmodule Oli.Delivery.Metrics do
 
       Map.put(acc, resource_id, res)
     end)
+  end
+
+  @doc """
+  The resource_ids whose evidence contributes to an objective's aggregated
+  proficiency, given its own `resource_id` and its Sub-LO `children` (both
+  resource_ids): always the objective's own resource_id plus every one of its
+  children (an empty list for a leaf objective, contributing nothing extra).
+
+  A parent LO's own directly-tagged evidence is always included alongside its
+  Sub-LOs' evidence, even when the parent has Sub-LOs. This is a deliberate
+  product decision ("Option B" — Darren Siegel, Slack, 2026-09-01: "the
+  simplest thing that we can (and should) do"), not an oversight: if an
+  activity happens to be tagged to both a parent and one of its Sub-LOs, that
+  activity's evidence is double-counted (it contributes once via the parent's
+  own `ResourceSummary` row and again via the Sub-LO's row) — this risk is
+  explicitly accepted rather than mitigated. See
+  `docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md`
+  for the alternatives considered and why this one was chosen.
+
+  Shared by every runtime call site that rolls up Sub-LO proficiency into a
+  parent LO, so they all apply this rule identically instead of each
+  re-deriving it.
+  """
+  @spec evidence_resource_ids(resource_id :: integer(), children :: [integer()]) :: [integer()]
+  def evidence_resource_ids(resource_id, children), do: [resource_id | children]
+
+  @doc """
+  Combines the raw `{proficiency, count}` evidence for a set of resource_ids
+  (as resolved by `evidence_resource_ids/2`) into a single weighted-average
+  proficiency via `aggregate_weighted_proficiency/1`, then categorizes it into
+  a bucket ("Not enough data" / "Low" / "Medium" / "High") via
+  `proficiency_range/2`, for one student.
+  """
+  @spec proficiency_bucket_for_student(
+          resource_ids :: [integer()],
+          raw_proficiency_by_resource_id :: %{
+            integer() => %{integer() => {float() | nil, non_neg_integer()}}
+          },
+          student_id :: integer()
+        ) :: String.t()
+  def proficiency_bucket_for_student(resource_ids, raw_proficiency_by_resource_id, student_id) do
+    pairs =
+      Enum.map(resource_ids, fn resource_id ->
+        raw_proficiency_by_resource_id
+        |> Map.get(resource_id, %{})
+        |> Map.get(student_id, {nil, 0})
+      end)
+
+    {score, total_count} = aggregate_weighted_proficiency(pairs)
+
+    proficiency_range(score, total_count)
   end
 
   defp proficiency_mode(proficiencies_for_resources) do

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -774,41 +774,19 @@ defmodule Oli.Delivery.Metrics do
       Enum.flat_map(learning_objectives, &evidence_resource_ids(&1.resource_id, &1.children))
       |> Enum.uniq()
 
-    raw_proficiency_per_learning_objective =
-      raw_proficiency_per_learning_objective(
+    raw_proficiency_by_resource_id =
+      raw_proficiency_per_student_for_objective(
         section.id,
-        student_id: student_id,
-        objective_ids: unique_objective_and_subobjective_ids
+        unique_objective_and_subobjective_ids,
+        student_id: student_id
       )
 
     Enum.into(learning_objectives, %{}, fn rev ->
-      aggregated_proficiency =
-        evidence_resource_ids(rev.resource_id, rev.children)
-        |> Enum.map(&Map.get(raw_proficiency_per_learning_objective, &1))
-        |> Enum.reject(&is_nil/1)
-        |> aggregate_raw_proficiency()
+      resource_ids = evidence_resource_ids(rev.resource_id, rev.children)
 
-      {rev.resource_id, aggregated_proficiency}
+      {rev.resource_id,
+       proficiency_bucket_for_student(resource_ids, raw_proficiency_by_resource_id, student_id)}
     end)
-  end
-
-  defp aggregate_raw_proficiency([]), do: proficiency_range(nil, 0)
-
-  defp aggregate_raw_proficiency(raw_values) do
-    {score, total_first_attempts} =
-      raw_values
-      |> Enum.map(fn {first_correct, first_count, _correct, _count} ->
-        {naive_child_proficiency(first_correct, first_count), first_count}
-      end)
-      |> aggregate_weighted_proficiency()
-
-    proficiency_range(score, total_first_attempts)
-  end
-
-  defp naive_child_proficiency(_first_correct, 0), do: nil
-
-  defp naive_child_proficiency(first_correct, first_count) do
-    (1.0 * first_correct + 0.2 * (first_count - first_correct)) / first_count
   end
 
   @doc """

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -804,22 +804,20 @@ defmodule Oli.Delivery.Metrics do
   defp aggregate_raw_proficiency([]), do: proficiency_range(nil, 0)
 
   defp aggregate_raw_proficiency(raw_values) do
-    {first_correct, first_count, _correct, _total} =
-      Enum.reduce(raw_values, {0, 0, 0, 0}, fn {first_correct, first_count, correct, count},
-                                               acc ->
-        {first_correct + elem(acc, 0), first_count + elem(acc, 1), correct + elem(acc, 2),
-         count + elem(acc, 3)}
+    {score, total_first_attempts} =
+      raw_values
+      |> Enum.map(fn {first_correct, first_count, _correct, _count} ->
+        {naive_child_proficiency(first_correct, first_count), first_count}
       end)
+      |> aggregate_weighted_proficiency()
 
-    proficiency_value =
-      if first_count == 0 do
-        0
-      else
-        (1.0 * first_correct + 0.2 * (first_count - first_correct)) /
-          first_count
-      end
+    proficiency_range(score, total_first_attempts)
+  end
 
-    proficiency_range(proficiency_value, first_count)
+  defp naive_child_proficiency(_first_correct, 0), do: nil
+
+  defp naive_child_proficiency(first_correct, first_count) do
+    (1.0 * first_correct + 0.2 * (first_count - first_correct)) / first_count
   end
 
   @doc """

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1183,6 +1183,56 @@ defmodule Oli.Delivery.Metrics do
   def proficiency_range(proficiency, _num_first_attempts) when proficiency <= 0.8, do: "Medium"
   def proficiency_range(_proficiency, _num_first_attempts), do: "High"
 
+  @doc """
+  Aggregates a parent Learning Objective's proficiency from the proficiency
+  estimates of its Sub-LOs (and, optionally, its own directly-tagged evidence),
+  producing a single weighted average.
+
+  Each child is passed as `{proficiency, count}`, where `count` is a measure
+  of how much evidence backs that child's proficiency estimate. This function
+  is agnostic to which learner model produced `proficiency` — it is the
+  CALLER's responsibility to supply a `count` that is consistent with how
+  that proficiency value was calculated:
+
+    * Legacy (naive, first-attempt-only) algorithm: `count` MUST be the
+      number of FIRST attempts (`num_first_attempts`), since only first
+      attempts contribute to that model's proficiency estimate. Passing a
+      total attempt count here would over-weight children whose score was
+      computed from a smaller subset of evidence than their attempt count
+      implies.
+
+    * Learning Proficiency Framework v2 (LKT-AOA): `count` must reflect the
+      total evidence count used by that model (all attempts / "tagged
+      opportunities"), per the LKT-AOA technical definition
+      (`docs/exec-plans/current/epics/learning_model_v2/lkt_technical_notes.docx.md`,
+      section 6.2), since LKT-AOA's own Sub-LO score is a mean over every
+      attempt rather than only the first.
+
+  Mismatching `count` semantics across children (e.g. mixing first-attempt
+  counts with total-attempt counts within the same aggregation call) will
+  silently skew the weighted average — this function has no way to detect
+  that on its own.
+  """
+  @spec aggregate_weighted_proficiency([
+          {proficiency :: float() | nil, count :: non_neg_integer()}
+        ]) ::
+          {score :: float() | nil, total_count :: non_neg_integer()}
+  def aggregate_weighted_proficiency(children) do
+    {weighted_sum, total_count} =
+      Enum.reduce(children, {0.0, 0}, fn
+        {nil, _count}, acc ->
+          acc
+
+        {proficiency, count}, {sum, total} ->
+          {sum + proficiency * count, total + count}
+      end)
+
+    case total_count do
+      0 -> {nil, 0}
+      _ -> {weighted_sum / total_count, total_count}
+    end
+  end
+
   def progress_range(nil), do: "Not enough data"
   def progress_range(progress) when progress <= 0.5, do: "Low"
   def progress_range(progress) when progress <= 0.8, do: "Medium"

--- a/lib/oli/delivery/metrics.ex
+++ b/lib/oli/delivery/metrics.ex
@@ -1560,6 +1560,35 @@ defmodule Oli.Delivery.Metrics do
           opts :: Keyword.t()
         ) :: %{integer => %{integer => String.t()}}
   def proficiency_per_student_for_objective(section_id, objective_ids, opts \\ []) do
+    raw_proficiency_per_student_for_objective(section_id, objective_ids, opts)
+    |> Enum.into(%{}, fn {resource_id, proficiency_by_student} ->
+      bucketed =
+        Enum.into(proficiency_by_student, %{}, fn {student_id, {proficiency, num_first_attempts}} ->
+          {student_id, proficiency_range(proficiency, num_first_attempts)}
+        end)
+
+      {resource_id, bucketed}
+    end)
+  end
+
+  @doc """
+  Like `proficiency_per_student_for_objective/3`, but returns the raw
+  `{proficiency, num_first_attempts}` pair per objective/student instead of a
+  bucketed proficiency string (i.e. one already categorized into "Not enough
+  data" / "Low" / "Medium" / "High"), so a caller can combine an objective's
+  own evidence with its Sub-LOs' evidence (e.g. via
+  `aggregate_weighted_proficiency/1`) before bucketing.
+
+  Returns a map where each key is an objective_id, and the value is another map
+  where each key is a student_id and the value is a `{proficiency, num_first_attempts}`
+  tuple.
+  """
+  @spec raw_proficiency_per_student_for_objective(
+          section_id :: integer,
+          objective_ids :: list(integer),
+          opts :: Keyword.t()
+        ) :: %{integer => %{integer => {float() | nil, non_neg_integer()}}}
+  def raw_proficiency_per_student_for_objective(section_id, objective_ids, opts \\ []) do
     objective_type_id = Oli.Resources.ResourceType.id_for_objective()
 
     maybe_filter_by_student_id =
@@ -1597,7 +1626,7 @@ defmodule Oli.Delivery.Metrics do
     |> Enum.reduce(%{}, fn {student_id, resource_id, proficiency, num_first_attempts}, acc ->
       res =
         Map.get(acc, resource_id, %{})
-        |> Map.put(student_id, proficiency_range(proficiency, num_first_attempts))
+        |> Map.put(student_id, {proficiency, num_first_attempts})
 
       Map.put(acc, resource_id, res)
     end)

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5901,9 +5901,11 @@ defmodule Oli.Delivery.Sections do
   }
 
   For objectives that are subobjectives, the objective is shown as the `subobjective` like the
-  above example, with the aggregated proficiency for its parent shown.  For objectives that are
-  top level objectives, they appear with their proficiency for only those activities that
-  directly attached to them.
+  above example, with the aggregated proficiency for its parent shown. For objectives that are
+  top level objectives, their proficiency is the weighted average of their own directly-attached
+  evidence (when present) combined with all their Sub-LOs' evidence (see
+  `Metrics.evidence_resource_ids/2`) — a leaf objective with no Sub-LOs reduces to just its own
+  directly-attached evidence.
 
   ## Options
 

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5972,18 +5972,31 @@ defmodule Oli.Delivery.Sections do
 
     id_list = Enum.map(objectives, & &1.resource_id)
 
-    proficiencies_for_objectives =
-      Metrics.proficiency_per_student_for_objective(section.id, id_list, student_id: student_id)
+    # Raw (not yet bucketed, i.e. not yet categorized into "Not enough data" /
+    # "Low" / "Medium" / "High") proficiency per objective/student, so a
+    # parent objective's Sub-LOs' evidence can be combined via
+    # Metrics.aggregate_weighted_proficiency/1 before bucketing. See
+    # aggregated_proficiency_bucket/3 below for why a parent's own evidence is
+    # excluded once it has Sub-LOs.
+    raw_proficiency_for_objectives =
+      Metrics.raw_proficiency_per_student_for_objective(section.id, id_list,
+        student_id: student_id
+      )
 
     student_proficiency_for_objectives =
       if student_id do
-        Enum.reduce(id_list, %{}, fn objective_id, acc ->
-          proficiency =
-            proficiencies_for_objectives
-            |> Map.get(objective_id, %{})
-            |> Map.get(student_id, "Not enough data")
+        Enum.reduce(objectives, %{}, fn objective, acc ->
+          resource_ids = objective_evidence_resource_ids(objective)
 
-          Map.put(acc, objective_id, proficiency)
+          Map.put(
+            acc,
+            objective.resource_id,
+            aggregated_proficiency_bucket(
+              resource_ids,
+              raw_proficiency_for_objectives,
+              student_id
+            )
+          )
         end)
       else
         %{}
@@ -5992,25 +6005,20 @@ defmodule Oli.Delivery.Sections do
     {student_ids, proficiency_dist_for_objectives} =
       if is_nil(student_id) do
         student_ids = Sections.enrolled_student_ids(section_slug)
-        student_id_set = MapSet.new(student_ids)
 
         proficiency_dist_for_objectives =
-          proficiencies_for_objectives
-          |> Enum.reduce(%{}, fn {objective_id, student_proficiency}, acc ->
-            # Filter proficiency data to only include enrolled students (exclude instructors)
-            filtered_student_proficiency =
-              student_proficiency
-              |> Enum.filter(fn {user_id, _proficiency_level} ->
-                MapSet.member?(student_id_set, user_id)
-              end)
-              |> Map.new()
+          objectives
+          |> Enum.reduce(%{}, fn objective, acc ->
+            resource_ids = objective_evidence_resource_ids(objective)
 
-            # Add "Not enough data" for students who don't have proficiency data
             student_proficiency =
-              student_ids
-              |> Enum.reject(&Map.has_key?(filtered_student_proficiency, &1))
-              |> Enum.reduce(filtered_student_proficiency, fn user_id, acc ->
-                Map.put(acc, user_id, "Not enough data")
+              Enum.into(student_ids, %{}, fn enrolled_student_id ->
+                {enrolled_student_id,
+                 aggregated_proficiency_bucket(
+                   resource_ids,
+                   raw_proficiency_for_objectives,
+                   enrolled_student_id
+                 )}
               end)
 
             proficiency_dist =
@@ -6042,7 +6050,7 @@ defmodule Oli.Delivery.Sections do
                 {proficiency_mode, proficiency_dist}
               end
 
-            Map.put(acc, objective_id,
+            Map.put(acc, objective.resource_id,
               proficiency_dist: proficiency_dist,
               proficiency_mode: proficiency_mode
             )
@@ -6182,6 +6190,37 @@ defmodule Oli.Delivery.Sections do
           all
       end
     end)
+  end
+
+  # The resource_ids whose evidence contributes to an objective's aggregated
+  # proficiency. A parent's own directly-tagged evidence is deliberately
+  # excluded whenever it has Sub-LOs: an activity tagged to both a parent and
+  # one of its Sub-LOs produces a separate ResourceSummary row under each
+  # resource_id, so combining the parent's own row with its Sub-LOs' rows
+  # would double count that activity's evidence. This mirrors the exclusion
+  # rule `Metrics.proficiency_for_student_per_learning_objective/3` already
+  # applies (count only at the more specific Sub-LO level, per FR-003). A leaf
+  # objective (children == []) falls back to just its own evidence.
+  defp objective_evidence_resource_ids(%{resource_id: resource_id, children: []}),
+    do: [resource_id]
+
+  defp objective_evidence_resource_ids(%{children: children}), do: children
+
+  # Combines the raw evidence for a set of resource_ids (as resolved by
+  # objective_evidence_resource_ids/1) into a single weighted-average
+  # proficiency, then categorizes it into a bucket ("Not enough data" / "Low"
+  # / "Medium" / "High") for one student.
+  defp aggregated_proficiency_bucket(resource_ids, raw_proficiency_for_objectives, student_id) do
+    pairs =
+      Enum.map(resource_ids, fn resource_id ->
+        raw_proficiency_for_objectives
+        |> Map.get(resource_id, %{})
+        |> Map.get(student_id, {nil, 0})
+      end)
+
+    {score, total_count} = Metrics.aggregate_weighted_proficiency(pairs)
+
+    Metrics.proficiency_range(score, total_count)
   end
 
   @doc """

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5974,10 +5974,9 @@ defmodule Oli.Delivery.Sections do
 
     # Raw (not yet bucketed, i.e. not yet categorized into "Not enough data" /
     # "Low" / "Medium" / "High") proficiency per objective/student, so a
-    # parent objective's Sub-LOs' evidence can be combined via
-    # Metrics.aggregate_weighted_proficiency/1 before bucketing. See
-    # aggregated_proficiency_bucket/3 below for why a parent's own evidence is
-    # excluded once it has Sub-LOs.
+    # parent objective's own evidence and its Sub-LOs' evidence can be
+    # combined via Metrics.aggregate_weighted_proficiency/1 before bucketing.
+    # See Metrics.evidence_resource_ids/2.
     raw_proficiency_for_objectives =
       Metrics.raw_proficiency_per_student_for_objective(section.id, id_list,
         student_id: student_id
@@ -5986,12 +5985,12 @@ defmodule Oli.Delivery.Sections do
     student_proficiency_for_objectives =
       if student_id do
         Enum.reduce(objectives, %{}, fn objective, acc ->
-          resource_ids = objective_evidence_resource_ids(objective)
+          resource_ids = Metrics.evidence_resource_ids(objective.resource_id, objective.children)
 
           Map.put(
             acc,
             objective.resource_id,
-            aggregated_proficiency_bucket(
+            Metrics.proficiency_bucket_for_student(
               resource_ids,
               raw_proficiency_for_objectives,
               student_id
@@ -6009,12 +6008,13 @@ defmodule Oli.Delivery.Sections do
         proficiency_dist_for_objectives =
           objectives
           |> Enum.reduce(%{}, fn objective, acc ->
-            resource_ids = objective_evidence_resource_ids(objective)
+            resource_ids =
+              Metrics.evidence_resource_ids(objective.resource_id, objective.children)
 
             student_proficiency =
               Enum.into(student_ids, %{}, fn enrolled_student_id ->
                 {enrolled_student_id,
-                 aggregated_proficiency_bucket(
+                 Metrics.proficiency_bucket_for_student(
                    resource_ids,
                    raw_proficiency_for_objectives,
                    enrolled_student_id
@@ -6190,37 +6190,6 @@ defmodule Oli.Delivery.Sections do
           all
       end
     end)
-  end
-
-  # The resource_ids whose evidence contributes to an objective's aggregated
-  # proficiency. A parent's own directly-tagged evidence is deliberately
-  # excluded whenever it has Sub-LOs: an activity tagged to both a parent and
-  # one of its Sub-LOs produces a separate ResourceSummary row under each
-  # resource_id, so combining the parent's own row with its Sub-LOs' rows
-  # would double count that activity's evidence. This mirrors the exclusion
-  # rule `Metrics.proficiency_for_student_per_learning_objective/3` already
-  # applies (count only at the more specific Sub-LO level, per FR-003). A leaf
-  # objective (children == []) falls back to just its own evidence.
-  defp objective_evidence_resource_ids(%{resource_id: resource_id, children: []}),
-    do: [resource_id]
-
-  defp objective_evidence_resource_ids(%{children: children}), do: children
-
-  # Combines the raw evidence for a set of resource_ids (as resolved by
-  # objective_evidence_resource_ids/1) into a single weighted-average
-  # proficiency, then categorizes it into a bucket ("Not enough data" / "Low"
-  # / "Medium" / "High") for one student.
-  defp aggregated_proficiency_bucket(resource_ids, raw_proficiency_for_objectives, student_id) do
-    pairs =
-      Enum.map(resource_ids, fn resource_id ->
-        raw_proficiency_for_objectives
-        |> Map.get(resource_id, %{})
-        |> Map.get(student_id, {nil, 0})
-      end)
-
-    {score, total_count} = Metrics.aggregate_weighted_proficiency(pairs)
-
-    Metrics.proficiency_range(score, total_count)
   end
 
   @doc """

--- a/lib/oli/scenarios/builder.ex
+++ b/lib/oli/scenarios/builder.ex
@@ -191,24 +191,26 @@ defmodule Oli.Scenarios.Builder do
       {:ok, %{revision: parent_rev}} =
         ObjectiveEditor.add_new(%{title: objective.title}, author, project)
 
-      parent_map = Map.put(acc, objective.title, parent_rev)
-
-      # Create sub-objectives if any
+      # Create sub-objectives if any, attaching each to the parent. Each
+      # attachment produces a new parent revision (its `children` list
+      # grows), so the returned `container` -- not the original `parent_rev`
+      # -- is the up-to-date parent once all children are attached.
       case objective[:children] do
-        nil ->
-          parent_map
-
-        [] ->
-          parent_map
+        children when children in [nil, []] ->
+          Map.put(acc, objective.title, parent_rev)
 
         children when is_list(children) ->
-          # Create each sub-objective and attach to parent
-          Enum.reduce(children, parent_map, fn child_title, child_acc ->
-            {:ok, %{revision: child_rev}} =
-              ObjectiveEditor.add_new(%{title: child_title}, author, project, parent_rev.slug)
+          {child_map, updated_parent_rev} =
+            Enum.reduce(children, {%{}, parent_rev}, fn child_title, {child_acc, _parent_rev} ->
+              {:ok, %{revision: child_rev, container: updated_parent_rev}} =
+                ObjectiveEditor.add_new(%{title: child_title}, author, project, parent_rev.slug)
 
-            Map.put(child_acc, child_title, child_rev)
-          end)
+              {Map.put(child_acc, child_title, child_rev), updated_parent_rev}
+            end)
+
+          acc
+          |> Map.put(objective.title, updated_parent_rev)
+          |> Map.merge(child_map)
       end
     end)
   end

--- a/test/oli/analytics/summary/metrics_v2_test.exs
+++ b/test/oli/analytics/summary/metrics_v2_test.exs
@@ -211,6 +211,48 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
       assert Map.get(results, id3) == "High"
     end
 
+    test "proficiency_for_student_per_learning_objective/3 does not double count a parent's own directly-tagged evidence when it also has a Sub-LO",
+         %{
+           user1: user1,
+           section: section,
+           o1: o1,
+           o2: o2
+         } do
+      objective_type_id = Oli.Resources.ResourceType.id_for_objective()
+      {:ok, section} = Oli.Delivery.Sections.update_section(section, %{analytics_version: :v2})
+
+      # o1 is the parent, with o2 as its only Sub-LO.
+      {:ok, o1_revision} =
+        Oli.Resources.Revision.changeset(o1.revision, %{children: [o2.resource.id]})
+        |> Oli.Repo.update()
+
+      id = o1.resource.id
+      id2 = o2.resource.id
+
+      [
+        # o2 (the Sub-LO): 1 correct out of 5 first attempts => 0.36 => "Low"
+        [-1, -1, section.id, user1.id, id2, nil, objective_type_id, 1, 5, 0, 5, 1],
+        # o1's own direct row: if this were combined with o2's instead of being
+        # ignored in favor of the Sub-LO, the pooled result would be "Medium"
+        # rather than "Low".
+        [-1, -1, section.id, user1.id, id, nil, objective_type_id, 5, 5, 0, 5, 5]
+      ]
+      |> Enum.each(fn v -> add_resource_summary(v) end)
+
+      # Only the parent is passed in, matching how real callers invoke this
+      # function (e.g. prologue_live.ex passes only the page-attached LOs, never
+      # their Sub-LOs alongside them); the Sub-LO's evidence is reached via
+      # o1_revision.children, not by also including it in this list.
+      results =
+        Metrics.proficiency_for_student_per_learning_objective(
+          [o1_revision],
+          user1.id,
+          section
+        )
+
+      assert Map.get(results, id) == "Low"
+    end
+
     test "proficiency_per_student_for_objective/2", %{
       user1: user1,
       user2: user2,

--- a/test/oli/analytics/summary/metrics_v2_test.exs
+++ b/test/oli/analytics/summary/metrics_v2_test.exs
@@ -211,7 +211,7 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
       assert Map.get(results, id3) == "High"
     end
 
-    test "proficiency_for_student_per_learning_objective/3 does not double count a parent's own directly-tagged evidence when it also has a Sub-LO",
+    test "proficiency_for_student_per_learning_objective/3 combines a parent's own directly-tagged evidence with its Sub-LO's evidence",
          %{
            user1: user1,
            section: section,
@@ -230,11 +230,9 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
       id2 = o2.resource.id
 
       [
-        # o2 (the Sub-LO): 1 correct out of 5 first attempts => 0.36 => "Low"
+        # o2 (the Sub-LO): 1 correct out of 5 first attempts => 0.36
         [-1, -1, section.id, user1.id, id2, nil, objective_type_id, 1, 5, 0, 5, 1],
-        # o1's own direct row: if this were combined with o2's instead of being
-        # ignored in favor of the Sub-LO, the pooled result would be "Medium"
-        # rather than "Low".
+        # o1's own direct row: 5 correct out of 5 first attempts => 1.0
         [-1, -1, section.id, user1.id, id, nil, objective_type_id, 5, 5, 0, 5, 5]
       ]
       |> Enum.each(fn v -> add_resource_summary(v) end)
@@ -250,7 +248,15 @@ defmodule Oli.Analytics.Summary.MetricsV2Test do
           section
         )
 
-      assert Map.get(results, id) == "Low"
+      # o1's own evidence (0.36, count=5) and o2's evidence (1.0, count=5) are
+      # always combined: (0.36*5 + 1.0*5) / (5+5) = 6.8/10 = 0.68 => "Medium".
+      # This is a deliberate product decision (Darren Siegel, Slack,
+      # 2026-09-01, "Option B" in
+      # docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md):
+      # a parent's own evidence is never excluded just because it has a
+      # Sub-LO, even though this means an activity tagged to both the parent
+      # and the Sub-LO would be double-counted.
+      assert Map.get(results, id) == "Medium"
     end
 
     test "proficiency_per_student_for_objective/2", %{

--- a/test/oli/delivery/learning_objectives/page_element_test.exs
+++ b/test/oli/delivery/learning_objectives/page_element_test.exs
@@ -25,7 +25,7 @@ defmodule Oli.Delivery.LearningObjectives.PageElementTest do
                schedule_fun: fn _ -> flunk("schedule should not be loaded") end,
                objectives_fun: fn _ -> flunk("objectives should not be loaded") end,
                activity_refs_fun: fn _ -> flunk("activity refs should not be loaded") end,
-               proficiency_fun: fn _, _, _ -> flunk("proficiency should not be loaded") end
+               raw_proficiency_fun: fn _, _, _ -> flunk("proficiency should not be loaded") end
              ) == nil
     end
 
@@ -135,7 +135,7 @@ defmodule Oli.Delivery.LearningObjectives.PageElementTest do
         resources.page_resource_2.id,
         learning_objectives_content("introduction"),
         user,
-        proficiency_fun: fn _, _, _ ->
+        raw_proficiency_fun: fn _, _, _ ->
           send(parent, :unexpected_proficiency)
           %{}
         end
@@ -149,16 +149,28 @@ defmodule Oli.Delivery.LearningObjectives.PageElementTest do
           resources.page_resource_2.id,
           learning_objectives_content("summary"),
           user,
-          proficiency_fun: fn section_id, objective_ids, student_id: student_id ->
-            send(parent, {:proficiency, section_id, objective_ids, student_id})
-            Map.new(objective_ids, &{&1, %{student_id => "High"}})
+          raw_proficiency_fun: fn section_id, resource_ids, student_id: student_id ->
+            send(parent, {:proficiency, section_id, resource_ids, student_id})
+            Map.new(resource_ids, &{&1, %{student_id => {1.0, 5}}})
           end
         )
 
-      assert_received {:proficiency, section_id, objective_ids, student_id}
+      assert_received {:proficiency, section_id, resource_ids, student_id}
       assert section_id == section.id
       assert student_id == user.id
-      assert Enum.sort(objective_ids) == Enum.sort(Enum.map(payload.objectives, & &1.resource_id))
+
+      # obj_resource_c has obj_resource_c1 as its only Sub-LO, so its evidence
+      # is fetched for both obj_resource_c's own resource_id and
+      # obj_resource_c1's; obj_resource_c1 and obj_resource_d are leaves, so
+      # each fetches only its own evidence. A parent's own resource_id is
+      # always requested alongside its Sub-LOs' (Option B — see
+      # Metrics.evidence_resource_ids/2).
+      assert Enum.sort(resource_ids) ==
+               Enum.sort([
+                 resources.obj_resource_c.id,
+                 resources.obj_resource_c1.id,
+                 resources.obj_resource_d.id
+               ])
 
       assert Enum.all?(payload.performance_by_objective_id, fn {_objective_id, value} ->
                value == "High"
@@ -177,7 +189,7 @@ defmodule Oli.Delivery.LearningObjectives.PageElementTest do
             resources.page_resource_2.id,
             learning_objectives_content("summary"),
             non_delivery_user,
-            proficiency_fun: fn _, _, _ ->
+            raw_proficiency_fun: fn _, _, _ ->
               send(parent, :unexpected_proficiency)
               %{}
             end
@@ -186,6 +198,92 @@ defmodule Oli.Delivery.LearningObjectives.PageElementTest do
         assert payload.performance_by_objective_id == %{}
         refute_received :unexpected_proficiency
       end)
+    end
+
+    test "combines a parent's own evidence with a Sub-LO's evidence, including a Sub-LO outside this page element's own scope, consistent with the Instructor Dashboard",
+         %{
+           seeds: %{section: section, resources: resources, revisions: revisions}
+         } do
+      user = insert(:user)
+      objective_type_id = Resources.ResourceType.id_for_objective()
+
+      # Give obj_resource_d a Sub-LO (obj_resource_e) that has no activity on
+      # page_resource_2: page_resource_2's own render scope will not include
+      # E, but E's evidence must still be combined into D's aggregated
+      # proficiency, consistent with the Instructor Dashboard (Phase 3).
+      #
+      # Set via the revision's `children` (resource ids), not the
+      # SectionResource-level `children` (section_resource ids, per
+      # Sections.populate_children_for_objectives/4) that `force_children`
+      # sets — Sections.get_objectives_and_subobjectives/2 and
+      # SectionResourceDepot.objectives_with_effective_children/1 only agree
+      # on the same resolved children when the SectionResource's own
+      # `children` is empty and both fall back to reading the revision.
+      {:ok, _} =
+        revisions.obj_revision_d
+        |> Ecto.Changeset.change(children: [resources.obj_resource_e.id])
+        |> Oli.Repo.update()
+
+      # D's own directly-tagged evidence (from Activity Z) is always combined
+      # with its Sub-LO's evidence, per a deliberate product decision (Darren
+      # Siegel, Slack, 2026-09-01, "Option B" in
+      # docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md).
+      insert(:resource_summary, %{
+        project_id: -1,
+        section_id: section.id,
+        user_id: user.id,
+        resource_id: resources.obj_resource_d.id,
+        resource_type_id: objective_type_id,
+        part_id: "unknown",
+        num_correct: 5,
+        num_attempts: 5,
+        num_hints: 0,
+        num_first_attempts: 5,
+        num_first_attempts_correct: 5
+      })
+
+      # obj_resource_e's evidence combines with D's own evidence above.
+      insert(:resource_summary, %{
+        project_id: -1,
+        section_id: section.id,
+        user_id: user.id,
+        resource_id: resources.obj_resource_e.id,
+        resource_type_id: objective_type_id,
+        part_id: "unknown",
+        num_correct: 0,
+        num_attempts: 4,
+        num_hints: 0,
+        num_first_attempts: 4,
+        num_first_attempts_correct: 0
+      })
+
+      payload =
+        PageElement.prepare_render_payload(
+          section,
+          resources.page_resource_2.id,
+          learning_objectives_content("summary"),
+          user
+        )
+
+      # obj_resource_e is not directly matched on page_resource_2 and is not
+      # an ancestor of anything that is, so it is not rendered here — only D
+      # is.
+      refute Enum.any?(payload.objectives, &(&1.resource_id == resources.obj_resource_e.id))
+      assert Enum.any?(payload.objectives, &(&1.resource_id == resources.obj_resource_d.id))
+
+      page_element_proficiency =
+        Map.fetch!(payload.performance_by_objective_id, resources.obj_resource_d.id)
+
+      # (1.0*5 + 0.2*4) / (5+4) = 5.8/9 = 0.644 => "Medium". If E's
+      # out-of-scope evidence were dropped, this would be "High" (D's own
+      # evidence alone) instead.
+      assert page_element_proficiency == "Medium"
+
+      dashboard_result =
+        Sections.get_objectives_and_subobjectives(section, student_id: user.id)
+        |> Enum.find(&(&1.objective_resource_id == resources.obj_resource_d.id))
+
+      assert dashboard_result.student_proficiency_obj == page_element_proficiency
     end
   end
 

--- a/test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
+++ b/test/oli/delivery/metrics/aggregate_weighted_proficiency_test.exs
@@ -1,0 +1,62 @@
+defmodule Oli.Delivery.Metrics.AggregateWeightedProficiencyTest do
+  use ExUnit.Case, async: true
+
+  alias Oli.Delivery.Metrics
+
+  describe "aggregate_weighted_proficiency/1" do
+    test "computes a weighted average across multiple Sub-LOs with different counts" do
+      # weighted average = (1.0*10 + 0.5*2) / (10 + 2) = 11.0 / 12 = 0.9166...
+      assert {score, total_count} =
+               Metrics.aggregate_weighted_proficiency([{1.0, 10}, {0.5, 2}])
+
+      assert_in_delta score, 11.0 / 12, 0.0001
+      assert total_count == 12
+    end
+
+    test "combines a parent's own directly-tagged evidence with its Sub-LOs' evidence" do
+      # parent has its own (0.6, 5) pair in addition to two Sub-LOs
+      children = [{0.6, 5}, {1.0, 5}, {0.0, 5}]
+
+      assert {score, total_count} = Metrics.aggregate_weighted_proficiency(children)
+
+      assert_in_delta score, (0.6 * 5 + 1.0 * 5 + 0.0 * 5) / 15, 0.0001
+      assert total_count == 15
+    end
+
+    test "does not silently drop a Sub-LO with insufficient (but nonzero) evidence" do
+      # a Sub-LO with only 1 attempt still contributes its weight to the aggregate
+      # instead of being excluded as if only the other Sub-LO existed.
+      with_thin_child = Metrics.aggregate_weighted_proficiency([{1.0, 10}, {0.0, 1}])
+      without_thin_child = Metrics.aggregate_weighted_proficiency([{1.0, 10}])
+
+      assert with_thin_child != without_thin_child
+      assert {score, 11} = with_thin_child
+      assert_in_delta score, 10.0 / 11, 0.0001
+    end
+
+    test "a wholly unattempted Sub-LO (zero count, nil proficiency) contributes no weight, since it carries no evidence to weight by" do
+      # This is expected, not a gap: a zero-count child cannot change a weighted
+      # average by definition. The guarantee that thin evidence isn't silently
+      # excluded (see the test above) is about never dropping a child that HAS
+      # some evidence; it does not imply a child with literally zero evidence
+      # should skew the score.
+      children = [{1.0, 10}, {nil, 0}]
+
+      assert Metrics.aggregate_weighted_proficiency(children) ==
+               Metrics.aggregate_weighted_proficiency([{1.0, 10}])
+    end
+
+    test "returns nil score and zero total count when there is no evidence at all" do
+      assert Metrics.aggregate_weighted_proficiency([]) == {nil, 0}
+      assert Metrics.aggregate_weighted_proficiency([{nil, 0}, {nil, 0}]) == {nil, 0}
+    end
+
+    test "produces a deterministic result for repeated calls with the same inputs" do
+      children = [{0.7, 4}, {0.3, 6}, {nil, 0}]
+
+      results = for _ <- 1..5, do: Metrics.aggregate_weighted_proficiency(children)
+
+      assert Enum.uniq(results) == [Enum.at(results, 0)]
+    end
+  end
+end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -3489,20 +3489,28 @@ defmodule Oli.Delivery.SectionsTest do
       assert top_level_a.section_id == section.id
 
       # objective_a has Sub-LOs (sub_objective_a1 and sub_objective_a2), so its
-      # displayed proficiency now reflects its Sub-LOs' combined evidence
-      # instead of only its own directly-tagged evidence. objective_a's own row
-      # (3/3 first attempts) is excluded to avoid double counting an activity
-      # that could be tagged to both it and a Sub-LO; only Sub-LO evidence is
-      # combined: sub_objective_a1 (0/3, proficiency 0.0) and sub_objective_a2
-      # (no evidence) => proficiency_range(0.0, 3) => "Low". Previously this
-      # showed objective_a's own evidence directly ("High"), ignoring its
-      # Sub-LOs entirely.
-      assert top_level_a.student_proficiency_obj == "Low"
+      # displayed proficiency now reflects its Sub-LOs' combined evidence in
+      # addition to its own directly-tagged evidence — always combined, never
+      # excluded, per a deliberate product decision (Darren Siegel, Slack,
+      # 2026-09-01, "Option B" in
+      # docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md):
+      # objective_a's own evidence (3/3 first attempts, proficiency 1.0) and
+      # sub_objective_a1's evidence (0/3, proficiency 0.2) combine as
+      # (1.0*3 + 0.2*3) / (3+3) = 0.6 => "Medium" (sub_objective_a2 has no
+      # evidence and contributes nothing). Previously this showed only
+      # objective_a's own evidence directly ("High"), ignoring its Sub-LOs
+      # entirely.
+      assert top_level_a.student_proficiency_obj == "Medium"
       assert top_level_a.student_proficiency_obj_dist == nil
 
       sub_a1 = Enum.find(result, &(&1.subobjective == "Sub-objective A.1"))
       assert sub_a1 != nil
-      assert sub_a1.student_proficiency_obj == "Low"
+      # student_proficiency_obj on a sub-objective's row always mirrors its
+      # parent's (combined) proficiency, not the sub-objective's own.
+      assert sub_a1.student_proficiency_obj == "Medium"
+      # student_proficiency_subobj is sub_objective_a1's own proficiency. It
+      # is itself a leaf (no Sub-LOs of its own), so it is unaffected by the
+      # parent's combined value.
       assert sub_a1.student_proficiency_subobj == "Low"
       assert sub_a1.student_proficiency_subobj_dist == nil
     end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -3487,14 +3487,115 @@ defmodule Oli.Delivery.SectionsTest do
       top_level_a = Enum.find(result, &(&1.objective_resource_id == objective_a.resource_id))
       assert top_level_a != nil
       assert top_level_a.section_id == section.id
-      assert top_level_a.student_proficiency_obj == "High"
+
+      # objective_a has Sub-LOs (sub_objective_a1 and sub_objective_a2), so its
+      # displayed proficiency now reflects its Sub-LOs' combined evidence
+      # instead of only its own directly-tagged evidence. objective_a's own row
+      # (3/3 first attempts) is excluded to avoid double counting an activity
+      # that could be tagged to both it and a Sub-LO; only Sub-LO evidence is
+      # combined: sub_objective_a1 (0/3, proficiency 0.0) and sub_objective_a2
+      # (no evidence) => proficiency_range(0.0, 3) => "Low". Previously this
+      # showed objective_a's own evidence directly ("High"), ignoring its
+      # Sub-LOs entirely.
+      assert top_level_a.student_proficiency_obj == "Low"
       assert top_level_a.student_proficiency_obj_dist == nil
 
       sub_a1 = Enum.find(result, &(&1.subobjective == "Sub-objective A.1"))
       assert sub_a1 != nil
-      assert sub_a1.student_proficiency_obj == "High"
+      assert sub_a1.student_proficiency_obj == "Low"
       assert sub_a1.student_proficiency_subobj == "Low"
       assert sub_a1.student_proficiency_subobj_dist == nil
+    end
+
+    test "reflects incomplete coverage instead of ignoring an under-evidenced Sub-LO", %{
+      section: section,
+      objectives: %{
+        objective_a: objective_a,
+        sub_objective_a1: sub_objective_a1,
+        sub_objective_a2: sub_objective_a2
+      }
+    } do
+      student = insert(:user)
+      objective_type_id = ResourceType.id_for_objective()
+
+      # sub_objective_a1: well-attempted, perfect proficiency.
+      insert(:resource_summary, %{
+        project_id: -1,
+        section_id: section.id,
+        user_id: student.id,
+        resource_id: sub_objective_a1.resource_id,
+        resource_type_id: objective_type_id,
+        part_id: "unknown",
+        num_correct: 10,
+        num_attempts: 10,
+        num_hints: 0,
+        num_first_attempts: 10,
+        num_first_attempts_correct: 10
+      })
+
+      # sub_objective_a2: under-evidenced (attempted, but with a thin, nonzero
+      # count), not wholly unattempted. This distinguishes "correctly weighted
+      # in" from "silently dropped": a zero-count child can't change a weighted
+      # average by definition, so testing only that case wouldn't prove
+      # anything (see the aggregate_weighted_proficiency/1 unit tests for that
+      # boundary case instead).
+      insert(:resource_summary, %{
+        project_id: -1,
+        section_id: section.id,
+        user_id: student.id,
+        resource_id: sub_objective_a2.resource_id,
+        resource_type_id: objective_type_id,
+        part_id: "unknown",
+        num_correct: 0,
+        num_attempts: 5,
+        num_hints: 0,
+        num_first_attempts: 5,
+        num_first_attempts_correct: 0
+      })
+
+      result =
+        Sections.get_objectives_and_subobjectives(section, student_id: student.id)
+        |> Enum.find(&(&1.objective_resource_id == objective_a.resource_id))
+
+      # If sub_objective_a2's under-evidenced result were silently dropped,
+      # objective_a would be computed as if only sub_objective_a1 existed:
+      # proficiency 1.0 => "High". Correctly weighting both Sub-LOs together
+      # instead yields (1.0*10 + 0.2*5) / 15 = 0.733 => "Medium" — a different
+      # bucket, so this test actually discriminates between the two outcomes.
+      # (0.2, not 0.0, because the naive formula gives 0.2 partial credit per
+      # incorrect first attempt rather than 0 — see naive_child_proficiency/2
+      # in metrics.ex: sub_objective_a2's 0 correct out of 5 first attempts is
+      # (1.0*0 + 0.2*5) / 5 = 0.2, not 0.0.)
+      assert result.student_proficiency_obj == "Medium"
+    end
+
+    test "a leaf Learning Objective with no Sub-LOs uses only its own evidence, unaffected by aggregation",
+         %{section: section, objectives: %{objective_c: objective_c}} do
+      student = insert(:user)
+      objective_type_id = ResourceType.id_for_objective()
+
+      insert(:resource_summary, %{
+        project_id: -1,
+        section_id: section.id,
+        user_id: student.id,
+        resource_id: objective_c.resource_id,
+        resource_type_id: objective_type_id,
+        part_id: "unknown",
+        num_correct: 2,
+        num_attempts: 4,
+        num_hints: 0,
+        num_first_attempts: 4,
+        num_first_attempts_correct: 2
+      })
+
+      result =
+        Sections.get_objectives_and_subobjectives(section, student_id: student.id)
+        |> Enum.find(&(&1.objective_resource_id == objective_c.resource_id))
+
+      assert objective_c.children == []
+      # (1.0*2 + 0.2*2) / 4 = 0.6 => "Medium", identical to reading
+      # objective_c's own evidence directly (no Sub-LOs to combine).
+      assert result.student_proficiency_obj == "Medium"
     end
 
     test "returns proficiency data with correct structure", %{section: section} do

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -3571,9 +3571,10 @@ defmodule Oli.Delivery.SectionsTest do
       # instead yields (1.0*10 + 0.2*5) / 15 = 0.733 => "Medium" — a different
       # bucket, so this test actually discriminates between the two outcomes.
       # (0.2, not 0.0, because the naive formula gives 0.2 partial credit per
-      # incorrect first attempt rather than 0 — see naive_child_proficiency/2
-      # in metrics.ex: sub_objective_a2's 0 correct out of 5 first attempts is
-      # (1.0*0 + 0.2*5) / 5 = 0.2, not 0.0.)
+      # incorrect first attempt rather than 0 — see the SQL fragment in
+      # Metrics.raw_proficiency_per_student_for_objective/3: sub_objective_a2's
+      # 0 correct out of 5 first attempts is (1.0*0 + 0.2*5) / 5 = 0.2, not
+      # 0.0.)
       assert result.student_proficiency_obj == "Medium"
     end
 

--- a/test/oli/scenarios/objectives_test.exs
+++ b/test/oli/scenarios/objectives_test.exs
@@ -58,6 +58,12 @@ defmodule Oli.Scenarios.ObjectivesTest do
       lo1_current = AuthoringResolver.from_resource_id(project.project.slug, lo1.resource_id)
       assert sub1_1.resource_id in lo1_current.children
       assert sub1_2.resource_id in lo1_current.children
+
+      # objectives_by_title itself must also reflect the up-to-date parent
+      # revision (its children list, not just AuthoringResolver's), since
+      # callers such as the proficiency assertion directive read the parent
+      # straight out of objectives_by_title rather than re-resolving it.
+      assert lo1.children == lo1_current.children
     end
 
     test "can create a project with flat objectives list" do

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/lo_aggregation_ui_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/lo_aggregation_ui_test.exs
@@ -1,0 +1,150 @@
+defmodule OliWeb.Delivery.InstructorDashboard.Insights.LoAggregationUiTest do
+  @moduledoc """
+  Verifies parent Learning Objective proficiency aggregation end to end,
+  through the real Instructor Dashboard Learning Objectives tab, the
+  per-student instructor view, and the CSV export -- not just the Metrics
+  functions in isolation.
+
+  The course, section, enrollments, and student attempts are all seeded by
+  `Oli.Scenarios` (see the scenario file below), which exercises the real
+  attempt-submission pipeline rather than inserting ResourceSummary rows
+  directly.
+  """
+
+  use ExUnit.Case, async: true
+  use OliWeb.ConnCase
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  alias Oli.Scenarios
+  alias Oli.Scenarios.TestSupport
+
+  @scenario_path Path.join(
+                   File.cwd!(),
+                   "test/scenarios/instructor_dashboard/lo_aggregation_weighted_and_combined.scenario.yaml"
+                 )
+
+  defp learning_objectives_route(section_slug, params \\ %{}) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive,
+      section_slug,
+      :insights,
+      :learning_objectives,
+      params
+    )
+  end
+
+  defp student_dashboard_route(section_slug, student_id, tab, params \\ %{}) do
+    Routes.live_path(
+      OliWeb.Endpoint,
+      OliWeb.Delivery.StudentDashboard.StudentDashboardLive,
+      section_slug,
+      student_id,
+      tab,
+      params
+    )
+  end
+
+  setup %{conn: conn} do
+    result = TestSupport.execute_file_with_fixtures(@scenario_path)
+
+    assert result.errors == []
+    assert Enum.all?(result.verifications, & &1.passed)
+
+    section = Scenarios.get_section(result, "lo_aggregation_ui_section")
+    instructor = Scenarios.get_user(result, "lo_ui_instructor")
+    student = Scenarios.get_user(result, "lo_ui_student")
+    project = Scenarios.get_project(result, "lo_aggregation_ui_project")
+
+    %{
+      conn: log_in_user(conn, instructor),
+      section: section,
+      student: student,
+      weighted_parent_resource_id: project.objectives_by_title["Weighted Parent"].resource_id,
+      combined_parent_resource_id: project.objectives_by_title["Combined Parent"].resource_id
+    }
+  end
+
+  describe "Instructor Dashboard Learning Objectives tab" do
+    test "shows the parent's proficiency as the count-weighted average of its Sub-LOs, with no evidence of its own",
+         %{conn: conn, section: section, weighted_parent_resource_id: weighted_parent_resource_id} do
+      {:ok, view, _html} = live(conn, learning_objectives_route(section.slug))
+
+      row =
+        view
+        |> element("tr[data-row-id='row_#{weighted_parent_resource_id}']")
+        |> render()
+
+      assert row =~ "Weighted Parent"
+      assert row =~ "High"
+    end
+
+    test "shows the parent's proficiency as its own evidence combined with its Sub-LO's evidence",
+         %{conn: conn, section: section, combined_parent_resource_id: combined_parent_resource_id} do
+      {:ok, view, _html} = live(conn, learning_objectives_route(section.slug))
+
+      row =
+        view
+        |> element("tr[data-row-id='row_#{combined_parent_resource_id}']")
+        |> render()
+
+      assert row =~ "Combined Parent"
+      assert row =~ "Medium"
+    end
+  end
+
+  describe "per-student instructor view Learning Objectives tab" do
+    test "shows the same combined proficiency values as the Instructor Dashboard tab", %{
+      conn: conn,
+      section: section,
+      student: student,
+      weighted_parent_resource_id: weighted_parent_resource_id,
+      combined_parent_resource_id: combined_parent_resource_id
+    } do
+      {:ok, view, _html} =
+        live(conn, student_dashboard_route(section.slug, student.id, :learning_objectives))
+
+      # Unlike the Instructor Dashboard tab (`data-row-id="row_<resource_id>"`,
+      # one row per top-level objective), the per-student view flattens one
+      # row per (objective, subobjective) pair and uses the bare resource_id
+      # as `data-row-id`. The row whose subobjective column is "-" is the
+      # objective's own aggregated row (student_proficiency_obj); the other
+      # rows show each Sub-LO's own individual proficiency, not the parent's
+      # aggregate, so only the "-" row is the one to check here.
+      weighted_row =
+        view
+        |> element("tr[data-row-id='#{weighted_parent_resource_id}']")
+        |> render()
+
+      combined_row =
+        view
+        |> element("tr[data-row-id='#{combined_parent_resource_id}']")
+        |> render()
+
+      assert weighted_row =~ "High"
+      assert combined_row =~ "Medium"
+    end
+  end
+
+  describe "Learning Objectives CSV export" do
+    test "includes the same combined proficiency values as the Instructor Dashboard tab", %{
+      conn: conn,
+      section: section
+    } do
+      conn =
+        get(
+          conn,
+          "/sections/#{section.slug}/instructor_dashboard/downloads/learning_objectives"
+        )
+
+      csv = response(conn, 200)
+
+      assert csv =~ "Weighted Parent"
+      assert csv =~ "Combined Parent"
+      assert csv =~ "High"
+      assert csv =~ "Medium"
+    end
+  end
+end

--- a/test/scenarios/instructor_dashboard/lo_aggregation_weighted_and_combined.scenario.yaml
+++ b/test/scenarios/instructor_dashboard/lo_aggregation_weighted_and_combined.scenario.yaml
@@ -1,0 +1,316 @@
+# Scenario: Seeds real course/section/attempt data for two Learning
+# Objective aggregation cases. The `assert: proficiency` checks
+# below are a pipeline sanity check; the actual coverage this fixture exists
+# for is in the LiveView/controller tests that load it directly (see
+# test/oli_web/live/delivery/instructor_dashboard/insights/lo_aggregation_ui_test.exs),
+# which log in as the seeded instructor/student and check the real
+# Instructor Dashboard Learning Objectives tab, the per-student instructor
+# view, and the CSV export -- not just the Metrics functions in isolation.
+#
+# Case 1, "Weighted Parent": no evidence of its own, only its two Sub-LOs.
+# - Weighted Child A: 4 correct first attempts -> proficiency 1.0, weight 4.
+# - Weighted Child B: 1 incorrect first attempt -> proficiency 0.2, weight 1.
+# - Weighted average = (1.0*4 + 0.2*1) / 5 = 4.2/5 = 0.84 (High).
+# A naive *unweighted* average of the two Sub-LO proficiencies would give
+# (1.0+0.2)/2 = 0.6 (Medium) -- a different bucket -- so this demonstrates
+# real count-weighted aggregation, not just "some combination happened".
+#
+# Case 2, "Combined Parent": has both its own evidence and a Sub-LO's
+# evidence.
+# - Combined Parent's own evidence: 3 correct first attempts -> proficiency
+#   1.0, weight 3.
+# - Combined Child: 1 incorrect first attempt -> proficiency 0.2, weight 1.
+# - Weighted average = (1.0*3 + 0.2*1) / 4 = 3.2/4 = 0.8 (Medium).
+# If the parent's own evidence were dropped whenever a Sub-LO has evidence
+# (a design once considered and rejected), only the Sub-LO's single attempt
+# would remain, which is below the 3-attempt minimum -> "Not enough data".
+# That bucket flip is what the LiveView tests assert against.
+
+- project:
+    name: "lo_aggregation_ui_project"
+    title: "LO Aggregation UI Project"
+    objectives:
+      - Weighted Parent:
+        - Weighted Child A
+        - Weighted Child B
+      - Combined Parent:
+        - Combined Child
+    root:
+      children:
+        - page: "Weighted Practice A"
+        - page: "Weighted Practice B"
+        - page: "Combined Direct Practice"
+        - page: "Combined Child Practice"
+
+- edit_page:
+    project: "lo_aggregation_ui_project"
+    page: "Weighted Practice A"
+    content: |
+      title: "Weighted Practice A"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "weighted_a_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Weighted Child A"]
+            stem_md: "Weighted Child A, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "weighted_a_q2"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Weighted Child A"]
+            stem_md: "Weighted Child A, question 2"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "weighted_a_q3"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Weighted Child A"]
+            stem_md: "Weighted Child A, question 3"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "weighted_a_q4"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Weighted Child A"]
+            stem_md: "Weighted Child A, question 4"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "lo_aggregation_ui_project"
+    page: "Weighted Practice B"
+    content: |
+      title: "Weighted Practice B"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "weighted_b_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Weighted Child B"]
+            stem_md: "Weighted Child B, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "lo_aggregation_ui_project"
+    page: "Combined Direct Practice"
+    content: |
+      title: "Combined Direct Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "combined_direct_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Parent"]
+            stem_md: "Combined Parent, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "combined_direct_q2"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Parent"]
+            stem_md: "Combined Parent, question 2"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "combined_direct_q3"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Parent"]
+            stem_md: "Combined Parent, question 3"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "lo_aggregation_ui_project"
+    page: "Combined Child Practice"
+    content: |
+      title: "Combined Child Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "combined_child_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Child"]
+            stem_md: "Combined Child, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- publish:
+    to: "lo_aggregation_ui_project"
+    description: "Initial publication"
+
+- section:
+    name: "lo_aggregation_ui_section"
+    title: "LO Aggregation UI Section"
+    from: "lo_aggregation_ui_project"
+
+- user:
+    name: "lo_ui_instructor"
+    type: "instructor"
+    email: "lo_ui_instructor@example.edu"
+    given_name: "Ivy"
+    family_name: "Instructor"
+
+- user:
+    name: "lo_ui_student"
+    type: "student"
+    email: "lo_ui_student@example.edu"
+    given_name: "Sam"
+    family_name: "Student"
+
+- enroll:
+    user: "lo_ui_instructor"
+    section: "lo_aggregation_ui_section"
+    role: instructor
+
+- enroll:
+    user: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    role: student
+
+- view_practice_page:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice A"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice A"
+    activity_virtual_id: "weighted_a_q1"
+    response: "b"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice A"
+    activity_virtual_id: "weighted_a_q2"
+    response: "b"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice A"
+    activity_virtual_id: "weighted_a_q3"
+    response: "b"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice A"
+    activity_virtual_id: "weighted_a_q4"
+    response: "b"
+
+- view_practice_page:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice B"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Weighted Practice B"
+    activity_virtual_id: "weighted_b_q1"
+    response: "a"
+
+- view_practice_page:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Direct Practice"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Direct Practice"
+    activity_virtual_id: "combined_direct_q1"
+    response: "b"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Direct Practice"
+    activity_virtual_id: "combined_direct_q2"
+    response: "b"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Direct Practice"
+    activity_virtual_id: "combined_direct_q3"
+    response: "b"
+
+- view_practice_page:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Child Practice"
+
+- answer_question:
+    student: "lo_ui_student"
+    section: "lo_aggregation_ui_section"
+    page: "Combined Child Practice"
+    activity_virtual_id: "combined_child_q1"
+    response: "a"
+
+- dashboard_analytics_ready:
+    section: "lo_aggregation_ui_section"
+
+- assert:
+    proficiency:
+      section: "lo_aggregation_ui_section"
+      objective: "Weighted Parent"
+      student: "lo_ui_student"
+      bucket: "High"
+
+- assert:
+    proficiency:
+      section: "lo_aggregation_ui_section"
+      objective: "Combined Parent"
+      student: "lo_ui_student"
+      bucket: "Medium"

--- a/test/scenarios/proficiency/parent_combines_own_and_subobjective_evidence.scenario.yaml
+++ b/test/scenarios/proficiency/parent_combines_own_and_subobjective_evidence.scenario.yaml
@@ -1,0 +1,146 @@
+# Scenario: Parent Learning Objective combines its own evidence with a
+# Sub-LO's evidence.
+#
+# Unlike the unit tests for this rule (test/oli/analytics/summary/metrics_v2_test.exs),
+# this scenario exercises the real attempt pipeline end to end: a student
+# answers real activities through Oli.Delivery.Attempts, real analytics
+# summary rows get generated, and only then is proficiency aggregated and
+# read back — no ResourceSummary row is inserted directly.
+#
+# "Combined Objective" has its own directly-tagged activity (1 correct
+# first attempt -> proficiency 1.0, weight 1) and a Sub-LO "Combined
+# Sub Objective" with two directly-tagged activities (1 correct, 1
+# incorrect first attempt -> proficiency 0.6, weight 2).
+#
+# Weighted average = (1.0*1 + 0.6*2) / (1+2) = 2.2/3 = 0.73 (Medium), from a
+# combined total of 3 first attempts.
+# If the parent's own evidence were dropped whenever a Sub-LO has evidence
+# (a design once considered and rejected), only the Sub-LO's 2 attempts
+# would remain, which is below the 3-attempt minimum -> "Not enough data"
+# instead of "Medium". That bucket flip is what this assertion actually
+# pins down.
+
+- project:
+    name: "combines_own_and_subobjective_evidence_project"
+    title: "Combines Own And Subobjective Evidence"
+    objectives:
+      - Combined Objective:
+        - Combined Sub Objective
+    root:
+      children:
+        - page: "Parent Direct Practice"
+        - page: "Sub Objective Practice"
+
+- edit_page:
+    project: "combines_own_and_subobjective_evidence_project"
+    page: "Parent Direct Practice"
+    content: |
+      title: "Parent Direct Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "parent_direct_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Objective"]
+            stem_md: "Directly tagged to the parent objective"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "combines_own_and_subobjective_evidence_project"
+    page: "Sub Objective Practice"
+    content: |
+      title: "Sub Objective Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "sub_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Sub Objective"]
+            stem_md: "Tagged to the Sub-LO, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "sub_q2"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Combined Sub Objective"]
+            stem_md: "Tagged to the Sub-LO, question 2"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- publish:
+    to: "combines_own_and_subobjective_evidence_project"
+    description: "Initial publication"
+
+- section:
+    name: "combines_own_and_subobjective_evidence_section"
+    title: "Combines Own And Subobjective Evidence Section"
+    from: "combines_own_and_subobjective_evidence_project"
+
+- user:
+    name: "learner"
+    type: "student"
+    email: "combines_own_and_subobjective_evidence_learner@example.edu"
+    given_name: "Lee"
+    family_name: "Learner"
+
+- enroll:
+    user: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    role: student
+
+- view_practice_page:
+    student: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    page: "Parent Direct Practice"
+
+- answer_question:
+    student: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    page: "Parent Direct Practice"
+    activity_virtual_id: "parent_direct_q1"
+    response: "b"
+
+- view_practice_page:
+    student: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    page: "Sub Objective Practice"
+
+- answer_question:
+    student: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    page: "Sub Objective Practice"
+    activity_virtual_id: "sub_q1"
+    response: "b"
+
+- answer_question:
+    student: "learner"
+    section: "combines_own_and_subobjective_evidence_section"
+    page: "Sub Objective Practice"
+    activity_virtual_id: "sub_q2"
+    response: "a"
+
+- dashboard_analytics_ready:
+    section: "combines_own_and_subobjective_evidence_section"
+
+- assert:
+    proficiency:
+      section: "combines_own_and_subobjective_evidence_section"
+      objective: "Combined Objective"
+      student: "learner"
+      bucket: "Medium"

--- a/test/scenarios/proficiency/parent_double_counts_activity_tagged_to_both_parent_and_subobjective.scenario.yaml
+++ b/test/scenarios/proficiency/parent_double_counts_activity_tagged_to_both_parent_and_subobjective.scenario.yaml
@@ -1,0 +1,126 @@
+# Scenario: An activity tagged to BOTH a parent Learning Objective and one of
+# its Sub-LOs contributes its evidence twice to the parent's aggregated
+# proficiency -- once via the parent's own row, again via the Sub-LO's row.
+# This is a deliberate, accepted trade-off, not a defect: real evidence is
+# never dropped, but a shared activity is not deduplicated across the two
+# rows it lands in.
+#
+# "Shared Activity" is tagged to BOTH "Double Count Parent" and its Sub-LO
+# "Double Count Child" and is answered once, correctly. A second activity,
+# tagged only to the Sub-LO, is also answered once, correctly. So only 2
+# real attempts are made in total.
+#
+# If the shared activity were correctly deduplicated (counted once), the
+# parent's aggregation would see 2 total attempts -- below the 3-attempt
+# minimum -> "Not enough data". Because it is instead counted once under the
+# parent's own row and again under the Sub-LO's row, the parent's
+# aggregation sees 3 total attempts (1 own + 2 Sub-LO, both correct) ->
+# proficiency 1.0 -> "High". That a 2-real-attempt course clears the
+# 3-attempt "enough data" minimum is only possible because of the double
+# count, which is exactly what this assertion pins down.
+
+- project:
+    name: "double_counts_shared_activity_project"
+    title: "Double Counts Shared Activity"
+    objectives:
+      - Double Count Parent:
+        - Double Count Child
+    root:
+      children:
+        - page: "Shared Activity Practice"
+        - page: "Child Only Practice"
+
+- edit_page:
+    project: "double_counts_shared_activity_project"
+    page: "Shared Activity Practice"
+    content: |
+      title: "Shared Activity Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "shared_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Double Count Parent", "Double Count Child"]
+            stem_md: "Tagged to both the parent and the Sub-LO"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "double_counts_shared_activity_project"
+    page: "Child Only Practice"
+    content: |
+      title: "Child Only Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "child_only_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Double Count Child"]
+            stem_md: "Tagged only to the Sub-LO"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- publish:
+    to: "double_counts_shared_activity_project"
+    description: "Initial publication"
+
+- section:
+    name: "double_counts_shared_activity_section"
+    title: "Double Counts Shared Activity Section"
+    from: "double_counts_shared_activity_project"
+
+- user:
+    name: "learner"
+    type: "student"
+    email: "double_counts_shared_activity_learner@example.edu"
+    given_name: "Riley"
+    family_name: "Learner"
+
+- enroll:
+    user: "learner"
+    section: "double_counts_shared_activity_section"
+    role: student
+
+- view_practice_page:
+    student: "learner"
+    section: "double_counts_shared_activity_section"
+    page: "Shared Activity Practice"
+
+- answer_question:
+    student: "learner"
+    section: "double_counts_shared_activity_section"
+    page: "Shared Activity Practice"
+    activity_virtual_id: "shared_q1"
+    response: "b"
+
+- view_practice_page:
+    student: "learner"
+    section: "double_counts_shared_activity_section"
+    page: "Child Only Practice"
+
+- answer_question:
+    student: "learner"
+    section: "double_counts_shared_activity_section"
+    page: "Child Only Practice"
+    activity_virtual_id: "child_only_q1"
+    response: "b"
+
+- dashboard_analytics_ready:
+    section: "double_counts_shared_activity_section"
+
+- assert:
+    proficiency:
+      section: "double_counts_shared_activity_section"
+      objective: "Double Count Parent"
+      student: "learner"
+      bucket: "High"

--- a/test/scenarios/proficiency/parent_reflects_incomplete_subobjective_coverage.scenario.yaml
+++ b/test/scenarios/proficiency/parent_reflects_incomplete_subobjective_coverage.scenario.yaml
@@ -1,0 +1,159 @@
+# Scenario: Parent Learning Objective proficiency reflects an under-evidenced
+# Sub-LO instead of being calculated as if only the well-evidenced Sub-LO
+# existed.
+#
+# "Coverage Objective" has no evidence of its own. Its Sub-LO "Coverage Sub A"
+# has 3 correct first attempts (proficiency 1.0, weight 3) and its Sub-LO
+# "Coverage Sub B" has a single *incorrect* first attempt (proficiency 0.2,
+# weight 1) -- thin, but real, evidence, not zero evidence.
+#
+# Weighted average = (1.0*3 + 0.2*1) / (3+1) = 3.2/4 = 0.8 (Medium).
+# If Sub B's thin evidence were ignored (as if it had never been attempted),
+# the result would instead be Sub A's evidence alone: 1.0 (High) -- a
+# different bucket, which is what makes this assertion diagnostic rather
+# than coincidental.
+
+- project:
+    name: "reflects_incomplete_subobjective_coverage_project"
+    title: "Reflects Incomplete Subobjective Coverage"
+    objectives:
+      - Coverage Objective:
+        - Coverage Sub A
+        - Coverage Sub B
+    root:
+      children:
+        - page: "Coverage Sub A Practice"
+        - page: "Coverage Sub B Practice"
+
+- edit_page:
+    project: "reflects_incomplete_subobjective_coverage_project"
+    page: "Coverage Sub A Practice"
+    content: |
+      title: "Coverage Sub A Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "sub_a_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Coverage Sub A"]
+            stem_md: "Coverage Sub A, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "sub_a_q2"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Coverage Sub A"]
+            stem_md: "Coverage Sub A, question 2"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+        - type: activity
+          virtual_id: "sub_a_q3"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Coverage Sub A"]
+            stem_md: "Coverage Sub A, question 3"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- edit_page:
+    project: "reflects_incomplete_subobjective_coverage_project"
+    page: "Coverage Sub B Practice"
+    content: |
+      title: "Coverage Sub B Practice"
+      graded: false
+      blocks:
+        - type: activity
+          virtual_id: "sub_b_q1"
+          activity:
+            type: "oli_multiple_choice"
+            objectives: ["Coverage Sub B"]
+            stem_md: "Coverage Sub B, question 1"
+            choices:
+              - id: "a"
+                body_md: "Wrong"
+              - id: "b"
+                body_md: "Correct"
+                score: 1
+
+- publish:
+    to: "reflects_incomplete_subobjective_coverage_project"
+    description: "Initial publication"
+
+- section:
+    name: "reflects_incomplete_subobjective_coverage_section"
+    title: "Reflects Incomplete Subobjective Coverage Section"
+    from: "reflects_incomplete_subobjective_coverage_project"
+
+- user:
+    name: "learner"
+    type: "student"
+    email: "reflects_incomplete_subobjective_coverage_learner@example.edu"
+    given_name: "Casey"
+    family_name: "Learner"
+
+- enroll:
+    user: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    role: student
+
+- view_practice_page:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub A Practice"
+
+- answer_question:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub A Practice"
+    activity_virtual_id: "sub_a_q1"
+    response: "b"
+
+- answer_question:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub A Practice"
+    activity_virtual_id: "sub_a_q2"
+    response: "b"
+
+- answer_question:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub A Practice"
+    activity_virtual_id: "sub_a_q3"
+    response: "b"
+
+- view_practice_page:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub B Practice"
+
+- answer_question:
+    student: "learner"
+    section: "reflects_incomplete_subobjective_coverage_section"
+    page: "Coverage Sub B Practice"
+    activity_virtual_id: "sub_b_q1"
+    response: "a"
+
+- dashboard_analytics_ready:
+    section: "reflects_incomplete_subobjective_coverage_section"
+
+- assert:
+    proficiency:
+      section: "reflects_incomplete_subobjective_coverage_section"
+      objective: "Coverage Objective"
+      student: "learner"
+      bucket: "Medium"


### PR DESCRIPTION
## Jira

- Ticket: https://eliterate.atlassian.net/browse/MER-5821

## Summary

Parent Learning Objectives now show an aggregated proficiency that combines their own
directly-tagged evidence (when present) with all their Sub-LOs' evidence, instead of showing
"not enough data" whenever a parent has no direct evidence of its own. The exact aggregation
rule ("Option B": always combine, accepting that an activity tagged to both a parent and a
Sub-LO contributes to both) was confirmed with the ticket owner after implementation surfaced a
genuine ambiguity in the original acceptance criteria — see
`docs/exec-plans/current/epics/learning_model_v2/lo_aggregation/parent_evidence_aggregation_options.md`
for the alternatives considered.

## What Was Added

- `Metrics.aggregate_weighted_proficiency/1`: a shared, algorithm-agnostic weighted-average
  aggregation function.
- `Metrics.evidence_resource_ids/2` and `Metrics.proficiency_bucket_for_student/3`: the shared
  always-combine rule and bucketing, now used identically by all three real call sites — student
  delivery pages, the Instructor Dashboard / per-student view / CSV export, and the
  "learning_objectives" page element.
- Consolidated the pre-existing student-facing proficiency calculation onto this shared
  pipeline, removing the dead code it replaced.
- A bug fix in `Oli.Scenarios.Builder`: a scenario-built parent objective's cached revision
  went stale once its Sub-LOs were attached, found while adding test coverage below.
- New `Oli.Scenarios`-based tests that exercise the real attempt-submission pipeline instead of
  factory-inserted `ResourceSummary` rows, including a LiveView/controller suite that checks the
  actual rendered Instructor Dashboard tab, per-student view, and CSV export.

## Validation

- `mix format`, `mix compile --warnings-as-errors` clean.
- `yarn format`, `yarn check-types`, `yarn deploy` clean.
- Automated test suite green (unit, Instructor Dashboard/student LiveView, and the full
  `Oli.Scenarios` suite — 750 tests, 0 failures).
- Manual QA and the Jira status update are still open — this PR covers implementation and
  automated test coverage.