### PR TITLE
[ENHANCEMENT] [MER-5918] Homogenize and document Playwright nightly adaptive tests

### DIFF
--- a/.github/workflows/nightly-playwright.yml
+++ b/.github/workflows/nightly-playwright.yml
@@ -25,6 +25,7 @@ jobs:
       PLAYWRIGHT_SCENARIO_TOKEN: ${{ secrets.PLAYWRIGHT_SCENARIO_TOKEN }}
       CANVAS_UI_EMAIL: ${{ secrets.CANVAS_UI_EMAIL }}
       CANVAS_UI_PASSWORD: ${{ secrets.CANVAS_UI_PASSWORD }}
+      PLAYWRIGHT_PARAMETER_CONFIG_URL: ${{ secrets.PLAYWRIGHT_PARAMETER_CONFIG_URL }}
 
     steps:
       - name: Checkout

--- a/assets/automation/playwright.config.ts
+++ b/assets/automation/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: false,
+  forbidOnly: true,
   /* Retry on CI only */
   retries: 0,
   /* Opt out of parallel tests on CI. */

--- a/assets/automation/playwright.config.ts
+++ b/assets/automation/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: true,
   /* Retry on CI only */
-  retries: 0,
+  retries: 1,
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/assets/automation/tests/resources/adaptive-tests-setup.md
+++ b/assets/automation/tests/resources/adaptive-tests-setup.md
@@ -1,0 +1,136 @@
+# Playwright Adaptive Tests — Assets & Setup Guide
+
+## Background
+
+The adaptive lesson Playwright tests automate real student flows through private course content.
+Because course archives and answer keys are instructional property that must never be committed to
+this repository, tests load them at runtime from a private S3-compatible object-storage bucket.
+
+## Architecture
+
+### Why S3 and a server-side proxy?
+
+Tests never access the bucket directly. Instead:
+
+1. The test runner requests an asset through the Torus server's `/test/assets/:key` endpoint.
+   For example: `GET https://torus-server/test/assets/phases_of_the_moon-phases_of_the_moon/course.zip`
+2. The server validates the `x-playwright-scenario-token` header, then fetches the object from S3
+   using server-side credentials and streams it back to the test runner.
+3. The test runner stores the zip in a temp directory and posts it to `/api/v1/automation_setup`
+   for Torus to ingest.
+
+Bucket credentials never leave the server and never appear in Playwright traces. Adding new tests
+does not require distributing S3 credentials to engineers — only the server needs them.
+A local MinIO instance is API-compatible with S3, so the same code path works in development.
+
+### Server-side gating
+
+The `/test/assets/*`, `/api/v1/automation_setup`, `/api/v1/automation_teardown`, and
+scenario-seeding routes are **compiled out of the production router** unless
+`enable_playwright_scenarios: true` is set at **compile time** (this is a value in the Mix config
+file used to build the app, not a runtime environment variable). The default in `config/prod.exs`
+is `false`. `config/ci_e2e.exs` already sets it to `true`.
+
+Any environment intended to run nightly tests must be built with `enable_playwright_scenarios: true`
+— either by using `MIX_ENV=ci_e2e` or by configuring a dedicated Mix environment. This is a
+deployment decision to coordinate with DevOps.
+
+## S3 key naming convention
+
+All assets live inside a folder named `{section}-{page}`, where section and page names use
+underscores in place of spaces. Files within the folder are always named `course.zip` and
+`answers.json`.
+
+```
+{section_name_with_underscores}-{page_name_with_underscores}/
+  course.zip
+  answers.json   (only for tests that validate specific answers)
+```
+
+Example: `bio_beyond-designer_planet/course.zip`
+
+## Required assets per adaptive test
+
+All adaptive tests that load from the bucket and the S3 keys they expect:
+
+| Test file | S3 archive key | S3 answers key | `@nightly` |
+|-----------|---------------|----------------|-----------|
+| `designer-planet-adaptive.spec.ts` | `bio_beyond-designer_planet/course.zip` | `bio_beyond-designer_planet/answers.json` | ✅ |
+| `our-blue-planet-adaptive.spec.ts` | `bio_beyond-our_blue_planet/course.zip` | `bio_beyond-our_blue_planet/answers.json` | ✅ |
+| `phases-of-the-moon.spec.ts` | `phases_of_the_moon-phases_of_the_moon/course.zip` | `phases_of_the_moon-phases_of_the_moon/answers.json` | ✅ |
+| `stellar-life-cycles-training.spec.ts` | `habitable_worlds-stellar_life_cycles_training/course.zip` | `habitable_worlds-stellar_life_cycles_training/answers.json` | ✅ |
+| `real-chem-greenhouse-molecules.spec.ts` | `real_chem-greenhouse_molecules/course.zip` | `real_chem-greenhouse_molecules/answers.json` | ✅ |
+| `real-chem-dazzling-d-orbitals.spec.ts` | `real_chem_ii-dazzling_d_orbitals/course.zip` | `real_chem_ii-dazzling_d_orbitals/answers.json` | ✅ |
+| `hw-brightness-assessment.spec.ts` | `habitable_worlds-brightness_assessment/course.zip` | _(none — no secret answers required)_ | ✅ |
+
+## Environment variables
+
+### Torus server (target environment)
+
+These are set in the deployment configuration of the Torus server being tested.
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `PLAYWRIGHT_ASSETS_BUCKET` | Yes | Name of the S3/MinIO bucket containing test assets |
+| `PLAYWRIGHT_SCENARIO_TOKEN` | Yes | Shared secret you choose — must match the value set on the test runner. No admin UI needed; set it as an env var on both sides. |
+| `AWS_ACCESS_KEY_ID` | Yes (prod S3) | S3 access key. Use `AWS_S3_ACCESS_KEY_ID` to override with a dedicated key for the PW bucket, separate from other AWS credentials the server may already have. |
+| `AWS_SECRET_ACCESS_KEY` | Yes (prod S3) | S3 secret key. Same override pattern via `AWS_S3_SECRET_ACCESS_KEY`. |
+| `AWS_S3_SCHEME` | Dev/MinIO only | URL scheme for MinIO (default: `http`). Not needed for real S3. |
+| `AWS_S3_HOST` | Dev/MinIO only | MinIO host (default: `localhost`). Not needed for real S3. |
+| `AWS_S3_PORT` | Dev/MinIO only | MinIO port (default: `9000`). Not needed for real S3. |
+
+### Playwright test runner
+
+These are set on the CI agent (e.g. as GitHub Actions secrets on the `nightly-ui` environment).
+The Torus server and the test runner are separate processes — the runner only needs to know how to
+reach the server and authenticate its requests.
+
+| Variable | Required for | Description |
+|----------|-------------|-------------|
+| `PLAYWRIGHT_BASE_URL` | All tests | Torus server URL (e.g. `https://nightly.oli.cmu.edu`) |
+| `PLAYWRIGHT_SCENARIO_TOKEN` | All tests | Same value as the server-side token |
+| `PLAYWRIGHT_AUTOMATION_API_KEY` | Adaptive tests | See [Automation API key](#automation-api-key) |
+| `CANVAS_UI_EMAIL` | LTI tests | Canvas test-account email |
+| `CANVAS_UI_PASSWORD` | LTI tests | Canvas test-account password |
+| `PLAYWRIGHT_PARAMETER_CONFIG_URL` | Dot chatbot smoke | URL to the YAML config file (see `nightly-ci.md`) |
+
+## Automation API key
+
+`PLAYWRIGHT_AUTOMATION_API_KEY` must correspond to an API key in the target Torus environment that
+has `automation_setup_enabled: true`. To create one:
+
+1. Log in as an admin on the target Torus instance.
+2. Go to `/admin/api_keys`, enter a hint, and click **Create** — Torus generates the key value.
+3. Toggle `automation_setup_enabled` on for the newly created key.
+4. Export the generated value as `PLAYWRIGHT_AUTOMATION_API_KEY` in the CI environment.
+
+Never reuse a key value that appears in the repository. `/api/v1/automation_setup` is reachable
+in any environment where the flag is compiled in, and is gated solely by this key.
+
+## Seeding the bucket
+
+For each adaptive test in the table above, the corresponding `course.zip` (and `answers.json` where
+applicable) must be uploaded to the Playwright assets bucket under the exact S3 key path shown.
+
+The person responsible for managing the bucket (typically DevOps) should upload the files using
+whatever access method they have available. The folder structure and file names must match the paths
+in the table exactly.
+
+## Running the nightly suite
+
+The nightly subset is identified by the `@nightly` tag embedded in test descriptions. Run it with:
+
+```sh
+npx playwright test --grep @nightly
+```
+
+## Known issues
+
+1. **`enable_playwright_scenarios` is a compile-time flag, not a runtime env var** — any nightly
+   environment must be built with it set to `true` in the Mix config. Coordinate with DevOps to
+   confirm which `MIX_ENV` the nightly environment uses.
+
+2. **Tags are plain text, not Playwright tag filters** — `@nightly` currently appears inside the
+   test description string. This works with `--grep` today. Migrating to
+   `test('...', { tag: '@nightly' }, ...)` is a future clean-up item that enables native UI
+   filtering in Playwright, but it is not a blocker.

--- a/assets/automation/tests/resources/adaptive-tests-setup.md
+++ b/assets/automation/tests/resources/adaptive-tests-setup.md
@@ -10,17 +10,15 @@ this repository, tests load them at runtime from a private S3-compatible object-
 
 ### Why S3 and a server-side proxy?
 
-Tests never access the bucket directly. Instead:
+Adaptive lesson tests run against real course content — the course archive and the answer key are
+instructional property that must not be committed to the repository. To keep them private while
+still making them available to the test suite, they are stored in a private S3 bucket and fetched
+at runtime.
 
-1. The test runner requests an asset through the Torus server's `/test/assets/:key` endpoint.
-   For example: `GET https://torus-server/test/assets/phases_of_the_moon-phases_of_the_moon/course.zip`
-2. The server validates the `x-playwright-scenario-token` header, then fetches the object from S3
-   using server-side credentials and streams it back to the test runner.
-3. The test runner stores the zip in a temp directory and posts it to `/api/v1/automation_setup`
-   for Torus to ingest.
-
-Bucket credentials never leave the server and never appear in Playwright traces. Adding new tests
-does not require distributing S3 credentials to engineers — only the server needs them.
+Tests do not access the bucket directly. Instead, they request assets through the Torus server's
+`/test/assets/:key` endpoint, which proxies the request to S3 using server-side credentials. This
+keeps bucket credentials off the test runner entirely — no engineer or CI agent ever needs S3
+access, and Playwright traces (which capture all network traffic by default) cannot leak credentials.
 A local MinIO instance is API-compatible with S3, so the same code path works in development.
 
 ### Server-side gating
@@ -49,80 +47,82 @@ underscores in place of spaces. Files within the folder are always named `course
 
 Example: `bio_beyond-designer_planet/course.zip`
 
-## Required assets per adaptive test
+---
 
-All adaptive tests that load from the bucket and the S3 keys they expect:
+## Setup
 
-| Test file | S3 archive key | S3 answers key | `@nightly` |
-|-----------|---------------|----------------|-----------|
-| `designer-planet-adaptive.spec.ts` | `bio_beyond-designer_planet/course.zip` | `bio_beyond-designer_planet/answers.json` | ✅ |
-| `our-blue-planet-adaptive.spec.ts` | `bio_beyond-our_blue_planet/course.zip` | `bio_beyond-our_blue_planet/answers.json` | ✅ |
-| `phases-of-the-moon.spec.ts` | `phases_of_the_moon-phases_of_the_moon/course.zip` | `phases_of_the_moon-phases_of_the_moon/answers.json` | ✅ |
-| `stellar-life-cycles-training.spec.ts` | `habitable_worlds-stellar_life_cycles_training/course.zip` | `habitable_worlds-stellar_life_cycles_training/answers.json` | ✅ |
-| `real-chem-greenhouse-molecules.spec.ts` | `real_chem-greenhouse_molecules/course.zip` | `real_chem-greenhouse_molecules/answers.json` | ✅ |
-| `real-chem-dazzling-d-orbitals.spec.ts` | `real_chem_ii-dazzling_d_orbitals/course.zip` | `real_chem_ii-dazzling_d_orbitals/answers.json` | ✅ |
-| `hw-brightness-assessment.spec.ts` | `habitable_worlds-brightness_assessment/course.zip` | _(none — no secret answers required)_ | ✅ |
+### Step 1 — Seed the S3 bucket
 
-## Environment variables
+For each adaptive test below, the corresponding files must be uploaded to the Playwright assets
+bucket under the exact S3 key path shown. The person responsible for managing the bucket (typically
+DevOps) should upload the files using whatever access method they have available.
 
-### Torus server (target environment)
+| Test file | S3 archive key | S3 answers key |
+|-----------|---------------|----------------|
+| `designer-planet-adaptive.spec.ts` | `bio_beyond-designer_planet/course.zip` | `bio_beyond-designer_planet/answers.json` |
+| `our-blue-planet-adaptive.spec.ts` | `bio_beyond-our_blue_planet/course.zip` | `bio_beyond-our_blue_planet/answers.json` |
+| `phases-of-the-moon.spec.ts` | `phases_of_the_moon-phases_of_the_moon/course.zip` | `phases_of_the_moon-phases_of_the_moon/answers.json` |
+| `stellar-life-cycles-training.spec.ts` | `habitable_worlds-stellar_life_cycles_training/course.zip` | `habitable_worlds-stellar_life_cycles_training/answers.json` |
+| `real-chem-greenhouse-molecules.spec.ts` | `real_chem-greenhouse_molecules/course.zip` | `real_chem-greenhouse_molecules/answers.json` |
+| `real-chem-dazzling-d-orbitals.spec.ts` | `real_chem_ii-dazzling_d_orbitals/course.zip` | `real_chem_ii-dazzling_d_orbitals/answers.json` |
+| `hw-brightness-assessment.spec.ts` | `habitable_worlds-brightness_assessment/course.zip` | _(none — no secret answers required)_ |
 
-These are set in the deployment configuration of the Torus server being tested.
+### Step 2 — Configure the Torus server
+
+The following environment variables must be set on the Torus server for the target environment.
 
 | Variable | Required | Notes |
 |----------|----------|-------|
 | `PLAYWRIGHT_ASSETS_BUCKET` | Yes | Name of the S3/MinIO bucket containing test assets |
-| `PLAYWRIGHT_SCENARIO_TOKEN` | Yes | Shared secret you choose — must match the value set on the test runner. No admin UI needed; set it as an env var on both sides. |
+| `PLAYWRIGHT_SCENARIO_TOKEN` | Yes | Shared secret you choose — must match the value set on the CI runner. No admin UI needed; set it as an env var on both sides. |
 | `AWS_ACCESS_KEY_ID` | Yes (prod S3) | S3 access key. Use `AWS_S3_ACCESS_KEY_ID` to override with a dedicated key for the PW bucket, separate from other AWS credentials the server may already have. |
 | `AWS_SECRET_ACCESS_KEY` | Yes (prod S3) | S3 secret key. Same override pattern via `AWS_S3_SECRET_ACCESS_KEY`. |
 | `AWS_S3_SCHEME` | Dev/MinIO only | URL scheme for MinIO (default: `http`). Not needed for real S3. |
 | `AWS_S3_HOST` | Dev/MinIO only | MinIO host (default: `localhost`). Not needed for real S3. |
 | `AWS_S3_PORT` | Dev/MinIO only | MinIO port (default: `9000`). Not needed for real S3. |
 
-### Playwright test runner
+### Step 3 — Create the automation API key
 
-These are set on the CI agent (e.g. as GitHub Actions secrets on the `nightly-ui` environment).
-The Torus server and the test runner are separate processes — the runner only needs to know how to
-reach the server and authenticate its requests.
+The adaptive tests authenticate course import requests using a dedicated API key with
+`automation_setup_enabled: true`. To create one on the target Torus instance:
 
-| Variable | Required for | Description |
-|----------|-------------|-------------|
-| `PLAYWRIGHT_BASE_URL` | All tests | Torus server URL (e.g. `https://nightly.oli.cmu.edu`) |
-| `PLAYWRIGHT_SCENARIO_TOKEN` | All tests | Same value as the server-side token |
-| `PLAYWRIGHT_AUTOMATION_API_KEY` | Adaptive tests | See [Automation API key](#automation-api-key) |
-| `CANVAS_UI_EMAIL` | LTI tests | Canvas test-account email |
-| `CANVAS_UI_PASSWORD` | LTI tests | Canvas test-account password |
-| `PLAYWRIGHT_PARAMETER_CONFIG_URL` | Dot chatbot smoke | URL to the YAML config file (see `nightly-ci.md`) |
-
-## Automation API key
-
-`PLAYWRIGHT_AUTOMATION_API_KEY` must correspond to an API key in the target Torus environment that
-has `automation_setup_enabled: true`. To create one:
-
-1. Log in as an admin on the target Torus instance.
-2. Go to `/admin/api_keys`, enter a hint, and click **Create** — Torus generates the key value.
+1. Log in as an admin and go to `/admin/api_keys`.
+2. Enter a hint and click **Create** — Torus generates the key value.
 3. Toggle `automation_setup_enabled` on for the newly created key.
-4. Export the generated value as `PLAYWRIGHT_AUTOMATION_API_KEY` in the CI environment.
+4. Store the generated value as the `PLAYWRIGHT_AUTOMATION_API_KEY` CI secret (see Step 4).
 
 Never reuse a key value that appears in the repository. `/api/v1/automation_setup` is reachable
 in any environment where the flag is compiled in, and is gated solely by this key.
 
-## Seeding the bucket
+### Step 4 — Configure the CI environment
 
-For each adaptive test in the table above, the corresponding `course.zip` (and `answers.json` where
-applicable) must be uploaded to the Playwright assets bucket under the exact S3 key path shown.
+The nightly workflow reads its secrets and variables from the `nightly-ui` GitHub Actions
+environment (repo Settings → Environments → nightly-ui). These must be populated by someone with
+admin access to the repository — they are not set in the codebase.
 
-The person responsible for managing the bucket (typically DevOps) should upload the files using
-whatever access method they have available. The folder structure and file names must match the paths
-in the table exactly.
+| Variable | Type | Description |
+|----------|------|-------------|
+| `PLAYWRIGHT_BASE_URL` | Variable | URL of the target Torus server |
+| `PLAYWRIGHT_SCENARIO_TOKEN` | Secret | Same value as the server-side token (Step 2) |
+| `PLAYWRIGHT_AUTOMATION_API_KEY` | Secret | Key created in Step 3 |
+| `PLAYWRIGHT_PARAMETER_CONFIG_URL` | Secret | URL to the Dot chatbot YAML config (see `nightly-ci.md`) |
+| `CANVAS_UI_EMAIL` | Secret | Canvas test-account email (for LTI tests) |
+| `CANVAS_UI_PASSWORD` | Secret | Canvas test-account password (for LTI tests) |
 
-## Running the nightly suite
+### Step 5 — Run the nightly suite
 
-The nightly subset is identified by the `@nightly` tag embedded in test descriptions. Run it with:
+The nightly Playwright tests run automatically every day at 05:17 UTC via
+`.github/workflows/nightly-playwright.yml`. The workflow can also be triggered manually from the
+GitHub Actions UI at any time.
+
+All tests tagged `@nightly` are included in the run. To run the nightly suite locally against a
+configured environment:
 
 ```sh
 npx playwright test --grep @nightly
 ```
+
+---
 
 ## Known issues
 

--- a/assets/automation/tests/torus/student_delivery/hw-brightness-assessment.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/hw-brightness-assessment.spec.ts
@@ -107,7 +107,7 @@ test.describe.serial('Habitable Worlds Brightness assessment adaptive lesson', (
     }
   });
 
-  test('student completes the Brightness assessment happy path', async ({ page }) => {
+  test('student completes the Brightness assessment happy path @nightly', async ({ page }) => {
     test.setTimeout(360_000);
 
     if (!seededCourse) {

--- a/assets/automation/tests/torus/student_delivery/phases-of-the-moon.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/phases-of-the-moon.spec.ts
@@ -24,13 +24,13 @@ import { completeAdaptiveHappyPath, LessonAnswers } from '@tasks/AdaptiveHappyPa
  * The course archive and answer key are instructional IP. They are fetched
  * from the private Playwright assets bucket and must never be committed.
  * Seed these keys before running:
- *   - phases-of-the-moon_phases-of-the-moon/course.zip
- *   - phases-of-the-moon_phases-of-the-moon/answers.json
+ *   - phases_of_the_moon-phases_of_the_moon/course.zip
+ *   - phases_of_the_moon-phases_of_the_moon/answers.json
  *
  * Then: npx playwright test phases-of-the-moon
  */
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const assetPrefix = 'phases-of-the-moon_phases-of-the-moon';
+const assetPrefix = 'phases_of_the_moon-phases_of_the_moon';
 const archiveKey = `${assetPrefix}/course.zip`;
 const answersKey = `${assetPrefix}/answers.json`;
 const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
@@ -113,7 +113,7 @@ test.describe.serial('Phases of the Moon adaptive lesson', () => {
     }
   });
 
-  test('student completes the Phases of the Moon Easy-to-Difficult path', async ({ page }) => {
+  test('student completes the Phases of the Moon Easy-to-Difficult path @nightly', async ({ page }) => {
     test.setTimeout(1_200_000);
 
     if (!seededCourse || !answers) {

--- a/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/real-chem-dazzling-d-orbitals.spec.ts
@@ -40,16 +40,16 @@ import { completeAdaptiveHappyPath, LessonAnswers } from '@tasks/AdaptiveHappyPa
  *   - the private assets seeded ONCE in your own playwright assets bucket
  *     (MinIO in dev, console at :9001; name it whatever you like, e.g.
  *     torus-playwright-assets-dev — there's no default, export that name as
- *     PLAYWRIGHT_ASSETS_BUCKET server-side): mer-5673/real-chem-ii-course.zip
- *     and mer-5673/answers.json. The test fetches them through
+ *     PLAYWRIGHT_ASSETS_BUCKET server-side): real_chem_ii-dazzling_d_orbitals/course.zip
+ *     and real_chem_ii-dazzling_d_orbitals/answers.json. The test fetches them through
  *     GET /test/assets/* on the server. The server must also be started with
  *     PLAYWRIGHT_SCENARIO_TOKEN.
  *
  * Then: npx playwright test real-chem-dazzling-d-orbitals
  */
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const archiveKey = 'mer-5673/real-chem-ii-course.zip';
-const answersKey = 'mer-5673/answers.json';
+const archiveKey = 'real_chem_ii-dazzling_d_orbitals/course.zip';
+const answersKey = 'real_chem_ii-dazzling_d_orbitals/answers.json';
 const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
 const EXPECTED_LESSON = /Dazzling d-Orbitals/i;
 
@@ -131,7 +131,7 @@ test.describe.serial('Real Chem II dazzling d-orbitals adaptive lesson', () => {
     }
   });
 
-  test('student completes the dazzling d-orbitals happy path', async ({ page }) => {
+  test('student completes the dazzling d-orbitals happy path @nightly', async ({ page }) => {
     test.setTimeout(900_000); // 30 screens with server-side rule evaluation per check
 
     if (!seededCourse || !answers) {

--- a/assets/automation/tests/torus/student_delivery/real-chem-greenhouse-molecules.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/real-chem-greenhouse-molecules.spec.ts
@@ -41,16 +41,16 @@ import { completeAdaptiveHappyPath, LessonAnswers } from '@tasks/AdaptiveHappyPa
  *   - the private assets seeded ONCE in your own playwright assets bucket
  *     (MinIO in dev, console at :9001; name it whatever you like, e.g.
  *     torus-playwright-assets-dev — there's no default, export that name as
- *     PLAYWRIGHT_ASSETS_BUCKET server-side): mer-5672/real-chem-course.zip
- *     and mer-5672/answers.json. The test fetches them through
+ *     PLAYWRIGHT_ASSETS_BUCKET server-side): real_chem-greenhouse_molecules/course.zip
+ *     and real_chem-greenhouse_molecules/answers.json. The test fetches them through
  *     GET /test/assets/* on the server. The server must also be started with
  *     PLAYWRIGHT_SCENARIO_TOKEN.
  *
  * Then: npx playwright test real-chem-greenhouse-molecules
  */
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const archiveKey = 'mer-5672/real-chem-course.zip';
-const answersKey = 'mer-5672/answers.json';
+const archiveKey = 'real_chem-greenhouse_molecules/course.zip';
+const answersKey = 'real_chem-greenhouse_molecules/answers.json';
 const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
 
 let seededCourse: AutomationSetupResponse | null = null;
@@ -111,7 +111,7 @@ test.describe.serial('Real Chem I greenhouse molecules adaptive lesson', () => {
     }
   });
 
-  test('student completes the greenhouse molecules happy path', async ({ page }) => {
+  test('student completes the greenhouse molecules happy path @nightly', async ({ page }) => {
     test.setTimeout(900_000); // 33 screens with server-side rule evaluation per check
 
     if (!seededCourse || !answers) {

--- a/assets/automation/tests/torus/student_delivery/stellar-life-cycles-training.spec.ts
+++ b/assets/automation/tests/torus/student_delivery/stellar-life-cycles-training.spec.ts
@@ -30,13 +30,13 @@ import { fetchTestArchiveToTempFile, fetchTestAsset } from '@tasks/AutomationAss
  * simulator or through the authored alternate path; see the "tutorial" rule.
  *
  * Private assets expected in the Playwright assets bucket:
- *   - habitable-worlds_stellar-life-cycles-training/course.zip
- *   - habitable-worlds_stellar-life-cycles-training/answers.json
+ *   - habitable_worlds-stellar_life_cycles_training/course.zip
+ *   - habitable_worlds-stellar_life_cycles_training/answers.json
  *
  * Then: npx playwright test stellar-life-cycles-training
  */
 const baseUrl = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost';
-const assetPrefix = 'habitable-worlds_stellar-life-cycles-training';
+const assetPrefix = 'habitable_worlds-stellar_life_cycles_training';
 const archiveKey = `${assetPrefix}/course.zip`;
 const answersKey = `${assetPrefix}/answers.json`;
 const automationApiKey = process.env.PLAYWRIGHT_AUTOMATION_API_KEY;
@@ -96,7 +96,7 @@ test.describe.serial('HW Stellar Life Cycles adaptive lesson', () => {
     }
   });
 
-  test('student completes the stellar life cycles happy path', async ({ page }) => {
+  test('student completes the stellar life cycles happy path @nightly', async ({ page }) => {
     // 32 screens, each with a server-side rule evaluation, plus the per-screen
     // grace period interactive parts get to mount
     test.setTimeout(1_200_000);


### PR DESCRIPTION
Prepares the Playwright nightly suite for production use. All adaptive tests now follow a consistent S3 asset pattern, and a new setup guide documents the architecture and configuration steps needed to launch the nightly run.

## Changes

- Add `adaptive-tests-setup.md`: documents the S3 proxy architecture, the naming convention for bucket assets, and a step-by-step setup guide for configuring and running the nightly suite
- Standardize S3 key naming across all adaptive test spec files (`{section}-{page}/course.zip`)
- Add missing `@nightly` tag to all adaptive tests not yet included in the nightly run
- Fix `forbidOnly: false` → `true` to prevent accidental `test.only` from silently skipping CI
- Set `retries: 1` for resilience against transient failures on a live server
- Add missing `PLAYWRIGHT_PARAMETER_CONFIG_URL` to the nightly workflow (required by the Dot chatbot `@nightly` test)

> **Draft** — opened for review of the architecture and S3 naming decisions before the nightly environment is configured and assets are uploaded.
