### PR TITLE
[ENHANCEMENT] [MER-5859] Retain legacy project descriptions

### DIFF
--- a/lib/oli/authoring/course/project.ex
+++ b/lib/oli/authoring/course/project.ex
@@ -7,8 +7,6 @@ defmodule Oli.Authoring.Course.Project do
   alias Oli.LearningModel.ModelVersion
   alias Oli.Utils.Slug
 
-  @description_character_limit 300
-
   @derive {Phoenix.Param, key: :slug}
   schema "projects" do
     field(:description, :string)
@@ -111,10 +109,6 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
-    |> validate_length(:description,
-      max: @description_character_limit,
-      message: "must be %{count} characters or fewer"
-    )
     |> Slug.update_never("projects")
   end
 
@@ -141,10 +135,6 @@ defmodule Oli.Authoring.Course.Project do
     |> validate_required([:title, :version, :family_id, :publisher_id])
     |> foreign_key_constraint(:publisher_id)
     |> check_constraint(:learning_model_version, name: :projects_learning_model_version_check)
-    |> validate_length(:description,
-      max: @description_character_limit,
-      message: "must be %{count} characters or fewer"
-    )
     |> Slug.update_never("projects")
   end
 

--- a/lib/oli/delivery/sections/section.ex
+++ b/lib/oli/delivery/sections/section.ex
@@ -19,8 +19,6 @@ defmodule Oli.Delivery.Sections.Section do
     Section
   }
 
-  @description_character_limit 300
-
   @required_fields [
     :type,
     :title,
@@ -260,10 +258,6 @@ defmodule Oli.Delivery.Sections.Section do
     |> check_constraint(:learning_model_version, name: :sections_learning_model_version_check)
     |> Slug.update_never("sections")
     |> validate_length(:title, max: 255)
-    |> validate_length(:description,
-      max: @description_character_limit,
-      message: "must be %{count} characters or fewer"
-    )
     |> cast_assoc(:certificate)
   end
 

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -7,6 +7,24 @@ defmodule OliWeb.Components.Common do
   alias OliWeb.Icons
   alias Phoenix.LiveView.JS
 
+  @description_character_limit 300
+
+  @doc """
+  Returns the authoring character limit for a saved description.
+
+  Legacy descriptions that already exceed the limit are grandfathered so they can
+  continue to be edited without blocking related project and section operations.
+  """
+  @spec description_maxlength(String.t() | nil) :: pos_integer() | nil
+  def description_maxlength(description) when is_binary(description) do
+    case String.length(description) <= @description_character_limit do
+      true -> @description_character_limit
+      false -> nil
+    end
+  end
+
+  def description_maxlength(_description), do: @description_character_limit
+
   def not_found(assigns) do
     ~H"""
     <main role="main" class="container mx-auto">

--- a/lib/oli_web/components/common.ex
+++ b/lib/oli_web/components/common.ex
@@ -10,10 +10,10 @@ defmodule OliWeb.Components.Common do
   @description_character_limit 300
 
   @doc """
-  Returns the authoring character limit for a saved description.
+  Returns the `maxlength` value for an authored description.
 
-  Legacy descriptions that already exceed the limit are grandfathered so they can
-  continue to be edited without blocking related project and section operations.
+  Returning `nil` for a saved description that already exceeds the limit omits the
+  HTML constraint and preserves that legacy content until it is shortened.
   """
   @spec description_maxlength(String.t() | nil) :: pos_integer() | nil
   def description_maxlength(description) when is_binary(description) do
@@ -23,7 +23,7 @@ defmodule OliWeb.Components.Common do
     end
   end
 
-  def description_maxlength(_description), do: @description_character_limit
+  def description_maxlength(nil), do: @description_character_limit
 
   def not_found(assigns) do
     ~H"""

--- a/lib/oli_web/live/products/details/edit.ex
+++ b/lib/oli_web/live/products/details/edit.ex
@@ -49,7 +49,10 @@ defmodule OliWeb.Products.Details.Edit do
 
         <div class="form-group mb-2">
           {label(f, :description)}
-          {text_input(f, :description, class: "form-control", maxlength: 300)}
+          {text_input(f, :description,
+            class: "form-control",
+            maxlength: Common.description_maxlength(@product.description)
+          )}
           <div>{error_tag(f, :description)}</div>
         </div>
 

--- a/lib/oli_web/live/sections/edit_view.ex
+++ b/lib/oli_web/live/sections/edit_view.ex
@@ -139,6 +139,7 @@ defmodule OliWeb.Sections.EditView do
         >
           <MainDetails.render
             form={@form}
+            description={@section.description}
             disabled={false}
             is_admin={@is_admin}
             brands={@brands}

--- a/lib/oli_web/live/sections/main_details.ex
+++ b/lib/oli_web/live/sections/main_details.ex
@@ -10,6 +10,7 @@ defmodule OliWeb.Sections.MainDetails do
   attr(:institutions, :list, required: true)
   attr(:project_slug, :string, required: true)
   attr(:ctx, :map, required: true)
+  attr(:description, :string, default: nil)
 
   def render(assigns) do
     ~H"""
@@ -22,7 +23,7 @@ defmodule OliWeb.Sections.MainDetails do
           field={@form[:description]}
           label="Description"
           class="form-control"
-          maxlength="300"
+          maxlength={Common.description_maxlength(@description)}
           disabled={@disabled}
         />
       </div>

--- a/lib/oli_web/live/workspaces/course_author/overview_live.ex
+++ b/lib/oli_web/live/workspaces/course_author/overview_live.ex
@@ -160,7 +160,7 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLive do
               label="Project Description"
               type="textarea"
               class="form-control"
-              maxlength="300"
+              maxlength={Common.description_maxlength(@project.description)}
               placeholder="A brief description of your project..."
               error_position={:top}
               errors={f.errors}

--- a/test/oli/delivery/sections/blueprint_test.exs
+++ b/test/oli/delivery/sections/blueprint_test.exs
@@ -137,6 +137,30 @@ defmodule Oli.Delivery.Sections.BlueprintTest do
       assert enrollable_section.type == :enrollable
       assert enrollable_section.learning_model_version == :lkt_aoa
     end
+
+    test "duplicates a legacy description over the authoring character limit" do
+      %{project: project, publication: publication, institution: institution} =
+        Seeder.base_project_with_resource2()
+
+      description = String.duplicate("Legacy description", 20)
+
+      {:ok, blueprint} =
+        Sections.create_section(%{
+          type: :blueprint,
+          title: "Legacy description template",
+          description: description,
+          registration_open: true,
+          context_id: UUID.uuid4(),
+          institution_id: institution.id,
+          base_project_id: project.id,
+          publisher_id: project.publisher_id
+        })
+        |> then(fn {:ok, section} -> section end)
+        |> Sections.create_section_resources(publication)
+
+      assert {:ok, duplicate} = Blueprint.duplicate(blueprint)
+      assert duplicate.description == description
+    end
   end
 
   describe "basic blueprint operations" do

--- a/test/oli/delivery/sections/section_test.exs
+++ b/test/oli/delivery/sections/section_test.exs
@@ -89,15 +89,14 @@ defmodule Oli.Delivery.Sections.SectionTest do
       assert changeset.errors[:title] |> elem(0) =~ ~r/should be at most .* character/
     end
 
-    test "validates the description character limit" do
+    test "accepts descriptions over the authoring character limit" do
       section = build(:section, @valid_section_attrs)
       description = String.duplicate("a", 301)
 
       changeset = Section.changeset(section, %{description: description})
 
-      assert changeset.errors[:description] ==
-               {"must be %{count} characters or fewer",
-                [count: 300, validation: :length, kind: :max, type: :string]}
+      refute changeset.errors[:description]
+      assert Ecto.Changeset.get_change(changeset, :description) == description
     end
 
     test "default assistant_enabled is false" do

--- a/test/oli/delivery_test.exs
+++ b/test/oli/delivery_test.exs
@@ -316,10 +316,12 @@ defmodule Oli.DeliveryTest do
         ]
       }
 
+      description = String.duplicate("Project description", 20)
+
       project =
         context.project
         |> Project.changeset(%{
-          description: "Project description",
+          description: description,
           welcome_title: welcome_title,
           encouraging_subtitle: "Project subtitle"
         })
@@ -336,7 +338,7 @@ defmodule Oli.DeliveryTest do
                )
 
       section = Sections.get_section!(section_id)
-      assert section.description == "Project description"
+      assert section.description == description
       assert section.welcome_title == welcome_title
       assert section.encouraging_subtitle == "Project subtitle"
     end

--- a/test/oli/interop/ingest_test.exs
+++ b/test/oli/interop/ingest_test.exs
@@ -210,6 +210,18 @@ defmodule Oli.Interop.IngestTest do
 
       assert Enum.count(product_root.children) == 2
     end
+
+    test "ingests a legacy project description over the authoring character limit", %{
+      author: author
+    } do
+      description = String.duplicate("Legacy description", 20)
+
+      assert {:ok, project} =
+               minimal_digest(%{"title" => "Legacy project", "description" => description})
+               |> Ingest.process(author)
+
+      assert project.description == description
+    end
   end
 
   describe "learning-model archive compatibility" do

--- a/test/oli_web/live/products/details_view_test.exs
+++ b/test/oli_web/live/products/details_view_test.exs
@@ -66,6 +66,19 @@ defmodule OliWeb.Products.DetailsViewTest do
       assert tags_index < welcome_title_index
     end
 
+    test "grandfathers template descriptions that already exceed 300 characters", %{
+      conn: conn,
+      product: product
+    } do
+      product
+      |> Ecto.Changeset.change(description: String.duplicate("a", 301))
+      |> Oli.Repo.update!()
+
+      {:ok, view, _html} = live(conn, product_route(product.slug))
+
+      refute has_element?(view, ~s(input[name="section[description]"][maxlength]))
+    end
+
     test "displays Tags section with editable TagsComponent", %{
       conn: conn,
       product: product,

--- a/test/oli_web/live/sections/edit_live_test.exs
+++ b/test/oli_web/live/sections/edit_live_test.exs
@@ -8,6 +8,7 @@ defmodule OliWeb.Sections.EditLiveTest do
   alias Oli.Delivery.Sections
   alias Oli.Delivery.Sections.Section
   alias Lti_1p3.Roles.ContextRoles
+  alias Oli.Repo
 
   defp live_view_edit_route(section_slug) do
     ~p"/sections/#{section_slug}/edit"
@@ -223,20 +224,40 @@ defmodule OliWeb.Sections.EditLiveTest do
       refute html =~ "/authoring/products/#{section.slug}/discounts"
     end
 
-    test "section description cannot exceed 300 characters", %{conn: conn, section: section} do
+    test "limits section descriptions that do not exceed 300 characters", %{
+      conn: conn,
+      section: section
+    } do
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
+
+      assert has_element?(
+               view,
+               ~s(input[name="section[description]"][maxlength="300"])
+             )
+    end
+
+    test "grandfathers section descriptions that already exceed 300 characters", %{
+      conn: conn,
+      section: section
+    } do
       description = String.duplicate("a", 301)
 
-      {:ok, view, html} = live(conn, live_view_edit_route(section.slug))
+      section =
+        section
+        |> Ecto.Changeset.change(description: description)
+        |> Repo.update!()
 
-      assert html =~ ~s(maxlength="300")
+      {:ok, view, _html} = live(conn, live_view_edit_route(section.slug))
 
-      html =
-        view
-        |> element("#section-edit-form")
-        |> render_submit(section: %{description: description})
+      refute has_element?(view, ~s(input[name="section[description]"][maxlength]))
 
-      assert html =~ "must be 300 characters or fewer"
-      assert Oli.Repo.get(Section, section.id).description == section.description
+      updated_description = description <> "b"
+
+      view
+      |> element("#section-edit-form")
+      |> render_submit(section: %{description: updated_description})
+
+      assert Repo.get(Section, section.id).description == updated_description
     end
 
     test "loads open and free section data correctly", %{conn: conn} do

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -208,6 +208,16 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
 
       assert has_element?(view, "div.alert-info", "Project updated successfully.")
       assert Course.get_project_by_slug(project.slug).description == updated_description
+
+      shortened_description = String.duplicate("b", 300)
+
+      element(view, "form[phx-submit='update']")
+      |> render_submit(%{"project" => %{"description" => shortened_description}})
+
+      assert has_element?(
+               view,
+               ~s(textarea[name="project[description]"][maxlength="300"])
+             )
     end
 
     test "publisher dropdown displays publishers sorted alphabetically", %{

--- a/test/oli_web/live/workspaces/course_author/overview_live_test.exs
+++ b/test/oli_web/live/workspaces/course_author/overview_live_test.exs
@@ -171,20 +171,43 @@ defmodule OliWeb.Workspaces.CourseAuthor.OverviewLiveTest do
       |> hd() =~ "Welcome Title"
     end
 
-    test "project description cannot exceed 300 characters", %{conn: conn, author: author} do
+    test "limits project descriptions that do not exceed 300 characters", %{
+      conn: conn,
+      author: author
+    } do
       project = create_project_with_author(author)
+
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      assert has_element?(
+               view,
+               ~s(textarea[name="project[description]"][maxlength="300"])
+             )
+    end
+
+    test "grandfathers project descriptions that already exceed 300 characters", %{
+      conn: conn,
+      author: author
+    } do
       description = String.duplicate("a", 301)
 
-      {:ok, view, html} = live(conn, live_view_route(project.slug))
+      project =
+        author
+        |> create_project_with_author()
+        |> Ecto.Changeset.change(description: description)
+        |> Repo.update!()
 
-      assert html =~ ~s(maxlength="300")
+      {:ok, view, _html} = live(conn, live_view_route(project.slug))
+
+      refute has_element?(view, ~s(textarea[name="project[description]"][maxlength]))
+
+      updated_description = description <> "b"
 
       element(view, "form[phx-submit='update']")
-      |> render_submit(%{"project" => %{"description" => description}})
+      |> render_submit(%{"project" => %{"description" => updated_description}})
 
-      assert has_element?(view, "div.alert-danger", "Project could not be updated.")
-      assert render(view) =~ "must be 300 characters or fewer"
-      assert Course.get_project_by_slug(project.slug).description == project.description
+      assert has_element?(view, "div.alert-info", "Project updated successfully.")
+      assert Course.get_project_by_slug(project.slug).description == updated_description
     end
 
     test "publisher dropdown displays publishers sorted alphabetically", %{


### PR DESCRIPTION
- Enforces the 300-character description limit in authoring forms for new projects, sections, and templates.
- Grandfathers existing descriptions longer than 300 characters so they remain editable.
- Re-enables the limit once a grandfathered description is shortened to 300 characters or fewer.
- Removes schema-level validation to prevent long legacy descriptions from breaking ingestion, section creation, and template duplication.