### PR TITLE
[CHORE] [MER-0000] Fix TypeScript typecheck errors surfaced after Node 24 upgrade

### DIFF
--- a/assets/test/components/resource/editors/learning_objectives_editor_test.tsx
+++ b/assets/test/components/resource/editors/learning_objectives_editor_test.tsx
@@ -39,23 +39,23 @@ const element = (updates: Partial<LearningObjectivesContent> = {}): LearningObje
   ...updates,
 });
 
-const resourceContext = (learningObjectives: ResolvedLearningObjective[]): ResourceContext =>
-  ({
-    graded: false,
-    authorEmail: 'author@example.edu',
-    projectSlug: 'project-1',
-    resourceSlug: 'page-1',
-    resourceId: 100,
-    hasExperiments: false,
-    title: 'Page 1',
-    content: { model: [] },
-    objectives: { attached: [] },
-    allObjectives: [],
-    learningObjectives,
-    allTags: [],
-    activityContexts: [],
-    optionalContentTypes: { ecl: false, triggers: false },
-  } as ResourceContext);
+const resourceContext = (learningObjectives: ResolvedLearningObjective[]): ResourceContext => ({
+  graded: false,
+  authorEmail: 'author@example.edu',
+  projectSlug: 'project-1',
+  resourceSlug: 'page-1',
+  resourceId: 100,
+  experimentsEnabled: false,
+  alternativesEnabled: false,
+  title: 'Page 1',
+  content: { model: [] },
+  objectives: { attached: [] },
+  allObjectives: [],
+  learningObjectives,
+  allTags: [],
+  activityContexts: [],
+  optionalContentTypes: { ecl: false, triggers: false },
+});
 
 const unresolvedLearningObjectivesContext = (): ResourceContext => {
   const context = resourceContext([]);

--- a/assets/test/data/content/resource_test.ts
+++ b/assets/test/data/content/resource_test.ts
@@ -41,7 +41,7 @@ describe('ResourceContent learning objectives element', () => {
     const group = createGroup();
     const survey = createSurvey();
     const alternative = createAlternative('A');
-    const alternatives = createAlternatives(1, 'select_all', Immutable.List([alternative]));
+    const alternatives = createAlternatives(1, Immutable.List([alternative]));
 
     expect(isResourceGroup(content)).toBe(false);
     expect('children' in content).toBe(false);

--- a/assets/test/page_editor/non_activities_feature_gating_test.tsx
+++ b/assets/test/page_editor/non_activities_feature_gating_test.tsx
@@ -42,6 +42,9 @@ const renderMenu = (
       parents={parents}
       featureFlags={{ adaptivity: false, equity: false, survey: false }}
       resourceContext={resourceContext}
+      onRefreshLearningObjectives={jest.fn()}
+      onStartLearningObjectivesRefresh={jest.fn()}
+      onFinishLearningObjectivesRefresh={jest.fn()}
       onSetTip={jest.fn()}
       onResetTip={jest.fn()}
     />,


### PR DESCRIPTION
## Summary

Followup to #6829 (Node 24 upgrade).

That PR fixed the `actions/setup-node` `Configure` step, which had been failing and silently preventing the `Typecheck` step from ever running. Once `Configure` succeeds, `Typecheck` runs and exposes 3 pre-existing type errors in test files that were out of sync with type changes already on `master` (unrelated to the Node bump itself, but only became visible because of it):

- `test/components/resource/editors/learning_objectives_editor_test.tsx`: mock was missing `experimentsEnabled` / `alternativesEnabled` (still had a stale `hasExperiments` field) that `ResourceContext` now requires.
- `test/data/content/resource_test.ts`: `createAlternatives` call passed an obsolete `strategy` argument that the function no longer accepts.
- `test/page_editor/non_activities_feature_gating_test.tsx`: `NonActivities` `Props` now requires `onRefreshLearningObjectives`, `onStartLearningObjectivesRefresh`, and `onFinishLearningObjectivesRefresh` callbacks, which the test wasn't passing.

No production code changes — test-only fixes to match already-shipped type contracts.

## Validation

- `yarn check-types` — passes
- `yarn jest test/components/resource/editors/learning_objectives_editor_test.tsx test/data/content/resource_test.ts test/page_editor/non_activities_feature_gating_test.tsx` — 3 suites, 35 tests, all passing
- `yarn lint` (eslint) on the changed files — clean