### PR TITLE
[BUG FIX] [MER-5920] Restore experiment-controlled Alternatives in review

### DIFF
--- a/lib/oli/rendering/alternatives.ex
+++ b/lib/oli/rendering/alternatives.ex
@@ -30,6 +30,7 @@ defmodule Oli.Rendering.Alternatives do
           section_id: section_id,
           section_slug: section_slug,
           project_slug: project_slug,
+          page_id: page_resource_id,
           activity_map: activity_map,
           mode: mode,
           alternatives_selector_fn: alternatives_selector_fn,
@@ -60,6 +61,7 @@ defmodule Oli.Rendering.Alternatives do
         section_slug: section_slug,
         mode: mode,
         project_slug: project_slug,
+        page_resource_id: page_resource_id,
         activity_resource_ids: activity_resource_ids(activity_map),
         alternative_groups_by_id: by_id,
         experiment_decisions: experiment_decisions

--- a/lib/oli/resources/alternatives/experiment_controlled_strategy.ex
+++ b/lib/oli/resources/alternatives/experiment_controlled_strategy.ex
@@ -473,7 +473,8 @@ defmodule Oli.Resources.Alternatives.ExperimentControlledStrategy do
     end
   end
 
-  defp activity_ids(%{"type" => "activity", "activity_id" => activity_id}), do: [activity_id]
+  defp activity_ids(%{"type" => "activity-reference", "activity_id" => activity_id}),
+    do: [activity_id]
 
   defp activity_ids(%{"children" => children}) when is_list(children) do
     Enum.flat_map(children, &activity_ids/1)

--- a/test/oli/rendering/alternatives/html_test.exs
+++ b/test/oli/rendering/alternatives/html_test.exs
@@ -47,6 +47,41 @@ defmodule Oli.Rendering.Alternatives.HtmlTest do
                ~s|class="alternative alternative-b" data-alternatives-id="23"|
     end
 
+    test "passes the page resource id to the alternatives strategy", %{author: author} do
+      test_process = self()
+
+      element = %{
+        "type" => "alternatives",
+        "id" => "experiment-placement",
+        "alternatives_id" => 23,
+        "children" => [%{"type" => "alternative", "value" => "a", "children" => []}]
+      }
+
+      Alternatives.render(
+        %Context{
+          user: author,
+          page_id: 42,
+          activity_map: %{},
+          alternatives_groups_fn: fn ->
+            {:ok, [%{id: 23, strategy: "select_all", options: []}]}
+          end,
+          alternatives_selector_fn: fn strategy_context, alternatives_element ->
+            send(test_process, {:strategy_context, strategy_context})
+
+            Oli.Resources.Alternatives.SelectAllStrategy.select(
+              strategy_context,
+              alternatives_element
+            )
+          end,
+          mode: :review
+        },
+        element,
+        Alternatives.Html
+      )
+
+      assert_receive {:strategy_context, %{page_resource_id: 42}}
+    end
+
     test "renders well-formed survey properly", %{author: author} do
       activity_map = %{
         1 => %ActivitySummary{

--- a/test/oli/resources/alternatives_test.exs
+++ b/test/oli/resources/alternatives_test.exs
@@ -769,7 +769,7 @@ defmodule Oli.Resources.AlternativesTest do
       "value" => value,
       "children" => [
         %{
-          "type" => "activity",
+          "type" => "activity-reference",
           "activity_id" => activity_id
         }
       ]


### PR DESCRIPTION
https://eliterate.atlassian.net/browse/MER-5920

## Summary

QA identified that assessments using native experiment-controlled Alternatives rendered correctly during delivery and could be submitted, but the selected branch appeared blank in both student and instructor review. The issue affects experiment-controlled Alternatives under both Thompson Sampling and Weighted Random policies.

## Root cause

Review first attempts to recover the selected branch by matching activities in the submitted attempt against activities in each alternative. Persisted page content represents those nodes as `activity-reference`, while the review strategy incorrectly matched the non-persisted `activity` shape, so the attempted branch was not found.

The fallback path then attempts to recover the persisted experiment assignment. Although the rendering context contains the page resource ID, it was not propagated into the Alternatives strategy context. Assignment lookup requires that page ID as part of placement identity, so the lookup failed and review returned no selected alternatives.

## Other affected review cases

The same failure was not limited to the assessment reported by QA. It also affected experiment-controlled Alternatives during review when:

- an activity was nested inside a group, survey, or other container, because the recursive traversal still ignored every persisted `activity-reference` node;
- a branch used bank-selected or dynamically selected activities that could not be matched directly against a static activity reference and therefore depended on assignment recovery;
- an attempt's activity map was empty or did not map cleanly back to the branch content, requiring the persisted assignment fallback;
- a selected branch contained only prose or other non-activity content, leaving assignment recovery as the only way to identify the branch; or
- review content was rendered through the shared Markdown or plaintext Alternatives writers. Student review also uses Markdown rendering for the page-content cache, so the cached review representation could be blank along with the HTML output.

Normal delivery and preview were not affected: delivery uses its prepared experiment decision, while author and instructor preview intentionally render all branches.

## Changes

- Recognize persisted `activity-reference` nodes when matching attempted activities.
- Propagate the rendering context's page ID as the Alternatives strategy's `page_resource_id`.
- Correct the regression fixture to use the real persisted activity-reference shape.
- Add coverage verifying page resource ID propagation into the strategy context.

## Verification

- `mix test test/oli/resources/alternatives_test.exs test/oli/rendering/alternatives/html_test.exs`
- 19 tests, 0 failures
- `mix format`
- `git diff --check`
