### PR TITLE
[ENHANCEMENT] [MER-5928] Fix LO Summary/Introduction Mobile Layout

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -496,7 +496,7 @@ https://tailwindcss.com/docs/utility-first
   align-items: center;
   gap: 12px;
   min-width: 0;
-  padding: 12px;
+  padding: 0 12px;
   border-radius: 12px;
   box-shadow: 0 2px 10px 0 rgba(0, 50, 99, 0.05);
 }
@@ -646,12 +646,34 @@ https://tailwindcss.com/docs/utility-first
   }
 
   .content .learning-objectives-summary__explain-card {
-    align-items: flex-start;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: start;
+    column-gap: 12px;
+    row-gap: 8px;
+    padding: 12px;
+  }
+
+  .content .learning-objectives-summary__recommendation-link {
+    font-size: 14px;
+  }
+
+  .content .learning-objectives-summary__explain-icon {
+    width: 36px;
+    height: 36px;
+  }
+
+  .content .learning-objectives-summary__explain-copy {
+    grid-column: 2;
+    grid-row: 1;
+    gap: 6px;
   }
 
   .content .learning-objectives-summary__explain-button {
-    width: 100%;
+    grid-column: 2;
+    grid-row: 2;
+    width: 50%;
+    align-self: start;
   }
 }
 
@@ -827,7 +849,7 @@ https://tailwindcss.com/docs/utility-first
 
 @media (max-width: 720px) {
   .learning-objectives-editor__proficiency-cards {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -851,6 +851,14 @@ https://tailwindcss.com/docs/utility-first
   .learning-objectives-editor__proficiency-cards {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+
+  .learning-objectives-editor__proficiency-card--strong {
+    order: 3;
+  }
+
+  .learning-objectives-editor__proficiency-card--growing {
+    order: 4;
+  }
 }
 
 .truncate-form-control p {

--- a/lib/oli/rendering/content/learning_objectives.ex
+++ b/lib/oli/rendering/content/learning_objectives.ex
@@ -336,7 +336,7 @@ defmodule Oli.Rendering.Content.LearningObjectives do
   defp maybe_dot_explain_card(%Context{assistant_available?: true} = context, objective) do
     [
       ~s|<section class="learning-objectives-summary__explain-card border border-Border-border-subtle bg-Surface-surface-secondary-hover" aria-label="Ask DOT to explain this objective">|,
-      ~s|<div class="w-[72px] h-[72px] relative shrink-0" aria-hidden="true">|,
+      ~s|<div class="learning-objectives-summary__explain-icon w-[62px] h-[62px] relative shrink-0" aria-hidden="true">|,
       ~s|<img class="animate-[spin_40s_cubic-bezier(0.4,0,0.6,1)_infinite]" src="/images/assistant/footer_dot_ai.png" alt="" />|,
       ~s|<div class="w-[28px] h-[28px] absolute inset-0 m-auto bg-zinc-300 rounded-full blur-[16px] animate-[pulse_6s_cubic-bezier(0.4,0,0.6,1)_infinite]"></div>|,
       ~s|</div>|,


### PR DESCRIPTION
## Summary

Closes out the mobile responsive work left after #6792 and #6816 for the LO Summary/Introduction components: aligns the shared proficiency 2×2 grid, the Explain card layout (icon size, title/subtitle spacing, button width/alignment), and desktop-only Explain card padding with the Figma mobile designs.

## Changes

- Proficiency cards (`What is proficiency and how is it estimated?`) now render as a 2×2 grid on mobile instead of stacking in a single column.
- Explain card on mobile: smaller AI icon (top-left), title/subtitle in a right column with proper spacing, `Explain` button left-aligned at 50% width instead of full-width.
- Explain card padding is horizontal-only on non-mobile (vertical padding removed so the card no longer inherits extra height from the 72px icon).
- AI icon reduced from 72px to 62px on non-mobile to better match Figma.
- Revisit/Practice recommendation links reduced to 14px on mobile only (was 16px everywhere).


https://github.com/user-attachments/assets/d9118b98-7db1-4001-a791-6dc4c7d294b5

