### PR TITLE
[BUG FIX] [MER-5823] Student LO proficiency view shows deleted objectives

### DIFF
--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5973,13 +5973,15 @@ defmodule Oli.Delivery.Sections do
         }
       end)
 
+    # Only the two containment fields are needed, and both consumers of `container_ids` are
+    # membership checks, so the grouped lists are prepended and never reversed.
     objective_to_container_ids_map =
       from(co in ContainedObjective)
       |> where([co], co.section_id == ^section.id)
-      |> select([co], co)
+      |> select([co], {co.objective_id, co.container_id})
       |> Repo.all()
-      |> Enum.reduce(%{}, fn co, acc ->
-        Map.update(acc, co.objective_id, [co.container_id], &(&1 ++ [co.container_id]))
+      |> Enum.reduce(%{}, fn {objective_id, container_id}, acc ->
+        Map.update(acc, objective_id, [container_id], &[container_id | &1])
       end)
 
     # Section resources outlive the content that referenced them, so containment - not the

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -5905,6 +5905,9 @@ defmodule Oli.Delivery.Sections do
   top level objectives, they appear with their proficiency for only those activities that
   directly attached to them.
 
+  Only objectives contained by the currently delivered course content are returned, so that the
+  instructor dashboard, the student dashboard and the CSV export report on the same objective set.
+
   ## Options
 
   * `:student_id` - If provided, filters proficiency results for a specific student
@@ -5969,6 +5972,62 @@ defmodule Oli.Delivery.Sections do
           related_activities: sr.related_activities || []
         }
       end)
+
+    objective_to_container_ids_map =
+      from(co in ContainedObjective)
+      |> where([co], co.section_id == ^section.id)
+      |> select([co], co)
+      |> Repo.all()
+      |> Enum.reduce(%{}, fn co, acc ->
+        Map.update(acc, co.objective_id, [co.container_id], &(&1 ++ [co.container_id]))
+      end)
+
+    # Section resources outlive the content that referenced them, so containment - not the
+    # `deleted` flag - decides whether an objective still belongs to the delivered course.
+    root_contained? = fn resource_id ->
+      nil in Map.get(objective_to_container_ids_map, resource_id, [])
+    end
+
+    # From `objectives`, so membership proves a section resource exists: `children` may come from
+    # the revision fallback and name objectives absent here, breaking `lookup_map` below.
+    root_contained_ids =
+      objectives
+      |> Enum.filter(&root_contained?.(&1.resource_id))
+      |> MapSet.new(& &1.resource_id)
+
+    # Applied before proficiency so discards never reach the metrics queries. The parent rule
+    # reads `children`, not the expanded rows, so `exclude_sub_objectives` cannot change it.
+    contained_ids =
+      objectives
+      |> Enum.filter(fn objective ->
+        MapSet.member?(root_contained_ids, objective.resource_id) or
+          Enum.any?(objective.children, &MapSet.member?(root_contained_ids, &1))
+      end)
+      |> MapSet.new(& &1.resource_id)
+
+    objectives =
+      objectives
+      |> Enum.filter(&MapSet.member?(contained_ids, &1.resource_id))
+      |> Enum.map(fn objective ->
+        Map.merge(objective, %{
+          children: Enum.filter(objective.children, &MapSet.member?(root_contained_ids, &1)),
+          container_ids: Map.get(objective_to_container_ids_map, objective.resource_id, [])
+        })
+      end)
+
+    objectives =
+      if include_related_activities_count do
+        # Use pre-calculated related_activities field for performance
+        Enum.map(objectives, fn objective ->
+          Map.put(
+            objective,
+            :related_activities_count,
+            length(objective.related_activities || [])
+          )
+        end)
+      else
+        objectives
+      end
 
     id_list = Enum.map(objectives, & &1.resource_id)
 
@@ -6051,32 +6110,6 @@ defmodule Oli.Delivery.Sections do
         {student_ids, proficiency_dist_for_objectives}
       else
         {[], %{}}
-      end
-
-    objective_to_container_ids_map =
-      from(co in ContainedObjective)
-      |> where([co], co.section_id == ^section.id)
-      |> select([co], co)
-      |> Repo.all()
-      |> Enum.reduce(%{}, fn co, acc ->
-        Map.update(acc, co.objective_id, [co.container_id], &(&1 ++ [co.container_id]))
-      end)
-
-    objectives =
-      if include_related_activities_count do
-        # Use pre-calculated related_activities field for performance
-        Enum.map(objectives, fn obj ->
-          Map.merge(obj, %{
-            container_ids: Map.get(objective_to_container_ids_map, obj.resource_id, []),
-            related_activities_count: length(obj.related_activities || [])
-          })
-        end)
-      else
-        Enum.map(objectives, fn obj ->
-          Map.merge(obj, %{
-            container_ids: Map.get(objective_to_container_ids_map, obj.resource_id, [])
-          })
-        end)
       end
 
     lookup_map =

--- a/lib/oli/delivery/sections.ex
+++ b/lib/oli/delivery/sections.ex
@@ -6010,7 +6010,6 @@ defmodule Oli.Delivery.Sections do
       |> Enum.filter(&MapSet.member?(contained_ids, &1.resource_id))
       |> Enum.map(fn objective ->
         Map.merge(objective, %{
-          children: Enum.filter(objective.children, &MapSet.member?(root_contained_ids, &1)),
           container_ids: Map.get(objective_to_container_ids_map, objective.resource_id, [])
         })
       end)
@@ -6167,8 +6166,13 @@ defmodule Oli.Delivery.Sections do
             false ->
               # this is a top-level objective, so we need to include its subobjectives
               # in the result set as well
+              # `children` keeps every authored subobjective so callers can still resolve them
+              # by id; only contained ones become rows here, and membership in
+              # `root_contained_ids` guarantees `lookup_map` resolves them.
               sub_objectives =
-                Enum.map(objective.children, fn child ->
+                objective.children
+                |> Enum.filter(&MapSet.member?(root_contained_ids, &1))
+                |> Enum.map(fn child ->
                   sub_objective = Map.get(lookup_map, child)
 
                   {student_proficiency_subobj, student_proficiency_subobj_dist} =

--- a/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
+++ b/lib/oli_web/live/delivery/instructor_dashboard/instructor_dashboard_live.ex
@@ -120,8 +120,7 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
             Sections.get_objectives_and_subobjectives(socket.assigns.section,
               exclude_sub_objectives: false,
               include_related_activities_count: true
-            )
-            |> filter_root_contained_objectives(),
+            ),
           navigator_items:
             Oli.Delivery.Sections.SectionResourceDepot.containers(socket.assigns.section.id,
               numbering_level: {:in, [1, 2]}
@@ -1749,31 +1748,4 @@ defmodule OliWeb.Delivery.InstructorDashboard.InstructorDashboardLive do
   end
 
   defp parse_dashboard_section_split(_split), do: :error
-
-  defp filter_root_contained_objectives(objectives) do
-    root_contained_ids =
-      objectives
-      |> Enum.filter(&root_contained_objective?/1)
-      |> Enum.map(& &1.resource_id)
-      |> MapSet.new()
-
-    parent_ids_for_root_contained_subobjectives =
-      objectives
-      |> Enum.filter(fn objective ->
-        not is_nil(objective.subobjective) and
-          MapSet.member?(root_contained_ids, objective.resource_id)
-      end)
-      |> Enum.map(& &1.objective_resource_id)
-      |> MapSet.new()
-
-    Enum.filter(objectives, fn objective ->
-      MapSet.member?(root_contained_ids, objective.resource_id) or
-        (is_nil(objective.subobjective) and
-           MapSet.member?(parent_ids_for_root_contained_subobjectives, objective.resource_id))
-    end)
-  end
-
-  defp root_contained_objective?(objective) do
-    nil in List.wrap(Map.get(objective, :container_ids))
-  end
 end

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -3715,8 +3715,7 @@ defmodule Oli.Delivery.SectionsTest do
 
       assert Oli.Repo.exists?(
                from(sr in SectionResource,
-                 where:
-                   sr.section_id == ^section.id and sr.resource_id == ^deleted_objective_id
+                 where: sr.section_id == ^section.id and sr.resource_id == ^deleted_objective_id
                )
              ),
              "expected the deleted objective to still have a section resource"

--- a/test/oli/delivery/sections_test.exs
+++ b/test/oli/delivery/sections_test.exs
@@ -10,6 +10,7 @@ defmodule Oli.Delivery.SectionsTest do
   alias Oli.Delivery.Sections
 
   alias Oli.Delivery.Sections.{
+    ContainedObjective,
     PostProcessing,
     SectionResource,
     ScheduledContainerGroup,
@@ -19,8 +20,10 @@ defmodule Oli.Delivery.SectionsTest do
   alias Oli.Delivery.Attempts.Core
   alias Oli.Delivery.Attempts.Core.ResourceAccess
 
+  alias Oli.Publishing
   alias Oli.Publishing.DeliveryResolver
   alias Oli.Resources.ResourceType
+  alias Oli.Resources.Revision
   alias Lti_1p3.Roles.ContextRoles
 
   defp set_progress(
@@ -3334,8 +3337,10 @@ defmodule Oli.Delivery.SectionsTest do
     } do
       result = Sections.get_objectives_and_subobjectives(section)
 
-      # Should return 9 items: 5 top-level objectives + 4 subobjectives
-      assert length(result) == 9
+      # Should return 8 items: 4 top-level objectives + 4 subobjectives. The fifth top-level
+      # objective is not contained by any page or activity, so it is not part of the course
+      # as it is currently delivered.
+      assert length(result) == 8
 
       # Find top-level objectives
       top_level_a = Enum.find(result, &(&1.objective_resource_id == objective_a.resource_id))
@@ -3404,8 +3409,8 @@ defmodule Oli.Delivery.SectionsTest do
     } do
       result = Sections.get_objectives_and_subobjectives(section, exclude_sub_objectives: true)
 
-      # Should return only 5 top-level objectives
-      assert length(result) == 5
+      # Should return only the 4 contained top-level objectives
+      assert length(result) == 4
 
       # Verify only top-level objectives are returned
       objective_ids = Enum.map(result, & &1.objective_resource_id)
@@ -3554,19 +3559,83 @@ defmodule Oli.Delivery.SectionsTest do
       assert result == []
     end
 
-    test "handles objectives with no activities", %{
+    test "excludes objectives that no active page or activity references", %{
       section: section,
       objectives: %{objective_no_activities: objective_no_activities}
     } do
       result =
         Sections.get_objectives_and_subobjectives(section, include_related_activities_count: true)
 
-      # Find objective with no activities
-      no_activities_obj =
-        Enum.find(result, &(&1.objective_resource_id == objective_no_activities.resource_id))
+      refute Enum.any?(
+               result,
+               &(&1.objective_resource_id == objective_no_activities.resource_id)
+             )
+    end
 
-      # Objective with no activities should have 0 related activities
-      assert no_activities_obj.related_activities_count == 0
+    test "excludes uncontained objectives for the individual student view", %{
+      section: section,
+      objectives: %{
+        objective_a: objective_a,
+        objective_no_activities: objective_no_activities
+      }
+    } do
+      student = insert(:user)
+      Sections.enroll(student.id, section.id, [ContextRoles.get_role(:context_learner)])
+
+      result = Sections.get_objectives_and_subobjectives(section, student_id: student.id)
+
+      assert Enum.any?(result, &(&1.objective_resource_id == objective_a.resource_id))
+
+      refute Enum.any?(
+               result,
+               &(&1.objective_resource_id == objective_no_activities.resource_id)
+             )
+    end
+
+    test "preserves a parent objective when only one of its subobjectives is contained", %{
+      section: section,
+      objectives: %{
+        objective_a: objective_a,
+        sub_objective_a1: sub_objective_a1,
+        sub_objective_a2: sub_objective_a2
+      }
+    } do
+      # Objective A is attached to "Page 1 MCQ 1", A.1 to "Page 1 MCQ 2" and A.2 to "Page 1 MCQ 3".
+      # Dropping the containment of the parent and of A.2 leaves A.1 as the only contained member
+      # of the tree, which is the case where the parent must still be reported.
+      uncontained_ids = [objective_a.resource_id, sub_objective_a2.resource_id]
+
+      from(co in ContainedObjective,
+        where:
+          co.section_id == ^section.id and
+            co.objective_id in ^uncontained_ids
+      )
+      |> Oli.Repo.delete_all()
+
+      result = Sections.get_objectives_and_subobjectives(section)
+
+      parent_row =
+        Enum.find(
+          result,
+          &(&1.objective_resource_id == objective_a.resource_id and is_nil(&1.subobjective))
+        )
+
+      assert parent_row != nil
+      assert parent_row.objective == "Objective A"
+
+      assert Enum.any?(
+               result,
+               &(&1.subobjective_resource_id == sub_objective_a1.resource_id)
+             )
+
+      refute Enum.any?(
+               result,
+               &(&1.subobjective_resource_id == sub_objective_a2.resource_id)
+             )
+
+      # The preserved parent must not depend on whether subobjectives are expanded.
+      assert Sections.get_objectives_and_subobjectives(section, exclude_sub_objectives: true)
+             |> Enum.any?(&(&1.objective_resource_id == objective_a.resource_id))
     end
 
     test "falls back to revision children when objective section resources do not store hierarchy",
@@ -3595,6 +3664,77 @@ defmodule Oli.Delivery.SectionsTest do
       assert sub_a1.objective_resource_id == objective_a.resource_id
       assert sub_a2 != nil
       assert sub_a2.objective_resource_id == objective_a.resource_id
+    end
+  end
+
+  describe "get_objectives_and_subobjectives/2 for a section built from a publication with deleted objectives" do
+    setup [:create_project_with_objectives]
+
+    test "omits an objective deleted in authoring before the section was created", %{
+      project: project,
+      publication: publication,
+      obj_revision_1: obj_revision_1,
+      obj_revision_2: obj_revision_2
+    } do
+      %{authors: [author]} = project
+
+      # The author deletes Objective 2 and detaches it from Page 2.
+      {:ok, _} =
+        Oli.Resources.update_revision(obj_revision_2, %{deleted: true, author_id: author.id})
+
+      page_2 = Oli.Repo.one!(from(r in Revision, where: r.slug == "page_2"))
+
+      {:ok, _} =
+        Oli.Resources.update_revision(page_2, %{
+          objectives: %{"attached" => []},
+          author_id: author.id
+        })
+
+      {:ok, _} = Publishing.update_publication(publication, %{published: nil})
+
+      {:ok, new_publication} =
+        Publishing.publish_project(project, "deleted objective 2", author.id)
+
+      # A section created from this publication gets a section resource for the deleted
+      # objective, because create_nonstructural_section_resources/3 builds them from the
+      # published resource mappings without excluding deleted revisions.
+      section =
+        insert(:section,
+          base_project: project,
+          context_id: UUID.uuid4(),
+          open_and_free: true,
+          registration_open: true,
+          type: :enrollable
+        )
+
+      {:ok, section} = Sections.create_section_resources(section, new_publication)
+      {:ok, _} = Sections.rebuild_contained_pages(section)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
+
+      deleted_objective_id = obj_revision_2.resource_id
+
+      assert Oli.Repo.exists?(
+               from(sr in SectionResource,
+                 where:
+                   sr.section_id == ^section.id and sr.resource_id == ^deleted_objective_id
+               )
+             ),
+             "expected the deleted objective to still have a section resource"
+
+      refute Oli.Repo.exists?(
+               from(co in ContainedObjective,
+                 where:
+                   co.section_id == ^section.id and
+                     co.objective_id == ^deleted_objective_id and
+                     is_nil(co.container_id)
+               )
+             ),
+             "expected the deleted objective to have no root containment"
+
+      titles = Sections.get_objectives_and_subobjectives(section) |> Enum.map(& &1.objective)
+
+      assert obj_revision_1.title in titles
+      refute obj_revision_2.title in titles
     end
   end
 

--- a/test/oli_web/controllers/delivery_controller_test.exs
+++ b/test/oli_web/controllers/delivery_controller_test.exs
@@ -651,6 +651,66 @@ defmodule OliWeb.DeliveryControllerTest do
     end
   end
 
+  describe "download_learning_objectives with objectives that left the course content" do
+    setup [:instructor_conn, :create_project_with_objectives]
+
+    test "omits objectives that no active page or activity references", %{
+      conn: conn,
+      instructor: instructor,
+      section: section,
+      project: project,
+      publication: publication,
+      obj_revision_1: obj_revision_1
+    } do
+      %{authors: [author]} = project
+
+      # An objective that was deleted in authoring, and so is not attached to any page or
+      # activity of the section, but still has its own section resource.
+      orphan_resource = insert(:resource)
+
+      orphan_revision =
+        insert(:revision,
+          resource: orphan_resource,
+          resource_type_id: Oli.Resources.ResourceType.id_for_objective(),
+          slug: "orphan_objective",
+          title: "Orphan Objective",
+          deleted: true
+        )
+
+      insert(:project_resource, project_id: project.id, resource_id: orphan_resource.id)
+
+      insert(:published_resource,
+        publication: publication,
+        resource: orphan_resource,
+        revision: orphan_revision
+      )
+
+      {:ok, _publication} = Publishing.update_publication(publication, %{published: nil})
+      {:ok, publication} = Publishing.publish_project(project, "some changes", author.id)
+      Sections.update_section_project_publication(section, project.id, publication.id)
+      Sections.rebuild_section_resources(section: section, publication: publication)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
+      Sections.PostProcessing.apply(section, :all)
+
+      Sections.enroll(instructor.id, section.id, [ContextRoles.get_role(:context_instructor)])
+
+      assert Enum.any?(
+               Oli.Delivery.Sections.SectionResourceDepot.objectives(section.id),
+               &(&1.resource_id == orphan_resource.id)
+             )
+
+      conn =
+        conn
+        |> log_in_user(instructor)
+        |> get(Routes.delivery_path(conn, :download_learning_objectives, section.slug))
+
+      csv = response(conn, 200)
+
+      assert csv =~ obj_revision_1.title
+      refute csv =~ orphan_revision.title
+    end
+  end
+
   describe "download_student_progress" do
     test "downloads student-specific progress csv", %{conn: conn} do
       %{instructor: instructor, section: section, student1: student} =

--- a/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs
@@ -75,11 +75,29 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
           author_id: author.id
         })
 
+      # Attaching the subobjectives to a page, so they are contained by the course content
+      page_revision_1 = Oli.Publishing.DeliveryResolver.from_revision_slug(section.slug, "page_1")
+
+      {:ok, _page_revision_1} =
+        Oli.Resources.update_revision(page_revision_1, %{
+          objectives: %{
+            "attached" => [
+              obj_revision_1.resource_id,
+              subobj_rev_1.resource_id,
+              subobj_rev_2.resource_id,
+              subobj_rev_3.resource_id
+            ]
+          },
+          author_id: author.id
+        })
+
       # Publishing the project
       {:ok, _publication} = Oli.Publishing.update_publication(publication, %{published: nil})
       {:ok, publication} = Oli.Publishing.publish_project(project, "some changes", author.id)
       Sections.update_section_project_publication(section, project.id, publication.id)
       Sections.rebuild_section_resources(section: section, publication: publication)
+      # rebuild_section_resources does not pick up the objectives attached by the republish above
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
       Sections.PostProcessing.apply(section, :all)
 
       {:ok, view, _html} =
@@ -98,6 +116,59 @@ defmodule OliWeb.Delivery.StudentDashboard.Components.LearningObjectivesTabTest 
       assert [obj_revision_1.title, subobj_rev_3.title] == pull_data_from_table(view, 4)
       # Row 5 - has subobjective 2 (We also check here the order)
       assert [obj_revision_1.title, subobj_rev_2.title] == pull_data_from_table(view, 5)
+    end
+
+    test "does not render objectives that are no longer part of the course content", %{
+      section: section,
+      conn: conn,
+      student: student,
+      obj_revision_1: obj_revision_1,
+      project: project,
+      publication: publication
+    } do
+      %{authors: [author]} = project
+
+      # An objective that was deleted in authoring, and so is not attached to any page or
+      # activity of the section, but still has its own section resource.
+      orphan_resource = insert(:resource)
+
+      orphan_revision =
+        insert(:revision,
+          resource: orphan_resource,
+          resource_type_id: Oli.Resources.ResourceType.id_for_objective(),
+          slug: "orphan_objective",
+          title: "Orphan Objective",
+          deleted: true
+        )
+
+      insert(:project_resource, project_id: project.id, resource_id: orphan_resource.id)
+
+      insert(:published_resource,
+        publication: publication,
+        resource: orphan_resource,
+        revision: orphan_revision
+      )
+
+      {:ok, _publication} = Oli.Publishing.update_publication(publication, %{published: nil})
+      {:ok, publication} = Oli.Publishing.publish_project(project, "some changes", author.id)
+      Sections.update_section_project_publication(section, project.id, publication.id)
+      Sections.rebuild_section_resources(section: section, publication: publication)
+      {:ok, _} = Sections.rebuild_contained_objectives(section)
+      Sections.PostProcessing.apply(section, :all)
+
+      assert Enum.any?(
+               Oli.Delivery.Sections.SectionResourceDepot.objectives(section.id),
+               &(&1.resource_id == orphan_resource.id)
+             )
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          live_view_students_dashboard_route(section.slug, student.id, :learning_objectives)
+        )
+
+      assert has_element?(view, "span", obj_revision_1.title)
+      refute has_element?(view, "span", orphan_revision.title)
     end
 
     test "gets rendered correctly", %{


### PR DESCRIPTION
[MER-5823](https://eliterate.atlassian.net/browse/MER-5823)

## Summary

This PR fixes delivery learning objective filtering so deleted or no-longer-contained objectives are not shown in current course views.

**Behavior change:** the criterion is containment, not the `deleted` flag. A live objective that is not attached to any page or activity is also hidden. This affects the CSV export and the instructor dashboard.

### Changes

- Centralized filtering in `Sections.get_objectives_and_subobjectives/2`.
- Excludes objectives that still have a `section_resource` but are no longer actively contained by pages or activities.
- Preserves a parent objective when at least one of its subobjectives is still contained.
- Removed duplicate instructor dashboard filtering.
- Subobjective rows are filtered at expansion time rather than by pruning `children` on the row, so callers that resolve subobjectives by id from that field keep working.
- Added coverage for delivery context behavior, learning objectives CSV export, and the individual student dashboard.

### Tests

```
mix test test/oli/delivery/sections_test.exs \
  test/oli_web/controllers/delivery_controller_test.exs \
  test/oli_web/live/delivery/student_dashboard/components/learning_objectives_tab_test.exs \
  test/oli_web/components/delivery/learning_objectives/ \
  test/oli_web/live/delivery/instructor_dashboard/insights/
```

Result: **309 tests, 0 failures**

### How to verify

Open both views of an affected section and compare: Insights → Objectives and Overview → Students → *(student)* → Objectives should show the same set. They currently do not match.

This only reproduces in sections created or rebuilt after the content was deleted, because `create_nonstructural_section_resources` does not filter `deleted` revisions. That is why it does not happen in every course.

[MER-5823]: https://eliterate.atlassian.net/browse/MER-5823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ