### PR TITLE
[FEATURE] [MER-5864] CSV upload and download for LKT_AOA parameters

### DIFF
--- a/docs/features/learning-model-parameter-csv.md
+++ b/docs/features/learning-model-parameter-csv.md
@@ -36,11 +36,20 @@ Published mappings remain unchanged.
 - `lib/oli/learning_model/parameter_csv.ex` owns authorization, streaming, validation,
   effective defaults, mapping locks, and atomic revision creation. CSV parsing produces
   the existing typed parameter structs; export and no-op detection share the same
-  effective-default calculation. Each imported row validates its values, locks its
-  current mapping, and creates a successor revision only when those values differ.
-- Export selects compact fields and part metadata in cursor batches of 100. Import
-  consumes CSV rows incrementally and loads full revision content only one changed
-  resource at a time to copy it faithfully into its successor.
+  effective-default calculation. Import validates and applies batches of resources,
+  creating successor revisions only when parameter values differ.
+- `@batch_size 250` near the top of `ParameterCsv` controls import batches and export
+  cursor batches. Both handle fewer than 250 rows and a partial final batch.
+- Import executes five queries per changed batch: lock mappings in resource order,
+  verify the publication is still unpublished, read compact parameter projections,
+  `INSERT … SELECT … RETURNING` successor revisions, and bulk-update mappings.
+  Unchanged batches skip both writes. All batches share one transaction.
+- Revision copying stays inside PostgreSQL. The copied column list derives from
+  persisted Ecto schema fields, including embeds. Identity, previous revision ID,
+  importing author, parameters, and timestamps are replaced; other fields, including
+  content and slug, are copied. Only new IDs return to Elixir for mapping updates.
+- Tests cover batch boundaries, rollback across batches, full field preservation,
+  and query counts for 2,000 resources (at most 45 queries, including overhead).
 - `lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex` provides
   the upload UI; a controller streams the download over HTTP.
 - `test/oli/learning_model/parameter_csv_test.exs` and

--- a/docs/features/learning-model-parameter-csv.md
+++ b/docs/features/learning-model-parameter-csv.md
@@ -1,0 +1,47 @@
+# Learning model parameter CSV (MER-5864)
+
+Content administrators and system administrators can open **Learning Model Parameters**
+from a project's overview Actions section. This is available regardless of the project's
+learning-model algorithm.
+
+## Workflow and format
+
+1. Select **Generate and Download** to export the current working publication.
+2. Train offline and edit the numeric parameter values.
+3. Select the CSV and wait for the automatic file transfer to finish. Click **Upload**
+   to apply the values; the page reports changed and unchanged counts.
+4. Publish the project through the normal publishing workflow to make the revisions available to sections.
+
+The exact header is `title,resource_id,children_ids,beta_lo,beta_difficulty`.
+There is one row per non-deleted objective or activity, including unreferenced resources.
+Objective children are a CSV-quoted JSON array, such as `[12,34]`. A child appears once
+as its own row even if multiple objectives reference it. Activity children are blank.
+
+Objectives have a numeric `beta_lo` and blank `beta_difficulty`. Activities have blank
+`beta_lo` and a CSV-quoted JSON object mapping each part ID to a numeric difficulty,
+such as `{"part-1":0.5,"part-2":-1.2}`. Activities without parts use `{}`.
+Missing parameters export as their effective default, zero.
+
+Keep resource IDs and activity part IDs intact. Titles and children are informational;
+import ignores edits to those columns. CSVs may contain a subset of resources, but each
+activity row must contain all of its current parts. The upload limit is 20 MB.
+Invalid headers, duplicate or foreign resource IDs, invalid numbers, unknown/missing
+parts, and actively edited resources reject the entire upload without partial writes.
+An unchanged effective value creates no revision, including missing parameters exported
+as zero. Changed resources get new revisions attributed to the importing administrator.
+Published mappings remain unchanged.
+
+## Implementation and verification
+
+- `lib/oli/learning_model/parameter_csv.ex` owns authorization, streaming, validation,
+  effective defaults, mapping locks, and atomic revision creation. CSV parsing produces
+  the existing typed parameter structs; export and no-op detection share the same
+  effective-default calculation. Each imported row validates its values, locks its
+  current mapping, and creates a successor revision only when those values differ.
+- Export selects compact fields and part metadata in cursor batches of 100. Import
+  consumes CSV rows incrementally and loads full revision content only one changed
+  resource at a time to copy it faithfully into its successor.
+- `lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex` provides
+  the upload UI; a controller streams the download over HTTP.
+- `test/oli/learning_model/parameter_csv_test.exs` and
+  `test/oli_web/learning_model_parameters_test.exs` cover transfer behavior and access.

--- a/lib/oli/learning_model/parameter_csv.ex
+++ b/lib/oli/learning_model/parameter_csv.ex
@@ -1,0 +1,321 @@
+defmodule Oli.LearningModel.ParameterCsv do
+  @moduledoc """
+  Project-scoped LKT-AOA CSV transfer. Reads compact projections through a cursor;
+  imports are atomic and load a full revision only when copying an actual edit.
+  Titles and children are informational. Missing parameters export as effective zeros.
+  """
+
+  import Ecto.Query
+
+  alias Oli.Accounts
+  alias Oli.Accounts.Author
+  alias Oli.Authoring.Course.Project
+  alias Oli.Authoring.Locks
+  alias Oli.LearningModel.{Parameters, PartIds}
+  alias Oli.LearningModel.V2.{ActivityParameters, LearningObjectiveParameters, PartParameters}
+  alias Oli.Publishing
+  alias Oli.Publishing.{PublishedResource, Publications.Publication}
+  alias Oli.Repo
+  alias Oli.Resources
+  alias Oli.Resources.{ResourceType, Revision}
+
+  @headers ["title", "resource_id", "children_ids", "beta_lo", "beta_difficulty"]
+  @objective ResourceType.id_for_objective()
+  @activity ResourceType.id_for_activity()
+  @transfer_timeout :timer.minutes(2)
+
+  @type import_counts :: %{changed: non_neg_integer(), unchanged: non_neg_integer()}
+
+  @doc "Checks the content-admin authorization required for both transfer directions."
+  @spec authorize(%Project{}, %Author{}) ::
+          :ok | {:error, String.t()}
+  def authorize(project, author) do
+    case Accounts.at_least_content_admin?(author) and project.status == :active and
+           Accounts.can_access?(author, project) do
+      true -> :ok
+      false -> {:error, "Content administrator access is required."}
+    end
+  end
+
+  @doc """
+  Passes encoded CSV lines to `consume` inside a database transaction.
+
+  The callback must consume the stream before returning; it cannot return the lazy
+  stream for later use. Its return value is wrapped in `{:ok, result}`.
+  """
+  @spec export(%Project{}, %Author{}, (Enumerable.t() -> result)) ::
+          {:ok, result} | {:error, String.t()}
+        when result: term()
+  def export(project, author, consume) do
+    with :ok <- authorize(project, author) do
+      Repo.transaction(
+        fn ->
+          rows =
+            working_resources_query(project.id)
+            |> Repo.stream(max_rows: 100)
+            |> Stream.map(&export_row/1)
+
+          Stream.concat([@headers], rows) |> CSV.encode() |> consume.()
+        end,
+        timeout: @transfer_timeout
+      )
+    end
+  end
+
+  @doc """
+  Imports CSV lines atomically, returning changed and unchanged resource counts.
+
+  Titles and children are informational; only parameter values are applied. Missing
+  stored parameters compare as zero, so downloading and re-uploading defaults is a
+  no-op. An invalid row or an authoring lock rolls back the entire import.
+  """
+  @spec import(%Project{}, %Author{}, Enumerable.t()) ::
+          {:ok, import_counts()} | {:error, String.t()}
+  def import(project, author, lines) do
+    with :ok <- authorize(project, author) do
+      Repo.transaction(
+        fn ->
+          result =
+            lines
+            |> CSV.decode(headers: false)
+            |> Enum.with_index(1)
+            |> Enum.reduce(%{changed: 0, unchanged: 0, seen: MapSet.new()}, fn
+              {{:ok, @headers}, 1}, acc ->
+                acc
+
+              {_, 1}, _acc ->
+                Repo.rollback("Row 1: expected #{Enum.join(@headers, ",")} headers.")
+
+              {{:error, _}, row}, _acc ->
+                Repo.rollback("Row #{row}: malformed CSV.")
+
+              {{:ok, values}, row}, acc ->
+                import_row(project, author, values, row, acc)
+            end)
+
+          case MapSet.size(result.seen) do
+            0 -> Repo.rollback("The CSV must contain at least one resource.")
+            _ -> Map.take(result, [:changed, :unchanged])
+          end
+        end,
+        timeout: @transfer_timeout
+      )
+    end
+  end
+
+  # The projection retains only the content fields PartIds needs. Adaptive part
+  # membership depends on layout types and rule conditions as well as authored IDs.
+  # Keeping that shape lets us reuse PartIds rather than reimplement its rules in SQL.
+  # Do not replace this projection with full revision content: courses can be large.
+  defp working_resources_query(project_id) do
+    from r in Revision,
+      join: pr in PublishedResource,
+      on: pr.revision_id == r.id,
+      join: p in Publication,
+      on: p.id == pr.publication_id,
+      where:
+        p.project_id == ^project_id and is_nil(p.published) and not r.deleted and
+          r.resource_type_id in [@objective, @activity],
+      order_by: r.resource_id,
+      select: %{
+        id: r.id,
+        resource_id: r.resource_id,
+        title: r.title,
+        children: r.children,
+        resource_type_id: r.resource_type_id,
+        parameters: r.learning_model_parameters,
+        publication_id: p.id,
+        part_content:
+          fragment(
+            """
+            (
+              SELECT jsonb_strip_nulls(jsonb_build_object(
+                'advancedDelivery', content->'advancedDelivery',
+                'advancedAuthoring', content->'advancedAuthoring',
+                'partsLayout', CASE WHEN jsonb_typeof(content->'partsLayout') = 'array' THEN (
+                  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                    'id', part->'id', 'type', part->'type'
+                  )), '[]'::jsonb)
+                  FROM jsonb_array_elements(content->'partsLayout') part
+                ) END,
+                'authoring', jsonb_build_object(
+                  'parts', (
+                    SELECT COALESCE(jsonb_agg(
+                      CASE WHEN jsonb_typeof(part) = 'string' THEN part
+                        ELSE jsonb_build_object('id', part->'id', 'type', part->'type')
+                      END
+                    ), '[]'::jsonb)
+                    FROM jsonb_array_elements(
+                      CASE WHEN jsonb_typeof(content->'authoring'->'parts') = 'array'
+                        THEN content->'authoring'->'parts' ELSE '[]'::jsonb
+                      END
+                    ) part
+                  ),
+                  'rules', (
+                    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                      'disabled', rule->'disabled', 'conditions', rule->'conditions'
+                    )), '[]'::jsonb)
+                    FROM jsonb_array_elements(
+                      CASE WHEN jsonb_typeof(content->'authoring'->'rules') = 'array'
+                        THEN content->'authoring'->'rules' ELSE '[]'::jsonb
+                      END
+                    ) rule
+                  )
+                )
+              ))
+              FROM (SELECT ? AS content) source
+            )
+            """,
+            r.content
+          )
+      }
+  end
+
+  defp effective_payload(%{resource_type_id: @objective, parameters: nil}),
+    do: %LearningObjectiveParameters{beta_lo: 0.0}
+
+  defp effective_payload(%{resource_type_id: @objective, parameters: parameters}),
+    do: parameters.payload
+
+  defp effective_payload(%{resource_type_id: @activity} = record) do
+    stored_parts =
+      case record.parameters do
+        nil -> %{}
+        %Parameters{payload: %ActivityParameters{parts: parts}} -> parts
+      end
+
+    parts =
+      Map.new(PartIds.for_content(record.part_content), fn id ->
+        {id, Map.get(stored_parts, id, %PartParameters{beta_difficulty: 0.0})}
+      end)
+
+    %ActivityParameters{parts: parts}
+  end
+
+  defp export_row(record) do
+    case effective_payload(record) do
+      %LearningObjectiveParameters{beta_lo: beta} ->
+        [
+          safe_title(record.title),
+          record.resource_id,
+          Jason.encode!(record.children || []),
+          beta,
+          ""
+        ]
+
+      %ActivityParameters{parts: parts} ->
+        values = Map.new(parts, fn {id, parameters} -> {id, parameters.beta_difficulty} end)
+        [safe_title(record.title), record.resource_id, "", "", Jason.encode!(values)]
+    end
+  end
+
+  defp import_row(project, author, [_title, id, _children, beta, difficulties], row, acc) do
+    with {id, ""} when id > 0 <- Integer.parse(id),
+         false <- MapSet.member?(acc.seen, id),
+         %{} = record <-
+           Repo.one(from r in working_resources_query(project.id), where: r.resource_id == ^id),
+         {:ok, parameters} <- parse_parameters(record, beta, difficulties),
+         {:ok, mapping} <- lock_working_resource(record),
+         {:ok, outcome} <- apply_parameters(record, mapping, parameters, author) do
+      acc
+      |> Map.update!(outcome, &(&1 + 1))
+      |> Map.update!(:seen, &MapSet.put(&1, id))
+    else
+      {:error, message} ->
+        Repo.rollback("Row #{row}: #{message}")
+
+      _ ->
+        Repo.rollback("Row #{row}: invalid, duplicate, deleted, or out-of-project resource ID.")
+    end
+  end
+
+  defp import_row(_project, _author, _values, row, _acc),
+    do: Repo.rollback("Row #{row}: expected five columns.")
+
+  defp lock_working_resource(record) do
+    # Lock the exact mapping we will update. Re-check both revision and publication
+    # after waiting for the lock, since either may have changed during validation.
+    mapping =
+      Repo.one!(
+        from pr in PublishedResource,
+          where:
+            pr.publication_id == ^record.publication_id and pr.resource_id == ^record.resource_id,
+          lock: "FOR UPDATE"
+      )
+
+    publication = Repo.get!(Publication, record.publication_id)
+
+    case is_nil(publication.published) and mapping.revision_id == record.id and
+           Locks.expired_or_empty?(mapping) do
+      true -> {:ok, mapping}
+      false -> {:error, "resource is being edited; retry after editing finishes."}
+    end
+  end
+
+  defp apply_parameters(record, mapping, parameters, author) do
+    case effective_payload(record) == parameters.payload do
+      true -> {:ok, :unchanged}
+      false -> create_parameter_revision(record, mapping, parameters, author)
+    end
+  end
+
+  defp create_parameter_revision(record, mapping, parameters, author) do
+    # Only an actual edit needs the full revision, to preserve its content and history.
+    previous = Repo.get!(Revision, record.id)
+
+    with {:ok, revision} <-
+           Resources.create_revision_from_previous(previous, %{
+             author_id: author.id,
+             learning_model_parameters: parameters
+           }),
+         {:ok, _} <- Publishing.update_published_resource(mapping, %{revision_id: revision.id}) do
+      {:ok, :changed}
+    else
+      _ -> {:error, "could not save parameters."}
+    end
+  end
+
+  defp parse_parameters(%{resource_type_id: @objective}, beta, "") do
+    case Float.parse(beta) do
+      {value, ""} -> decode_parameters("learning_objective", %{"beta_lo" => value})
+      _ -> {:error, "beta_lo must be a finite number."}
+    end
+  end
+
+  defp parse_parameters(%{resource_type_id: @activity} = record, "", difficulties) do
+    with {:ok, values} when is_map(values) <- Jason.decode(difficulties),
+         true <- MapSet.new(Map.keys(values)) == PartIds.for_content(record.part_content) do
+      decode_parameters("activity", %{
+        "parts" =>
+          Map.new(values, fn {id, value} ->
+            {id, %{"beta_difficulty" => value}}
+          end)
+      })
+    else
+      _ -> {:error, "beta_difficulty must be a JSON object containing every current part ID."}
+    end
+  end
+
+  defp parse_parameters(_, _, _),
+    do: {:error, "use beta_lo for objectives and beta_difficulty for activities."}
+
+  defp decode_parameters(type, payload) do
+    case Parameters.decode(%{
+           schema_version: 1,
+           model: "lkt_aoa",
+           model_version: 2,
+           parameter_type: type,
+           payload: payload
+         }) do
+      {:ok, parameters} -> {:ok, parameters}
+      _ -> {:error, "parameter values must be finite numbers."}
+    end
+  end
+
+  defp safe_title(title) do
+    case String.trim_leading(title || "") do
+      <<prefix::binary-size(1), _::binary>> when prefix in ["=", "+", "-", "@"] -> "'" <> title
+      _ -> title || ""
+    end
+  end
+end

--- a/lib/oli/learning_model/parameter_csv.ex
+++ b/lib/oli/learning_model/parameter_csv.ex
@@ -106,7 +106,7 @@ defmodule Oli.LearningModel.ParameterCsv do
           result =
             lines
             |> CSV.decode(headers: false)
-            |> Enum.with_index(1)
+            |> Stream.with_index(1)
             |> Stream.reject(fn
               {{:ok, @headers}, 1} -> true
               {_, 1} -> Repo.rollback("Row 1: expected #{Enum.join(@headers, ",")} headers.")

--- a/lib/oli/learning_model/parameter_csv.ex
+++ b/lib/oli/learning_model/parameter_csv.ex
@@ -1,7 +1,7 @@
 defmodule Oli.LearningModel.ParameterCsv do
   @moduledoc """
   Project-scoped LKT-AOA CSV transfer. Reads compact projections through a cursor;
-  imports are atomic and load a full revision only when copying an actual edit.
+  imports are atomic and copy changed revisions directly inside PostgreSQL.
   Titles and children are informational. Missing parameters export as effective zeros.
   """
 
@@ -16,13 +16,30 @@ defmodule Oli.LearningModel.ParameterCsv do
   alias Oli.Publishing
   alias Oli.Publishing.{PublishedResource, Publications.Publication}
   alias Oli.Repo
-  alias Oli.Resources
   alias Oli.Resources.{ResourceType, Revision}
+
+  @batch_size 250
 
   @headers ["title", "resource_id", "children_ids", "beta_lo", "beta_difficulty"]
   @objective ResourceType.id_for_objective()
   @activity ResourceType.id_for_activity()
   @transfer_timeout :timer.minutes(2)
+
+  # Copy every persisted field, including embeds, without loading revision content.
+  # Only identity, ancestry, attribution, parameters, and timestamps change.
+  @copied_revision_columns Revision.__schema__(:fields)
+                           |> Enum.reject(
+                             &(&1 in [
+                                 :id,
+                                 :previous_revision_id,
+                                 :author_id,
+                                 :learning_model_parameters,
+                                 :inserted_at,
+                                 :updated_at
+                               ])
+                           )
+                           |> Enum.map(&Revision.__schema__(:field_source, &1))
+                           |> Enum.map_join(", ", &~s("#{&1}"))
 
   @type import_counts :: %{changed: non_neg_integer(), unchanged: non_neg_integer()}
 
@@ -52,7 +69,7 @@ defmodule Oli.LearningModel.ParameterCsv do
         fn ->
           rows =
             working_resources_query(project.id)
-            |> Repo.stream(max_rows: 100)
+            |> Repo.stream(max_rows: @batch_size)
             |> Stream.map(&export_row/1)
 
           Stream.concat([@headers], rows) |> CSV.encode() |> consume.()
@@ -68,6 +85,10 @@ defmodule Oli.LearningModel.ParameterCsv do
   Titles and children are informational; only parameter values are applied. Missing
   stored parameters compare as zero, so downloading and re-uploading defaults is a
   no-op. An invalid row or an authoring lock rolls back the entire import.
+
+  Batches use `@batch_size` rows. Each batch locks and reads resources together,
+  inserts changed revisions with INSERT … SELECT, and updates mappings in bulk.
+  The final batch may be smaller; batches never commit independently.
   """
   @spec import(%Project{}, %Author{}, Enumerable.t()) ::
           {:ok, import_counts()} | {:error, String.t()}
@@ -75,22 +96,25 @@ defmodule Oli.LearningModel.ParameterCsv do
     with :ok <- authorize(project, author) do
       Repo.transaction(
         fn ->
+          publication = Publishing.project_working_publication(project.slug)
+
+          case publication do
+            nil -> Repo.rollback("The project has no working publication.")
+            _ -> :ok
+          end
+
           result =
             lines
             |> CSV.decode(headers: false)
             |> Enum.with_index(1)
-            |> Enum.reduce(%{changed: 0, unchanged: 0, seen: MapSet.new()}, fn
-              {{:ok, @headers}, 1}, acc ->
-                acc
-
-              {_, 1}, _acc ->
-                Repo.rollback("Row 1: expected #{Enum.join(@headers, ",")} headers.")
-
-              {{:error, _}, row}, _acc ->
-                Repo.rollback("Row #{row}: malformed CSV.")
-
-              {{:ok, values}, row}, acc ->
-                import_row(project, author, values, row, acc)
+            |> Stream.reject(fn
+              {{:ok, @headers}, 1} -> true
+              {_, 1} -> Repo.rollback("Row 1: expected #{Enum.join(@headers, ",")} headers.")
+              _ -> false
+            end)
+            |> Stream.chunk_every(@batch_size)
+            |> Enum.reduce(%{changed: 0, unchanged: 0, seen: MapSet.new()}, fn batch, acc ->
+              import_batch(project, publication, author, batch, acc)
             end)
 
           case MapSet.size(result.seen) do
@@ -209,69 +233,144 @@ defmodule Oli.LearningModel.ParameterCsv do
     end
   end
 
-  defp import_row(project, author, [_title, id, _children, beta, difficulties], row, acc) do
-    with {id, ""} when id > 0 <- Integer.parse(id),
-         false <- MapSet.member?(acc.seen, id),
-         %{} = record <-
-           Repo.one(from r in working_resources_query(project.id), where: r.resource_id == ^id),
-         {:ok, parameters} <- parse_parameters(record, beta, difficulties),
-         {:ok, mapping} <- lock_working_resource(record),
-         {:ok, outcome} <- apply_parameters(record, mapping, parameters, author) do
-      acc
-      |> Map.update!(outcome, &(&1 + 1))
-      |> Map.update!(:seen, &MapSet.put(&1, id))
-    else
-      {:error, message} ->
-        Repo.rollback("Row #{row}: #{message}")
+  defp import_batch(project, publication, author, batch, acc) do
+    {rows, seen} = Enum.map_reduce(batch, acc.seen, &parse_row/2)
+    resource_ids = Enum.map(rows, & &1.resource_id)
 
-      _ ->
-        Repo.rollback("Row #{row}: invalid, duplicate, deleted, or out-of-project resource ID.")
-    end
-  end
-
-  defp import_row(_project, _author, _values, row, _acc),
-    do: Repo.rollback("Row #{row}: expected five columns.")
-
-  defp lock_working_resource(record) do
-    # Lock the exact mapping we will update. Re-check both revision and publication
-    # after waiting for the lock, since either may have changed during validation.
-    mapping =
-      Repo.one!(
+    # Acquire mapping locks in resource order before reading parameter projections.
+    # The locks remain held until the entire CSV transaction commits or rolls back.
+    mappings =
+      Repo.all(
         from pr in PublishedResource,
-          where:
-            pr.publication_id == ^record.publication_id and pr.resource_id == ^record.resource_id,
+          where: pr.publication_id == ^publication.id and pr.resource_id in ^resource_ids,
+          order_by: pr.resource_id,
           lock: "FOR UPDATE"
       )
+      |> Map.new(&{&1.resource_id, &1})
 
-    publication = Repo.get!(Publication, record.publication_id)
-
-    case is_nil(publication.published) and mapping.revision_id == record.id and
-           Locks.expired_or_empty?(mapping) do
-      true -> {:ok, mapping}
-      false -> {:error, "resource is being edited; retry after editing finishes."}
+    # Publishing also acquires mapping locks. Recheck after waiting so an import
+    # cannot modify a publication that finished publishing while we were blocked.
+    case Repo.exists?(
+           from p in Publication, where: p.id == ^publication.id and is_nil(p.published)
+         ) do
+      true -> :ok
+      false -> Repo.rollback("The working publication changed; download a fresh CSV and retry.")
     end
+
+    records =
+      Repo.all(
+        from r in working_resources_query(project.id), where: r.resource_id in ^resource_ids
+      )
+      |> Map.new(&{&1.resource_id, &1})
+
+    changes =
+      Enum.flat_map(rows, fn row ->
+        with %{} = mapping <- Map.get(mappings, row.resource_id),
+             %{} = record <- Map.get(records, row.resource_id),
+             true <- mapping.revision_id == record.id,
+             {:ok, parameters} <- parse_parameters(record, row.beta, row.difficulties) do
+          case Locks.expired_or_empty?(mapping) do
+            false ->
+              Repo.rollback(
+                "Row #{row.number}: resource is being edited; retry after editing finishes."
+              )
+
+            true ->
+              :ok
+          end
+
+          case effective_payload(record) == parameters.payload do
+            true ->
+              []
+
+            false ->
+              {:ok, encoded} = Parameters.encode(parameters)
+              [%{previous_revision_id: record.id, parameters: encoded}]
+          end
+        else
+          {:error, message} ->
+            Repo.rollback("Row #{row.number}: #{message}")
+
+          _ ->
+            Repo.rollback("Row #{row.number}: invalid, deleted, or out-of-project resource ID.")
+        end
+      end)
+
+    changed = create_parameter_revisions(changes, publication.id, author.id)
+
+    %{
+      changed: acc.changed + changed,
+      unchanged: acc.unchanged + length(rows) - changed,
+      seen: seen
+    }
   end
 
-  defp apply_parameters(record, mapping, parameters, author) do
-    case effective_payload(record) == parameters.payload do
-      true -> {:ok, :unchanged}
-      false -> create_parameter_revision(record, mapping, parameters, author)
-    end
-  end
-
-  defp create_parameter_revision(record, mapping, parameters, author) do
-    # Only an actual edit needs the full revision, to preserve its content and history.
-    previous = Repo.get!(Revision, record.id)
-
-    with {:ok, revision} <-
-           Resources.create_revision_from_previous(previous, %{
-             author_id: author.id,
-             learning_model_parameters: parameters
-           }),
-         {:ok, _} <- Publishing.update_published_resource(mapping, %{revision_id: revision.id}) do
-      {:ok, :changed}
+  defp parse_row({{:ok, [_title, id, _children, beta, difficulties]}, number}, seen) do
+    with {id, ""} when id > 0 <- Integer.parse(id),
+         false <- MapSet.member?(seen, id) do
+      {%{resource_id: id, beta: beta, difficulties: difficulties, number: number},
+       MapSet.put(seen, id)}
     else
-      _ -> {:error, "could not save parameters."}
+      _ -> Repo.rollback("Row #{number}: invalid or duplicate resource ID.")
+    end
+  end
+
+  defp parse_row({{:ok, _}, number}, _seen),
+    do: Repo.rollback("Row #{number}: expected five columns.")
+
+  defp parse_row({{:error, _}, number}, _seen),
+    do: Repo.rollback("Row #{number}: malformed CSV.")
+
+  defp create_parameter_revisions([], _publication_id, _author_id), do: 0
+
+  defp create_parameter_revisions(changes, publication_id, author_id) do
+    now = NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+
+    # Values are bound parameters; the column list comes only from the Ecto schema.
+    # Parameters and part membership were validated against the locked revisions.
+    # Titles are unchanged, so successors retain their existing slugs.
+    %{rows: revisions, num_rows: inserted} =
+      Ecto.Adapters.SQL.query!(
+        Repo,
+        """
+        INSERT INTO revisions (
+          #{@copied_revision_columns}, previous_revision_id, author_id,
+          learning_model_parameters, inserted_at, updated_at
+        )
+        SELECT old.#{String.replace(@copied_revision_columns, ", ", ", old.")},
+          old.id, $2::bigint, updates.parameters, $3::timestamp, $3::timestamp
+        FROM revisions AS old
+        JOIN jsonb_to_recordset($1::jsonb)
+          AS updates(previous_revision_id bigint, parameters jsonb)
+          ON old.id = updates.previous_revision_id
+        RETURNING id, resource_id, previous_revision_id
+        """,
+        [changes, author_id, now]
+      )
+
+    replacements =
+      Enum.map(revisions, fn [id, resource_id, previous_revision_id] ->
+        %{revision_id: id, resource_id: resource_id, previous_revision_id: previous_revision_id}
+      end)
+
+    %{num_rows: updated} =
+      Ecto.Adapters.SQL.query!(
+        Repo,
+        """
+        UPDATE published_resources AS mapping
+        SET revision_id = updates.revision_id, updated_at = $3::timestamp
+        FROM jsonb_to_recordset($1::jsonb)
+          AS updates(revision_id bigint, resource_id bigint, previous_revision_id bigint)
+        WHERE mapping.publication_id = $2::bigint
+          AND mapping.resource_id = updates.resource_id
+          AND mapping.revision_id = updates.previous_revision_id
+        """,
+        [replacements, publication_id, now]
+      )
+
+    case inserted == length(changes) and updated == inserted do
+      true -> inserted
+      false -> Repo.rollback("The working revisions changed; download a fresh CSV and retry.")
     end
   end
 

--- a/lib/oli_web/controllers/learning_model_parameters_controller.ex
+++ b/lib/oli_web/controllers/learning_model_parameters_controller.ex
@@ -3,6 +3,8 @@ defmodule OliWeb.LearningModelParametersController do
 
   use OliWeb, :controller
 
+  require Logger
+
   alias Oli.Authoring.Course
   alias Oli.LearningModel.ParameterCsv
 
@@ -19,14 +21,28 @@ defmodule OliWeb.LearningModelParametersController do
         )
         |> send_chunked(200)
 
-      {:ok, conn} =
-        ParameterCsv.export(project, conn.assigns.current_author, &stream_download(conn, &1))
-
-      conn
+      try do
+        case ParameterCsv.export(project, conn.assigns.current_author, &stream_download(conn, &1)) do
+          {:ok, conn} -> conn
+          {:error, reason} -> export_failed(conn, reason)
+        end
+      rescue
+        exception -> export_failed(conn, exception)
+      end
     else
       nil -> send_resp(conn, 404, "Project not found")
       {:error, _} -> send_resp(conn, 403, "Forbidden")
     end
+  end
+
+  # Headers have already been sent. Return the chunked connection to end the
+  # response instead of trying to send a second status/body or raising MatchError.
+  defp export_failed(conn, reason) do
+    Logger.error(
+      "Learning-model CSV export failed: #{inspect(reason, limit: 10, printable_limit: 1000)}"
+    )
+
+    conn
   end
 
   defp stream_download(conn, lines) do

--- a/lib/oli_web/controllers/learning_model_parameters_controller.ex
+++ b/lib/oli_web/controllers/learning_model_parameters_controller.ex
@@ -1,0 +1,42 @@
+defmodule OliWeb.LearningModelParametersController do
+  @moduledoc "Streams project parameter CSV downloads without buffering the entire file."
+
+  use OliWeb, :controller
+
+  alias Oli.Authoring.Course
+  alias Oli.LearningModel.ParameterCsv
+
+  @doc "Streams the authorized project’s current LKT-AOA parameters as a CSV attachment."
+  def download(conn, %{"project_slug" => slug}) do
+    with %{} = project <- Course.get_project_by_slug(slug),
+         :ok <- ParameterCsv.authorize(project, conn.assigns.current_author) do
+      conn =
+        conn
+        |> put_resp_content_type("text/csv")
+        |> put_resp_header(
+          "content-disposition",
+          "attachment; filename=learning-model-parameters.csv"
+        )
+        |> send_chunked(200)
+
+      {:ok, conn} =
+        ParameterCsv.export(project, conn.assigns.current_author, &stream_download(conn, &1))
+
+      conn
+    else
+      nil -> send_resp(conn, 404, "Project not found")
+      {:error, _} -> send_resp(conn, 403, "Forbidden")
+    end
+  end
+
+  defp stream_download(conn, lines) do
+    lines
+    |> Stream.chunk_every(100)
+    |> Enum.reduce_while(conn, fn batch, conn ->
+      case chunk(conn, batch) do
+        {:ok, conn} -> {:cont, conn}
+        {:error, _} -> {:halt, conn}
+      end
+    end)
+  end
+end

--- a/lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex
@@ -1,0 +1,140 @@
+defmodule OliWeb.Workspaces.CourseAuthor.LearningModelParametersLive do
+  @moduledoc "Admin workspace for downloading and applying project learning-model parameters."
+
+  use OliWeb, :live_view
+
+  alias Oli.LearningModel.ParameterCsv
+  alias OliWeb.Common.Breadcrumb
+
+  @impl true
+  def mount(_params, _session, socket) do
+    %{project: project, current_author: author} = socket.assigns
+
+    case ParameterCsv.authorize(project, author) do
+      :ok ->
+        {:ok,
+         socket
+         |> assign(
+           resource_slug: project.slug,
+           resource_title: project.title,
+           page_title: "Learning Model Parameters",
+           breadcrumbs: [
+             Breadcrumb.new(%{
+               full_title: "Project Overview",
+               link: ~p"/workspaces/course_author/#{project.slug}/overview"
+             }),
+             Breadcrumb.new(%{full_title: "Learning Model Parameters"})
+           ]
+         )
+         |> allow_upload(:csv,
+           accept: ~w(.csv),
+           auto_upload: true,
+           max_entries: 1,
+           max_file_size: 20_000_000
+         )}
+
+      {:error, message} ->
+        {:ok, socket |> put_flash(:error, message) |> redirect(to: ~p"/workspaces/course_author")}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="mx-auto max-w-3xl p-8 space-y-6">
+      <h1 class="text-2xl font-bold">Learning Model Parameters</h1>
+      <p>
+        Download all current objectives and activities, edit their LKT-AOA values, and upload the CSV.
+        Changes apply to the working publication and must be published to reach course sections.
+      </p>
+      <.link
+        href={~p"/learning_model_parameters/#{@project.slug}/download"}
+        class="inline-block text-primary underline"
+      >
+        Generate and Download
+      </.link>
+      <p>
+        Edit <code>beta_lo</code>
+        for objectives. For activities, edit the numbers in the <code>beta_difficulty</code>
+        JSON object, keeping its part IDs. Missing values export as zero.
+        Titles and child IDs are informational and are not imported.
+      </p>
+      <p>Only changed values create revisions. An invalid row rejects the entire upload.</p>
+      <.form
+        for={%{}}
+        id="parameter-upload"
+        phx-submit="upload"
+        phx-change="validate"
+        class="space-y-3"
+      >
+        <label for={@uploads.csv.ref} class="block">CSV file (up to 20 MB)</label>
+        <.live_file_input upload={@uploads.csv} />
+        <p :for={error <- upload_errors(@uploads.csv)} role="alert">{upload_error(error)}</p>
+        <div :for={entry <- @uploads.csv.entries}>
+          <span>{entry.client_name} — {entry.progress}%</span>
+          <p :for={error <- upload_errors(@uploads.csv, entry)} role="alert">{upload_error(error)}</p>
+          <button type="button" phx-click="cancel" phx-value-ref={entry.ref} class="underline">
+            Remove
+          </button>
+        </div>
+        <button
+          type="submit"
+          class="rounded bg-primary px-4 py-2 text-white disabled:opacity-50"
+          disabled={!upload_ready?(@uploads.csv)}
+        >
+          Upload
+        </button>
+      </.form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("validate", _, socket), do: {:noreply, socket}
+
+  def handle_event("cancel", %{"ref" => ref}, socket),
+    do: {:noreply, cancel_upload(socket, :csv, ref)}
+
+  def handle_event("upload", _, socket) do
+    case upload_ready?(socket.assigns.uploads.csv) do
+      true ->
+        [result] =
+          consume_uploaded_entries(socket, :csv, fn %{path: path}, _entry ->
+            {:ok,
+             ParameterCsv.import(
+               socket.assigns.project,
+               socket.assigns.current_author,
+               File.stream!(path, [:trim_bom])
+             )}
+          end)
+
+        {kind, message} =
+          case result do
+            {:ok, counts} ->
+              {:info, "Updated #{counts.changed} resources; #{counts.unchanged} unchanged."}
+
+            {:error, message} ->
+              {:error, message}
+          end
+
+        {:noreply, put_flash(socket, kind, message)}
+
+      false ->
+        {:noreply,
+         put_flash(socket, :error, "Select a valid CSV and wait for the upload to finish.")}
+    end
+  end
+
+  # The same readiness check guards the button and server event. Auto-upload moves
+  # the file first; submitting applies its values only once the transfer is complete.
+  defp upload_ready?(%{entries: [entry]} = upload) do
+    entry.done? and upload_errors(upload) == [] and upload_errors(upload, entry) == []
+  end
+
+  defp upload_ready?(_upload), do: false
+
+  defp upload_error(:too_large), do: "The file exceeds 20 MB."
+  defp upload_error(:too_many_files), do: "Select one CSV file."
+  defp upload_error(:not_accepted), do: "Select a .csv file."
+  defp upload_error(_), do: "The file could not be uploaded."
+end

--- a/lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/learning_model_parameters_live.ex
@@ -3,6 +3,8 @@ defmodule OliWeb.Workspaces.CourseAuthor.LearningModelParametersLive do
 
   use OliWeb, :live_view
 
+  require Logger
+
   alias Oli.LearningModel.ParameterCsv
   alias OliWeb.Common.Breadcrumb
 
@@ -18,6 +20,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.LearningModelParametersLive do
            resource_slug: project.slug,
            resource_title: project.title,
            page_title: "Learning Model Parameters",
+           importing?: false,
            breadcrumbs: [
              Breadcrumb.new(%{
                full_title: "Project Overview",
@@ -68,23 +71,37 @@ defmodule OliWeb.Workspaces.CourseAuthor.LearningModelParametersLive do
         class="space-y-3"
       >
         <label for={@uploads.csv.ref} class="block">CSV file (up to 20 MB)</label>
-        <.live_file_input upload={@uploads.csv} />
+        <.live_file_input upload={@uploads.csv} disabled={@importing?} />
         <p :for={error <- upload_errors(@uploads.csv)} role="alert">{upload_error(error)}</p>
         <div :for={entry <- @uploads.csv.entries}>
           <span>{entry.client_name} — {entry.progress}%</span>
+          <progress
+            value={entry.progress}
+            max="100"
+            aria-label={"Upload progress for #{entry.client_name}"}
+          >
+            {entry.progress}%
+          </progress>
           <p :for={error <- upload_errors(@uploads.csv, entry)} role="alert">{upload_error(error)}</p>
-          <button type="button" phx-click="cancel" phx-value-ref={entry.ref} class="underline">
+          <button
+            type="button"
+            phx-click="cancel"
+            phx-value-ref={entry.ref}
+            class="underline"
+            disabled={@importing?}
+          >
             Remove
           </button>
         </div>
         <button
           type="submit"
           class="rounded bg-primary px-4 py-2 text-white disabled:opacity-50"
-          disabled={!upload_ready?(@uploads.csv)}
+          disabled={@importing? or !upload_ready?(@uploads.csv)}
         >
           Upload
         </button>
       </.form>
+      <p :if={@importing?} role="status">Importing parameters…</p>
     </div>
     """
   end
@@ -92,37 +109,61 @@ defmodule OliWeb.Workspaces.CourseAuthor.LearningModelParametersLive do
   @impl true
   def handle_event("validate", _, socket), do: {:noreply, socket}
 
+  def handle_event(event, _, %{assigns: %{importing?: true}} = socket)
+      when event in ["upload", "cancel"], do: {:noreply, socket}
+
   def handle_event("cancel", %{"ref" => ref}, socket),
     do: {:noreply, cancel_upload(socket, :csv, ref)}
 
   def handle_event("upload", _, socket) do
     case upload_ready?(socket.assigns.uploads.csv) do
       true ->
-        [result] =
+        # Keep LiveView's temporary file until the async task finishes. Consuming
+        # it here would delete it before the task could read it.
+        [path] =
           consume_uploaded_entries(socket, :csv, fn %{path: path}, _entry ->
-            {:ok,
-             ParameterCsv.import(
-               socket.assigns.project,
-               socket.assigns.current_author,
-               File.stream!(path, [:trim_bom])
-             )}
+            {:postpone, path}
           end)
 
-        {kind, message} =
-          case result do
-            {:ok, counts} ->
-              {:info, "Updated #{counts.changed} resources; #{counts.unchanged} unchanged."}
+        %{project: project, current_author: author} = socket.assigns
 
-            {:error, message} ->
-              {:error, message}
-          end
-
-        {:noreply, put_flash(socket, kind, message)}
+        {:noreply,
+         socket
+         |> assign(importing?: true)
+         |> start_async(:import_parameters, fn ->
+           ParameterCsv.import(project, author, File.stream!(path, [:trim_bom]))
+         end)}
 
       false ->
         {:noreply,
          put_flash(socket, :error, "Select a valid CSV and wait for the upload to finish.")}
     end
+  end
+
+  @impl true
+  def handle_async(:import_parameters, {:ok, {:ok, counts}}, socket) do
+    finish_import(
+      socket,
+      :info,
+      "Updated #{counts.changed} resources; #{counts.unchanged} unchanged."
+    )
+  end
+
+  def handle_async(:import_parameters, {:ok, {:error, message}}, socket) do
+    finish_import(socket, :error, message)
+  end
+
+  def handle_async(:import_parameters, {:exit, reason}, socket) do
+    Logger.error(
+      "Learning-model CSV import failed: #{inspect(reason, limit: 10, printable_limit: 1000)}"
+    )
+
+    finish_import(socket, :error, "The import failed. Please try again.")
+  end
+
+  defp finish_import(socket, kind, message) do
+    consume_uploaded_entries(socket, :csv, fn _meta, _entry -> {:ok, :done} end)
+    {:noreply, socket |> assign(importing?: false) |> put_flash(kind, message)}
   end
 
   # The same readiness check guards the button and server event. Auto-upload moves

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -560,6 +560,15 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
       <% end %>
 
       <Overview.section title="Actions" is_last={true}>
+        <div :if={@is_admin} class="flex items-center">
+          <.link
+            class="text-Text-text-button hover:underline pr-3 py-2"
+            href={~p"/workspaces/course_author/#{@project.slug}/learning_model_parameters"}
+          >
+            Learning Model Parameters
+          </.link>
+          <span>Download and upload LKT-AOA parameter values.</span>
+        </div>
         <%= if @is_admin do %>
           <div class="flex items-center">
             <.link

--- a/lib/oli_web/router.ex
+++ b/lib/oli_web/router.ex
@@ -1060,6 +1060,11 @@ defmodule OliWeb.Router do
     post "/scores", LtiAgsController, :post_score
   end
 
+  scope "/learning_model_parameters", OliWeb do
+    pipe_through([:browser, :authoring_protected, :require_authenticated_content_admin])
+    get("/:project_slug/download", LearningModelParametersController, :download)
+  end
+
   ### Workspaces
   scope "/workspaces", OliWeb.Workspaces do
     pipe_through([:browser, :authoring_protected, :require_authenticated_system_admin])
@@ -1122,6 +1127,7 @@ defmodule OliWeb.Router do
         live("/:project_id/overview", OverviewLive)
         live("/:project_id/alternatives", AlternativesLive)
         live("/:project_id/index_csv", IndexCsvLive)
+        live("/:project_id/learning_model_parameters", LearningModelParametersLive)
         live("/:project_id/activity_bank", ActivityBankLive)
         live("/:project_id/objectives", ObjectivesLive)
         live("/:project_id/experiments", ExperimentsLive)

--- a/test/oli/learning_model/parameter_csv_test.exs
+++ b/test/oli/learning_model/parameter_csv_test.exs
@@ -239,7 +239,7 @@ defmodule Oli.LearningModel.ParameterCsvTest do
   end
 
   test "streaming export crosses cursor batches without losing resources", s do
-    for index <- 1..101 do
+    for index <- 1..251 do
       {:ok, _} =
         ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_objective(), %{
           title: "LO #{index}"
@@ -247,8 +247,150 @@ defmodule Oli.LearningModel.ParameterCsvTest do
     end
 
     rows = export_rows(s)
-    assert length(rows) == 103
-    assert length(Enum.uniq_by(rows, & &1["resource_id"])) == 103
+    assert length(rows) == 253
+    assert length(Enum.uniq_by(rows, & &1["resource_id"])) == 253
+  end
+
+  for size <- [1, 249, 250, 251, 505, 2000] do
+    @tag timeout: 120_000
+    test "imports #{size} resources with queries proportional to batches", s do
+      size = unquote(size)
+      rows = rows_for_count(s, size)
+      batches = div(size + 249, 250)
+
+      {result, queries} = capture_queries(fn -> upload(s, rows) end)
+      assert result == {:ok, %{changed: size, unchanged: 0}}
+      assert length(queries) <= 5 * batches + 5
+      assert Enum.count(queries, &String.starts_with?(&1, "INSERT INTO revisions")) == batches
+
+      assert Enum.count(queries, &String.starts_with?(&1, "UPDATE published_resources")) ==
+               batches
+
+      # All mappings, including the final partial batch, must point at their new values.
+      current = Map.new(export_rows(s), &{&1["resource_id"], &1})
+      for row <- rows, do: assert(current[row["resource_id"]] == row)
+
+      {result, queries} = capture_queries(fn -> upload(s, rows) end)
+      assert result == {:ok, %{changed: 0, unchanged: size}}
+      assert length(queries) <= 3 * batches + 5
+      refute Enum.any?(queries, &String.starts_with?(&1, "INSERT INTO revisions"))
+      refute Enum.any?(queries, &String.starts_with?(&1, "UPDATE published_resources"))
+    end
+  end
+
+  test "a failure in the second batch rolls back revisions and mappings from the first", s do
+    rows = rows_for_count(s, 251)
+    original_rows = export_rows(s)
+    count = Repo.aggregate(Revision, :count)
+    invalid_rows = List.update_at(rows, 250, &Map.put(&1, "beta_difficulty", "invalid"))
+
+    {result, queries} = capture_queries(fn -> upload(s, invalid_rows) end)
+    assert {:error, message} = result
+    assert message =~ "Row 252"
+    assert Enum.count(queries, &String.starts_with?(&1, "INSERT INTO revisions")) == 1
+    assert Repo.aggregate(Revision, :count) == count
+    assert export_rows(s) == original_rows
+  end
+
+  test "duplicate IDs across batches roll back the entire import", s do
+    rows = rows_for_count(s, 250)
+    count = Repo.aggregate(Revision, :count)
+    assert {:error, message} = upload(s, rows ++ [hd(rows)])
+    assert message =~ "Row 252"
+    assert message =~ "duplicate"
+    assert Repo.aggregate(Revision, :count) == count
+    assert latest(s, s.objective).id == s.objective.id
+  end
+
+  test "bulk copy preserves every other persisted field, including content and embeds", s do
+    {:ok, previous} =
+      ResourceEditor.edit(s.project.slug, s.activity.resource_id, s.admin, %{
+        content:
+          Map.put(s.activity.content, "large_content", String.duplicate("content", 10_000)),
+        objectives: %{"p1" => [s.objective.resource_id]},
+        tags: [s.objective.resource_id],
+        intro_content: %{"text" => "Introduction"},
+        graded: true,
+        ai_enabled: true,
+        scope: :banked,
+        max_attempts: 7,
+        time_limit: 50,
+        duration_minutes: 9,
+        legacy: %{path: "legacy/path", id: "original"},
+        explanation_strategy: %{type: :after_set_num_attempts, set_num_attempts: 3},
+        collab_space_config: %{
+          status: :enabled,
+          participation_min_replies: 2,
+          participation_min_posts: 1
+        }
+      })
+
+    assert {:ok, %{changed: 2}} = upload(s, trained_rows(s))
+    successor = latest(s, previous)
+
+    copied_fields =
+      Revision.__schema__(:fields) --
+        [
+          :id,
+          :previous_revision_id,
+          :author_id,
+          :learning_model_parameters,
+          :inserted_at,
+          :updated_at
+        ]
+
+    assert Map.take(successor, copied_fields) == Map.take(previous, copied_fields)
+    assert successor.previous_revision_id == previous.id
+    assert successor.author_id == s.admin.id
+    assert successor.inserted_at != nil
+    assert successor.updated_at == successor.inserted_at
+    assert successor.learning_model_parameters.payload.parts["p1"].beta_difficulty == 2.5
+  end
+
+  defp rows_for_count(s, size) do
+    for index <- Enum.take(Stream.iterate(1, &(&1 + 1)), max(size - 2, 0)) do
+      {:ok, _} =
+        ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_activity(), %{
+          title: "Batch activity #{index}",
+          activity_type_id: s.activity.activity_type_id,
+          content: s.activity.content
+        })
+    end
+
+    Enum.take(trained_rows(s), size)
+  end
+
+  defp capture_queries(fun) do
+    handler = {__MODULE__, make_ref()}
+    parent = self()
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        [:oli, :repo, :query],
+        fn _, _, metadata, _ ->
+          case self() == parent do
+            true -> send(parent, {handler, metadata.query})
+            false -> :ok
+          end
+        end,
+        nil
+      )
+
+    try do
+      result = fun.()
+      {result, collect_queries(handler, [])}
+    after
+      :telemetry.detach(handler)
+    end
+  end
+
+  defp collect_queries(handler, acc) do
+    receive do
+      {^handler, query} -> collect_queries(handler, [query | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
   end
 
   defp export_rows(s) do

--- a/test/oli/learning_model/parameter_csv_test.exs
+++ b/test/oli/learning_model/parameter_csv_test.exs
@@ -1,0 +1,281 @@
+defmodule Oli.LearningModel.ParameterCsvTest do
+  use Oli.DataCase
+
+  alias Oli.Accounts.SystemRole
+  alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.LearningModel.ParameterCsv
+  alias Oli.Publishing.{AuthoringResolver, PublishedResource}
+  alias Oli.Resources.{ResourceType, Revision}
+
+  @moduletag capture_log: true
+
+  setup do
+    seed = Seeder.base_project_with_resource2()
+    admin = author_fixture(%{system_role_id: SystemRole.role_id().content_admin})
+
+    {:ok, objective} =
+      ResourceEditor.create(seed.project.slug, admin, ResourceType.id_for_objective(), %{
+        title: "Objective, one"
+      })
+
+    {:ok, activity} =
+      ResourceEditor.create(seed.project.slug, admin, ResourceType.id_for_activity(), %{
+        title: "Activity",
+        activity_type_id: Oli.Activities.get_registration_by_slug("oli_multiple_choice").id,
+        content: %{"authoring" => %{"parts" => [%{"id" => "p1"}, %{"id" => "p2"}]}}
+      })
+
+    {:ok, Map.merge(seed, %{admin: admin, objective: objective, activity: activity})}
+  end
+
+  test "exports every working resource with default parameters and round trips without revisions",
+       s do
+    rows = export_rows(s)
+
+    assert Enum.find(rows, &(&1["resource_id"] == to_string(s.objective.resource_id))) == %{
+             "title" => "Objective, one",
+             "resource_id" => to_string(s.objective.resource_id),
+             "children_ids" => "[]",
+             "beta_lo" => "0.0",
+             "beta_difficulty" => ""
+           }
+
+    activity = Enum.find(rows, &(&1["resource_id"] == to_string(s.activity.resource_id)))
+    assert Jason.decode!(activity["beta_difficulty"]) == %{"p1" => 0.0, "p2" => 0.0}
+    count = Repo.aggregate(Revision, :count)
+    assert {:ok, %{changed: 0, unchanged: 2}} = upload(s, rows)
+    assert Repo.aggregate(Revision, :count) == count
+    assert latest(s, s.objective).learning_model_parameters == nil
+  end
+
+  test "changes both types with tracked revisions, preserves original content, and reimport is a no-op",
+       s do
+    rows = trained_rows(s)
+    assert {:ok, %{changed: 2, unchanged: 0}} = upload(s, rows)
+    objective = latest(s, s.objective)
+    activity = latest(s, s.activity)
+    assert objective.previous_revision_id == s.objective.id
+    assert activity.previous_revision_id == s.activity.id
+    assert objective.author_id == s.admin.id
+    assert objective.learning_model_parameters.payload.beta_lo == -1.25
+    assert activity.learning_model_parameters.payload.parts["p1"].beta_difficulty == 2.5
+    assert activity.content == s.activity.content
+    assert Repo.get!(Revision, s.objective.id).learning_model_parameters == nil
+    assert {:ok, %{changed: 0, unchanged: 2}} = upload(s, rows)
+    assert latest(s, s.objective).id == objective.id
+    assert export_rows(s) == rows
+  end
+
+  test "exports shared children once and quotes multiline and formula titles", s do
+    {:ok, child} =
+      ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_objective(), %{
+        title: "=SUM(1,2)"
+      })
+
+    for title <- ["Parent\nA", "Parent B"] do
+      ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_objective(), %{
+        title: title,
+        children: [child.resource_id]
+      })
+    end
+
+    rows = export_rows(s)
+    assert Enum.count(rows, &(&1["resource_id"] == to_string(child.resource_id))) == 1
+    assert Enum.count(rows, &(&1["children_ids"] == Jason.encode!([child.resource_id]))) == 2
+    assert Enum.any?(rows, &(&1["title"] == "'=SUM(1,2)"))
+    assert Enum.any?(rows, &(&1["title"] == "Parent\nA"))
+  end
+
+  test "invalid later row rolls back earlier changes", s do
+    [first, second] = trained_rows(s)
+    rows = [first, Map.put(second, "beta_difficulty", ~s({"unknown": 4}))]
+    assert {:error, message} = upload(s, rows)
+    assert message =~ "Row 3"
+    assert latest(s, s.objective).id == s.objective.id
+    assert latest(s, s.activity).id == s.activity.id
+  end
+
+  test "rejects duplicates and resources from another project", s do
+    [row | _] = trained_rows(s)
+    assert {:error, _} = upload(s, [row, row])
+    assert latest(s, s.objective).id == s.objective.id
+    other = Seeder.base_project_with_resource2()
+    assert {:error, _} = upload(%{s | project: other.project}, [row])
+  end
+
+  test "rejects malformed headers, empty files, invalid numbers and mismatched columns", s do
+    for csv <- ["", "bad,headers\n", "title,resource_id,children_ids,beta_lo,beta_difficulty\n"] do
+      assert {:error, _} = ParameterCsv.import(s.project, s.admin, [csv])
+    end
+
+    [row | _] = export_rows(s)
+
+    for invalid <- ["NaN", "Infinity", "1e999", "1.2x", ""] do
+      assert {:error, _} = upload(s, [Map.put(row, "beta_lo", invalid)])
+    end
+
+    assert {:error, _} = upload(s, [Map.put(row, "beta_difficulty", "{}")])
+  end
+
+  test "rejects nonnumeric activity values and missing part IDs", s do
+    row = List.last(export_rows(s))
+
+    for value <- [~s({"p1":"2","p2":0}), ~s({"p1":2}), "[]", "null", "broken"] do
+      assert {:error, _} = upload(s, [Map.put(row, "beta_difficulty", value)])
+    end
+  end
+
+  test "respects active authoring locks", s do
+    Repo.update_all(from(pr in PublishedResource, where: pr.revision_id == ^s.objective.id),
+      set: [
+        locked_by_id: s.author.id,
+        lock_updated_at: NaiveDateTime.utc_now() |> NaiveDateTime.truncate(:second)
+      ]
+    )
+
+    assert {:error, message} = upload(s, trained_rows(s))
+    assert message =~ "being edited"
+    assert latest(s, s.objective).id == s.objective.id
+  end
+
+  test "ordinary project authors cannot export or import", s do
+    assert {:error, _} = ParameterCsv.export(s.project, s.author, &Enum.to_list/1)
+    assert {:error, _} = ParameterCsv.import(s.project, s.author, [])
+  end
+
+  test "includes activities without parts and excludes deleted resources", s do
+    {:ok, empty} =
+      ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_activity(), %{
+        title: "No parts",
+        activity_type_id: s.activity.activity_type_id,
+        content: %{}
+      })
+
+    ResourceEditor.delete(s.project.slug, s.objective.resource_id, s.admin)
+    rows = export_rows(s)
+    assert length(rows) == 2
+
+    assert Enum.find(rows, &(&1["resource_id"] == to_string(empty.resource_id)))[
+             "beta_difficulty"
+           ] == "{}"
+
+    assert {:ok, %{changed: 0, unchanged: 2}} = upload(s, rows)
+  end
+
+  test "adaptive export follows persisted parts including rule-scored and stateful parts", s do
+    content = %{
+      "partsLayout" => [],
+      "authoring" => %{
+        "parts" => [
+          %{"id" => "scorable", "type" => "janus-mcq"},
+          %{"id" => "stateful", "type" => "janus-video"},
+          %{"id" => "rule", "type" => "custom-widget"},
+          %{"id" => "ignored", "type" => "custom-widget"}
+        ],
+        "rules" => [%{"conditions" => %{"value" => "stage.rule.value"}}]
+      }
+    }
+
+    {:ok, adaptive} =
+      ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_activity(), %{
+        title: "Adaptive",
+        activity_type_id: s.activity.activity_type_id,
+        content: content
+      })
+
+    row = Enum.find(export_rows(s), &(&1["resource_id"] == to_string(adaptive.resource_id)))
+
+    assert Jason.decode!(row["beta_difficulty"]) == %{
+             "scorable" => 0.0,
+             "stateful" => 0.0,
+             "rule" => 0.0
+           }
+
+    values = %{"scorable" => 1.0, "stateful" => 2.0, "rule" => 3.0}
+
+    assert {:ok, %{changed: 1}} =
+             upload(s, [Map.put(row, "beta_difficulty", Jason.encode!(values))])
+  end
+
+  test "working edits leave published mappings and parameters untouched", s do
+    {:ok, published} =
+      Oli.Publishing.create_publication(%{
+        project_id: s.project.id,
+        root_resource_id: s.publication.root_resource_id,
+        published: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    {:ok, mapping} =
+      Oli.Publishing.create_published_resource(%{
+        publication_id: published.id,
+        resource_id: s.objective.resource_id,
+        revision_id: s.objective.id
+      })
+
+    assert length(export_rows(s)) == 2
+    assert {:ok, %{changed: 2}} = upload(s, trained_rows(s))
+    assert Repo.get!(PublishedResource, mapping.id).revision_id == s.objective.id
+    assert Repo.get!(Revision, s.objective.id).learning_model_parameters == nil
+  end
+
+  test "partial stored parameters export missing parts as defaults without a no-op revision", s do
+    parameters = %{
+      schema_version: 1,
+      model: "lkt_aoa",
+      model_version: 2,
+      parameter_type: "activity",
+      payload: %{parts: %{"p1" => %{beta_difficulty: 4.0}}}
+    }
+
+    {:ok, revision} =
+      ResourceEditor.edit(s.project.slug, s.activity.resource_id, s.admin, %{
+        learning_model_parameters: parameters
+      })
+
+    rows = export_rows(s)
+    assert Jason.decode!(List.last(rows)["beta_difficulty"]) == %{"p1" => 4.0, "p2" => 0.0}
+    assert {:ok, %{changed: 0}} = upload(s, rows)
+    assert latest(s, s.activity).id == revision.id
+  end
+
+  test "streaming export crosses cursor batches without losing resources", s do
+    for index <- 1..101 do
+      {:ok, _} =
+        ResourceEditor.create(s.project.slug, s.admin, ResourceType.id_for_objective(), %{
+          title: "LO #{index}"
+        })
+    end
+
+    rows = export_rows(s)
+    assert length(rows) == 103
+    assert length(Enum.uniq_by(rows, & &1["resource_id"])) == 103
+  end
+
+  defp export_rows(s) do
+    {:ok, lines} = ParameterCsv.export(s.project, s.admin, &Enum.to_list/1)
+    CSV.decode!(lines, headers: true) |> Enum.to_list()
+  end
+
+  defp trained_rows(s) do
+    export_rows(s)
+    |> Enum.map(fn row ->
+      case row["beta_lo"] do
+        "" -> Map.put(row, "beta_difficulty", Jason.encode!(%{"p1" => 2.5, "p2" => -0.5}))
+        _ -> Map.put(row, "beta_lo", "-1.25")
+      end
+    end)
+  end
+
+  defp upload(s, rows),
+    do:
+      ParameterCsv.import(
+        s.project,
+        s.admin,
+        CSV.encode(rows,
+          headers: ["title", "resource_id", "children_ids", "beta_lo", "beta_difficulty"]
+        )
+      )
+
+  defp latest(s, revision),
+    do: AuthoringResolver.from_resource_id(s.project.slug, revision.resource_id)
+end

--- a/test/oli/learning_model/parameter_csv_test.exs
+++ b/test/oli/learning_model/parameter_csv_test.exs
@@ -292,6 +292,23 @@ defmodule Oli.LearningModel.ParameterCsvTest do
     assert export_rows(s) == original_rows
   end
 
+  test "invalid first batch stops reading before the rest of the upload is decoded", s do
+    remaining_lines =
+      Stream.map(1..1000, fn index ->
+        assert index < 1000,
+               "import eagerly consumed the entire upload before validating its first batch"
+
+        "Objective,invalid,[],1.0,\n"
+      end)
+
+    lines =
+      Stream.concat(["title,resource_id,children_ids,beta_lo,beta_difficulty\n"], remaining_lines)
+
+    assert {:error, message} = ParameterCsv.import(s.project, s.admin, lines)
+    assert message =~ "Row 2"
+    assert message =~ "invalid"
+  end
+
   test "duplicate IDs across batches roll back the entire import", s do
     rows = rows_for_count(s, 250)
     count = Repo.aggregate(Revision, :count)

--- a/test/oli_web/learning_model_parameters_test.exs
+++ b/test/oli_web/learning_model_parameters_test.exs
@@ -48,10 +48,22 @@ defmodule OliWeb.LearningModelParametersTest do
       ])
 
     render_upload(upload, "parameters.csv", 50)
+
+    assert has_element?(
+             view,
+             "progress[value='50'][max='100'][aria-label='Upload progress for parameters.csv']"
+           )
+
     assert has_element?(view, "#parameter-upload button[type=submit][disabled]")
     assert render_click(view, "upload") =~ "wait for the upload to finish"
 
     render_upload(upload, "parameters.csv", 50)
+
+    assert has_element?(
+             view,
+             "progress[value='100'][max='100'][aria-label='Upload progress for parameters.csv']"
+           )
+
     assert has_element?(view, "#parameter-upload button[type=submit]:not([disabled])")
 
     assert Oli.Publishing.AuthoringResolver.from_resource_id(
@@ -59,7 +71,11 @@ defmodule OliWeb.LearningModelParametersTest do
              s.objective.resource_id
            ).id == s.objective.id
 
-    assert view |> form("#parameter-upload") |> render_submit() =~ "Updated 1 resources"
+    assert view |> form("#parameter-upload") |> render_submit() =~ "Importing parameters"
+    assert render_async(view) =~ "Updated 1 resources"
+    refute has_element?(view, "[role=status]", "Importing parameters")
+    refute has_element?(view, "input[type=file][disabled]")
+    refute has_element?(view, "button", "Remove")
 
     revision =
       Oli.Publishing.AuthoringResolver.from_resource_id(s.project.slug, s.objective.resource_id)
@@ -89,7 +105,9 @@ defmodule OliWeb.LearningModelParametersTest do
       ])
 
     render_upload(upload, "bad.csv")
-    assert view |> form("#parameter-upload") |> render_submit() =~ "Row 1"
+    view |> form("#parameter-upload") |> render_submit()
+    assert render_async(view) =~ "Row 1"
+    refute has_element?(view, "input[type=file][disabled]")
 
     revision =
       Oli.Publishing.AuthoringResolver.from_resource_id(s.project.slug, s.objective.resource_id)
@@ -119,6 +137,108 @@ defmodule OliWeb.LearningModelParametersTest do
 
     assert {:error, _} = render_upload(upload, "bad.txt")
     assert render(view) =~ "Select a .csv file."
+  end
+
+  test "LiveView remains responsive and rejects duplicate imports while the task runs", s do
+    {:ok, view, _} = live(log_in_author(s.conn, s.admin), path(s.project))
+
+    csv =
+      "title,resource_id,children_ids,beta_lo,beta_difficulty\nObjective,#{s.objective.resource_id},[],1.5,\n"
+
+    upload =
+      file_input(view, "#parameter-upload", :csv, [
+        %{name: "parameters.csv", content: csv, type: "text/csv"}
+      ])
+
+    render_upload(upload, "parameters.csv")
+
+    parent = self()
+    handler = {__MODULE__, make_ref()}
+
+    :telemetry.attach(
+      handler,
+      [:oli, :repo, :query],
+      fn _, _, metadata, _ ->
+        case String.starts_with?(metadata.query, "SELECT") do
+          true ->
+            send(parent, {:import_waiting, self()})
+
+            receive do
+              :continue_import -> :ok
+            after
+              5_000 -> :ok
+            end
+
+          false ->
+            :ok
+        end
+      end,
+      nil
+    )
+
+    try do
+      assert view |> form("#parameter-upload") |> render_submit() =~ "Importing parameters"
+      assert_receive {:import_waiting, worker}, 5_000
+
+      try do
+        assert has_element?(view, "input[type=file][disabled]")
+        assert render_click(view, "upload") =~ "Importing parameters"
+        assert render_click(view, "cancel", %{"ref" => "ignored"}) =~ "Importing parameters"
+        assert render_change(view, "validate", %{}) =~ "Importing parameters"
+      after
+        :telemetry.detach(handler)
+        send(worker, :continue_import)
+      end
+
+      assert render_async(view) =~ "Updated 1 resources"
+    after
+      :telemetry.detach(handler)
+    end
+  end
+
+  test "an async import crash clears loading state and releases the upload", s do
+    Ecto.Adapters.SQL.query!(
+      Oli.Repo,
+      "UPDATE revisions SET learning_model_parameters = '{}'::jsonb WHERE id = $1",
+      [s.objective.id]
+    )
+
+    {:ok, view, _} = live(log_in_author(s.conn, s.admin), path(s.project))
+
+    csv =
+      "title,resource_id,children_ids,beta_lo,beta_difficulty\nObjective,#{s.objective.resource_id},[],1.5,\n"
+
+    upload =
+      file_input(view, "#parameter-upload", :csv, [
+        %{name: "parameters.csv", content: csv, type: "text/csv"}
+      ])
+
+    render_upload(upload, "parameters.csv")
+    view |> form("#parameter-upload") |> render_submit()
+    assert render_async(view) =~ "The import failed. Please try again."
+    refute has_element?(view, "input[type=file][disabled]")
+    refute has_element?(view, "[role=status]", "Importing parameters")
+    refute has_element?(view, "button", "Remove")
+  end
+
+  test "export failure after headers are sent ends the response and logs the failure", s do
+    # Simulate a bad persisted envelope that fails decoding during cursor iteration.
+    Ecto.Adapters.SQL.query!(
+      Oli.Repo,
+      "UPDATE revisions SET learning_model_parameters = '{}'::jsonb WHERE id = $1",
+      [s.objective.id]
+    )
+
+    conn = log_in_author(s.conn, s.admin)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        response = get(conn, "/learning_model_parameters/#{s.project.slug}/download")
+        assert response.status == 200
+        assert response.state == :chunked
+      end)
+
+    assert log =~ "Learning-model CSV export failed"
   end
 
   defp path(project), do: "/workspaces/course_author/#{project.slug}/learning_model_parameters"

--- a/test/oli_web/learning_model_parameters_test.exs
+++ b/test/oli_web/learning_model_parameters_test.exs
@@ -1,0 +1,125 @@
+defmodule OliWeb.LearningModelParametersTest do
+  use OliWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Oli.Accounts.SystemRole
+  alias Oli.Authoring.Editing.ResourceEditor
+  alias Oli.Resources.ResourceType
+
+  @moduletag capture_log: true
+
+  setup do
+    seed = Oli.Seeder.base_project_with_resource2()
+    admin = author_fixture(%{system_role_id: SystemRole.role_id().content_admin})
+
+    {:ok, objective} =
+      ResourceEditor.create(seed.project.slug, admin, ResourceType.id_for_objective(), %{
+        title: "Objective"
+      })
+
+    {:ok, Map.merge(seed, %{admin: admin, objective: objective})}
+  end
+
+  test "admin downloads and uploads CSV through the project page", s do
+    conn = log_in_author(s.conn, s.admin)
+    download = get(conn, "/learning_model_parameters/#{s.project.slug}/download")
+    assert download.status == 200
+    assert get_resp_header(download, "content-type") == ["text/csv; charset=utf-8"]
+
+    assert get_resp_header(download, "content-disposition") == [
+             "attachment; filename=learning-model-parameters.csv"
+           ]
+
+    assert download.resp_body =~ "Objective"
+    {:ok, view, html} = live(conn, path(s.project))
+    assert html =~ "Generate and Download"
+    assert has_element?(view, "input[type=file][data-phx-auto-upload]")
+    assert has_element?(view, "#parameter-upload button[type=submit][disabled]")
+    csv = "\uFEFF" <> String.replace(download.resp_body, ",0.0,", ",1.5,")
+
+    upload =
+      file_input(view, "#parameter-upload", :csv, [
+        %{
+          name: "parameters.csv",
+          content: csv,
+          type: "text/csv"
+        }
+      ])
+
+    render_upload(upload, "parameters.csv", 50)
+    assert has_element?(view, "#parameter-upload button[type=submit][disabled]")
+    assert render_click(view, "upload") =~ "wait for the upload to finish"
+
+    render_upload(upload, "parameters.csv", 50)
+    assert has_element?(view, "#parameter-upload button[type=submit]:not([disabled])")
+
+    assert Oli.Publishing.AuthoringResolver.from_resource_id(
+             s.project.slug,
+             s.objective.resource_id
+           ).id == s.objective.id
+
+    assert view |> form("#parameter-upload") |> render_submit() =~ "Updated 1 resources"
+
+    revision =
+      Oli.Publishing.AuthoringResolver.from_resource_id(s.project.slug, s.objective.resource_id)
+
+    assert revision.learning_model_parameters.payload.beta_lo == 1.5
+    assert revision.previous_revision_id == s.objective.id
+  end
+
+  test "ordinary author cannot mount or download", s do
+    conn = log_in_author(s.conn, s.author)
+    assert {:error, {:redirect, _}} = live(conn, path(s.project))
+    conn = get(conn, "/learning_model_parameters/#{s.project.slug}/download")
+    assert conn.status in [302, 403]
+  end
+
+  test "anonymous requests require login", s do
+    assert get(s.conn, path(s.project)).status == 302
+    assert get(s.conn, "/learning_model_parameters/#{s.project.slug}/download").status == 302
+  end
+
+  test "upload validation errors are shown without editing the resource", s do
+    {:ok, view, _} = live(log_in_author(s.conn, s.admin), path(s.project))
+
+    upload =
+      file_input(view, "#parameter-upload", :csv, [
+        %{name: "bad.csv", content: "bad,headers\n", type: "text/csv"}
+      ])
+
+    render_upload(upload, "bad.csv")
+    assert view |> form("#parameter-upload") |> render_submit() =~ "Row 1"
+
+    revision =
+      Oli.Publishing.AuthoringResolver.from_resource_id(s.project.slug, s.objective.resource_id)
+
+    assert revision.id == s.objective.id
+  end
+
+  test "overview link is visible only to content administrators", s do
+    for {author, visible?} <- [{s.admin, true}, {s.author, false}] do
+      {:ok, view, _} =
+        live(
+          log_in_author(s.conn, author),
+          "/workspaces/course_author/#{s.project.slug}/overview"
+        )
+
+      assert has_element?(view, "a[href='#{path(s.project)}']") == visible?
+    end
+  end
+
+  test "invalid file type is rejected", s do
+    {:ok, view, _} = live(log_in_author(s.conn, s.admin), path(s.project))
+
+    upload =
+      file_input(view, "#parameter-upload", :csv, [
+        %{name: "bad.txt", content: "bad", type: "text/plain"}
+      ])
+
+    assert {:error, _} = render_upload(upload, "bad.txt")
+    assert render(view) =~ "Select a .csv file."
+  end
+
+  defp path(project), do: "/workspaces/course_author/#{project.slug}/learning_model_parameters"
+end


### PR DESCRIPTION
This implements, both for learning objectives and activities:

1. Downloading (and thus access) of the existing LKT_AOA parameters in a course project.  
2. Uploading (and thus updating) of LKT_AOA parameters for a project.  

This impl pays careful attention to large course project impacts, by streaming and using batch update mechanisms. 

