### PR TITLE
[BUG FIX] [MER-5790] Upgrade docker/build-push-action to v7

### DIFF
--- a/.github/workflows/amazon-linux-builder.yml
+++ b/.github/workflows/amazon-linux-builder.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3

--- a/.github/workflows/amazon-linux-builder.yml
+++ b/.github/workflows/amazon-linux-builder.yml
@@ -41,7 +41,7 @@ jobs:
           tags: latest,${{ github.event.inputs.tag }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/build-preview-image.yml
+++ b/.github/workflows/build-preview-image.yml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build info
         id: info
@@ -173,7 +173,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build info
         id: info

--- a/.github/workflows/build-preview-image.yml
+++ b/.github/workflows/build-preview-image.yml
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -201,7 +201,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -48,7 +48,7 @@ jobs:
 
         # build (or retrieve from cache) the amazon-linux-builder image, used by the next step to build the release for Amazon Linux 2
       - name: 🐳 Build amazon-linux-builder image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: ./.github/actions/amazon-linux-builder
           load: true
@@ -153,7 +153,7 @@ jobs:
 
       # builds the official oli-torus app image
       - name: 🐳 Docker Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,7 +37,7 @@ jobs:
           echo "workspace=$GITHUB_WORKSPACE" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: 🔑 Log in to Github Container Registry
         uses: docker/login-action@v3
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 🔧 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
 
       - name: 🧾 Build info
         id: info


### PR DESCRIPTION
Updates all five uses of `docker/build-push-action` from v5 to v7 across the package, preview image, and Amazon Linux builder workflows.
Update references of `docker/setup-buildx-action` to v4