### PR TITLE
[BUG FIX] [MER-5849] Fix flaky credential-account Playwright suite in PR CI

### DIFF
--- a/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
+++ b/assets/automation/src/systems/torus/pom/home/CredentialAccountPO.ts
@@ -17,6 +17,7 @@ export class CredentialAccountPO {
 
   async register(account: AccountDetails) {
     await this.page.goto(`/${this.pathSegment()}/register`);
+    await this.waitForLiveViewReady();
 
     const form = this.page.locator('#registration_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(account.email);
@@ -28,42 +29,61 @@ export class CredentialAccountPO {
       .fill(account.password);
 
     await this.acceptCookieConsentIfVisible();
-    await form.getByRole('button', { name: 'Create account', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/confirm`, { waitUntil: 'commit' });
+    await Promise.all([
+      this.page.waitForURL(`/${this.pathSegment()}/confirm`, { waitUntil: 'commit' }),
+      form.getByRole('button', { name: 'Create account', exact: true }).click(),
+    ]);
+    // The confirm-instructions LiveView must finish joining before the
+    // session cookie is cleared (clearSessionCookie, called by the caller
+    // right after this returns): if the join is still in flight when the
+    // cookie disappears, the server rejects it as a stale session and the
+    // LiveView client reloads the page on its own, racing with whatever
+    // navigation the test performs next.
+    await this.waitForLiveViewReady();
   }
 
   async confirm(url: string) {
     await this.page.goto(url);
+    await this.waitForLiveViewReady();
     await this.acceptCookieConsentIfVisible();
-    await this.page.getByRole('button', { name: 'Confirm', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' });
+    await Promise.all([
+      this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' }),
+      this.page.getByRole('button', { name: 'Confirm', exact: true }).click(),
+    ]);
     await expect(this.page.getByText('Email successfully confirmed.')).toBeVisible();
   }
 
   async requestPasswordReset(email: string) {
     await this.page.goto(`/${this.pathSegment()}/reset_password`);
+    await this.waitForLiveViewReady();
 
     const form = this.page.locator('#reset_password_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
     await this.acceptCookieConsentIfVisible();
-    await form.getByRole('button', { name: 'Send password reset instructions' }).click();
-    await this.page.waitForURL(this.resetRequestDestination());
+    await Promise.all([
+      this.page.waitForURL(this.resetRequestDestination()),
+      form.getByRole('button', { name: 'Send password reset instructions' }).click(),
+    ]);
   }
 
   async resetPassword(url: string, password: string) {
     await this.page.goto(url);
+    await this.waitForLiveViewReady();
 
     const form = this.page.locator('#reset_password_form');
     await form.locator(`input[name="${this.formName()}[password]"]`).fill(password);
     await form.locator(`input[name="${this.formName()}[password_confirmation]"]`).fill(password);
     await this.acceptCookieConsentIfVisible();
-    await form.getByRole('button', { name: 'Reset Password', exact: true }).click();
-    await this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' });
+    await Promise.all([
+      this.page.waitForURL(`/${this.pathSegment()}/log_in`, { waitUntil: 'commit' }),
+      form.getByRole('button', { name: 'Reset Password', exact: true }).click(),
+    ]);
     await expect(this.page.getByText('Password reset successfully.')).toBeVisible();
   }
 
   async login(email: string, password: string, loginPath?: string) {
     await this.page.goto(loginPath ?? `/${this.pathSegment()}/log_in`);
+    await this.waitForLiveViewReady();
 
     const form = this.page.locator('#login_form');
     await form.locator(`input[name="${this.formName()}[email]"]`).fill(email);
@@ -106,6 +126,12 @@ export class CredentialAccountPO {
 
   private resetRequestDestination() {
     return this.type === 'author' ? '/authors/log_in' : '/';
+  }
+
+  private async waitForLiveViewReady() {
+    await expect(this.page.locator('[data-phx-main].phx-connected').first()).toBeAttached({
+      timeout: 15_000,
+    });
   }
 
   private async acceptCookieConsentIfVisible() {

--- a/config/ci_e2e.exs
+++ b/config/ci_e2e.exs
@@ -15,7 +15,9 @@ config :oli, Oli.Repo, database: System.get_env("DB_NAME", "oli_ci_e2e")
 
 config :oli, OliWeb.Endpoint,
   code_reloader: false,
-  live_reload: [],
-  watchers: []
+  # Config.Reader recursively merges keyword lists, so [] would leave the
+  # values imported from dev.exs intact. nil explicitly disables them.
+  live_reload: nil,
+  watchers: nil
 
 config :oli, Oli.Mailer, adapter: Swoosh.Adapters.Local


### PR DESCRIPTION
## Summary

Follow-up to #6787 (`[FEATURE] [MER-5849] Add Playwright coverage for credential-based account flows`). After ~15 days and roughly 48 runs of `pr-playwright.yml` in production, the credential-account suite showed a recurring intermittent failure. This PR fixes the underlying cause instead of relying on reruns.

## Investigation

The workflow had run ~48 times since it was introduced on 2026-08-19. Excluding 4 failures from that same day while the workflow was still being developed, 7 later executions failed intermittently, always in the same test, and reruns (or pushing another commit) usually produced a passing run:

| Date | Run | PR/title | Failure location |
| --- | --- | --- | --- |
| 2026-08-31 | [33443506527](https://github.com/Simon-Initiative/oli-torus/actions/runs/33443506527) | MER-5859 onboarding customization | Password-reset request, `CredentialAccountPO.ts:50` |
| 2026-09-01 | [33531346020](https://github.com/Simon-Initiative/oli-torus/actions/runs/33531346020) | MER-5846 learning model v2 | Password-reset request, `CredentialAccountPO.ts:50` |
| 2026-09-02 | [33674253893](https://github.com/Simon-Initiative/oli-torus/actions/runs/33674253893) | Dependabot `@humanfs/node` | Password-reset request, `CredentialAccountPO.ts:50` |
| 2026-09-02 | [33682438040](https://github.com/Simon-Initiative/oli-torus/actions/runs/33682438040) | MER-5861 restrict LOs by content type | Password-reset submission, `CredentialAccountPO.ts:61` |
| 2026-09-03 | [33745678511](https://github.com/Simon-Initiative/oli-torus/actions/runs/33745678511) | MER-5846 learning model v2 | Password-reset request, `CredentialAccountPO.ts:50` |
| 2026-09-03 | [33753905296](https://github.com/Simon-Initiative/oli-torus/actions/runs/33753905296) | MER-5823 deleted objectives | Password-reset request, `CredentialAccountPO.ts:50` |
| 2026-09-03 | [33757901964](https://github.com/Simon-Initiative/oli-torus/actions/runs/33757901964) | MER-5888 LO delivery corrections | Password-reset request, `CredentialAccountPO.ts:50` |

Common characteristics across all 7 failures:
- All occurred in `credential-based account flows @pr › author self-service lifecycle`.
- Six timed out while requesting reset instructions, one while submitting the new password — each consuming the test's full 120s `page.waitForURL(...)` timeout.
- The other three `@pr` tests always passed.
- Checkout, compile, DB create/seed, asset build, browser install, Torus startup, and the HTTP readiness check all succeeded every time. No Postgres, mail, or application exception explained the failures.

### Decisive runtime evidence

The failed Playwright trace said it was waiting for `/authors/log_in`, but the browser remained on the reset-form URL, e.g.:

```
waiting for navigation to "/authors/log_in"
navigated to "http://localhost:4002/authors/reset_password?author[email]=..."
```

The Torus server log for run `33757901964` confirmed the click produced a **native HTML form submission**:

```
GET /authors/reset_password
Parameters: %{"author" => %{"email" => "pw-...-author@example.test"}}
```

A correctly connected LiveView would instead have logged `HANDLE EVENT "send_email" in OliWeb.AuthorForgotPasswordLive` and redirected to `/authors/log_in`. This proves the test was interacting with a rendered page **before its LiveView client had connected**: the button existed and was clickable, but no handler was attached to it, so the browser fell back to a native form submit that never redirects.

### Root cause: CI environment race

`config/ci_e2e.exs` imports `config/dev.exs` and tried to disable dev-only behavior with:

```elixir
config :oli, OliWeb.Endpoint,
  code_reloader: false,
  live_reload: [],
  watchers: []
```

`Config.Reader` recursively merges keyword lists, so `[]` does **not** clear the lists inherited from `dev.exs` — it merges an empty list into the existing one, which is a no-op:

```elixir
Config.Reader.merge(
  [oli: [endpoint: [watchers: [x: 1]]]],
  [oli: [endpoint: [watchers: []]]]
)
# => [oli: [endpoint: [watchers: [x: 1]]]]
```

The failed server log confirmed this in practice — right after Phoenix started, Webpack, Tailwind, and both Gleam watchers (all inherited from `dev.exs`) started up and rebuilt assets *while Playwright was already running*:

```
yarn run v1.22.22
$ chokidar ... gleam build --target erlang ...
$ chokidar ... gleam build --target javascript ...
Watching ...
Rebuilding...
webpack ... compiled ...
```

The workflow's readiness check only waits for `/` to return HTTP 200, which proves Cowboy/Phoenix is listening, not that the dev asset rebuild has finished or that a newly loaded page's LiveView socket has connected. Depending on runner timing, the credential test could reach a form while assets were still rebuilding — explaining why reruns usually passed with no code change.

### Related precedent

This class of Playwright/LiveView race has occurred before in this repo: #6584 (`Stabilize Playwright login and menu interactions`) hardened account tests by waiting for `.phx-connected` before interacting, and `AdaptiveLessonTask.ts` (introduced in #6752) documents explicitly that a click landing before the LiveView handler binds can be silently dropped even though the button looks clickable.

## Fix

**Layer 1 — remove the CI environment race** (`config/ci_e2e.exs`): use `nil` instead of `[]` for `live_reload`/`watchers`. Phoenix reads watchers as `conf[:watchers] || []`, so `nil` safely becomes "no watchers" — but unlike `[]`, `nil` is not recursively merged as a keyword list, so it actually replaces the inherited value instead of appending to it. This is safe for `ci_e2e` because the workflow already runs `yarn run deploy` before starting Torus, building assets once with no source edits happening afterward; `dev.exs`'s own watcher config is untouched.

**Layer 2 — make the test express its real precondition** (`CredentialAccountPO.ts`): added a strict `waitForLiveViewReady()` helper that asserts `[data-phx-main].phx-connected` is attached (15s timeout) immediately after every navigation to a credential LiveView (registration, confirmation, password-reset request/submission, login). This follows the existing repo convention (see precedent above) rather than the best-effort/`.catch()` pattern used elsewhere, because these are known LiveViews — if the socket doesn't connect, the test should fail fast and explicitly instead of silently degrading to a native form submit and timing out 120s later on a misleading error. Known navigations are also now coordinated with their triggering click via `Promise.all([waitForURL(...), click()])` so the navigation observer is installed before the click fires.

**A second, related race found during local validation:** while repeatedly running the suite locally to validate Layer 1/2, `register()` intermittently failed with `page.goto: Navigation to ".../authors/confirm/<token>" is interrupted by another navigation to ".../authors/confirm"`. The server log pinned it down exactly:

```
CONNECTED TO Phoenix.LiveView.Socket ...
[debug] LiveView session was misconfigured or the user token is outdated.
...
GET /authors/confirm   <- a second, real navigation triggered by the LiveView client
```

`register()` navigates to `/authors/confirm` but — unlike every other transition in this file — never waited for that page's LiveView socket to finish joining before the test called `clearSessionCookie()`. On a cold server, the join could still be in flight when the cookie disappeared; the server then rejected the (now stale) join as an invalid session, and the LiveView client reloaded the page on its own, racing with the test's subsequent navigation to the confirmation link. Fixed by adding the same `waitForLiveViewReady()` call at the end of `register()`, so the confirm-instructions LiveView is fully joined (with a valid session) before the cookie is ever touched.

## Local validation

Replicated the workflow's environment locally: a dedicated, disposable Postgres database, `MIX_ENV=ci_e2e`, assets built once via `yarn run deploy` (no dev server/watchers), Torus started on an isolated port, then `npx playwright test --grep @pr --reporter=line` against it.

- **Watchers confirmed disabled:** grepped the full server startup log for `chokidar|watcher|webpack.*compil|gleam build|watching` — no matches. No asset rebuild competes with the tests anymore.
- **Suite run repeatedly, including cold starts** (server freshly started immediately before the first test, which is when the race conditions above are most likely to surface): 2/2 cold-start full-suite runs passed after the fix, plus 3 additional warm reruns — 5 full runs, 20/20 individual test executions passed, with **zero** recurrence of either the original 120s timeout/native-form-submit symptom or the newly found confirm-navigation race.
- Before the `register()` fix, the confirm-navigation race reproduced consistently (2/2) on a cold server and never on a warm one, consistent with it being a timing race exposed by slower first-request latency.
- `npx prettier --write` and `npx eslint` pass clean on the modified file.
- `npx tsc --noEmit` still fails on two pre-existing, unrelated errors (`liveSocket` typing in `CourseManagePO.ts` and `ProductsPO.ts`) not touched by this change.

## Next steps

The immediate causal mechanism is proven by the browser URL/server request evidence above, and the fix removed it in repeated local runs. The remaining confirmation is statistical, in the real GitHub Actions runner: this PR is opened as a draft specifically so `pr-playwright.yml` runs against it repeatedly without merging, to gather enough consecutive passing runs to treat the flake as resolved (a single pass is necessary but not sufficient).


[MER-5849]: https://eliterate.atlassian.net/browse/MER-5849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ