### PR TITLE
[FEATURE] [MER-5861] Restrict learning objectives by content type

### DIFF
--- a/assets/src/apps/authoring/Authoring.tsx
+++ b/assets/src/apps/authoring/Authoring.tsx
@@ -274,6 +274,7 @@ const Authoring: React.FC<AuthoringProps> = (props: AuthoringProps) => {
       partComponentTypes,
       activityTypes,
       allObjectives: content.allObjectives || [],
+      loWellFormed: content.loWellFormed === true,
       applicationMode:
         content.content?.custom?.contentMode === 'flowchart' ? 'flowchart' : 'expert',
     };

--- a/assets/src/apps/authoring/components/PropertyEditor/custom/LearningObjectivesModal.tsx
+++ b/assets/src/apps/authoring/components/PropertyEditor/custom/LearningObjectivesModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button, Modal } from 'react-bootstrap';
 import { useSelector } from 'react-redux';
 import { ObjectivesSelection } from '../../../../../components/resource/objectives/ObjectivesSelection';
-import { ObjectivesMap, selectProjectSlug } from '../../../store/app/slice';
+import { ObjectivesMap, selectLoWellFormed, selectProjectSlug } from '../../../store/app/slice';
 import { AdvancedAuthoringModal } from '../../AdvancedAuthoringModal';
 
 interface LearningModalObjectiveProps {
@@ -20,6 +20,7 @@ export const LearningObjectivesModal: React.FC<LearningModalObjectiveProps> = ({
   objectiveMap,
 }) => {
   const projectSlug = useSelector(selectProjectSlug);
+  const loWellFormed = useSelector(selectLoWellFormed);
 
   return (
     <AdvancedAuthoringModal onHide={handleClose} show={true} size="xl">
@@ -29,6 +30,8 @@ export const LearningObjectivesModal: React.FC<LearningModalObjectiveProps> = ({
       <Modal.Body>
         <ObjectivesSelection
           editMode={!readonly}
+          attachmentType="activity"
+          loWellFormed={loWellFormed}
           objectives={Object.values(objectiveMap)}
           selected={currentObjectives}
           onEdit={onChange}

--- a/assets/src/apps/authoring/store/app/slice.ts
+++ b/assets/src/apps/authoring/store/app/slice.ts
@@ -70,6 +70,7 @@ export interface AppState {
   partComponentTypes: PartComponentRegistration[];
   activityTypes: ActivityRegistration[];
   allObjectives: Objective[];
+  loWellFormed: boolean;
   copiedPart: any | null;
   copiedPartActivityId: any | null;
   allowTriggers: boolean;
@@ -100,6 +101,7 @@ const initialState: AppState = {
   partComponentTypes: [],
   activityTypes: [],
   allObjectives: [],
+  loWellFormed: false,
   copiedPart: null,
   copiedPartActivityId: null,
   allowTriggers: false,
@@ -120,6 +122,7 @@ export interface AppConfig {
   partComponentTypes?: any[];
   activityTypes?: any[];
   allObjectives?: Objective[];
+  loWellFormed?: boolean;
   copiedPart?: any;
   copiedPartActivityId?: any;
   allowTriggers?: boolean;
@@ -148,6 +151,7 @@ const slice: Slice<AppState> = createSlice({
       state.partComponentTypes =
         action.payload.partComponentTypes || initialState.partComponentTypes;
       state.allObjectives = action.payload.allObjectives || initialState.allObjectives;
+      state.loWellFormed = action.payload.loWellFormed === true;
 
       state.activityTypes = action.payload.activityTypes || initialState.activityTypes;
       state.copiedPart = action.payload.copiedPart || initialState.copiedPart;
@@ -289,6 +293,10 @@ export const selectRevisionSlug = createSelector(
 export const selectAllObjectives = createSelector(
   selectState,
   (state: AppState) => state.allObjectives,
+);
+export const selectLoWellFormed = createSelector(
+  selectState,
+  (state: AppState) => state.loWellFormed,
 );
 
 // Returns the allObjectives as a map of id to Objective

--- a/assets/src/apps/authoring/types.ts
+++ b/assets/src/apps/authoring/types.ts
@@ -19,6 +19,7 @@ export interface PageContext {
   title: string;
   content: PageContent;
   allObjectives?: any[];
+  loWellFormed?: boolean;
   editorMap?: any;
   projectSlug?: string;
   resourceSlug?: string;

--- a/assets/src/apps/bank/ActivityBank.tsx
+++ b/assets/src/apps/bank/ActivityBank.tsx
@@ -56,6 +56,7 @@ export interface ActivityBankProps {
   appsignalKey: string | null;
   revisionHistoryLink: boolean;
   allowTriggers: boolean;
+  loWellFormed?: boolean;
 }
 
 type ActivityBankState = {
@@ -561,6 +562,7 @@ export class ActivityBank extends React.Component<ActivityBankProps, ActivityBan
             revisionHistoryLink={this.props.revisionHistoryLink}
             editMode={editMode}
             allObjectives={this.state.allObjectives.toArray()}
+            loWellFormed={this.props.loWellFormed}
             allTags={this.state.allTags.toArray()}
             onPostUndoable={this.onPostUndoable.bind(this, key)}
             onEdit={this.onActivityEdit.bind(this, key)}

--- a/assets/src/apps/page-editor/PageEditor.tsx
+++ b/assets/src/apps/page-editor/PageEditor.tsx
@@ -732,6 +732,8 @@ export class PageEditor extends React.Component<PageEditorProps, PageEditorState
                 <Objectives>
                   <ObjectivesSelection
                     editMode={this.state.editMode}
+                    attachmentType="page"
+                    loWellFormed={this.props.loWellFormed}
                     projectSlug={this.props.projectSlug}
                     objectives={this.state.allObjectives.toArray()}
                     selected={this.state.objectives.toArray()}

--- a/assets/src/components/activity/InlineActivityEditor.tsx
+++ b/assets/src/components/activity/InlineActivityEditor.tsx
@@ -32,6 +32,7 @@ export interface ActivityEditorProps extends ActivityEditContext {
   onRemove: () => void;
   onDuplicate?: () => void;
   responsiveLayout?: boolean;
+  loWellFormed?: boolean;
 }
 
 // This is the state of our activity editing that is undoable
@@ -289,6 +290,7 @@ export class InlineActivityEditor extends React.Component<
           projectSlug={webComponentProps.projectslug}
           objectives={this.props.objectives}
           allObjectives={this.props.allObjectives}
+          loWellFormed={this.props.loWellFormed}
           onRegisterNewObjective={this.props.onRegisterNewObjective}
           onEdit={(objectives) => this.update({ objectives })}
         />

--- a/assets/src/components/resource/editors/ActivityEditor.tsx
+++ b/assets/src/components/resource/editors/ActivityEditor.tsx
@@ -51,6 +51,7 @@ export const ActivityEditor = ({
           description={activity.description}
           objectives={activity.objectives}
           allObjectives={allObjectives}
+          loWellFormed={resourceContext.loWellFormed}
           tags={activity.tags}
           allTags={allTags}
           activityId={activity.activityId}

--- a/assets/src/components/resource/objectives/ActivityLOs.tsx
+++ b/assets/src/components/resource/objectives/ActivityLOs.tsx
@@ -13,6 +13,7 @@ type Props = {
   projectSlug: string;
   onEdit: (objectives: ObjectiveMap) => void;
   onRegisterNewObjective: (objective: Objective) => void;
+  loWellFormed?: boolean;
 };
 
 // Allows attaching and removal of objectives to activity parts
@@ -43,6 +44,7 @@ const MultiPartSelection = (props: Props & { id: string; index: number }) => {
       <PartLabel />
       <ObjectivesSelection
         {...props}
+        attachmentType="activity"
         selected={props.objectives[props.id] || []}
         objectives={props.allObjectives}
         onEdit={(objectives) => {
@@ -66,6 +68,7 @@ const SinglePartSelection = (props: Props) => {
   return (
     <ObjectivesSelection
       {...props}
+      attachmentType="activity"
       selected={props.objectives[partId] || []}
       objectives={props.allObjectives}
       onEdit={(objectives) => props.onEdit({ ...props.objectives, ...{ [partId]: objectives } })}

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -192,7 +192,13 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
         emptyLabel={searchOnly ? 'No eligible learning objectives found.' : undefined}
         onBlur={() => searchOnly && clearSearch()}
         onKeyDown={(event) => {
-          if (searchOnly && (event as KeyboardEvent).key === 'Escape') clearSearch(true);
+          const keyboardEvent = event as unknown as React.KeyboardEvent<HTMLInputElement>;
+
+          if (searchOnly && keyboardEvent.key === 'Escape' && keyboardEvent.currentTarget.value) {
+            keyboardEvent.preventDefault();
+            keyboardEvent.stopPropagation();
+            clearSearch(true);
+          }
         }}
         onChange={(updated: (Objective & { customOption?: boolean })[]) => {
           // we can safely assume that only one objective will ever be selected at a time

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -20,11 +20,44 @@ export type ObjectivesProps = {
   projectSlug: ProjectSlug;
   onEdit: (objectives: ResourceId[]) => void;
   onRegisterNewObjective?: (objective: Objective) => void;
+  attachmentType?: 'page' | 'activity';
+  loWellFormed?: boolean;
 };
+
+export type ObjectiveOption = Objective & { disabled?: boolean };
+
+export const objectivesForAttachment = (
+  objectives: Objective[],
+  attachmentType?: ObjectivesProps['attachmentType'],
+  loWellFormed?: boolean,
+): ObjectiveOption[] => {
+  if (!loWellFormed) return objectives;
+
+  switch (attachmentType) {
+    case 'page':
+      return objectives.filter((objective) => !objective.parentIds?.length);
+    case 'activity':
+      return objectives.map((objective) => ({
+        ...objective,
+        disabled: !objective.parentIds?.length,
+      }));
+    default:
+      return objectives;
+  }
+};
+
+export const canCreateObjective = (
+  onRegisterNewObjective?: (objective: Objective) => void,
+  loWellFormed?: boolean,
+) => !!onRegisterNewObjective && !loWellFormed;
 
 // Custom filterBy function for the Typeahead. This allows searches to
 // pick up child objectives for text that matches any of their parents
-function filterBy(byId: any, option: Objective, props: AllTypeaheadOwnAndInjectedProps<Objective>) {
+function filterBy(
+  byId: any,
+  option: ObjectiveOption,
+  props: AllTypeaheadOwnAndInjectedProps<ObjectiveOption>,
+) {
   const searchText = props.text.toLocaleLowerCase();
 
   // First check if the objective's own title matches
@@ -61,7 +94,16 @@ const getPlaceholderLabel = (hasObjectives: boolean, editMode: boolean) => {
 };
 
 export const ObjectivesSelection = (props: ObjectivesProps) => {
-  const { objectives, editMode, selected, onEdit, onRegisterNewObjective } = props;
+  const {
+    objectives,
+    editMode,
+    selected,
+    onEdit,
+    onRegisterNewObjective,
+    attachmentType,
+    loWellFormed,
+  } = props;
+  const attachmentObjectives = objectivesForAttachment(objectives, attachmentType, loWellFormed);
 
   // Typeahead throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
@@ -78,15 +120,21 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   }, [objectives]);
 
   const renderMenuItemChildren = (
-    option: TypeaheadResult<Objective>,
-    _props: TypeaheadMenuProps<Objective>,
+    option: TypeaheadResult<ObjectiveOption>,
+    _props: TypeaheadMenuProps<ObjectiveOption>,
     _index: number,
   ) => {
     const isChild = option.parentIds !== null && option.parentIds.length > 0;
     return (
       <div>
         {isChild ? <span className="ml-3">&nbsp;</span> : null}
-        <input className="mr-2" type="checkbox" readOnly checked={allSelected[option.id]}></input>
+        <input
+          className="mr-2"
+          type="checkbox"
+          readOnly
+          disabled={option.disabled}
+          checked={allSelected[option.id]}
+        ></input>
         {option.title}
       </div>
     );
@@ -97,9 +145,9 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const map = Immutable.Map<ResourceId, Objective>(objectives.map((o) => [o.id, o]));
   const asObjectives = selected.map((s) => map.get(s) as Objective).filter((o) => !!o);
 
-  const allowNewObjective = !!onRegisterNewObjective;
-  const hasObjectives = objectives.length > 0;
-  const placeholder = getPlaceholderLabel(hasObjectives, editMode && !!onRegisterNewObjective);
+  const allowNewObjective = canCreateObjective(onRegisterNewObjective, loWellFormed);
+  const hasObjectives = attachmentObjectives.length > 0;
+  const placeholder = getPlaceholderLabel(hasObjectives, editMode && allowNewObjective);
 
   return (
     <div className={classNames(styles.objectivesSelection, 'flex-grow-1')}>
@@ -159,7 +207,7 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
             }
           }
         }}
-        options={props.objectives}
+        options={attachmentObjectives}
         allowNew={allowNewObjective}
         newSelectionPrefix="Create new objective: "
         labelKey="title"

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -48,8 +48,14 @@ export const objectivesForAttachment = (
 
 export const canCreateObjective = (
   onRegisterNewObjective?: (objective: Objective) => void,
+  attachmentType?: ObjectivesProps['attachmentType'],
   loWellFormed?: boolean,
-) => !!onRegisterNewObjective && !loWellFormed;
+) => !!onRegisterNewObjective && !(loWellFormed === true && attachmentType === 'activity');
+
+export const isSearchOnly = (
+  attachmentType?: ObjectivesProps['attachmentType'],
+  loWellFormed?: boolean,
+) => loWellFormed === true && attachmentType === 'activity';
 
 // Custom filterBy function for the Typeahead. This allows searches to
 // pick up child objectives for text that matches any of their parents
@@ -83,7 +89,9 @@ function createMapById(objectives: Objective[]) {
   }, {});
 }
 
-const getPlaceholderLabel = (hasObjectives: boolean, editMode: boolean) => {
+const getPlaceholderLabel = (hasObjectives: boolean, editMode: boolean, searchOnly: boolean) => {
+  if (editMode && searchOnly) return 'Search learning objectives...';
+
   if (editMode) {
     return hasObjectives
       ? 'Select or Create learning objectives...'
@@ -108,6 +116,7 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   // Typeahead throws a bunch of warnings if it doesn't contain
   // a unique DOM id.  So we generate one for it.
   const [id] = useState(guid());
+  const [searchResetNonce, setSearchResetNonce] = useState(0);
   const [byId, setById] = useState(createMapById(objectives));
 
   const allSelected = selected.reduce((m: any, id: any) => {
@@ -145,18 +154,31 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const map = Immutable.Map<ResourceId, Objective>(objectives.map((o) => [o.id, o]));
   const asObjectives = selected.map((s) => map.get(s) as Objective).filter((o) => !!o);
 
-  const allowNewObjective = canCreateObjective(onRegisterNewObjective, loWellFormed);
+  const searchOnly = isSearchOnly(attachmentType, loWellFormed);
+  const allowNewObjective = canCreateObjective(
+    onRegisterNewObjective,
+    attachmentType,
+    loWellFormed,
+  );
   const hasObjectives = attachmentObjectives.length > 0;
-  const placeholder = getPlaceholderLabel(hasObjectives, editMode && allowNewObjective);
+  const placeholder = getPlaceholderLabel(hasObjectives, editMode, searchOnly);
+
+  const clearSearch = () => setSearchResetNonce((nonce) => nonce + 1);
 
   return (
     <div className={classNames(styles.objectivesSelection, 'flex-grow-1')}>
       <Typeahead
+        key={searchResetNonce}
         id={id}
         filterBy={filterBy.bind(this, byId)}
         renderMenuItemChildren={renderMenuItemChildren}
         multiple={true}
         disabled={!editMode}
+        emptyLabel={searchOnly ? 'No eligible learning objectives found.' : undefined}
+        onBlur={() => searchOnly && clearSearch()}
+        onKeyDown={(event) => {
+          if (searchOnly && (event as KeyboardEvent).key === 'Escape') clearSearch();
+        }}
         onChange={(updated: (Objective & { customOption?: boolean })[]) => {
           // we can safely assume that only one objective will ever be selected at a time
           const createdObjective = updated.find((o) => o.customOption);

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   AllTypeaheadOwnAndInjectedProps,
   Typeahead,
@@ -25,8 +25,6 @@ export type ObjectivesProps = {
 };
 
 export type ObjectiveOption = Objective & { disabled?: boolean };
-
-type TypeaheadInstance = Typeahead<ObjectiveOption> & { focus: () => void };
 
 export const objectivesForAttachment = (
   objectives: Objective[],
@@ -120,8 +118,6 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const [id] = useState(guid());
   const [searchResetNonce, setSearchResetNonce] = useState(0);
   const [byId, setById] = useState(createMapById(objectives));
-  const typeaheadRef = useRef<TypeaheadInstance>(null);
-  const restoreFocusAfterReset = useRef(false);
 
   const allSelected = selected.reduce((m: any, id: any) => {
     m[id] = true;
@@ -131,13 +127,6 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   useEffect(() => {
     setById(createMapById(objectives));
   }, [objectives]);
-
-  useEffect(() => {
-    if (restoreFocusAfterReset.current) {
-      restoreFocusAfterReset.current = false;
-      typeaheadRef.current?.focus();
-    }
-  }, [searchResetNonce]);
 
   const renderMenuItemChildren = (
     option: TypeaheadResult<ObjectiveOption>,
@@ -174,16 +163,12 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const hasObjectives = attachmentObjectives.length > 0;
   const placeholder = getPlaceholderLabel(hasObjectives, editMode, searchOnly);
 
-  const clearSearch = (restoreFocus = false) => {
-    restoreFocusAfterReset.current = restoreFocus;
-    setSearchResetNonce((nonce) => nonce + 1);
-  };
+  const clearSearch = () => setSearchResetNonce((nonce) => nonce + 1);
 
   return (
     <div className={classNames(styles.objectivesSelection, 'flex-grow-1')}>
       <Typeahead
         key={searchResetNonce}
-        ref={typeaheadRef}
         id={id}
         filterBy={filterBy.bind(this, byId)}
         renderMenuItemChildren={renderMenuItemChildren}
@@ -191,15 +176,6 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
         disabled={!editMode}
         emptyLabel={searchOnly ? 'No eligible learning objectives found.' : undefined}
         onBlur={() => searchOnly && clearSearch()}
-        onKeyDown={(event) => {
-          const keyboardEvent = event as unknown as React.KeyboardEvent<HTMLInputElement>;
-
-          if (searchOnly && keyboardEvent.key === 'Escape' && keyboardEvent.currentTarget.value) {
-            keyboardEvent.preventDefault();
-            keyboardEvent.stopPropagation();
-            clearSearch(true);
-          }
-        }}
         onChange={(updated: (Objective & { customOption?: boolean })[]) => {
           // we can safely assume that only one objective will ever be selected at a time
           const createdObjective = updated.find((o) => o.customOption);

--- a/assets/src/components/resource/objectives/ObjectivesSelection.tsx
+++ b/assets/src/components/resource/objectives/ObjectivesSelection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import {
   AllTypeaheadOwnAndInjectedProps,
   Typeahead,
@@ -25,6 +25,8 @@ export type ObjectivesProps = {
 };
 
 export type ObjectiveOption = Objective & { disabled?: boolean };
+
+type TypeaheadInstance = Typeahead<ObjectiveOption> & { focus: () => void };
 
 export const objectivesForAttachment = (
   objectives: Objective[],
@@ -118,6 +120,8 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const [id] = useState(guid());
   const [searchResetNonce, setSearchResetNonce] = useState(0);
   const [byId, setById] = useState(createMapById(objectives));
+  const typeaheadRef = useRef<TypeaheadInstance>(null);
+  const restoreFocusAfterReset = useRef(false);
 
   const allSelected = selected.reduce((m: any, id: any) => {
     m[id] = true;
@@ -127,6 +131,13 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   useEffect(() => {
     setById(createMapById(objectives));
   }, [objectives]);
+
+  useEffect(() => {
+    if (restoreFocusAfterReset.current) {
+      restoreFocusAfterReset.current = false;
+      typeaheadRef.current?.focus();
+    }
+  }, [searchResetNonce]);
 
   const renderMenuItemChildren = (
     option: TypeaheadResult<ObjectiveOption>,
@@ -163,12 +174,16 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
   const hasObjectives = attachmentObjectives.length > 0;
   const placeholder = getPlaceholderLabel(hasObjectives, editMode, searchOnly);
 
-  const clearSearch = () => setSearchResetNonce((nonce) => nonce + 1);
+  const clearSearch = (restoreFocus = false) => {
+    restoreFocusAfterReset.current = restoreFocus;
+    setSearchResetNonce((nonce) => nonce + 1);
+  };
 
   return (
     <div className={classNames(styles.objectivesSelection, 'flex-grow-1')}>
       <Typeahead
         key={searchResetNonce}
+        ref={typeaheadRef}
         id={id}
         filterBy={filterBy.bind(this, byId)}
         renderMenuItemChildren={renderMenuItemChildren}
@@ -177,7 +192,7 @@ export const ObjectivesSelection = (props: ObjectivesProps) => {
         emptyLabel={searchOnly ? 'No eligible learning objectives found.' : undefined}
         onBlur={() => searchOnly && clearSearch()}
         onKeyDown={(event) => {
-          if (searchOnly && (event as KeyboardEvent).key === 'Escape') clearSearch();
+          if (searchOnly && (event as KeyboardEvent).key === 'Escape') clearSearch(true);
         }}
         onChange={(updated: (Objective & { customOption?: boolean })[]) => {
           // we can safely assume that only one objective will ever be selected at a time

--- a/assets/src/data/content/resource.ts
+++ b/assets/src/data/content/resource.ts
@@ -195,6 +195,7 @@ export type ResourceContext = {
   content: PageContent; // Content of the resource
   objectives: AttachedObjectives; // Attached objectives
   allObjectives: Objective[]; // All objectives
+  loWellFormed?: boolean; // Whether LO attachment hierarchy is enforced
   learningObjectives?: ResolvedLearningObjective[]; // Resolved LOs for this page's container scope
   learningObjectivesRefreshPendingFor?: string; // LO element currently waiting for container-scoped LOs
   allTags: Tag[]; // All available tags

--- a/assets/test/apps/authoring/app_slice_test.ts
+++ b/assets/test/apps/authoring/app_slice_test.ts
@@ -1,5 +1,5 @@
 import { releaseEditingLock } from 'apps/authoring/store/app/actions/locking';
-import reducer, { setHasEditingLock } from 'apps/authoring/store/app/slice';
+import reducer, { setHasEditingLock, setInitialConfig } from 'apps/authoring/store/app/slice';
 
 describe('authoring app slice lock state', () => {
   test('preserves hasEditingLock when releasing the lock fails', () => {
@@ -19,5 +19,22 @@ describe('authoring app slice lock state', () => {
     const nextState = reducer(initialState, releaseEditingLock.fulfilled(undefined, 'request-id'));
 
     expect(nextState.hasEditingLock).toBe(false);
+  });
+});
+
+describe('authoring app LO compatibility state', () => {
+  test.each([false, undefined])('defaults loWellFormed to false for %s', (loWellFormed) => {
+    const state = reducer(undefined, setInitialConfig({ applicationMode: 'expert', loWellFormed }));
+
+    expect(state.loWellFormed).toBe(false);
+  });
+
+  test('enables LO hierarchy enforcement only for an explicit true value', () => {
+    const state = reducer(
+      undefined,
+      setInitialConfig({ applicationMode: 'expert', loWellFormed: true }),
+    );
+
+    expect(state.loWellFormed).toBe(true);
   });
 });

--- a/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
+++ b/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
@@ -49,9 +49,11 @@ describe('well-formed activity objective search', () => {
     renderSearchOnlySelector();
 
     const input = screen.getByRole('textbox');
+    input.focus();
     fireEvent.change(input, { target: { value: 'Unsaved search' } });
     fireEvent.keyDown(input, { key: 'Escape', keyCode: 27 });
 
     expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('textbox')).toHaveFocus();
   });
 });

--- a/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
+++ b/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
@@ -8,18 +8,20 @@ const objectives: Objective[] = [
   { id: 2, title: 'Child', parentIds: [1] },
 ];
 
-const renderSearchOnlySelector = (selected: number[] = []) =>
+const renderSearchOnlySelector = (selected: number[] = [], onKeyDown?: () => void) =>
   render(
-    <ObjectivesSelection
-      objectives={objectives}
-      selected={selected}
-      editMode={true}
-      projectSlug="project"
-      attachmentType="activity"
-      loWellFormed={true}
-      onEdit={jest.fn()}
-      onRegisterNewObjective={jest.fn()}
-    />,
+    <div onKeyDown={onKeyDown}>
+      <ObjectivesSelection
+        objectives={objectives}
+        selected={selected}
+        editMode={true}
+        projectSlug="project"
+        attachmentType="activity"
+        loWellFormed={true}
+        onEdit={jest.fn()}
+        onRegisterNewObjective={jest.fn()}
+      />
+    </div>,
   );
 
 describe('well-formed activity objective search', () => {
@@ -46,7 +48,8 @@ describe('well-formed activity objective search', () => {
   });
 
   it('clears unmatched search text on Escape', () => {
-    renderSearchOnlySelector();
+    const onParentKeyDown = jest.fn();
+    renderSearchOnlySelector([], onParentKeyDown);
 
     const input = screen.getByRole('textbox');
     input.focus();
@@ -55,5 +58,15 @@ describe('well-formed activity objective search', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('');
     expect(screen.getByRole('textbox')).toHaveFocus();
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('allows Escape to propagate when the search is empty', () => {
+    const onParentKeyDown = jest.fn();
+    renderSearchOnlySelector([], onParentKeyDown);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape', keyCode: 27 });
+
+    expect(onParentKeyDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
+++ b/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ObjectivesSelection } from 'components/resource/objectives/ObjectivesSelection';
+import { Objective } from 'data/content/objective';
+
+const objectives: Objective[] = [
+  { id: 1, title: 'Parent', parentIds: null },
+  { id: 2, title: 'Child', parentIds: [1] },
+];
+
+const renderSearchOnlySelector = (selected: number[] = []) =>
+  render(
+    <ObjectivesSelection
+      objectives={objectives}
+      selected={selected}
+      editMode={true}
+      projectSlug="project"
+      attachmentType="activity"
+      loWellFormed={true}
+      onEdit={jest.fn()}
+      onRegisterNewObjective={jest.fn()}
+    />,
+  );
+
+describe('well-formed activity objective search', () => {
+  it('identifies the input as search and explains when no eligible objective matches', () => {
+    renderSearchOnlySelector();
+
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('placeholder', 'Search learning objectives...');
+
+    fireEvent.change(input, { target: { value: 'No matching objective' } });
+
+    expect(screen.getByText('No eligible learning objectives found.')).toBeInTheDocument();
+  });
+
+  it('clears unmatched search text on blur', () => {
+    renderSearchOnlySelector([2]);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Unsaved search' } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+
+  it('clears unmatched search text on Escape', () => {
+    renderSearchOnlySelector();
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Unsaved search' } });
+    fireEvent.keyDown(input, { key: 'Escape', keyCode: 27 });
+
+    expect(screen.getByRole('textbox')).toHaveValue('');
+  });
+});

--- a/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
+++ b/assets/test/components/resource/objectives/objectives_selection_search_test.tsx
@@ -8,20 +8,18 @@ const objectives: Objective[] = [
   { id: 2, title: 'Child', parentIds: [1] },
 ];
 
-const renderSearchOnlySelector = (selected: number[] = [], onKeyDown?: () => void) =>
+const renderSearchOnlySelector = (selected: number[] = []) =>
   render(
-    <div onKeyDown={onKeyDown}>
-      <ObjectivesSelection
-        objectives={objectives}
-        selected={selected}
-        editMode={true}
-        projectSlug="project"
-        attachmentType="activity"
-        loWellFormed={true}
-        onEdit={jest.fn()}
-        onRegisterNewObjective={jest.fn()}
-      />
-    </div>,
+    <ObjectivesSelection
+      objectives={objectives}
+      selected={selected}
+      editMode={true}
+      projectSlug="project"
+      attachmentType="activity"
+      loWellFormed={true}
+      onEdit={jest.fn()}
+      onRegisterNewObjective={jest.fn()}
+    />,
   );
 
 describe('well-formed activity objective search', () => {
@@ -45,28 +43,5 @@ describe('well-formed activity objective search', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('');
     expect(screen.getByText('Child')).toBeInTheDocument();
-  });
-
-  it('clears unmatched search text on Escape', () => {
-    const onParentKeyDown = jest.fn();
-    renderSearchOnlySelector([], onParentKeyDown);
-
-    const input = screen.getByRole('textbox');
-    input.focus();
-    fireEvent.change(input, { target: { value: 'Unsaved search' } });
-    fireEvent.keyDown(input, { key: 'Escape', keyCode: 27 });
-
-    expect(screen.getByRole('textbox')).toHaveValue('');
-    expect(screen.getByRole('textbox')).toHaveFocus();
-    expect(onParentKeyDown).not.toHaveBeenCalled();
-  });
-
-  it('allows Escape to propagate when the search is empty', () => {
-    const onParentKeyDown = jest.fn();
-    renderSearchOnlySelector([], onParentKeyDown);
-
-    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Escape', keyCode: 27 });
-
-    expect(onParentKeyDown).toHaveBeenCalledTimes(1);
   });
 });

--- a/assets/test/components/resource/objectives/objectives_selection_test.ts
+++ b/assets/test/components/resource/objectives/objectives_selection_test.ts
@@ -1,0 +1,42 @@
+import {
+  canCreateObjective,
+  objectivesForAttachment,
+} from 'components/resource/objectives/ObjectivesSelection';
+import { Objective } from 'data/content/objective';
+
+const objectives: Objective[] = [
+  { id: 1, title: 'Parent', parentIds: null },
+  { id: 2, title: 'Another parent', parentIds: [] },
+  { id: 3, title: 'Child', parentIds: [1] },
+];
+
+describe('objective attachment restrictions', () => {
+  it('only offers top-level objectives for well-formed page attachments', () => {
+    expect(objectivesForAttachment(objectives, 'page', true)).toEqual(objectives.slice(0, 2));
+  });
+
+  it('disables top-level objectives for well-formed activity attachments', () => {
+    expect(objectivesForAttachment(objectives, 'activity', true)).toEqual([
+      { ...objectives[0], disabled: true },
+      { ...objectives[1], disabled: true },
+      { ...objectives[2], disabled: false },
+    ]);
+  });
+
+  it.each([false, undefined])(
+    'keeps attachment choices unrestricted when loWellFormed is %s',
+    (loWellFormed) => {
+      expect(objectivesForAttachment(objectives, 'page', loWellFormed)).toBe(objectives);
+      expect(objectivesForAttachment(objectives, 'activity', loWellFormed)).toBe(objectives);
+    },
+  );
+
+  it('disables just-in-time objective creation for well-formed projects', () => {
+    const register = jest.fn();
+
+    expect(canCreateObjective(register, true)).toBe(false);
+    expect(canCreateObjective(register, false)).toBe(true);
+    expect(canCreateObjective(register)).toBe(true);
+    expect(canCreateObjective(undefined, false)).toBe(false);
+  });
+});

--- a/assets/test/components/resource/objectives/objectives_selection_test.ts
+++ b/assets/test/components/resource/objectives/objectives_selection_test.ts
@@ -1,5 +1,6 @@
 import {
   canCreateObjective,
+  isSearchOnly,
   objectivesForAttachment,
 } from 'components/resource/objectives/ObjectivesSelection';
 import { Objective } from 'data/content/objective';
@@ -31,12 +32,24 @@ describe('objective attachment restrictions', () => {
     },
   );
 
-  it('disables just-in-time objective creation for well-formed projects', () => {
+  it('allows just-in-time objective creation for well-formed page attachments', () => {
     const register = jest.fn();
 
-    expect(canCreateObjective(register, true)).toBe(false);
-    expect(canCreateObjective(register, false)).toBe(true);
-    expect(canCreateObjective(register)).toBe(true);
-    expect(canCreateObjective(undefined, false)).toBe(false);
+    expect(canCreateObjective(register, 'page', true)).toBe(true);
+  });
+
+  it('disables just-in-time objective creation only for well-formed activity attachments', () => {
+    const register = jest.fn();
+
+    expect(canCreateObjective(register, 'activity', true)).toBe(false);
+    expect(canCreateObjective(register, 'activity', false)).toBe(true);
+    expect(canCreateObjective(register, 'activity')).toBe(true);
+    expect(canCreateObjective(undefined, 'activity', false)).toBe(false);
+  });
+
+  it('uses search-only behavior only for well-formed activity attachments', () => {
+    expect(isSearchOnly('activity', true)).toBe(true);
+    expect(isSearchOnly('page', true)).toBe(false);
+    expect(isSearchOnly('activity', false)).toBe(false);
   });
 });

--- a/lib/oli/authoring/course.ex
+++ b/lib/oli/authoring/course.ex
@@ -1069,9 +1069,9 @@ defmodule Oli.Authoring.Course do
   end
 
   @doc """
-  Creates a Project whose learning-model selection is copied from a trusted source Project.
+  Creates a Project whose trusted compatibility state is copied from a source Project.
 
-  The source value takes precedence over any value present in `attrs`.
+  Source values take precedence over any values present in `attrs`.
   """
   def create_project_from_source(attrs, %Project{} = source_project) do
     %Project{}
@@ -1079,11 +1079,14 @@ defmodule Oli.Authoring.Course do
     |> Project.trusted_learning_model_changeset(%{
       learning_model_version: source_project.learning_model_version
     })
+    |> Project.trusted_lo_well_formed_changeset(%{
+      lo_well_formed: source_project.lo_well_formed
+    })
     |> Repo.insert()
   end
 
   def create_project(title, author, additional_attrs \\ %{}) do
-    do_create_project(title, author, additional_attrs, nil)
+    do_create_project(title, author, additional_attrs, nil, :use_default)
   end
 
   @doc """
@@ -1094,16 +1097,29 @@ defmodule Oli.Authoring.Course do
   """
   def create_project_from_archive(title, author, learning_model_version, additional_attrs \\ %{})
       when learning_model_version in [:naive, :lkt_aoa] do
-    do_create_project(title, author, additional_attrs, learning_model_version)
+    do_create_project(
+      title,
+      author,
+      Map.delete(additional_attrs, :lo_well_formed),
+      learning_model_version,
+      Map.get(additional_attrs, :lo_well_formed)
+    )
   end
 
-  defp do_create_project(title, author, additional_attrs, learning_model_version) do
+  defp do_create_project(
+         title,
+         author,
+         additional_attrs,
+         learning_model_version,
+         lo_well_formed
+       ) do
     Repo.transaction(fn ->
       with {:ok, project_family} <- create_family(default_family(title)),
            {:ok, project} <-
-             create_project_with_learning_model(
+             create_project_with_trusted_state(
                default_project(title, project_family, additional_attrs),
-               learning_model_version
+               learning_model_version,
+               lo_well_formed
              ),
            {:ok, collaborator} <- Collaborators.add_collaborator(author, project),
            {:ok, %{resource: resource, revision: resource_revision}} <-
@@ -1125,15 +1141,28 @@ defmodule Oli.Authoring.Course do
     end)
   end
 
-  defp create_project_with_learning_model(attrs, nil), do: create_project(attrs)
-
-  defp create_project_with_learning_model(attrs, learning_model_version) do
+  defp create_project_with_trusted_state(attrs, learning_model_version, lo_well_formed) do
     %Project{}
     |> Project.changeset(attrs)
-    |> Project.trusted_learning_model_changeset(%{
+    |> maybe_set_learning_model(learning_model_version)
+    |> maybe_set_lo_well_formed(lo_well_formed)
+    |> Repo.insert()
+  end
+
+  defp maybe_set_learning_model(changeset, nil), do: changeset
+
+  defp maybe_set_learning_model(changeset, learning_model_version) do
+    Project.trusted_learning_model_changeset(changeset, %{
       learning_model_version: learning_model_version
     })
-    |> Repo.insert()
+  end
+
+  defp maybe_set_lo_well_formed(changeset, :use_default), do: changeset
+
+  defp maybe_set_lo_well_formed(changeset, lo_well_formed) do
+    Project.trusted_lo_well_formed_changeset(changeset, %{
+      lo_well_formed: lo_well_formed
+    })
   end
 
   defp default_project(title, family, additional_attrs) do

--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -30,6 +30,7 @@ defmodule Oli.Authoring.Course.Project do
     field(:latest_datashop_snapshot_timestamp, :utc_datetime)
     field(:analytics_version, Ecto.Enum, values: [:v1, :v2], default: :v2)
     field(:learning_model_version, Ecto.Enum, values: ModelVersion.values(), default: :naive)
+    field(:lo_well_formed, :boolean, default: true)
     field(:allow_transfer_payment_codes, :boolean, default: false)
     field(:welcome_title, :map, default: %{})
 
@@ -154,5 +155,14 @@ defmodule Oli.Authoring.Course.Project do
     |> cast(attrs, [:learning_model_version])
     |> validate_required([:learning_model_version])
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
+  end
+
+  @doc """
+  Casts the learning-objective compatibility state at trusted domain boundaries.
+
+  Do not use this function with unfiltered user or form parameters.
+  """
+  def trusted_lo_well_formed_changeset(project_or_changeset, attrs) do
+    cast(project_or_changeset, attrs, [:lo_well_formed])
   end
 end

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -50,7 +50,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
          {:ok, %Result{totalCount: total_count}} <-
            query(project_slug, author, %Logic{conditions: nil}, %Paging{limit: 1, offset: 0}),
          {:ok, lo_well_formed} <-
-           ProjectClassifier.ensure_classified(publication.project, publication.id) do
+           ProjectClassifier.ensure_classified(publication.project, publication) do
       editor_map =
         Activities.create_registered_activity_map(project_slug)
         |> Enum.reject(fn {_key, entry} -> entry.isLtiActivity end)

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -39,9 +39,8 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   """
   def context(project_slug, author) do
     with {:ok, publication} <-
-           Publishing.project_working_publication(project_slug)
-           |> Repo.preload(:project)
-           |> trap_nil(),
+           Publishing.project_working_publication(project_slug) |> trap_nil(),
+         publication = Repo.preload(publication, :project),
          {:ok, objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, objectives_with_parent_reference} <-

--- a/lib/oli/authoring/editing/activity_bank.ex
+++ b/lib/oli/authoring/editing/activity_bank.ex
@@ -22,6 +22,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   alias Oli.Authoring.Editing.BankContext
   alias Oli.Authoring.Editing.PageEditor
   alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Authoring.LearningObjectives.ProjectClassifier
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Oli.Delivery.Sections.SectionsProjectsPublications
@@ -39,6 +40,7 @@ defmodule Oli.Authoring.Editing.ActivityBank do
   def context(project_slug, author) do
     with {:ok, publication} <-
            Publishing.project_working_publication(project_slug)
+           |> Repo.preload(:project)
            |> trap_nil(),
          {:ok, objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
@@ -47,13 +49,13 @@ defmodule Oli.Authoring.Editing.ActivityBank do
          {:ok, tags} <-
            ResourceEditor.list(project_slug, author, ResourceType.id_for_tag()),
          {:ok, %Result{totalCount: total_count}} <-
-           query(project_slug, author, %Logic{conditions: nil}, %Paging{limit: 1, offset: 0}) do
+           query(project_slug, author, %Logic{conditions: nil}, %Paging{limit: 1, offset: 0}),
+         {:ok, lo_well_formed} <-
+           ProjectClassifier.ensure_classified(publication.project, publication.id) do
       editor_map =
         Activities.create_registered_activity_map(project_slug)
         |> Enum.reject(fn {_key, entry} -> entry.isLtiActivity end)
         |> Enum.into(%{})
-
-      project = Course.get_project_by_slug(project_slug)
 
       {:ok,
        %BankContext{
@@ -61,9 +63,10 @@ defmodule Oli.Authoring.Editing.ActivityBank do
          projectSlug: project_slug,
          editorMap: editor_map,
          allObjectives: objectives_with_parent_reference,
+         loWellFormed: lo_well_formed,
          allTags: Enum.map(tags, fn tag -> %{id: tag.resource_id, title: tag.title} end),
          totalCount: total_count,
-         allowTriggers: project.allow_triggers
+         allowTriggers: publication.project.allow_triggers
        }}
     else
       _ -> {:error, :not_found}

--- a/lib/oli/authoring/editing/activity_context.ex
+++ b/lib/oli/authoring/editing/activity_context.ex
@@ -16,6 +16,7 @@ defmodule Oli.Authoring.Editing.ActivityContext do
     :model,
     :objectives,
     :allObjectives,
+    :loWellFormed,
     :typeSlug,
     :tags,
     :variables

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -28,6 +28,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   alias Oli.Authoring.Broadcaster
   alias Oli.Resources.ContentMigrator
   alias Oli.LearningModel.Parameters.Validation, as: ParameterValidation
+  alias Oli.Authoring.LearningObjectives.ProjectClassifier
   alias Oli.Adaptive.DynamicLinks.Telemetry, as: DynamicLinksTelemetry
   alias ExAws.S3
 
@@ -2051,6 +2052,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
                authoringScript: any,
                description: any,
                friendlyName: any,
+               loWellFormed: boolean,
                model: any,
                objectives: any,
                projectSlug: any,
@@ -2066,8 +2068,12 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   """
   def create_context(project_slug, revision_slug, activity_slug, author) do
     with {:ok, publication} <-
-           Publishing.project_working_publication(project_slug) |> trap_nil(),
+           Publishing.project_working_publication(project_slug)
+           |> Repo.preload(:project)
+           |> trap_nil(),
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
+         {:ok, lo_well_formed} <-
+           ProjectClassifier.ensure_classified(publication.project, publication.id),
          {:ok, all_objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, %{title: resource_title}} <-
@@ -2102,6 +2108,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         model: model,
         objectives: filtered_objectives,
         allObjectives: all_objectives_with_parents,
+        loWellFormed: lo_well_formed,
         typeSlug: activity_type.slug,
         tags: tags,
         variables:
@@ -2117,7 +2124,12 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
     end
   end
 
-  def create_contexts(all_objectives_with_parents, project_slug, activity_ids) do
+  def create_contexts(
+        all_objectives_with_parents,
+        project_slug,
+        activity_ids,
+        lo_well_formed
+      ) do
     type_by_id =
       Activities.list_activity_registrations()
       |> Enum.reduce(%{}, fn t, m -> Map.put(m, t.id, t) end)
@@ -2143,6 +2155,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
         model: r.content,
         objectives: filtered_objectives,
         allObjectives: all_objectives_with_parents,
+        loWellFormed: lo_well_formed,
         typeSlug: activity_type.slug,
         tags: r.tags,
         variables:

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -2072,7 +2072,7 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
          publication = Repo.preload(publication, :project),
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
          {:ok, lo_well_formed} <-
-           ProjectClassifier.ensure_classified(publication.project, publication.id),
+           ProjectClassifier.ensure_classified(publication.project, publication),
          {:ok, all_objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, %{title: resource_title}} <-

--- a/lib/oli/authoring/editing/activity_editor.ex
+++ b/lib/oli/authoring/editing/activity_editor.ex
@@ -2068,9 +2068,8 @@ defmodule Oli.Authoring.Editing.ActivityEditor do
   """
   def create_context(project_slug, revision_slug, activity_slug, author) do
     with {:ok, publication} <-
-           Publishing.project_working_publication(project_slug)
-           |> Repo.preload(:project)
-           |> trap_nil(),
+           Publishing.project_working_publication(project_slug) |> trap_nil(),
+         publication = Repo.preload(publication, :project),
          {:ok, resource} <- Resources.get_resource_from_slug(revision_slug) |> trap_nil(),
          {:ok, lo_well_formed} <-
            ProjectClassifier.ensure_classified(publication.project, publication.id),

--- a/lib/oli/authoring/editing/bank_context.ex
+++ b/lib/oli/authoring/editing/bank_context.ex
@@ -4,6 +4,7 @@ defmodule Oli.Authoring.Editing.BankContext do
     :authorEmail,
     :projectSlug,
     :allObjectives,
+    :loWellFormed,
     :allTags,
     :editorMap,
     :totalCount,

--- a/lib/oli/authoring/editing/page_context.ex
+++ b/lib/oli/authoring/editing/page_context.ex
@@ -11,6 +11,7 @@ defmodule Oli.Authoring.Editing.ResourceContext do
     :objectives,
     :allObjectives,
     :learningObjectives,
+    :loWellFormed,
     :allTags,
     :editorMap,
     :activities,

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -22,6 +22,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
   alias Oli.Authoring.Broadcaster
   alias Oli.Delivery.Page.ActivityContext
   alias Oli.Authoring.LearningObjectives.PageElement, as: LearningObjectivesPageElement
+  alias Oli.Authoring.LearningObjectives.ProjectClassifier
   alias Oli.Rendering.Activity.ActivitySummary
   alias Oli.Activities
   alias Oli.Authoring.Editing.ActivityEditor
@@ -205,6 +206,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
          {:ok, %{deleted: false} = revision} <-
            AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
          {:ok, %{content: content} = revision} <- maybe_migrate_revision_content(revision),
+         {:ok, lo_well_formed} <-
+           ProjectClassifier.ensure_classified(publication.project, publication.id),
          {:ok, objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, objectives_with_parent_reference} <-
@@ -241,6 +244,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
          editorMap: editor_map,
          objectives: revision.objectives,
          allObjectives: objectives_with_parent_reference,
+         loWellFormed: lo_well_formed,
          learningObjectives: learning_objectives,
          allTags: Enum.map(tags, fn t -> %{id: t.resource_id, title: t.title} end),
          title: revision.title,
@@ -256,7 +260,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
            ActivityEditor.create_contexts(
              objectives_with_parent_reference,
              project_slug,
-             activity_ids
+             activity_ids,
+             lo_well_formed
            ),
          featureFlags:
            Features.list_features_and_states()

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -200,9 +200,8 @@ defmodule Oli.Authoring.Editing.PageEditor do
     editor_map = Activities.create_registered_activity_map(project_slug)
 
     with {:ok, publication} <-
-           Publishing.project_working_publication(project_slug)
-           |> Repo.preload(:project)
-           |> trap_nil(),
+           Publishing.project_working_publication(project_slug) |> trap_nil(),
+         publication = Repo.preload(publication, :project),
          {:ok, %{deleted: false} = revision} <-
            AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
          {:ok, %{content: content} = revision} <- maybe_migrate_revision_content(revision),

--- a/lib/oli/authoring/editing/page_editor.ex
+++ b/lib/oli/authoring/editing/page_editor.ex
@@ -206,7 +206,7 @@ defmodule Oli.Authoring.Editing.PageEditor do
            AuthoringResolver.from_revision_slug(project_slug, revision_slug) |> trap_nil(),
          {:ok, %{content: content} = revision} <- maybe_migrate_revision_content(revision),
          {:ok, lo_well_formed} <-
-           ProjectClassifier.ensure_classified(publication.project, publication.id),
+           ProjectClassifier.ensure_classified(publication.project, publication),
          {:ok, objectives} <-
            Publishing.get_published_objective_details(publication.id) |> trap_nil(),
          {:ok, objectives_with_parent_reference} <-

--- a/lib/oli/authoring/learning_objectives/project_classifier.ex
+++ b/lib/oli/authoring/learning_objectives/project_classifier.ex
@@ -1,0 +1,113 @@
+defmodule Oli.Authoring.LearningObjectives.ProjectClassifier do
+  @moduledoc """
+  Classifies whether a project follows the supported learning-objective attachment structure.
+
+  A well-formed project attaches only top-level objectives to pages and only sub-objectives
+  to activities. Existing classifications are sticky; only projects whose classification is
+  `nil` are inspected and updated.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Publishing.PublishedResource
+  alias Oli.Repo
+  alias Oli.Resources.{ResourceType, Revision}
+
+  @objective_type_id ResourceType.id_for_objective()
+  @page_type_id ResourceType.id_for_page()
+  @activity_type_id ResourceType.id_for_activity()
+  @classified_resource_type_ids [@objective_type_id, @page_type_id, @activity_type_id]
+
+  @doc """
+  Returns a project's existing classification, or computes and persists it when currently nil.
+  """
+  def ensure_classified(%Project{lo_well_formed: value}, _publication_id)
+      when is_boolean(value),
+      do: {:ok, value}
+
+  def ensure_classified(%Project{id: project_id}, publication_id) do
+    value = publication_id |> classification_data() |> well_formed?()
+
+    case persist_if_unclassified(project_id, value) do
+      :updated -> {:ok, value}
+      :already_classified -> current_classification(project_id)
+    end
+  end
+
+  @doc """
+  Determines whether classification data follows the learning-objective attachment rules.
+
+  References to objectives absent from the current publication make the project malformed,
+  because they cannot be verified as valid for either attachment type.
+  """
+  def well_formed?(rows) do
+    objective_rows = Enum.filter(rows, &(&1.resource_type_id == @objective_type_id))
+
+    objective_ids = objective_rows |> Enum.map(& &1.resource_id) |> MapSet.new()
+
+    sub_objective_ids =
+      objective_rows
+      |> Enum.flat_map(&(&1.children || []))
+      |> MapSet.new()
+      |> MapSet.intersection(objective_ids)
+
+    top_level_objective_ids = MapSet.difference(objective_ids, sub_objective_ids)
+
+    Enum.all?(rows, fn row ->
+      attached_ids = row.objectives |> flatten_objective_ids() |> MapSet.new()
+
+      case row.resource_type_id do
+        @page_type_id -> MapSet.subset?(attached_ids, top_level_objective_ids)
+        @activity_type_id -> MapSet.subset?(attached_ids, sub_objective_ids)
+        _ -> true
+      end
+    end)
+  end
+
+  defp classification_data(publication_id) do
+    Repo.all(
+      from published_resource in PublishedResource,
+        join: revision in Revision,
+        on: published_resource.revision_id == revision.id,
+        where:
+          published_resource.publication_id == ^publication_id and
+            revision.deleted == false and
+            revision.resource_type_id in ^@classified_resource_type_ids,
+        select: map(revision, [:resource_id, :resource_type_id, :children, :objectives])
+    )
+  end
+
+  defp persist_if_unclassified(project_id, value) do
+    {updated_count, _} =
+      from(project in Project,
+        where: project.id == ^project_id and is_nil(project.lo_well_formed)
+      )
+      |> Repo.update_all(set: [lo_well_formed: value])
+
+    case updated_count do
+      1 -> :updated
+      0 -> :already_classified
+    end
+  end
+
+  defp current_classification(project_id) do
+    case Repo.get(Project, project_id) do
+      %Project{lo_well_formed: value} when is_boolean(value) -> {:ok, value}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  defp flatten_objective_ids(nil), do: []
+
+  defp flatten_objective_ids(objectives) when is_map(objectives) do
+    objectives |> Map.values() |> Enum.flat_map(&flatten_objective_ids/1)
+  end
+
+  defp flatten_objective_ids(objectives) when is_list(objectives) do
+    Enum.flat_map(objectives, &flatten_objective_ids/1)
+  end
+
+  defp flatten_objective_ids(objective_id) when is_integer(objective_id), do: [objective_id]
+  defp flatten_objective_ids(_), do: []
+end

--- a/lib/oli/authoring/learning_objectives/project_classifier.ex
+++ b/lib/oli/authoring/learning_objectives/project_classifier.ex
@@ -11,6 +11,7 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifier do
 
   alias Oli.Authoring.Course.Project
   alias Oli.Publishing.PublishedResource
+  alias Oli.Publishing.Publications.Publication
   alias Oli.Repo
   alias Oli.Resources.{ResourceType, Revision}
 
@@ -21,12 +22,20 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifier do
 
   @doc """
   Returns a project's existing classification, or computes and persists it when currently nil.
+
+  The publication must belong to the project being classified.
   """
-  def ensure_classified(%Project{lo_well_formed: value}, _publication_id)
+  def ensure_classified(
+        %Project{id: project_id, lo_well_formed: value},
+        %Publication{project_id: project_id}
+      )
       when is_boolean(value),
       do: {:ok, value}
 
-  def ensure_classified(%Project{id: project_id}, publication_id) do
+  def ensure_classified(
+        %Project{id: project_id},
+        %Publication{id: publication_id, project_id: project_id}
+      ) do
     value = publication_id |> classification_data() |> well_formed?()
 
     case persist_if_unclassified(project_id, value) do
@@ -34,6 +43,8 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifier do
       :already_classified -> current_classification(project_id)
     end
   end
+
+  def ensure_classified(%Project{}, %Publication{}), do: {:error, :not_found}
 
   @doc """
   Determines whether classification data follows the learning-objective attachment rules.

--- a/lib/oli/interop/export.ex
+++ b/lib/oli/interop/export.ex
@@ -467,6 +467,7 @@ defmodule Oli.Interop.Export do
       welcomeTitle: project.welcome_title,
       encouragingSubtitle: project.encouraging_subtitle,
       learningModelVersion: ModelVersion.encode(project.learning_model_version),
+      loWellFormed: project.lo_well_formed,
       type: "Manifest",
       required_student_survey: required_survey_resource_id,
       attributes: Map.get(project, :attributes)

--- a/lib/oli/interop/ingest/processor/project.ex
+++ b/lib/oli/interop/ingest/processor/project.ex
@@ -48,7 +48,8 @@ defmodule Oli.Interop.Ingest.Processor.Project do
           legacy_svn_root: Map.get(project_details, "svnRoot"),
           attributes: Map.get(project_details, "attributes"),
           welcome_title: Map.get(project_details, "welcomeTitle"),
-          encouraging_subtitle: Map.get(project_details, "encouragingSubtitle")
+          encouraging_subtitle: Map.get(project_details, "encouragingSubtitle"),
+          lo_well_formed: Map.get(project_details, "loWellFormed")
         }
       )
 

--- a/priv/repo/migrations/20260902160000_add_lo_well_formed_to_projects.exs
+++ b/priv/repo/migrations/20260902160000_add_lo_well_formed_to_projects.exs
@@ -1,0 +1,21 @@
+defmodule Oli.Repo.Migrations.AddLoWellFormedToProjects do
+  use Ecto.Migration
+
+  def up do
+    execute("SET LOCAL lock_timeout = '5s'")
+
+    alter table(:projects) do
+      add :lo_well_formed, :boolean
+    end
+
+    execute("ALTER TABLE projects ALTER COLUMN lo_well_formed SET DEFAULT TRUE")
+  end
+
+  def down do
+    execute("SET LOCAL lock_timeout = '5s'")
+
+    alter table(:projects) do
+      remove :lo_well_formed
+    end
+  end
+end

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -5,8 +5,10 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
 
   alias Oli.Activities.Realizer.Logic
   alias Oli.Activities.Realizer.Query.Paging
+  alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Editing.ResourceEditor
   alias Oli.Authoring.Editing.ActivityBank
+  alias Oli.Repo
   alias Oli.Resources.ResourceType
   alias Oli.Seeder
 
@@ -435,14 +437,20 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
     setup [:project_with_activity_bank]
 
     test "builds the Activity Bank editor context", %{author: author, project: project} do
+      project
+      |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: nil})
+      |> Repo.update!()
+
       assert {:ok, context} = ActivityBank.context(project.slug, author)
 
       assert context.authorEmail == author.email
       assert context.projectSlug == project.slug
       assert context.totalCount == 2
+      refute context.loWellFormed
       assert is_map(context.editorMap)
       assert is_list(context.allObjectives)
       assert is_list(context.allTags)
+      refute Repo.get!(Project, project.id).lo_well_formed
     end
   end
 

--- a/test/oli/authoring/editing/activity_bank_test.exs
+++ b/test/oli/authoring/editing/activity_bank_test.exs
@@ -452,6 +452,10 @@ defmodule Oli.Authoring.Editing.ActivityBankTest do
       assert is_list(context.allTags)
       refute Repo.get!(Project, project.id).lo_well_formed
     end
+
+    test "returns not found when working publication lookup returns nil", %{author: author} do
+      assert {:error, :not_found} = ActivityBank.context("missing-project", author)
+    end
   end
 
   defp project_with_activity_bank(_context) do

--- a/test/oli/authoring/learning_objectives/project_classifier_test.exs
+++ b/test/oli/authoring/learning_objectives/project_classifier_test.exs
@@ -1,0 +1,157 @@
+defmodule Oli.Authoring.LearningObjectives.ProjectClassifierTest do
+  use Oli.DataCase
+
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.LearningObjectives.ProjectClassifier
+  alias Oli.Repo
+  alias Oli.Resources.ResourceType
+  alias Oli.Seeder
+
+  describe "well_formed?/1" do
+    test "accepts top-level objectives on pages and sub-objectives on activities" do
+      assert ProjectClassifier.well_formed?([
+               objective_row(1, [2]),
+               objective_row(2),
+               content_row(:page, %{"attached" => [1]}),
+               content_row(:activity, %{"part-1" => [2]})
+             ])
+    end
+
+    test "rejects sub-objectives on pages" do
+      refute ProjectClassifier.well_formed?([
+               objective_row(1, [2]),
+               objective_row(2),
+               content_row(:page, %{"attached" => [2]})
+             ])
+    end
+
+    test "rejects top-level objectives on activities" do
+      refute ProjectClassifier.well_formed?([
+               objective_row(1, [2]),
+               objective_row(2),
+               content_row(:activity, %{"part-1" => [1]})
+             ])
+    end
+
+    test "rejects dangling objective references" do
+      rows = [objective_row(1, [2]), objective_row(2)]
+
+      refute ProjectClassifier.well_formed?([
+               content_row(:page, %{"attached" => [999]}) | rows
+             ])
+
+      refute ProjectClassifier.well_formed?([
+               content_row(:activity, %{"part-1" => [999]}) | rows
+             ])
+    end
+  end
+
+  describe "ensure_classified/2" do
+    setup do
+      map =
+        Seeder.base_project_with_resource2()
+        |> Seeder.add_objective("Sub-objective", :sub_objective)
+        |> Seeder.add_objective_with_children("Top-level objective", [:sub_objective], :objective)
+
+      project = set_classification(map.project, nil)
+
+      {:ok, Map.put(map, :project, project)}
+    end
+
+    test "classifies and persists a well-formed working publication", map do
+      parent_id = map.objective.resource.id
+      child_id = map.sub_objective.resource.id
+
+      revise_page_objectives(map, [parent_id])
+      create_activity(map, [child_id])
+
+      assert {:ok, true} =
+               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+
+      assert Repo.get!(Project, map.project.id).lo_well_formed == true
+    end
+
+    test "classifies and persists a project with a sub-objective on a page", map do
+      revise_page_objectives(map, [map.sub_objective.resource.id])
+
+      assert {:ok, false} =
+               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+
+      assert Repo.get!(Project, map.project.id).lo_well_formed == false
+    end
+
+    test "classifies and persists a project with a top-level objective on an activity", map do
+      create_activity(map, [map.objective.resource.id])
+
+      assert {:ok, false} =
+               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+
+      assert Repo.get!(Project, map.project.id).lo_well_formed == false
+    end
+
+    test "ignores deleted content revisions", map do
+      Seeder.create_activity(
+        %{deleted: true, objectives: %{"part-1" => [map.objective.resource.id]}},
+        map.publication,
+        map.project,
+        map.author
+      )
+
+      assert {:ok, true} =
+               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+    end
+
+    test "does not inspect or overwrite an existing classification", map do
+      Enum.each([true, false], fn classification ->
+        project = set_classification(map.project, classification)
+
+        assert {:ok, ^classification} =
+                 ProjectClassifier.ensure_classified(project, -1)
+
+        assert Repo.get!(Project, project.id).lo_well_formed == classification
+      end)
+    end
+  end
+
+  defp objective_row(resource_id, children \\ []) do
+    %{
+      resource_id: resource_id,
+      resource_type_id: ResourceType.id_for_objective(),
+      children: children,
+      objectives: %{}
+    }
+  end
+
+  defp content_row(type, objectives) do
+    %{
+      resource_id: System.unique_integer([:positive]),
+      resource_type_id: ResourceType.get_id_by_type(Atom.to_string(type)),
+      children: [],
+      objectives: objectives
+    }
+  end
+
+  defp set_classification(project, value) do
+    project
+    |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: value})
+    |> Repo.update!()
+  end
+
+  defp revise_page_objectives(map, objective_ids) do
+    Seeder.revise_page(
+      %{objectives: %{"attached" => objective_ids}},
+      map.page1,
+      map.revision1,
+      map.publication
+    )
+  end
+
+  defp create_activity(map, objective_ids) do
+    Seeder.create_activity(
+      %{objectives: %{"part-1" => objective_ids}},
+      map.publication,
+      map.project,
+      map.author
+    )
+  end
+end

--- a/test/oli/authoring/learning_objectives/project_classifier_test.exs
+++ b/test/oli/authoring/learning_objectives/project_classifier_test.exs
@@ -66,7 +66,7 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifierTest do
       create_activity(map, [child_id])
 
       assert {:ok, true} =
-               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+               ProjectClassifier.ensure_classified(map.project, map.publication)
 
       assert Repo.get!(Project, map.project.id).lo_well_formed == true
     end
@@ -75,7 +75,7 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifierTest do
       revise_page_objectives(map, [map.sub_objective.resource.id])
 
       assert {:ok, false} =
-               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+               ProjectClassifier.ensure_classified(map.project, map.publication)
 
       assert Repo.get!(Project, map.project.id).lo_well_formed == false
     end
@@ -84,7 +84,7 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifierTest do
       create_activity(map, [map.objective.resource.id])
 
       assert {:ok, false} =
-               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+               ProjectClassifier.ensure_classified(map.project, map.publication)
 
       assert Repo.get!(Project, map.project.id).lo_well_formed == false
     end
@@ -98,15 +98,25 @@ defmodule Oli.Authoring.LearningObjectives.ProjectClassifierTest do
       )
 
       assert {:ok, true} =
-               ProjectClassifier.ensure_classified(map.project, map.publication.id)
+               ProjectClassifier.ensure_classified(map.project, map.publication)
+    end
+
+    test "rejects a publication belonging to another project", map do
+      mismatched_publication = %{map.publication | project_id: map.project.id + 1}
+
+      assert {:error, :not_found} =
+               ProjectClassifier.ensure_classified(map.project, mismatched_publication)
+
+      assert is_nil(Repo.get!(Project, map.project.id).lo_well_formed)
     end
 
     test "does not inspect or overwrite an existing classification", map do
       Enum.each([true, false], fn classification ->
         project = set_classification(map.project, classification)
+        missing_publication = %{map.publication | id: -1}
 
         assert {:ok, ^classification} =
-                 ProjectClassifier.ensure_classified(project, -1)
+                 ProjectClassifier.ensure_classified(project, missing_publication)
 
         assert Repo.get!(Project, project.id).lo_well_formed == classification
       end)

--- a/test/oli/clone_test.exs
+++ b/test/oli/clone_test.exs
@@ -186,6 +186,21 @@ defmodule Oli.CloneTest do
       assert duplicated.learning_model_version == :lkt_aoa
     end
 
+    test "clone_project/2 preserves learning-objective compatibility state", %{
+      project: project,
+      author2: author2
+    } do
+      Enum.each([true, false, nil], fn lo_well_formed ->
+        project =
+          project
+          |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: lo_well_formed})
+          |> Repo.update!()
+
+        assert {:ok, duplicated} = Clone.clone_project(project.slug, author2)
+        assert duplicated.lo_well_formed == lo_well_formed
+      end)
+    end
+
     test "clone_project/2 shares exact parameterized published Revisions", %{
       project: project,
       publication: publication,

--- a/test/oli/course_test.exs
+++ b/test/oli/course_test.exs
@@ -53,6 +53,7 @@ defmodule Oli.CourseTest do
       assert project.description == "some description"
       assert project.slug == "some_title"
       assert project.title == "some title"
+      assert project.lo_well_formed
     end
 
     test "create_empty_project/1 with invalid data returns error changeset" do

--- a/test/oli/editing/activity_editor_test.exs
+++ b/test/oli/editing/activity_editor_test.exs
@@ -786,6 +786,23 @@ defmodule Oli.ActivityEditingTest do
       assert Repo.get!(Project, project.id).lo_well_formed
     end
 
+    test "activity context creation returns not found when working publication lookup returns nil",
+         %{author: author} do
+      assert {:error, :not_found} =
+               ActivityEditor.create_context(
+                 "missing-project",
+                 "missing-revision",
+                 "missing-activity",
+                 author
+               )
+    end
+
+    test "page context creation returns not found when working publication lookup returns nil",
+         %{author: author} do
+      assert {:error, :not_found} =
+               PageEditor.create_context("missing-project", "missing-revision", author)
+    end
+
     test "attaching an unknown activity to a resource fails", %{
       author: author,
       project: project,

--- a/test/oli/editing/activity_editor_test.exs
+++ b/test/oli/editing/activity_editor_test.exs
@@ -3,10 +3,12 @@ defmodule Oli.ActivityEditingTest do
 
   import Mox
 
+  alias Oli.Authoring.Course.Project
   alias Oli.Authoring.Editing.{ResourceContext, PageEditor, ActivityEditor, ObjectiveEditor}
   alias Oli.LearningModel.Parameters
   alias Oli.LearningModel.V2.{ActivityParameters, PartParameters}
   alias Oli.Publishing
+  alias Oli.Repo
   alias Oli.Resources
 
   describe "activity editing" do
@@ -668,7 +670,17 @@ defmodule Oli.ActivityEditingTest do
       # Now generate the resource editing context with this attached activity in place
       # so that we can verify that the activities, editorMap and content are all wired
       # together correctly
-      {:ok, %ResourceContext{activities: activities, content: content, editorMap: editorMap}} =
+      project
+      |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: nil})
+      |> Repo.update!()
+
+      {:ok,
+       %ResourceContext{
+         activities: activities,
+         content: content,
+         editorMap: editorMap,
+         loWellFormed: true
+       }} =
         PageEditor.create_context(project.slug, updated_revision.slug, author)
 
       activity_ref = hd(Map.get(content, "model"))
@@ -680,6 +692,7 @@ defmodule Oli.ActivityEditingTest do
       # and that activity map entry has a type slug that references an editor map entry
       %{typeSlug: typeSlug} = Map.get(activities, activity_slug)
       assert Map.has_key?(editorMap, typeSlug)
+      assert Repo.get!(Project, project.id).lo_well_formed
     end
 
     test "can repeatedly edit an activity", %{
@@ -752,6 +765,10 @@ defmodule Oli.ActivityEditingTest do
       assert {:ok, %{slug: revision_slug}} =
                PageEditor.edit(project.slug, revision.slug, author.email, update)
 
+      project
+      |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: nil})
+      |> Repo.update!()
+
       # create the activity context
       {:ok, context} = ActivityEditor.create_context(project.slug, revision_slug, slug_1, author)
 
@@ -765,6 +782,8 @@ defmodule Oli.ActivityEditingTest do
       assert context.resourceSlug == revision_slug
       assert context.authorEmail == author.email
       assert length(context.allObjectives) == 2
+      assert context.loWellFormed
+      assert Repo.get!(Project, project.id).lo_well_formed
     end
 
     test "attaching an unknown activity to a resource fails", %{

--- a/test/oli/interop/export_test.exs
+++ b/test/oli/interop/export_test.exs
@@ -78,6 +78,30 @@ defmodule Oli.Interop.ExportTest do
       assert section.learning_model_version == :naive
     end
 
+    test "project export includes its learning-objective compatibility state", %{
+      project: project,
+      export: export
+    } do
+      project_json = Jason.decode!(Map.fetch!(export, ~c"_project.json"))
+
+      assert project_json["loWellFormed"] == true
+
+      project =
+        project
+        |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: nil})
+        |> Repo.update!()
+
+      null_project_json =
+        project
+        |> Export.export()
+        |> unzip_to_memory()
+        |> Map.new()
+        |> Map.fetch!(~c"_project.json")
+        |> Jason.decode!()
+
+      assert is_nil(null_project_json["loWellFormed"])
+    end
+
     test "round trip preserves divergent selections and typed LO/activity parameters", %{
       project: project,
       section: exported_product,
@@ -86,6 +110,7 @@ defmodule Oli.Interop.ExportTest do
       project =
         project
         |> Project.trusted_learning_model_changeset(%{learning_model_version: :lkt_aoa})
+        |> Project.trusted_lo_well_formed_changeset(%{lo_well_formed: false})
         |> Repo.update!()
 
       objective_parameters = learning_objective_parameters(-0.42)
@@ -148,6 +173,7 @@ defmodule Oli.Interop.ExportTest do
 
       assert {:ok, imported_project} = Oli.Interop.Ingest.process(entries, author)
       assert imported_project.learning_model_version == :lkt_aoa
+      refute imported_project.lo_well_formed
 
       imported_product =
         Sections.get_section_by(base_project_id: imported_project.id, type: :blueprint)

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -444,6 +444,39 @@ defmodule Oli.Interop.IngestTest do
     end
   end
 
+  describe "learning-objective compatibility archive handling" do
+    setup do
+      Oli.Seeder.base_project_with_resource2()
+    end
+
+    test "preserves explicit boolean values", %{author: author} do
+      Enum.each([true, false], fn lo_well_formed ->
+        {:ok, project} =
+          minimal_digest(%{
+            "title" => "Explicit LO compatibility #{lo_well_formed}",
+            "loWellFormed" => lo_well_formed
+          })
+          |> Ingest.process(author)
+
+        assert project.lo_well_formed == lo_well_formed
+      end)
+    end
+
+    test "maps a null or missing archive value to nil", %{author: author} do
+      Enum.each(
+        [
+          %{"title" => "Null LO compatibility", "loWellFormed" => nil},
+          %{"title" => "Missing LO compatibility"}
+        ],
+        fn project_details ->
+          {:ok, project} = minimal_digest(project_details) |> Ingest.process(author)
+
+          assert is_nil(project.lo_well_formed)
+        end
+      )
+    end
+  end
+
   defp minimal_digest(project, products \\ [], resources \\ []) do
     base = [
       {~c"_project.json", Map.put_new(project, "description", "")},


### PR DESCRIPTION
## Jira

[MER-5861: Restrict learning objectives by content type](https://eliterate.atlassian.net/browse/MER-5861)

## Summary

Adds a persisted compatibility state that allows well-formed projects to enforce the intended learning-objective hierarchy while preserving permissive behavior for legacy projects.

## Behavior

- Adds nullable `projects.lo_well_formed`; existing projects remain unclassified and new projects default to `true`.
- Lazily classifies unclassified projects from their working publication when Basic Page, Adaptive Page, or Activity Bank authoring is opened.
- Treats a project as well formed when pages attach only top-level objectives and activities attach only sub-objectives.
- Keeps an existing `true` or `false` classification sticky.
- Preserves the exact `true`, `false`, or `nil` state when cloning.
- Preserves the state through project export and ingest; legacy archives with a missing or null value remain unclassified.
- For well-formed projects, page selectors offer only top-level objectives and continue to support just-in-time top-level objective creation.
- For well-formed projects, activity selectors display top-level objectives as disabled and allow only sub-objective attachment.
- Activity selectors with creation disabled behave as search fields, with clear no-results messaging and transient text cleared on blur.
- Legacy projects retain the existing permissive selector behavior.

## Testing

- Relevant backend suite: 143 tests passing.
- Classifier suite: 9 tests passing.
- Focused objective-selector Jest suites: 10 tests passing.
- `yarn check-types`
- Targeted ESLint and formatting checks.