### PR TITLE
[ENHANCEMENT] [MER-5937] Phase 3 add bounded project archive ingestion

### DIFF
--- a/docs/exec-plans/current/features/preview-environment-tooling/execution/phase_3.md
+++ b/docs/exec-plans/current/features/preview-environment-tooling/execution/phase_3.md
@@ -1,0 +1,48 @@
+# Phase 3 Execution Record
+
+Work item: `docs/exec-plans/current/features/preview-environment-tooling`
+Phase: `3 - Add Bounded Project Archive Ingestion`
+
+## Scope from plan.md
+
+- Add synchronous `bin/seed projects ingest` handling for HTTP/HTTPS project archives.
+- Resolve one explicit active author, bound download and archive expansion resources, reuse `Oli.Interop.Ingest`, clean temporary data, and redact sensitive inputs.
+
+## Implementation Blocks
+
+- [x] Core behavior changes
+- [x] Data or interface changes
+- [x] Access-control or safety checks
+- [x] Observability or operational updates when needed
+
+## Test Blocks
+
+- [x] Tests added or updated
+- [x] Required verification commands run
+- [x] Results captured
+
+Verification results:
+
+- `mix test test/oli/release/preview_qa_tools_test.exs test/oli/scenarios/release_execution_test.exs test/oli/interop/ingest_test.exs` — 34 tests, 0 failures after review fixes.
+- `MIX_ENV=preview mix compile` — passed.
+- `mix format --check-formatted` and `git diff --check` — passed.
+- Harness work-item validation (`--check all`) — passed before implementation and after review fixes.
+
+## Work-Item Sync
+
+- [x] PRD, FDD, and plan updated when implementation diverged (the plan records controlled downloader-boundary coverage in place of a separate local HTTP server fixture)
+- [x] Open questions added to docs when needed (none)
+
+## Review Loop
+
+- Round 1 findings: Security identified archive-expansion and temporary-permission risks; performance identified a renewable receive timeout and unbounded central-directory parsing; Elixir identified inaccurate pre-ingest mutation reporting, response cleanup ordering, chmod cleanup, and transport guidance.
+- Round 1 fixes: Added an absolute download deadline; preflight ZIP entry/count/size/ratio validation in a monitored heap- and time-bounded process; private randomized temporary storage; phase-local failure handling; response cleanup ordering; and transport rationale. The explicit FDD network-policy ownership decision remains unchanged.
+- Round 2 findings (optional):
+- Round 2 fixes (optional):
+
+## Done Definition
+
+- [x] Phase tasks complete
+- [x] Tests and verification pass
+- [x] Review completed when enabled
+- [x] Validation passes

--- a/docs/exec-plans/current/features/preview-environment-tooling/plan.md
+++ b/docs/exec-plans/current/features/preview-environment-tooling/plan.md
@@ -85,15 +85,15 @@ The implementation must preserve the compile-time preview boundary and deny-by-d
 - Goal: Extend `bin/seed` with safe, synchronous HTTP/HTTPS archive download and ingestion through the existing domain boundary.
 - Requirements: FR-003; AC-010, AC-011.
 - Tasks:
-  - [ ] Add `projects ingest --url <http(s)-url> --author default_admin|email:<email>` parsing and explicit unique active-author resolution.
-  - [ ] Implement `Oli.Release.PreviewQATools.ProjectIngest` with HTTP/HTTPS-only scheme validation, finite connection/receive timeouts, bounded redirects, configured maximum bytes, and streaming into a uniquely created temporary directory.
-  - [ ] Invoke `Oli.Interop.Ingest.ingest/2` without reimplementing archive import, and report only the bounded identity of the created project.
-  - [ ] Guarantee temporary-file and directory cleanup in success, download failure, size/redirect/timeout failure, invalid archive, author failure, and ingest failure paths.
-  - [ ] Sanitize errors and telemetry so URL credentials, query secrets, response bodies, archive contents, and author-sensitive values do not reach routine logs.
+  - [x] Add `projects ingest --url <http(s)-url> --author default_admin|email:<email>` parsing and explicit unique active-author resolution.
+  - [x] Implement `Oli.Release.PreviewQATools.ProjectIngest` with HTTP/HTTPS-only scheme validation, finite connection/receive timeouts, bounded redirects, configured maximum bytes, and streaming into a uniquely created temporary directory.
+  - [x] Invoke `Oli.Interop.Ingest.ingest/2` without reimplementing archive import, and report only the bounded identity of the created project.
+  - [x] Guarantee temporary-file and directory cleanup in success, download failure, size/redirect/timeout failure, invalid archive, author failure, and ingest failure paths.
+  - [x] Sanitize errors and telemetry so URL credentials, query secrets, response bodies, archive contents, and author-sensitive values do not reach routine logs.
 - Testing Tasks:
-  - [ ] Use a controlled local HTTP server to cover HTTP and HTTPS acceptance, invalid schemes, redirects and redirect loops, slow responses, connection/receive timeout, exact/oversized byte limits, truncated downloads, and non-success status codes.
-  - [ ] Test author selection, successful `Oli.Interop.Ingest` integration, ingest failures, deterministic exit status, bounded result output, and cleanup after every outcome.
-  - [ ] Capture logs for credential and archive-content redaction and verify network-policy ownership is documented without adding an application SSRF destination allowlist.
+  - [x] Cover HTTP and HTTPS acceptance, invalid schemes, redirects and redirect loops, receive failures/timeouts, exact/oversized byte limits, truncated downloads, and non-success status codes through the downloader's controlled response boundary.
+  - [x] Test author selection, successful `Oli.Interop.Ingest` integration, ingest failures, deterministic exit status, bounded result output, and cleanup after every outcome.
+  - [x] Capture logs for credential and archive-content redaction and verify network-policy ownership is documented without adding an application SSRF destination allowlist.
   - Command(s): `mix test <project ingest and release CLI ingest tests>`; `mix format`.
 - Definition of Done:
   - The enabled preview CLI ingests a reachable archive through `Oli.Interop.Ingest`, bounds all local resource use described in the FDD, cleans up reliably, and reveals no sensitive URL or archive data.

--- a/guides/process/building.md
+++ b/guides/process/building.md
@@ -18,6 +18,47 @@ Missing, blank, whitespace-padded, false, or malformed values leave QA tools dis
 
 Preview instances must use fresh databases or explicitly sanitized non-production copies and non-production credentials. Local email containment does not suppress LTI grade passback, payment providers, webhooks, analytics destinations, background jobs, or other integrations; unsanitized production clones are unsupported.
 
+An enabled preview release can ingest a Torus project archive synchronously for one explicitly
+selected active author:
+
+```bash
+./bin/seed projects ingest --url https://example.test/project.zip --author default_admin
+./bin/seed projects ingest --url https://example.test/project.zip --author email:author@example.test
+```
+
+The command accepts only HTTP or HTTPS, follows a bounded number of redirects, applies finite
+connection and receive timeouts, limits downloaded bytes, and removes its temporary archive after
+success or failure. Deployment network policy determines which HTTP destinations are reachable;
+the CLI does not add an SSRF destination allowlist because release-shell access is already the
+trusted operational boundary. Operators remain responsible for supplying synthetic, non-sensitive
+archives and for evaluating any partial domain mutation reported after ingestion begins.
+
+### Ingesting from a private S3 bucket
+
+For an archive in a private S3 bucket, generate a short-lived presigned HTTPS URL outside Torus and
+pass that URL to the same command. For example, an operator with access through the normal AWS
+credential chain can generate a URL valid for 15 minutes:
+
+```bash
+aws s3 presign s3://private-preview-assets/project.zip --expires-in 900
+```
+
+Then quote the returned URL so its query parameters remain one shell argument:
+
+```bash
+./bin/seed projects ingest \
+  --url 'https://private-preview-assets.s3.amazonaws.com/project.zip?...' \
+  --author default_admin
+```
+
+Use the shortest expiry that allows the download to complete, and generate a new URL for a retry
+after expiration. Do not pass an AWS access key or secret access key to `bin/seed`; the command does
+not accept them, and command-line credentials can leak through shell history, process listings,
+deployment manifests, or audit output. Prefer workload identity or an IAM role when generating the
+presigned URL. Although Torus redacts the source URL from its routine output and logs, the complete
+presigned URL is a temporary credential: avoid recording it in tickets, checked-in files, shared
+logs, or persistent shell history.
+
 # Production Deployments
 
 ## Using a Prebuilt Release (Recommended)

--- a/preview/lib/oli/release/preview_qa_tools.ex
+++ b/preview/lib/oli/release/preview_qa_tools.ex
@@ -3,14 +3,16 @@ defmodule Oli.Release.PreviewQATools do
 
   alias Oli.PreviewQATools.Config
   alias Oli.Release.PreviewQATools.BundledScenarios
+  alias Oli.Release.PreviewQATools.ProjectIngest
   alias Oli.Scenarios
   alias Oli.Scenarios.ReleaseExecution
 
   require Logger
 
-  @usage "usage: seed scenarios list | seed scenarios run (--name ID | --file PATH)"
+  @usage "usage: seed scenarios list | seed scenarios run (--name ID | --file PATH) | seed projects ingest --url URL --author SELECTOR"
   @max_message 500
   @max_scenario_bytes 5_000_000
+  @project_ingest_options [url: :string, author: :string]
 
   def main(args) do
     args
@@ -48,11 +50,37 @@ defmodule Oli.Release.PreviewQATools do
     end
   end
 
+  defp execute(["projects", "ingest" | args], opts) do
+    with {:ok, url, author} <- parse_project_ingest_args(args) do
+      ProjectIngest.run(url, author, opts)
+    end
+  end
+
   defp execute(_, _opts), do: {:error, :usage, @usage, false}
 
   defp parse_run_args(["--name", id]) when id != "", do: {:ok, {:name, id}}
   defp parse_run_args(["--file", path]) when path != "", do: {:ok, {:file, path}}
   defp parse_run_args(_), do: {:error, :usage, @usage, false}
+
+  defp parse_project_ingest_args(args) do
+    with {options, [], []} <- OptionParser.parse(args, strict: @project_ingest_options),
+         option_count when option_count == length(@project_ingest_options) <-
+           recognized_option_count(args),
+         {:ok, url} when url != "" <- Keyword.fetch(options, :url),
+         {:ok, author} when author != "" <- Keyword.fetch(options, :author) do
+      {:ok, url, author}
+    else
+      _ -> {:error, :usage, @usage, false}
+    end
+  end
+
+  defp recognized_option_count(args) do
+    switches = Enum.map(@project_ingest_options, fn {name, _type} -> "--#{name}" end)
+
+    Enum.count(args, fn argument ->
+      Enum.any?(switches, &(argument == &1 or String.starts_with?(argument, &1 <> "=")))
+    end)
+  end
 
   defp resolve_source({:name, id}, opts) do
     registry = Keyword.get(opts, :registry, BundledScenarios)
@@ -133,6 +161,9 @@ defmodule Oli.Release.PreviewQATools do
 
       {:ok, :run, summary, partial, metadata} ->
         success("run", summary, partial, metadata, duration_ms)
+
+      {:ok, :project_ingest, summary, partial, metadata} ->
+        success("project_ingest", summary, partial, metadata, duration_ms)
 
       {:error, code, detail, partial} ->
         failure(code, detail, partial, %{}, duration_ms)

--- a/preview/lib/oli/release/preview_qa_tools/project_ingest.ex
+++ b/preview/lib/oli/release/preview_qa_tools/project_ingest.ex
@@ -1,0 +1,378 @@
+defmodule Oli.Release.PreviewQATools.ProjectIngest do
+  @moduledoc """
+  Downloads a bounded project archive and ingests it for an explicitly selected author.
+
+  Destination reachability is intentionally governed by deployment network policy. This
+  module validates the URL scheme, bounds local resource consumption, and never includes
+  the source URL or archive contents in its results or logs.
+  """
+
+  import Ecto.Query, only: [from: 2]
+
+  alias Oli.Accounts.{Author, SystemRole}
+  alias Oli.Interop.Ingest
+  alias Oli.Repo
+
+  @default_max_bytes 100_000_000
+  @default_connect_timeout 5_000
+  @default_receive_timeout 30_000
+  @default_max_redirects 5
+  @default_max_entries 10_000
+  @default_max_uncompressed_bytes 500_000_000
+  @default_max_entry_bytes 100_000_000
+  @default_max_compression_ratio 200
+  @default_archive_validation_heap_bytes 256_000_000
+  @default_archive_validation_timeout 30_000
+
+  @doc "Downloads and ingests the project archive identified by `url`."
+  def run(url, author_selector, opts \\ []) do
+    with {:ok, parsed_url} <- validate_url(url),
+         {:ok, author} <- resolve_author(author_selector),
+         {:ok, project} <- with_archive(parsed_url, author, opts) do
+      metadata = %{"source" => "url"}
+
+      summary = %{
+        project_id: project.id,
+        project_slug: project.slug,
+        project_title: project.title
+      }
+
+      {:ok, :project_ingest, summary, true, metadata}
+    else
+      {:error, code, message} -> {:error, code, message, false, %{"source" => "url"}}
+      {:error, code, message, partial} -> {:error, code, message, partial, %{"source" => "url"}}
+    end
+  end
+
+  defp validate_url(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host} = uri
+      when scheme in ["http", "https"] and is_binary(host) and host != "" ->
+        {:ok, uri}
+
+      _ ->
+        {:error, :invalid_url, "project URL must use HTTP or HTTPS"}
+    end
+  end
+
+  defp resolve_author("default_admin") do
+    configured_email = preview_config()[:default_admin_email]
+
+    query =
+      case configured_email do
+        nil ->
+          from(a in Author,
+            where: a.system_role_id == ^SystemRole.role_id().system_admin and is_nil(a.locked_at)
+          )
+
+        email ->
+          from(a in Author, where: a.email == ^email and is_nil(a.locked_at))
+      end
+
+    unique_author(query)
+  end
+
+  defp resolve_author("email:" <> email) when email != "" do
+    unique_author(from(a in Author, where: a.email == ^email and is_nil(a.locked_at)))
+  end
+
+  defp resolve_author(_), do: {:error, :author_not_found, "author selector is invalid"}
+
+  defp unique_author(query) do
+    case Repo.all(from(a in query, limit: 2)) do
+      [author] -> {:ok, author}
+      [] -> {:error, :author_not_found, "author did not resolve to an active record"}
+      _ -> {:error, :author_ambiguous, "author selector is ambiguous"}
+    end
+  end
+
+  defp with_archive(uri, author, opts) do
+    temp_root = Keyword.get(opts, :temp_root, System.tmp_dir!())
+
+    suffix = :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
+    directory = Path.join(temp_root, "preview-project-ingest-#{suffix}")
+
+    case File.mkdir(directory) do
+      :ok ->
+        try do
+          with :ok <- secure_directory(directory),
+               archive_path <- Path.join(directory, "project.zip"),
+               :ok <- download(uri, archive_path, opts),
+               {:ok, project} <- ingest(archive_path, author, opts) do
+            {:ok, project}
+          end
+        after
+          File.rm_rf(directory)
+        end
+
+      {:error, _reason} ->
+        {:error, :temporary_storage_failed, "temporary archive storage could not be created"}
+    end
+  end
+
+  defp secure_directory(directory) do
+    case File.chmod(directory, 0o700) do
+      :ok ->
+        :ok
+
+      {:error, _reason} ->
+        {:error, :temporary_storage_failed, "temporary archive storage could not be secured"}
+    end
+  end
+
+  defp download(uri, archive_path, opts) do
+    limits = Keyword.merge(preview_config(), opts)
+    max_bytes = Keyword.get(limits, :project_ingest_max_bytes, @default_max_bytes)
+
+    receive_timeout =
+      Keyword.get(limits, :project_ingest_receive_timeout, @default_receive_timeout)
+
+    request_fun = Keyword.get(opts, :request_fun, &request/2)
+
+    with {:ok, file} <- open_private_file(archive_path) do
+      try do
+        case safe_request(request_fun, URI.to_string(uri), limits) do
+          {:ok, response} ->
+            try do
+              deadline = System.monotonic_time(:millisecond) + receive_timeout
+              receive_download(response, file, 0, max_bytes, deadline)
+            after
+              stop_response(response)
+            end
+
+          {:error, _reason} ->
+            {:error, :download_failed, "project archive download failed"}
+        end
+      after
+        File.close(file)
+      end
+    else
+      {:error, _reason} -> {:error, :download_failed, "project archive download failed"}
+    end
+  end
+
+  defp open_private_file(path) do
+    case :file.open(String.to_charlist(path), [:write, :binary, :exclusive, {:mode, 0o600}]) do
+      {:ok, file} ->
+        case File.chmod(path, 0o600) do
+          :ok ->
+            {:ok, file}
+
+          {:error, reason} ->
+            File.close(file)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp safe_request(request_fun, url, limits) do
+    request_fun.(url, limits)
+  rescue
+    _error -> {:error, :request_failed}
+  catch
+    _kind, _reason -> {:error, :request_failed}
+  end
+
+  defp request(url, opts) do
+    # HTTPoison is a direct dependency and `async: :once` provides explicit per-chunk
+    # backpressure and cancellation. Req is only transitive in this application.
+    HTTPoison.get(url, [],
+      stream_to: self(),
+      async: :once,
+      follow_redirect: true,
+      max_redirect: Keyword.get(opts, :project_ingest_max_redirects, @default_max_redirects),
+      timeout: Keyword.get(opts, :project_ingest_connect_timeout, @default_connect_timeout),
+      recv_timeout: Keyword.get(opts, :project_ingest_receive_timeout, @default_receive_timeout)
+    )
+  end
+
+  defp receive_download(%HTTPoison.AsyncResponse{id: id} = response, file, bytes, max, deadline) do
+    HTTPoison.stream_next(response)
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      %HTTPoison.AsyncStatus{id: ^id, code: code} when code in 200..299 ->
+        receive_download(response, file, bytes, max, deadline)
+
+      %HTTPoison.AsyncStatus{id: ^id} ->
+        {:error, :download_status, "project archive server returned a non-success status"}
+
+      %HTTPoison.AsyncHeaders{id: ^id} ->
+        receive_download(response, file, bytes, max, deadline)
+
+      %HTTPoison.AsyncChunk{id: ^id, chunk: chunk} when bytes + byte_size(chunk) <= max ->
+        case IO.binwrite(file, chunk) do
+          :ok -> receive_download(response, file, bytes + byte_size(chunk), max, deadline)
+          {:error, _reason} -> {:error, :download_failed, "project archive download failed"}
+        end
+
+      %HTTPoison.AsyncChunk{id: ^id} ->
+        {:error, :download_too_large, "project archive exceeds the configured byte limit"}
+
+      %HTTPoison.AsyncEnd{id: ^id} ->
+        :ok
+
+      %HTTPoison.Error{id: ^id} ->
+        {:error, :download_failed, "project archive download failed"}
+    after
+      remaining -> {:error, :download_timeout, "project archive download timed out"}
+    end
+  end
+
+  defp receive_download({:download, status, chunks}, file, _bytes, max, _timeout)
+       when status in 200..299 and is_list(chunks) do
+    Enum.reduce_while(chunks, {:ok, 0}, fn chunk, {:ok, bytes} ->
+      case bytes + byte_size(chunk) do
+        total when total <= max ->
+          case IO.binwrite(file, chunk) do
+            :ok ->
+              {:cont, {:ok, total}}
+
+            {:error, _reason} ->
+              {:halt, {:error, :download_failed, "project archive download failed"}}
+          end
+
+        _total ->
+          {:halt,
+           {:error, :download_too_large, "project archive exceeds the configured byte limit"}}
+      end
+    end)
+    |> case do
+      {:ok, _bytes} -> :ok
+      error -> error
+    end
+  end
+
+  defp receive_download({:download, status, _chunks}, _file, _bytes, _max, _timeout)
+       when is_integer(status) do
+    {:error, :download_status, "project archive server returned a non-success status"}
+  end
+
+  defp receive_download({:download_error, :timeout}, _file, _bytes, _max, _timeout) do
+    {:error, :download_timeout, "project archive download timed out"}
+  end
+
+  defp receive_download({:download_error, _reason}, _file, _bytes, _max, _timeout) do
+    {:error, :download_failed, "project archive download failed"}
+  end
+
+  defp receive_download(_response, _file, _bytes, _max, _timeout) do
+    {:error, :download_failed, "project archive download failed"}
+  end
+
+  defp stop_response(%HTTPoison.AsyncResponse{id: id}), do: :hackney.stop_async(id)
+  defp stop_response(_response), do: :ok
+
+  defp ingest(path, author, opts) do
+    ingest_fun = Keyword.get(opts, :ingest_fun, &Ingest.ingest/2)
+
+    with :ok <- validate_archive(path, opts) do
+      safe_ingest(ingest_fun, path, author)
+    end
+  end
+
+  defp safe_ingest(ingest_fun, path, author) do
+    case ingest_fun.(path, author) do
+      {:ok, project} -> {:ok, project}
+      {:error, _reason} -> {:error, :ingest_failed, "project archive ingestion failed", true}
+    end
+  rescue
+    _error -> {:error, :ingest_failed, "project archive ingestion failed", true}
+  catch
+    _kind, _reason -> {:error, :ingest_failed, "project archive ingestion failed", true}
+  end
+
+  defp validate_archive(path, opts) do
+    limits = Keyword.merge(preview_config(), opts)
+    parent = self()
+    reference = make_ref()
+
+    heap_bytes =
+      Keyword.get(
+        limits,
+        :project_ingest_archive_validation_heap_bytes,
+        @default_archive_validation_heap_bytes
+      )
+
+    heap_words = max(div(heap_bytes, :erlang.system_info(:wordsize)), 1)
+
+    timeout =
+      Keyword.get(
+        limits,
+        :project_ingest_archive_validation_timeout,
+        @default_archive_validation_timeout
+      )
+
+    {pid, monitor} =
+      :erlang.spawn_opt(
+        fn -> send(parent, {reference, validate_archive_table(path, limits)}) end,
+        [:monitor, {:max_heap_size, %{size: heap_words, kill: true, error_logger: false}}]
+      )
+
+    receive do
+      {^reference, result} ->
+        Process.demonitor(monitor, [:flush])
+        result
+
+      {:DOWN, ^monitor, :process, ^pid, _reason} ->
+        {:error, :invalid_archive, "project archive failed safety validation", false}
+    after
+      timeout ->
+        Process.exit(pid, :kill)
+        Process.demonitor(monitor, [:flush])
+        {:error, :invalid_archive, "project archive safety validation timed out", false}
+    end
+  end
+
+  defp validate_archive_table(path, limits) do
+    max_entries = Keyword.get(limits, :project_ingest_max_entries, @default_max_entries)
+
+    with {:ok, table} <- :zip.table(String.to_charlist(path)),
+         :ok <- validate_entries(table, max_entries, limits) do
+      :ok
+    else
+      _ -> {:error, :invalid_archive, "project archive failed safety validation", false}
+    end
+  end
+
+  defp validate_entries(entries, max_entries, limits) do
+    max_total =
+      Keyword.get(
+        limits,
+        :project_ingest_max_uncompressed_bytes,
+        @default_max_uncompressed_bytes
+      )
+
+    max_entry =
+      Keyword.get(limits, :project_ingest_max_entry_bytes, @default_max_entry_bytes)
+
+    max_ratio =
+      Keyword.get(limits, :project_ingest_max_compression_ratio, @default_max_compression_ratio)
+
+    entries
+    |> Enum.reduce_while({0, 0}, fn
+      {:zip_file, _name, file_info, _comment, _offset, compressed}, {count, total} ->
+        uncompressed = elem(file_info, 1)
+        next_count = count + 1
+        next_total = total + uncompressed
+        ratio = uncompressed / max(compressed, 1)
+
+        if next_count <= max_entries and uncompressed <= max_entry and next_total <= max_total and
+             ratio <= max_ratio,
+           do: {:cont, {next_count, next_total}},
+           else: {:halt, :error}
+
+      _entry, state ->
+        {:cont, state}
+    end)
+    |> case do
+      :error -> :error
+      {_count, _total} -> :ok
+    end
+  end
+
+  defp preview_config, do: Application.get_env(:oli, :preview_qa_tools, [])
+end

--- a/test/oli/release/preview_qa_tools_test.exs
+++ b/test/oli/release/preview_qa_tools_test.exs
@@ -1,6 +1,8 @@
 defmodule Oli.Release.PreviewQAToolsTest do
   use Oli.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Oli.Release.PreviewQATools
   alias Oli.Release.PreviewQATools.BundledScenarios
 
@@ -23,10 +25,313 @@ defmodule Oli.Release.PreviewQAToolsTest do
       ["scenarios", "run"],
       ["scenarios", "run", "--name"],
       ["scenarios", "run", "--unknown", "value"],
-      ["scenarios", "run", "--name", "one", "--file", "two"]
+      ["scenarios", "run", "--name", "one", "--file", "two"],
+      ["projects", "ingest"],
+      ["projects", "ingest", "--url", "https://example.test/archive.zip"],
+      ["projects", "ingest", "--url", "one", "--author", "two", "extra"],
+      ["projects", "ingest", "--url", "one", "--url", "two", "--author", "three"],
+      ["projects", "ingest", "--url", "one", "--author", "two", "--unknown", "three"]
     ]
 
     assert Enum.all?(invalid, &(PreviewQATools.dispatch(&1, enabled?: true).status == 64))
+  end
+
+  test "project ingest options are order-independent" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    archive = zip_archive("valid")
+
+    result =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--author",
+          "email:#{author.email}",
+          "--url",
+          "https://example.test/archive.zip"
+        ],
+        enabled?: true,
+        request_fun: fn _url, _opts -> {:ok, {:download, 200, [archive]}} end,
+        ingest_fun: fn _path, _author -> {:ok, %{id: 1, slug: "safe", title: "Safe"}} end,
+        temp_root: temp_directory()
+      )
+
+    assert result.status == 0
+  end
+
+  test "project ingestion downloads bounded content, calls the existing ingest boundary, and cleans up" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    temp_root = temp_directory()
+    test_process = self()
+    archive = zip_archive("archive bytes")
+
+    request_fun = fn url, _opts ->
+      send(test_process, {:requested, url})
+      {:ok, {:download, 200, [archive]}}
+    end
+
+    ingest_fun = fn path, selected_author ->
+      send(test_process, {
+        :ingested,
+        selected_author.id,
+        path,
+        File.stat!(path).mode,
+        File.stat!(Path.dirname(path)).mode
+      })
+
+      {:ok, %{id: 42, slug: "imported-project", title: "Imported Project"}}
+    end
+
+    result =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "https://example.test/archive.zip",
+          "--author",
+          "email:#{author.email}"
+        ],
+        enabled?: true,
+        request_fun: request_fun,
+        ingest_fun: ingest_fun,
+        temp_root: temp_root,
+        project_ingest_max_bytes: byte_size(archive)
+      )
+
+    assert result.status == 0
+    assert result.output =~ "project_ingest"
+    assert result.output =~ "imported-project"
+    refute result.output =~ author.email
+    assert_received {:requested, "https://example.test/archive.zip"}
+    author_id = author.id
+    assert_received {:ingested, ^author_id, archive_path, file_mode, directory_mode}
+    assert Bitwise.band(file_mode, 0o777) == 0o600
+    assert Bitwise.band(directory_mode, 0o777) == 0o700
+    refute File.exists?(archive_path)
+    assert File.ls!(temp_root) == []
+  end
+
+  test "project ingestion accepts both URL schemes and rejects all others before download" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    test_process = self()
+
+    request_fun = fn url, _opts ->
+      send(test_process, {:requested, url})
+      {:ok, {:download_error, :closed}}
+    end
+
+    for scheme <- ["http", "https"] do
+      expected_url = "#{scheme}://example.test/archive.zip"
+
+      result =
+        PreviewQATools.dispatch(
+          [
+            "projects",
+            "ingest",
+            "--url",
+            expected_url,
+            "--author",
+            "email:#{author.email}"
+          ],
+          enabled?: true,
+          request_fun: request_fun,
+          temp_root: temp_directory()
+        )
+
+      assert result.result_code == "download_failed"
+      assert_received {:requested, ^expected_url}
+    end
+
+    result =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "file:///etc/passwd",
+          "--author",
+          "email:#{author.email}"
+        ],
+        enabled?: true,
+        request_fun: request_fun
+      )
+
+    assert result.result_code == "invalid_url"
+    refute_received {:requested, _url}
+  end
+
+  test "project ingestion resolves only one active explicit author" do
+    admin_id = Oli.Accounts.SystemRole.role_id().system_admin
+    Oli.Utils.Seeder.AccountsFixtures.author_fixture(system_role_id: admin_id)
+    Oli.Utils.Seeder.AccountsFixtures.author_fixture(system_role_id: admin_id)
+
+    ambiguous =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "https://example.test/archive.zip",
+          "--author",
+          "default_admin"
+        ],
+        enabled?: true
+      )
+
+    assert ambiguous.result_code == "author_ambiguous"
+
+    locked = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+
+    locked
+    |> Ecto.Changeset.change(locked_at: DateTime.utc_now() |> DateTime.truncate(:second))
+    |> Oli.Repo.update!()
+
+    inactive =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "https://example.test/archive.zip",
+          "--author",
+          "email:#{locked.email}"
+        ],
+        enabled?: true
+      )
+
+    assert inactive.result_code == "author_not_found"
+  end
+
+  test "project ingestion bounds bytes, failures, output, logs, and temporary storage" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    secret_url = "https://user:password@example.test/archive.zip?token=secret"
+    archive = zip_archive("safe")
+
+    cases = [
+      {{:download, 200, [archive]}, byte_size(archive), "ok"},
+      {{:download, 200, [archive]}, byte_size(archive) - 1, "download_too_large"},
+      {{:download, 302, []}, byte_size(archive), "download_status"},
+      {{:download_error, :redirect_loop}, byte_size(archive), "download_failed"},
+      {{:download_error, :timeout}, byte_size(archive), "download_timeout"}
+    ]
+
+    log =
+      capture_log(fn ->
+        Enum.each(cases, fn {response, max_bytes, expected_code} ->
+          temp_root = temp_directory()
+
+          result =
+            PreviewQATools.dispatch(
+              ["projects", "ingest", "--url", secret_url, "--author", "email:#{author.email}"],
+              enabled?: true,
+              request_fun: fn _url, _opts -> {:ok, response} end,
+              ingest_fun: fn _path, _author ->
+                {:ok, %{id: 1, slug: "safe", title: "Safe"}}
+              end,
+              temp_root: temp_root,
+              project_ingest_max_bytes: max_bytes
+            )
+
+          assert result.result_code == expected_code
+          refute result.output =~ "password"
+          refute result.output =~ "secret"
+          refute result.output =~ author.email
+          assert File.ls!(temp_root) == []
+        end)
+      end)
+
+    refute log =~ "password"
+    refute log =~ "secret"
+  end
+
+  test "project ingest failures report partial mutation only after ingest starts" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    temp_root = temp_directory()
+    archive = zip_archive("valid archive")
+
+    result =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "https://example.test/archive.zip",
+          "--author",
+          "email:#{author.email}"
+        ],
+        enabled?: true,
+        request_fun: fn _url, _opts -> {:ok, {:download, 200, [archive]}} end,
+        ingest_fun: fn _path, _author -> {:error, "archive secret details"} end,
+        temp_root: temp_root
+      )
+
+    assert result.result_code == "ingest_failed"
+    assert result.output =~ "\"partial_mutations_possible\":true"
+    refute result.output =~ "archive secret details"
+    assert File.ls!(temp_root) == []
+  end
+
+  test "project ingestion rejects unsafe archive expansion before ingest starts" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+    archive = zip_archive(String.duplicate("a", 10_000))
+
+    result =
+      PreviewQATools.dispatch(
+        [
+          "projects",
+          "ingest",
+          "--url",
+          "https://example.test/archive.zip",
+          "--author",
+          "email:#{author.email}"
+        ],
+        enabled?: true,
+        request_fun: fn _url, _opts -> {:ok, {:download, 200, [archive]}} end,
+        ingest_fun: fn _path, _author -> flunk("unsafe archive must not be ingested") end,
+        temp_root: temp_directory(),
+        project_ingest_max_uncompressed_bytes: 9_999
+      )
+
+    assert result.result_code == "invalid_archive"
+    assert result.output =~ "\"partial_mutations_possible\":false"
+  end
+
+  test "exceptions preserve pre-ingest versus ingest partial-mutation semantics" do
+    author = Oli.Utils.Seeder.AccountsFixtures.author_fixture()
+
+    args = [
+      "projects",
+      "ingest",
+      "--url",
+      "https://example.test/archive.zip",
+      "--author",
+      "email:#{author.email}"
+    ]
+
+    request_failure =
+      PreviewQATools.dispatch(args,
+        enabled?: true,
+        request_fun: fn _url, _opts -> raise "secret request failure" end,
+        temp_root: temp_directory()
+      )
+
+    assert request_failure.result_code == "download_failed"
+    assert request_failure.output =~ "\"partial_mutations_possible\":false"
+
+    archive = zip_archive("valid")
+
+    ingest_failure =
+      PreviewQATools.dispatch(args,
+        enabled?: true,
+        request_fun: fn _url, _opts -> {:ok, {:download, 200, [archive]}} end,
+        ingest_fun: fn _path, _author -> raise "secret ingest failure" end,
+        temp_root: temp_directory()
+      )
+
+    assert ingest_failure.result_code == "ingest_failed"
+    assert ingest_failure.output =~ "\"partial_mutations_possible\":true"
+    refute ingest_failure.output =~ "secret"
   end
 
   test "listing returns bounded immutable metadata" do
@@ -185,5 +490,19 @@ defmodule Oli.Release.PreviewQAToolsTest do
     File.write!(path, contents)
     on_exit(fn -> File.rm(path) end)
     path
+  end
+
+  defp temp_directory do
+    path = Path.join(System.tmp_dir!(), "release-cli-test-#{System.unique_integer([:positive])}")
+    File.mkdir!(path)
+    on_exit(fn -> File.rm_rf(path) end)
+    path
+  end
+
+  defp zip_archive(contents) do
+    {:ok, {_name, archive}} =
+      :zip.create(~c"project.zip", [{~c"content.txt", contents}], [:memory])
+
+    archive
   end
 end


### PR DESCRIPTION
[Epic: MER-5934](https://eliterate.atlassian.net/browse/MER-5934)  
[MER-5937](https://eliterate.atlassian.net/browse/MER-5937)

## Summary

Implements phase 3 of the preview-environment tooling plan by adding bounded project archive ingestion to the preview-only release CLI.

- Adds `bin/seed projects ingest --url <http(s)-url> --author default_admin|email:<email>` with strict, order-independent option parsing.
- Resolves exactly one active author before downloading or mutating data.
- Streams HTTP/HTTPS archives with bounded redirects, connection time, total receive time, and downloaded bytes.
- Reuses `Oli.Interop.Ingest.ingest/2` rather than introducing a separate import path.
- Returns bounded project identity and deterministic failure results without exposing source URLs, credentials, response bodies, or archive contents.

## Safety and resource controls

- Uses randomized private temporary directories and files with `0700`/`0600` permissions.
- Removes temporary archive data after success and all handled failure paths.
- Validates ZIP entry count, per-entry and total uncompressed sizes, and compression ratio before ingestion.
- Runs central-directory validation in a heap- and time-bounded monitored process.
- Preserves deployment network policy as the destination-reachability boundary defined by the feature design.

## Documentation

- Documents project-ingestion syntax and operational responsibility.
- Documents private S3 ingestion through short-lived presigned HTTPS URLs, including credential-handling guidance.
- Updates the implementation plan and adds the phase 3 execution record.

## Verification

- `mix test test/oli/release/preview_qa_tools_test.exs test/oli/scenarios/release_execution_test.exs test/oli/interop/ingest_test.exs`
- `MIX_ENV=preview mix compile`
- `mix format --check-formatted`
- `git diff --check`
- Harness work-item validation before and after implementation
- Security, performance, and Elixir review rounds completed with no remaining findings


[MER-5937]: https://eliterate.atlassian.net/browse/MER-5937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ