### PR TITLE
[ENHANCEMENT] [MER-5810] Restore proficiency distribution gaps in instructor LO view

### DIFF
--- a/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/objectives_table_model.ex
@@ -329,10 +329,10 @@ defmodule OliWeb.Delivery.LearningObjectives.ObjectivesTableModel do
 
     spec = %{
       height: 12,
-      mark: "bar",
+      mark: %{type: "bar", binSpacing: 2},
       data: %{values: data_with_positions},
       encoding: %{
-        x: %{field: "start", type: "quantitative", scale: %{nice: false}},
+        x: %{field: "start", type: "quantitative", bin: "binned", scale: %{nice: false}},
         x2: %{field: "end"},
         color: %{
           field: "proficiency",

--- a/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
+++ b/lib/oli_web/components/delivery/learning_objectives/sub_objectives_table_model.ex
@@ -146,10 +146,10 @@ defmodule OliWeb.Delivery.LearningObjectives.SubObjectivesTableModel do
 
     spec = %{
       height: 12,
-      mark: "bar",
+      mark: %{type: "bar", binSpacing: 2},
       data: %{values: data_with_positions},
       encoding: %{
-        x: %{field: "start", type: "quantitative", scale: %{nice: false}},
+        x: %{field: "start", type: "quantitative", bin: "binned", scale: %{nice: false}},
         x2: %{field: "end"},
         color: %{
           field: "proficiency",

--- a/test/oli_web/components/delivery/learning_objectives/sub_objectives_list_test.exs
+++ b/test/oli_web/components/delivery/learning_objectives/sub_objectives_list_test.exs
@@ -120,6 +120,18 @@ defmodule OliWeb.Components.Delivery.LearningObjectives.SubObjectivesListTest do
       for color <- ~w(#CED1D9 #CE2C31 #BF5B13 #218358 #353740 #FF8787 #FFB387 #39E581) do
         assert html =~ color
       end
+
+      chart_props =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find(~s{div[data-live-react-class="Components.VegaLiteRenderer"]})
+        |> hd()
+        |> Floki.attribute("data-live-react-props")
+        |> hd()
+        |> Jason.decode!()
+
+      assert chart_props["spec"]["mark"] == %{"type" => "bar", "binSpacing" => 2}
+      assert chart_props["spec"]["encoding"]["x"]["bin"] == "binned"
     end
 
     test "handles empty sub-objectives data", %{conn: conn} do

--- a/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
+++ b/test/oli_web/live/delivery/instructor_dashboard/insights/learning_objectives_tab_test.exs
@@ -409,6 +409,17 @@ defmodule OliWeb.Delivery.InstructorDashboard.LearningObjectivesTabTest do
       for color <- ~w(#CED1D9 #CE2C31 #BF5B13 #218358 #353740 #FF8787 #FFB387 #39E581) do
         assert html =~ color
       end
+
+      chart_props =
+        html
+        |> Floki.parse_fragment!()
+        |> Floki.find("#proficiency-data-bar-chart-for-objective-#{obj_revision_1.resource_id}")
+        |> Floki.attribute("data-live-react-props")
+        |> hd()
+        |> Jason.decode!()
+
+      assert chart_props["spec"]["mark"] == %{"type" => "bar", "binSpacing" => 2}
+      assert chart_props["spec"]["encoding"]["x"]["bin"] == "binned"
     end
   end
 


### PR DESCRIPTION
## Summary

- Jira [MER-5810](https://eliterate.atlassian.net/browse/MER-5810)
- restore the 2px gap between adjacent proficiency distribution regions shown in Figma
- apply the spacing consistently to objective and sub-objective charts
- retain the approved light and dark proficiency color tokens and existing distribution calculations

## Implementation

The Vega-Lite specs now identify their manually calculated ranges as pre-binned and use binSpacing: 2. This lets Vega render the designed separation without introducing background-colored strokes that would conflict with alternating row surfaces or dark mode.

## Verification

- Focused Learning Objectives tests: 35 tests, 0 failures, 3 excluded
- browser QA against the seeded instructor Learning Objectives page
- verified all eight visible objective and sub-objective charts in light and dark mode
- pixel inspection confirmed transparent separation at every adjacent non-zero segment boundary

## Screenshot

<img width="1134" height="325" alt="Screenshot 2026-09-09 at 12 52 21 PM" src="https://github.com/user-attachments/assets/94312f5c-b97e-4c7d-a4ec-3205bb479cd2" />

## Design references

- Light: Figma node 325:20260
- Dark: Figma node 358:10043

[MER-5810]: https://eliterate.atlassian.net/browse/MER-5810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ